### PR TITLE
Abort the startup if we encounter a assembly scanning error

### DIFF
--- a/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllTransports.cs
+++ b/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllTransports.cs
@@ -89,16 +89,6 @@
                 {
                     var result = new AssemblyScanner().GetScannableAssemblies();
 
-                    if (result.Errors.Any())
-                    {
-                        foreach (var errors in result.Errors)
-                        {
-                            Console.Out.WriteLine(errors);
-                        }
-
-                        throw new InvalidOperationException("Assembly scanning failed");
-                    }
-
                     assemblies = result.Assemblies;
                 }
                     

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
@@ -173,7 +173,6 @@
             public void only_files_explicitly_included_are_returned()
             {
                 Assert.That(results.Assemblies, Has.Count.EqualTo(1));
-                Assert.That(results.Errors, Has.Count.EqualTo(0));
                 Assert.That(skippedFiles, Has.Count.GreaterThan(0));
 
                 Assert.That(results.Assemblies.Single().GetName().Name, Is.EqualTo("NServiceBus.Core.Tests"));
@@ -272,7 +271,6 @@
             {
                 //TODO: change back to "Has.Count.EqualTo(1)" when we make message scanning lazy #1617"
                 Assert.That(results.Assemblies, Has.Count.EqualTo(2));
-                Assert.That(results.Errors, Has.Count.EqualTo(0));
 
                 var containsHandlers = "NServiceBus.Core.Tests"; //< assembly name, not file name
                 var assembly = results.Assemblies

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerResults.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerResults.cs
@@ -2,7 +2,6 @@
 {
     using System.Collections.Generic;
     using System.Reflection;
-    using System.Text;
 
     /// <summary>
     /// Holds GetScannableAssemblies results.
@@ -15,36 +14,10 @@
         /// </summary>
         public AssemblyScannerResults()
         {
-            Errors = new List<string>();
             Assemblies = new List<Assembly>();
             SkippedFiles = new List<SkippedFile>();
         }
-
-        /// <summary>
-        /// Format errors.
-        /// </summary>
-        public string FormattedErrors()
-        {
-            if ((Errors == null) || (Errors.Count < 1))
-            {
-                return string.Empty;
-            }
-
-            var sb = new StringBuilder();
-            
-            foreach (var error in Errors)
-            {
-                sb.Append(error);
-            }
-            
-            return sb.ToString();
-        }
-        
-        /// <summary>
-        /// List of errors that occurred while attempting to load an assembly
-        /// </summary>
-        public List<string> Errors { get; private set; }
-        
+       
         /// <summary>
         /// List of successfully found and loaded assemblies
         /// </summary>

--- a/src/NServiceBus.Hosting.Windows/EndpointTypeDeterminer.cs
+++ b/src/NServiceBus.Hosting.Windows/EndpointTypeDeterminer.cs
@@ -127,7 +127,6 @@
             var endpoints = ScanAssembliesForEndpoints().ToList();
             if (!endpoints.Any())
             {
-                Console.Out.WriteLine(assemblyScannerResults.FormattedErrors());
                 type = null;
                 return false;
             }


### PR DESCRIPTION
Since we now detect and don't even try to load non .net asm we can now blow up and stop the endpoint from starting.

We should make sure we create a good exception message telling the user:
- The assembly that failed
- The inner loader ex
- Tell them how to asm redirect
- Give them the syntax for the redirect (since we know the versions)

We also need a option to opt in to the old behaviour just to be safe. 

This also needs to work for the host (since the host passes the list of asms)
