### PR TITLE
Solves issue 1512

### DIFF
--- a/src/nhibernate/NServiceBus.NHibernate/TimeoutPersisters/NHibernate/Config/TimeoutEntityMap.cs
+++ b/src/nhibernate/NServiceBus.NHibernate/TimeoutPersisters/NHibernate/Config/TimeoutEntityMap.cs
@@ -31,6 +31,7 @@ namespace NServiceBus.TimeoutPersisters.NHibernate.Config
             {
                 pm.Index("TimeoutEntity_EndpointIdx");
                 pm.Length(440);
+            });
         }
     }
 }


### PR DESCRIPTION
This PR solves issue 1512 : https://github.com/Particular/NServiceBus/issues/1512

Is extends the 'TimeoutEntity_EndpointIdx' index with the Time column.

I have done a run-time test by using the NHibernate timeout persister in the pubsub sample and running NServiceBus.Host.exe -install to see if the table index was created correctly.
