### PR TITLE
Transaction isolation set on bus is not honored in NH transaction in UoW (3.0)

### DIFF
--- a/src/nhibernate/UnitOfWork/NServiceBus.UnitOfWork.NHibernate/UnitOfWorkManager.cs
+++ b/src/nhibernate/UnitOfWork/NServiceBus.UnitOfWork.NHibernate/UnitOfWorkManager.cs
@@ -19,7 +19,7 @@ namespace NServiceBus.UnitOfWork.NHibernate
 
             CurrentSessionContext.Bind(session);
 
-            session.BeginTransaction();
+            session.BeginTransaction(GetIsolationLevel());
         }
 
         void IManageUnitsOfWork.End(Exception ex)
@@ -45,5 +45,31 @@ namespace NServiceBus.UnitOfWork.NHibernate
         /// Injected NHibernate session factory.
         /// </summary>
         public ISessionFactory SessionFactory { get; set; }
+
+        private System.Data.IsolationLevel GetIsolationLevel()
+        {
+            if (Transaction.Current == null)
+                return System.Data.IsolationLevel.Unspecified;
+
+            switch (Transaction.Current.IsolationLevel)
+            {
+                case IsolationLevel.Chaos:
+                    return System.Data.IsolationLevel.Chaos;
+                case IsolationLevel.ReadCommitted:
+                    return System.Data.IsolationLevel.ReadCommitted;
+                case IsolationLevel.ReadUncommitted:
+                    return System.Data.IsolationLevel.ReadUncommitted;
+                case IsolationLevel.RepeatableRead:
+                    return System.Data.IsolationLevel.RepeatableRead;
+                case IsolationLevel.Serializable:
+                    return System.Data.IsolationLevel.Serializable;
+                case IsolationLevel.Snapshot:
+                    return System.Data.IsolationLevel.Snapshot;
+                case IsolationLevel.Unspecified:
+                    return System.Data.IsolationLevel.Unspecified;
+                default:
+                    return System.Data.IsolationLevel.Unspecified;
+            }
+        }
     }
 }


### PR DESCRIPTION
In the unit of work for the saga persister, the transaction isolation level is always set to sql server default (usually  read committed). This is a serious bug since the user believes he uses repeatable read if he sets it on the bus when in fact he is using read committed.

This pull request fixes this by fetching the isolation level from the transaction scope before starting the NH transaction.
