### PR TITLE
Configure.With now take an instance of the configuration builder

### DIFF
--- a/src/NServiceBus.Core.Tests/Config/When_calling_Configure_With_from_IConfigureThisEndpoint.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_calling_Configure_With_from_IConfigureThisEndpoint.cs
@@ -18,8 +18,10 @@ namespace NServiceBus.Core.Tests.Config
         public class Foo : IConfigureThisEndpoint
         {
             public void Customize(ConfigurationBuilder builder)
-            {
-                Configure.With(o => o.TypesToScan(new Type[] { }));
+            {   
+                builder.TypesToScan(new Type[]{});
+             
+                Configure.With(builder);
             }
         }
     }

--- a/src/NServiceBus.Core.Tests/Config/When_loading_types.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_loading_types.cs
@@ -14,7 +14,11 @@ namespace NServiceBus.Core.Tests.Config
         [SetUp]
         public void SetUp()
         {
-            var configure = Configure.With(o => o.AssembliesToScan(Assembly.GetExecutingAssembly()));
+            var builder = new ConfigurationBuilder();
+
+            builder.AssembliesToScan(Assembly.GetExecutingAssembly());
+
+            var configure = Configure.With(builder);
             loadedTypes = configure.TypesToScan.ToList();
         }
 

--- a/src/NServiceBus.Core.Tests/Config/When_no_custom_configuration_source_is_specified.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_no_custom_configuration_source_is_specified.cs
@@ -9,9 +9,11 @@ namespace NServiceBus.Core.Tests.Config
         [Test]
         public void The_default_configuration_source_should_be_default()
         {
-            var config = Configure.With(o => o.TypesToScan(new Type[]
-            {
-            }));
+            var builder = new ConfigurationBuilder();
+
+            builder.TypesToScan(new Type[]{});
+
+            var config = Configure.With(builder);
 
             var configSection = config.Settings.GetConfigSection<TestConfigurationSection>();
 

--- a/src/NServiceBus.Core.Tests/Config/When_users_override_the_configuration_source.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_users_override_the_configuration_source.cs
@@ -15,13 +15,14 @@ namespace NServiceBus.Core.Tests.Config
         public void SetUp()
         {
             userConfigurationSource = new UserConfigurationSource();
-            config = Configure.With(o =>
-            {
-                o.TypesToScan(new Type[]
+
+            var builder = new ConfigurationBuilder();
+            builder.TypesToScan(new Type[]
                 {
                 });
-                o.CustomConfigurationSource(userConfigurationSource);
-            });
+            builder.CustomConfigurationSource(userConfigurationSource);
+
+            config = Configure.With(builder);
         }
 
       

--- a/src/NServiceBus.Core.Tests/DataBus/When_nservicebus_is_initalizing.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_nservicebus_is_initalizing.cs
@@ -14,14 +14,12 @@ namespace NServiceBus.Core.Tests.DataBus
         [Test]
         public void Databus_should_be_activated_if_a_databus_property_is_found()
         {
-            var config = Configure.With(o =>
-            {
-                o.EndpointName("xyz");
-                o.TypesToScan(new[]
-                {
-                    typeof(MessageWithDataBusProperty)
-                });
-            });
+            var builder = new ConfigurationBuilder();
+
+            builder.EndpointName("xyz");
+            builder.TypesToScan(new[]{typeof(MessageWithDataBusProperty)});
+
+            var config = Configure.With(builder);
 
             var feature = new DataBusFeature();
 
@@ -33,14 +31,13 @@ namespace NServiceBus.Core.Tests.DataBus
         [Test]
         public void Databus_should_not_be_activated_if_no_databus_property_is_found()
         {
-            var config = Configure.With(o =>
-            {
-                o.EndpointName("xyz");
-                o.TypesToScan(new[]
-                {
-                    typeof(MessageWithoutDataBusProperty)
-                });
-            });
+            var builder = new ConfigurationBuilder();
+
+            builder.EndpointName("xyz");
+            builder.TypesToScan(new[] { typeof(MessageWithoutDataBusProperty) });
+
+            var config = Configure.With(builder);
+
             var feature = new DataBusFeature();
 
             Assert.False(feature.CheckPrerequisites(new FeatureConfigurationContext(config)).IsSatisfied);
@@ -54,15 +51,15 @@ namespace NServiceBus.Core.Tests.DataBus
                 Assert.Ignore("This only work in debug mode.");
             }
 
-            var config = Configure.With(o =>
-            {
-                o.EndpointName("xyz");
-                o.TypesToScan(new[]
+            var builder = new ConfigurationBuilder();
+            builder.EndpointName("xyz");
+            builder.TypesToScan(new[]
                 {
                     typeof(MessageWithNonSerializableDataBusProperty)
                 });
-                o.Conventions().DefiningDataBusPropertiesAs(p => p.Name.EndsWith("DataBus"));
-            });
+            builder.Conventions().DefiningDataBusPropertiesAs(p => p.Name.EndsWith("DataBus"));
+            
+            var config = Configure.With(builder);
 
             var feature = new DataBusFeature();
 
@@ -77,15 +74,15 @@ namespace NServiceBus.Core.Tests.DataBus
                 Assert.Ignore("This only work in debug mode.");
             }
 
-            var config = Configure.With(o =>
-            {
-                o.EndpointName("xyz");
-                o.TypesToScan(new[]
+            var builder = new ConfigurationBuilder();
+            builder.EndpointName("xyz");
+            builder.TypesToScan(new[]
                 {
                     typeof(MessageWithNonSerializableDataBusProperty)
                 });
-                o.Conventions().DefiningDataBusPropertiesAs(p => p.Name.EndsWith("DataBus"));
-            });
+            builder.Conventions().DefiningDataBusPropertiesAs(p => p.Name.EndsWith("DataBus"));
+
+            var config = Configure.With(builder);
             
             config.configurer.RegisterSingleton<IDataBus>(new InMemoryDataBus());
 

--- a/src/NServiceBus.Core.Tests/Satellite/SatelliteLauncherContext.cs
+++ b/src/NServiceBus.Core.Tests/Satellite/SatelliteLauncherContext.cs
@@ -25,12 +25,12 @@
             InMemoryFaultManager = new Faults.InMemory.FaultManager();
             FakeReceiver = new FakeReceiver();
 
+            var configurationBuilder = new ConfigurationBuilder();
 
-            var config = Configure.With(o =>
-            {
-                o.EndpointName("xyz");
-                o.AssembliesToScan(new Assembly[0]);
-            });
+            configurationBuilder.EndpointName("xyz");
+            configurationBuilder.AssembliesToScan(new Assembly[0]);
+       
+            var config = Configure.With(configurationBuilder);
 
             Transport = new TransportReceiver(new TransactionSettings(true, TimeSpan.FromSeconds(30), IsolationLevel.ReadCommitted, 5, false, false), 1, 0, FakeReceiver, InMemoryFaultManager, new SettingsHolder(),  config);
 

--- a/src/NServiceBus.Core.Tests/Scheduler/ScheduleTests.cs
+++ b/src/NServiceBus.Core.Tests/Scheduler/ScheduleTests.cs
@@ -12,7 +12,7 @@
     public class ScheduleTests
     {
         const string ACTION_NAME = "my action";
-        FuncBuilder builder = new FuncBuilder();
+        FuncBuilder container = new FuncBuilder();
         FakeBus bus = new FakeBus();
         Schedule schedule;
 
@@ -20,17 +20,17 @@
         [SetUp]
         public void SetUp()
         {
-            Configure.With(o =>
-            {
-                o.AssembliesToScan(new Assembly[0]);
-                o.UseContainer(builder);
-            });
+            var builder = new ConfigurationBuilder();
+            builder.AssembliesToScan(new Assembly[0]);
+            builder.UseContainer(container);
+
+            Configure.With(builder);
 
             defaultScheduler = new DefaultScheduler(bus);
-            builder.Register<IBus>(() => bus);
-            builder.Register<DefaultScheduler>(() => defaultScheduler);
+            container.Register<IBus>(() => bus);
+            container.Register<DefaultScheduler>(() => defaultScheduler);
 
-            schedule = new Schedule(builder);
+            schedule = new Schedule(container);
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Serializers/Json/When_not_overriding_stream_encoding.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/When_not_overriding_stream_encoding.cs
@@ -13,11 +13,12 @@ namespace NServiceBus.Serializers.Json.Tests
         [SetUp]
         public void SetUp()
         {
-            configure = Configure.With(o =>
-            {
-                o.TypesToScan(new Type[0]);
-                o.UseSerialization<NServiceBus.Json>();
-            });
+            var builder = new ConfigurationBuilder();
+
+            builder.TypesToScan(new Type[0]);
+            builder.UseSerialization<NServiceBus.Json>();
+
+            configure = Configure.With(builder);
 
             var context = new FeatureConfigurationContext(configure);
             new JsonSerialization().SetupFeature(context);

--- a/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
@@ -13,11 +13,12 @@ namespace NServiceBus.Serializers.Json.Tests
         [SetUp]
         public void SetUp()
         {
-            configure = Configure.With(o =>
-            {
-                o.TypesToScan(new Type[0]);
-                o.UseSerialization<NServiceBus.Json>().Encoding(Encoding.UTF7);
-            });
+            var builder = new ConfigurationBuilder();
+            
+            builder.TypesToScan(new Type[0]);
+            builder.UseSerialization<NServiceBus.Json>().Encoding(Encoding.UTF7);
+
+            configure = Configure.With(builder);
 
             var context = new FeatureConfigurationContext(configure);
             new JsonSerialization().SetupFeature(context);

--- a/src/NServiceBus.Core/ConfigurationBuilder.cs
+++ b/src/NServiceBus.Core/ConfigurationBuilder.cs
@@ -26,7 +26,10 @@ namespace NServiceBus
     /// </summary>
     public class ConfigurationBuilder : ExposeSettings
     {
-        internal ConfigurationBuilder() : base(new SettingsHolder())
+        /// <summary>
+        /// Initializes a fresh instance of the builder
+        /// </summary>
+        public ConfigurationBuilder() : base(new SettingsHolder())
         {
             LogManager.HasConfigBeenInitialised = true;
             configurationSourceToUse = new DefaultConfigurationSource();

--- a/src/NServiceBus.Core/Configure.cs
+++ b/src/NServiceBus.Core/Configure.cs
@@ -90,22 +90,18 @@ namespace NServiceBus
         /// </summary>
         public static Configure With()
         {
-            return With(o => { });
+            return With(new ConfigurationBuilder());
         }
 
 
         /// <summary>
         ///     Initializes the endpoint configuration with the specified customizations.
         /// </summary>
-        /// <param name="customizations">The customizations builder.</param>
+        /// <param name="builder">The configuration builder.</param>
         /// <returns>A new endpoint configuration.</returns>
-        public static Configure With(Action<ConfigurationBuilder> customizations)
+        public static Configure With(ConfigurationBuilder builder)
         {
-            var options = new ConfigurationBuilder();
-
-            customizations(options);
-
-            return options.BuildConfiguration();
+            return builder.BuildConfiguration();
         }
 
         /// <summary>

--- a/src/NServiceBus.Hosting.Tests/EndpointTypeTests.cs
+++ b/src/NServiceBus.Hosting.Tests/EndpointTypeTests.cs
@@ -58,7 +58,12 @@ namespace NServiceBus.Hosting.Tests
             [Test]
             public void when_endpointName_attribute_exists_it_should_have_first_priority()
             {
-                Configure.With(o => o.EndpointName("EndpointNameFromConfiguration"));
+                var builder = new ConfigurationBuilder();
+                
+                builder.EndpointName("EndpointNameFromConfiguration");
+
+                Configure.With(builder);
+                
                 EndpointType = new EndpointType(hostArguments, typeof (TestEndpointTypeWithEndpointNameAttribute));
 
                 Assert.AreEqual("EndpointNameFromAttribute", EndpointType.EndpointName);
@@ -68,7 +73,12 @@ namespace NServiceBus.Hosting.Tests
             [Ignore("this hasn't been implemented yet as far as i can tell")]
             public void when_endpointName_is_provided_via_configuration_it_should_have_second_priority()
             {
-                Configure.With(o => o.EndpointName("EndpointNameFromConfiguration"));
+                var builder = new ConfigurationBuilder();
+
+                builder.EndpointName("EndpointNameFromConfiguration");
+
+                Configure.With(builder);
+
                 EndpointType = new EndpointType(hostArguments, typeof (TestEndpointType));
 
                 Assert.AreEqual("EndpointNameFromConfiguration", EndpointType.EndpointName);

--- a/src/NServiceBus.Hosting.Tests/With_transport_tests.cs
+++ b/src/NServiceBus.Hosting.Tests/With_transport_tests.cs
@@ -10,11 +10,11 @@ namespace NServiceBus.Hosting.Tests
         [Test]
         public void Should_configure_requested_transport()
         {
-            var config = Configure.With(o =>
-            {
-                o.EndpointName("myTests");
-                o.UseTransport<MyTestTransport>();
-            });
+            var builder = new ConfigurationBuilder();
+
+            builder.EndpointName("myTests");
+            builder.UseTransport<MyTestTransport>();
+            var config = Configure.With(builder);
 
             Assert.IsInstanceOf<MyTestTransport>(config.Settings.Get<TransportDefinition>());
         }
@@ -22,7 +22,10 @@ namespace NServiceBus.Hosting.Tests
         [Test]
         public void Should_default_to_msmq_if_no_other_transport_is_configured()
         {
-            var config = Configure.With(o => o.EndpointName("myTests"));
+            var builder = new ConfigurationBuilder();
+            builder.EndpointName("myTests");
+
+            var config = Configure.With(builder);
             
             Assert.True(config.Settings.Get<TransportDefinition>() is Msmq);
         }

--- a/src/NServiceBus.Hosting.Windows/GenericHost.cs
+++ b/src/NServiceBus.Hosting.Windows/GenericHost.cs
@@ -106,22 +106,23 @@ namespace NServiceBus
                 loggingConfigurer.Configure(specifier);
             }
 
-            config = Configure.With(builder =>
+            var builder = new ConfigurationBuilder();
+
+            builder.EndpointName(endpointNameToUse);
+            builder.EndpointVersion(endpointVersionToUse);
+            builder.AssembliesToScan(assembliesToScan);
+            builder.DefineCriticalErrorAction(OnCriticalError);
+
+            if (moreConfiguration != null)
             {
-                builder.EndpointName(endpointNameToUse);
-                builder.EndpointVersion(endpointVersionToUse);
-                builder.AssembliesToScan(assembliesToScan);
-                builder.DefineCriticalErrorAction(OnCriticalError);
+                moreConfiguration(builder);
+            }
 
-                if (moreConfiguration != null)
-                {
-                    moreConfiguration(builder);
-                }
+            specifier.Customize(builder);
+            RoleManager.TweakConfigurationBuilder(specifier, builder);
+            profileManager.ActivateProfileHandlers(builder);
 
-                specifier.Customize(builder);
-                RoleManager.TweakConfigurationBuilder(specifier, builder);
-                profileManager.ActivateProfileHandlers(builder);
-            });
+            config = Configure.With(builder);
         }
 
         // Windows hosting behavior when critical error occurs is suicide.

--- a/src/NServiceBus.PerformanceTests/PubSub/PubSubTestCase.cs
+++ b/src/NServiceBus.PerformanceTests/PubSub/PubSubTestCase.cs
@@ -41,24 +41,25 @@ public class PubSubTestCase : TestCase
     {
         TransportConfigOverride.MaximumConcurrencyLevel = NumberOfThreads;
 
-        var config = Configure.With(o =>
-        {
-            o.EndpointName("PubSubPerformanceTest");
-            o.EnableInstallers();
-            o.DiscardFailedMessagesInsteadOfSendingToErrorQueue();
-            o.UseTransport<Msmq>();
-            o.DisableFeature<Audit>();
+        var builder = new ConfigurationBuilder();
 
-            switch (GetStorageType())
-            {
-                case "inmemory":
-                    o.UsePersistence<InMemory>();
-                    break;
-                case "msmq":
-                    o.UsePersistence<NServiceBus.Persistence.Legacy.Msmq>();
-                    break;
-            }
-        });
+        builder.EndpointName("PubSubPerformanceTest");
+        builder.EnableInstallers();
+        builder.DiscardFailedMessagesInsteadOfSendingToErrorQueue();
+        builder.UseTransport<Msmq>();
+        builder.DisableFeature<Audit>();
+
+        switch (GetStorageType())
+        {
+            case "inmemory":
+                builder.UsePersistence<InMemory>();
+                break;
+            case "msmq":
+                builder.UsePersistence<NServiceBus.Persistence.Legacy.Msmq>();
+                break;
+        }
+
+        var config = Configure.With(builder);
 
 
         using (var bus = config.CreateBus())

--- a/src/NServiceBus.Testing/Test.cs
+++ b/src/NServiceBus.Testing/Test.cs
@@ -33,25 +33,26 @@
                 customisations = o => {};
             }
 
-            InitializeInternal(Configure.With(c =>
+            var builder = new ConfigurationBuilder();
+
+            builder.EndpointName("UnitTests");
+            builder.CustomConfigurationSource(testConfigurationSource);
+            builder.DiscardFailedMessagesInsteadOfSendingToErrorQueue();
+            builder.DisableFeature<Sagas>();
+            builder.DisableFeature<Audit>();
+            builder.UseTransport<FakeTestTransport>();
+            builder.UsePersistence<InMemory>();
+            builder.RegisterEncryptionService(b => new FakeEncryptor());
+            builder.RegisterComponents(r =>
             {
-                c.EndpointName("UnitTests");
-                c.CustomConfigurationSource(testConfigurationSource);
-                c.DiscardFailedMessagesInsteadOfSendingToErrorQueue();
-                c.DisableFeature<Sagas>();
-                c.DisableFeature<Audit>();
-                c.UseTransport<FakeTestTransport>();
-                c.UsePersistence<InMemory>();
-                c.RegisterEncryptionService(b => new FakeEncryptor());
-                c.RegisterComponents(r =>
-                {
-                    r.ConfigureComponent<InMemoryDataBus>(DependencyLifecycle.SingleInstance);
-                    r.ConfigureComponent<FakeQueueCreator>(DependencyLifecycle.InstancePerCall);
-                    r.ConfigureComponent<FakeDequer>(DependencyLifecycle.InstancePerCall);
-                    r.ConfigureComponent<FakeSender>(DependencyLifecycle.InstancePerCall);
-                });
-                customisations(c);
-            }));
+                r.ConfigureComponent<InMemoryDataBus>(DependencyLifecycle.SingleInstance);
+                r.ConfigureComponent<FakeQueueCreator>(DependencyLifecycle.InstancePerCall);
+                r.ConfigureComponent<FakeDequer>(DependencyLifecycle.InstancePerCall);
+                r.ConfigureComponent<FakeSender>(DependencyLifecycle.InstancePerCall);
+            });
+            customisations(builder);
+
+            InitializeInternal(Configure.With(builder));
         }
         
         // ReSharper disable UnusedParameter.Global


### PR DESCRIPTION
This avoids using lambdas which is easier and more discoverable for new users. It also creates a more intuitive flow.

Old syntax:

```
var config = Configure.With(b=>b.UsePersitence<MyPersistence>());
```

New syntax:

```
var builder = new ConfigurationBuilder();

builder.UsePersitence<MyPersistence>();

var config = Configure.With(builder); 
```
