### PR TITLE
Removed throttling / falling back to basic licensing mode when license expires

### DIFF
--- a/src/NServiceBus.Core.Tests/Unicast/Contexts/using_the_unicastbus.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/Contexts/using_the_unicastbus.cs
@@ -69,7 +69,7 @@ namespace NServiceBus.Unicast.Tests.Contexts
         {
           
             transportDefinition = new Msmq();
-            LicenseManager.Verify();
+            LicenseManager.InitializeLicense();
             HandlerInvocationCache.Clear();
 
             SettingsHolder.Reset();

--- a/src/NServiceBus.Core/Licensing/LicenseExpiredForm.resx
+++ b/src/NServiceBus.Core/Licensing/LicenseExpiredForm.resx
@@ -120,9 +120,7 @@
   <data name="richTextBox1.Text" xml:space="preserve">
     <value>Your license has expired and a new license is needed to continue.
 
-Please purchase a license online or browse for a license file.
-
-If you close this dialog NServiceBus will fall back to running in basic mode.</value>
+Please purchase a license online or browse for a license file.     </value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/src/NServiceBus.Core/Licensing/LicenseExpiredFormDisplayer.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseExpiredFormDisplayer.cs
@@ -9,7 +9,7 @@ namespace NServiceBus.Licensing
                 form.ShowDialog();
                 if (form.ResultingLicenseText == null)
                 {
-                    return LicenseDeserializer.GetBasicLicense();
+                    return null;
                 }
                 LicenseLocationConventions.StoreLicenseInRegistry(form.ResultingLicenseText);
                 return LicenseDeserializer.Deserialize(form.ResultingLicenseText);


### PR DESCRIPTION
Fixes #1991 
When a license expires, since we continue to use the trial license (expiration date), the distributor max nodes is not affected. 

@andreasohlund @SimonCropp @johnsimons - please review. 
