### PR TITLE
Fixes #1827 - SingleCallChannelReceiver doesn't work with unity

### DIFF
--- a/src/NServiceBus.Core/Gateway/Gateway.cs
+++ b/src/NServiceBus.Core/Gateway/Gateway.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Features
 {
+    using System;
     using System.Linq;
     using Config;
     using NServiceBus.Gateway.Channels;
@@ -80,11 +81,15 @@
 
         static void ConfigureReceiver()
         {
-            if (!Configure.Instance.Configurer.HasComponent<IReceiveMessagesFromSites>())
+            if (!Configure.HasComponent<IReceiveMessagesFromSites>())
             {
                 Configure.Component<IdempotentChannelReceiver>(DependencyLifecycle.InstancePerCall);
                 Configure.Component<SingleCallChannelReceiver>(DependencyLifecycle.InstancePerCall);
+                Configure.Component<Func<IReceiveMessagesFromSites>>(builder => () => builder.Build<SingleCallChannelReceiver>(), DependencyLifecycle.InstancePerCall);
             }
+
+            if (!Configure.HasComponent<Func<IReceiveMessagesFromSites>>())
+	            Configure.Component<Func<IReceiveMessagesFromSites>>(builder => () => builder.Build<IReceiveMessagesFromSites>(), DependencyLifecycle.InstancePerCall);
 
             Configure.Component<DataBusHeaderManager>(DependencyLifecycle.InstancePerCall);
 

--- a/src/NServiceBus.Core/Gateway/Receiving/GatewayReceiver.cs
+++ b/src/NServiceBus.Core/Gateway/Receiving/GatewayReceiver.cs
@@ -1,10 +1,10 @@
 namespace NServiceBus.Gateway.Receiving
 {
+    using System;
     using System.Collections.Generic;
     using Features;
     using Logging;
     using Notifications;
-    using ObjectBuilder;
     using Routing;
     using Satellites;
     using Settings;
@@ -20,7 +20,7 @@ namespace NServiceBus.Gateway.Receiving
         public ISendMessages MessageSender { get; set; }
         public IManageReceiveChannels ChannelManager { get; set; }
         public IRouteMessagesToEndpoints EndpointRouter { get; set; }
-        public IBuilder builder { get; set; }
+        public Func<IReceiveMessagesFromSites> builder { get; set; }
 
         public void Stop()
         {
@@ -61,7 +61,7 @@ namespace NServiceBus.Gateway.Receiving
 
             foreach (var receiveChannel in ChannelManager.GetReceiveChannels())
             {
-                var receiver = builder.Build<IReceiveMessagesFromSites>();
+                var receiver = builder();
 
                 receiver.MessageReceived += MessageReceivedOnChannel;
                 receiver.Start(receiveChannel, receiveChannel.NumberOfWorkerThreads);


### PR DESCRIPTION
Add factory to resolve gateway channel receivers. Create & register `Func<IReceiveMessagesFromSites>`

Edit: Not tested with Unity. Tested with DefaultBuilder()
