### PR TITLE
Fixed raven saga persister so that it can correctly find the saga data document by id

### DIFF
--- a/src/impl/SagaPersisters/RavenSagaPersister/NServiceBus.SagaPersisters.Raven/RavenSagaPersister.cs
+++ b/src/impl/SagaPersisters/RavenSagaPersister/NServiceBus.SagaPersisters.Raven/RavenSagaPersister.cs
@@ -39,12 +39,10 @@ namespace NServiceBus.SagaPersisters.Raven
 
         public T Get<T>(string property, object value) where T : ISagaEntity
         {
-            var luceneQuery = string.Format("{0}:{1}", property, value);
-
             using (var session = OpenSession())
             {
                 return session.Advanced.LuceneQuery<T>()
-                .Where(luceneQuery).FirstOrDefault();
+                .WhereEquals(property, value).FirstOrDefault();
             }
         }
 


### PR DESCRIPTION
Note: This issue prevents the Raven saga persister from working in the current build.

The root cause of the problem was that original code was making the following call to RavenDB:
/indexes/dynamic/AppHarborProvisioningSaga?query=Id%253Afb1940d3-9b96-4b68-b8fa-47fd79db9cea&start=0&pageSize=128&aggregation=None

The problem here is that the document name was not being included in the query parameter. Changing the RavenSagaPersister to use .WhereEquals() produces the following call to RavenDB:
/indexes/dynamic/AppHarborProvisioningSaga?query=__document_id%253Aappharborprovisioning
saga%252Fea6220ec-496b-4d6e-ad00-98a624e3d265&start=0&pageSize=128&aggregation=N
one

Notice how in the latter example the document name "appharborprovisioningsaga" is included in the query parameter.
