### PR TITLE
Add overloads that take actions when testing sagas.

### DIFF
--- a/src/testing/Saga.cs
+++ b/src/testing/Saga.cs
@@ -100,6 +100,17 @@ namespace NServiceBus.Testing
         }
 
         /// <summary>
+        /// Check that the saga sends a message of the given type complying with user-supplied assertions.
+        /// </summary>
+        /// <typeparam name="TMessage"></typeparam>
+        /// <param name="check">An action containing assertions on the message.</param>
+        /// <returns></returns>
+        public Saga<T> ExpectSend<TMessage>(Action<TMessage> check)
+        {
+            return ExpectSend(CheckActionToFunc(check));
+        }
+
+        /// <summary>
         /// Check that the saga does not send a message of the given type complying with the given predicate.
         /// </summary>
         /// <typeparam name="TMessage"></typeparam>
@@ -108,6 +119,18 @@ namespace NServiceBus.Testing
         public Saga<T> ExpectNotSend<TMessage>(Func<TMessage, bool> check)
         {
             expectedInvocations.Add(new ExpectedNotSendInvocation<TMessage> { Check = check });
+            return this;
+        }
+
+        /// <summary>
+        /// Check that the saga does not send a message of the given type complying with the given predicate.
+        /// </summary>
+        /// <typeparam name="TMessage"></typeparam>
+        /// <param name="check">An action containing assertions on the message.</param>
+        /// <returns></returns>
+        public Saga<T> ExpectNotSend<TMessage>(Action<TMessage> check)
+        {
+            expectedInvocations.Add(new ExpectedNotSendInvocation<TMessage> { Check = CheckActionToFunc(check) });
             return this;
         }
 
@@ -137,6 +160,18 @@ namespace NServiceBus.Testing
         }
 
         /// <summary>
+        /// Check that the saga sends the given message type to its local queue
+        /// and that the message complies with the given predicate.
+        /// </summary>
+        /// <typeparam name="TMessage"></typeparam>
+        /// <param name="check">An action that performs assertions on the message.</param>
+        /// <returns></returns>
+        public Saga<T> ExpectSendLocal<TMessage>(Action<TMessage> check)
+        {
+            return ExpectSendLocal(CheckActionToFunc(check));
+        }
+
+        /// <summary>
         /// Check that the saga does not send a message type to its local queue that complies with the given predicate.
         /// </summary>
         /// <typeparam name="TMessage"></typeparam>
@@ -146,6 +181,17 @@ namespace NServiceBus.Testing
         {
             expectedInvocations.Add(new ExpectedNotSendLocalInvocation<TMessage> { Check = check });
             return this;
+        }
+
+        /// <summary>
+        /// Check that the saga does not send a message type to its local queue that complies with the given predicate.
+        /// </summary>
+        /// <typeparam name="TMessage"></typeparam>
+        /// <param name="check">An action that performs assertions on the message.</param>
+        /// <returns></returns>
+        public Saga<T> ExpectNotSendLocal<TMessage>(Action<TMessage> check)
+        {
+            return ExpectNotSendLocal(CheckActionToFunc(check));
         }
 
         /// <summary>
@@ -170,6 +216,17 @@ namespace NServiceBus.Testing
             expectedInvocations.Add(new ExpectedSendToDestinationInvocation<TMessage> { Check = check });
 
             return this;
+        }
+
+        /// <summary>
+        /// Check that the saga sends the given message type to the appropriate destination.
+        /// </summary>
+        /// <typeparam name="TMessage"></typeparam>
+        /// <param name="check">An action that performs assertions on the message.</param>
+        /// <returns></returns>
+        public Saga<T> ExpectSendToDestination<TMessage>(Action<TMessage, Address> check)
+        {
+            return ExpectSendToDestination(CheckActionToFunc(check));
         }
 
         /// <summary>
@@ -209,6 +266,17 @@ namespace NServiceBus.Testing
         }
 
         /// <summary>
