### PR TITLE
Made visibility timeout for messages the same as the configured value

### DIFF
--- a/src/azure/NServiceBus.Azure/Transports/StorageQueues/AzureMessageQueueReceiver.cs
+++ b/src/azure/NServiceBus.Azure/Transports/StorageQueues/AzureMessageQueueReceiver.cs
@@ -143,7 +143,7 @@ namespace NServiceBus.Unicast.Queuing.Azure
                     batchQueue.Enqueue(receivedMessage);
                 }
             });
-            azureQueue.BeginGetMessages(BatchSize, TimeSpan.FromMilliseconds(MessageInvisibleTime * BatchSize), null, null, callback, null);
+            azureQueue.BeginGetMessages(BatchSize, TimeSpan.FromMilliseconds(MessageInvisibleTime), null, null, callback, null);
             return null;
         }
 


### PR DESCRIPTION
It's better to use the configured invisible time rather than multiplying it by the batch size for the following reasons:

1) Multiplying by the batch size makes it impossible to set a specific invisible time without changing the batch size.
2) Using the configured invisible time is more intuitive.
