### PR TITLE
Bug where individual storage persistence overrides all storage options

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Logging\DefaultFactoryTests.cs" />
     <Compile Include="Msmq\ConnectionStringParserTests.cs" />
     <Compile Include="Persistence\InMemory\InMemorySagaPersistenceFixture.cs" />
+    <Compile Include="Persistence\PersistenceStorageMergerTests.cs" />
     <Compile Include="Sagas\SagaModelTests.cs" />
     <Compile Include="Sagas\TypeBasedSagaMetaModelTests.cs" />
     <Compile Include="StandardsTests.cs" />

--- a/src/NServiceBus.Core.Tests/Persistence/PersistenceStorageMergerTests.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/PersistenceStorageMergerTests.cs
@@ -1,0 +1,71 @@
+﻿namespace NServiceBus.Core.Tests.Persistence
+{
+    using System;
+    using System.Collections.Generic;
+    using NServiceBus.Persistence;
+    using NServiceBus.Settings;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_no_storage_persistence_overrides_are_enabled
+    {
+        [Test]
+        public void Should_use_all_storages_supported_by_persistence()
+        {
+            var settingsHolder = new SettingsHolder();
+            var userProvidedEnabledPersistences = new List<EnabledPersistence>
+            {
+                new EnabledPersistence
+                {
+                    DefinitionType = typeof(InMemoryPersistence),
+                    SelectedStorages = new List<Type>()
+                }
+            };
+
+            var resultedEnabledPersistences = PersistenceStorageMerger.Merge(userProvidedEnabledPersistences, settingsHolder);
+
+            Assert.That(resultedEnabledPersistences[0].SelectedStorages, Is.EquivalentTo(StorageType.GetAvailableStorageTypes()));
+        }
+    }
+
+    [TestFixture]
+    public class When_storage_overrides_are_provided
+    {
+        [Test]
+        public void Should_replace_default_storages_by_overrides()
+        {
+            var settingsHolder = new SettingsHolder();
+            var userProvidedEnabledPersistences = new List<EnabledPersistence>
+            {
+                new EnabledPersistence
+                {
+                    DefinitionType = typeof(InMemoryPersistence),
+                    SelectedStorages = new List<Type>()
+                },
+                // user provided overrides
+                new EnabledPersistence
+                {
+                    DefinitionType = typeof(FakePersistence),
+                    SelectedStorages = new List<Type>{ typeof(StorageType.Sagas), typeof(StorageType.Subscriptions) }
+                }
+            };
+
+            var resultedEnabledPersistences = PersistenceStorageMerger.Merge(userProvidedEnabledPersistences, settingsHolder);
+            
+            Assert.That(resultedEnabledPersistences[0].SelectedStorages, Is.EquivalentTo(
+                new List<Type> { typeof(StorageType.Sagas), typeof(StorageType.Subscriptions) }));
+            Assert.That(resultedEnabledPersistences[1].SelectedStorages, Is.EquivalentTo(
+                new List<Type> { typeof(StorageType.GatewayDeduplication), typeof(StorageType.Outbox), typeof(StorageType.Timeouts) }));
+        }
+
+        class FakePersistence : PersistenceDefinition
+        {
+            public FakePersistence()
+            {
+                Supports<StorageType.Sagas>(settings => { });
+                Supports<StorageType.Subscriptions>(settings => { });
+                Supports<StorageType.Timeouts>(settings => { });
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Persistence\Msmq\SubscriptionStorage\MsmqSubscriptionPersistence.cs" />
     <Compile Include="Persistence\PersistenceExtentions.cs" />
     <Compile Include="Persistence\PersistenceStartup.cs" />
+    <Compile Include="Persistence\PersistenceStorageMerger.cs" />
     <Compile Include="Persistence\Storage.cs" />
     <Compile Include="Persistence\StorageType.cs" />
     <Compile Include="Pipeline\PipelineModifications.cs" />

--- a/src/NServiceBus.Core/Persistence/PersistenceConfig.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceConfig.cs
@@ -39,7 +39,7 @@
         /// <param name="definitionType">The persistence definition eg <see cref="InMemoryPersistence"/>, NHibernate etc</param>
         public static PersistenceExtentions UsePersistence(this BusConfiguration config, Type definitionType)
         {
-            return new PersistenceExtentions(definitionType, config.Settings);
+            return new PersistenceExtentions(definitionType, config.Settings, null);
         }
     }
 }

--- a/src/NServiceBus.Core/Persistence/PersistenceExtentions.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceExtentions.cs
@@ -17,23 +17,11 @@
         where S : StorageType
     {
         /// <summary>
+        /// Default constructor.
         /// </summary>
-        /// <param name="settings"></param>
         public PersistenceExtentions(SettingsHolder settings) : base(settings, typeof(S))
         {
         }
-
-        /// <summary>
-        /// Defines the list of specific storage needs this persistence should provide
-        /// </summary>
-        /// <param name="specificStorages"></param>
-        /// <returns></returns>
-        /// <exception cref="InvalidOperationException"></exception>
-        [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "5.2")]
-        public new PersistenceExtentions<T> For(params Storage[] specificStorages)
-        {
-            throw new InvalidOperationException("Do not invoke .For() when StorageType is already specified.");
-        } 
     }
 
     /// <summary>
@@ -53,8 +41,6 @@
         /// <summary>
         /// Constructor for a specific <see cref="StorageType"/>
         /// </summary>
-        /// <param name="settings"></param>
-        /// <param name="storageType"></param>
         protected PersistenceExtentions(SettingsHolder settings, Type storageType) : base(typeof(T), settings, storageType)
         {
         }

--- a/src/NServiceBus.Core/Persistence/PersistenceExtentions.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceExtentions.cs
@@ -19,10 +19,21 @@
         /// <summary>
         /// </summary>
         /// <param name="settings"></param>
-        public PersistenceExtentions(SettingsHolder settings)
-            : base(settings)
+        public PersistenceExtentions(SettingsHolder settings) : base(settings, typeof(S))
         {
         }
+
+        /// <summary>
+        /// Defines the list of specific storage needs this persistence should provide
+        /// </summary>
+        /// <param name="specificStorages"></param>
+        /// <returns></returns>
+        /// <exception cref="InvalidOperationException"></exception>
+        [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "5.2")]
+        public new PersistenceExtentions<T> For(params Storage[] specificStorages)
+        {
+            throw new InvalidOperationException("Do not invoke .For() when StorageType is already specified.");
+        } 
     }
 
     /// <summary>
