### PR TITLE
Publisher not publishing derived events for classes, fixes #1558

### DIFF
--- a/src/NServiceBus.Core/Unicast/UnicastBus.cs
+++ b/src/NServiceBus.Core/Unicast/UnicastBus.cs
@@ -12,7 +12,6 @@ namespace NServiceBus.Unicast
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using AutomaticSubscriptions;
     using Impersonation;
     using Licensing;
     using Logging;
@@ -691,12 +690,6 @@ namespace NServiceBus.Unicast
         List<Type> GetFullTypes(IEnumerable<object> messages)
         {
             var types = new List<Type>();
-            var subscribePlainMessages = false;
-
-            if (Configure.HasComponent<DefaultAutoSubscriptionStrategy>())
-            {
-                subscribePlainMessages = Builder.Build<DefaultAutoSubscriptionStrategy>().SubscribePlainMessages;
-            }
 
             foreach (var m in messages)
             {
@@ -709,7 +702,7 @@ namespace NServiceBus.Unicast
 
                 types.Add(s);
 
-                foreach (var t in GetParentTypes(messageType, subscribePlainMessages)
+                foreach (var t in GetParentTypes(messageType)
                     .Where(MessageConventionExtensions.IsMessageType)
                     .Where(t => !types.Contains(t)))
                 {
@@ -720,16 +713,11 @@ namespace NServiceBus.Unicast
             return types;
         }
 
-        static IEnumerable<Type> GetParentTypes(Type type, bool returnBaseTypes)
+        static IEnumerable<Type> GetParentTypes(Type type)
         {
             foreach (var i in type.GetInterfaces())
             {
                 yield return i;
-            }
-
-            if (!returnBaseTypes)
-            {
-                yield break;
             }
 
             // return all inherited types


### PR DESCRIPTION
Proposed fix for #1558.

But I'm not too sure about piggy backing of `AutoSubscribePlainMessages`, because this means that the publisher would be the one having to include:
`Configure.Features.AutoSubscribe(f=>f.AutoSubscribePlainMessages())`

Thoughts?
