### PR TITLE
UnicastBus.DispatchMessageToHandlersBasedOnType can result in information loss with the created TransportMessageHandlingFailedException

### DIFF
--- a/src/unicast/NServiceBus.Unicast/UnicastBus.cs
+++ b/src/unicast/NServiceBus.Unicast/UnicastBus.cs
@@ -1195,10 +1195,8 @@ namespace NServiceBus.Unicast
                 }
                 catch (Exception e)
                 {
-                    var innerEx = GetInnermostException(e);
-                    Log.Warn(handlerType.Name + " failed handling message.", innerEx);
-
-                    throw new TransportMessageHandlingFailedException(innerEx);
+                    Log.Warn(handlerType.Name + " failed handling message.", GetInnermostException(e));
+                    throw new TransportMessageHandlingFailedException(e);
                 }
             }
             return invokedHandlers;


### PR DESCRIPTION
The UnicastBus.DispatchMessageToHandlersBasedOnType can result in information loss with the created TransportMessageHandlingFailedException as it previously passed the most inner exception.
