### PR TITLE
Register all interfaces for func with Unity

### DIFF
--- a/src/impl/ObjectBuilder/ObjectBuilder.Tests/When_registering_components.cs
+++ b/src/impl/ObjectBuilder/ObjectBuilder.Tests/When_registering_components.cs
@@ -176,6 +176,21 @@ namespace ObjectBuilder.Tests
         }
 
         [Test]
+        public void All_implemented_interfaces_should_be_registered_for_func()
+        {
+            ForAllBuilders(builder =>
+            {
+                builder.Configure(() => new ComponentWithMultipleInterfaces(), DependencyLifecycle.InstancePerCall);
+
+                Assert.True(builder.HasComponent(typeof(ISomeInterface)));
+                Assert.True(builder.HasComponent(typeof(ISomeOtherInterface)));
+                Assert.True(builder.HasComponent(typeof(IYetAnotherInterface)));
+                Assert.AreEqual(1, builder.BuildAll(typeof(IYetAnotherInterface)).Count());
+            },
+            typeof(SpringObjectBuilder));
+        }
+
+        [Test]
         public void Multiple_implementations_should_be_supported()
         {
             ForAllBuilders(builder =>

--- a/src/impl/ObjectBuilder/ObjectBuilder.Unity/UnityObjectBuilder.cs
+++ b/src/impl/ObjectBuilder/ObjectBuilder.Unity/UnityObjectBuilder.cs
@@ -129,9 +129,21 @@ namespace NServiceBus.ObjectBuilder.Unity
            if (HasComponent(componentType))
                return;
 
-            container.RegisterType<T>(GetLifetimeManager(dependencyLifecycle),
-                                      new InjectionFactory(unityContainer => componentFactory()));
-            DefaultInstances.Add(componentType);
+           var interfaces = GetAllServiceTypesFor(componentType);
+
+           foreach (Type t in interfaces)
+           {
+               if (DefaultInstances.Contains(t))
+               {
+                   container.RegisterType(t, Guid.NewGuid().ToString(), GetLifetimeManager(dependencyLifecycle), 
+                       new InjectionFactory(unityContainer => componentFactory()));
+               }
+               else
+               {
+                   container.RegisterType(t, GetLifetimeManager(dependencyLifecycle), new InjectionFactory(unityContainer => componentFactory()));
+                   DefaultInstances.Add(t);
+               }
+           }
         }
 
         public void ConfigureProperty(Type concreteComponent, string property, object value)


### PR DESCRIPTION
The UnityObjectBuilder doesn't register funcs for all interfaces (unlike the other implementations), which causes problems in the v4 Beta.
