### PR TITLE
Fixes #618

### DIFF
--- a/src/gateway/NServiceBus.Gateway/HeaderManagement/GatewayHeaderManager.cs
+++ b/src/gateway/NServiceBus.Gateway/HeaderManagement/GatewayHeaderManager.cs
@@ -36,7 +36,7 @@
                 return;
 
             transportMessage.Headers[Headers.HttpTo] = returnInfo.HttpFrom;
-            transportMessage.Headers[Headers.DestinationSites] = returnInfo.OriginatingSite;
+            transportMessage.Headers[Headers.OriginatingSite] = returnInfo.OriginatingSite;
 
             if (!transportMessage.Headers.ContainsKey(Headers.RouteTo))
                 transportMessage.Headers[Headers.RouteTo] = returnInfo.ReplyToAddress.ToString();


### PR DESCRIPTION
Gateway replies were working accidentally, by using KeyPrefixConventionSiteRouter instead of OriginatingSiteHeaderRouter.
