### PR TITLE
Removed the check for callbacks with id == correlation id to avoid mem leaks

### DIFF
--- a/src/NServiceBus.Core/Unicast/Behaviors/CallbackInvocationBehavior.cs
+++ b/src/NServiceBus.Core/Unicast/Behaviors/CallbackInvocationBehavior.cs
@@ -30,7 +30,7 @@
                 return false;
             }
 
-            if (transportMessage.CorrelationId == transportMessage.Id) //to make sure that we don't fire callbacks when doing send locals
+            if (transportMessage.MessageIntent != MessageIntentEnum.Reply)
             {
                 return false;
             }


### PR DESCRIPTION
We check for message intent == reply instead since that is more correct.
