### PR TITLE
Honor routing topology being used in RabbitMQMessageSender

### DIFF
--- a/src/RabbitMQ/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
+++ b/src/RabbitMQ/NServiceBus.RabbitMQ.Tests/RabbitMqContext.cs
@@ -75,7 +75,7 @@
 
             unitOfWork = new RabbitMqUnitOfWork { ConnectionManager = connectionManager,UsePublisherConfirms = true,MaxWaitTimeForConfirms = TimeSpan.FromSeconds(10) };
 
-            sender = new RabbitMqMessageSender { UnitOfWork = unitOfWork };
+            sender = new RabbitMqMessageSender { UnitOfWork = unitOfWork, RoutingTopology = routingTopology };
 
 
             dequeueStrategy = new RabbitMqDequeueStrategy { ConnectionManager = connectionManager, PurgeOnStartup = true };

--- a/src/RabbitMQ/NServiceBus.RabbitMQ/RabbitMqMessageSender.cs
+++ b/src/RabbitMQ/NServiceBus.RabbitMQ/RabbitMqMessageSender.cs
@@ -1,14 +1,16 @@
 ﻿namespace NServiceBus.Transports.RabbitMQ
 {
+    using Routing;
+
     public class RabbitMqMessageSender : ISendMessages
     {
+        public IRoutingTopology RoutingTopology { get; set; }
         public void Send(TransportMessage message, Address address)
         {
             UnitOfWork.Add(channel =>
                 {
                     var properties = RabbitMqTransportMessageExtensions.FillRabbitMqProperties(message,channel.CreateBasicProperties());
-
-                    channel.BasicPublish(string.Empty, address.Queue, true, false, properties, message.Body);
+                    RoutingTopology.Send(channel, address, message, properties);
                 });
         }
 

--- a/src/RabbitMQ/NServiceBus.RabbitMQ/Routing/DirectRoutingTopology.cs
+++ b/src/RabbitMQ/NServiceBus.RabbitMQ/Routing/DirectRoutingTopology.cs
@@ -28,6 +28,11 @@
             channel.BasicPublish(ExchangeName(), GetRoutingKeyForPublish(type), true, false, properties, message.Body);
         }
 
+        public void Send(IModel channel, Address address, TransportMessage message, IBasicProperties properties)
+        {
+            channel.BasicPublish(string.Empty, address.Queue, true, false, properties, message.Body);
+        }
+
         string ExchangeName()
         {
             return ExchangeNameConvention(null,null);

--- a/src/RabbitMQ/NServiceBus.RabbitMQ/Routing/IRoutingTopology.cs
+++ b/src/RabbitMQ/NServiceBus.RabbitMQ/Routing/IRoutingTopology.cs
@@ -30,5 +30,13 @@
         /// <param name="message">Message to publish</param>
         /// <param name="properties">RabbitMQ properties of the message to publish</param>
         void Publish(IModel channel, Type type, TransportMessage message, IBasicProperties properties);
+        /// <summary>
+        /// Send message to the specified endpoint
+        /// </summary>
+        /// <param name="channel"></param>
+        /// <param name="address"></param>
+        /// <param name="message"></param>
+        /// <param name="properties"></param>
+        void Send(IModel channel, Address address, TransportMessage message, IBasicProperties properties);
     }
 }


### PR DESCRIPTION
Bus.Send for RabbitMQ should use the routing topology to determine how to publish to an endpoint. This changes RabbitMQMessageSender.cs to use the Routing Topology to send the message. Also adds a method in IRoutingTopology to allow sending to an endpoint.
