### PR TITLE
NinjectObjectBuilder child container binding traversal

### DIFF
--- a/src/impl/ObjectBuilder/ObjectBuilder.Ninject/NinjectObjectBuilder.cs
+++ b/src/impl/ObjectBuilder/ObjectBuilder.Ninject/NinjectObjectBuilder.cs
@@ -195,8 +195,9 @@ namespace NServiceBus.ObjectBuilder.Ninject
         /// </returns>
         public bool HasComponent(Type componentType)
         {
-            var bindings = this.kernel.GetBindings(componentType);
-            return bindings.Any();
+            var req = this.kernel.CreateRequest(componentType, null, new IParameter[0], false, true);
+
+            return this.kernel.CanResolve(req);
         }
 
         /// <summary>


### PR DESCRIPTION
Fix issue where HasComponent was only checking if a binding was present in the child kernel instead of all the way up the chain.
