### PR TITLE
Do not configure logging if already configured.

### DIFF
--- a/src/NServiceBus.Core/Logging/LogManager.cs
+++ b/src/NServiceBus.Core/Logging/LogManager.cs
@@ -7,6 +7,8 @@ namespace NServiceBus.Logging
     {
         static ILoggerFactory loggerFactory = new NullLoggerFactory();
 
+        public static bool IsConfigured { get { return loggerFactory.GetType() != typeof(NullLoggerFactory); } }
+
         public static ILoggerFactory LoggerFactory
         {
             get { return loggerFactory; }

--- a/src/NServiceBus.Hosting.Windows/LoggingHandlers/IntegrationLoggingHandler.cs
+++ b/src/NServiceBus.Hosting.Windows/LoggingHandlers/IntegrationLoggingHandler.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Hosting.Windows.LoggingHandlers
 {
     using Internal;
+    using Logging;
     using Logging.Loggers.Log4NetAdapter;
     using Logging.Loggers.NLogAdapter;
 
@@ -11,6 +12,9 @@
     {
         void IConfigureLogging.Configure(IConfigureThisEndpoint specifier)
         {
+            if (LogManager.IsConfigured)
+                return;
+          
             if (Log4NetConfigurator.Log4NetExists)
                 SetLoggingLibrary.Log4Net(null, Log4NetAppenderFactory.CreateColoredConsoleAppender("Info"));
             else if (NLogConfigurator.NLogExists)

--- a/src/NServiceBus.Hosting.Windows/LoggingHandlers/LiteLoggingHandler.cs
+++ b/src/NServiceBus.Hosting.Windows/LoggingHandlers/LiteLoggingHandler.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Hosting.Windows.LoggingHandlers
 {
     using Internal;
+    using Logging;
     using Logging.Loggers.Log4NetAdapter;
     using Logging.Loggers.NLogAdapter;
 
@@ -11,6 +12,9 @@
     {
         void IConfigureLogging.Configure(IConfigureThisEndpoint specifier)
         {
+            if (LogManager.IsConfigured)
+                return;
+          
             if (Log4NetConfigurator.Log4NetExists)
                 SetLoggingLibrary.Log4Net(null, Log4NetAppenderFactory.CreateColoredConsoleAppender("Info"));
             else if (NLogConfigurator.NLogExists)

--- a/src/NServiceBus.Hosting.Windows/LoggingHandlers/ProductionLoggingHandler.cs
+++ b/src/NServiceBus.Hosting.Windows/LoggingHandlers/ProductionLoggingHandler.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Runtime.InteropServices;
     using Internal;
+    using Logging;
     using Logging.Loggers.Log4NetAdapter;
     using Logging.Loggers.NLogAdapter;
 
@@ -14,6 +15,9 @@
     {
         void IConfigureLogging.Configure(IConfigureThisEndpoint specifier)
         {
+            if (LogManager.IsConfigured)
+                return;
+
             var logToConsole = GetStdHandle(STD_OUTPUT_HANDLE) != IntPtr.Zero;
 
             if (Log4NetConfigurator.Log4NetExists)


### PR DESCRIPTION
The default logging handlers inside the host are run last. So, if you implement your own logging handler, any configuration you do will be overridden by the default.

This fix adds a check to see if any logging framework has already been configured. If yes, the default handler will do nothing.
