### PR TITLE
CastleWindsorObjectBuilder now can build components registered after first call of build

### DIFF
--- a/src/impl/ObjectBuilder/ObjectBuilder.Tests/BuilderFixture.cs
+++ b/src/impl/ObjectBuilder/ObjectBuilder.Tests/BuilderFixture.cs
@@ -24,7 +24,7 @@ namespace ObjectBuilder.Tests
 
         private IList<IContainer> objectBuilders;
 
-        protected void VerifyForAllBuilders(Action<IContainer> assertion,params Type[] containersToIgnore)
+        protected void ForAllBuilders(Action<IContainer> assertion,params Type[] containersToIgnore)
         {
             bool failed = false;
 

--- a/src/impl/ObjectBuilder/ObjectBuilder.Tests/When_building_components.cs
+++ b/src/impl/ObjectBuilder/ObjectBuilder.Tests/When_building_components.cs
@@ -1,6 +1,7 @@
 using System;
 using NServiceBus.ObjectBuilder;
 using NServiceBus.ObjectBuilder.Common;
+using NServiceBus.ObjectBuilder.Spring;
 using NUnit.Framework;
 
 namespace ObjectBuilder.Tests
@@ -11,14 +12,14 @@ namespace ObjectBuilder.Tests
         [Test]
         public void Singleton_components_should_yield_the_same_instance()
         {
-            VerifyForAllBuilders((builder) =>
+            ForAllBuilders((builder) =>
                Assert.AreEqual(builder.Build(typeof(SingletonComponent)),builder.Build(typeof(SingletonComponent))));
         }
 
         [Test]
         public void Singlecall_components_should_yield_unique_instances()
         {
-            VerifyForAllBuilders((builder) =>
+            ForAllBuilders((builder) =>
                Assert.AreNotEqual(builder.Build(typeof(SinglecallComponent)),builder.Build(typeof(SinglecallComponent))));
         }
 
@@ -26,9 +27,24 @@ namespace ObjectBuilder.Tests
         public void Reguesting_an_unregistered_component_should_throw()
         {
             
-            VerifyForAllBuilders((builder)=> 
+            ForAllBuilders((builder)=> 
                 Assert.That(() => builder.Build(typeof (UnregisteredComponent)),
                 Throws.Exception));
+        }
+
+        [Test]
+        public void Should_be_able_to_build_components_registered_after_first_build()
+        {
+            //first build call
+            ForAllBuilders(builder=>builder.Build(typeof(SingletonComponent)));
+
+            //register new component
+            ForAllBuilders(builder=>builder.Configure(typeof(UnregisteredComponent), DependencyLifecycle.SingleInstance));
+
+            //should be able to build the newly registered component
+            ForAllBuilders((builder) =>
+               Assert.AreEqual(builder.Build(typeof(UnregisteredComponent)), builder.Build(typeof(UnregisteredComponent))), 
+               typeof(SpringObjectBuilder));
         }
 
         protected override Action<IContainer> InitializeBuilder()

--- a/src/impl/ObjectBuilder/ObjectBuilder.Tests/When_querying_for_registered_components.cs
+++ b/src/impl/ObjectBuilder/ObjectBuilder.Tests/When_querying_for_registered_components.cs
@@ -11,20 +11,20 @@ namespace ObjectBuilder.Tests
         [Test]
         public void Existing_components_should_return_true()
         {
-            VerifyForAllBuilders(builder =>
+            ForAllBuilders(builder =>
                                  Assert.True(builder.HasComponent(typeof(ExistingComponent))));
         }
         [Test]
         public void Non_existing_components_should_return_false()
         {
-            VerifyForAllBuilders(builder =>
+            ForAllBuilders(builder =>
                                  Assert.False(builder.HasComponent(typeof(NonExistingComponent))));
         }
 
         [Test]
         public void Builders_should_not_determine_existence_by_building_components()
         {
-            VerifyForAllBuilders(builder =>
+            ForAllBuilders(builder =>
                                  Assert.True(builder.HasComponent(typeof(ExistingComponentWithUnsatisfiedDep))));
         }
 

--- a/src/impl/ObjectBuilder/ObjectBuilder.Tests/When_registering_components.cs
+++ b/src/impl/ObjectBuilder/ObjectBuilder.Tests/When_registering_components.cs
@@ -12,7 +12,7 @@ namespace ObjectBuilder.Tests
         [Test]
         public void Multiple_registrations_of_the_same_component_should_be_allowed()
         {
-            VerifyForAllBuilders((builder) =>
+            ForAllBuilders((builder) =>
                                      {
                                          builder.Configure(typeof(DuplicateClass), DependencyLifecycle.InstancePerCall);
                                          builder.Configure(typeof(DuplicateClass), DependencyLifecycle.InstancePerCall);
@@ -25,7 +25,7 @@ namespace ObjectBuilder.Tests
         [Test]
         public void Register_singleton_should_be_supported()
         {
-            VerifyForAllBuilders((builder) =>
+            ForAllBuilders((builder) =>
             {
                 var singleton = new SingletonComponent();
                 builder.RegisterSingleton(typeof(ISingletonComponent), singleton);
@@ -38,7 +38,7 @@ namespace ObjectBuilder.Tests
         [Test]
         public void Properties_set_on_duplicate_registrations_should_not_be_discarded()
         {
-            VerifyForAllBuilders((builder) =>
+            ForAllBuilders((builder) =>
             {
                 builder.Configure(typeof(DuplicateClass), DependencyLifecycle.SingleInstance);
                 builder.ConfigureProperty(typeof(DuplicateClass), "SomeProperty", true);
@@ -59,7 +59,7 @@ namespace ObjectBuilder.Tests
         [Test]
         public void Setter_dependencies_should_be_supported()
         {
-            VerifyForAllBuilders((builder) =>
+            ForAllBuilders((builder) =>
             {
                 builder.Configure(typeof(SomeClass), DependencyLifecycle.InstancePerCall);
                 builder.Configure(typeof(ClassWithSetterDependencies), DependencyLifecycle.SingleInstance);
@@ -81,7 +81,7 @@ namespace ObjectBuilder.Tests
         [Test]
         public void Concrete_classes_should_get_the_same_lifecycle_as_their_interfaces()
         {
-            VerifyForAllBuilders(builder =>
+            ForAllBuilders(builder =>
             {
                 builder.Configure(typeof(SingletonComponent), DependencyLifecycle.SingleInstance);
 
@@ -94,7 +94,7 @@ namespace ObjectBuilder.Tests
         [Test]
         public void All_implemented_interfaces_should_be_registered()
         {
-            VerifyForAllBuilders(builder =>
+            ForAllBuilders(builder =>
             {
                 builder.Configure(typeof(ComponentWithMultipleInterfaces), DependencyLifecycle.InstancePerCall);
 

--- a/src/impl/ObjectBuilder/ObjectBuilder.Tests/When_using_nested_containers.cs
+++ b/src/impl/ObjectBuilder/ObjectBuilder.Tests/When_using_nested_containers.cs
@@ -14,7 +14,7 @@ namespace ObjectBuilder.Tests
         [Test]
         public void Instance_per_uow__components_should_be_disposed_when_the_child_container_is_disposed()
         {
-            VerifyForAllBuilders(builder =>
+            ForAllBuilders(builder =>
             {
                 builder.Configure(typeof(InstancePerUoWComponent), DependencyLifecycle.InstancePerUnitOfWork);
 
@@ -32,7 +32,7 @@ namespace ObjectBuilder.Tests
         [Test]
         public void UoW_components_in_the_parent_container_should_be_singletons_in_the_child_container()
         {
-            VerifyForAllBuilders(builder =>
+            ForAllBuilders(builder =>
             {
                 builder.Configure(typeof(InstancePerUoWComponent), DependencyLifecycle.InstancePerUnitOfWork);
 


### PR DESCRIPTION
This pull request is for Issue #153

The test I created to highlight the issue shows that the SpringObjectBuilder also fails.

I have simply set the SpringObjectBuilder to be ignored for the test.  Someone else may wish to fix it.  
