### PR TITLE
Added ExpectNotSend and ExpectNotSendLocal to test DSL

### DIFF
--- a/src/testing/Handler.cs
+++ b/src/testing/Handler.cs
@@ -82,6 +82,18 @@ namespace NServiceBus.Testing
             helper.ExpectSend(check);
             return this;
         }
+        
+        /// <summary>
+        /// Check that the saga does not send a message of the given type complying with the given predicate.
+        /// </summary>
+        /// <typeparam name="TMessage"></typeparam>
+        /// <param name="check"></param>
+        /// <returns></returns>
+        public Handler<T> ExpectNotSend<TMessage>(SendPredicate<TMessage> check)
+        {
+            helper.ExpectNotSend(check);
+            return this;
+        }
 
         /// <summary>
         /// Check that the saga replies with the given message type complying with the given predicate.
@@ -105,6 +117,18 @@ namespace NServiceBus.Testing
         public Handler<T> ExpectSendLocal<TMessage>(SendPredicate<TMessage> check)
         {
             helper.ExpectSendLocal(check);
+            return this;
+        }
+
+        /// <summary>
+        /// Check that the saga does not send a message type to its local queue that complies with the given predicate.
+        /// </summary>
+        /// <typeparam name="TMessage"></typeparam>
+        /// <param name="check"></param>
+        /// <returns></returns>
+        public Handler<T> ExpectNotSendLocal<TMessage>(SendPredicate<TMessage> check)
+        {
+            helper.ExpectNotSendLocal(check);
             return this;
         }
 


### PR DESCRIPTION
Hi there,

we hit a problem when we tried to validate that a message was not sent using the test DSL.

The DSL has a ExpectNotPublish but there is no corresponding ExpectNotSend. This commit adds those.

It's already been mentioned in a previous pull https://github.com/NServiceBus/NServiceBus/pull/30

Cheers,
Alex
