### PR TITLE
Fixes#1065 - added ChannelType attribute to gateway

### DIFF
--- a/src/NServiceBus.Core/Gateway/Channels/ChannelFactory.cs
+++ b/src/NServiceBus.Core/Gateway/Channels/ChannelFactory.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Gateway.Channels
 {
     using System;
+    using System.Linq;
     using System.Collections.Generic;
 
     public interface IChannelFactory
@@ -39,7 +40,11 @@ namespace NServiceBus.Gateway.Channels
 
         public void RegisterSender(Type sender)
         {
-            RegisterSender(sender, sender.Name.Substring(0, sender.Name.IndexOf("Channel")));
+            var channelTypes = sender.GetCustomAttributes(true).OfType<ChannelTypeAttribute>().ToList();
+            if(channelTypes.Any())
+                channelTypes.ForEach(type => RegisterSender(sender, type.Type));
+            else
+                RegisterSender(sender, sender.Name.Substring(0, sender.Name.IndexOf("Channel")));
         }
 
         public void RegisterSender(Type sender, string type)

--- a/src/NServiceBus.Core/Gateway/Channels/ChannelTypeAttribute.cs
+++ b/src/NServiceBus.Core/Gateway/Channels/ChannelTypeAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace NServiceBus.Gateway.Channels
+{
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = true)]
+    public class ChannelTypeAttribute : Attribute
+    {
+        public ChannelTypeAttribute(string type)
+        {
+            Type = type;
+        }
+
+        public string Type { get; set; }
+    }
+}

--- a/src/NServiceBus.Core/Gateway/Channels/Http/HttpChannelSender.cs
+++ b/src/NServiceBus.Core/Gateway/Channels/Http/HttpChannelSender.cs
@@ -8,6 +8,8 @@ namespace NServiceBus.Gateway.Channels.Http
     using Logging;
     using Utils;
 
+    [ChannelType("http")]
+    [ChannelType("https")]
     public class HttpChannelSender : IChannelSender
     {
         public void Send(string remoteUrl, IDictionary<string,string> headers,Stream data)

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Features\FeatureSettings.cs" />
     <Compile Include="Features\Support\FeatureInitializer.cs" />
     <Compile Include="Features\Support\EnableDefaultFeatures.cs" />
+    <Compile Include="Gateway\Channels\ChannelTypeAttribute.cs" />
     <Compile Include="MasterNode\AdjustSettingsForNonMasterNodes.cs" />
     <Compile Include="SecondLevelRetries\Config\FeatureSettingsExtensions.cs" />
     <Compile Include="SecondLevelRetries\Config\SecondLevelRetriesSettings.cs" />


### PR DESCRIPTION
so the HttpChannelSender can handle both http and https when using KeyPrefixConventionSiteRouter. If no attributes are found, ChannelFactory.RegisterSender uses the old convention based registration
