### PR TITLE
less fluent conventions

### DIFF
--- a/src/NServiceBus.Core.Tests/Conventions/MessageConventionSpecs.cs
+++ b/src/NServiceBus.Core.Tests/Conventions/MessageConventionSpecs.cs
@@ -12,16 +12,19 @@
             public void Should_cache_the_message_convention()
             {
                 var timesCalled = 0;
-                conventions = new Conventions(isMessageTypeAction: t =>
+                conventions = new Conventions
                 {
-                    timesCalled++;
-                    return false;
-                });
+                    IsMessageTypeAction= t =>
+                    {
+                        timesCalled++;
+                        return false;
+                    }
+                };
 
-                conventions.IsMessage(this);
+                conventions.IsMessageType(GetType());
                 Assert.AreEqual(1, timesCalled);
 
-                conventions.IsMessage(this);
+                conventions.IsMessageType(GetType());
                 Assert.AreEqual(1, timesCalled);
             }
         }
@@ -33,16 +36,19 @@
             public void Should_cache_the_message_convention()
             {
                 var timesCalled = 0;
-                conventions = new Conventions(isEventTypeAction: t =>
+                conventions = new Conventions
                 {
-                    timesCalled++;
-                    return false;
-                });
+                    IsEventTypeAction = t =>
+                    {
+                        timesCalled++;
+                        return false;
+                    }
+                };
 
-                conventions.IsEvent(this);
+                conventions.IsEventType(GetType());
                 Assert.AreEqual(1, timesCalled);
 
-                conventions.IsEvent(this);
+                conventions.IsEventType(GetType());
                 Assert.AreEqual(1, timesCalled);
             }
         }
@@ -54,16 +60,19 @@
             public void Should_cache_the_message_convention()
             {
                 var timesCalled = 0;
-                conventions = new Conventions(isCommandTypeAction: t =>
+                conventions = new Conventions
                 {
-                    timesCalled++;
-                    return false;
-                });
+                    IsCommandTypeAction = t =>
+                    {
+                        timesCalled++;
+                        return false;
+                    }
+                };
 
-                conventions.IsCommand(this);
+                conventions.IsCommandType(GetType());
                 Assert.AreEqual(1, timesCalled);
 
-                conventions.IsCommand(this);
+                conventions.IsCommandType(GetType());
                 Assert.AreEqual(1, timesCalled);
             }
         }

--- a/src/NServiceBus.Core.Tests/DataBus/When_nservicebus_is_initalizing.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_nservicebus_is_initalizing.cs
@@ -61,7 +61,7 @@ namespace NServiceBus.Core.Tests.DataBus
                 {
                     typeof(MessageWithNonSerializableDataBusProperty)
                 });
-                o.Conventions(c => c.DefiningDataBusPropertiesAs(p => p.Name.EndsWith("DataBus")));
+                o.Conventions().DefiningDataBusPropertiesAs(p => p.Name.EndsWith("DataBus"));
             });
 
             var feature = new DataBusFeature();
@@ -84,7 +84,7 @@ namespace NServiceBus.Core.Tests.DataBus
                 {
                     typeof(MessageWithNonSerializableDataBusProperty)
                 });
-                o.Conventions(c => c.DefiningDataBusPropertiesAs(p => p.Name.EndsWith("DataBus")));
+                o.Conventions().DefiningDataBusPropertiesAs(p => p.Name.EndsWith("DataBus"));
             });
             
             config.configurer.RegisterSingleton<IDataBus>(new InMemoryDataBus());

--- a/src/NServiceBus.Core.Tests/Encryption/ConventionBasedEncryptedStringSpecs.cs
+++ b/src/NServiceBus.Core.Tests/Encryption/ConventionBasedEncryptedStringSpecs.cs
@@ -62,7 +62,10 @@
     {
         protected override Conventions BuildConventions()
         {
-            return new Conventions(isEncryptedPropertyAction: p => p.Name.StartsWith("Encrypted"));
+            return new Conventions
+            {
+                IsEncryptedPropertyAction= p => p.Name.StartsWith("Encrypted")
+            };
         }
     }
 

