### PR TITLE
Updated windows registry key in init.ps1 powershell script.

### DIFF
--- a/packaging/nuget/tools/init.ps1
+++ b/packaging/nuget/tools/init.ps1
@@ -15,7 +15,7 @@ Write-Host ""
 Write-Host "Type 'get-help about_NServiceBus' to see all available NServiceBus commands."
 Write-Host ""
 
-$nserviceBusKeyPath =  "HKCU:SOFTWARE\NServiceBus" 
+$nserviceBusKeyPath =  "HKCU:SOFTWARE\ParticularSoftware\NServiceBus" 
 $machinePreparedKey = "MachinePrepared"
 $machinePrepared = $false
 $nservicebusVersion = Get-NServiceBusVersion


### PR DESCRIPTION
Updated path to NServiceBus key in windows registry in init.ps1 powershell script.

It caused annoying error "missing key" in powershell console while opening solution in Visual Studio
