### PR TITLE
Expanding registration options to work with Tasks

### DIFF
--- a/src/core/NServiceBus/ICallback.cs
+++ b/src/core/NServiceBus/ICallback.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 
 namespace NServiceBus
 {
@@ -9,6 +10,23 @@ namespace NServiceBus
     /// </summary>
     public interface ICallback
     {
+    	  /// <summary>
+        /// Registers a function to be invoked when a response arrives to the message sent.
+        /// Returns a Task that can be used with async/await operations.
+        /// </summary>
+        /// <param name="completion">A function to call upon completion that returns a value of type T.</param>
+        /// <typeparam name="T">The type of the value to be returned from the function.</typeparam>
+        /// <returns>A Task that can be used with async/await operations.</returns>
+        Task<T> Register<T>(Func<CompletionResult, T> completion);
+
+        /// <summary>
+        /// Registers an action to be invoked when a response arrives to the message sent.
+        /// Returns a Task that can be used with async/await operations.
+        /// </summary>
+        /// <param name="completion">An action to call upon completion that does not return a value.</param>
+        /// <returns>A Task that can be used with async/await operations.</returns>
+        Task Register(Action<CompletionResult> completion);
+    	
         /// <summary>
         /// Registers a callback to be invoked when a response arrives to the message sent.
         /// </summary>

--- a/src/unicast/NServiceBus.Unicast/Callback.cs
+++ b/src/unicast/NServiceBus.Unicast/Callback.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Web;
 using System.Web.UI;
 using System.Web.Mvc;
@@ -38,6 +39,20 @@ namespace NServiceBus.Unicast
         }
 
         #region ICallback Members
+        
+        Task<T> ICallback.Register<T>(Func<CompletionResult, T> completion)
+        {
+            var asyncResult = ((ICallback) this).Register(null, null);
+            var task = Task<T>.Factory.FromAsync(asyncResult, x => completion((CompletionResult)x.AsyncState));
+            return task;
+        }
+
+        Task ICallback.Register(Action<CompletionResult> completion)
+        {
+            var asyncResult = ((ICallback)this).Register(null, null);
+            var task = Task.Factory.FromAsync(asyncResult, x => completion((CompletionResult)x.AsyncState));
+            return task;
+        }
 
         IAsyncResult ICallback.Register(AsyncCallback callback, object state)
         {


### PR DESCRIPTION
Adding two new ways to register a callback that are more easily used with the Task Parallel Library and the new async/await features of .net 4.5.  These methods return a Task, or a Task<T> such that they can be consumed, for example, by an async webapi controller - or some other asynchronous operation.
