### PR TITLE
Added logging to explain why an exception is being thrown

### DIFF
--- a/src/NServiceBus.Core/Unicast/Messages/DefaultMessageRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/DefaultMessageRegistry.cs
@@ -54,7 +54,14 @@
                 }
 
                 if (messageType != null)
-                    yield return messages[messageType];
+                {
+                    if (messages.ContainsKey(messageType))
+                        yield return messages[messageType];
+                    else
+                    {
+                        Logger.ErrorFormat("Asked for Message Metadata for a message of type {0}, which it has not been registered. If you are using unobtrusive mode, you need to register your types", messageType);
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
If a sender uses unobtrusive mode and the receiver has not then
an exception about a missing key is thrown, which is not informative as to how to fix things. Added a check and logging to suggest looking at adding unobtrusive mode.
