### PR TITLE
ActiveMQ NMSType is now set to FullTypeName instead of FullyQualifiedAss...

### DIFF
--- a/src/ActiveMQ/NServiceBus.ActiveMQ/ActiveMqMessageMapper.cs
+++ b/src/ActiveMQ/NServiceBus.ActiveMQ/ActiveMqMessageMapper.cs
@@ -40,7 +40,7 @@ namespace NServiceBus.Transports.ActiveMQ
 
             if (message.Headers.ContainsKey(Headers.EnclosedMessageTypes))
             {
-                jmsmessage.NMSType = message.Headers[Headers.EnclosedMessageTypes].Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+                jmsmessage.NMSType = message.Headers[Headers.EnclosedMessageTypes].Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
             }
 
             jmsmessage.NMSDeliveryMode = message.Recoverable ? MsgDeliveryMode.Persistent : MsgDeliveryMode.NonPersistent;


### PR DESCRIPTION
...emblyName for better interoperability.

EnclosedMessageType custom header stays the same
