### PR TITLE
Added capability to omit raw xml wrapping with property name

### DIFF
--- a/src/NServiceBus.Core/ConfigureXmlSerializer.cs
+++ b/src/NServiceBus.Core/ConfigureXmlSerializer.cs
@@ -17,8 +17,36 @@ namespace NServiceBus
         /// <param name="nameSpace">The namespace to use</param>
         /// <param name="sanitizeInput">Sanatizes the xml input if set to true</param>
         /// <param name="dontWrapSingleMessages">Tells the serializer to not wrap single messages with a "messages" element. This will break compatibility with endpoints older thatn 3.4.0 </param>
+        /// <param name="dontWrapRawXml">Tells the serializer to not wrap properties which have either XDocument or XElement with a "PropertyName" element.
+        /// By default the xml serializer serializes the following message
+        /// <code>
+        /// interface MyMessage { XDocument Property { get; set; } }
+        /// </code>
+        /// into the following structure
+        /// <code>
+        /// <MyMessage>
+        ///     <Property>
+        ///       ... Content of the XDocument
+        ///     </Property>
+        /// </MyMessage>
+        /// </code>
+        /// This flag allows to omit the property tag wrapping. Which results to
+        /// <code>
+        /// <MyMessage>
+        ///       ... Content of the XDocument
+        /// </MyMessage>
+        /// </code>
+        /// When this feature is enable the root element of the XDocument must match the name of the property. The following would not work and lead to deserialization error:
+        /// <code>
+        /// <MyMessage>
+        ///       <Root>
+        ///         ...
+        ///       </Root>
+        /// </MyMessage>
+        /// </code>
+        /// </param>
         /// <returns></returns>
-        public static Configure XmlSerializer(this Configure config, string nameSpace = null, bool sanitizeInput = false, bool dontWrapSingleMessages = false)
+        public static Configure XmlSerializer(this Configure config, string nameSpace = null, bool sanitizeInput = false, bool dontWrapSingleMessages = false, bool dontWrapRawXml = false)
         {
             if (!Configure.BuilderIsConfigured())
             {
@@ -30,6 +58,7 @@ namespace NServiceBus
             config.Configurer.ConfigureComponent<XmlMessageSerializer>(DependencyLifecycle.SingleInstance);
             config.Configurer.ConfigureProperty<XmlMessageSerializer>(x => x.SanitizeInput, sanitizeInput);
             config.Configurer.ConfigureProperty<XmlMessageSerializer>(x => x.SkipWrappingElementForSingleMessages, dontWrapSingleMessages);
+            config.Configurer.ConfigureProperty<XmlMessageSerializer>(x => x.SkipWrappingRawXml, dontWrapRawXml);
 
             if(!string.IsNullOrEmpty(nameSpace))
                 config.Configurer.ConfigureProperty<XmlMessageSerializer>(x => x.Namespace, nameSpace);

--- a/src/NServiceBus.Core/Serializers/XML/XmlMessageSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlMessageSerializer.cs
@@ -44,6 +44,11 @@ namespace NServiceBus.Serializers.XML
         public bool SkipWrappingElementForSingleMessages { get; set; }
 
         /// <summary>
+        /// Removes the wrapping of properties containing XDocument or XElement with property name as root element
+        /// </summary>
+        public bool SkipWrappingRawXml { get; set; }
+
+        /// <summary>
         /// Scans the given type storing maps to fields and properties to save on reflection at runtime.
         /// </summary>
         /// <param name="t"></param>
@@ -575,7 +580,7 @@ namespace NServiceBus.Serializers.XML
 
             if (typeof(XContainer).IsAssignableFrom(type))
             {
-                var reader = new StringReader(n.InnerXml);
+                var reader = new StringReader(SkipWrappingRawXml ? n.OuterXml : n.InnerXml);
 
                 if (type == typeof(XDocument))
                 {
@@ -879,7 +884,15 @@ namespace NServiceBus.Serializers.XML
             if (typeof(XContainer).IsAssignableFrom(type))
             {
                 var container = (XContainer)value;
-                builder.AppendFormat("<{0}>{1}</{0}>\n", name, container);
+                if(SkipWrappingRawXml)
+                {
+                    builder.AppendFormat("{0}\n", container); 
+                }
+                else
+                {
+                    builder.AppendFormat("<{0}>{1}</{0}>\n", name, container); 
+                }
+                
                 return;
             }
 


### PR DESCRIPTION
This commit adds a capability which I have discussed with @andreasohlund on skype chat. The idea is the following and helps to improve the interoperability story with XML messages. Currently we already have the possibility to omit the <Messages /> wrapping for better interoperability. Now there is another option on the XmlSerializer which allows to omit wrapping with the property name in case you are embedding XML raw data into the message.

Here is an example. With my support for XDocument and XElement over all serializer you can now define a message like:

``` csharp
   public interface MyMessage
   {
      XElement SomeData { get; set; }
      // more properties even other with XElement or XDocument
   }
```

let's consider you want to send MyMessage with the following payload

``` xml
   <SomeData smart="true">
     ...
   </SomeData>
```

If you serialize that with the xml serializer it turns into that:

``` xml
<MyMessage>
   <SomeData>
     <SomeData smart="true">
        ...
     </SomeData>
   </SomeData>
</MyMessage>
```

with the new Option XmlSerializer(dontWrapRawXml : true) the serializer will serialize the message into the following format:

``` xml
<MyMessage>
     <SomeData smart="true">
        ...
     </SomeData>
</MyMessage>
```

This is fine. BUT there is a convention which needs to be followed because somehow the serializer must be able to deserialize such payloads. Therefore the following convention is introduced:

== Important ==
When you use dontWrapRawXml the root node name of the XDocument or XElement MUST match (even casing) the name of the property declared on the message interface or class definition. 

Without that convention it would not be possible to deserialize unwrapped XML data into the correct property.

The beauty of this is that you can fully leverage the power of all XML features including attributes on the payload without having to write a custom serializer for messages. This is especially useful for gateway message to external systems which need to define a strong schema. 
