### PR TITLE
Make DataBus serializer overridable

### DIFF
--- a/src/NServiceBus.Core/ConfigureFileShareDataBus.cs
+++ b/src/NServiceBus.Core/ConfigureFileShareDataBus.cs
@@ -9,16 +9,16 @@ namespace NServiceBus
 	public static class ConfigureFileShareDataBus
 	{
 		/// <summary>
-		/// Use the in memory saga persister implementation.
+		/// Use the file-based databus implementation with the default binary serializer.
 		/// </summary>
-		/// <param name="config"></param>
-		/// <param name="basePath">Path to file share to store the data on</param>
-		/// <returns></returns>
+		/// <param name="config">The fluent configuration.</param>
+		/// <param name="basePath">The location to which to write serialized properties for the databus.</param>
 		public static Configure FileShareDataBus(this Configure config,string basePath)
 		{
 			var dataBus = new FileShareDataBus(basePath);
 
 			config.Configurer.RegisterSingleton<IDataBus>(dataBus);
+			config.Configurer.ConfigureComponent<DefaultDataBusSerializer>(DependencyLifecycle.SingleInstance);
 
 			return config;
 		}

--- a/src/NServiceBus.Core/DataBus/Config/Bootstrapper.cs
+++ b/src/NServiceBus.Core/DataBus/Config/Bootstrapper.cs
@@ -1,54 +1,33 @@
 namespace NServiceBus.DataBus.Config
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
+    using System.Reflection;
     using NServiceBus.Config;
 
     public class Bootstrapper : NServiceBus.INeedInitialization, IWantToRunWhenConfigurationIsComplete
 	{
 		public void Init()
 		{
-            if (System.Diagnostics.Debugger.IsAttached)
-            {
-                var properties = Configure.TypesToScan
-                    .Where(MessageConventionExtensions.IsMessageType)
-                    .SelectMany(messageType => messageType.GetProperties())
-                    .Where(MessageConventionExtensions.IsDataBusProperty);
+            // check data bus
+            if (!Configure.Instance.Configurer.HasComponent<IDataBus>())
+                throw new InvalidOperationException("Messages containing databus properties found, please configure a databus!");
+            if (!Configure.Instance.Configurer.HasComponent<IDataBusSerializer>())
+                throw new InvalidOperationException("Messages containing databus properties found, please configure a databus serializer!");
 
-                foreach (var property in properties)
-                {
-                    dataBusPropertyFound = true;
+            // check properties
+            IEnumerable<PropertyInfo> properties = Configure.TypesToScan
+                .Where(MessageConventionExtensions.IsMessageType)
+                .SelectMany(messageType => messageType.GetProperties())
+                .Where(MessageConventionExtensions.IsDataBusProperty);
+            dataBusPropertyFound = properties.Any();
+            Configure.Instance.Builder.Build<IDataBusSerializer>().Validate(properties);
 
-                    if (!property.PropertyType.IsSerializable)
-                    {
-                        throw new InvalidOperationException(
-                            String.Format(
-                                @"The property type for '{0}' is not serializable. 
-In order to use the databus feature for transporting the data stored in the property types defined in the call '.DefiningDataBusPropertiesAs()', need to be serializable. 
-To fix this, please mark the property type '{0}' as serializable, see http://msdn.microsoft.com/en-us/library/system.runtime.serialization.iserializable.aspx on how to do this.",
-                                String.Format("{0}.{1}", property.DeclaringType.FullName, property.Name)));
-                    }
-                }
-            }
-            else
-            {
-                dataBusPropertyFound = Configure.TypesToScan
-                    .Where(MessageConventionExtensions.IsMessageType)
-                    .SelectMany(messageType => messageType.GetProperties())
-                    .Any(MessageConventionExtensions.IsDataBusProperty);
-            }
-
-		    if (!dataBusPropertyFound)
-				return;
-
-			if (!Configure.Instance.Configurer.HasComponent<IDataBus>())
-				throw new InvalidOperationException("Messages containing databus properties found, please configure a databus!");
-
-			Configure.Instance.Configurer.ConfigureComponent<DataBusMessageMutator>(
-                DependencyLifecycle.InstancePerCall);
-
-			Configure.Instance.Configurer.ConfigureComponent<DefaultDataBusSerializer>(
-				DependencyLifecycle.SingleInstance);
+            // register mutator
+            if (!dataBusPropertyFound)
+                return;
+            Configure.Instance.Configurer.ConfigureComponent<DataBusMessageMutator>(DependencyLifecycle.InstancePerCall);
 		}
 
 	    public void Run()

--- a/src/NServiceBus.Core/DataBus/DefaultDatabusSerializer.cs
+++ b/src/NServiceBus.Core/DataBus/DefaultDatabusSerializer.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
 namespace NServiceBus.DataBus
 {
     using System.IO;
@@ -16,5 +20,31 @@ namespace NServiceBus.DataBus
 		{
 			return formatter.Deserialize(stream);
 		}
-	}
+
+		/// <summary>
+		/// Validates that the discovered databus properties can be serialized by this serializer.
+		/// </summary>
+		/// <param name="properties">The properties to be serialized.</param>
+		/// <exception cref="Exception">One or more properties cannot be serialized by this serializer.</exception>
+		public void Validate(IEnumerable<PropertyInfo> properties)
+		{
+			if (System.Diagnostics.Debugger.IsAttached)
+			{
+				foreach (PropertyInfo property in properties)
+				{
+					if (!property.PropertyType.IsSerializable)
+					{
+						throw new InvalidOperationException(
+							String.Format(
+								@"The property type for '{0}' is not serializable. 
+In order to use the databus feature for transporting the data stored in the property, types defined in the call '.DefiningDataBusPropertiesAs()' need to be serializable. 
+To fix this, please mark the property type '{0}' as serializable, see http://msdn.microsoft.com/en-us/library/system.runtime.serialization.iserializable.aspx on how to do this.",
+								String.Format("{0}.{1}", property.DeclaringType.FullName, property.Name)
+							)
+						);
+					}
+				}
+			}
+		}
+    }
 }

