### PR TITLE
Added support for individualizing endpoint queue names when Scaling-Out

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -81,6 +81,9 @@
     <Compile Include="Basic\When_TimeToBeReceived_has_expired.cs" />
     <Compile Include="Basic\When_Deferring_a_message.cs" />
     <Compile Include="Basic\When_using_callback_to_get_message.cs" />
+    <Compile Include="ScaleOut\When_individualization_is_enabled_for_msmq.cs" />
+    <Compile Include="ScaleOut\When_no_discriminator_is_available.cs" />
+    <Compile Include="ScaleOut\When_individualization_is_enabled.cs" />
     <Compile Include="Config\When_IWantToRunWhenBusStartsAndStops_Start_throws.cs" />
     <Compile Include="Config\When__startup_is_complete.cs" />
     <Compile Include="CriticalError\When_registering_a_custom_criticalErrorHandler.cs" />

--- a/src/NServiceBus.AcceptanceTests/ScaleOut/When_individualization_is_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/ScaleOut/When_individualization_is_enabled.cs
@@ -1,0 +1,54 @@
+﻿namespace NServiceBus.AcceptanceTests.ScaleOut
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_individualization_is_enabled : NServiceBusAcceptanceTest
+    {
+        const string discriminator = "-something";
+
+        
+        [Test]
+        public void Should_use_the_configured_differentiator()
+        {
+            var context = Scenario.Define<Context>()
+                    .WithEndpoint<IndividualizedEndpoint>().Done(c =>c.EndpointsStarted)
+                    .Run();
+
+           
+            Assert.True(context.Address.Contains("-something"),context.Address + " should contain the discriminator " + discriminator);
+
+        }
+
+        public class Context : ScenarioContext
+        {
+            public string Address { get; set; }
+        }
+
+        public class IndividualizedEndpoint : EndpointConfigurationBuilder
+        {
+       
+            public IndividualizedEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c=>c.ScaleOut().UniqueQueuePerEndpointInstance(discriminator));
+            }
+
+            class AddressSpy : IWantToRunWhenBusStartsAndStops
+            {
+                public Context Context { get; set; }
+
+                public Configure Configure { get; set; }
+
+                public void Start()
+                {
+                    Context.Address = Configure.LocalAddress.ToString();
+                }
+
+                public void Stop()
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/ScaleOut/When_individualization_is_enabled_for_msmq.cs
+++ b/src/NServiceBus.AcceptanceTests/ScaleOut/When_individualization_is_enabled_for_msmq.cs
@@ -1,0 +1,55 @@
+﻿namespace NServiceBus.AcceptanceTests.ScaleOut
+{
+    using System.Linq;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Settings;
+    using NUnit.Framework;
+
+    public class When_individualization_is_enabled_for_msmq : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_be_a_no_op_discriminator()
+        {
+            Scenario.Define<Context>()
+                    .WithEndpoint<IndividualizedEndpoint>().Done(c =>c.EndpointsStarted)
+                    .Repeat(r=>r.For(ScenarioDescriptors.Transports.Msmq))
+                    .Should(c=>Assert.AreEqual(c.EndpointName,c.Address.Split('@').First()))
+                    .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public string Address { get; set; }
+            public string EndpointName { get; set; }
+        }
+
+        public class IndividualizedEndpoint : EndpointConfigurationBuilder
+        {
+       
+            public IndividualizedEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c=>c.ScaleOut().UniqueQueuePerEndpointInstance());
+            }
+
+            class AddressSpy : IWantToRunWhenBusStartsAndStops
+            {
+                public Context Context { get; set; }
+
+                public Configure Configure { get; set; }
+
+                public ReadOnlySettings ReadOnlySettings { get; set; }
+
+                public void Start()
+                {
+                    Context.Address = Configure.LocalAddress.ToString();
+                    Context.EndpointName = ReadOnlySettings.EndpointName();
+                }
+
+                public void Stop()
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/ScaleOut/When_no_discriminator_is_available.cs
+++ b/src/NServiceBus.AcceptanceTests/ScaleOut/When_no_discriminator_is_available.cs
@@ -1,0 +1,68 @@
+﻿namespace NServiceBus.AcceptanceTests.ScaleOut
+{
+    using System;
+    using System.Linq;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    public class When_no_discriminator_is_available : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_blow_up()
+        {
+            var ex = Assert.Throws<AggregateException>(()=> Scenario.Define<Context>()
+                    .WithEndpoint<IndividualizedEndpoint>().Done(c =>c.EndpointsStarted)
+                    .AllowExceptions()
+                    .Run());
+
+            var configEx = ex.InnerExceptions.First()
+                .InnerException;
+
+            Assert.True(configEx.Message.StartsWith("No endpoint instance discriminator found"));
+
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class IndividualizedEndpoint : EndpointConfigurationBuilder
+        {
+       
+            public IndividualizedEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.ScaleOut().UniqueQueuePerEndpointInstance();
+                    c.UseTransport<TransportThatDoesntSetADefaultDiscriminator>();
+                });
+            }
+        }
+
+        public class TransportThatDoesntSetADefaultDiscriminator:TransportDefinition
+        {
+            protected override void Configure(BusConfiguration config)
+            {
+                config.EnableFeature<TransportThatDoesntSetADefaultDiscriminatorConfigurator>();
+            }
+        }
+
+            public class TransportThatDoesntSetADefaultDiscriminatorConfigurator : ConfigureTransport
+            {
+                protected override void Configure(FeatureConfigurationContext context, string connectionString)
+                {
+                    
+                }
+
+                protected override string ExampleConnectionStringForErrorMessage
+                {
+                    get { return ""; }
+                }
+            }
+    }
+
+    
+}

