### PR TITLE
make Order.Types public

### DIFF
--- a/src/NServiceBus/ISpecifyMessageHandlerOrdering.cs
+++ b/src/NServiceBus/ISpecifyMessageHandlerOrdering.cs
@@ -24,7 +24,7 @@ namespace NServiceBus
         ///<summary>
         /// Gets the types whose order has been specified.
         ///</summary>
-        public IEnumerable<Type> Types { get; private set; }
+        public IEnumerable<Type> Types { get; set; }
 
 
         /// <summary>


### PR DESCRIPTION
So i dont have to do reflection here
https://github.com/SimonCropp/HandlerOrdering/blob/master/HandlerOrdering/OrderHandlers.cs#L15

There is really no reason for it to be private as it block extensibility
