### PR TITLE
Dispose of stream only once

### DIFF
--- a/src/NServiceBus.Core/Gateway/Receiving/IdempotentChannelReceiver.cs
+++ b/src/NServiceBus.Core/Gateway/Receiving/IdempotentChannelReceiver.cs
@@ -176,12 +176,7 @@ namespace NServiceBus.Gateway.Receiving
                 timeToBeReceived = TimeSpan.FromHours(1);
             }
 
-            string newDatabusKey;
-
-            using (callInfo.Data)
-            {
-                newDatabusKey = DataBus.Put(callInfo.Data, timeToBeReceived);
-            }
+            var newDatabusKey = DataBus.Put(callInfo.Data, timeToBeReceived);
 
             var specificDataBusHeaderToUpdate = callInfo.Headers[GatewayHeaders.DatabusKey];
 


### PR DESCRIPTION
Stream already disposed of by `using` in `DataReceivedOnChannel`
See comments in #1890