@@ -35,8 +46,16 @@
         /// <summary>
         ///     Default constructor.
         /// </summary>
-        public PersistenceExtentions(SettingsHolder settings)
-            : base(typeof(T), settings)
+        public PersistenceExtentions(SettingsHolder settings) : base(typeof(T), settings, null)
+        {
+        }
+
+        /// <summary>
+        /// Constructor for a specific <see cref="StorageType"/>
+        /// </summary>
+        /// <param name="settings"></param>
+        /// <param name="storageType"></param>
+        protected PersistenceExtentions(SettingsHolder settings, Type storageType) : base(typeof(T), settings, storageType)
         {
         }
 
@@ -64,7 +83,7 @@
         /// <summary>
         ///     Default constructor.
         /// </summary>
-        public PersistenceExtentions(Type definitionType, SettingsHolder settings)
+        public PersistenceExtentions(Type definitionType, SettingsHolder settings, Type storageType)
             : base(settings)
         {
             List<EnabledPersistence> definitions;
@@ -79,6 +98,12 @@
                 DefinitionType = definitionType,
                 SelectedStorages = new List<Type>(),
             };
+
+            if (storageType != null)
+            {
+                enabledPersistence.SelectedStorages.Add(storageType);
+            }
+
             definitions.Add(enabledPersistence);
         }
 

--- a/src/NServiceBus.Core/Persistence/PersistenceStartup.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceStartup.cs
@@ -27,31 +27,21 @@
                 throw new Exception(errorMessage);
             }
 
-            definitions.Reverse();
+            var enabledPersistences = PersistenceStorageMerger.Merge(definitions, settings);
 
-            var availableStorages = StorageType.GetAvailableStorageTypes();
             var resultingSupportedStorages = new List<Type>();
 
-            foreach (var definition in definitions)
+            foreach (var definition in enabledPersistences)
             {
                 var persistenceDefinition = definition.DefinitionType.Construct<PersistenceDefinition>();
-                var supportedStorages = persistenceDefinition.GetSupportedStorages(definition.SelectedStorages);
 
                 persistenceDefinition.ApplyDefaults(settings);
 
-                foreach (var storageType in supportedStorages)
+                foreach (var storageType in definition.SelectedStorages)
                 {
-                    if (availableStorages.Contains(storageType))
-                    {
-                        Logger.InfoFormat("Activating persistence '{0}' to provide storage for '{1}' storage.", definition.DefinitionType.Name, storageType);
-                        availableStorages.Remove(storageType);
-                        persistenceDefinition.ApplyActionForStorage(storageType, settings);
-                        resultingSupportedStorages.Add(storageType);
-                    }
-                    else
-                    {
-                        Logger.InfoFormat("Persistence '{0}' was not applied to storage '{1}' since that storage has been claimed by another persistence. This is a 'last one wins' scenario.", definition.DefinitionType.Name, storageType);
-                    }
+                    Logger.InfoFormat("Activating persistence '{0}' to provide storage for '{1}' storage.", definition.DefinitionType.Name, storageType);
+                    persistenceDefinition.ApplyActionForStorage(storageType, settings);
+                    resultingSupportedStorages.Add(storageType);
                 }
             }
 

