### PR TITLE
Endpoint name not used when specifying Raven connection string with Url only

### DIFF
--- a/src/NServiceBus.Core.Tests/Persistence/RavenDB/When_configuring_persistence_to_use_a_raven_server_instance_using_a_connection_string.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/RavenDB/When_configuring_persistence_to_use_a_raven_server_instance_using_a_connection_string.cs
@@ -22,5 +22,11 @@ namespace NServiceBus.Core.Tests.Persistence.RavenDB
             Assert.AreEqual("http://localhost:8080", store.Url);
             Assert.AreEqual("b5058088-3a5d-4f35-8a64-49b06719d6ef", store.ApiKey);
         }
+
+        [Test]
+        public void It_should_configure_the_document_store_to_use_the_calling_assembly_name_as_the_database()
+        {
+            Assert.AreEqual("UnitTests", store.DefaultDatabase);
+        }
     }
 }

--- a/src/NServiceBus.Core/ConfigureRavenPersistence.cs
+++ b/src/NServiceBus.Core/ConfigureRavenPersistence.cs
@@ -211,16 +211,16 @@ namespace NServiceBus
             }
             else
             {
-                if (database == null)
-                {
-                    database = Configure.EndpointName;
-                }
-
                 store.Url = RavenPersistenceConstants.DefaultUrl;
                 store.ResourceManagerId = RavenPersistenceConstants.DefaultResourceManagerId;
             }
 
-            if (database != null)
+            if (database == null)
+            {
+                database = Configure.EndpointName;
+            }
+
+            if (store.DefaultDatabase == null)
             {
                 store.DefaultDatabase = database;
             }


### PR DESCRIPTION
Pull request based on #1000 done against develop branch
