### PR TITLE
NRE on IEnumerable<T> members with null elements

### DIFF
--- a/src/impl/Serializers/NServiceBus.Serializers.XML.Test/NServiceBus.Serializers.XML.Test.csproj
+++ b/src/impl/Serializers/NServiceBus.Serializers.XML.Test/NServiceBus.Serializers.XML.Test.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Risk.cs" />
     <Compile Include="SerializingArrayTests.cs" />
+    <Compile Include="SerializingEnumerableTests.cs" />
     <Compile Include="SomeEnum.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/impl/Serializers/NServiceBus.Serializers.XML.Test/SerializingEnumerableTests.cs
+++ b/src/impl/Serializers/NServiceBus.Serializers.XML.Test/SerializingEnumerableTests.cs
@@ -1,0 +1,37 @@
+﻿﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace NServiceBus.Serializers.XML.Test
+{
+    [Serializable]
+    public class MessageWithEnumerableOfString
+    {
+        public Guid SagaId { get; set; }
+        public IEnumerable<string> SomeStrings { get; set; }
+    }
+
+    [TestFixture]
+    public class SerializingEnumerableTests
+    {
+        [Test]
+        public void CanSerializeNullElements()
+        {
+            var message = new MessageWithEnumerableOfString
+                {
+                    SomeStrings = new[]
+                        {
+                            "element 1",
+                            null,
+                            null,
+                           "element 2"
+                        }
+                };
+
+            var result = ExecuteSerializer.ForMessage<MessageWithEnumerableOfString>(message);
+            Assert.IsNotNull(result.SomeStrings);
+            Assert.AreEqual(4, result.SomeStrings.Count());
+        }
+    }
+}

--- a/src/impl/Serializers/NServiceBus.Serializers.XML/XmlMessageSerializer.cs
+++ b/src/impl/Serializers/NServiceBus.Serializers.XML/XmlMessageSerializer.cs
@@ -769,8 +769,11 @@ namespace NServiceBus.Serializers.XML
                 {
                     Type baseType = typeof(object);
 
+                    Type[] interfaces = type.GetInterfaces();
+                    if (type.IsInterface) interfaces = interfaces.Union(new[] { type }).ToArray();
+                    
                     //Get generic type from list: T for List<T>, KeyValuePair<T,K> for IDictionary<T,K>
-                    foreach (Type interfaceType in type.GetInterfaces())
+                    foreach (Type interfaceType in interfaces)
                     {
                         Type[] arr = interfaceType.GetGenericArguments();
                         if (arr.Length == 1)
@@ -783,7 +786,7 @@ namespace NServiceBus.Serializers.XML
 
 
                     foreach (object obj in ((IEnumerable)value))
-                        if (obj.GetType().IsSimpleType())
+                        if (obj != null && obj.GetType().IsSimpleType())
                             WriteEntry(obj.GetType().Name, obj.GetType(), obj, builder);
                         else
                             WriteObject(baseType.SerializationFriendlyName(), baseType, obj, builder);


### PR DESCRIPTION
XmlSerializer couldn't work out the type to serialize for elements of
IEnumerable which were null resulting in a NullReferenceException
