### PR TITLE
InMemorySagaPersister overwrites changes with stale data

### DIFF
--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_multiple_workers_retrieve_same_saga.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_multiple_workers_retrieve_same_saga.cs
@@ -38,6 +38,23 @@
         }
 
         [Test]
+        public void Save_fails_when_data_changes_between_read_and_update_on_same_thread()
+        {
+            var inMemorySagaPersister = new InMemorySagaPersister();
+            var saga = new TestSaga { Id = Guid.NewGuid() };
+            inMemorySagaPersister.Save(saga);
+
+            var record = inMemorySagaPersister.Get<TestSaga>(saga.Id);
+            var staleRecord = inMemorySagaPersister.Get<TestSaga>("Id", saga.Id);
+
+            inMemorySagaPersister.Save(record);
+            inMemorySagaPersister.Get<TestSaga>(saga.Id);
+
+            var exception = Assert.Throws<Exception>(() => inMemorySagaPersister.Save(staleRecord));
+            Assert.IsTrue(exception.Message.StartsWith(string.Format("InMemorySagaPersister concurrency violation: saga entity Id[{0}] already saved by [Worker.", saga.Id)));
+        }
+
+        [Test]
         public void Save_process_is_repeatable()
         {
             var inMemorySagaPersister = new InMemorySagaPersister();


### PR DESCRIPTION
There's checks in `InMemorySagaPersister` to ensure that reads after a write fail if the read has stale data, but the checks only work if the read and writes occur on different threads.

If they occur on the same thread then it's possible to overwrite changed data.

Not sure how much of a priority this is as we shouldn't be using InMemorySagaPersister in a production environment. Right?