### PR TITLE
Issue JsonMessageSerializerBase - TypeNameHandling.None

### DIFF
--- a/src/NServiceBus.Core/Serializers/Json/JsonMessageSerializerBase.cs
+++ b/src/NServiceBus.Core/Serializers/Json/JsonMessageSerializerBase.cs
@@ -64,21 +64,10 @@ namespace NServiceBus.Serializers.Json
         /// <returns>Deserialized messages.</returns>
         public object[] Deserialize(Stream stream, IList<Type> messageTypes = null)
         {
-            var settings = serializerSettings;
-
             var mostConcreteType = messageTypes != null ? messageTypes.FirstOrDefault() : null;
-            var requiresDynamicDeserialization = mostConcreteType != null && mostConcreteType.IsInterface;
+            var requiresDynamicDeserialization = mostConcreteType != null && mostConcreteType.IsAbstract;
 
-            if (requiresDynamicDeserialization)
-            {
-                settings = new JsonSerializerSettings{
-                        TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple,
-                        TypeNameHandling = TypeNameHandling.None,
-                        Converters = { new IsoDateTimeConverter { DateTimeStyles = DateTimeStyles.RoundtripKind }, new XContainerConverter() }
-                };
-            }
-
-            var jsonSerializer = JsonSerializer.Create(settings);
+            var jsonSerializer = JsonSerializer.Create(serializerSettings);
             jsonSerializer.ContractResolver = new MessageContractResolver(messageMapper);
 
             var reader = CreateJsonReader(stream);


### PR DESCRIPTION
The serializer method has different serializerSettings than the deserializer. This means the serializer has TypeNameHandling = TypeNameHandling.Auto but the deserializer has the TypeNameHandling = TypeNameHandling.None

So the deserializer can't benefit from the special json attributes $type, which has been created by the serializer, and causes the deserialization to fail.

The deserializer has the following condition

    var requiresDynamicDeserialization = mostConcreteType != null && mostConcreteType.IsInterface

In my case looks the event as following

IMyInterface

MyBaseClassProperty
So MyBaseClassProperty is an abstract class and can represent multiple concrete types. Because the event it self is an interface you are turning the TypeNameHandling to None. MyBaseClassProperty requires the TypeNameHandling = Auto to be able to deserialize.

An abstract class or interface can have properties which are also interfaces or abstract classes and so on
