### PR TITLE
RavenSagaPersister can now retrieve saga-entities by Id

### DIFF
--- a/src/impl/SagaPersisters/RavenSagaPersister/NServiceBus.SagaPersisters.Raven.Tests/Persisting_a_saga_entity_with_a_raven_saga_persister.cs
+++ b/src/impl/SagaPersisters/RavenSagaPersister/NServiceBus.SagaPersisters.Raven.Tests/Persisting_a_saga_entity_with_a_raven_saga_persister.cs
@@ -6,7 +6,6 @@ namespace NServiceBus.SagaPersisters.Raven.Tests
 {
     using global::Raven.Client.Embedded;
 
-    [Ignore]
     public abstract class Persisting_a_saga_entity_with_a_raven_saga_persister
     {
         protected TestSaga entity;

--- a/src/impl/SagaPersisters/RavenSagaPersister/NServiceBus.SagaPersisters.Raven/RavenSagaPersister.cs
+++ b/src/impl/SagaPersisters/RavenSagaPersister/NServiceBus.SagaPersisters.Raven/RavenSagaPersister.cs
@@ -31,7 +31,7 @@ namespace NServiceBus.SagaPersisters.Raven
         {
             using (var session = Store.OpenSession())
             {
-                return session.Load<T>(sagaId.ToString());
+                return session.Load<T>(sagaId);
             }
         }
 


### PR DESCRIPTION
This pull-request is for Issue #156

``` C#
public T Get<T>(Guid sagaId) where T : ISagaEntity
{
      using (var session = Store.OpenSession())
      {
          return session.Load<T>(sagaId.ToString());
      }
 }
```

becomes 

``` C#
public T Get<T>(Guid sagaId) where T : ISagaEntity
{
      using (var session = Store.OpenSession())
      {
          return session.Load<T>(sagaId);
      }
 }
```

The persistence unit-tests now succeed, and have been un-ignored.
