### PR TITLE
Check for royalty free license expiry

### DIFF
--- a/src/NServiceBus.Core/Licensing/ExpiryChecker.cs
+++ b/src/NServiceBus.Core/Licensing/ExpiryChecker.cs
@@ -6,7 +6,7 @@ namespace NServiceBus.Licensing
     {
         public static bool IsExpired(DateTime expiry)
         {
-            var oneDayGrace = expiry.AddDays(1);
+            var oneDayGrace = expiry >= DateTime.MaxValue.Date ? expiry : expiry.AddDays(1);
             return oneDayGrace < DateTime.UtcNow.Date;
         }
     }


### PR DESCRIPTION
Add grace period only if date less than DateTime.MaxValue
