### PR TITLE
Fixes #1528

### DIFF
--- a/src/NServiceBus.Core.Tests/Unicast/Receiving.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/Receiving.cs
@@ -46,6 +46,16 @@
             Assert.True(CatchAllHandler_object.Called);
         }
         [Test]
+        public void Should_throw_when_there_are_no_registered_message_handlers()
+        {
+            var receivedMessage = Helpers.Helpers.Serialize(new EventMessage());
+            RegisterMessageType<EventMessage>();
+            ReceiveMessage(receivedMessage);
+            Assert.IsTrue(ResultingException != null, "When no handlers are found and a message ends up in the endpoint, an exception should be thrown");
+            Assert.IsTrue(ResultingException.InnerException.GetType() == typeof(InvalidOperationException), "The inner exception must contain an InvalidOperationException");
+            Assert.IsTrue(ResultingException.InnerException.Message.Contains(typeof(EventMessage).ToString()), "The exception message should be meaningful and should inform the user the message type for which a handler could not be found.");
+        }
+        [Test]
         public void Should_invoke_the_registered_catch_all_handler_using_a_dynamic_parameter()
         {
             var receivedMessage = Helpers.Helpers.Serialize(new EventMessage());

--- a/src/NServiceBus.Core/Unicast/UnicastBus.cs
+++ b/src/NServiceBus.Core/Unicast/UnicastBus.cs
@@ -1065,12 +1065,8 @@ namespace NServiceBus.Unicast
 
                 if (!callbackInvoked && !handlers.Any())
                 {
-                    var warning = string.Format("No handlers could be found for message type: {0}", messageToHandle.GetType().FullName);
-
-                    if (Debugger.IsAttached)
-                        throw new InvalidOperationException(warning);
-
-                    Log.WarnFormat(warning);
+                    var error = string.Format("No handlers could be found for message type: {0}", messageToHandle.GetType().FullName);
+                    throw new InvalidOperationException(error);
                 }
 
                 LogPipelineInfo(messageToHandle, handlers);


### PR DESCRIPTION
Throwing an invalid operation exception when a message arrives at the endpoint and no registered message handlers are found.
