### PR TITLE
ncrunch cannot build licenseinstaller

### DIFF
--- a/src/licenseinstaller/LicenseInstaller.csproj
+++ b/src/licenseinstaller/LicenseInstaller.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{857C5E77-1946-4C83-BC8D-EFF8E1611A0D}</ProjectGuid>


### PR DESCRIPTION
ncrunch fails because x86 debug/release configurations not defined in project file
