### PR TITLE
Fixed issue #1012 - Transaction failures with NHibernate TimeoutStorage

### DIFF
--- a/src/nhibernate/NServiceBus.NHibernate/TimeoutPersisters/NHibernate/TimeoutStorage.cs
+++ b/src/nhibernate/NServiceBus.NHibernate/TimeoutPersisters/NHibernate/TimeoutStorage.cs
@@ -108,6 +108,7 @@ namespace NServiceBus.TimeoutPersisters.NHibernate
 
                 if (te == null)
                 {
+                    tx.Commit();
                     timeoutData = null;
                     return false;
                 }


### PR DESCRIPTION
Committing the transaction in the te==null case fixes the problem
