### PR TITLE
Only update CorrId header if it isn't already populated

### DIFF
--- a/src/NServiceBus.Core/Unicast/BackwardCompatibility/AssignIdForCorrelationToCorrelationIdOfOutgoingTransportMessages.cs
+++ b/src/NServiceBus.Core/Unicast/BackwardCompatibility/AssignIdForCorrelationToCorrelationIdOfOutgoingTransportMessages.cs
@@ -6,7 +6,10 @@
     {
         public void MutateOutgoing(object[] messages, TransportMessage transportMessage)
         {
-            transportMessage.Headers["CorrId"] = transportMessage.CorrelationId;
+            if (transportMessage.Headers.ContainsKey("CorrId") == false)
+            {
+                transportMessage.Headers["CorrId"] = transportMessage.CorrelationId;
+            }
         }
 
         public void Init()


### PR DESCRIPTION
A problem exists in 4.0.0-unstable3157-3167 where the CorrId header is already in the Headers dictionary when calling Saga.RequestTimeout. Example:

RequestTimeout<CheckForHardBounce>(TimeSpan.FromHours(1));
