### PR TITLE
Fixes #2133: Stop losing timeouts

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -253,6 +253,7 @@
     <Compile Include="Serializers\XML\SomeEnum.cs" />
     <Compile Include="Serializers\XML\Using_Infer_Type_With_Non_Nested_Class.cs" />
     <Compile Include="Timeout\FakeMessageSender.cs" />
+    <Compile Include="Timeout\RavenTimeoutPersisterTests.cs" />
     <Compile Include="Timeout\When_fetching_timeouts_from_storage.cs" />
     <Compile Include="Timeout\When_pooling_timeouts.cs" />
     <Compile Include="Timeout\When_receiving_timeouts.cs" />

--- a/src/NServiceBus.Core.Tests/Timeout/RavenTimeoutPersisterTests.cs
+++ b/src/NServiceBus.Core.Tests/Timeout/RavenTimeoutPersisterTests.cs
@@ -1,0 +1,260 @@
+﻿namespace NServiceBus.Core.Tests.Timeout
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using NServiceBus.Persistence.Raven;
+    using NServiceBus.Persistence.Raven.TimeoutPersister;
+    using NServiceBus.Timeout.Core;
+    using NUnit.Framework;
+    using Raven.Client;
+    using Raven.Client.Document;
+
+    [TestFixture]
+    public class RavenTimeoutPersisterTests
+    {
+        [TestCase, Repeat(200)]
+        public void Should_not_skip_timeouts()
+        {
+            var db = Guid.NewGuid().ToString();
+            documentStore = new DocumentStore
+            {
+                Url = "http://localhost:8080",
+                DefaultDatabase = db,
+            }.Initialize();
+            persister = new RavenTimeoutPersistence(new StoreAccessor(documentStore))
+            {
+                TriggerCleanupEvery = TimeSpan.FromHours(1), // Make sure cleanup doesn't run automatically
+            };
+
+            var startSlice = DateTime.UtcNow.AddYears(-10);
+            // avoid cleanup from running during the test by making it register as being run
+            Assert.AreEqual(0, persister.GetCleanupChunk(startSlice).Count());
+
+            var expected = new List<Tuple<string, DateTime>>();
+            var lastExpectedTimeout = DateTime.UtcNow;
+            var finishedAdding = false;
+
+            new Thread(() =>
+                       {
+                           var sagaId = Guid.NewGuid();
+                           for (var i = 0; i < 10000; i++)
+                           {
+                               var td = new TimeoutData
+                                        {
+                                            SagaId = sagaId,
+                                            Destination = new Address("queue", "machine"),
+                                            Time = DateTime.UtcNow.AddSeconds(RandomProvider.GetThreadRandom().Next(5, 20)),
+                                            OwningTimeoutManager = string.Empty,
+                                        };
+                               persister.Add(td);
+                               expected.Add(new Tuple<string, DateTime>(td.Id, td.Time));
+                               lastExpectedTimeout = (td.Time > lastExpectedTimeout) ? td.Time : lastExpectedTimeout;
+                           }
+                           finishedAdding = true;
+                           Console.WriteLine("*** Finished adding ***");
+                       }).Start();
+
+            // Mimic the behavior of the TimeoutPersister coordinator
+            var found = 0;
+            TimeoutData tempTd;
+            while (!finishedAdding || startSlice < lastExpectedTimeout)
+            {
+                DateTime nextRetrieval;
+                var timeoutDatas = persister.GetNextChunk(startSlice, out nextRetrieval);
+                foreach (var timeoutData in timeoutDatas)
+                {
+                    if (startSlice < timeoutData.Item2)
+                    {
+                        startSlice = timeoutData.Item2;
+                    }
+
+                    Assert.IsTrue(persister.TryRemove(timeoutData.Item1, out tempTd));
+                    found++;
+                }
+            }
+
+            WaitForIndexing(documentStore);
+
+            // If the persister reports stale results have been seen at one point during its normal operation,
+            // we need to perform manual cleaup.
+            while (true)
+            {
+                var chunkToCleanup = persister.GetCleanupChunk(DateTime.UtcNow.AddDays(1)).ToArray();
+                Console.WriteLine("Cleanup: got a chunk of size " + chunkToCleanup.Length);
+                if (chunkToCleanup.Length == 0) break;
+
+                found += chunkToCleanup.Length;
+                foreach (var tuple in chunkToCleanup)
+                {
+                    Assert.IsTrue(persister.TryRemove(tuple.Item1, out tempTd));
+                }
+
+                WaitForIndexing(documentStore);
+            }
+
+            using (var session = documentStore.OpenSession())
+            {
+                var results = session.Query<TimeoutData>().ToList();
+                Assert.AreEqual(0, results.Count);
+            }
+
+            Assert.AreEqual(expected.Count, found);
+        }
+
+        [TestCase, Repeat(200)]
+        public void Should_not_skip_timeouts_also_with_multiple_clients_adding_timeouts()
+        {
+            var db = Guid.NewGuid().ToString();
+            documentStore = new DocumentStore
+            {
+                Url = "http://localhost:8080",
+                DefaultDatabase = db,
+            }.Initialize();
+            persister = new RavenTimeoutPersistence(new StoreAccessor(documentStore))
+            {
+                TriggerCleanupEvery = TimeSpan.FromDays(1), // Make sure cleanup doesn't run automatically
+            };
+
+            var startSlice = DateTime.UtcNow.AddYears(-10);
+            // avoid cleanup from running during the test by making it register as being run
+            Assert.AreEqual(0, persister.GetCleanupChunk(startSlice).Count());
+
+            const int insertsPerThread = 10000;
+            var expected1 = new List<Tuple<string, DateTime>>();
+            var expected2 = new List<Tuple<string, DateTime>>();
+            var lastExpectedTimeout = DateTime.UtcNow;
+            var finishedAdding1 = false;
+            var finishedAdding2 = false;
+
+            new Thread(() =>
+            {
+                var sagaId = Guid.NewGuid();
+                for (var i = 0; i < insertsPerThread; i++)
+                {
+                    var td = new TimeoutData
+                    {
+                        SagaId = sagaId,
+                        Destination = new Address("queue", "machine"),
+                        Time = DateTime.UtcNow.AddSeconds(RandomProvider.GetThreadRandom().Next(1, 20)),
+                        OwningTimeoutManager = string.Empty,
+                    };
+                    persister.Add(td);
+                    expected1.Add(new Tuple<string, DateTime>(td.Id, td.Time));
+                    lastExpectedTimeout = (td.Time > lastExpectedTimeout) ? td.Time : lastExpectedTimeout;
+                }
+                finishedAdding1 = true;
+                Console.WriteLine("*** Finished adding ***");
+            }).Start();
+
+            new Thread(() =>
+            {
+                using (var store = new DocumentStore
+                {
+                    Url = "http://localhost:8080",
+                    DefaultDatabase = db,
+                }.Initialize())
+                {
+                    var persister2 = new RavenTimeoutPersistence(new StoreAccessor(store));
+
+                    var sagaId = Guid.NewGuid();
+                    for (var i = 0; i < insertsPerThread; i++)
+                    {
+                        var td = new TimeoutData
+                        {
+                            SagaId = sagaId,
+                            Destination = new Address("queue", "machine"),
+                            Time = DateTime.UtcNow.AddSeconds(RandomProvider.GetThreadRandom().Next(1, 20)),
+                            OwningTimeoutManager = string.Empty,
+                        };
+                        persister2.Add(td);
+                        expected2.Add(new Tuple<string, DateTime>(td.Id, td.Time));
+                        lastExpectedTimeout = (td.Time > lastExpectedTimeout) ? td.Time : lastExpectedTimeout;
+                    }
+                }
+                finishedAdding2 = true;
+                Console.WriteLine("*** Finished adding via a second client connection ***");
+            }).Start();
+
+            // Mimic the behavior of the TimeoutPersister coordinator
+            var found = 0;
+            TimeoutData tempTd;
+            while (!finishedAdding1 || !finishedAdding2 || startSlice < lastExpectedTimeout)
+            {
+                DateTime nextRetrieval;
+                var timeoutDatas = persister.GetNextChunk(startSlice, out nextRetrieval);
+                foreach (var timeoutData in timeoutDatas)
+                {
+                    if (startSlice < timeoutData.Item2)
+                    {
+                        startSlice = timeoutData.Item2;
+                    }
+
+                    Assert.IsTrue(persister.TryRemove(timeoutData.Item1, out tempTd)); // Raven returns duplicates, so we can't assert on this here
+                    found++;
+                }
+            }
+
+            WaitForIndexing(documentStore);
+
+            // If the persister reports stale results have been seen at one point during its normal operation,
+            // we need to perform manual cleaup.
+            while (true)
+            {
+                var chunkToCleanup = persister.GetCleanupChunk(DateTime.UtcNow.AddDays(1)).ToArray();
+                Console.WriteLine("Cleanup: got a chunk of size " + chunkToCleanup.Length);
+                if (chunkToCleanup.Length == 0) break;
+
+                found += chunkToCleanup.Length;
+                foreach (var tuple in chunkToCleanup)
+                {
+                    Assert.IsTrue(persister.TryRemove(tuple.Item1, out tempTd));
+                }
+
+                WaitForIndexing(documentStore);
+            }
+
+            using (var session = documentStore.OpenSession())
+            {
+                var results = session.Query<TimeoutData>().ToList();
+                Assert.AreEqual(0, results.Count);
+            }
+
+            Assert.AreEqual(expected1.Count + expected2.Count, found);
+        }
+
+        IDocumentStore documentStore;
+        RavenTimeoutPersistence persister;
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (documentStore != null)
+                documentStore.Dispose();
+        }
+
+        static void WaitForIndexing(IDocumentStore store, string db = null, TimeSpan? timeout = null)
+        {
+            var databaseCommands = store.DatabaseCommands;
+            if (db != null)
+                databaseCommands = databaseCommands.ForDatabase(db);
+            var spinUntil = SpinWait.SpinUntil(() => databaseCommands.GetStatistics().StaleIndexes.Length == 0, timeout ?? TimeSpan.FromSeconds(20));
+            Assert.True(spinUntil);
+        }
+
+        static class RandomProvider
+        {
+            private static int seed = Environment.TickCount;
+
+            private static ThreadLocal<Random> randomWrapper = new ThreadLocal<Random>(() =>
+                new Random(Interlocked.Increment(ref seed))
+            );
+
+            public static Random GetThreadRandom()
+            {
+                return randomWrapper.Value;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Persistence/Raven/TimeoutPersister/RavenTimeoutPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/Raven/TimeoutPersister/RavenTimeoutPersistence.cs
@@ -14,9 +14,47 @@ namespace NServiceBus.Persistence.Raven.TimeoutPersister
     {
         readonly IDocumentStore store;
 
-        public RavenTimeoutPersistence(StoreAccessor  storeAccessor)
+        public TimeSpan CleanupGapFromTimeslice { get; set; }
+        public TimeSpan TriggerCleanupEvery { get; set; }
+        DateTime lastCleanupTime = DateTime.MinValue;
+
+        public RavenTimeoutPersistence(StoreAccessor storeAccessor)
         {
             store = storeAccessor.Store;
+            TriggerCleanupEvery = TimeSpan.FromMinutes(2);
+            CleanupGapFromTimeslice = TimeSpan.FromMinutes(1);
+        }
+
+        private static IRavenQueryable<TimeoutData> GetChunkQuery(IDocumentSession session)
+        {
+            session.Advanced.AllowNonAuthoritativeInformation = true;
+            return session.Query<TimeoutData>()
+                .OrderBy(t => t.Time)
+                .Where(
+                    t =>
+                        t.OwningTimeoutManager == String.Empty ||
+                        t.OwningTimeoutManager == Configure.EndpointName);
+        }
+
+        public IEnumerable<Tuple<string, DateTime>> GetCleanupChunk(DateTime startSlice)
+        {
+            using (var session = OpenSession())
+            {
+                var chunk = GetChunkQuery(session)
+                    .Where(t => t.Time <= startSlice.Subtract(CleanupGapFromTimeslice))
+                    .Select(t => new
+                    {
+                        t.Id,
+                        t.Time
+                    })
+                    .Take(1024)
+                    .ToList()
+                    .Select(arg => new Tuple<string, DateTime>(arg.Id, arg.Time));
+
+                lastCleanupTime = DateTime.UtcNow;
+
+                return chunk;
+            }
         }
 
         public List<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
@@ -24,70 +62,46 @@ namespace NServiceBus.Persistence.Raven.TimeoutPersister
             try
             {
                 var now = DateTime.UtcNow;
-                var skip = 0;
                 var results = new List<Tuple<string, DateTime>>();
-                var numberOfRequestsExecutedSoFar = 0;
+
+                // Allow for occasionally cleaning up old timeouts for edge cases where timeouts have been
+                // added after startSlice have been set to a later timout and we might have missed them
+                // because of stale indexes.
+                if (lastCleanupTime.Add(TriggerCleanupEvery) > now || lastCleanupTime == DateTime.MinValue)
+                {                    
+                    results.AddRange(GetCleanupChunk(startSlice));
+                }
+
                 RavenQueryStatistics stats;
-
-                do
-                {
-                    using (var session = OpenSession())
-                    {
-                        session.Advanced.AllowNonAuthoritativeInformation = true;
-
-                        var query = session.Query<TimeoutData>()
-                            .Where(
-                                t =>
-                                    t.OwningTimeoutManager == String.Empty ||
-                                    t.OwningTimeoutManager == Configure.EndpointName)
-                            .Where(
-                                t => 
-                                    t.Time > startSlice && 
-                                    t.Time <= now)
-                            .OrderBy(t => t.Time)
-                            .Select(t => new {t.Id, t.Time})
-                            .Statistics(out stats);
-                        do
-                        {
-                            results.AddRange(query
-                                                 .Skip(skip)
-                                                 .Take(1024)
-                                                 .ToList()
-                                                 .Select(arg => new Tuple<string, DateTime>(arg.Id, arg.Time)));
-
-                            skip += 1024;
-                        } while (skip < stats.TotalResults &&
-                                 ++numberOfRequestsExecutedSoFar < session.Advanced.MaxNumberOfRequestsPerSession);
-                    }
-                } while (skip < stats.TotalResults);
-
                 using (var session = OpenSession())
                 {
-                    session.Advanced.AllowNonAuthoritativeInformation = true;
+                    var query = GetChunkQuery(session)
+                        .Where(t => t.Time > startSlice && t.Time <= now)
+                        .Statistics(out stats)
+                        .Select(t => new
+                        {
+                            t.Id,
+                            t.Time
+                        })
+                        .Take(1024);
 
-                    //Retrieve next time we need to run query
-                    var startOfNextChunk =
-                        session.Query<TimeoutData>()
-                            .Where(
-                                t =>
-                                t.OwningTimeoutManager == String.Empty ||
-                                t.OwningTimeoutManager == Configure.EndpointName)
-                            .Where(t => t.Time > now)
-                            .OrderBy(t => t.Time)
-                            .Select(t => new {t.Id, t.Time})
-                            .FirstOrDefault();
-
-                    if (startOfNextChunk != null)
-                    {
-                        nextTimeToRunQuery = startOfNextChunk.Time;
-                    }
-                    else
-                    {
-                        nextTimeToRunQuery = DateTime.UtcNow.AddMinutes(10);
-                    }
-
-                    return results;
+                    results.AddRange(query.ToList()
+                        .Select(arg => new Tuple<string, DateTime>(arg.Id, arg.Time))
+                        );
                 }
+
+                // Set next execution to be now if we haven't consumed the entire thing or received stale results.
+                // Delay the next execution a bit if we results weren't stale and we got the full chunk.
+                if (stats.TotalResults > 1024 || stats.IsStale)
+                {
+                    nextTimeToRunQuery = now;
+                }
+                else
+                {
+                    nextTimeToRunQuery = DateTime.UtcNow.AddMinutes(10);
+                }
+
+                return results;
             }
             catch (WebException ex)
             {
@@ -113,9 +127,6 @@ namespace NServiceBus.Persistence.Raven.TimeoutPersister
 
                 if (timeoutData == null)
                     return false;
-
-                timeoutData.Time = DateTime.UtcNow.AddYears(-1);
-                session.SaveChanges();
 
                 session.Delete(timeoutData);
                 session.SaveChanges();


### PR DESCRIPTION
Simplify querying for timeouts, and introduce cleaning-up abilities to guarantee we don't skip any timeouts
1. One simple query is getting executed with a 1024 page size and with a projection to make sure we minimize traffic while still getting one stable, sorted page of results
2. nextTimeToRunQuery is only used to control subsequent executions. So we set it to immediate if we know the page of results is not the last one (we have more than 1024 results, or the results were stale). When new messages come in this wait time is invalidated and query is run again (and again, until results are not stale or we found no results at all).
3. We don't care about duplicates since TryRemove is getting called by the dispatcher later, and it does a lookup by ID. This provides us the deduplication that we need.
4. While this simple query, without paging, should provide assurance that no timeouts are being skipped while querying, in some rare edge cases this can still happen. We can either change `TimeoutPersisterReceiver` to take Eventually Consistent stores into account and invalidate the startSlice when needed, or have each individual such store take this up upon itself. For this PR we chose the latter, and use periodical cleanup process to make sure no timeouts are missed in the long run.

The defaults I wired to the gap and timing auto-props may require a bit more thinking, but overall I'm happy with this change now.

Also pending thorough discussion on timeouts SLA - do we rather fire timeouts late than miss firing any (taking into account the previous implementation was firing missed timeouts after a restart).

/cc @andreasohlund @SimonCropp @johnsimons @udidahan @dannycohen 
