### PR TITLE
Prevent erroneous Pub/Sub warning messages.

### DIFF
--- a/src/unicast/NServiceBus.Unicast/UnicastBus.cs
+++ b/src/unicast/NServiceBus.Unicast/UnicastBus.cs
@@ -340,8 +340,6 @@ namespace NServiceBus.Unicast
         /// <param name="messages"></param>
         public virtual void Publish<T>(params T[] messages)
         {
-            AssertIsValidForPubSub(typeof(T));
-
             if (SubscriptionStorage == null)
                 throw new InvalidOperationException("Cannot publish on this endpoint - no subscription storage has been configured. Add either 'MsmqSubscriptionStorage()' or 'DbSubscriptionStorage()' after 'NServiceBus.Configure.With()'.");
 
@@ -350,6 +348,9 @@ namespace NServiceBus.Unicast
                 Publish(CreateInstance<T>(m => { }));
                 return;
             }
+
+            AssertIsValidForPubSub(messages[0].GetType());
+
             var fullTypes = GetFullTypes(messages as object[]);
             var subscribers = SubscriptionStorage.GetSubscriberAddressesForMessage(fullTypes.Select(t => new MessageType(t)))
                 .ToList();


### PR DESCRIPTION
Change .Publish so that AssertIsValidForPubSub uses the actual type of the first message. This is better than using typeof(T) because the caller may have boxed the message in an Object. This prevents the warning that is fired erroneously when publishing from an EventStore dispatcher. (See recent topic "Dispatching events to NServiceBus from EventStore" on the NServiceBus yahoo group.)
