### PR TITLE
MessageMapper now populates custom attributes on derived instances

### DIFF
--- a/src/impl/messageInterfaces/NServiceBus.MessageInterfaces.MessageMapper.Reflection/MessageMapper.cs
+++ b/src/impl/messageInterfaces/NServiceBus.MessageInterfaces.MessageMapper.Reflection/MessageMapper.cs
@@ -152,6 +152,11 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
                     propertyType,
                     null);
 
+                foreach (var customAttribute in prop.GetCustomAttributes(true))
+                {
+                    AddCustomAttributeToProperty(customAttribute, propBuilder);
+                }
+
                 MethodBuilder getMethodBuilder = typeBuilder.DefineMethod(
                     "get_" + prop.Name,
                     MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig | MethodAttributes.Final | MethodAttributes.Virtual | MethodAttributes.VtableLayoutMask,
@@ -191,6 +196,20 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
             typeBuilder.AddInterfaceImplementation(t);
 
             return typeBuilder.CreateType();
+        }
+
+        /// <summary>
+        /// Given a custom attribute and property builder, adds an instance of custom attribute
+        /// to the property builder
+        /// </summary>
+        /// <param name="customAttribute"></param>
+        /// <param name="propBuilder"></param>
+        private void AddCustomAttributeToProperty(object customAttribute, PropertyBuilder propBuilder)
+        {
+            var classConstructorInfo = customAttribute.GetType().GetConstructor(new Type[] { });
+            var customAttributeBuilder = new CustomAttributeBuilder(classConstructorInfo,
+                                                                            new object[] { });
+            propBuilder.SetCustomAttribute(customAttributeBuilder);
         }
 
         /// <summary>

--- a/src/impl/messageInterfaces/NServiceBus.MessageInterfaces.Tests/When_mapping_interfaces.cs
+++ b/src/impl/messageInterfaces/NServiceBus.MessageInterfaces.Tests/When_mapping_interfaces.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Reflection;
 using NUnit.Framework;
 
 namespace NServiceBus.MessageInterfaces.Tests
@@ -27,6 +29,21 @@ namespace NServiceBus.MessageInterfaces.Tests
 
             Assert.Null(mapper.GetMappedTypeFor(typeof(InterfaceWithMethods)));
         }
+        
+        [Test]
+        public void Attributes_on_properties_should_be_mapped()
+        {
+            mapper.Initialize(new[]{typeof(InterfaceWithPropertiesAndAttributes)});
+            Assert.IsTrue(PropertyContainsAttribute("SomeProperty",typeof(SomeAttribute),mapper.CreateInstance(typeof(InterfaceWithPropertiesAndAttributes))));
+            
+            // Doesn't affect properties without attributes
+            Assert.IsFalse(PropertyContainsAttribute("SomeOtherProperty", typeof(SomeAttribute), mapper.CreateInstance(typeof(InterfaceWithPropertiesAndAttributes))));
+        }
+
+        private bool PropertyContainsAttribute(string propertyName, Type attributeType, object obj)
+        {
+            return obj.GetType().GetProperty(propertyName).GetCustomAttributes(attributeType,true).Length > 0;
+        }
     }
 
     public interface InterfaceWithProperties
@@ -38,5 +55,18 @@ namespace NServiceBus.MessageInterfaces.Tests
     {
         string SomeProperty { get; set; }
         void MethodOnInterface();
+    }
+
+    public interface InterfaceWithPropertiesAndAttributes
+    {
+        [SomeAttribute]
+        string SomeProperty { get; set; }
+        
+        string SomeOtherProperty { get; set; }
+    }
+
+    public class SomeAttribute : Attribute
+    {
+        
     }
 }


### PR DESCRIPTION
As per mailing list discussion (http://tech.groups.yahoo.com/group/nservicebus/message/9224)

Includes passing unit test.
