### PR TITLE
DTC install fails on Win 2003 R2 x64 SP2 from x86 process

### DIFF
--- a/src/NServiceBus.PowerShell/Dtc/DtcSetup.cs
+++ b/src/NServiceBus.PowerShell/Dtc/DtcSetup.cs
@@ -42,7 +42,9 @@
             Console.WriteLine("Checking if DTC is configured correctly.");
 
             bool requireRestart;
-            using (var key = Registry.LocalMachine.OpenSubKey(@"Software\Microsoft\MSDTC\Security", doChanges))
+            using (var rootKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine,
+                                 Environment.Is64BitOperatingSystem ? RegistryView.Registry64 : RegistryView.Default))
+            using (var key = rootKey.OpenSubKey(@"SOFTWARE\Microsoft\MSDTC\Security", doChanges))
             {
                 if (key == null)
                 {

--- a/src/NServiceBus.PowerShell/Msmq/MsmqSetup.cs
+++ b/src/NServiceBus.PowerShell/Msmq/MsmqSetup.cs
@@ -61,16 +61,12 @@
         /// </summary>
         public static bool IsInstallationGood()
         {
-            var msmqSetup = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\MSMQ\Setup");
-            if (msmqSetup == null)
+            using (var rootKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine,
+                                 Environment.Is64BitOperatingSystem ? RegistryView.Registry64 : RegistryView.Default))
+            using (var msmqSetup = rootKey.OpenSubKey(@"SOFTWARE\Microsoft\MSMQ\Setup"))
             {
-                return false;
+                return msmqSetup != null && HasOnlyNeededComponents(msmqSetup.GetValueNames());
             }
-
-            var installedComponents = new List<string>(msmqSetup.GetValueNames());
-            msmqSetup.Close();
-
-            return HasOnlyNeededComponents(installedComponents);
         }
 
         static bool InstallMsmqIfNecessary()


### PR DESCRIPTION
`SOFTWARE\Wow6432Node\Microsoft\MSDTC\Security` doesn't exist on a fully patched Server 2003 R2 x64
so registry key was always NULL. May also fix #1690

Tested on
- 2003 R2 x86 SP2 with all critical updates
- 2003 R2 x64 SP2 with all critical updates
- 2012 R2
