### PR TITLE
Turn off indentation in the json serializer

### DIFF
--- a/src/impl/Serializers/NServiceBus.Serializers.Json/JsonMessageSerializer.cs
+++ b/src/impl/Serializers/NServiceBus.Serializers.Json/JsonMessageSerializer.cs
@@ -14,7 +14,7 @@ namespace NServiceBus.Serializers.Json
     protected override JsonWriter CreateJsonWriter(Stream stream)
     {
       var streamWriter = new StreamWriter(stream, Encoding.UTF8);
-      return new JsonTextWriter(streamWriter) { Formatting = Formatting.Indented };
+      return new JsonTextWriter(streamWriter) { Formatting = Formatting.None };
     }
 
     protected override JsonReader CreateJsonReader(Stream stream)


### PR DESCRIPTION
This will reduce size of messages by up to 30% 