--- a/src/NServiceBus.Core.Tests/Encryption/WireEncryptedStringSpecs.cs
+++ b/src/NServiceBus.Core.Tests/Encryption/WireEncryptedStringSpecs.cs
@@ -305,7 +305,10 @@
 
         protected virtual Conventions BuildConventions()
         {
-            return new Conventions(isEncryptedPropertyAction: property => typeof(WireEncryptedString).IsAssignableFrom(property.PropertyType));
+            return new Conventions
+            {
+                IsEncryptedPropertyAction = property => typeof(WireEncryptedString).IsAssignableFrom(property.PropertyType)
+            };
         }
 
         protected WireEncryptedString Create()

--- a/src/NServiceBus.Core.Tests/MessageConventionExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageConventionExtensionsTests.cs
@@ -11,14 +11,14 @@
         public void Should_use_TimeToBeReceived_from_bottom_of_tree()
         {
             var conventions = new Conventions();
-            var timeToBeReceivedAction = conventions.TimeToBeReceivedAction(typeof(InheritedClassWithAttribute));
+            var timeToBeReceivedAction = conventions.GetTimeToBeReceived(typeof(InheritedClassWithAttribute));
             Assert.AreEqual(TimeSpan.FromSeconds(2), timeToBeReceivedAction);
         }
         [Test]
         public void Should_use_inherited_TimeToBeReceived()
         {
             var conventions = new Conventions();
-            var timeToBeReceivedAction = conventions.TimeToBeReceivedAction(typeof(InheritedClassWithNoAttribute));
+            var timeToBeReceivedAction = conventions.GetTimeToBeReceived(typeof(InheritedClassWithNoAttribute));
             Assert.AreEqual(TimeSpan.FromSeconds(1), timeToBeReceivedAction);
         }
 

--- a/src/NServiceBus.Core/ConfigurationBuilder.cs
+++ b/src/NServiceBus.Core/ConfigurationBuilder.cs
@@ -107,9 +107,9 @@ namespace NServiceBus
         /// <summary>
         ///     Defines the conventions to use for this endpoint.
         /// </summary>
-        public void Conventions(Action<ConventionsBuilder> conventions)
+        public ConventionsBuilder Conventions()
         {
-            conventions(conventionsBuilder);
+            return conventionsBuilder;
         }
 
         /// <summary>
@@ -176,10 +176,9 @@ namespace NServiceBus
             var container = customBuilder ?? new AutofacObjectBuilder();
             RegisterEndpointWideDefaults();
 
-            var conventions = conventionsBuilder.BuildConventions();
-            container.RegisterSingleton(typeof(Conventions), conventions);
+            container.RegisterSingleton(typeof(Conventions), conventionsBuilder.Conventions);
 
-            Settings.SetDefault<Conventions>(conventions);
+            Settings.SetDefault<Conventions>(conventionsBuilder.Conventions);
 
             Configure.ActivateAndInvoke<INeedInitialization>(scannedTypes, t => t.Customize(this));
 

