### PR TITLE
Adding update lock to saga reads

### DIFF
--- a/src/nhibernate/SagaPersister/NServiceBus.SagaPersisters.NHibernate/SagaPersister.cs
+++ b/src/nhibernate/SagaPersister/NServiceBus.SagaPersisters.NHibernate/SagaPersister.cs
@@ -44,7 +44,9 @@ namespace NServiceBus.SagaPersisters.NHibernate
         T ISagaPersister.Get<T>(string property, object value)
         {
             return SessionFactory.GetCurrentSession().CreateCriteria(typeof(T))
+                .SetLockMode(LockMode.Upgrade)
                 .Add(Restrictions.Eq(property, value))
+
                 .UniqueResult<T>();
         }
 


### PR DESCRIPTION
Hi, I've worked with NSB for over an year now. We currently have a special scenario where one specific saga has high level of contention. Our DBA looked at the NSB approach for optimistic concurrency check, via repeatable reads. 

The problem is that the implementation of repeatable reads of SQL Server relies on deadlocks..which is an expensive approach (detecting deadlocks is not cheap) and it also generates lots of noise in our log files (+ DBAs freak out when they see deadlocks in error logs). Also, we get (plenty of) scenarios where some competing messages end up in the error queue.

So, we decided to apply update locks to saga reads so that concurrent workers need to wait until the saga is released.  This is currently working well and we are applying it selectively to some endpoints where contention may be high. 

Ideally this is an optional and configurable (per saga?) feature, but for us it makes sense to be the default, since it is very rare to hit a saga and not update it.

Thanks very much in advance,
Sebastian
