### PR TITLE
UnicastBus.Defer should not have any time related logic

### DIFF
--- a/src/ActiveMQ/NServiceBus.ActiveMQ/ActiveMQMessageDefer.cs
+++ b/src/ActiveMQ/NServiceBus.ActiveMQ/ActiveMQMessageDefer.cs
@@ -17,6 +17,11 @@
             this.MessageSender.Send(message, address);
         }
 
+        public void Defer(TransportMessage message, TimeSpan delay, Address address)
+        {
+            Defer(message, DateTime.UtcNow + delay, address);
+        }
+
         public void ClearDeferredMessages(string headerKey, string headerValue)
         {
             var selector = string.Format("{0} = '{1}'", ActiveMqMessageMapper.ConvertMessageHeaderKeyToActiveMQ(headerKey), headerValue);

--- a/src/NServiceBus.Core.Tests/SecondLevelRetries/SecondLevelRetriesTests.cs
+++ b/src/NServiceBus.Core.Tests/SecondLevelRetries/SecondLevelRetriesTests.cs
@@ -157,6 +157,11 @@
             DeferredMessage = message;
         }
 
+        public void Defer(TransportMessage message, TimeSpan delay, Address address)
+        {
+            Defer(message, DateTime.UtcNow + delay, address);
+        }
+
         public void ClearDeferredMessages(string headerKey, string headerValue)
         {
             

--- a/src/NServiceBus.Core/Timeout/Core/TimeoutManagerDeferrer.cs
+++ b/src/NServiceBus.Core/Timeout/Core/TimeoutManagerDeferrer.cs
@@ -13,6 +13,12 @@
 
         public void Defer(TransportMessage message, DateTime processAt, Address address)
         {
+            if (processAt.ToUniversalTime() <= DateTime.UtcNow)
+            {
+                MessageSender.Send(message, address);
+                return;
+            }
+
             message.Headers[TimeoutManagerHeaders.Expire] = DateTimeExtensions.ToWireFormattedString(processAt);
 
             message.Headers[TimeoutManagerHeaders.RouteExpiredTimeoutTo] = address.ToString();
@@ -28,6 +34,11 @@
                     ex);
                 throw;
             }
+        }
+
+        public void Defer(TransportMessage message, TimeSpan delay, Address address)
+        {
+            Defer(message, DateTime.UtcNow + delay, address);
         }
 
         public void ClearDeferredMessages(string headerKey, string headerValue)

--- a/src/NServiceBus.Core/Transports/IDeferMessages.cs
+++ b/src/NServiceBus.Core/Transports/IDeferMessages.cs
@@ -16,6 +16,14 @@
         void Defer(TransportMessage message, DateTime processAt, Address address);
 
         /// <summary>
+        /// Defers the given message which processing will be delayed as specified
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="delay"></param>
+        /// <param name="address">The endpoint of the endpoint who should get the message</param>
+        void Defer(TransportMessage message, TimeSpan delay, Address address);
+
+        /// <summary>
         /// Clears all timeouts for the given header
         /// </summary>
         /// <param name="headerKey"></param>


### PR DESCRIPTION
I refactored all time related stuff out of UnicastBus. For that I had to create a second overload in IDeferMessages, that takes TimeSpan delay as a parameter instead of DateTime processAt.

This change makes it much easier to create a time simulation feature (by creating a custom MessageDeferrer only).
As a result #1353, which I will close, becomes obsolete.
