### PR TITLE
Moved RetryPolicy check to FaultManager

### DIFF
--- a/src/NServiceBus.Core.Tests/SecondLevelRetries/SecondLevelRetriesProcessorTests.cs
+++ b/src/NServiceBus.Core.Tests/SecondLevelRetries/SecondLevelRetriesProcessorTests.cs
@@ -8,8 +8,14 @@
     [TestFixture]
     public class SecondLevelRetriesProcessorTests
     {
-        private readonly int[] _expectedResults = new[] {10,20,30};
-        private TransportMessage _message;
+        readonly int[] _expectedResults = new[]
+        {
+            10,
+            20,
+            30
+        };
+
+        TransportMessage _message;
 
         [SetUp]
         public void SetUp()
@@ -20,15 +26,19 @@
         [Test]
         public void The_time_span_should_increase_with_10_sec_for_every_retry()
         {
-            var retriesProcessor = new SecondLevelRetriesProcessor();
-            for (var i=0; i<3; i++)
+            var retriesProcessor = new SecondLevelRetriesProcessor
             {
-                var timeSpan = retriesProcessor.Validate(_message);
-                
+                SecondLevelRetriesConfiguration = new SecondLevelRetriesConfiguration()
+            };
+
+            for (var i = 0; i < 3; i++)
+            {
+                var timeSpan = retriesProcessor.SecondLevelRetriesConfiguration.RetryPolicy(_message);
+
                 Defer();
 
                 Assert.AreEqual(_expectedResults[i], timeSpan.Seconds);
-            }          
+            }
         }
 
         [Test]
@@ -36,12 +46,16 @@
         {
             TransportMessageHeaderHelper.SetHeader(_message, SecondLevelRetriesHeaders.RetriesTimestamp, DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow.AddDays(-1).AddSeconds(-1)));
 
-            var retriesProcessor = new SecondLevelRetriesProcessor();
-            var hasTimedOut = retriesProcessor.Validate(_message) == TimeSpan.MinValue;
+            var retriesProcessor = new SecondLevelRetriesProcessor
+            {
+                SecondLevelRetriesConfiguration = new SecondLevelRetriesConfiguration()
+            };
+
+            var hasTimedOut = retriesProcessor.SecondLevelRetriesConfiguration.RetryPolicy(_message) == TimeSpan.MinValue;
             Assert.IsTrue(hasTimedOut);
         }
 
-        private void Defer()
+        void Defer()
         {
             TransportMessageHeaderHelper.SetHeader(_message, Headers.Retries, (TransportMessageHeaderHelper.GetNumberOfRetries(_message) + 1).ToString());
         }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -192,6 +192,7 @@
     <Compile Include="Scheduling\Scheduler.cs" />
     <Compile Include="Scheduling\TaskDefinition.cs" />
     <Compile Include="SecondLevelRetries\Helpers\TransportMessageHelpers_Obsolete.cs" />
+    <Compile Include="SecondLevelRetries\SecondLevelRetriesConfiguration.cs" />
     <Compile Include="Serialization\CustomSerialization.cs" />
     <Compile Include="Serialization\CustomSerializer.cs" />
     <Compile Include="Serialization\SerializationConfigExtensions.cs" />

