### PR TITLE
Making gateway an IAdvancedSatellite

### DIFF
--- a/Samples/Gateway/SiteA/App.config
+++ b/Samples/Gateway/SiteA/App.config
@@ -4,7 +4,7 @@
     <section name="MessageForwardingInCaseOfFaultConfig" type="NServiceBus.Config.MessageForwardingInCaseOfFaultConfig, NServiceBus.Core" />
     <section name="GatewayConfig" type="NServiceBus.Config.GatewayConfig, NServiceBus.Core" />
   </configSections>
-  <GatewayConfig>
+  <GatewayConfig TransactionTimeout="00:10:00">
     <Channels>
       <Channel Address="http://localhost:25899/SiteA/" ChannelType="Http" Default="true"/>
     </Channels>

--- a/src/NServiceBus.Core/Config/GatewayConfig.cs
+++ b/src/NServiceBus.Core/Config/GatewayConfig.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Config
 {
+    using System;
     using System.Collections.Generic;
     using System.Configuration;
     using Gateway.Channels;
@@ -9,6 +10,24 @@ namespace NServiceBus.Config
     /// </summary>
     public class GatewayConfig : ConfigurationSection
     {
+        /// <summary>
+        /// Property for getting/setting the period of time when the outgoing gateway transaction times out.
+        /// Only relevant when <see cref="IsTransactional"/> is set to true.
+        /// Defaults to the TransactionTimeout of the main transport.
+        /// </summary>
+        [ConfigurationProperty("TransactionTimeout", IsRequired = false, DefaultValue = "00:00:00")]
+        public TimeSpan TransactionTimeout
+        {
+            get
+            {
+                return (TimeSpan)this["TransactionTimeout"];
+            }
+            set
+            {
+                this["TransactionTimeout"] = value;
+            }
+        }
+
         /// <summary>
         /// Collection of sites
         /// </summary>

--- a/src/NServiceBus.Core/Gateway/Sending/GatewaySender.cs
+++ b/src/NServiceBus.Core/Gateway/Sending/GatewaySender.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Gateway.Sending
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Config;
     using Features;
     using HeaderManagement;
     using Notifications;
@@ -14,7 +15,7 @@ namespace NServiceBus.Gateway.Sending
     using Transports;
     using Unicast;
    
-    public class GatewaySender : ISatellite
+    public class GatewaySender : IAdvancedSatellite
     {
        
         public UnicastBus UnicastBus { get; set; }
@@ -106,6 +107,16 @@ namespace NServiceBus.Gateway.Sending
         private string GetDefaultAddressForThisSite()
         {
             return ChannelManager.GetDefaultChannel().ToString();
+        }
+
+        public Action<Unicast.Transport.TransportReceiver> GetReceiverCustomization()
+        {
+            return transport =>
+            {
+                var configSection = Configure.ConfigurationSource.GetConfiguration<GatewayConfig>();
+                if (configSection.TransactionTimeout > transport.TransactionSettings.TransactionTimeout)
+                    transport.TransactionSettings.TransactionTimeout = configSection.TransactionTimeout;
+            };
         }
     }
 }


### PR DESCRIPTION
Added config to cater for longer transaction timeouts on messages
forwarded to other sites. This is helpful when bandwidth between sites
is limited.
