### PR TITLE
start powershell script with execution policy RemotedSigned

### DIFF
--- a/build-coreonly.bat
+++ b/build-coreonly.bat
@@ -1,3 +1,3 @@
-powershell .\install-packages.ps1
+powershell -ExecutionPolicy RemoteSigned -noLogo -NonInteractive -File .\install-packages.ps1
 
 .\tools\nant\NAnt -D:include.dependencies=false  %1

--- a/build-net3.5.bat
+++ b/build-net3.5.bat
@@ -1,3 +1,3 @@
-powershell .\install-packages.ps1
+powershell -ExecutionPolicy RemoteSigned -noLogo -NonInteractive -File .\install-packages.ps1
 
 .\tools\nant\nant.exe -D:targetframework=net-3.5  %1

--- a/build.bat
+++ b/build.bat
@@ -1,2 +1,2 @@
-powershell .\install-packages.ps1
+powershell -ExecutionPolicy RemoteSigned -noLogo -NonInteractive -File .\install-packages.ps1
 .\tools\nant\nant %1


### PR DESCRIPTION
start powershell script with execution policy RemotedSigned
for make sure that configuration for powershell is not need for build.
