### PR TITLE
Fixes #1683 - Gateway logs ProtocolViolationException error in response to HTTP HEAD requests

### DIFF
--- a/src/NServiceBus.Core/Gateway/Channels/Http/DefaultResponder.cs
+++ b/src/NServiceBus.Core/Gateway/Channels/Http/DefaultResponder.cs
@@ -13,6 +13,13 @@ namespace NServiceBus.Gateway.Channels.Http
                 Configure.EndpointName);
 
             ctx.Response.ContentType = "text/html";
+
+            if (ctx.Request.HttpMethod == WebRequestMethods.Http.Head)
+            {
+                ctx.Response.Close();
+                return;
+            }
+
             ctx.Response.Close(Encoding.UTF8.GetBytes(response), true);
         }
     }


### PR DESCRIPTION
Respond with 0 length body to HEAD requests over gateway. The HEAD method is identical to GET except that the server MUST NOT return a message-body in the response.
