### PR TITLE
JSON Optimization

### DIFF
--- a/src/impl/Serializers/NServiceBus.Serializers.Json/Internal/MessageSerializationBinder.cs
+++ b/src/impl/Serializers/NServiceBus.Serializers.Json/Internal/MessageSerializationBinder.cs
@@ -15,16 +15,17 @@ namespace NServiceBus.Serializers.Json.Internal
 
         public override void BindToName(Type serializedType, out string assemblyName, out string typeName)
         {
-            var mappedType = _messageMapper.GetMappedTypeFor(serializedType);
-            assemblyName = mappedType.Assembly.GetName().Name;
-            typeName = mappedType.FullName;
+            var mappedType = _messageMapper.GetMappedTypeFor(serializedType) ?? serializedType;
+
+            assemblyName = null;
+            typeName = mappedType.AssemblyQualifiedName;
         }
 
         public override Type BindToType(string assemblyName, string typeName)
         {
-            string resolvedTypeName = typeName + ", " + assemblyName;
-
-            return Type.GetType(resolvedTypeName, true);
+          throw new NotImplementedException();
+          //string resolvedTypeName = typeName + ", " + assemblyName;
+          //return Type.GetType(resolvedTypeName, true);
         }
     }
 }


### PR DESCRIPTION
I found out that using Assembly.GetName() is quite expensive and found an easy way to work around it. If there is a large number of type bindings, for example when serializing polymorphic types, the performance gain is staggering.

The performance of the json serializer is now comparable to the xml serializer. I made some (probably completely unscientific and biased) benchmarks:

10000 messages, each message is an array of 100 messages:

JSON: Serialize: 27.122 sec. Deserialize: 28.865 sec. Total:  55.987 sec. Size: 455,040,000 bytes
XML:  Serialize: 39.368 sec. Deserialize: 8.1784 sec. Total: 121.152 sec. Size: 553,960,000 bytes

50000 messages, each message is a single message:

JSON: Serialize: 1.823 sec. Deserialize: 1.628 sec. Total: 3.451 sec. Size: 22,800,000 bytes
XML:  Serialize: 2.283 sec. Deserialize: 5.918 sec. Total: 8.201 sec. Size: 37,400,000 bytes

In most cases, json is both faster and yields smaller payloads. Also, when looking at the process in the task manager, it seems like the memory footprint is smaller, around 10-20%.
