### PR TITLE
Fix for Issue#96

### DIFF
--- a/src/impl/messageInterfaces/NServiceBus.MessageInterfaces.MessageMapper.Reflection/MessageMapper.cs
+++ b/src/impl/messageInterfaces/NServiceBus.MessageInterfaces.MessageMapper.Reflection/MessageMapper.cs
@@ -208,7 +208,10 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
         {
             var classConstructorInfo = customAttribute.GetType().GetConstructor(new Type[] { });
             if (classConstructorInfo == null)
-                throw new ArgumentException("NServiceBus does not support attributes without a default constructor. Attribute: " + customAttribute.GetType().Name);
+            {
+                Logger.Warn(string.Format("Ignoring attribute '{0}' on property {1}.{2} as it has no parameterless .ctor.", customAttribute.GetType(), propBuilder.DeclaringType.Name, propBuilder.Name));
+                return;
+            }
 
             var customAttributeBuilder = new CustomAttributeBuilder(classConstructorInfo,
                                                                             new object[] { });


### PR DESCRIPTION
Avoids throwing an exception when an IMessage interface/class uses some attribute without a parameterless .ctor, logging a Warning instead... keeping backwards compatibility.

/cc @andreasohlund
