### PR TITLE
Implement convention based routing on RabbitMQ transport

### DIFF
--- a/src/RabbitMQ/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/RabbitMQ/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
@@ -2,12 +2,11 @@
 {
     using System;
     using System.Collections.Concurrent;
-    using System.Transactions;
     using Config;
     using NServiceBus;
     using NUnit.Framework;
-    using NServiceBus.Transports.RabbitMQ;
-    using Settings;
+    using RabbitMQ;
+    using Routing;
     using global::RabbitMQ.Client;
     using TransactionSettings = Unicast.Transport.TransactionSettings;
 
@@ -28,19 +27,7 @@
                 return;
 
             var connection = connectionManager.GetConnection(ConnectionPurpose.Administration);
-            using (var channel = connection.CreateModel())
-            {
-                try
-                {
-                    channel.ExchangeDelete(exchangeName);
-                }
-                catch (Exception)
-                {
-
-                }
-
-
-            }
+            DeleteExchange(exchangeName);
 
             using (var channel = connection.CreateModel())
             {
@@ -56,10 +43,27 @@
             }
         }
 
+        void DeleteExchange(string exchangeName)
+        {
+            var connection = connectionManager.GetConnection(ConnectionPurpose.Administration);
+            using (var channel = connection.CreateModel())
+            {
+                try
+                {
+                    channel.ExchangeDelete(exchangeName);
+                }
+                catch (Exception)
+                {
+                }
+            }
+        }
+
 
         [SetUp]
         public void SetUp()
         {
+            //var routingTopology = new ConventionalRoutingTopology();
+            var routingTopology = new DirectRoutingTopology { ExchangeNameConvention = ExchangeNameConvention };
             receivedMessages = new BlockingCollection<TransportMessage>();
             connectionManager = new RabbitMqConnectionManager(new ConnectionFactory { HostName = "localhost" },new ConnectionRetrySettings());
 
@@ -73,24 +77,24 @@
                 };
 
             dequeueStrategy = new RabbitMqDequeueStrategy { ConnectionManager = connectionManager, PurgeOnStartup = true };
-
+            
             MakeSureQueueExists(MYRECEIVEQUEUE);
 
+            DeleteExchange(MYRECEIVEQUEUE);
             MakeSureExchangeExists(ExchangeNameConvention(Address.Parse(MYRECEIVEQUEUE),null));
+            
+            
 
             MessagePublisher = new RabbitMqMessagePublisher
                 {
                     UnitOfWork = unitOfWork,
-                    ExchangeName = ExchangeNameConvention,
-                    RoutingKeyBuilder = RoutingKeyBuilder
-                    
+                    RoutingTopology = routingTopology
                 };
             subscriptionManager = new RabbitMqSubscriptionManager
             {
                 ConnectionManager = connectionManager,
                 EndpointQueueName = MYRECEIVEQUEUE,
-                ExchangeName = ExchangeNameConvention,
-                RoutingKeyBuilder = RoutingKeyBuilder
+                RoutingTopology = routingTopology
             };
 
             dequeueStrategy.Init(Address.Parse(MYRECEIVEQUEUE), TransactionSettings.Default, (m) =>
@@ -135,7 +139,6 @@
 
         BlockingCollection<TransportMessage> receivedMessages;
 
-        protected const string PUBLISHERNAME = "publisherendpoint";
         protected const string MYRECEIVEQUEUE = "testreceiver";
         protected RabbitMqDequeueStrategy dequeueStrategy;
         protected RabbitMqConnectionManager connectionManager;

--- a/src/RabbitMQ/NServiceBus.RabbitMQ.Tests/When_subscribed_to_a_event.cs
+++ b/src/RabbitMQ/NServiceBus.RabbitMQ.Tests/When_subscribed_to_a_event.cs
@@ -132,7 +132,7 @@
         {
             Subscribe<MyEvent>();
 
-            subscriptionManager.Unsubscribe(typeof(MyEvent), Address.Parse(PUBLISHERNAME));
+            subscriptionManager.Unsubscribe(typeof(MyEvent), Address.Parse(ExchangeNameConvention(null, null)));
 
             //publish a event that that this publisher isn't subscribed to
             Publish<MyEvent>();
@@ -140,10 +140,9 @@
             AsserNoEventReceived();
         }
 
-
         void Subscribe<T>()
         {
-            subscriptionManager.Subscribe(typeof(T), Address.Parse(PUBLISHERNAME));
+            subscriptionManager.Subscribe(typeof(T), Address.Parse(ExchangeNameConvention(null,null)));
         }
 
         void Publish<T>()

--- a/src/RabbitMQ/NServiceBus.RabbitMQ/Config/RabbitMqConventions.cs
+++ b/src/RabbitMQ/NServiceBus.RabbitMQ/Config/RabbitMqConventions.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transports.RabbitMQ.Config
 {
     using System;
+    using Routing;
     using Settings;
 
     public class RabbitMqConventions
@@ -36,6 +37,7 @@
 
             SettingsHolder.SetDefault("Conventions.RabbitMq.ExchangeNameForPubSub", exchangeNameConvention);
             SettingsHolder.SetDefault("Conventions.RabbitMq.RoutingKeyForEvent", routingKeyConvention);
+            SettingsHolder.SetDefault("Conventions.RabbitMq.RoutingTopology", new DirectRoutingTopology{ExchangeNameConvention = exchangeNameConvention});
         }
     }
 }