--- a/src/NServiceBus.Core/DataBus/IDatabusSerializer.cs
+++ b/src/NServiceBus.Core/DataBus/IDatabusSerializer.cs
@@ -1,6 +1,9 @@
 namespace NServiceBus.DataBus
 {
+    using System;
+    using System.Collections.Generic;
     using System.IO;
+    using System.Reflection;
 
     /// <summary>
 	/// Interface used for serializing and deserializing of databus properties.
@@ -10,15 +13,21 @@ namespace NServiceBus.DataBus
 		/// <summary>
 		/// Serializes the property into the given stream.
 		/// </summary>
-		/// <param name="databusProperty"></param>
-		/// <param name="stream"></param>
+		/// <param name="databusProperty">The property to serialize.</param>
+		/// <param name="stream">The stream to which to write the property.</param>
 		void Serialize(object databusProperty, Stream stream);
 
 		/// <summary>
 		/// Deserializes a property from the given stream.
 		/// </summary>
-		/// <param name="stream"></param>
-		/// <returns></returns>
+		/// <param name="stream">The stream from which to read the property.</param>
 		object Deserialize(Stream stream);
+
+		/// <summary>
+		/// Validates that the discovered databus properties can be serialized by this serializer.
+		/// </summary>
+		/// <param name="properties">The properties to be serialized.</param>
+		/// <exception cref="Exception">One or more properties cannot be serialized by this serializer.</exception>
+		void Validate(IEnumerable<PropertyInfo> properties);
 	}
 }


### PR DESCRIPTION
This pull request resolves issue #829 (in which NServiceBus throws an exception for unserializable properties even if the `IDataBusSerializer` can in fact serialize them) by making property validation part of the `IDataBuSerializer` implementation and moving configuration to the Configure chain.
