### PR TITLE
Modified TimeoutRunner to execute on a background thread

### DIFF
--- a/src/timeout/NServiceBus.Timeout.Core/TimeoutRunner.cs
+++ b/src/timeout/NServiceBus.Timeout.Core/TimeoutRunner.cs
@@ -39,6 +39,7 @@
                 TimeoutManager.PushTimeout(td));
 
             thread = new Thread(Poll);
+            thread.IsBackground = true;
             thread.Start();
         }
 


### PR DESCRIPTION
Hi guys,

the TimeoutRunner starts the polling thread on a foreground thread. This prevents applications like the Starbucks sample from shutting down.

Just like the transport threads, the timeout runner should execute on a background thread.

Thanks,
Alex
