### PR TITLE
Add support for settings injection

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Basic/When_injecting_handler_props.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_injecting_handler_props.cs
@@ -1,0 +1,67 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_injecting_handler_props : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Run()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<Receiver>(c=>c.When(b=>b.SendLocal(new MyMessage())))
+                    .Done(c => c.WasCalled)
+                    .Run();
+
+            Assert.AreEqual(10, context.Number);
+            Assert.AreEqual("Foo", context.Name);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+            public string Name { get; set; }
+            public int Number { get; set; }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.InitializeHandlerProperty<MyMessageHandler>("Number", 10);
+                    c.InitializeHandlerProperty<MyMessageHandler>("Name", "Foo");
+                });
+
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public string Name { get; set; }
+
+                public int Number { get; set; }
+
+                public void Handle(MyMessage message)
+                {
+                    Context.Number = Number;
+                    Context.Name = Name;
+                    Context.WasCalled = true;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Audit\When_using_audit_message_is_received.cs" />
     <Compile Include="Basic\When_registering_custom_serializer.cs" />
     <Compile Include="Basic\When_callback_from_a_send_only.cs" />
+    <Compile Include="Basic\When_injecting_handler_props.cs" />
     <Compile Include="Basic\When_using_ineedinitialization.cs" />
     <Compile Include="Basic\When_sending_with_conventions.cs" />
     <Compile Include="Basic\When_using_callbacks_with_messageid_eq_cid_.cs" />

--- a/src/NServiceBus.Core/ConfigureHandlerSettings.cs
+++ b/src/NServiceBus.Core/ConfigureHandlerSettings.cs
@@ -1,0 +1,31 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using NServiceBus.ObjectBuilder;
+
+    /// <summary>
+    /// Extension methods for injecting props in <see cref="IHandleMessages{T}"/>.
+    /// </summary>
+    public static class ConfigureHandlerSettings
+    {
+        /// <summary>
+        /// Initializes <see cref="IHandleMessages{T}"/> with the specified properties.
+        /// </summary>
+        /// <typeparam name="THandler">The <see cref="IHandleMessages{T}"/> type.</typeparam>
+        /// <param name="config">The configuration instance.</param>
+        /// <param name="property">The property name to be injected.</param>
+        /// <param name="value">The value to assign to the <paramref name="property"/>.</param>
+        public static void InitializeHandlerProperty<THandler>(this BusConfiguration config, string property, object value)
+        {
+            List<Action<IConfigureComponents>> list;
+            if (!config.Settings.TryGet("NServiceBus.HandlerProperties", out list))
+            {
+                list = new List<Action<IConfigureComponents>>();
+                config.Settings.Set("NServiceBus.HandlerProperties", list);
+            }
+
+            list.Add(c=> c.ConfigureProperty<THandler>(property, value));
+        }
+    }
+}

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -89,6 +89,7 @@
     <Compile Include="App_Packages\Particular.Licensing\UserSidChecker.cs" />
     <Compile Include="Bus.cs" />
     <Compile Include="BusConfiguration.cs" />
+    <Compile Include="ConfigureHandlerSettings.cs" />
     <Compile Include="ConfigureQueueCreation_Obsolete.cs" />
     <Compile Include="ConfigureInMemoryFaultManagement_obsolete.cs" />
     <Compile Include="Config\MsmqConnectionStringBuilder.cs" />

--- a/src/NServiceBus.Core/Unicast/Config/RegisterHandlersInOrder.cs
+++ b/src/NServiceBus.Core/Unicast/Config/RegisterHandlersInOrder.cs
@@ -5,6 +5,7 @@ namespace NServiceBus.Features
     using System.Configuration;
     using System.Linq;
     using NServiceBus.Logging;
+    using NServiceBus.ObjectBuilder;
     using NServiceBus.Settings;
     using NServiceBus.Unicast;
 
@@ -86,6 +87,15 @@ namespace NServiceBus.Features
                 context.Container.ConfigureComponent(t, DependencyLifecycle.InstancePerUnitOfWork);
                 handlerRegistry.RegisterHandler(t);
                 handlers.Add(t);
+            }
+
+            List<Action<IConfigureComponents>> propertiesToInject;
+            if (context.Settings.TryGet("NServiceBus.HandlerProperties", out propertiesToInject))
+            {
+                foreach (var action in propertiesToInject)
+                {
+                    action(context.Container);
+                }
             }
 
             context.Container.RegisterSingleton<IMessageHandlerRegistry>(handlerRegistry);


### PR DESCRIPTION
### Problem
As currently pointed out in #2600, v5 of NServiceBus no longer has a hook to assign config settings to `IHandleMessages<T>` types.

This PR addresses this issue by introducing a more explicit API.

### Current limitations
Only property injection is supported, no ctor injection :disappointed: 

### New API
```c#
config.InitializeHandlerProperty<MyHandler>("MyProp", myvalue);
config.InitializeHandlerProperty<MyHandler2>("MyProp2", myvalue2);
```

