### PR TITLE
exclude abstract types when searching for IConfigureThisEndpoint

### DIFF
--- a/src/hosting/NServiceBus.Hosting.Azure/Entrypoint.cs
+++ b/src/hosting/NServiceBus.Hosting.Azure/Entrypoint.cs
@@ -95,7 +95,11 @@ namespace NServiceBus.Hosting.Azure
 
         private static IEnumerable<Type> ScanAssembliesForEndpoints()
         {
-            return AssemblyScanner.GetScannableAssemblies().SelectMany(assembly => assembly.GetTypes().Where(t => typeof(IConfigureThisEndpoint).IsAssignableFrom(t) && t != typeof(IConfigureThisEndpoint)));
+        	return AssemblyScanner.GetScannableAssemblies().SelectMany(
+        		assembly => assembly.GetTypes().Where(
+        			t => typeof(IConfigureThisEndpoint).IsAssignableFrom(t)
+        			     && t != typeof(IConfigureThisEndpoint)
+        			     && !t.IsAbstract));
         }
 
         private static void ValidateEndpoints(IEnumerable<Type> endpointConfigurationTypes)

--- a/src/hosting/NServiceBus.Hosting.Windows/Program.cs
+++ b/src/hosting/NServiceBus.Hosting.Windows/Program.cs
@@ -189,10 +189,13 @@ namespace NServiceBus.Hosting.Windows
         private static IEnumerable<Type> ScanAssembliesForEndpoints()
         {
             foreach (var assembly in AssemblyScanner.GetScannableAssemblies())
-                foreach (Type type in assembly.GetTypes().Where(t => typeof(IConfigureThisEndpoint).IsAssignableFrom(t) && t != typeof(IConfigureThisEndpoint)))
-                {
-                    yield return type;
-                }
+				foreach (Type type in assembly.GetTypes().Where(
+						t => typeof(IConfigureThisEndpoint).IsAssignableFrom(t) 
+						&& t != typeof(IConfigureThisEndpoint)
+						&& !t.IsAbstract))
+				{
+					yield return type;
+				}
         }
 
         private static void ValidateEndpoints(IEnumerable<Type> endpointConfigurationTypes)


### PR DESCRIPTION
I was creating an endpoint configuration base (abstract) class in another assembly. 
NServiceBus complains about having multiple endpoint configurations.

Fixed this by excluding abstract types in the scanner. Tested and works.

I applied this to Azure hosting too.