--- a/src/NServiceBus.Core/Persistence/PersistenceStorageMerger.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceStorageMerger.cs
@@ -1,0 +1,50 @@
+﻿namespace NServiceBus.Persistence
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using NServiceBus.Settings;
+    using NServiceBus.Utils.Reflection;
+
+    class PersistenceStorageMerger
+    {
+        public static List<EnabledPersistence> Merge(List<EnabledPersistence> definitions, SettingsHolder settings)
+        {
+            definitions.Reverse();
+
+            var availableStorages = StorageType.GetAvailableStorageTypes();
+            var resultingSupportedStorages = new List<Type>();
+            var mergedEnabledPersistences = new List<EnabledPersistence>();
+
+            foreach (var definition in definitions)
+            {
+                var persistenceDefinition = definition.DefinitionType.Construct<PersistenceDefinition>();
+                var supportedStorages = persistenceDefinition.GetSupportedStorages(definition.SelectedStorages);
+
+                var currentDefinition = new EnabledPersistence
+                {
+                    DefinitionType = definition.DefinitionType,
+                    SelectedStorages = new List<Type>()
+                };
+
+                foreach (var storageType in supportedStorages)
+                {
+                    if (availableStorages.Contains(storageType))
+                    {
+                        currentDefinition.SelectedStorages.Add(storageType);
+                        availableStorages.Remove(storageType);
+                        persistenceDefinition.ApplyActionForStorage(storageType, settings);
+                        resultingSupportedStorages.Add(storageType);
+                    }
+                }
+
+                if (currentDefinition.SelectedStorages.Any())
+                {
+                    mergedEnabledPersistences.Add(currentDefinition);
+                }
+            }
+
+            return mergedEnabledPersistences;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Persistence/PersistenceStorageMerger.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceStorageMerger.cs
@@ -13,7 +13,6 @@
             definitions.Reverse();
 
             var availableStorages = StorageType.GetAvailableStorageTypes();
-            var resultingSupportedStorages = new List<Type>();
             var mergedEnabledPersistences = new List<EnabledPersistence>();
 
             foreach (var definition in definitions)
@@ -34,7 +33,6 @@
                         currentDefinition.SelectedStorages.Add(storageType);
                         availableStorages.Remove(storageType);
                         persistenceDefinition.ApplyActionForStorage(storageType, settings);
-                        resultingSupportedStorages.Add(storageType);
                     }
                 }
 

--- a/src/NServiceBus.Core/Settings/SettingsHolder.cs
+++ b/src/NServiceBus.Core/Settings/SettingsHolder.cs
@@ -4,11 +4,9 @@ namespace NServiceBus.Settings
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Configuration;
-    using System.Linq;
     using System.Linq.Expressions;
-    using NServiceBus.Persistence;
-    using ObjectBuilder;
-    using Utils.Reflection;
+    using NServiceBus.ObjectBuilder;
+    using NServiceBus.Utils.Reflection;
 
     /// <summary>
     /// Setting container.
@@ -292,44 +290,5 @@ namespace NServiceBus.Settings
 
         readonly ConcurrentDictionary<string, object> Overrides = new ConcurrentDictionary<string, object>(StringComparer.OrdinalIgnoreCase);
         readonly ConcurrentDictionary<string, object> Defaults = new ConcurrentDictionary<string, object>(StringComparer.OrdinalIgnoreCase);
-
-        public List<EnabledPersistence> Merge(List<EnabledPersistence> definitions)
-        {
-            definitions.Reverse();
-
-            var availableStorages = StorageType.GetAvailableStorageTypes();
-            var resultingSupportedStorages = new List<Type>();
-            var mergedEnabledPersistences = new List<EnabledPersistence>();
-
-            foreach (var definition in definitions)
-            {
-                var persistenceDefinition = definition.DefinitionType.Construct<PersistenceDefinition>();
-                var supportedStorages = persistenceDefinition.GetSupportedStorages(definition.SelectedStorages);
-
-                var currentDefinition = new EnabledPersistence
-                {
-                    DefinitionType = definition.DefinitionType,
-                    SelectedStorages = new List<Type>()
-                };
-
-                foreach (var storageType in supportedStorages)
-                {
-                    if (availableStorages.Contains(storageType))
-                    {
-                        currentDefinition.SelectedStorages.Add(storageType);
-                        availableStorages.Remove(storageType);
-                        persistenceDefinition.ApplyActionForStorage(storageType, this);
-                        resultingSupportedStorages.Add(storageType);
-                    }
-                }
-
-                if (currentDefinition.SelectedStorages.Any())
-                {
-                    mergedEnabledPersistences.Add(currentDefinition);
-                }
-            }
-
-            return mergedEnabledPersistences;
-        }
     }
 }


### PR DESCRIPTION
Fix for issue https://github.com/Particular/NServiceBus/issues/2622  as a result of bug in https://github.com/Particular/NServiceBus/pull/2587 PR 

`PersistenceExtentions<PersistenceDefinition, StorageType>` did not provide a way for `PersistenceExtentions<PersistenceDefinition>` to know what `StorageType` `PersistenceExtentions` should set as selected storage when using extension method `configuration.UsePersistence<T, S>()`

Items left:
- [x] test(s) (unit vs approval)
- [ ] review