### PR TITLE
NHMessageModule: Don't call rollback in HandleError() since it is called outside the transaction

### DIFF
--- a/src/impl/SagaPersisters/NHibernateSagaPersister/NServiceBus.SagaPersisters.NHibernate/NHibernateMessageModule.cs
+++ b/src/impl/SagaPersisters/NHibernateSagaPersister/NServiceBus.SagaPersisters.NHibernate/NHibernateMessageModule.cs
@@ -26,6 +26,10 @@ namespace NServiceBus.SagaPersisters.NHibernate
         {
             if (SessionFactory == null) return;
 
+            // HandleEndMessage can be called before HandleBeginMessage in case of an error, so check for the existence of a session first.
+            if (!CurrentSessionContext.HasBind(SessionFactory))
+              return;
+
             var session = CurrentSessionContext.Unbind(SessionFactory);
 
             using (session)
@@ -50,10 +54,12 @@ namespace NServiceBus.SagaPersisters.NHibernate
             using (session)
             using (session.Transaction)
             {
-                if (!session.Transaction.IsActive)
-                    return;
+                // HandleError is run outside of the DTC transaction so calling rollback here is pointless.
 
-                session.Transaction.Rollback();
+                //if (!session.Transaction.IsActive)
+                //    return;
+
+                //session.Transaction.Rollback();
             }
         }
 


### PR DESCRIPTION
This makes a rollback pointless and also causes the connection to be corrupted and unusable whenever someone fetches it again from the connection pool.
