### PR TITLE
Allow specifying handlers order without using First<T>

### DIFF
--- a/src/core/NServiceBus/ISpecifyMessageHandlerOrdering.cs
+++ b/src/core/NServiceBus/ISpecifyMessageHandlerOrdering.cs
@@ -56,6 +56,16 @@ namespace NServiceBus
         {
             Types = ordering.Types;
         }
+
+        /// <summary>
+        /// Specifies an ordering of multiple types directly, where ordering
+        /// may be decided dynamically at runtime.
+        /// </summary>
+        /// <param name="priorityHandlers"></param>
+        public void Specify(params Type[] priorityHandlers)
+        {
+            Types = priorityHandlers;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
I raised issue #1036 to cover this change, where it should be possible to specify ordering without the help of the 'First' class and therefore dynamically order handlers at runtime during startup.

This is my second attempt, this time hopefully I've understood and chose the develop branch as the base branch to send the changes to, albeit still from my master repo this time.
