### PR TITLE
Hint how to fix NinjectObjectBuilder

### DIFF
--- a/src/impl/ObjectBuilder/ObjectBuilder.Ninject/Internal/ObjectBuilderPropertyHeuristic.cs
+++ b/src/impl/ObjectBuilder/ObjectBuilder.Ninject/Internal/ObjectBuilderPropertyHeuristic.cs
@@ -55,7 +55,7 @@ namespace NServiceBus.ObjectBuilder.Ninject.Internal
         {
             var propertyInfo = member as PropertyInfo;
 
-            if (propertyInfo == null)
+            if (propertyInfo == null || propertyInfo.GetSetMethod(Settings.InjectNonPublic) == null)
             {
                 return false;
             }


### PR DESCRIPTION
Without this check public properties with a none public setter are considered as valid targets for property injection even if Ninject is configured to inject only public members. This ends in a null reference in Ninject.

NOTE: I didn't test this code. I'm just giving here a hint how to fix the problem due to a bug report on the Ninject project. I leave verification and adjustment of the unit tests to the NServiceBus maintainers.

Related information:
http://tech.groups.yahoo.com/group/nservicebus/message/12853
http://stackoverflow.com/questions/9484789/nservicebus-objectbuilder-ninject-critical-bug
