### PR TITLE
Moved the feature prereq checks to run after the setting has been locked...

### DIFF
--- a/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
@@ -10,10 +10,10 @@
     public class FeatureSettingsTests
     {
         [Test]
-        public void Should_check_activation_conditions()
+        public void Should_check_prerequisites()
         {
-            var featureWithTrueCondition = new MyFeatureWithTrueActivationCondition();
-            var featureWithFalseCondition = new MyFeatureWithFalseActivationCondition();
+            var featureWithTrueCondition = new MyFeatureWithSatisfiedPrerequisite();
+            var featureWithFalseCondition = new MyFeatureWithUnsatisfiedPrerequisite();
 
             var featureSettings = new FeatureActivator(new SettingsHolder());
 
@@ -42,14 +42,14 @@
             Assert.True(settings.HasSetting("Test1"));
         }
 
-        [Test]
+        [Test,Ignore("We need to discuss if this is possible since prereqs can only be checked when settings is locked. And with settings locked we can't register defaults. So there is always a chance that the feature decides to not go ahead with the setup and in that case defaults would already been applied")]
         public void Should_not_register_defaults_if_feature_is_not_activated()
         {
             var settings = new SettingsHolder();
             var featureSettings = new FeatureActivator(settings);
 
             featureSettings.Add(new MyFeatureWithDefaultsNotActive());
-            featureSettings.Add(new MyFeatureWithDefaultsNotActiveDueToCondition());
+            featureSettings.Add(new MyFeatureWithDefaultsNotActiveDueToUnsatisfiedPrerequisite());
 
             featureSettings.SetupFeatures(new FeatureConfigurationContext(Configure.With()));
 
@@ -79,9 +79,9 @@
             }
         }
 
-        public class MyFeatureWithDefaultsNotActiveDueToCondition : TestFeature
+        public class MyFeatureWithDefaultsNotActiveDueToUnsatisfiedPrerequisite : TestFeature
         {
-            public MyFeatureWithDefaultsNotActiveDueToCondition()
+            public MyFeatureWithDefaultsNotActiveDueToUnsatisfiedPrerequisite()
             {
                 EnableByDefault();
                 Defaults(s => s.SetDefault("Test2", true));
@@ -89,18 +89,18 @@
             }
         }
 
-        public class MyFeatureWithTrueActivationCondition : TestFeature
+        public class MyFeatureWithSatisfiedPrerequisite : TestFeature
         {
-            public MyFeatureWithTrueActivationCondition()
+            public MyFeatureWithSatisfiedPrerequisite()
             {
                 EnableByDefault();
                 Prerequisite(c => true, "Wont be used");
             }
         }
 
-        public class MyFeatureWithFalseActivationCondition : TestFeature
+        public class MyFeatureWithUnsatisfiedPrerequisite : TestFeature
         {
-            public MyFeatureWithFalseActivationCondition()
+            public MyFeatureWithUnsatisfiedPrerequisite()
             {
                 EnableByDefault();
                 Prerequisite(c => false, "The description");


### PR DESCRIPTION
This one is good to go

@johnsimons this is slightly different from what we discussed but I realized that the main issue is that prereqs is checked to early. I now moved them to run after settings has been locked. I still see the potential need to have the setup to return false to allow for a final chance to abort but I think that can be a separate pull and I argue that we can keep the prereqs as is since they now seem to be correct?

This change highlighted an issue that I don't see a fix for. Since prereqs can only be checked when settings are locked and defaults only can be executed as long as settings are NOT locked. This means that there is always a chance that the feature decides to not go ahead with the setup and in that case defaults would remain applied. I argue that we have to leave it this way since the order seems to be correct and that we need to avoid code that assumes those defaults to be in place. Ie only code in the setup of the feature it self can assume default to be there.

Thoughts?

(I've ignored the test that checks for this - https://github.com/Particular/NServiceBus/commit/94d70b7f33d9137cf46012048a7855754b169f65#diff-79016c895ef1d7bb88e05108cbae5a8bR45)

Potential fix for #2277
