### PR TITLE
Feature prereqs now requires a reason to enable better diagnostics

### DIFF
--- a/src/NServiceBus.Core.Tests/DataBus/When_nservicebus_is_initalizing.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_nservicebus_is_initalizing.cs
@@ -27,7 +27,7 @@ namespace NServiceBus.Core.Tests.DataBus
 
             config.Configurer.ConfigureComponent<InMemoryDataBus>(DependencyLifecycle.SingleInstance);
 
-            Assert.True(feature.ShouldBeSetup(new FeatureConfigurationContext(config)));
+            Assert.True(feature.CheckPrerequisites(new FeatureConfigurationContext(config)).IsSatisfied);
         }
 
         [Test]
@@ -43,7 +43,7 @@ namespace NServiceBus.Core.Tests.DataBus
             });
             var feature = new DataBusFeature();
 
-            Assert.False(feature.ShouldBeSetup(new FeatureConfigurationContext(config)));
+            Assert.False(feature.CheckPrerequisites(new FeatureConfigurationContext(config)).IsSatisfied);
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace NServiceBus.Core.Tests.DataBus
 
             var feature = new DataBusFeature();
 
-            Assert.Throws<InvalidOperationException>(() => feature.ShouldBeSetup(new FeatureConfigurationContext(config)));
+            Assert.Throws<InvalidOperationException>(() => feature.CheckPrerequisites(new FeatureConfigurationContext(config)));
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace NServiceBus.Core.Tests.DataBus
 
             config.Configurer.ConfigureComponent<IDataBusSerializer>(() => new MyDataBusSerializer(), DependencyLifecycle.SingleInstance);
 
-            Assert.DoesNotThrow(() => feature.ShouldBeSetup(new FeatureConfigurationContext(config)));
+            Assert.DoesNotThrow(() => feature.CheckPrerequisites(new FeatureConfigurationContext(config)));
         }
 
         class MyDataBusSerializer : IDataBusSerializer

--- a/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Core.Tests.Features
 {
     using System;
+    using System.Linq;
     using NServiceBus.Features;
     using NUnit.Framework;
     using Settings;
@@ -25,6 +26,8 @@
 
             Assert.True(featureWithTrueCondition.IsActive);
             Assert.False(featureWithFalseCondition.IsActive);
+            Assert.AreEqual("The description",
+                featureSettings.Status.Single(s => s.Name == featureWithFalseCondition.Name).PrerequisiteStatus.Reasons.First());
         }
 
         [Test]
@@ -60,7 +63,7 @@
             public MyFeatureWithTrueActivationCondition()
             {
                 EnableByDefault();
-                Prerequisite(c => true);
+                Prerequisite(c => true,"Wont be used");
             }
         }
 
@@ -69,7 +72,7 @@
             public MyFeatureWithFalseActivationCondition()
             {
                 EnableByDefault();
-                Prerequisite(c => false);
+                Prerequisite(c => false,"The description");
             }
         }
 

--- a/src/NServiceBus.Core/Audit/Audit.cs
+++ b/src/NServiceBus.Core/Audit/Audit.cs
@@ -12,12 +12,11 @@
     /// Enabled message auditing for this endpoint.
     /// </summary>
     public class Audit : Feature
