### PR TITLE
Use Exception.ToString in headers

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Config\When_using_convention_based_messages.cs" />
     <Compile Include="Conventions\MessageConventionSpecs.cs" />
     <Compile Include="AttributeTests.cs" />
+    <Compile Include="Utils\ExceptionHeaderHelperTests.cs" />
     <Compile Include="Hosting\When_creating_host_information_from_environment.cs" />
     <Compile Include="SetLoggingLibraryTests.cs" />
     <Compile Include="Gateway\Receiving\ChannelReceiverHeaderReaderTests.cs" />

--- a/src/NServiceBus.Core.Tests/Utils/ExceptionHeaderHelperTests.cs
+++ b/src/NServiceBus.Core.Tests/Utils/ExceptionHeaderHelperTests.cs
@@ -1,0 +1,87 @@
+﻿namespace NServiceBus.Core.Tests.Encryption
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.CompilerServices;
+    using NServiceBus.Faults;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ExceptionHeaderHelperTests
+    {
+        [Test]
+        public void VerifyHeadersAreSet()
+        {
+            var exception = GetAnException();
+            var dictionary = new Dictionary<string, string>();
+
+            var failedQueue = new Address("TheErrorQueue","TheErrorQueueMachine");
+            ExceptionHeaderHelper.SetExceptionHeaders(dictionary,exception,failedQueue, "The reason", false);
+            Assert.AreEqual("The reason",dictionary["NServiceBus.ExceptionInfo.Reason"]);
+            Assert.AreEqual("System.AggregateException", dictionary["NServiceBus.ExceptionInfo.ExceptionType"]);
+            var stackTrace = dictionary["NServiceBus.ExceptionInfo.StackTrace"];
+            Assert.IsTrue(stackTrace.StartsWith(@"System.AggregateException: My Exception ---> System.Exception: My Inner Exception
+   at NServiceBus.Core.Tests.Encryption.ExceptionHeaderHelperTests.MethodThatThrows2() in "));
+            Assert.AreEqual("TheErrorQueue@TheErrorQueueMachine", dictionary[FaultsHeaderKeys.FailedQ]);
+            Assert.IsTrue(dictionary.ContainsKey("NServiceBus.TimeOfFailure"));
+
+            Assert.AreEqual("System.Exception", dictionary["NServiceBus.ExceptionInfo.InnerExceptionType"]);
+            Assert.AreEqual("A fake help link", dictionary["NServiceBus.ExceptionInfo.HelpLink"]);
+            Assert.AreEqual("NServiceBus.Core.Tests", dictionary["NServiceBus.ExceptionInfo.Source"]);
+        }
+
+        
+
+        [Test]
+        public void VerifyLegacyHeadersAreSet()
+        {
+            var exception = GetAnException();
+            var dictionary = new Dictionary<string, string>();
+
+            var failedQueue = new Address("TheErrorQueue","TheErrorQueueMachine");
+            ExceptionHeaderHelper.SetExceptionHeaders(dictionary,exception,failedQueue, "The reason",true);
+            Assert.AreEqual("The reason",dictionary["NServiceBus.ExceptionInfo.Reason"]);
+            Assert.AreEqual("System.AggregateException", dictionary["NServiceBus.ExceptionInfo.ExceptionType"]);
+            var stackTrace = dictionary["NServiceBus.ExceptionInfo.StackTrace"];
+            Assert.IsTrue(stackTrace.StartsWith(@"   at NServiceBus.Core.Tests.Encryption.ExceptionHeaderHelperTests.MethodThatThrows1() in "));
+            Assert.AreEqual("TheErrorQueue@TheErrorQueueMachine", dictionary[FaultsHeaderKeys.FailedQ]);
+            Assert.IsTrue(dictionary.ContainsKey("NServiceBus.TimeOfFailure"));
+
+            Assert.AreEqual("System.Exception", dictionary["NServiceBus.ExceptionInfo.InnerExceptionType"]);
+            Assert.AreEqual("A fake help link", dictionary["NServiceBus.ExceptionInfo.HelpLink"]);
+            Assert.AreEqual("NServiceBus.Core.Tests", dictionary["NServiceBus.ExceptionInfo.Source"]);
+        }
+
+        Exception GetAnException()
+        {
+            try
+            {
+                MethodThatThrows1();
+            }
+            catch (Exception e)
+            {
+                return e;
+            }
+            return null;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void MethodThatThrows1()
+        {
+            try
+            {
+                MethodThatThrows2();
+            }
+            catch (Exception exception)
+            {
+                throw new AggregateException("My Exception", exception){HelpLink = "A fake help link"};
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void MethodThatThrows2()
+        {
+            throw new Exception("My Inner Exception");
+        }
+    }
+}


### PR DESCRIPTION
Store `Exception.ToString()` instead of `Exception.StackTrace` inside the `NServiceBus.ExceptionInfo.StackTrace` header
## 
### Default

Replace the value written to `NServiceBus.ExceptionInfo.StackTrace` with `Exception.ToString`
### Legacy

Force exception headers back to `legacy mode` ie keep original headers and use `Exception.StackTrace` in `NServiceBus.ExceptionInfo.StackTrace`.

Enabled by setting the `NServiceBus/Headers/UseLegacyExceptionStackTrace` AppSetting to `true`.
