### PR TITLE
NHibernate gateway deduplication fails on large messages

### DIFF
--- a/src/nhibernate/NServiceBus.NHibernate/GatewayPersister/NHibernate/Config/GatewayMessageMap.cs
+++ b/src/nhibernate/NServiceBus.NHibernate/GatewayPersister/NHibernate/Config/GatewayMessageMap.cs
@@ -16,7 +16,7 @@ namespace NServiceBus.GatewayPersister.NHibernate.Config
         {
             Table("GatewayMessages");
             Id(x => x.Id, m => m.Generator(Generators.Assigned));
-            Property(p => p.OriginalMessage);
+            Property(p => p.OriginalMessage, pm => pm.Type(NHibernateUtil.BinaryBlob));
             Property(p => p.Acknowledged);
             Property(p => p.TimeReceived);
             Property(p => p.Headers, pm => pm.Type(NHibernateUtil.StringClob));


### PR DESCRIPTION
SQL deduplication fails on messages larger than 8KB with error message
The length of the byte[] value exceeds the length configured in the mapping/parameter.
