### PR TITLE
AcceptanceTesting: Add ExcludeTypesFromNamespace

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
@@ -105,6 +105,13 @@
             return this;
         }
 
+        public EndpointConfigurationBuilder ExcludeTypesFromNamespace(string fullyQualifiedNamespace)
+        {
+            configuration.NamespaceTypesToExclude.Add(fullyQualifiedNamespace);
+
+            return this;
+        }
+
         public EndpointConfigurationBuilder SendOnly()
         {
             configuration.SendOnly = true;

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointConfiguration.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointConfiguration.cs
@@ -10,6 +10,7 @@
             UserDefinedConfigSections = new Dictionary<Type, object>();
             TypesToExclude = new List<Type>();
             TypesToInclude = new List<Type>();
+            NamespaceTypesToExclude = new List<string>();
         }
 
         public IDictionary<Type, Type> EndpointMappings { get; set; }
@@ -17,6 +18,8 @@
         public IList<Type> TypesToExclude { get; set; }
 
         public IList<Type> TypesToInclude { get; set; }
+
+        public IList<string> NamespaceTypesToExclude { get; set; }
 
         public Func<RunDescriptor, IDictionary<Type, string>, BusConfiguration> GetConfiguration { get; set; }
 

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
@@ -81,7 +81,10 @@
 
             types = types.Union(endpointConfiguration.TypesToInclude);
 
-            return types.Where(t => !endpointConfiguration.TypesToExclude.Contains(t)).ToList();
+            return types
+                .Where(t => !endpointConfiguration.TypesToExclude.Contains(t))
+                .Where(t => t.Namespace != null && !endpointConfiguration.NamespaceTypesToExclude.Any(n => t.Namespace.Equals(n, StringComparison.InvariantCultureIgnoreCase) || t.Namespace.StartsWith(n.EndsWith(".") ? n : string.Format("{0}.", n), StringComparison.InvariantCultureIgnoreCase)))
+                .ToList();
         }
 
         static IEnumerable<Type> GetNestedTypeRecursive(Type rootType, Type builderType)


### PR DESCRIPTION
**For your consideration/comment;**

Due to our use of an older version of the acceptance-testing framework I would like to submit a small change we found helpful in excluding all types from a nominated namespace. The main motivation for this to stop duplicate handlers firing when adding fake implementations. I appreciate types can already be excluded using `.ExcludeType<>()` but this creates a maintenance nightmare when new handlers are added.

Example usage;
```csharp
this.EndpointSetup<DefaultServer>()
      .ExcludeTypesFromNamespace("Company.Bus.Tests.Acceptance.Sagas")
      .WithConfig<TransportConfig>(c => c.MaxRetries = 0);
```

The usage of this `EndpointConfiguration` value it obviously relies on adjusted type-scanning in `DefaultServer.cs` which I've included in the pull-request. Obviously anyone with custom implementations of `EndpointConfigurationBuilder` would need to update their type scanning to use this new setting.