### PR TITLE
Remove the warning when a 4.x endpoint receives an event from a 3.x pub, when the event is an interface. 

### DIFF
--- a/src/NServiceBus.Core/Unicast/Messages/ExtractLogicalMessagesBehavior.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/ExtractLogicalMessagesBehavior.cs
@@ -77,12 +77,12 @@
                         continue;
                     }
 
-                    var metaData = MessageMetadataRegistry.GetMessageMetaData(messageTypeString);
-                    if (metaData == null)
+                    var metadata = MessageMetadataRegistry.GetMessageMetadata(messageTypeString);
+                    if (metadata == null)
                     {
                         continue;
                     }
-                    messageMetadata.Add(metaData);
+                    messageMetadata.Add(metadata);
                 }
 
                 if (messageMetadata.Count == 0 && physicalMessage.MessageIntent != MessageIntentEnum.Publish)

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -38,11 +38,11 @@
             }
             foreach (var messageTypeString in header.Split(';'))
             {
-                yield return GetMessageMetaData(messageTypeString);
+                yield return GetMessageMetadata(messageTypeString);
             }
         }
 
-        public MessageMetadata GetMessageMetaData(string messageTypeIdentifier)
+        public MessageMetadata GetMessageMetadata(string messageTypeIdentifier)
         {
             if (string.IsNullOrEmpty(messageTypeIdentifier))
             {


### PR DESCRIPTION
- Relates to #1834
- Refactored the MessageMetadataRegistry class. 
- Facilitated to remove the un-necessary warning which is displayed when a 3.x endpoint publishes an event which is an interface, where the 3.x endpoint added an __impl to the event type in the header. 
