### PR TITLE
Fix compiler warning

### DIFF
--- a/src/core/NServiceBus/NServiceBus.csproj
+++ b/src/core/NServiceBus/NServiceBus.csproj
@@ -60,9 +60,7 @@
       <HintPath>..\..\..\lib\log4net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
+    <Reference Include="System.Core"/>
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>


### PR DESCRIPTION
When I reference NServiceBus from a .net 4.5 project, I get several compiler warnings similar to the following:
The predefined type 'System.Runtime.CompilerServices.AsyncTaskMethodBuilder' is defined in multiple assemblies in the global alias; using definition from 'c:\Program Files (x86)\Reference Assemblies\Microsoft\Framework.NETFramework\v4.5\mscorlib.dll'

This seems to be caused by the line I'm removing here.  See the following:
http://www.wwco.com/~wls/blog/2010/10/14/defined-in-multiple-assemblies/
