### PR TITLE
Add SQLite/Interop.dll's to exclusions.

### DIFF
--- a/src/NServiceBus.Core/Configure.cs
+++ b/src/NServiceBus.Core/Configure.cs
@@ -768,8 +768,12 @@ namespace NServiceBus
 
                   // Azure host process, which is typically referenced for ease of deployment but should not be scanned
                   "NServiceBus.Hosting.Azure.HostProcess.exe",
+
                   // And other windows azure stuff
-                  "Microsoft.WindowsAzure."
+                  "Microsoft.WindowsAzure.",
+
+                  // SQLite unmanaged DLLs that cause BadImageFormatException's
+                  "sqlite3.dll", "SQLite.Interop.dll"
               };
 
         // TODO: rename to additionalTypeExclusions 


### PR DESCRIPTION
We use SQLite extensively for our system and integration testing and NSB throws BadImageFormatException's when trying to scan them, which although just an inconvenience is annoying. Suggested mod below.
