### PR TITLE
Update ScheduledTask.cs

### DIFF
--- a/src/NServiceBus.Core/Scheduling/ScheduledTask.cs
+++ b/src/NServiceBus.Core/Scheduling/ScheduledTask.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Scheduling
 {
     using System;
 
+    [Serializable]
     public class ScheduledTask
     {
         public ScheduledTask()
@@ -9,7 +10,7 @@ namespace NServiceBus.Scheduling
             Id = Guid.NewGuid();
         }
 
-        public Guid Id { get; private set; }
+        public Guid Id { get; set; }
         public string Name { get; set; }
         public Action Task { get; set; }
         public TimeSpan Every { get; set; }


### PR DESCRIPTION
In order to support TaskSchedulerPersistency other then to InMemoery there is a need for the ScheduledTask to be serialazable for binary formatter to be able to persist it to storage other then the build in InMemory storage
