### PR TITLE
 Fix for slow debugging when using castle windsor: #1989

### DIFF
--- a/src/ObjectBuilder.CastleWindsor/WindsorObjectBuilder.cs
+++ b/src/ObjectBuilder.CastleWindsor/WindsorObjectBuilder.cs
@@ -116,11 +116,8 @@
                 throw new InvalidOperationException(message);
             }
 
-            var propertyInfo = component.GetProperty(property);
-
-            registration.AddProperty(
-                new PropertySet(propertyInfo, 
-                    new DependencyModel(property, value.GetType(), false, true, value )));
+            var dependency = Property.ForKey(property).Eq(value);
+            registration.CustomDependencies[dependency.Key] = dependency.Value;
         }
 
         void IContainer.RegisterSingleton(Type lookupType, object instance)


### PR DESCRIPTION
The fix mimics the way Castle:s registration API does when registering properties. So this code:

```
        NServiceBus.Configure.Component<MsmqMessageSender>(DependencyLifecycle.InstancePerCall)
            .ConfigureProperty(t => t.Settings, settings);
```

Will now be the same as:

```
        Container.Register(Component.For<MsmqMessageSender>().LifeStyle.Transient)
                               .DependsOn(
                                   Dependency.OnValue("Settings", settings))
```
