### PR TITLE
Moved SendOnly mode to ConfigurationBuilder

### DIFF
--- a/src/NServiceBus.Core/Config/ConfigureExtensions.cs
+++ b/src/NServiceBus.Core/Config/ConfigureExtensions.cs
@@ -1,5 +1,7 @@
 namespace NServiceBus
 {
+    using System;
+
     /// <summary>
     ///     Configure Extensions.
     /// </summary>
@@ -11,13 +13,25 @@ namespace NServiceBus
         /// <remarks>
         ///     Use this in endpoints whose only purpose is sending messages, websites are often a good example of send only endpoints.
         /// </remarks>
+        [ObsoleteEx(Replacement = "Configure.With(c => c.SendOnly())", RemoveInVersion = "6.0", TreatAsErrorFromVersion = "5.0")]
+// ReSharper disable UnusedParameter.Global
         public static IBus SendOnly(this Configure config)
+// ReSharper restore UnusedParameter.Global
         {
-            config.Settings.Set("Endpoint.SendOnly", true);
-            
-            config.Initialize();
-            
-            return config.Builder.Build<IBus>();
+            throw new InvalidOperationException();
+        }
+
+        /// <summary>
+        ///     Configures this endpoint as a send only endpoint.
+        /// </summary>
+        /// <remarks>
+        ///     Use this in endpoints whose only purpose is sending messages, websites are often a good example of send only endpoints.
+        /// </remarks>
+        public static ConfigurationBuilder SendOnly(this ConfigurationBuilder config)
+        {
+            config.settings.Set("Endpoint.SendOnly", true);
+
+            return config;
         }
     }
 }

--- a/src/NServiceBus.Core/Monitoring/SLA/SLAMonitoring.cs
+++ b/src/NServiceBus.Core/Monitoring/SLA/SLAMonitoring.cs
@@ -19,6 +19,11 @@ namespace NServiceBus.Features
         /// </summary>
         protected internal override void Setup(FeatureConfigurationContext context)
         {
+            if (context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"))
+            {
+                return;
+            }
+
             SetupSLABreachCounter(context);
 
             context.Pipeline.Register<SLABehavior.Registration>();

--- a/src/NServiceBus.Core/SecondLevelRetries/SecondLevelRetries.cs
+++ b/src/NServiceBus.Core/SecondLevelRetries/SecondLevelRetries.cs
@@ -36,6 +36,11 @@ namespace NServiceBus.Features
         /// </summary>
         protected internal override void Setup(FeatureConfigurationContext context)
         {
+            if (context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"))
+            {
+                return;
+            }
+
             var retriesConfig = context.Settings.GetConfigSection<SecondLevelRetriesConfig>();
 
             SetUpRetryPolicy(retriesConfig);

--- a/src/NServiceBus.Core/Unicast/Config/UnicastBus.cs
+++ b/src/NServiceBus.Core/Unicast/Config/UnicastBus.cs
@@ -38,12 +38,17 @@ namespace NServiceBus.Features
             ConfigureBehaviors(context);
 
             var knownMessages = context.Settings.GetAvailableTypes()
-            .Where(context.Settings.Get<Conventions>().IsMessageType)
-            .ToList();
+                .Where(context.Settings.Get<Conventions>().IsMessageType)
+                .ToList();
 
             RegisterMessageOwnersAndBusAddress(context, knownMessages);
 
             ConfigureMessageRegistry(context, knownMessages);
+
+            if (context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"))
+            {
+                return;
+            }
 
             SetTransportThresholds(context);
         }

--- a/src/NServiceBus.Core/Unicast/Transport/TransportReceiver.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/TransportReceiver.cs
@@ -25,7 +25,7 @@ namespace NServiceBus.Unicast.Transport
         /// <param name="receiver">The <see cref="IDequeueMessages"/> instance to use.</param>
         /// <param name="manageMessageFailures">The <see cref="IManageMessageFailures"/> instance to use.</param>
         /// <param name="settings">The current settings</param>
-        public TransportReceiver(TransactionSettings transactionSettings, int maximumConcurrencyLevel, int maximumThroughput, IDequeueMessages receiver, IManageMessageFailures manageMessageFailures,ReadOnlySettings settings)
+        public TransportReceiver(TransactionSettings transactionSettings, int maximumConcurrencyLevel, int maximumThroughput, IDequeueMessages receiver, IManageMessageFailures manageMessageFailures, ReadOnlySettings settings)
         {
             this.settings = settings;
             TransactionSettings = transactionSettings;


### PR DESCRIPTION
This also fixes #2101 and #1372
### New usage of sendonly

NServiceBus Host:

``` c#
public class Endpoint : IConfigureThisEndpoint {
    public void Customize(ConfigurationBuilder builder)
    {
        builder.UseTransport<Msmq>()
            .SendOnly();
    }
}
```

Self Hosting:

``` c#
var bus = Configure.With(
    b => b.UseTransport<Msmq>()
        .UseSerialization<Xml>()
        .SendOnly())
    .CreateBus();
```