-    {
-        
+    {   
         internal Audit()
         {
             EnableByDefault();
-            Prerequisite(config => GetConfiguredAuditQueue(config) != Address.Undefined);
+            Prerequisite(config => GetConfiguredAuditQueue(config) != Address.Undefined,"No configured audit queue was found");
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/DataBus/DataBusFeature.cs
+++ b/src/NServiceBus.Core/DataBus/DataBusFeature.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Features
         internal DataBusFeature()
         {
             EnableByDefault();
-            Prerequisite(DataBusPropertiesFound);
+            Prerequisite(DataBusPropertiesFound,"No databus properties was found in available messages");
             RegisterStartupTask<StorageInitializer>();
         }
 

--- a/src/NServiceBus.Core/Features/DisplayDiagnosticsForFeatures.cs
+++ b/src/NServiceBus.Core/Features/DisplayDiagnosticsForFeatures.cs
@@ -1,0 +1,61 @@
+namespace NServiceBus.Features
+{
+    using System;
+    using System.Linq;
+    using System.Text;
+    using Config;
+    using Logging;
+
+    class DisplayDiagnosticsForFeatures : IWantToRunWhenConfigurationIsComplete
+    {
+        public FeaturesReport FeaturesReport { get; set; }
+
+        public void Run(Configure config)
+        {
+            var statusText = new StringBuilder();
+
+            statusText.AppendLine("------------- FEATURES ----------------");
+
+            foreach (var diagnosticData in FeaturesReport.Features)
+            {
+                statusText.AppendLine(string.Format("Name: {0}", diagnosticData.Name));
+                statusText.AppendLine(string.Format("Version: {0}", diagnosticData.Version));
+                statusText.AppendLine(string.Format("Enabled by Default: {0}", diagnosticData.EnabledByDefault ? "Yes" : "No"));
+                statusText.AppendLine(string.Format("Status: {0}", diagnosticData.Active ? "Enabled" : "Disabled"));
+                if (!diagnosticData.Active)
+                {
+                    statusText.Append("Deactivation reason: ");
+                    if (diagnosticData.PrerequisiteStatus != null && !diagnosticData.PrerequisiteStatus.IsSatisfied)
+                    {
+                        statusText.AppendLine(string.Format("Did not fulfill its Prerequisites:"));
+
+                        foreach (var reason in diagnosticData.PrerequisiteStatus.Reasons)
+                        {
+                            statusText.AppendLine("   -"+ reason);
+                            
+                        }
+                    } 
+                    else if (!diagnosticData.DependenciesAreMeet)
+                    {
+                        statusText.AppendLine(string.Format("Did not meet one of the dependencies: {0}", String.Join(",", diagnosticData.Dependencies.Select(t => "[" + String.Join(",", t.Select(t1 => t1)) + "]"))));
+                    }
+                    else
+                    {
+                        statusText.AppendLine("Not explicitly enabled");            
+                    }
+                }
+                else
+                {
+                    statusText.AppendLine(string.Format("Dependencies: {0}", diagnosticData.Dependencies.Count == 0 ? "None" : String.Join(",", diagnosticData.Dependencies.Select(t => "[" + String.Join(",", t.Select(t1 => t1)) + "]"))));
+                    statusText.AppendLine(string.Format("Startup Tasks: {0}", diagnosticData.StartupTasks.Count == 0 ? "None" : String.Join(",", diagnosticData.StartupTasks.Select(t => t.Name))));
+                }
+
+                statusText.AppendLine();
+            }
+
+            Logger.Info(statusText.ToString());
+        }
+
+        static ILog Logger = LogManager.GetLogger<DisplayDiagnosticsForFeatures>();
+    }
+}

--- a/src/NServiceBus.Core/Features/Feature.cs
+++ b/src/NServiceBus.Core/Features/Feature.cs
@@ -89,9 +89,19 @@
         ///     Prerequisites are only evaluated if the feature is enabled
         /// </summary>
         /// <param name="condition">Condition that must be met in order for this feature to be activated</param>
-        protected void Prerequisite(Func<FeatureConfigurationContext, bool> condition)
+        /// <param name="description">Explanation of what this prerequisite checks</param>
+        protected void Prerequisite(Func<FeatureConfigurationContext, bool> condition,string description)
         {
-            setupPrerequisites.Add(condition);
+            if (string.IsNullOrEmpty(description))
+            {
+                throw new ArgumentException("Description can't be empty", "description");
+            }
+
+            setupPrerequisites.Add(new SetupPrerequisite
+            {
+                Condition = condition,
+                Description = description
+            });
         }
 
         /// <summary>
@@ -171,11 +181,20 @@
             return string.Format("{0} [{1}]", Name, Version);
         }
 
-        internal bool ShouldBeSetup(FeatureConfigurationContext config)
+        internal PrerequisiteStatus CheckPrerequisites(FeatureConfigurationContext context)
         {
-            return setupPrerequisites.All(condition => condition(config));
-        }
+            var status = new PrerequisiteStatus();
 
+            foreach (var prerequisite in setupPrerequisites)
+            {
+                if (!prerequisite.Condition(context))
+                {
+                    status.ReportFailure(prerequisite.Description);
+                }
+            }
+
+            return status;
+        }
 
         internal void SetupFeature(FeatureConfigurationContext config)
         {
@@ -209,8 +228,14 @@
         bool isActive;
         bool isEnabledByDefault;
         string name;
-        List<Func<FeatureConfigurationContext, bool>> setupPrerequisites = new List<Func<FeatureConfigurationContext, bool>>();
+        List<SetupPrerequisite> setupPrerequisites = new List<SetupPrerequisite>();
         List<Type> startupTasks = new List<Type>();
         List<Action<SettingsHolder>> defaults = new List<Action<SettingsHolder>>();
+
+        class SetupPrerequisite
+        {
+            public string Description;
+            public Func<FeatureConfigurationContext, bool> Condition;
+        }
     }
 }

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -3,9 +3,6 @@ namespace NServiceBus.Features
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text;
-    using Config;
-    using Logging;
     using ObjectBuilder;
     using Settings;
 
