### PR TITLE
Correct error message to reference IHandleMessages

### DIFF
--- a/src/testing/Test.cs
+++ b/src/testing/Test.cs
@@ -203,7 +203,7 @@ namespace NServiceBus.Testing
                               select i).Any();
 
             if (!isHandler)
-                throw new ArgumentException("The handler object created does not implement IMessageHandler<T>.", "handlerCreationCallback");
+                throw new ArgumentException("The handler object created does not implement IHandleMessages<T>.", "handlerCreationCallback");
 
             var messageTypes = Configure.TypesToScan.Where(MessageConventionExtensions.IsMessageType).ToList();
 


### PR DESCRIPTION
Testing code incorrectly says that the handler should implement IMessageHandler<T> instead of IHandleMessages<T> on error validating the handler. Corrected that message.
