### PR TITLE
Endpoint name not used when specifying Raven connection string with Url only

### DIFF
--- a/src/impl/Persistence/RavenPersistence/NServiceBus.Persistence.Raven.Tests/When_configuring_persistence_to_use_a_raven_server_instance_using_a_connection_string.cs
+++ b/src/impl/Persistence/RavenPersistence/NServiceBus.Persistence.Raven.Tests/When_configuring_persistence_to_use_a_raven_server_instance_using_a_connection_string.cs
@@ -22,5 +22,11 @@ namespace NServiceBus.Persistence.Raven.Tests
             Assert.AreEqual("http://localhost:8080", store.Url);
             Assert.AreEqual("b5058088-3a5d-4f35-8a64-49b06719d6ef", store.ApiKey);
         }
+
+        [Test]
+        public void It_should_configure_the_document_store_to_use_the_calling_assembly_name_as_the_database()
+        {
+            Assert.AreEqual("UnitTests", store.DefaultDatabase);
+        }
     }
 }

--- a/src/impl/Persistence/RavenPersistence/NServiceBus.Persistence.Raven/Config/ConfigureRavenPersistence.cs
+++ b/src/impl/Persistence/RavenPersistence/NServiceBus.Persistence.Raven/Config/ConfigureRavenPersistence.cs
@@ -119,17 +119,17 @@
                     store.ResourceManagerId = RavenPersistenceConstants.DefaultResourceManagerId;
             }
             else
-            {
-                if (database == null)
-                {
-                    database = databaseNamingConvention();
-                }
-
+            {   
                 store.Url = RavenPersistenceConstants.DefaultUrl;
                 store.ResourceManagerId = RavenPersistenceConstants.DefaultResourceManagerId;
             }
 
-            if (database != null)
+            if (database == null)
+            {
+                database = databaseNamingConvention();
+            }
+
+            if (store.DefaultDatabase == null)
             {
                 store.DefaultDatabase = database;
             }


### PR DESCRIPTION
According to the [docs](http://support.nservicebus.com/customer/portal/articles/859362-using-ravendb-in-nservicebus-%E2%80%93-connecting)  the expected behaviour is for the end point name to be used if the connection string specified the server url only.

The issue affects 4.0 (develop) as well, but this merge request is on master hoping there would be a 3.3.6 sometime soon
