### PR TITLE
Expanding message registration exception message as it is a little misleading

### DIFF
--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -14,7 +14,7 @@
             {
                 return metadata;
             }
-            var message = string.Format("Could not find Metadata for '{0}'.\nPlease ensure the following:\n1. '{0}' is included in initial scanning see File Scanning: http://particular.net/articles/the-nservicebus-host\n2. '{0}' implements either 'IMessage', 'IEvent' or 'ICommand' or alternatively, if you don't want to implement an interface, you can use 'Unobtrusive Mode' see: http://particular.net/articles/unobtrusive-mode-messages", messageType.FullName);
+            var message = string.Format("Could not find Metadata for '{0}'.{1}Please ensure the following:{1}1. '{0}' is included in initial scanning see File Scanning: http://particular.net/articles/the-nservicebus-host{1}2. '{0}' implements either 'IMessage', 'IEvent' or 'ICommand' or alternatively, if you don't want to implement an interface, you can use 'Unobtrusive Mode' see: http://particular.net/articles/unobtrusive-mode-messages", messageType.FullName, Environment.NewLine);
             throw new Exception(message);
         }
 


### PR DESCRIPTION
The exception message states that the messages must implement, IMessage, IEvent or ICommand however this may not have been the cause of the exception. If the user has configured NSB such that the message types have never been registered (e.g. NSB has not scanned the required assembly) then they will also get this error message even though their messages implement the correct interfaces.
