### PR TITLE
Timeoutmanager utc fix

### DIFF
--- a/src/core/NServiceBus.Saga/TimeoutMessage.cs
+++ b/src/core/NServiceBus.Saga/TimeoutMessage.cs
@@ -22,7 +22,7 @@ namespace NServiceBus.Saga
         /// <param name="state"></param>
         public TimeoutMessage(DateTime expiration, ISagaEntity saga, object state)
         {
-            expires = DateTime.SpecifyKind(expiration, DateTimeKind.Utc);
+            expires = expiration.ToUniversalTime();
             SagaId = saga.Id;
             State = state;
         }
@@ -60,7 +60,7 @@ namespace NServiceBus.Saga
         public DateTime Expires
         {
             get { return expires; }
-            set { expires = DateTime.SpecifyKind(value, DateTimeKind.Utc); }
+        	set { expires = value.ToUniversalTime(); }
         }
 
 		/// <summary>
@@ -86,7 +86,7 @@ namespace NServiceBus.Saga
 		/// <returns>true if the message has expired, otherwise false.</returns>
         public bool HasNotExpired()
         {
-            return DateTime.Now < expires;
+			return DateTime.UtcNow < expires;
         }
     }
 }


### PR DESCRIPTION
This patch ensures that TimeoutMessage keeps the timezone of the input DateTime in mind when converting to Utc.
