### PR TITLE
Improve output of ReturnToSourceQueue error messages

### DIFF
--- a/src/ReturnToSourceQueue/ErrorManager.cs
+++ b/src/ReturnToSourceQueue/ErrorManager.cs
@@ -82,17 +82,24 @@ namespace NServiceBus.Tools.Management.Errors.ReturnToSourceQueue
                     {
                         Console.WriteLine(NoMessageFoundErrorFormat, messageId);
 
+                        uint messageCount = 0;
                         foreach (var m in queue.GetAllMessages())
                         {
+                            messageCount++;
                             var tm = MsmqUtilities.Convert(m);
 
                             var originalId = GetOriginalId(tm);
 
                             if (string.IsNullOrEmpty(originalId) || messageId != originalId)
                             {
+                                if (messageCount % ProgressInterval == 0)
+                                {
+                                    Console.Write(".");
+                                }
                                 continue;
                             }
 
+                            Console.WriteLine();
                             Console.WriteLine("Found message - going to return to queue.");
 
                             using (var tx = new TransactionScope())
@@ -114,6 +121,7 @@ namespace NServiceBus.Tools.Management.Errors.ReturnToSourceQueue
                             return;
                         }
 
+                        Console.WriteLine();
                         Console.WriteLine(NoMessageFoundInHeadersErrorFormat, messageId);
                     }
                 }
@@ -139,6 +147,7 @@ namespace NServiceBus.Tools.Management.Errors.ReturnToSourceQueue
 
         const string NoMessageFoundErrorFormat = "INFO: No message found with ID '{0}'. Checking headers of all messages.";
         const string NoMessageFoundInHeadersErrorFormat = "INFO: No message found with ID '{0}' in any headers.";
+        const uint ProgressInterval = 100;
 
         TimeSpan TimeoutDuration = TimeSpan.FromSeconds(5);
         MessageQueue queue;


### PR DESCRIPTION
In relation to Issue #1857 the pull request:
1. fixes the display of the "no message found" error (commit 3cb3385)
2. adds an error message if the header search fails (commit 0529655)
3. adds a progress indicator for the header search (commit 2c8d924)
