### PR TITLE
Timeoutmanager utc fix

### DIFF
--- a/src/core/NServiceBus.Saga/TimeoutMessage.cs
+++ b/src/core/NServiceBus.Saga/TimeoutMessage.cs
@@ -22,7 +22,7 @@ namespace NServiceBus.Saga
         /// <param name="state"></param>
         public TimeoutMessage(DateTime expiration, ISagaEntity saga, object state)
         {
-            expires = DateTime.SpecifyKind(expiration, DateTimeKind.Utc);
+            expires = expiration.ToUniversalTime();
             SagaId = saga.Id;
             State = state;
         }
@@ -60,7 +60,7 @@ namespace NServiceBus.Saga
         public DateTime Expires
         {
             get { return expires; }
-            set { expires = DateTime.SpecifyKind(value, DateTimeKind.Utc); }
+			set { expires = value.ToUniversalTime(); }
         }
 
 		/// <summary>


### PR DESCRIPTION
This is a fix for issue #31. It makes sure the TimeoutMessage respects the DateTimeKind of the DateTime that is being put in, without always assuming it is Utc.

This was a bug, since Saga.RequestTimeout puts in DateTime.Now instead of DateTime.UtcNow.
