### PR TITLE
Turned on AggressivelyCacheFor in GetSubscriberAddressesForMessage.

### DIFF
--- a/src/NServiceBus.Core/Persistence/Raven/SubscriptionStorage/RavenSubscriptionStorage.cs
+++ b/src/NServiceBus.Core/Persistence/Raven/SubscriptionStorage/RavenSubscriptionStorage.cs
@@ -63,13 +63,12 @@ namespace NServiceBus.Persistence.Raven.SubscriptionStorage
         IEnumerable<Address> ISubscriptionStorage.GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes)
         {
             using (var session = OpenSession())
+            using (session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromSeconds(30)))
             {
-                session.Advanced.DocumentStore.AggressivelyCacheFor(TimeSpan.FromSeconds(30));
-
                 var subscriptions = GetSubscriptions(messageTypes, session);
                 return subscriptions.SelectMany(s => s.Clients)
-                                    .Distinct()
-                                    .ToArray();
+                    .Distinct()
+                    .ToArray();
             }
         }
 


### PR DESCRIPTION
This will give a small performance boost to raven subscriptions storage.

By running PubSub.ps1 I saw on my machine a small increase in throughput (about 100 more).
I think this will be even higher if Raven is not on the local machine.

I'm caching for 30secs, maybe that is too much ?

//cc @indualagarsamy @andreasohlund @SimonCropp 
