### PR TITLE
Always use an NH transaction even if ambient transaction exists (2.5)

### DIFF
--- a/src/impl/SagaPersisters/NHibernateSagaPersister/NServiceBus.SagaPersisters.NHibernate/NHibernateMessageModule.cs
+++ b/src/impl/SagaPersisters/NHibernateSagaPersister/NServiceBus.SagaPersisters.NHibernate/NHibernateMessageModule.cs
@@ -19,52 +19,62 @@ namespace NServiceBus.SagaPersisters.NHibernate
 
             CurrentSessionContext.Bind(session);
 
-            if (NoAmbientTransaction())
-            {
-                session.BeginTransaction();
-            }
+            session.BeginTransaction();
         }
 
         void IMessageModule.HandleEndMessage()
         {
             if (SessionFactory == null) return;
 
-            if (!NoAmbientTransaction()) return;
+            var session = CurrentSessionContext.Unbind(SessionFactory);
 
-            var session = SessionFactory.GetCurrentSession();
-
-            session.Transaction.Commit();
-            session.Transaction.Dispose();
-
-            session.Close();
+            try
+            {
+              try
+              {
+                session.Transaction.Commit();
+              }
+              finally
+              {
+                session.Transaction.Dispose();
+              }
+            }
+            finally
+            {
+              session.Dispose();
+            }
         }
 
         void IMessageModule.HandleError()
         {
             if (SessionFactory == null) return;
 
-            //HandleError always run after the transactionscope so we can't check for ambient trans here
-            var session = SessionFactory.GetCurrentSession();
+            if (!CurrentSessionContext.HasBind(SessionFactory))
+              return;
 
-            if (session.Transaction.IsActive)
+            var session = CurrentSessionContext.Unbind(SessionFactory);
+
+            try
             {
-                session.Transaction.Rollback();
+              try
+              {
+                if (session.Transaction.IsActive)
+                  session.Transaction.Rollback();
+              }
+              finally
+              {
                 session.Transaction.Dispose();
+              }
             }
-            if (session.IsOpen)
-                session.Close();
+            finally
+            {
+              session.Dispose();
+            }
         }
 
         /// <summary>
         /// Injected NHibernate session factory.
         /// </summary>
         public ISessionFactory SessionFactory { get; set; }
-
-
-        private static bool NoAmbientTransaction()
-        {
-            return Transaction.Current == null;
-        }
-
     }
 }


### PR DESCRIPTION
(This is a port from pull request #57 to v2.5)

When using NHibernate with TransactionScope, best practice is to also use a regular session.BeginTransaction() as well. If BeginTransaction is not used, NH might leak connections in certain circumstances, especially if an exception occurs.

This pull request makes sure that an NH transaction is always created.
