### PR TITLE
Replaced hard coded path in AzureConfigurationSource.

### DIFF
--- a/src/azure/NServiceBus.Azure/ConfigurationSource/Azure/AzureConfigurationSource.cs
+++ b/src/azure/NServiceBus.Azure/ConfigurationSource/Azure/AzureConfigurationSource.cs
@@ -44,7 +44,7 @@ namespace NServiceBus.Integration.Azure
 
         private static Configuration GetConfigurationHandler()
         {
-            if (IsWebsite()) return WebConfigurationManager.OpenWebConfiguration("/");
+            if (IsWebsite()) return WebConfigurationManager.OpenWebConfiguration(HostingEnvironment.ApplicationVirtualPath);
 
             return ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
         }


### PR DESCRIPTION
I changed the hard coded configuration path in AzureConfigurationSource to HostingEnvironment.ApplicationVirtualPath. This has the advantage of allowing virtual applications within a site to have their own web.config and NSB endpoint.