@@ -51,9 +48,9 @@ namespace NServiceBus.Features
         public bool Active { get; internal set; }
         
         /// <summary>
-        /// Gets whether all prerequisites are fulfilled for this <see cref="Feature"/>.
+        /// Gets the status of the prerequisites for this <see cref="Feature"/>.
         /// </summary>
-        public bool PrerequisitesFulfilled { get; internal set; }
+        public PrerequisiteStatus PrerequisiteStatus { get; internal set; }
         
         /// <summary>
         /// Gets the list of <see cref="Feature"/>s that this <see cref="Feature"/> depends on.
@@ -76,47 +73,6 @@ namespace NServiceBus.Features
         public bool DependenciesAreMeet { get; set; }
     }
 
-    class DisplayDiagnosticsForFeatures : IWantToRunWhenConfigurationIsComplete
-    {
-        public FeaturesReport FeaturesReport { get; set; }
-        static ILog Logger = LogManager.GetLogger<DisplayDiagnosticsForFeatures>();
-        public void Run(Configure config)
-        {
-            var statusText = new StringBuilder();
-
-            statusText.AppendLine("------------- FEATURES ----------------");
-
-            foreach (var diagnosticData in FeaturesReport.Features)
-            {
-                statusText.AppendLine(string.Format("Name: {0}", diagnosticData.Name));
-                statusText.AppendLine(string.Format("Version: {0}", diagnosticData.Version));
-                statusText.AppendLine(string.Format("Enabled by Default: {0}", diagnosticData.EnabledByDefault ? "Yes" : "No"));
-                statusText.AppendLine(string.Format("Status: {0}", diagnosticData.Active ? "Enabled" : "Disabled"));
-                if (!diagnosticData.Active)
-                {
-                    statusText.Append("Deactivation reason: ");
-                    if (!diagnosticData.PrerequisitesFulfilled)
-                    {
-                        statusText.AppendLine(string.Format("Did not fulfill one of the Prerequisites"));
-                    } 
-                    else if (!diagnosticData.DependenciesAreMeet)
-                    {
-                        statusText.AppendLine(string.Format("Did not meet one of the dependencies: {0}", String.Join(",", diagnosticData.Dependencies.Select(t => "[" + String.Join(",", t.Select(t1 => t1)) + "]"))));
-                    }
-                }
-                else
-                {
-                    statusText.AppendLine(string.Format("Dependencies: {0}", diagnosticData.Dependencies.Count == 0 ? "None" : String.Join(",", diagnosticData.Dependencies.Select(t => "[" + String.Join(",", t.Select(t1 => t1)) + "]"))));
-                    statusText.AppendLine(string.Format("Startup Tasks: {0}", diagnosticData.StartupTasks.Count == 0 ? "None" : String.Join(",", diagnosticData.StartupTasks.Select(t => t.Name))));
-                }
-
-                statusText.AppendLine();
-            }
-
-            Logger.Info(statusText.ToString());
-        }
-    }
-
     class FeatureActivator
     {
         public FeatureActivator(SettingsHolder settings)
@@ -136,7 +92,7 @@ namespace NServiceBus.Features
                 defaultSetting(settings);
             }
 
