### PR TITLE
Force the log4net dependency to version 1.2.10

### DIFF
--- a/default.ps1
+++ b/default.ps1
@@ -1,4 +1,4 @@
-﻿properties {
+﻿zprzoperties {
 	$ProductVersion = "3.0"
 	$BuildNumber = "0";
 	$PatchVersion = "0"
@@ -53,7 +53,7 @@ task CreatePackages -depends PrepareRelease  {
 	$packageNameNsb = "NServiceBus" + $PackageNameSuffix 
 	
 	$packit.package_description = "The most popular open-source service bus for .net"
-	invoke-packit $packageNameNsb $script:packageVersion @{log4net="1.2.10"} "binaries\NServiceBus.dll", "binaries\NServiceBus.Core.dll" @{} 
+	invoke-packit $packageNameNsb $script:packageVersion @{log4net="[1.2.10]"} "binaries\NServiceBus.dll", "binaries\NServiceBus.Core.dll" @{} 
 	#endregion
 	
     #region Packing NServiceBus.Host


### PR DESCRIPTION
The nuspec files for NServiceBus were being generated with the dependency on log4net as "1.2.10". On Dec 21, version 1.2.11 of log4net was released, which caused NuGet to automatically grab it as the latest version.

This was causing runtime issues since other libraries (like Topshelf) are still using log4net 1.2.10.

I changed the CreatePackages target in default.ps1 to specify the log4net version as "[1.2.10]", which should resolve the problem.
