### PR TITLE
Use Configure.GetConfigSection<T> for Gateway like other IProvideConfig<T>

### DIFF
--- a/src/NServiceBus.Core/Gateway/Gateway.cs
+++ b/src/NServiceBus.Core/Gateway/Gateway.cs
@@ -44,7 +44,7 @@
         {
             Configure.Component<IdempotentChannelForwarder>(DependencyLifecycle.InstancePerCall);
 
-            var configSection = Configure.ConfigurationSource.GetConfiguration<GatewayConfig>();
+            var configSection = Configure.GetConfigSection<GatewayConfig>();
 
             if (configSection != null && configSection.GetChannels().Any())
                 Configure.Component<ConfigurationBasedChannelManager>(DependencyLifecycle.SingleInstance);

--- a/src/NServiceBus.Core/Gateway/Receiving/ConfigurationBasedChannelManager.cs
+++ b/src/NServiceBus.Core/Gateway/Receiving/ConfigurationBasedChannelManager.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.Gateway.Receiving
 
         public ConfigurationBasedChannelManager()
         {
-            channels = Configure.ConfigurationSource.GetConfiguration<GatewayConfig>().GetChannels();
+            channels = Configure.GetConfigSection<GatewayConfig>().GetChannels();
 
         }
 

--- a/src/NServiceBus.Core/Gateway/Routing/Sites/ConfigurationBasedSiteRouter.cs
+++ b/src/NServiceBus.Core/Gateway/Routing/Sites/ConfigurationBasedSiteRouter.cs
@@ -9,7 +9,7 @@ namespace NServiceBus.Gateway.Routing.Sites
 
         public ConfigurationBasedSiteRouter()
         {
-            var section = Configure.ConfigurationSource.GetConfiguration<GatewayConfig>();
+            var section = Configure.GetConfigSection<GatewayConfig>();
             if(section != null)
                 sites = section.SitesAsDictionary();                 
         }


### PR DESCRIPTION
We were setting up Gateways using some convention based configuration and found it was the only place that went directly to Configure.ConfigurationSource rather than through the Configure.GetConfigSection<T> method.
