### PR TITLE
Installer chokes with the StructureMapBuilder plugging INeedToInitializeSomething into itself

### DIFF
--- a/src/installation/NServiceBus.Installation/Install.cs
+++ b/src/installation/NServiceBus.Installation/Install.cs
@@ -42,7 +42,7 @@ namespace NServiceBus
             if (config.Configurer == null)
                 throw new InvalidOperationException("No container found. Please call '.DefaultBuilder()' after 'Configure.With()' before calling this method (or provide an alternative container).");
 
-            Configure.TypesToScan.Where(t => typeof(INeedToInstallSomething).IsAssignableFrom(t))
+            Configure.TypesToScan.Where(t => typeof(INeedToInstallSomething).IsAssignableFrom(t) && t.IsInterface == false)
                 .ToList().ForEach(t => config.Configurer.ConfigureComponent(t, DependencyLifecycle.InstancePerCall));
 
             return new Installer<T>(new WindowsIdentity(userToken));


### PR DESCRIPTION
When stating up the Generic Host from the console using CustomInitialization to set the StructureMapBuilder I was getting the following exception:

Unhandled Exception: 
Magnum.StateMachine.StateMachineException: Exception occurred in Topshelf.Internal.ServiceController`1[[NServiceBus.Hos
ting.Windows.WindowsHost, NServiceBus.Host32, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c]] durin
g state Initial while handling OnStart ---> System.Exception: Exception when starting endpoint, error has been logged. 
Reason: StructureMap configuration failures
Error:  104
Source:  Registry:  StructureMap.Configuration.DSL.Registry, StructureMap, Version=2.6.2.0, Culture=neutral, PublicKeyToken=e60ad81abae3c223 Type Instance 'b9b47db6-ca34-433c-878d-7c05092dc29b' (Configured Instance of NServiceBus.Installation.INeedToInstallSomething, NServiceBus.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c) cannot be plugged into type NServiceBus.Installation.INeedToInstallSomething, NServiceBus.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c

Turns out that Installer.cs:45-46 was telling the container to register all types that implement INeedToInstallSomething and, at least when using the StructureMapBuilder, that included the interface INeedToInstallSomething itself.  StructureMap complained that the interface was not a valid instance to plug into the interface; adding this patch resolved the issue.
