### PR TITLE
Fix emptylist serializing

### DIFF
--- a/src/impl/Serializers/NServiceBus.Serializers.XML.Test/SerializerTests.cs
+++ b/src/impl/Serializers/NServiceBus.Serializers.XML.Test/SerializerTests.cs
@@ -85,6 +85,53 @@ namespace NServiceBus.Serializers.XML.Test
         }
 
         [Test]
+        public void SerializeLists()
+        {
+			var mapper = new MessageMapper();
+			var serializer = new MessageSerializer();
+			serializer.MessageMapper = mapper;
+
+			serializer.MessageTypes = new List<Type>(new[] { typeof(MessageWithList) });
+
+			var item = new MessageWithListItem { Data = "Hello" };
+			var items = new List<MessageWithListItem> { item };
+			var msg = new MessageWithList { Items = items };
+
+			using (var stream = new MemoryStream())
+			{
+				serializer.Serialize(new[] {msg}, stream);
+				stream.Position = 0;
+
+				var msgArray = serializer.Deserialize(stream);
+				var m = msgArray[0] as MessageWithList;
+				Assert.AreEqual("Hello", m.Items.First().Data);
+			}
+        }
+
+		[Test]
+		public void SerializeEmptyLists()
+		{
+			var mapper = new MessageMapper();
+			var serializer = new MessageSerializer();
+			serializer.MessageMapper = mapper;
+
+			serializer.MessageTypes = new List<Type>(new[] { typeof(MessageWithList) });
+
+			var items = new List<MessageWithListItem>();
+			var msg = new MessageWithList { Items = items };
+
+			using (var stream = new MemoryStream())
+			{
+				serializer.Serialize(new[] { msg }, stream);
+				stream.Position = 0;
+
+				var msgArray = serializer.Deserialize(stream);
+				var m = msgArray[0] as MessageWithList;
+				Assert.IsEmpty(m.Items);
+			}
+		}
+
+        [Test]
         public void Comparison()
         {
             TestInterfaces();
@@ -324,4 +371,14 @@ namespace NServiceBus.Serializers.XML.Test
 
         public string WhatEver { get; set; }
     }
+
+	public class MessageWithListItem
+	{
+		public string Data { get; set; }
+	}
+
+	public class MessageWithList : IMessage
+	{
+		public List<MessageWithListItem> Items { get; set; }
+	}
 }


### PR DESCRIPTION
The default XML serializer throws an exception when deserializing an empty list containing complex types:

``` csharp
System.InvalidCastException: Unable to cast object of type 'System.String' to type 'System.Collections.Generic.List`1[Messages.File.FileProcessResult]'.
at SetResults(Object , Object )
at NServiceBus.Serializers.XML.MessageSerializer.GetObjectOfTypeFromNode(Type t, XmlNode node) in c:\SVN\NServiceBus\src\impl\Serializers\NServiceBus.Serializers.XML\MessageSerializer.cs:line 383
at NServiceBus.Serializers.XML.MessageSerializer.Process(XmlNode node, Object parent) in c:\SVN\NServiceBus\src\impl\Serializers\NServiceBus.Serializers.XML\MessageSerializer.cs:line 336
at NServiceBus.Serializers.XML.MessageSerializer.Deserialize(Stream stream) in c:\SVN\NServiceBus\src\impl\Serializers\NServiceBus.Serializers.XML\MessageSerializer.cs:line 275
at NServiceBus.Unicast.Transport.Msmq.MsmqTransport.ReceiveFromQueue() in c:\SVN\NServiceBus\src\impl\unicast\NServiceBus.Unicast.Msmq\MsmqTransport.cs:line 469
```

I patched the serializer to handle this case and added the appropriate unit tests. All existing serializer tests still pass.
