### PR TITLE
distributor when running on same machines with workers

### DIFF
--- a/src/distributor/NServiceBus.Distributor/Config/ConfigureDistributor.cs
+++ b/src/distributor/NServiceBus.Distributor/Config/ConfigureDistributor.cs
@@ -90,7 +90,6 @@ namespace NServiceBus
             switch (IsLocalIpAddress(masterNodeName))
             {
                 case true:
-                    Address.InitializeLocalAddress(Address.Local.SubScope(Guid.NewGuid().ToString()).ToString());
                     logger.WarnFormat("'MasterNodeConfig.Node' points to a local host name: [{0}]. Worker input address name is [{1}]. It is randomly and uniquely generated to allow multiple workers working from the same machine as the Distributor.", masterNodeName, Address.Local);
                     break;
                 case false:


### PR DESCRIPTION
http://tech.groups.yahoo.com/group/nservicebus/message/17197
- it also helps during deployments - to make workers go to idle before reconfiguring service with new set of binaries.
- this type of infrastructure are intermediate steps when we scale out.  We start all projects with a basic distributor per module initially.  

The current approach changes the endpoint name of the worker when I've explicitly set  DefineEndpointName.

The changeset removes the specific line causing a random guid being appended when enlisting the worker to the distributor.
