### PR TITLE
add missing space to log message

### DIFF
--- a/src/NServiceBus.Core/Unicast/UnicastBus.cs
+++ b/src/NServiceBus.Core/Unicast/UnicastBus.cs
@@ -1113,7 +1113,7 @@ namespace NServiceBus.Unicast
 
                 dispatchers.ForEach(dispatch =>
                     {
-                        Log.DebugFormat("Dispatching message {0} to handler{1}", messageType, handlerTypeToInvoke);
+                        Log.DebugFormat("Dispatching message '{0}' to handler '{1}'", messageType, handlerTypeToInvoke);
                         try
                         {
                             dispatch();


### PR DESCRIPTION
also add some quotes to make it more clear that the types are
