### PR TITLE
Added ToString method to WireEncryptedString

### DIFF
--- a/src/core/NServiceBus/WireEncryptedString.cs
+++ b/src/core/NServiceBus/WireEncryptedString.cs
@@ -63,6 +63,15 @@ namespace NServiceBus
         {
             info.AddValue("EncryptedValue", EncryptedValue);
         }
+        
+        /// <summary>
+        /// Returns a string representation of the address.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return Value;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Added ToString, which is useful when sending a WireEncryptedString instance to methods like ILog.Info(object message)
