### PR TITLE
Testing additions

### DIFF
--- a/src/testing/Handler.cs
+++ b/src/testing/Handler.cs
@@ -165,6 +165,18 @@ namespace NServiceBus.Testing
         }
 
         /// <summary>
+        /// Check that the saga does not publish any messages of the given type complying with the given predicate.
+        /// </summary>
+        /// <typeparam name="TMessage"></typeparam>
+        /// <param name="check"></param>
+        /// <returns></returns>
+        public Handler<T> ExpectNotPublish<TMessage>(PublishPredicate<TMessage> check) where TMessage : IMessage
+        {
+          helper.ExpectNotPublish(check);
+          return this;
+        }
+
+        /// <summary>
         /// Check that the handler tells the bus to stop processing the current message.
         /// </summary>
         /// <returns></returns>

--- a/src/testing/Helper.cs
+++ b/src/testing/Helper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using Rhino.Mocks;
+using Rhino.Mocks.Exceptions;
 
 namespace NServiceBus.Testing
 {
@@ -181,6 +182,30 @@ namespace NServiceBus.Testing
         }
 
         /// <summary>
+        /// Check that the object does not publish any messages of the given type complying with the given predicate.
+        /// </summary>
+        /// <typeparam name="TMessage"></typeparam>
+        /// <param name="check"></param>
+        /// <returns></returns>
+        public void ExpectNotPublish<TMessage>(PublishPredicate<TMessage> check) where TMessage : IMessage
+        {
+          Delegate d = new HandleMessageDelegate(
+            () => DoNotExpectCallToPublish(
+                  delegate(TMessage[] msgs)
+                  {
+                    foreach (TMessage msg in msgs)
+                      if (!check(msg))
+                        return false;
+
+                    return true;
+                  }
+                  )
+            );
+
+          delegates.Add(d);
+        }
+
+        /// <summary>
         /// Check that the object tells the bus to not dispatch the current message to any other handlers.
         /// </summary>
         /// <returns></returns>
@@ -295,6 +320,18 @@ namespace NServiceBus.Testing
             Expect.Call(() => bus.Publish(messages))
                 .IgnoreArguments()
                 .Callback(callback);
+        }
+
+        private void DoNotExpectCallToPublish<T>(BusPublishDelegate<T> callback) where T : IMessage
+        {
+          T[] messages = null;
+
+          bus.Stub(b => bus.Publish(messages))
+            .IgnoreArguments()
+            .Callback(callback)
+            .Throw(
+              new ExpectationViolationException(string.Format("Did not expect a call to Publish<{0}> matching predicate {1}",
+                                                              typeof(T).FullName, callback)));
         }
 
         private void ExpectCallToDoNotContinueDispatchingCurrentMessageToHandlers()

--- a/src/testing/Saga.cs
+++ b/src/testing/Saga.cs
@@ -169,6 +169,28 @@ namespace NServiceBus.Testing
             helper.ExpectPublish(check);
             return this;
         }
+      
+      /// <summary>
+        /// Check that the saga does not publish any messages of the given type complying with the given predicate.
+        /// </summary>
+        /// <typeparam name="TMessage"></typeparam>
+        /// <param name="check"></param>
+        /// <returns></returns>
+        public Saga<T> ExpectNotPublish<TMessage>(PublishPredicate<TMessage> check) where TMessage : IMessage
+        {
+          helper.ExpectNotPublish(check);
+          return this;
+        }
+
+        /// <summary>
+        /// Check that the saga tells the bus to handle the current message later.
+        /// </summary>
+        /// <returns></returns>
+        public Saga<T> ExpectHandleCurrentMessageLater()
+        {
+          helper.ExpectHandleCurrentMessageLater();
+          return this;
+        }
 
         /// <summary>
         /// Uses the given delegate to invoke the saga, checking all the expectations previously set up,


### PR DESCRIPTION
We added some testing methods to Saga and took a few from another pull request.
It is now possible to test a saga for ExpectNotPublish and ExpectHandleCurrentMessageLater.
