### PR TITLE
Use upgrade lock when fetching saga from db to get blocking behavior

### DIFF
--- a/src/impl/SagaPersisters/NHibernateSagaPersister/NServiceBus.SagaPersisters.NHibernate/SagaPersister.cs
+++ b/src/impl/SagaPersisters/NHibernateSagaPersister/NServiceBus.SagaPersisters.NHibernate/SagaPersister.cs
@@ -38,12 +38,13 @@ namespace NServiceBus.SagaPersisters.NHibernate
         /// <returns>The saga entity if found, otherwise null.</returns>
         public T Get<T>(Guid sagaId) where T : ISagaEntity
         {
-            return SessionFactory.GetCurrentSession().Get<T>(sagaId);
+            return SessionFactory.GetCurrentSession().Get<T>(sagaId, LockMode.Upgrade);
         }
 
         T ISagaPersister.Get<T>(string property, object value)
         {
             return SessionFactory.GetCurrentSession().CreateCriteria(typeof(T))
+                .SetLockMode(LockMode.Upgrade)
                 .Add(Restrictions.Eq(property, value))
                 .UniqueResult<T>();
         }


### PR DESCRIPTION
Hi,

According to Udi, if 2 messages arrive at the same time to a saga then one of the message handlers will block if the transaction isolation level is at least repeatable read. However, repeatable read is not enough, the select statement needs to use an upgrade lock as well, otherwise both the handlers will run and eventually one of them will deadlock. This is tested and confirmed when using MS Sql Server.

This pull request puts upgrade locks on both Get-methods in the NHibernate SagaPersister. I have tested the fix using a modified manufacturing sample and it does not deadlock after the fix.

However, there are some potential problems with this fix that should be considered. 
1. Message throughput might be slower. For example 2 message handlers that don't change saga state would not deadlock anyway and in that case an upgrade lock would just slow them down.
2. I put an upgrade lock on the Get method that uses a mapped property. For this to be efficient, that property needs a unique constraint, otherwise the entire table will be locked which could severely affect performance. When using the automapping feature in NSB it looks like it does NOT create a unique constraint on the mapped properties so this might be a problem.

I decided to send this pull request anyway, since the expected behavior of the sagapersister is to block. However, maybe it would be better to have it as a configurable setting on the sagapersister instead...

Regards,
Johannes

PS. How does the RavenDB persister behave? Is that supposed to block as well? DS.