--- a/src/NServiceBus.Core/Conventions.cs
+++ b/src/NServiceBus.Core/Conventions.cs
@@ -11,102 +11,14 @@
     /// </summary>
     public class Conventions
     {
-        internal Conventions(Func<Type, TimeSpan> timeToBeReceivedAction = null, Func<Type, bool> isMessageTypeAction = null, Func<Type, bool> isExpressMessageAction = null, Func<Type, bool> isEventTypeAction = null, Func<Type, bool> isCommandTypeAction = null, Func<PropertyInfo, bool> isDataBusPropertyAction = null, Func<PropertyInfo, bool> isEncryptedPropertyAction = null)
-        {
-            if (isCommandTypeAction != null)
-            {
-                this.isCommandTypeAction = isCommandTypeAction;
-            }
-            if (isDataBusPropertyAction != null)
-            {
-                this.isDataBusPropertyAction = isDataBusPropertyAction;
-            }
-            if (isEncryptedPropertyAction != null)
-            {
-                this.isEncryptedPropertyAction = isEncryptedPropertyAction;
-            }
-            if (isEventTypeAction != null)
-            {
-                this.isEventTypeAction = isEventTypeAction;
-            }
-            if (isExpressMessageAction != null)
-            {
-                this.isExpressMessageAction = isExpressMessageAction;
-            }
-            if (isMessageTypeAction != null)
-            {
-                this.isMessageTypeAction = isMessageTypeAction;
-            }
-            if (timeToBeReceivedAction != null)
-            {
-                this.timeToBeReceivedAction = timeToBeReceivedAction;
-            }
-        }
-
         /// <summary>
-        ///     The function used to determine whether a type is a command type.
+        ///     Returns the time to be received for a give <paramref name="messageType"/>.
         /// </summary>
-        public Func<Type, bool> IsCommandTypeAction
+        public TimeSpan GetTimeToBeReceived(Type messageType)
         {
-            get { return isCommandTypeAction; }
+            return TimeToBeReceivedAction(messageType);
         }
-
-        /// <summary>
-        ///     The function used to determine whether a property should be treated as a databus property.
-        /// </summary>
-        public Func<PropertyInfo, bool> IsDataBusPropertyAction
-        {
-            get { return isDataBusPropertyAction; }
-        }
-
-        /// <summary>
-        ///     The function used to determine whether a property should be encrypted
-        /// </summary>
-        public Func<PropertyInfo, bool> IsEncryptedPropertyAction
-        {
-            get { return isEncryptedPropertyAction; }
-        }
-
-        /// <summary>
-        ///     The function used to determine whether a type is a event type.
-        /// </summary>
-        public Func<Type, bool> IsEventTypeAction
-        {
-            get { return isEventTypeAction; }
-        }
-
-        /// <summary>
-        ///     The function used to determine if a type is an express message (the message should not be written to disk).
-        /// </summary>
-        public Func<Type, bool> IsExpressMessageAction
-        {
-            get { return isExpressMessageAction; }
-        }
-
-        /// <summary>
-        ///     The function used to determine whether a type is a message type.
-        /// </summary>
-        public Func<Type, bool> IsMessageTypeAction
-        {
-            get { return isMessageTypeAction; }
-        }
-
-        /// <summary>
-        ///     The function to evaluate whether the message has a time to be received or not ( <see cref="TimeSpan.MaxValue" />).
-        /// </summary>
-        public Func<Type, TimeSpan> TimeToBeReceivedAction
-        {
-            get { return timeToBeReceivedAction; }
-        }
-
-        /// <summary>
-        ///     Returns true if the given object is a message.
-        /// </summary>
-        public bool IsMessage(object o)
-        {
-            return IsMessageType(o.GetType());
-        }
-
+        
         /// <summary>
         ///     Returns true if the given type is a message type.
         /// </summary>
@@ -148,14 +60,6 @@
         }
 
         /// <summary>
-        ///     Returns true if the given object is a command.
-        /// </summary>
-        public bool IsCommand(object o)
-        {
-            return IsCommandType(o.GetType());
-        }
-
-        /// <summary>
         ///     Returns true if the given type is a command type.
         /// </summary>
         public bool IsCommandType(Type t)
@@ -168,14 +72,6 @@
             {
                 throw new Exception("Failed to evaluate Command convention. See inner exception for details.", ex);
             }
-        }
-
-        /// <summary>
-        ///     Returns true if the given message should not be written to disk when sent.
-        /// </summary>
-        public bool IsExpressMessage(object o)
-        {
-            return IsExpressMessageType(o.GetType());
         }
 
         /// <summary>
@@ -225,14 +121,6 @@
         }
 
         /// <summary>
-        ///     Returns true if the given object is a event.
-        /// </summary>
-        public bool IsEvent(object o)
-        {
-            return IsEventType(o.GetType());
-        }
-
-        /// <summary>
         ///     Returns true if the given type is a event type.
         /// </summary>
         public bool IsEventType(Type t)
@@ -247,33 +135,30 @@
             }
         }
 
