### PR TITLE
null values are being inserted into the GetAllowedTypes result set

### DIFF
--- a/src/NServiceBus.Core/Configure.cs
+++ b/src/NServiceBus.Core/Configure.cs
@@ -168,7 +168,7 @@ namespace NServiceBus
                     {
                         var errorMessage = AssemblyScanner.FormatReflectionTypeLoadException(a.FullName, exception);
                         LogManager.GetLogger<Configure>().Warn(errorMessage);
-                        types.AddRange(exception.Types);
+                        types.AddRange(exception.Types.Where(AssemblyScanner.IsAllowedType));
                         //intentionally swallow exception
                     }
                 });

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -339,7 +339,8 @@ namespace NServiceBus.Hosting.Helpers
 
         internal static bool IsAllowedType(Type type)
         {
-            return !type.IsValueType &&
+            return type != null &&
+                   !type.IsValueType &&
                    !(type.GetCustomAttributes(typeof(CompilerGeneratedAttribute), false).Length > 0);
         }
 


### PR DESCRIPTION
When a ReflectionTypeLoadException occurs, the Types property may contain null values.  These null values are being inserted directly into the result set in GetAllowedTypes.

Explanation for why nulls exist: http://msdn.microsoft.com/en-us/library/system.reflection.reflectiontypeloadexception.types(v=vs.110).aspx

I also noticed the Types property was bypassing the AssemblyScanner.IsAllowedType check, so I placed the null check in that method and then ran the Types property through it to follow the same semantics used when no exception thrown.