### PR TITLE
Fix: Exception got thrown when deserializing an array with whitespace between the childnodes.

### DIFF
--- a/src/impl/Serializers/NServiceBus.Serializers.XML.Test/NServiceBus.Serializers.XML.Test.csproj
+++ b/src/impl/Serializers/NServiceBus.Serializers.XML.Test/NServiceBus.Serializers.XML.Test.csproj
@@ -84,6 +84,7 @@
     <Compile Include="M2.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Risk.cs" />
+    <Compile Include="SerializingArrayTests.cs" />
     <Compile Include="SomeEnum.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/impl/Serializers/NServiceBus.Serializers.XML.Test/SerializingArrayTests.cs
+++ b/src/impl/Serializers/NServiceBus.Serializers.XML.Test/SerializingArrayTests.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+using NServiceBus.Saga;
+using NUnit.Framework;
+
+namespace NServiceBus.Serializers.XML.Test
+{
+  [Serializable]
+  public class MessageWithArray : ISagaMessage
+  {
+    public Guid SagaId { get; set; }
+    public int[] SomeInts { get; set; }
+
+    public MessageWithArray(Guid sagaId, int[] someInts)
+    {
+      SagaId = sagaId;
+      SomeInts = someInts;
+    }
+  }
+  
+  [TestFixture]
+  public class SerializingArrayTests
+  {
+    [Test]
+    public void CanDeserializeXmlWithWhitespace()
+    {
+      var str =
+        @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Messages xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns=""http://tempuri.net/NServiceBus.Serializers.XML.Test"" xmlns:baseType=""NServiceBus.Saga.ISagaMessage"">
+	<MessageWithArray>
+		<SagaId>6bddc475-22a5-433b-a3ed-9edf00e8e353</SagaId>
+		<SomeInts>
+			<Int32>1405154</Int32>
+		</SomeInts>
+	</MessageWithArray>
+</Messages>";
+
+      var data = Encoding.UTF8.GetBytes(str);
+
+      var serializer = new MessageSerializer
+                         {
+                           MessageMapper = new MessageMapper(),
+                           MessageTypes = new List<Type> { typeof(MessageWithArray) }
+                         };
+
+      var messages = serializer.Deserialize(new MemoryStream(data));
+
+      Assert.NotNull(messages);
+      Assert.That(messages, Has.Length.EqualTo(1));
+
+      Assert.That(messages[0], Is.TypeOf(typeof(MessageWithArray)));
+      var m = (MessageWithArray)messages[0];
+
+      Assert.IsNotNull(m.SomeInts);
+      Assert.That(m.SomeInts, Has.Length.EqualTo(1));
+    }
+
+    [Test]
+    public void CanSerializeAndBack()
+    {
+      var serializer = new MessageSerializer
+                         {
+                           MessageMapper = new MessageMapper(),
+                           MessageTypes = new List<Type> { typeof(MessageWithArray) }
+                         };
+
+      var message = new MessageWithArray(Guid.NewGuid(), new int[] { 1234, 5323 });
+
+      var stream = new MemoryStream();
+      serializer.Serialize(new IMessage[] { message }, stream);
+
+      stream.Position = 0;
+
+      var messages = serializer.Deserialize(stream);
+
+      Assert.NotNull(messages);
+      Assert.That(messages, Has.Length.EqualTo(1));
+
+      Assert.That(messages[0], Is.TypeOf(typeof(MessageWithArray)));
+      var m = (MessageWithArray)messages[0];
+
+      Assert.IsNotNull(m.SomeInts);
+      Assert.That(m.SomeInts, Has.Length.EqualTo(2));
+      Assert.AreEqual(1234, m.SomeInts[0]);
+      Assert.AreEqual(5323, m.SomeInts[1]);
+    }
+  }
+}

--- a/src/impl/Serializers/NServiceBus.Serializers.XML/MessageSerializer.cs
+++ b/src/impl/Serializers/NServiceBus.Serializers.XML/MessageSerializer.cs
@@ -582,6 +582,9 @@ namespace NServiceBus.Serializers.XML
                     {
                         foreach (XmlNode xn in n.ChildNodes)
                         {
+                          if (xn.NodeType == XmlNodeType.Whitespace)
+                            continue;
+
                             object m = Process(xn, list);
 
                             list.Add(m);


### PR DESCRIPTION
Hi,

I got exceptions when trying to deserialize messages with arrays. It tried to parse nodes with whitespace and convert them to array items. This pull request contains a unittest + fix.

Thanks

/Johannes