-        readonly ConventionCache CommandsConventionCache = new ConventionCache();
-        readonly ConventionCache EventsConventionCache = new ConventionCache();
-        readonly ConventionCache ExpressConventionCache = new ConventionCache();
-        readonly ConventionCache MessagesConventionCache = new ConventionCache();
+        ConventionCache CommandsConventionCache = new ConventionCache();
+        ConventionCache EventsConventionCache = new ConventionCache();
+        ConventionCache ExpressConventionCache = new ConventionCache();
+        ConventionCache MessagesConventionCache = new ConventionCache();
 
-        /// <summary>
-        ///     Contains list of System messages' conventions
-        /// </summary>
         List<Func<Type, bool>> IsSystemMessageActions = new List<Func<Type, bool>>();
 
-        Func<Type, bool> isCommandTypeAction = t => typeof(ICommand).IsAssignableFrom(t) && typeof(ICommand) != t;
+        internal Func<Type, bool> IsCommandTypeAction = t => typeof(ICommand).IsAssignableFrom(t) && typeof(ICommand) != t;
 
-        Func<PropertyInfo, bool> isDataBusPropertyAction = property => typeof(IDataBusProperty).IsAssignableFrom(property.PropertyType) && typeof(IDataBusProperty) != property.PropertyType;
+        internal Func<PropertyInfo, bool> IsDataBusPropertyAction = p => typeof(IDataBusProperty).IsAssignableFrom(p.PropertyType) && typeof(IDataBusProperty) != p.PropertyType;
 
-        Func<PropertyInfo, bool> isEncryptedPropertyAction = property => typeof(WireEncryptedString).IsAssignableFrom(property.PropertyType);
+        internal Func<PropertyInfo, bool> IsEncryptedPropertyAction = p => typeof(WireEncryptedString).IsAssignableFrom(p.PropertyType);
 
-        Func<Type, bool> isEventTypeAction = t => typeof(IEvent).IsAssignableFrom(t) && typeof(IEvent) != t;
+        internal Func<Type, bool> IsEventTypeAction = t => typeof(IEvent).IsAssignableFrom(t) && typeof(IEvent) != t;
 
-        Func<Type, bool> isExpressMessageAction = t => t.GetCustomAttributes(typeof(ExpressAttribute), true)
+        internal Func<Type, bool> IsExpressMessageAction = t => t.GetCustomAttributes(typeof(ExpressAttribute), true)
             .Any();
 
-        Func<Type, bool> isMessageTypeAction = t => typeof(IMessage).IsAssignableFrom(t) &&
+        internal Func<Type, bool> IsMessageTypeAction = t => typeof(IMessage).IsAssignableFrom(t) &&
                                                     typeof(IMessage) != t &&
                                                     typeof(IEvent) != t &&
                                                     typeof(ICommand) != t;
 
-        Func<Type, TimeSpan> timeToBeReceivedAction = t =>
+        internal Func<Type, TimeSpan> TimeToBeReceivedAction = t =>
         {
             var attributes = t.GetCustomAttributes(typeof(TimeToBeReceivedAttribute), true)
                 .Select(s => s as TimeToBeReceivedAttribute)
@@ -286,18 +171,7 @@
         {
             public bool ApplyConvention(Type type, Func<Type, bool> action)
             {
-                bool result;
-
-                if (cache.TryGetValue(type, out result))
-                {
-                    return result;
-                }
-
-                result = action(type);
-
-                cache[type] = result;
-
-                return result;
+                return cache.GetOrAdd(type, action);
             }
 
             public void Reset()
@@ -305,7 +179,7 @@
                 cache.Clear();
             }
 
-            IDictionary<Type, bool> cache = new ConcurrentDictionary<Type, bool>();
+            ConcurrentDictionary<Type, bool> cache = new ConcurrentDictionary<Type, bool>();
         }
     }
 }

--- a/src/NServiceBus.Core/ConventionsBuilder.cs
+++ b/src/NServiceBus.Core/ConventionsBuilder.cs
@@ -13,7 +13,7 @@ namespace NServiceBus
         /// </summary>
         public ConventionsBuilder DefiningMessagesAs(Func<Type, bool> definesMessageType)
         {
-            this.definesMessageType = definesMessageType;
+            Conventions.IsMessageTypeAction = definesMessageType;
             return this;
         }
 
