### PR TITLE
Get building with NCrunch

### DIFF
--- a/buildsupport/GitFlowVersion/Build/GitFlowVersionTask.targets
+++ b/buildsupport/GitFlowVersion/Build/GitFlowVersionTask.targets
@@ -32,6 +32,8 @@
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\GitFlowVersionTask.dll" />
     <None Include="$(MSBuildThisFileDirectory)..\GitFlowVersionTask.pdb" />
+    <None Include="$(MSBuildThisFileDirectory)..\GitFlowVersion.exe" />
+    <None Include="$(MSBuildThisFileDirectory)..\GitFlowVersion.pdb" />
   </ItemGroup>
 
 

--- a/buildsupport/RippleRestoreTask.targets
+++ b/buildsupport/RippleRestoreTask.targets
@@ -2,10 +2,10 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)\..\</SolutionDir>
-    <BuildDependsOn>
+    <BeforeBuildDependsOn>
       RippleRestoreTarget;
-      $(BuildDependsOn);
-    </BuildDependsOn>
+      $(BeforeBuildDependsOn);
+    </BeforeBuildDependsOn>
   </PropertyGroup>
 
   <UsingTask


### PR DESCRIPTION
Changed RippleRestoreTarget to run during BeforeBuildDependsOn instead of BuildDependsOn
Copied GitFlowVersion.exe to ncrunch build folder
