### PR TITLE
Unit Tests fail with ConfigurationErrorsException

### DIFF
--- a/src/testing/Test.cs
+++ b/src/testing/Test.cs
@@ -9,6 +9,7 @@ namespace NServiceBus.Testing
 {
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using Features.Categories;
     using DataBus.InMemory;
 
     /// <summary>
@@ -65,7 +66,7 @@ namespace NServiceBus.Testing
             if (initialized)
                 return;
 
-            Configure.Serialization.Xml();
+            Serializers.SetDefault<Features.XmlSerialization>();
 
             Configure.Instance
                 .DefineEndpointName("UnitTests")


### PR DESCRIPTION
unit tests fail with 'Multiple serializers are not supported. Please make sure to only enable one' if using any serializer other than xml. Removed explicit serializer configuration & substituted with a default
