### PR TITLE
Make sure MsmqWorkerAvailabilityManager is thread safe on .NET 4 in NSB 3.3.9

### DIFF
--- a/src/distributor/NServiceBus.Distributor.MsmqWorkerAvailabilityManager/MsmqWorkerAvailabilityManager.cs
+++ b/src/distributor/NServiceBus.Distributor.MsmqWorkerAvailabilityManager/MsmqWorkerAvailabilityManager.cs
@@ -1,4 +1,4 @@
-using System;
+using System;   
 using NServiceBus.Unicast.Distributor;
 using System.Messaging;
 using NServiceBus.Utils;
@@ -46,15 +46,15 @@ namespace NServiceBus.Distributor.MsmqWorkerAvailabilityManager
         {
             try
             {
-                lock(lockobject)
-                {
-                    var m = storageQueue.Receive(TimeSpan.Zero, MessageQueueTransactionType.Automatic);
-
-                    if(m == null)
-                        return null;
-
-                    return MsmqUtilities.GetIndependentAddressForQueue(m.ResponseQueue);
-                }
+                Message m;
+                lock (lockobject)
+                    m = storageQueue.Receive(TimeSpan.Zero, MessageQueueTransactionType.Automatic);
+                
+                if(m == null)
+                    return null;
+                
+                return MsmqUtilities.GetIndependentAddressForQueue(m.ResponseQueue);
+                
             }
             catch(Exception)
             {
@@ -69,13 +69,10 @@ namespace NServiceBus.Distributor.MsmqWorkerAvailabilityManager
         {
             var path = MsmqUtilities.GetFullPath(StorageQueueAddress);
 
-            lock(lockobject)
-            {
-                storageQueue = new MessageQueue(path);
-
-                if(!storageQueue.Transactional)
+            storageQueue = new MessageQueue(path);
+            
+            if(!storageQueue.Transactional)
                     throw new Exception("Queue must be transactional.");
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
`MsmqWorkerAvailabilityManager.ClearAvailabilityForWorker()` throws "System.InvalidOperationException: Property ResponseQueue was not retrieved when receiving the message. Ensure that the PropertyFilter is set correctly" if you put some stress on it with NSB 3.3.9 on .NET 4+.

The problem is that Microsoft made almost everything on MessageQueue NOT thread safe between .NET 3.5 and .NET 4. 

3.5 docu: http://msdn.microsoft.com/en-us/library/system.messaging.messagequeue(v=vs.90).aspx vs
4 docu: http://msdn.microsoft.com/en-us/library/system.messaging.messagequeue(v=vs.100).aspx

Those changes by Microsoft makes the MsmqWorkerAvailabilityManager implementation in 3.3.9 not safe, as it needs locking to work. The proposed fix, which fixes the repro, is basically to revert  @7de28f8f1dbfdf39a810800b841b0df49f02aac6. Bad luck on that one, @andreasohlund. :)

Check out repro, available [here](https://github.com/janovesk/nsb-msmqdotnet4bug).