@@ -22,7 +22,7 @@ namespace NServiceBus
         /// </summary>
         public ConventionsBuilder DefiningCommandsAs(Func<Type, bool> definesCommandType)
         {
-            this.definesCommandType = definesCommandType;
+            Conventions.IsCommandTypeAction = definesCommandType;
             return this;
         }
 
@@ -31,7 +31,7 @@ namespace NServiceBus
         /// </summary>
         public ConventionsBuilder DefiningEventsAs(Func<Type, bool> definesEventType)
         {
-            this.definesEventType = definesEventType;
+            Conventions.IsEventTypeAction = definesEventType;
             return this;
         }
 
@@ -40,7 +40,7 @@ namespace NServiceBus
         /// </summary>
         public ConventionsBuilder DefiningEncryptedPropertiesAs(Func<PropertyInfo, bool> definesEncryptedProperty)
         {
-            this.definesEncryptedProperty = definesEncryptedProperty;
+            Conventions.IsEncryptedPropertyAction = definesEncryptedProperty;
             return this;
         }
 
@@ -49,7 +49,7 @@ namespace NServiceBus
         /// </summary>
         public ConventionsBuilder DefiningDataBusPropertiesAs(Func<PropertyInfo, bool> definesDataBusProperty)
         {
-            this.definesDataBusProperty = definesDataBusProperty;
+            Conventions.IsDataBusPropertyAction = definesDataBusProperty;
             return this;
         }
 
@@ -58,7 +58,7 @@ namespace NServiceBus
         /// </summary>
         public ConventionsBuilder DefiningTimeToBeReceivedAs(Func<Type, TimeSpan> retrieveTimeToBeReceived)
         {
-            this.retrieveTimeToBeReceived = retrieveTimeToBeReceived;
+            Conventions.TimeToBeReceivedAction = retrieveTimeToBeReceived;
             return this;
         }
 
@@ -67,21 +67,10 @@ namespace NServiceBus
         /// </summary>
         public ConventionsBuilder DefiningExpressMessagesAs(Func<Type, bool> definesExpressMessageType)
         {
-            this.definesExpressMessageType = definesExpressMessageType;
+            Conventions.IsExpressMessageAction = definesExpressMessageType;
             return this;
         }
 
-        internal Conventions BuildConventions()
-        {
-            return new Conventions(isCommandTypeAction: definesCommandType, isDataBusPropertyAction: definesDataBusProperty, isEncryptedPropertyAction: definesEncryptedProperty, isEventTypeAction: definesEventType, isExpressMessageAction: definesExpressMessageType, isMessageTypeAction: definesMessageType, timeToBeReceivedAction: retrieveTimeToBeReceived);
-        }
-
-        Func<Type, bool> definesCommandType;
-        Func<PropertyInfo, bool> definesDataBusProperty;
-        Func<PropertyInfo, bool> definesEncryptedProperty;
-        Func<Type, bool> definesEventType;
-        Func<Type, bool> definesExpressMessageType;
-        Func<Type, bool> definesMessageType;
-        Func<Type, TimeSpan> retrieveTimeToBeReceived;
+        internal Conventions Conventions = new Conventions();
     }
 }

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -79,7 +79,10 @@
                 .OrderByDescending(PlaceInMessageHierarchy)
                 .ToList();
 
-            var metadata = new MessageMetadata(messageType, !conventions.IsExpressMessageType(messageType) && !defaultToNonPersistentMessages, conventions.TimeToBeReceivedAction(messageType), new[]
+            var timeToBeReceived = conventions.GetTimeToBeReceived(messageType);
+            var isExpressMessageType = conventions.IsExpressMessageType(messageType);
+            var recoverable = !isExpressMessageType && !defaultToNonPersistentMessages;
+            var metadata = new MessageMetadata(messageType, recoverable, timeToBeReceived, new[]
             {
                 messageType
             }.Concat(parentMessages));


### PR DESCRIPTION
less fluenty API for conventions
better use of ConcurrentDictionary in ConventionCache
remove redundant methods from Conventions
Dont expose lambdas from Conventions, only expose methods that call the
conventions
remove need to huge conventions constructor
