### PR TITLE
Added Encoding extension point to JsonMessageSerializer

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -131,6 +131,8 @@
     <Compile Include="Sagas\When_receiving_a_timeout_message.cs" />
     <Compile Include="Sagas\When_sending_messages_from_a_saga.cs" />
     <Compile Include="GitFlowVersionTests.cs" />
+    <Compile Include="Serializers\Json\When_not_overriding_stream_encoding.cs" />
+    <Compile Include="Serializers\Json\When_overriding_stream_encoding.cs" />
     <Compile Include="StringStreamExtensions.cs" />
     <Compile Include="Fakes\FakeCentralizedPubSubTransportDefinition.cs" />
     <Compile Include="Licensing\LicenseExpiredFormDisplayerTests.cs" />

--- a/src/NServiceBus.Core.Tests/Serializers/Json/When_not_overriding_stream_encoding.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/When_not_overriding_stream_encoding.cs
@@ -1,0 +1,30 @@
+namespace NServiceBus.Serializers.Json.Tests
+{
+    using System;
+    using System.Text;
+    using Features;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_not_overriding_stream_encoding
+    {
+        Configure configure;
+
+        [SetUp]
+        public void SetUp()
+        {
+            configure = Configure.With(o => o.TypesToScan(new Type[0]))
+                .UseSerialization<NServiceBus.Json>();
+
+            var context = new FeatureConfigurationContext(configure);
+            new JsonSerialization().SetupFeature(context);
+        }
+
+        [Test]
+        public void Should_construct_serializer_that_uses_default_encoding()
+        {
+            var serializer = configure.Builder.Build<JsonMessageSerializer>();
+            Assert.AreSame(Encoding.UTF8, serializer.Encoding);
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
@@ -1,0 +1,30 @@
+namespace NServiceBus.Serializers.Json.Tests
+{
+    using System;
+    using System.Text;
+    using Features;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_overriding_stream_encoding
+    {
+        Configure configure;
+
+        [SetUp]
+        public void SetUp()
+        {
+            configure = Configure.With(o => o.TypesToScan(new Type[0]))
+                .UseSerialization<NServiceBus.Json>(c => c.JsonEncoding(Encoding.UTF7));
+
+            var context = new FeatureConfigurationContext(configure);
+            new JsonSerialization().SetupFeature(context);
+        }
+
+        [Test]
+        public void Should_construct_serializer_that_uses_requested_encoding()
+        {
+            var serializer = configure.Builder.Build<JsonMessageSerializer>();
+            Assert.AreSame(Encoding.UTF7, serializer.Encoding);
+        }
+    }
+}

--- a/src/NServiceBus.Core/Serializers/Json/Config/JsonSerialization.cs
+++ b/src/NServiceBus.Core/Serializers/Json/Config/JsonSerialization.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Features
 {
     using MessageInterfaces.MessageMapper.Reflection;
+    using ObjectBuilder;
     using Serializers.Json;
 
     /// <summary>
@@ -19,7 +20,9 @@
         protected internal override void Setup(FeatureConfigurationContext context)
         {
             context.Container.ConfigureComponent<MessageMapper>(DependencyLifecycle.SingleInstance);
-            context.Container.ConfigureComponent<JsonMessageSerializer>(DependencyLifecycle.SingleInstance);
+            var c = context.Container.ConfigureComponent<JsonMessageSerializer>(DependencyLifecycle.SingleInstance);
+
+            context.Settings.ApplyTo<JsonMessageSerializer>((IComponentConfig)c);
         }
     }
 }

--- a/src/NServiceBus.Core/Serializers/Json/Config/JsonSerializerConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Serializers/Json/Config/JsonSerializerConfigurationExtensions.cs
@@ -1,6 +1,9 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Text;
+    using Serialization;
+    using Serializers.Json;
     using Settings;
 
 #pragma warning disable 1591
@@ -27,6 +30,20 @@
 // ReSharper restore UnusedParameter.Global
         {
             throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Configures the encoding of JSON stream
+        /// </summary>
+        /// <param name="config">The configuration object</param>
+        /// <param name="encoding">Encoding to use for serialization and deserialization</param>
+        public static void JsonEncoding(this SerializationConfiguration config, Encoding encoding)
+        {
+            if (encoding == null)
+            {
+                throw new ArgumentNullException("encoding");
+            }
+            config.settings.SetProperty<JsonMessageSerializer>(s => s.Encoding, encoding);
         }
     }
 }

--- a/src/NServiceBus.Core/Serializers/Json/JsonMessageSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/Json/JsonMessageSerializer.cs
@@ -11,6 +11,8 @@ namespace NServiceBus.Serializers.Json
     /// </summary>
     public class JsonMessageSerializer : JsonMessageSerializerBase
     {
+        private Encoding encoding = Encoding.UTF8;
+
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -26,7 +28,7 @@ namespace NServiceBus.Serializers.Json
         /// <returns></returns>
         protected internal override JsonWriter CreateJsonWriter(Stream stream)
         {
-            var streamWriter = new StreamWriter(stream, Encoding.UTF8);
+            var streamWriter = new StreamWriter(stream, Encoding);
             return new JsonTextWriter(streamWriter) {Formatting = Formatting.None};
         }
 
@@ -37,7 +39,7 @@ namespace NServiceBus.Serializers.Json
         /// <returns></returns>
         protected internal override JsonReader CreateJsonReader(Stream stream)
         {
-            var streamReader = new StreamReader(stream, Encoding.UTF8);
+            var streamReader = new StreamReader(stream, Encoding);
             return new JsonTextReader(streamReader);
         }
 
@@ -69,6 +71,22 @@ namespace NServiceBus.Serializers.Json
         protected internal override string GetContentType()
         {
             return ContentTypes.Json;
+        }
+
+        /// <summary>
+        /// Gets or sets the stream encoding
+        /// </summary>
+        public Encoding Encoding
+        {
+            get { return encoding; }
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+                encoding = value;
+            }
         }
     }
 }


### PR DESCRIPTION
## 

`CreateJsonReader` and `CreateJsonWriter` methods are not overridable outside of NServiceBus code due to the fact that Newtonsoft.Json is merged and internalized. 

This extension point is necessary for EventStore transport to work because ES uses non-default encoding (UTF8 without BOM).
