### PR TITLE
AcceptanceTesting: AppConfig on Behaviour DSL + AppDomain ConfigFile

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointBehaviorBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointBehaviorBuilder.cs
@@ -57,6 +57,13 @@
             return this;
         }
 
+        public EndpointBehaviorBuilder<TContext> AppConfig(string appConfig)
+        {
+            behavior.AppConfig = appConfig;
+
+            return this;
+        }
+
         public EndpointBehavior Build()
         {
             return behavior;

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -369,13 +369,9 @@ namespace NServiceBus.AcceptanceTesting.Support
             var domainSetup = new AppDomainSetup
             {
                 ApplicationBase = AppDomain.CurrentDomain.SetupInformation.ApplicationBase,
-                LoaderOptimization = LoaderOptimization.SingleDomain
+                LoaderOptimization = LoaderOptimization.SingleDomain,
+                ConfigurationFile = appConfigPath ?? AppDomain.CurrentDomain.SetupInformation.ConfigurationFile
             };
-
-            if (appConfigPath != null)
-            {
-                domainSetup.ConfigurationFile = appConfigPath;
-            }
 
             var appDomain = AppDomain.CreateDomain(endpointName, AppDomain.CurrentDomain.Evidence, domainSetup);
 


### PR DESCRIPTION
**NB; we are migrating NSB v4 to v5, along w/our customised version of the v4 Acceptance Testing f/w.**

In our own custom version of the v4 Acceptance Testing framework we would specify an AppConfig on the `EndpointConfiguration` and set via `EndpointConfigurationBuilder`, but using this required calling `.Get()` on a *created* instance of the endpoint configuration given it wasn't 'to hand', this seems sub-optimal. We could have alternatively tried passing this setting into the `ScenarioRunner` for conditional usage (behaviour.AppConfig ?? endpointConfiguration.AppConfig), or better still default each new behaviour to use `AppConfig` from `EndpointConfiguration`. The changes required seemed quite substantial though.

Our aim is to switch to the vanilla v5 AcceptanceTesting NuGet with the minimum amount of impact on our codebase and the library itself, so instead I propose the change attached. It adds support to the Behaviour DSL to specify `AppConfig` (presumably omitted by accident?) and in the absence of this setting *default* to the `CurrentDomain.SetupInformation.ConfigurationFile`.

Thoughts/comments welcome?

 