--- a/src/NServiceBus.Core/SecondLevelRetries/Config/SecondLevelRetriesConfig.cs
+++ b/src/NServiceBus.Core/SecondLevelRetries/Config/SecondLevelRetriesConfig.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Config
 {
     using System;
     using System.Configuration;
+    using NServiceBus.SecondLevelRetries;
 
     /// <summary>
     /// Configuration options for the SLR feature
@@ -9,70 +10,40 @@ namespace NServiceBus.Config
     public class SecondLevelRetriesConfig : ConfigurationSection
     {
         /// <summary>
+        /// Creates an instance of <see cref="SecondLevelRetriesConfig"/>.
+        /// </summary>
+        public SecondLevelRetriesConfig()
+        {
+            base.Properties.Add(new ConfigurationProperty("Enabled", typeof(bool), true));
+            base.Properties.Add(new ConfigurationProperty("TimeIncrease", typeof(TimeSpan), SecondLevelRetriesConfiguration.DefaultTimeIncrease, null, new TimeSpanValidator(TimeSpan.Zero, TimeSpan.MaxValue), ConfigurationPropertyOptions.None));
+            base.Properties.Add(new ConfigurationProperty("NumberOfRetries", typeof(int), SecondLevelRetriesConfiguration.DefaultNumberOfRetries, null, new IntegerValidator(0, Int32.MaxValue), ConfigurationPropertyOptions.None));
+        }
+
+        /// <summary>
         /// True if SLR should be used
         /// </summary>
-        [ConfigurationProperty("Enabled", IsRequired = false,DefaultValue = true)]
         public bool Enabled
         {
-            get
-            {
-                return CastTo<bool>(this["Enabled"]);
-            }
-            set
-            {
-                this["Enabled"] = value;
-            }
+            get { return (bool)this["Enabled"]; }
+            set { this["Enabled"] = value; }
         }
 
         /// <summary>
         /// Sets the time to increase the delay between retries
         /// </summary>
-        [ConfigurationProperty("TimeIncrease", IsRequired = false,DefaultValue = "00:00:10")]
         public TimeSpan TimeIncrease
         {
-            get
-            {
-                try
-                {
-                    return (TimeSpan)this["TimeIncrease"];
-                }
-                catch (Exception)
-                {
-                    return TimeSpan.MinValue;
-                }
-                
-            }
-            set
-            {
-                this["TimeIncrease"] = value;
-            }
+            get { return (TimeSpan) this["TimeIncrease"]; }
+            set { this["TimeIncrease"] = value; }
         }
 
         /// <summary>
         /// Sets the number of retries to do before aborting and sending the message to the error queue
         /// </summary>
-        [ConfigurationProperty("NumberOfRetries", IsRequired = false,DefaultValue=3)]
         public int NumberOfRetries
         {
-            get
-            {
-                return CastTo<int>(this["NumberOfRetries"]);
-            }
-            set
-            {
-                this["NumberOfRetries"] = value;
-            }
-        }
-        static T CastTo<T>(object value)
-        {
-            try
-            {
-                return (T)value;
-            }
-            catch (Exception)
-            {
-                return default(T);
-            }
+            get { return (int)this["NumberOfRetries"]; }
+            set { this["NumberOfRetries"] = value; }
         }
     }
 }

--- a/src/NServiceBus.Core/SecondLevelRetries/SecondLevelRetriesConfiguration.cs
+++ b/src/NServiceBus.Core/SecondLevelRetries/SecondLevelRetriesConfiguration.cs
@@ -1,0 +1,66 @@
+namespace NServiceBus.SecondLevelRetries
+{
+    using System;
+    using NServiceBus.SecondLevelRetries.Helpers;
+
+    class SecondLevelRetriesConfiguration
+    {
+        public SecondLevelRetriesConfiguration()
+        {
+            TimeIncrease = DefaultTimeIncrease;
+            NumberOfRetries = DefaultNumberOfRetries;
+            RetryPolicy = DefaultRetryPolicy;
+        }
+
+        public Func<TransportMessage, TimeSpan> RetryPolicy { get; set; }
+        public int NumberOfRetries { get; set; }
+        public TimeSpan TimeIncrease { get; set; }
+
+        TimeSpan DefaultRetryPolicy(TransportMessage message)
+        {
+            if (HasReachedMaxTime(message))
+            {
+                return TimeSpan.MinValue;
+            }
+
+            var numberOfRetries = TransportMessageHeaderHelper.GetNumberOfRetries(message);
+
+            var timeToIncreaseInTicks = TimeIncrease.Ticks*(numberOfRetries + 1);
+            var timeIncrease = TimeSpan.FromTicks(timeToIncreaseInTicks);
+
+            return numberOfRetries >= NumberOfRetries ? TimeSpan.MinValue : timeIncrease;
+        }
+
+        static bool HasReachedMaxTime(TransportMessage message)
+        {
+            var timestampHeader = TransportMessageHeaderHelper.GetHeader(message, SecondLevelRetriesHeaders.RetriesTimestamp);
+
+            if (String.IsNullOrEmpty(timestampHeader))
+            {
+                return false;
+            }
+
+            try
+            {
+                var handledAt = DateTimeExtensions.ToUtcDateTime(timestampHeader);
+
+                if (DateTime.UtcNow > handledAt.AddDays(1))
+                {
+                    return true;
+                }
+            }
+                // ReSharper disable once EmptyGeneralCatchClause
+                // this code won't usually throw but in case a user has decided to hack a message/headers and for some bizarre reason 
+                // they changed the date and that parse fails, we want to make sure that doesn't prevent the message from being 
+                // forwarded to the error queue.
+            catch (Exception)
+            {
+            }
+
+            return false;
+        }
+
+        public static int DefaultNumberOfRetries = 3;
+        public static TimeSpan DefaultTimeIncrease = TimeSpan.FromSeconds(10);
+    }
+}


### PR DESCRIPTION
This allows us to keep the notification error stream as typed exceptions.
Fixed issue with notifications acceptance test would sometimes miss events.
Reusing default SLR settings for both config section and FaultManager.
Added validation rules to SecondLevelRetriesConfig section.
