### PR TITLE
NServiceBus.Testing.Handler.ExpectNotPublish

### DIFF
--- a/src/testing/Handler.cs
+++ b/src/testing/Handler.cs
@@ -143,7 +143,19 @@ namespace NServiceBus.Testing
             return this;
         }
 
-        /// <summary>
+		/// <summary>
+		/// Check that the saga does not publish any messages of the given type complying with the given predicate.
+		/// </summary>
+		/// <typeparam name="TMessage"></typeparam>
+		/// <param name="check"></param>
+		/// <returns></returns>
+		public Handler<T> ExpectNotPublish<TMessage>(PublishPredicate<TMessage> check) where TMessage : IMessage
+		{
+			helper.ExpectNotPublish(check);
+			return this;
+		}
+		
+		/// <summary>
         /// Check that the handler tells the bus to stop processing the current message.
         /// </summary>
         /// <returns></returns>


### PR DESCRIPTION
Added an ExpectNotPublish method to NServiceBus.Testing.Handler, and fleshed out the unit tests a bit to exercise it.  This work should maybe be replicated for the other Expects: ExpectNotReply, ExpectNotSend, etc.

See discussion here: http://tech.groups.yahoo.com/group/nservicebus/message/9992
