### PR TITLE
Fixes #1503 - SecondLevelRetriesProcessor is always started regardless of feature being disabled

### DIFF
--- a/src/NServiceBus.Core.Tests/SecondLevelRetries/SecondLevelRetriesTests.cs
+++ b/src/NServiceBus.Core.Tests/SecondLevelRetries/SecondLevelRetriesTests.cs
@@ -33,6 +33,13 @@
         }
 
         [Test]
+        public void When_feature_is_disabled_then_disabled_property_should_return_true()
+        {
+            Configure.Features.Disable<Features.SecondLevelRetries>();
+            Assert.IsTrue(satellite.Disabled);
+        }
+
+        [Test]
         public void Message_should_have_ReplyToAddress_set_to_original_sender_when_sent_to_real_errorq()
         {
             var expected = new Address("clientQ", "myMachine");

--- a/src/NServiceBus.Core/SecondLevelRetries/SecondLevelRetriesProcessor.cs
+++ b/src/NServiceBus.Core/SecondLevelRetries/SecondLevelRetriesProcessor.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.SecondLevelRetries
 {
     using System;
+    using Features;
     using Helpers;
     using Faults.Forwarder;
     using Logging;
@@ -15,7 +16,9 @@ namespace NServiceBus.SecondLevelRetries
         
         public Address InputAddress { get; set; }
 
-        public bool Disabled { get; set; }
+        public bool Disabled {
+            get { return !Feature.IsEnabled<SecondLevelRetries>(); }
+        }
 
         public FaultManager FaultManager { get; set; }
 


### PR DESCRIPTION
I'm a bit confused why this hasn't been noticed/fixed already.  I might be missing something completely obvious as to why but it escapes me and so I've put in this patch...

btw, develop branch already had 7 failing unit tests before I created this branch - they are still failing.