--- a/src/RabbitMQ/NServiceBus.RabbitMQ/Config/RabbitMqTransportConfigurer.cs
+++ b/src/RabbitMQ/NServiceBus.RabbitMQ/Config/RabbitMqTransportConfigurer.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using NServiceBus.Unicast.Queuing.Installers;
+    using Routing;
     using Settings;
     using Unicast.Subscriptions;
     using RabbitMQ = NServiceBus.RabbitMQ;
@@ -16,7 +17,6 @@
         protected override void InternalConfigure(Configure config, string connectionString)
         {
             var parser = new RabbitMqConnectionStringParser(connectionString);
-
             if (!NServiceBus.Configure.Instance.Configurer.HasComponent<IManageRabbitMqConnections>())
             {
 
@@ -37,11 +37,11 @@
             config.Configurer.ConfigureComponent<RabbitMqMessageSender>(DependencyLifecycle.InstancePerCall);
 
             config.Configurer.ConfigureComponent<RabbitMqMessagePublisher>(DependencyLifecycle.InstancePerCall)
-                .ConfigureProperty(p => p.ExchangeName, SettingsHolder.Get<Func<Address, Type, string>>("Conventions.RabbitMq.ExchangeNameForPubSub"));
+                .ConfigureProperty(p => p.RoutingTopology, SettingsHolder.Get<IRoutingTopology>("Conventions.RabbitMq.RoutingTopology"));
 
             config.Configurer.ConfigureComponent<RabbitMqSubscriptionManager>(DependencyLifecycle.SingleInstance)
              .ConfigureProperty(p => p.EndpointQueueName, Address.Local.Queue)
-             .ConfigureProperty(p => p.ExchangeName, SettingsHolder.Get<Func<Address, Type, string>>("Conventions.RabbitMq.ExchangeNameForPubSub"));
+             .ConfigureProperty(p => p.RoutingTopology, SettingsHolder.Get<IRoutingTopology>("Conventions.RabbitMq.RoutingTopology"));
 
             config.Configurer.ConfigureComponent<RabbitMqRoutingKeyBuilder>(DependencyLifecycle.SingleInstance)
             .ConfigureProperty(p => p.GenerateRoutingKey, SettingsHolder.Get<Func<Type, string>>("Conventions.RabbitMq.RoutingKeyForEvent"));

--- a/src/RabbitMQ/NServiceBus.RabbitMQ/NServiceBus.Transports.RabbitMQ.csproj
+++ b/src/RabbitMQ/NServiceBus.RabbitMQ/NServiceBus.Transports.RabbitMQ.csproj
@@ -65,6 +65,9 @@
     <Compile Include="RabbitMqRoutingKeyBuilder.cs" />
     <Compile Include="RabbitMqTransportMessageExtensions.cs" />
     <Compile Include="RabbitMqUnitOfWork.cs" />
+    <Compile Include="Routing\DirectRoutingTopology.cs" />
+    <Compile Include="Routing\IRoutingTopology.cs" />
+    <Compile Include="Routing\ConventionalRoutingTopology.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/RabbitMQ/NServiceBus.RabbitMQ/Routing/ConventionalRoutingTopology.cs
+++ b/src/RabbitMQ/NServiceBus.RabbitMQ/Routing/ConventionalRoutingTopology.cs
@@ -1,0 +1,113 @@
+﻿namespace NServiceBus.Transports.RabbitMQ.Routing
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Linq;
+    using global::RabbitMQ.Client;
+
+    /// <summary>
+    /// Implements the RabbitMQ routing topology as described at http://codebetter.com/drusellers/2011/05/08/brain-dump-conventional-routing-in-rabbitmq/
+    /// take 4:
+    /// <list type="bullet">
+    /// <item><description>we generate an exchange for each queue so that we can do direct sends to the queue. it is bound as a fanout exchange</description></item>
+    /// <item><description> for each message published we generate series of exchanges that go from concrete class to each of its subclass
+    /// / interfaces these are linked together from most specific to least specific. This way if you subscribe to the base interface you get
+    /// all the messages. or you can be more selective. all exchanges in this situation are bound as fanouts.</description></item>
+    /// <item><description>the subscriber declares his own queue and his queue exchange –
+    /// he then also declares/binds his exchange to each of the message type exchanges desired</description></item>
+    /// <item><description> the publisher discovers all of the exchanges needed for a given message, binds them all up
+    /// and then pushes the message into the most specific queue letting RabbitMQ do the fanout for him. (One publish, multiple receivers!)</description></item>
+    /// <item><description>we generate an exchange for each queue so that we can do direct sends to the queue. it is bound as a fanout exchange</description></item>
+    /// </list>
+    /// </summary>
+    public class ConventionalRoutingTopology : IRoutingTopology
+    {
+        public void SetupSubscription(IModel channel, Type type, string subscriberName)
+        {
+            CreateExchange(channel, subscriberName);
+            channel.QueueBind(subscriberName, subscriberName, string.Empty);
+            if (type == typeof(IEvent))
+            {
+                // Make handlers for IEvent handle all events whether they extend IEvent or not
+                type = typeof(object);
+            }
+            SetupTypeSubscriptions(channel, type);
+            channel.ExchangeBind(subscriberName, ExchangeName(type), string.Empty);
+        }
+
+        public void TeardownSubscription(IModel channel, Type type, string subscriberName)
+        {
+            try
+            {
+                channel.ExchangeUnbind(subscriberName, ExchangeName(type), string.Empty, null);
+            }
+            catch
+            {
+                // TODO: Any better way to make this idempotent?
+            }
+        }
+
+        public void Publish(IModel channel, Type type, TransportMessage message, IBasicProperties properties)
+        {
+            SetupTypeSubscriptions(channel, type);
+            channel.BasicPublish(ExchangeName(type), String.Empty, true, false, properties, message.Body);
+        }
+
+        private readonly ConcurrentDictionary<Type, string> typeTopologyConfiguredSet = new ConcurrentDictionary<Type, string>();
+
+        private static string ExchangeName(Type type)
+        {
+            return type.Namespace + ":" + type.Name;
+        }
+
+        private static void CreateExchange(IModel channel, string exchangeName)
+        {
+            try
+            {
+                channel.ExchangeDeclare(exchangeName, ExchangeType.Fanout, true);
+            }
+            catch (Exception)
+            {
+                // TODO: Any better way to make this idempotent?
+            }
+        }
+
+        private void SetupTypeSubscriptions(IModel channel, Type type)
+        {
+            if (type == typeof(Object) || IsTypeTopologyKnownConfigured(type))
+            {
+                return;
+            }
+            {
+                var typeToProcess = type;
+                CreateExchange(channel, ExchangeName(typeToProcess));
+                var baseType = typeToProcess.BaseType;
+                while (baseType != null)
+                {
+                    CreateExchange(channel, ExchangeName(baseType));
+                    channel.ExchangeBind(ExchangeName(baseType), ExchangeName(typeToProcess), string.Empty);
+                    typeToProcess = baseType;
+                    baseType = typeToProcess.BaseType;
+                }
+            }
+
+            foreach (var exchangeName in type.GetInterfaces().Select(ExchangeName))
+            {
+                CreateExchange(channel, exchangeName);
+                channel.ExchangeBind(exchangeName, ExchangeName(type), string.Empty);
+
+            }
+            MarkTypeConfigured(type);
+        }
+
+        private void MarkTypeConfigured(Type eventType)
+        {
+            typeTopologyConfiguredSet[eventType] = null;
+        }
+
+        private bool IsTypeTopologyKnownConfigured(Type eventType)
+        {
+            return typeTopologyConfiguredSet.ContainsKey(eventType);
+        }
+    }
+}

--- a/src/RabbitMQ/NServiceBus.RabbitMQ/Routing/DirectRoutingTopology.cs
+++ b/src/RabbitMQ/NServiceBus.RabbitMQ/Routing/DirectRoutingTopology.cs
@@ -1,0 +1,65 @@
+﻿namespace NServiceBus.Transports.RabbitMQ.Routing
+{
+    using System;
+    using global::RabbitMQ.Client;
+
+    /// <summary>
+    /// Route using a static routing convention for routing messages from publishers to subscribers using routing keys
+    /// </summary>
+    public class DirectRoutingTopology:IRoutingTopology
+    {
+        public DirectRoutingTopology()
+        {
+            ExchangeNameConvention = (a, t) => AmqpTopicExchange;
+        }
+
+        public void SetupSubscription(IModel channel, Type type, string subscriberName)
+        {
+            CreateExchange(channel, ExchangeName());
+            channel.QueueBind(subscriberName, ExchangeName(), RoutingKey(type));
+        }
+
+        public void TeardownSubscription(IModel channel, Type type, string subscriberName)
+        {
+            channel.QueueUnbind(subscriberName, ExchangeName(), RoutingKey(type), null);
+        }
+
+        public void Publish(IModel channel, Type type, TransportMessage message, IBasicProperties properties)
+        {
+            channel.BasicPublish(ExchangeName(), RoutingKey(type), true, false, properties, message.Body);
+        }
+
+        public Func<Address, Type, string> ExchangeNameConvention { get; set; }
+
+        const string AmqpTopicExchange = "amq.topic";
+
+        private readonly RabbitMqRoutingKeyBuilder routingKeyBuilder = new RabbitMqRoutingKeyBuilder
+        {
+            GenerateRoutingKey = DefaultRoutingKeyConvention.GenerateRoutingKey
+        };
+
+        private string ExchangeName()
+        {
+            return ExchangeNameConvention(null,null);
+        }
+
+        private static void CreateExchange(IModel channel, string exchangeName)
+        {
+            if (exchangeName == AmqpTopicExchange)
+                return;
+            try
+            {
+                channel.ExchangeDeclare(exchangeName, ExchangeType.Topic, true);
+            }
+            catch (Exception)
+            {
+
+            }
+        }
+
+        private string RoutingKey(Type eventType)
+        {
+            return routingKeyBuilder.GetRoutingKeyForBinding(eventType);
+        }
+    }
+}

--- a/src/RabbitMQ/NServiceBus.RabbitMQ/Routing/IRoutingTopology.cs
+++ b/src/RabbitMQ/NServiceBus.RabbitMQ/Routing/IRoutingTopology.cs
@@ -1,0 +1,34 @@
+﻿namespace NServiceBus.Transports.RabbitMQ.Routing
+{
+    using System;
+    using global::RabbitMQ.Client;
+
+    /// <summary>
+    /// Topology for routing messages on the transport
+    /// </summary>
+    public interface IRoutingTopology
+    {
+        /// <summary>
+        /// Set up subscription for subscriber to the specified type
+        /// </summary>
+        /// <param name="channel">RabbitMQ channel to operate on</param>
+        /// <param name="type">Type to handle with subscriber</param>
+        /// <param name="subscriberName">Subscriber name</param>
+        void SetupSubscription(IModel channel, Type type, string subscriberName);
+        /// <summary>
+        /// Stop subscription for subscriber to the specified type
+        /// </summary>
+        /// <param name="channel">RabbitMQ channel to operate on</param>
+        /// <param name="type">Type to handle with subscriber</param>
+        /// <param name="subscriberName">Subscriber name</param>
+        void TeardownSubscription(IModel channel, Type type, string subscriberName);
+        /// <summary>
+        /// Publish message of the specified type
+        /// </summary>
+        /// <param name="channel">RabbitMQ channel to operate on</param>
+        /// <param name="type">Type to handle with subscriber</param>
+        /// <param name="message">Message to publish</param>
+        /// <param name="properties">RabbitMQ properties of the message to publish</param>
+        void Publish(IModel channel, Type type, TransportMessage message, IBasicProperties properties);
+    }
+}


### PR DESCRIPTION
Implements convention based routing described as take 4 at http://codebetter.com/drusellers/2011/05/08/brain-dump-conventional-routing-in-rabbitmq/.

This convention models the types as exchanges in RabbitMQ, eliminating the need for using routing keys for routing messages between producers and consumers. This makes the routing topology visible within RabbitMQ and potentially makes the routing more performant.