-            features.Add(Tuple.Create(feature, new FeatureDiagnosticData
+            features.Add(new FeatureState(feature, new FeatureDiagnosticData
             {
                 EnabledByDefault = feature.IsEnabledByDefault,
                 Name = feature.Name,
@@ -148,7 +104,8 @@ namespace NServiceBus.Features
 
         public void SetupFeatures(FeatureConfigurationContext context)
         {
-            var featuresToActivate = features.Where(f => IsEnabled(f.Item1.GetType()) && (f.Item2.PrerequisitesFulfilled = MeetsActivationCondition(f.Item1, context)))
+            var featuresToActivate = features.Where(featureState => IsEnabled(featureState.Feature.GetType()) && 
+                MeetsActivationCondition(featureState.Feature,featureState.Diagnostics, context))
                 .ToList();
 
             foreach (var feature in featuresToActivate)
@@ -156,14 +113,14 @@ namespace NServiceBus.Features
                 ActivateFeature(feature, featuresToActivate, context);
             }
 
-            context.Container.RegisterSingleton<FeaturesReport>(new FeaturesReport(features.Select(t=>t.Item2)));
+            context.Container.RegisterSingleton<FeaturesReport>(new FeaturesReport(features.Select(t=>t.Diagnostics)));
         }
 
         public void RegisterStartupTasks(IConfigureComponents container)
         {
-            foreach (var feature in features.Where(f => f.Item1.IsActive))
+            foreach (var feature in features.Where(f => f.Feature.IsActive))
             {
-                foreach (var taskType in feature.Item1.StartupTasks)
+                foreach (var taskType in feature.Feature.StartupTasks)
                 {
                     container.ConfigureComponent(taskType, DependencyLifecycle.SingleInstance);
                 }
@@ -172,9 +129,9 @@ namespace NServiceBus.Features
 
         public void StartFeatures(IBuilder builder)
         {
-            foreach (var feature in features.Where(f => f.Item1.IsActive))
+            foreach (var feature in features.Where(f => f.Feature.IsActive))
             {
-                foreach (var taskType in feature.Item1.StartupTasks)
+                foreach (var taskType in feature.Feature.StartupTasks)
                 {
                     var task = (FeatureStartupTask)builder.Build(taskType);
 
@@ -183,19 +140,19 @@ namespace NServiceBus.Features
             }
         }
 
-        static bool ActivateFeature(Tuple<Feature, FeatureDiagnosticData> feature, List<Tuple<Feature, FeatureDiagnosticData>> featuresToActivate, FeatureConfigurationContext context)
+        static bool ActivateFeature(FeatureState feature, List<FeatureState> featuresToActivate, FeatureConfigurationContext context)
         {
-            if (feature.Item1.IsActive)
+            if (feature.Feature.IsActive)
             {
                 return true;
             }
 
             Func<List<string>, bool> dependencyActivator = dependencies =>
                                  {
-                                     var dependantFeaturesToActivate = new List<Tuple<Feature, FeatureDiagnosticData>>();
+                                     var dependantFeaturesToActivate = new List<FeatureState>();
 
                                      foreach (var dependency in dependencies.Select(dependencyName => featuresToActivate
-                                         .SingleOrDefault(f => f.Item1.Name == dependencyName))
+                                         .SingleOrDefault(f => f.Feature.Name == dependencyName))
                                          .Where(dependency => dependency != null))
                                      {
                                          dependantFeaturesToActivate.Add(dependency);
@@ -205,16 +162,16 @@ namespace NServiceBus.Features
                                      return hasAllUpstreamDepsBeenActivated;
                                  };
 
-            if (feature.Item1.Dependencies.All(dependencyActivator))
+            if (feature.Feature.Dependencies.All(dependencyActivator))
             {
-                feature.Item1.SetupFeature(context);
-                feature.Item2.Active = true;
-                feature.Item2.DependenciesAreMeet = true;
+                feature.Feature.SetupFeature(context);
+                feature.Diagnostics.Active = true;
+                feature.Diagnostics.DependenciesAreMeet = true;
 
                 return true;
             }
 
-            feature.Item2.DependenciesAreMeet = false;
+            feature.Diagnostics.DependenciesAreMeet = false;
 
             return false;
         }
@@ -224,18 +181,35 @@ namespace NServiceBus.Features
             return settings.GetOrDefault<bool>(featureType.FullName);
         }
 
-        bool MeetsActivationCondition(Feature feature, FeatureConfigurationContext context)
+        bool MeetsActivationCondition(Feature feature,FeatureDiagnosticData diagnosticData, FeatureConfigurationContext context)
         {
-            if (!feature.ShouldBeSetup(context))
-            {
-                return false;
-            }
+            diagnosticData.PrerequisiteStatus = feature.CheckPrerequisites(context);
 
-            return true;
+            return diagnosticData.PrerequisiteStatus.IsSatisfied;
+        }
+
+        internal List<FeatureDiagnosticData> Status
+        {
+            get
+            {
+                return features.Select(f=>f.Diagnostics).ToList();
+            }
         }
 
         readonly SettingsHolder settings;
-        readonly List<Tuple<Feature, FeatureDiagnosticData>> features = new List<Tuple<Feature, FeatureDiagnosticData>>();
+        readonly List<FeatureState> features = new List<FeatureState>();
+
+        class FeatureState
+        {
+            public FeatureState(Feature feature,FeatureDiagnosticData diagnostics)
+            {
+                Diagnostics = diagnostics;
+                Feature = feature;
+            }
+
+            public FeatureDiagnosticData Diagnostics { get; private set; }
+            public Feature Feature { get; private set; }
+        }
 
         class Runner : IWantToRunWhenBusStartsAndStops
         {

--- a/src/NServiceBus.Core/Features/PrerequisiteStatus.cs
+++ b/src/NServiceBus.Core/Features/PrerequisiteStatus.cs
@@ -1,0 +1,23 @@
+namespace NServiceBus.Features
+{
+    using System.Collections.Generic;
+
+    public class PrerequisiteStatus
+    {
+        public PrerequisiteStatus()
+        {
+            Reasons = new List<string>();
+            IsSatisfied = true;
+        }
+
+        public bool IsSatisfied { get; private set; }
+
+        public List<string> Reasons { get; private set; }
+
+        internal void ReportFailure(string description)
+        {
+            IsSatisfied = false;
+            Reasons.Add(description);
+        }
+    }
+}

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -84,6 +84,8 @@
     <Compile Include="ConfigurationBuilder.cs" />
     <Compile Include="Container\ContainerCustomizations.cs" />
     <Compile Include="Container\ContainerDefinition.cs" />
+    <Compile Include="Features\DisplayDiagnosticsForFeatures.cs" />
+    <Compile Include="Features\PrerequisiteStatus.cs" />
     <Compile Include="Gateway\IDeduplicateMessages.cs" />
     <Compile Include="Installation\InstallationSupport.cs" />
     <Compile Include="Installation\InstallConfigExtensions.cs" />

--- a/src/NServiceBus.Core/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Outbox/Outbox.cs
@@ -19,7 +19,7 @@
         {
             Defaults(s => s.SetDefault(TimeToKeepDeduplicationEntries, TimeSpan.FromDays(5)));
 
-            Prerequisite(c => c.Settings.Get<bool>("Transactions.Enabled"));
+            Prerequisite(c => c.Settings.Get<bool>("Transactions.Enabled"),"Outbox isn't needed since the receive transactions has been turned off");
 
             Prerequisite(c =>
             {
@@ -29,10 +29,9 @@
                 }
 
                 return RequireOutboxConsent(c);
-            });
+            },"This transport requires outbox consent");
 
             RegisterStartupTask<DtcRunningWarning>();
-
         }
 
         static bool RequireOutboxConsent(FeatureConfigurationContext context)

--- a/src/NServiceBus.Core/Sagas/Sagas.cs
+++ b/src/NServiceBus.Core/Sagas/Sagas.cs
@@ -25,7 +25,7 @@
                 s.Get<Conventions>().AddSystemMessagesConventions(t => IsTypeATimeoutHandledByAnySaga(t, sagas));
             });
 
-            Prerequisite(config => config.Settings.GetAvailableTypes().Any(IsSagaType));
+            Prerequisite(config => config.Settings.GetAvailableTypes().Any(IsSagaType), "No sagas was found in scabbed types");
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/SecondLevelRetries/SecondLevelRetries.cs
+++ b/src/NServiceBus.Core/SecondLevelRetries/SecondLevelRetries.cs
@@ -13,17 +13,15 @@ namespace NServiceBus.Features
         internal SecondLevelRetries()
         {
             EnableByDefault();
-            Prerequisite(ShouldRun);
-        }
-
-        bool ShouldRun(FeatureConfigurationContext context)
-        {
+           
             // if we're not using the Fault Forwarder, we should act as if SLR is disabled
             //this will change when we make SLR a first class citizen
-            if (!context.Container.HasComponent<FaultManager>())
-            {
-                return false;
-            }
+            Prerequisite(c => c.Container.HasComponent<FaultManager>(), "A custom faultmanager was defined");
+            Prerequisite(IsEnabledInConfig, "SLR was disabled in config");
+        }
+
+        bool IsEnabledInConfig(FeatureConfigurationContext context)
+        {
             var retriesConfig = context.Settings.GetConfigSection<SecondLevelRetriesConfig>();
 
             if (retriesConfig == null)

--- a/src/NServiceBus.Core/Timeout/TimeoutManager.cs
+++ b/src/NServiceBus.Core/Timeout/TimeoutManager.cs
@@ -13,15 +13,12 @@
         internal TimeoutManager()
         {
             DependsOn<TimeoutManagerBasedDeferral>();
+           
+            Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"),"Send only endpoints can't use the timeoutmanager since it requires receive capabilities");
             
-            //send only endpoints doesn't need a a timeout manager
-            Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"));
-            
-            //if we have a master node configured we should use the Master Node timeout manager instead
-            Prerequisite(context => !context.Settings.GetOrDefault<bool>("Distributor.Enabled"));
+            Prerequisite(context => !context.Settings.GetOrDefault<bool>("Distributor.Enabled"),"This endpoint is a worker and will be using the timeoutmanager running at its masternode instead");
 
-            //if the user has specified another TM we don't need to run our own
-            Prerequisite(context => !HasAlternateTimeoutManagerBeenConfigured(context.Settings));
+            Prerequisite(context => !HasAlternateTimeoutManagerBeenConfigured(context.Settings),"A user configured timeoutmanager address has been found and this endpoint will send timeouts to that endpoint");
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Unicast/Behaviors/ForwardBehavior.cs
+++ b/src/NServiceBus.Core/Unicast/Behaviors/ForwardBehavior.cs
@@ -12,9 +12,8 @@
     {
         public ForwardReceivedMessages()
         {
-           // Only enable if the configuration is defined in UnicastBus
-            Prerequisite(config => GetConfiguredForwardMessageQueue(config) != Address.Undefined);
-
+            // Only enable if the configuration is defined in UnicastBus
+            Prerequisite(config => GetConfiguredForwardMessageQueue(config) != Address.Undefined,"No forwarding address was defined in the unicastbus config");
         }
 
         protected override void Setup(FeatureConfigurationContext context)
@@ -31,7 +30,6 @@
             context.Container.ConfigureComponent<ForwardBehavior>(DependencyLifecycle.InstancePerCall)
                 .ConfigureProperty(p => p.ForwardReceivedMessagesTo, forwardReceivedMessagesQueue)
                 .ConfigureProperty(p => p.TimeToBeReceivedOnForwardedMessages, timeToBeReceived);
-
         }
 
         TimeSpan? GetConfiguredTimeToBeReceivedValue(FeatureConfigurationContext context)
@@ -52,9 +50,7 @@
             }
             return Address.Undefined;
         }
-
     }
-
 
     class ForwardBehavior : IBehavior<IncomingContext>
     {
@@ -72,7 +68,7 @@
             {
                 TimeToBeReceived = TimeToBeReceivedOnForwardedMessages
             }, context.PhysicalMessage);
-            
+
         }
 
         public class Registration : RegisterStep


### PR DESCRIPTION
Makes sure we're specifying a description for prereqs so that we can show it when it's not fullfilled