--- a/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/Transports.cs
+++ b/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/Transports.cs
@@ -78,10 +78,6 @@
                     runDescriptor.Settings.Add("Transport.ConnectionString", connectionString);
                     yield return runDescriptor;
                 }
-                else
-                {
-                    Console.Out.WriteLine("No connection string found for transport: {0}, test will not be executed for this transport", key);
-                }
             }
         }
 

--- a/src/NServiceBus.Core/Configure.cs
+++ b/src/NServiceBus.Core/Configure.cs
@@ -118,7 +118,7 @@ namespace NServiceBus
 
             featureActivator.RegisterStartupTasks(configurer);
 
-            localAddress = Address.Parse(Settings.Get<string>("NServiceBus.LocalAddress"));
+            localAddress =Settings.LocalAddress();
 
             foreach (var o in Builder.BuildAll<IWantToRunWhenConfigurationIsComplete>())
             {

--- a/src/NServiceBus.Core/Settings/ScaleOutSettings.cs
+++ b/src/NServiceBus.Core/Settings/ScaleOutSettings.cs
@@ -1,5 +1,7 @@
 namespace NServiceBus.Settings
 {
+    using System;
+
     /// <summary>
     /// Placeholder for the various settings related to how a endpoint is scaled out
     /// </summary>
@@ -30,6 +32,30 @@ namespace NServiceBus.Settings
         public void UseUniqueBrokerQueuePerMachine()
         {
             config.Settings.Set("ScaleOut.UseSingleBrokerQueue", false);
+        }
+
+        /// <summary>
+        /// Makes sure that each instance of this endpoint gets a unique queue based on the transport specific discriminator.
+        /// The default discriminator set by the transport will be used
+        /// </summary>
+        public void UniqueQueuePerEndpointInstance()
+        {
+            config.Settings.Set("IndividualizeEndpointAddress", true);
+        }
+
+        /// <summary>
+        /// Makes sure that each instance of this endpoint gets a unique queue based on the transport specific discriminator.
+        /// </summary>
+        /// <param name="discriminator">The discriminator to use</param>
+        public void UniqueQueuePerEndpointInstance(string discriminator)
+        {
+            if (discriminator == null)
+            {
+                throw new ArgumentException("Discriminator can't be null");
+            }
+
+            config.Settings.Set("EndpointInstanceDiscriminator", discriminator);
+            UniqueQueuePerEndpointInstance();
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/Config/Msmq.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/Config/Msmq.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus
 {
+    using NServiceBus.Configuration.AdvanceExtensibility;
     using NServiceBus.Features;
     using Transports;
 
@@ -21,6 +22,11 @@ namespace NServiceBus
         /// </summary>
         protected internal override void Configure(BusConfiguration config)
         {
+            // For MSMQ the endpoint differentiator is a no-op since you commonly scale out by running the same endpoint on a different machine.
+            // if users want to run more than one instance on the same machine they need to set an explicit discriminator
+            config.GetSettings()
+                .SetDefault("EndpointInstanceDiscriminator", "");
+               
             config.EnableFeature<MsmqTransportConfigurator>();
             config.EnableFeature<MessageDrivenSubscriptions>();
             config.EnableFeature<TimeoutManagerBasedDeferral>();

--- a/src/NServiceBus.Core/Transports/Msmq/Config/MsmqTransportConfigurator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/Config/MsmqTransportConfigurator.cs
@@ -16,7 +16,7 @@
         {
             
         }
-
+            
         /// <summary>
         /// Initializes a new instance of <see cref="ConfigureTransport"/>.
         /// </summary>
@@ -27,13 +27,13 @@
 
             context.Container.ConfigureComponent<CorrelationIdMutatorForBackwardsCompatibilityWithV3>(DependencyLifecycle.InstancePerCall);
             context.Container.ConfigureComponent<MsmqUnitOfWork>(DependencyLifecycle.SingleInstance);
-            
+
             if (!context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"))
             {
                 context.Container.ConfigureComponent<MsmqDequeueStrategy>(DependencyLifecycle.InstancePerCall)
                     .ConfigureProperty(p => p.ErrorQueue, ErrorQueueSettings.GetConfiguredErrorQueue(context.Settings));
             }
-            
+
             var cfg = context.Settings.GetConfigSection<MsmqMessageQueueConfig>();
 
             var settings = new MsmqSettings();

--- a/src/NServiceBus.Core/Unicast/Config/UnicastBus.cs
+++ b/src/NServiceBus.Core/Unicast/Config/UnicastBus.cs
@@ -18,16 +18,12 @@ namespace NServiceBus.Features
     using Unicast.Routing;
     using Unicast.Transport;
 
-    /// <summary>
-    ///   Used to configure the <see cref="Unicast.UnicastBus"/>
-    /// </summary>
     class UnicastBus : Feature
     {
         internal UnicastBus()
         {
             EnableByDefault();
 
-            Defaults(s => s.SetDefault("NServiceBus.LocalAddress", s.EndpointName()));
             Defaults(s =>
             {
                 string fullPathToStartingExe;
@@ -43,12 +39,10 @@ namespace NServiceBus.Features
             });
         }
 
-        /// <summary>
-        /// See <see cref="Feature.Setup"/>
-        /// </summary>
+      
         protected internal override void Setup(FeatureConfigurationContext context)
         {
-            var defaultAddress = Address.Parse(context.Settings.Get<string>("NServiceBus.LocalAddress"));
+            var defaultAddress = context.Settings.LocalAddress();
             var hostInfo = new HostInformation(context.Settings.Get<Guid>("NServiceBus.HostInformation.HostId"), 
                 context.Settings.Get<string>("NServiceBus.HostInformation.DisplayName"), 
                 context.Settings.Get<Dictionary<string, string>>("NServiceBus.HostInformation.Properties"));


### PR DESCRIPTION
## Problem

When scaling out endpoint you need to make sure it gets a unique input queue per instance while keeping the endpoint name the same.
## New API

```
configure.ScaleOut().UniqueQueuePerEndpointInstance()
```

This will tell NServiceBus to use the suffix registered by the transport or host to make sure that each instance of your endpoint will be unique. For MSMQ this is a no-op since you commonly scaled them out by running multiple instances on different machines and that will give them a unique address out of the box. Eg: `sales@server1, sales@serverN` etc.

For broker transports that's no longer true, hence the need for a suffix. For on-premise operations the machine name is likely to be used and in cloud scenarios like on Azure the instance id is better suited since machines will dynamically change. 

RabbitMQ example:  `sales-server1, sales-serverN` 
Azure ServiceBus example:  `sales-1, sales-N` where N is the role instance id

If you need full control over the suffixor if the transport hasn't registered a default you can control it using:

```
configure.ScaleOut().UniqueQueuePerEndpointInstance("-MyCustomSuffix")
```
