### PR TITLE
Timeout handling issues

### DIFF
--- a/src/timeout/NServiceBus.Timeout.Core/IManageTimeouts.cs
+++ b/src/timeout/NServiceBus.Timeout.Core/IManageTimeouts.cs
@@ -18,29 +18,35 @@
 
         /// <summary>
         /// When <see cref="PopTimeout"/> is called, this event is raised for 
-        /// every saga ID passed in to <see cref="PushTimeout"/> for a single time slot.
+        /// every timeout entry passed in to <see cref="PushTimeout"/> for a single time slot.
         /// </summary>
-        event EventHandler<TimeoutData> SagaTimedOut;
+        event EventHandler<TimeoutData> TimedOut;
+
+        /// <summary>
+        /// When <see cref="ClearTimeouts"/> is called, this event is raised for 
+        /// every timeout entry for the given saga id.
+        /// </summary>
+        event EventHandler<TimeoutData> TimeOutCleared;
 
         /// <summary>
         /// Adds a new timeout to be watched.
         /// </summary>
-        /// <param name="timeout">This value will be raised as a part of <see cref="SagaTimedOut"/>.</param>
+        /// <param name="timeout">This value will be raised as a part of <see cref="TimedOut"/>.</param>
         void PushTimeout(TimeoutData timeout);
 
         /// <summary>
         /// Checks to see if the next timeout is within the initialized interval, 
         /// if so, removes it, sleeping until that time is up, and then raises 
-        /// <see cref="SagaTimedOut"/> for each saga ID previously pushed for that time.
+        /// <see cref="TimedOut"/> for each saga ID previously pushed for that time.
         /// 
         /// If no timeouts are currently in the list, sleeps for defined Interval.
         /// </summary>
         void PopTimeout();
 
         /// <summary>
-        /// Clears the timeout for the given saga ID.
+        /// Clears all timeouts for the given saga ID.
         /// </summary>
         /// <param name="sagaId"></param>
-        void ClearTimeout(Guid sagaId);
+        void ClearTimeouts(Guid sagaId);
     }
 }

--- a/src/timeout/NServiceBus.Timeout.Core/IPersistTimeouts.cs
+++ b/src/timeout/NServiceBus.Timeout.Core/IPersistTimeouts.cs
@@ -9,6 +9,6 @@
 
         void Add(TimeoutData timeout);
 
-        void Remove(Guid sagaId);
+        void RemoveTimeout(Guid timeoutId);
     }
 }

--- a/src/timeout/NServiceBus.Timeout.Core/NServiceBus.Timeout.Core.csproj
+++ b/src/timeout/NServiceBus.Timeout.Core/NServiceBus.Timeout.Core.csproj
@@ -32,6 +32,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Common.Logging, Version=2.0.0.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL" />
     <Reference Include="NServiceBus">
       <HintPath>..\..\..\build\output\NServiceBus.dll</HintPath>
     </Reference>

--- a/src/timeout/NServiceBus.Timeout.Core/TimeoutData.cs
+++ b/src/timeout/NServiceBus.Timeout.Core/TimeoutData.cs
@@ -10,6 +10,11 @@
     public class TimeoutData : EventArgs
     {
         /// <summary>
+        /// The Id of the timeout. Assigned when timeout message arrives.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
         /// The address of the client who requested the timeout.
         /// </summary>
         public Address Destination { get; set; }

--- a/src/timeout/NServiceBus.Timeout.Core/TimeoutTransportMessageHandler.cs
+++ b/src/timeout/NServiceBus.Timeout.Core/TimeoutTransportMessageHandler.cs
@@ -22,8 +22,7 @@ namespace NServiceBus.Timeout.Core
                 if(sagaId == Guid.Empty)
                     throw new InvalidOperationException("Invalid saga id specified, clear timeouts is only supported for saga instances");
 
-                Manager.ClearTimeout(sagaId);
-                Persister.Remove(sagaId);
+                Manager.ClearTimeouts(sagaId);
             }
             else
             {
@@ -32,6 +31,7 @@ namespace NServiceBus.Timeout.Core
                 
                 var data = new TimeoutData
                                {
+                                   Id = Guid.NewGuid(),
                                    Destination = message.ReplyToAddress,
                                    SagaId = sagaId,
                                    State = message.Body,
@@ -40,8 +40,8 @@ namespace NServiceBus.Timeout.Core
                                    Headers = message.Headers
                                };
 
-                Manager.PushTimeout(data);
                 Persister.Add(data);
+                Manager.PushTimeout(data);
             }
         }
     }

--- a/src/timeout/NServiceBus.Timeout.Hosting.Windows/Persistence/InMemoryTimeoutPersistence.cs
+++ b/src/timeout/NServiceBus.Timeout.Hosting.Windows/Persistence/InMemoryTimeoutPersistence.cs
@@ -7,7 +7,7 @@
 
     public class InMemoryTimeoutPersistence : IPersistTimeouts
     {
-        readonly IList<TimeoutData> storage = new List<TimeoutData>(); 
+        readonly List<TimeoutData> storage = new List<TimeoutData>(); 
 
         public IEnumerable<TimeoutData> GetAll()
         {
@@ -21,11 +21,10 @@
                 storage.Add(timeout);
         }
 
-        public void Remove(Guid sagaId)
+        public void RemoveTimeout(Guid timeoutId)
         {
             lock (storage)
-                storage.Where(t => t.SagaId == sagaId).ToList().ForEach(item => storage.Remove(item));
-
+                storage.RemoveAll(t => t.Id == timeoutId);
         }
     }
 }


### PR DESCRIPTION
I've been looking deeply into the timeout logic after we experienced some strange behavior.

The first issue was related to timeouts that expired before they were added. There is a timing issue causing some timeouts not to be deleted from the persistence store (raven) after they are fired. The result is that they are fired once more when the endpoint is restarted (since the timeouts are loaded from the store again). This is most likely related to stale indexes in raven.

There is also another issue: The current implementation does not properly support more than one timeout for each saga, but it does not fail when registering a second timeout. Actually the in-memory timeout manager does support it partially and will be able to handle multiple timeouts if there is no restart, but then every time a timeout expires, the persistence store will delete all timeouts for the saga, since IPersistTimeouts only implements a Remove(Guid sagaId).

I'm not sure if these bugs can be fixed without a breaking change, so I have changed the implementation to handle these things as I think they should be.
