### PR TITLE
AcceptanceTesting: Enable domain data config

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Customization/Conventions.cs
+++ b/src/NServiceBus.AcceptanceTesting/Customization/Conventions.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.AcceptanceTesting.Customization
 {
     using System;
+    using System.Collections.Generic;
     using Support;
 
     public class Conventions
@@ -13,5 +14,7 @@ namespace NServiceBus.AcceptanceTesting.Customization
         public static Func<RunDescriptor> DefaultRunDescriptor = () => new RunDescriptor {Key = "Default"};
 
         public static Func<Type, string> EndpointNamingConvention { get; set; }
+
+        public static Func<IDictionary<string, object>> DefaultDomainData { get; set; }
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -379,6 +379,17 @@ namespace NServiceBus.AcceptanceTesting.Support
 
             var appDomain = AppDomain.CreateDomain(endpointName, AppDomain.CurrentDomain.Evidence, domainSetup);
 
+            if (Conventions.DefaultDomainData != null)
+            {
+                var domainData = Conventions.DefaultDomainData.Invoke();
+
+                foreach (var data in domainData)
+                {
+                    appDomain.SetData(data.Key, data.Value);
+                }
+
+            }
+
             return new ActiveRunner
             {
                 Instance = (EndpointRunner)appDomain.CreateInstanceAndUnwrap(Assembly.GetExecutingAssembly().FullName, typeof(EndpointRunner).FullName),


### PR DESCRIPTION
**For your consideration/comment;**

Due to our use of an older version of the acceptance-testing framework I would like to submit a small change we found necessary in setting data for the AppDomains created by the `ScenarioRunner`. In truth the only use we found for this (and the motivation for the change) was to set `DataDirectory` so we could - at test time - change the location of any file using `|DataDirectory|` in configs (e.g. app.config).

Example usage;
```csharp
            // Create a temporary database file for this test run in location X as 'databasePath'
            this.CreateDatabasesFromConfigUsingPath(this.databasePath);

            // Tell the AppDomain the path to use when parsing |DataDirectory|, for example
            // using VistaDB "Data Source=|DataDirectory|\BusTestsAcceptanceMhsFacadeNSB.vdb5;"
            Conventions.DefaultDomainData = () => new Dictionary<string, object>
                                                      {
                                                          { "DataDirectory", this.databasePath }
                                                      };
```

Given it is unlikely you'd want to specify a different value for individual endpoints, and perhaps even tests, we placed it in the `Conventions` which we set in our testing base class. Sadly we never found a way to do this nicely through `AppDomainSetup` (e.g. `ApplicationBase`) and thus perhaps use a setting on `RunDescriptor` (alongside the new  `UseSeparateAppdomains`).