+        /// Check that the saga replies to the originator with the given message type.
+        /// </summary>
+        /// <typeparam name="TMessage"></typeparam>
+        /// <param name="check">An action that performs assertions on the message.</param>
+        /// <returns></returns>
+        public Saga<T> ExpectReplyToOrginator<TMessage>(Action<TMessage> check)
+        {
+            return ExpectReplyToOrginator(CheckActionToFunc(check));
+        }
+        
+        /// <summary>
         /// Check that the saga publishes a message of the given type complying with the given predicate.
         /// </summary>
         /// <typeparam name="TMessage"></typeparam>
@@ -219,7 +287,18 @@ namespace NServiceBus.Testing
             expectedInvocations.Add(new ExpectedPublishInvocation<TMessage> { Check = check });
             return this;
         }
-      
+
+        /// <summary>
+        /// Check that the saga publishes a message of the given type complying with the given predicate.
+        /// </summary>
+        /// <typeparam name="TMessage"></typeparam>
+        /// <param name="check">An action that performs assertions on the message.</param>
+        /// <returns></returns>
+        public Saga<T> ExpectPublish<TMessage>(Action<TMessage> check)
+        {
+            return ExpectPublish(CheckActionToFunc(check));
+        }
+
         /// <summary>
         /// Check that the saga does not publish any messages of the given type complying with the given predicate.
         /// </summary>
@@ -230,6 +309,17 @@ namespace NServiceBus.Testing
         {
             expectedInvocations.Add(new ExpectedNotPublishInvocation<TMessage> { Check = check });
             return this;
+        }
+
+        /// <summary>
+        /// Check that the saga does not publish any messages of the given type complying with the given predicate.
+        /// </summary>
+        /// <typeparam name="TMessage"></typeparam>
+        /// <param name="check">An action that performs assertions on the message.</param>
+        /// <returns></returns>
+        public Saga<T> ExpectNotPublish<TMessage>(Action<TMessage> check)
+        {
+            return ExpectNotPublish(CheckActionToFunc(check));
         }
 
         /// <summary>
@@ -311,10 +401,50 @@ namespace NServiceBus.Testing
         /// <typeparam name="TMessage"></typeparam>
         /// <param name="check"></param>
         /// <returns></returns>
+        public Saga<T> ExpectTimeoutToBeSetIn<TMessage>(Action<TMessage, TimeSpan> check)
+        {
+            return ExpectTimeoutToBeSetIn(CheckActionToFunc(check));
+        }
+
+        /// <summary>
+        /// Verifies that the saga is setting the specified timeout
+        /// </summary>
+        /// <typeparam name="TMessage"></typeparam>
+        /// <param name="check"></param>
+        /// <returns></returns>
         public Saga<T> ExpectTimeoutToBeSetAt<TMessage>(Func<TMessage, DateTime, bool> check = null)
         {
             expectedInvocations.Add(new ExpectedDeferMessageInvocation<TMessage, DateTime> { Check = check });
             return this;
+        }
+
+        /// <summary>
+        /// Verifies that the saga is setting the specified timeout
+        /// </summary>
+        /// <typeparam name="TMessage"></typeparam>
+        /// <param name="check"></param>
+        /// <returns></returns>
+        public Saga<T> ExpectTimeoutToBeSetAt<TMessage>(Action<TMessage, DateTime> check)
+        {
+            return ExpectTimeoutToBeSetAt(CheckActionToFunc(check));
+        }
+
+        private static Func<T1, bool> CheckActionToFunc<T1>(Action<T1> check)
+        {
+            return arg =>
+            {
+                check(arg);
+                return true;
+            };
+        }
+        
+        private static Func<T1, T2, bool> CheckActionToFunc<T1, T2>(Action<T1, T2> check)
+        {
+            return (arg1, arg2) =>
+            {
+                check(arg1, arg2);
+                return true;
+            };
         }
     }
 }


### PR DESCRIPTION
I've found the lack of overloads that accept actions in testing to be an annoyance in an otherwise great product.  The reason I want to use Action is so that I can use NUnit assertions which provide more precise error information than just "the predicate failed somewhere."  (I often times have to make assertions on 5 or more message properties.)

I've done Sagas first and will be happy to do Handlers similarly if this contrib makes the team happy.  I added tests for my overloads only where tests for the corresponding Func<T, bool>  has them.
