### PR TITLE
Exclusion of Raven types should be more specific

### DIFF
--- a/src/config/NServiceBus.Config/Configure.cs
+++ b/src/config/NServiceBus.Config/Configure.cs
@@ -349,6 +349,6 @@ namespace NServiceBus
         private static Configure instance;
         private static ILog Logger = LogManager.GetLogger("NServiceBus.Config");
         static readonly IEnumerable<string> defaultAssemblyExclusions = new[] { "system.", "nhibernate.", "log4net." };
-        static readonly IEnumerable<string> defaultTypeExclusions = new[] { "raven" };
+        static readonly IEnumerable<string> defaultTypeExclusions = new[] { "raven." };
     }
 }


### PR DESCRIPTION
The string used to exclude Raven types was "raven", which could end up excluding non-RavenDB types such as "RavenFoo.Bar". This logic should be changed to exclude types that start with "raven.", as that would more accurately target the RavenDB set of types.
