### PR TITLE
Overriding Raven DB Persistence in a profile handler not working

### DIFF
--- a/src/hosting/NServiceBus.Hosting.Windows/Profiles/Handlers/IntegrationProfileHandler.cs
+++ b/src/hosting/NServiceBus.Hosting.Windows/Profiles/Handlers/IntegrationProfileHandler.cs
@@ -13,7 +13,8 @@ namespace NServiceBus.Hosting.Windows.Profiles.Handlers
     {
         void IHandleProfile.ProfileActivated()
         {
-            Configure.Instance.RavenPersistence();
+            if (!Configure.Instance.Configurer.HasComponent<IDocumentStore>())
+                Configure.Instance.RavenPersistence();
 
             if (!Configure.Instance.Configurer.HasComponent<IManageMessageFailures>())
                 Configure.Instance.MessageForwardingInCaseOfFault();

--- a/src/hosting/NServiceBus.Hosting.Windows/Profiles/Handlers/ProductionProfileHandler.cs
+++ b/src/hosting/NServiceBus.Hosting.Windows/Profiles/Handlers/ProductionProfileHandler.cs
@@ -6,22 +6,23 @@ namespace NServiceBus.Hosting.Windows.Profiles.Handlers
 {
     using Saga;
 
-    internal class ProductionProfileHandler : IHandleProfile<Production>, IWantTheEndpointConfig
+internal class ProductionProfileHandler : IHandleProfile<Production>, IWantTheEndpointConfig
+{
+    void IHandleProfile.ProfileActivated()
     {
-        void IHandleProfile.ProfileActivated()
-        {
+        if (!Configure.Instance.Configurer.HasComponent<IDocumentStore>())
             Configure.Instance.RavenPersistence();
 
-            if (!Configure.Instance.Configurer.HasComponent<ISagaPersister>())
-                Configure.Instance.RavenSagaPersister();
+        if (!Configure.Instance.Configurer.HasComponent<ISagaPersister>())
+            Configure.Instance.RavenSagaPersister();
 
-            if (!Configure.Instance.Configurer.HasComponent<IManageMessageFailures>())
-                Configure.Instance.MessageForwardingInCaseOfFault();
+        if (!Configure.Instance.Configurer.HasComponent<IManageMessageFailures>())
+            Configure.Instance.MessageForwardingInCaseOfFault();
 
-            if (Config is AsA_Publisher && !Configure.Instance.Configurer.HasComponent<ISubscriptionStorage>())
-                Configure.Instance.RavenSubscriptionStorage();
-        }
-
-        public IConfigureThisEndpoint Config { get; set; }
+        if (Config is AsA_Publisher && !Configure.Instance.Configurer.HasComponent<ISubscriptionStorage>())
+            Configure.Instance.RavenSubscriptionStorage();
     }
+
+    public IConfigureThisEndpoint Config { get; set; }
+}
 }


### PR DESCRIPTION
If you create a new profile handler for integration/production to override Raven Persistence like so:

``` ruby
public class RavenProductionPersistenceSetup 
    : IHandleProfile<Production>
{
    public void ProfileActivated()
    {
        Configure.Instance
            .RavenPersistence("MyProductionConnectionString");
    }
}
```

The ProductionProfileHandler wipes out the custom connection string value here. The commits are just an example of how I would want to change the behavior, but since that project doesn't reference Raven, I didn't want to necessarily go that route.
