### PR TITLE
Processing started/ended is now available on the pipeline.

### DIFF
--- a/src/NServiceBus.Core/Audit/AuditBehavior.cs
+++ b/src/NServiceBus.Core/Audit/AuditBehavior.cs
@@ -23,6 +23,11 @@
             {
                 TimeToBeReceived = TimeToBeReceivedOnForwardedMessages
             };
+
+            //set audit related headers
+            context.PhysicalMessage.Headers[Headers.ProcessingStarted] = DateTimeExtensions.ToWireFormattedString(context.Get<DateTime>("IncomingMessage.ProcessingStarted"));
+            context.PhysicalMessage.Headers[Headers.ProcessingEnded] = DateTimeExtensions.ToWireFormattedString(context.Get<DateTime>("IncomingMessage.ProcessingEnded"));
+
             MessageAuditer.Audit(sendOptions, context.PhysicalMessage);
         }
 

--- a/src/NServiceBus.Core/Monitoring/ProcessingStatisticsBehavior.cs
+++ b/src/NServiceBus.Core/Monitoring/ProcessingStatisticsBehavior.cs
@@ -8,16 +8,23 @@
     {
         public void Invoke(IncomingContext context, Action next)
         {
-            //since the audit captures the physical message headers then lets place them there
+            string timeSentString;
             var headers = context.PhysicalMessage.Headers;
-            headers[Headers.ProcessingStarted] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
+
+            if (headers.TryGetValue(Headers.TimeSent, out timeSentString))
+            {
+                context.Set("IncomingMessage.TimeSent", DateTimeExtensions.ToUtcDateTime(timeSentString));
+            }
+
+            context.Set("IncomingMessage.ProcessingStarted", DateTime.UtcNow);
+
             try
             {
                 next();
             }
             finally
             {
-                headers[Headers.ProcessingEnded] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
+                context.Set("IncomingMessage.ProcessingEnded", DateTime.UtcNow);
             }
         }
     }

--- a/src/NServiceBus.Core/Monitoring/SLA/SLABehavior.cs
+++ b/src/NServiceBus.Core/Monitoring/SLA/SLABehavior.cs
@@ -16,16 +16,15 @@
         public void Invoke(IncomingContext context, Action next)
         {
             next();
-            string timeSentString;
-            var headers = context.PhysicalMessage.Headers;
-            if (headers.TryGetValue(Headers.TimeSent, out timeSentString))
-            {
-                var timeSent = DateTimeExtensions.ToUtcDateTime(timeSentString);
-                var processingStarted = DateTimeExtensions.ToUtcDateTime(headers[Headers.ProcessingStarted]);
-                var processingEnded = DateTimeExtensions.ToUtcDateTime(headers[Headers.ProcessingEnded]);
 
-                breachCalculator.Update(timeSent, processingStarted, processingEnded);
+            DateTime timeSent;
+
+            if (!context.TryGet("IncomingMessage.TimeSent", out timeSent))
+            {
+                return;
             }
+
+            breachCalculator.Update(timeSent, context.Get<DateTime>("IncomingMessage.ProcessingStarted"), context.Get<DateTime>("IncomingMessage.ProcessingEnded"));
         }
 
         public class Registration:RegisterStep


### PR DESCRIPTION
Corresponding headers are now only set when moving the message to the
audit queue.
