### PR TITLE
NHibernate sub. storage leaks connections

### DIFF
--- a/src/impl/unicast/NServiceBus.Unicast.Subscriptions.NHibernate/SubscriptionStorage.cs
+++ b/src/impl/unicast/NServiceBus.Unicast.Subscriptions.NHibernate/SubscriptionStorage.cs
@@ -76,9 +76,9 @@ namespace NServiceBus.Unicast.Subscriptions.NHibernate
 
             IList<string> list;
 
-            using (var transaction = new TransactionScope(TransactionScopeOption.RequiresNew, new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted }))
-            using (var session = sessionSource.CreateSession())
-            using (var nhtransaction = session.BeginTransaction(System.Data.IsolationLevel.ReadCommitted))
+            using (new TransactionScope(TransactionScopeOption.Suppress))
+            using (var session = sessionSource.SessionFactory.OpenStatelessSession())
+            using (var tx = session.BeginTransaction(System.Data.IsolationLevel.ReadCommitted))
             {
                 list = session.CreateCriteria(typeof(Subscription))
                   .Add(Restrictions.In("MessageType", mt))
@@ -86,8 +86,7 @@ namespace NServiceBus.Unicast.Subscriptions.NHibernate
                   .SetResultTransformer(new DistinctRootEntityResultTransformer())
                   .List<string>();
 
-              nhtransaction.Commit();
-              transaction.Complete();
+              tx.Commit();
             }
 
             return list;


### PR DESCRIPTION
Hello,

I experienced a connection leak when publishing messages. It looked like the subscriptionstorage never released the connections so I added a nhibernate transaction inside the transactionscope (which is best practice when using nh + transactionscope) and also comitted the transactions. After that the leaks stopped. I might add that I'm using NHibernate 3.0 GA with nsb which is why this might not have been discovered before, since nsb 2.5 uses nh 2.1.2.

Thanks
/Johannes
