### PR TITLE
I have fixed an issue with sagas in the NServiceBus.Testing project

### DIFF
--- a/src/testing/Invocations.cs
+++ b/src/testing/Invocations.cs
@@ -130,8 +130,12 @@ namespace NServiceBus.Testing
     public class ExpectedDeferMessageInvocation<M, D> : ExpectedMessageAndValueInvocation<DeferMessageInvocation<M, D>, M, D> {}
     public class DeferMessageInvocation<M, D> : MessageAndValueInvocation<M, D> {}
 
-    public class ExpectedSendToDestinationInvocation<M> : ExpectedMessageAndValueInvocation<SendToDestinationInvocation<M>, M, Address> { }
-    public class SendToDestinationInvocation<M> : MessageAndValueInvocation<M, Address> { }
+    public class ExpectedSendToDestinationInvocation<M> : ExpectedMessageAndValueInvocation<SendToDestinationInvocation<M>, M, Address> {}
+
+    public class SendToDestinationInvocation<M> : MessageAndValueInvocation<M, Address>
+    {
+		public Address Address { get { return Value; } set { Value = value; } }
+    }
 
     public class ExpectedSendToSitesInvocation<M> : ExpectedMessageAndValueInvocation<SendToSitesInvocation<M>, M, IEnumerable<string>> { }
     public class SendToSitesInvocation<M> : MessageAndValueInvocation<M, IEnumerable<string>> { }


### PR DESCRIPTION
The NServiceBus testing project has a bug in it that causes an object reference error to be raised when sending a message to a specific address from a saga. 
