### PR TITLE
Load message handlers

### DIFF
--- a/Samples/VideoStore.SqlServer/VideoStore.ECommerce/Global.asax.cs
+++ b/Samples/VideoStore.SqlServer/VideoStore.ECommerce/Global.asax.cs
@@ -20,6 +20,7 @@ namespace VideoStore.ECommerce
                      .UseTransport<SqlServer>()
                      .PurgeOnStartup(true)
                      .UnicastBus()
+                     .LoadMessageHandlers()
                      .RunHandlersUnderIncomingPrincipal(false)
                      .RijndaelEncryptionService()
                      .CreateBus()


### PR DESCRIPTION
To get the Sql Server sample to work (in particular, feedback in the UI), the message handlers need to get loaded in the web client configuration.
