### PR TITLE
Gateway channel receiver throws ArgumentException when DataReceivedOnChannel called within ambient transaction

### DIFF
--- a/src/gateway/NServiceBus.Gateway/Receiving/IdempotentChannelReceiver.cs
+++ b/src/gateway/NServiceBus.Gateway/Receiving/IdempotentChannelReceiver.cs
@@ -64,7 +64,7 @@
             return new TransactionScope(TransactionScopeOption.Required,
                                         new TransactionOptions
                                             {
-                                                IsolationLevel = IsolationLevel.ReadCommitted,
+                                                IsolationLevel = Transaction.Current != null ? Transaction.Current.IsolationLevel : IsolationLevel.ReadCommitted,
                                                 Timeout = TimeSpan.FromSeconds(30)
                                             });
         }


### PR DESCRIPTION
http://tech.groups.yahoo.com/group/nservicebus/message/15464

All nested scopes must be configured to use exactly the same isolation level if they want to join an ambient transaction. If the nested scope's timeout is more than that of the ambient transaction, it has no effect.
