### PR TITLE
Handler.OnMessage now retrows inner exception in case of TargetException

### DIFF
--- a/src/testing/Handler.cs
+++ b/src/testing/Handler.cs
@@ -247,8 +247,15 @@ namespace NServiceBus.Testing
 
             ExtensionMethods.CurrentMessageBeingHandled = message;
 
-            MethodInfo method = GetMessageHandler(handler.GetType(), typeof(TMessage));
-            method.Invoke(handler, new object[] {message});
+            try
+            {
+                MethodInfo method = GetMessageHandler(handler.GetType(), typeof(TMessage));
+                method.Invoke(handler, new object[] {message});
+            }
+            catch (TargetInvocationException e)
+            {
+                throw e.InnerException;
+            }
 
             bus.ValidateAndReset(expectedInvocations);
             expectedInvocations.Clear();


### PR DESCRIPTION
Handler.OnMessage does currently Rethrow the reflection targetexception. Changed to to rethrow the inner exception which makes more sense. I decided to not reset the stack trace. Because it's only used in test
