### PR TITLE
Fix bios name warning

### DIFF
--- a/src/NServiceBus.Core/Unicast/Queuing/Msmq/Config/CheckMachineNameForComplianceWithDTCLimitation.cs
+++ b/src/NServiceBus.Core/Unicast/Queuing/Msmq/Config/CheckMachineNameForComplianceWithDTCLimitation.cs
@@ -42,10 +42,10 @@ namespace NServiceBus.Unicast.Queuing.Msmq.Config
             if (!GetComputerNameEx(COMPUTER_NAME_FORMAT.ComputerNameNetBIOS, buffer, ref capacity)) 
                 return;
             var netbiosName = buffer.ToString();
-            if (netbiosName.Length < 15) return;
+            if (netbiosName.Length <= 15) return;
 
             Logger.Warn(string.Format(
-                "NetBIOS name [{0}] is longer than 14 characters. Shorten it for DTC to work. See: http://nservicebus.com/faq/DTCPIngWARNING.aspx", netbiosName));
+                "NetBIOS name [{0}] is longer than 15 characters. Shorten it for DTC to work. See: http://nservicebus.com/faq/DTCPIngWARNING.aspx", netbiosName));
         }
     }
 }


### PR DESCRIPTION
@johnsimons, I see your commit "Fixed NETBIOS name warning." (commit b8f58f794f28355c70733fab4ae08bc72614e3c7) from a week ago.

As per the forum discussion, 15 characters _is_ actually ok.  Only reason I care is because I keep seeing erroneous warnings in the logs and that's just unnecessary noise.

relevant forum post: http://tech.groups.yahoo.com/group/nservicebus/message/18178
relevant ms reference: http://support.microsoft.com/kb/163409
and fwiw, I've had NSB running fine with DTC and my machine name is exactly 15 char long.  :)

cheers
justin
