### PR TITLE
Support to create instances of interface for Saga testing, fixes #2249

### DIFF
--- a/src/NServiceBus.Testing.Tests/SagaTests.cs
+++ b/src/NServiceBus.Testing.Tests/SagaTests.cs
@@ -37,6 +37,14 @@
         }
 
         [Test]
+        public void SagaThatIsStartedWithInterface()
+        {
+            Test.Saga<MySagaWithInterface>()
+                .ExpectSend<Command>()
+                .WhenHandling<StartsSagaWithInterface>(m => m.Foo = "Hello");
+        }
+
+        [Test]
         public void SagaThatDoesAReply()
         {
             Test.Saga<SagaThatDoesAReply>()
@@ -166,6 +174,27 @@
     {
     }
 
+    public class MySagaWithInterface : Saga<MySagaWithInterface.MySagaDataWithInterface>,
+        IAmStartedByMessages<StartsSagaWithInterface>
+    {
+        public class MySagaDataWithInterface : ContainSagaData
+        {
+            
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySagaDataWithInterface> mapper)
+        {
+        }
+
+        public void Handle(StartsSagaWithInterface message)
+        {
+            if (message.Foo == "Hello")
+            {
+                Bus.Send<Command>(null);
+            }
+        }
+    }
+
     public class MySaga : Saga<MySagaData>,
                           IAmStartedByMessages<StartsSaga>,
                           IHandleTimeouts<StartsSaga>
@@ -194,6 +223,11 @@
         public Guid Id { get; set; }
         public string Originator { get; set; }
         public string OriginalMessageId { get; set; }
+    }
+
+    public interface StartsSagaWithInterface: IEvent
+    {
+        string Foo { get; set; }
     }
 
     public class StartsSaga : ICommand

--- a/src/NServiceBus.Testing/NServiceBus.Testing.csproj
+++ b/src/NServiceBus.Testing/NServiceBus.Testing.csproj
@@ -52,6 +52,7 @@
     <None Include="FodyWeavers.xml">
       <SubType>Designer</SubType>
     </None>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Obsolete">
       <HintPath>..\packages\Obsolete.Fody\Lib\NET35\Obsolete.dll</HintPath>
     </Reference>

--- a/src/NServiceBus.Testing/Saga.cs
+++ b/src/NServiceBus.Testing/Saga.cs
@@ -278,6 +278,17 @@ namespace NServiceBus.Testing
         }
 
         /// <summary>
+        /// Initializes the given message type and checks all the expectations previously set up,
+        /// and then clears them for continued testing.
+        /// </summary>
+        public Saga<T> WhenHandling<TMessage>(Action<TMessage> initializeMessage = null)
+        {
+            var msg = bus.CreateInstance(initializeMessage);
+
+            return When(_ => ((dynamic)saga).Handle(msg));
+        }
+
+        /// <summary>
         /// Uses the given delegate to invoke the saga, checking all the expectations previously set up,
         /// and then clearing them for continued testing.
         /// </summary>


### PR DESCRIPTION
With the removal of `bus.CreateInstance()` it is no longer possible to create an interface instance in the Saga testing framework.

This addresses that issue by adding a new method (`WhenHandling`) that allows the user to test interface message types.
## 

An example on how to use the new API:

``` c#
[Test]
public void SagaThatIsStartedWithInterface()
{
    Test.Saga<MySagaWithInterface>()
        .ExpectSend<Command>()
        .WhenHandling<StartsSagaWithInterface>(m => m.Name = "John");
}

public class MySagaWithInterface : Saga<MySagaWithInterface.MySagaDataWithInterface>,
    IAmStartedByMessages<StartsSagaWithInterface>
{
    public class MySagaDataWithInterface : ContainSagaData
    {

    }

    protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySagaDataWithInterface> mapper)
    {
    }

    public void Handle(StartsSagaWithInterface message)
    {
        if (message.Name == "John")
        {
            Bus.Send<SayHello>(null);
        }
    }
}

public interface StartsSagaWithInterface: IEvent
{
    string Name { get; set; }
}

public class SayHello : ICommand
{
}
```
