### PR TITLE
Support inheritance-based sagas of +1 generic args

### DIFF
--- a/src/NServiceBus.Core.Tests/Sagas/TypeBasedSagaMetaModelTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/TypeBasedSagaMetaModelTests.cs
@@ -140,6 +140,14 @@
             Assert.AreEqual(typeof(MySagaWithScannedFinder.CustomFinder), finder.Properties["custom-finder-clr-type"]);
         }
 
+        [Test]
+        public void GetEntityClrTypeFromInheritanceChain()
+        {
+            var metadata = TypeBasedSagaMetaModel.Create(typeof(SagaWithInheirtanceChain));
+
+            Assert.AreEqual(typeof(SagaWithInheirtanceChain.SagaData), metadata.SagaEntityType);
+        }
+
         SagaFinderDefinition GetFinder(SagaMetadata metadata, string messageType)
         {
             SagaFinderDefinition finder;
@@ -352,6 +360,26 @@
             {
                 
             }
+        }
+
+         class SagaWithInheirtanceChain : SagaWithInheritanceChainBase<SagaWithInheirtanceChain.SagaData, SagaWithInheirtanceChain.SomeOtherData>
+         {
+             public class SagaData : ContainSagaData
+             {
+                 public string SomeId { get; set; }
+             }
+
+             public class SomeOtherData
+             {
+                 public string SomeData { get; set; }
+             }
+         }
+
+         class SagaWithInheritanceChainBase<T, O> : Saga<T> where T : IContainSagaData, new() where O : class
+        {
+             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<T> mapper)
+             {
+             }
         }
     }
 

--- a/src/NServiceBus.Core/Sagas/TypeBasedSagaMetaModel.cs
+++ b/src/NServiceBus.Core/Sagas/TypeBasedSagaMetaModel.cs
@@ -22,6 +22,23 @@ namespace NServiceBus.Sagas
             return typeof(Saga).IsAssignableFrom(t) && t != typeof(Saga) && !t.IsGenericType;
         }
 
+        static Type GetBaseSagaType(Type t)
+        {
+            var cur = t.BaseType;
+
+            while (cur != null)
+            {
+                if (cur.Name == "Saga`1")
+                {
+                    return cur;
+                }
+
+                cur = cur.BaseType;
+            }
+
+            throw new InvalidOperationException();
+        }
+
         public static SagaMetadata Create(Type sagaType)
         {
             return Create(sagaType, new List<Type>(), new Conventions());
@@ -33,7 +50,7 @@ namespace NServiceBus.Sagas
                 throw new Exception(sagaType.FullName + " is not a saga");
             }
 
-            var sagaEntityType = sagaType.BaseType.GetGenericArguments().Single();
+            var sagaEntityType = GetBaseSagaType(sagaType).GetGenericArguments().Single();
 
             var uniquePropertiesOnEntity = FindUniqueAttributes(sagaEntityType).ToList();
 


### PR DESCRIPTION
Whilst upgrading one of our repositories to v5 we noticed that our (admittedly unusual but historically necessary) use of an inheritance chain through to `Saga<>` was broken due to the v5 code-base assuming that only one generic-parameter would exist - *and* - that it would be the `SagaDataEntity`. 

Included in this PR is a slight amendment to `TypeBasedSagaMetaModel.cs` that follows the inheritance chain as to be certain the assumed call to `GetGenericArguments.Single()` will be correct, and thus avoiding the exception below. An accompanying test is included.

```text
System.InvalidOperationExceptionSequence contains more than one element
   at System.Linq.Enumerable.Single(IEnumerable`1 source)
   at NServiceBus.Sagas.TypeBasedSagaMetaModel.Create(Type sagaType, IEnumerable`1 availableTypes, Conventions conventions) in TypeBasedSagaMetaModel.cs: line 36
   at NServiceBus.Sagas.TypeBasedSagaMetaModel.<>c__DisplayClass1.<Create>b__0(Type t) in TypeBasedSagaMetaModel.cs: line 17
   at System.Linq.Enumerable.WhereSelectListIterator`2.MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList(IEnumerable`1 source)
   at NServiceBus.Sagas.TypeBasedSagaMetaModel.Create(IList`1 availableTypes, Conventions conventions) in TypeBasedSagaMetaModel.cs: line 16
   at NServiceBus.Features.Sagas.Setup(FeatureConfigurationContext context) in c:\BuildAgent\work\1b05a2fea6e4cd32\src\NServiceBus.Core\Sagas\Sagas.cs: line 41
   at NServiceBus.Features.FeatureActivator.ActivateFeature(FeatureState featureState, IEnumerable`1 featuresToActivate, FeatureConfigurationContext context) in c:\BuildAgent\work\1b05a2fea6e4cd32\src\NServiceBus.Core\Features\FeatureActivator.cs: line 240
   at NServiceBus.Features.FeatureActivator.SetupFeatures(FeatureConfigurationContext context) in c:\BuildAgent\work\1b05a2fea6e4cd32\src\NServiceBus.Core\Features\FeatureActivator.cs: line 118
   at NServiceBus.Configure.Initialize() in c:\BuildAgent\work\1b05a2fea6e4cd32\src\NServiceBus.Core\Configure.cs: line 115
   at NServiceBus.Bus.Create(BusConfiguration configuration) in c:\BuildAgent\work\1b05a2fea6e4cd32\src\NServiceBus.Core\Bus.cs: line 19
```

**Note** Comparison of the base-class against a magic-string seemed wrong, but optimal in terms of speed, and lacking the ability to do `== typeof(Saga<>)`, might be wrong though?