### PR TITLE
IHandleSagaNotFound fires multiple times for a message that targets multiple sagas

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -85,7 +85,7 @@
     <Compile Include="Basic\When_using_callback_to_get_message.cs" />
     <Compile Include="PerfMon\CriticalTime\When_deferring_a_message.cs" />
     <Compile Include="PubSub\When_publishing_an_event_implementing_two_unrelated_interfaces.cs" />
-    <Compile Include="Sagas\Issue_2080.cs" />
+    <Compile Include="Sagas\When_sagas_cant_be_found.cs" />
     <Compile Include="ScaleOut\When_individualization_is_enabled_for_msmq.cs" />
     <Compile Include="ScaleOut\When_no_discriminator_is_available.cs" />
     <Compile Include="ScaleOut\When_individualization_is_enabled.cs" />

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Basic\When_using_callback_to_get_message.cs" />
     <Compile Include="PerfMon\CriticalTime\When_deferring_a_message.cs" />
     <Compile Include="PubSub\When_publishing_an_event_implementing_two_unrelated_interfaces.cs" />
+    <Compile Include="Sagas\Issue_2080.cs" />
     <Compile Include="ScaleOut\When_individualization_is_enabled_for_msmq.cs" />
     <Compile Include="ScaleOut\When_no_discriminator_is_available.cs" />
     <Compile Include="ScaleOut\When_individualization_is_enabled.cs" />

--- a/src/NServiceBus.AcceptanceTests/Sagas/Issue_2080.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/Issue_2080.cs
@@ -1,0 +1,123 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+
+    public class Issue_2080 : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Run()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<ReceiverWithSaga>(b => b.Given((bus, c) => bus.SendLocal(new MessageToSaga())))
+                    .Done(c => c.Done)
+                    .Run();
+
+            Assert.AreEqual(1, context.TimesFired);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int TimesFired { get; set; }
+            public bool Done { get; set; }
+        }
+
+        public class ReceiverWithSaga : EndpointConfigurationBuilder
+        {
+            public ReceiverWithSaga()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MessageToSagaHandler : IHandleMessages<MessageToSaga>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(MessageToSaga message)
+                {
+                    Bus.Defer(TimeSpan.FromSeconds(10), new FinishMessage());
+                }
+            }
+
+            public class FinishHandler: IHandleMessages<FinishMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(FinishMessage message)
+                {
+                    Context.Done = true;
+                }
+            }
+
+            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
+            {
+
+                public void Handle(StartSaga message)
+                {
+                }
+
+                public void Handle(MessageToSaga message)
+                {
+                }
+
+                public class Saga1Data : ContainSagaData
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper)
+                {
+                }
+            }
+
+            public class Saga2 : Saga<Saga2.Saga2Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
+            {
+
+                public void Handle(StartSaga message)
+                {
+                }
+
+                public void Handle(MessageToSaga message)
+                {
+                }
+
+                public class Saga2Data : ContainSagaData
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga2Data> mapper)
+                {
+                }
+            }
+
+            public class SagaNotFound : IHandleSagaNotFound
+            {
+                public Context Context { get; set; }
+
+                public void Handle(object message)
+                {
+                    Context.TimesFired++;
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSaga : ICommand
+        {
+        }
+
+        [Serializable]
+        public class FinishMessage : ICommand
+        {
+        }
+
+        [Serializable]
+        public class MessageToSaga : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Sagas/Issue_2080.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/Issue_2080.cs
@@ -9,16 +9,29 @@
     public class Issue_2080 : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Run()
+        public void IHandleSagaNotFound_only_called_once()
         {
             var context = new Context();
 
             Scenario.Define(context)
-                    .WithEndpoint<ReceiverWithSaga>(b => b.Given((bus, c) => bus.SendLocal(new MessageToSaga())))
+                    .WithEndpoint<ReceiverWithSagas>(b => b.Given((bus, c) => bus.SendLocal(new MessageToSaga())))
                     .Done(c => c.Done)
                     .Run();
 
             Assert.AreEqual(1, context.TimesFired);
+        }
+
+        [Test]
+        public void IHandleSagaNotFound_not_called_if_second_saga_is_executed()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                    .WithEndpoint<ReceiverWithOrderedSagas>(b => b.Given((bus, c) => bus.SendLocal(new MessageToSaga())))
+                    .Done(c => c.Done)
+                    .Run();
+
+            Assert.AreEqual(0, context.TimesFired);
         }
 
         public class Context : ScenarioContext
@@ -27,9 +40,9 @@
             public bool Done { get; set; }
         }
 
-        public class ReceiverWithSaga : EndpointConfigurationBuilder
+        public class ReceiverWithSagas : EndpointConfigurationBuilder
         {
-            public ReceiverWithSaga()
+            public ReceiverWithSagas()
             {
                 EndpointSetup<DefaultServer>();
             }
@@ -105,6 +118,91 @@
             }
         }
 
+        public class ReceiverWithOrderedSagas : EndpointConfigurationBuilder
+        {
+            public ReceiverWithOrderedSagas()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class EnsureOrdering : ISpecifyMessageHandlerOrdering
+            {
+                public void SpecifyOrder(Order order)
+                {
+                    order.Specify(First<Saga1>.Then<Saga2>());
+                }
+            }
+
+            public class MessageToSagaHandler : IHandleMessages<MessageToSaga>
+            {
+                public IBus Bus { get; set; }
+
+                public void Handle(MessageToSaga message)
+                {
+                    Bus.Defer(TimeSpan.FromSeconds(10), new FinishMessage());
+                }
+            }
+
+            public class FinishHandler : IHandleMessages<FinishMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(FinishMessage message)
+                {
+                    Context.Done = true;
+                }
+            }
+
+            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
+            {
+
+                public void Handle(StartSaga message)
+                {
+                }
+
+                public void Handle(MessageToSaga message)
+                {
+                }
+
+                public class Saga1Data : ContainSagaData
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper)
+                {
+                }
+            }
+
+            public class Saga2 : Saga<Saga2.Saga2Data>, IHandleMessages<StartSaga>, IAmStartedByMessages<MessageToSaga>
+            {
+
+                public void Handle(StartSaga message)
+                {
+                }
+
+                public void Handle(MessageToSaga message)
+                {
+                }
+
+                public class Saga2Data : ContainSagaData
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga2Data> mapper)
+                {
+                }
+            }
+
+            public class SagaNotFound : IHandleSagaNotFound
+            {
+                public Context Context { get; set; }
+
+                public void Handle(object message)
+                {
+                    Context.TimesFired++;
+                }
+            }
+        }
         [Serializable]
         public class StartSaga : ICommand
         {

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
@@ -21,10 +21,10 @@
 
                     bus.SendLocal(message);
                 }))
-                .Done(c => c.NotFoundHandlerCalled && c.OtherSagaStarted)
+                .Done(c => c.OtherSagaStarted)
                 .Run(TimeSpan.FromSeconds(15));
 
-            Assert.True(context.NotFoundHandlerCalled);
+            Assert.False(context.NotFoundHandlerCalled);
             Assert.True(context.OtherSagaStarted);
             Assert.False(context.MessageHandlerCalled);
             Assert.False(context.TimeoutHandlerCalled);

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
@@ -22,7 +22,7 @@
                     bus.SendLocal(message);
                 }))
                 .Done(c => c.OtherSagaStarted)
-                .Run(TimeSpan.FromSeconds(15));
+                .Run();
 
             Assert.False(context.NotFoundHandlerCalled);
             Assert.True(context.OtherSagaStarted);

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
@@ -6,7 +6,7 @@
     using NUnit.Framework;
     using Saga;
 
-    public class Issue_2080 : NServiceBusAcceptanceTest
+    public class When_sagas_cant_be_found : NServiceBusAcceptanceTest
     {
         [Test]
         public void IHandleSagaNotFound_only_called_once()

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -236,6 +236,7 @@
     <Compile Include="Timeout\ConfigurationBuilderExtensions.cs" />
     <Compile Include="Transports\ConfigurePurging_Obsolete.cs" />
     <Compile Include="Unicast\Behaviors\ForwardReceivedMessages.cs" />
+    <Compile Include="Unicast\Behaviors\InvokeSagaNotFoundBehavior.cs" />
     <Compile Include="Unicast\BusAsyncResultEventArgs.cs" />
     <Compile Include="Unicast\Config\LoadMessageHandlersExtentions_Obsolete.cs" />
     <Compile Include="Unicast\Config\RegisterHandlersInOrder.cs" />

--- a/src/NServiceBus.Core/Sagas/Sagas.cs
+++ b/src/NServiceBus.Core/Sagas/Sagas.cs
@@ -35,8 +35,9 @@
         /// </summary>
         protected internal override void Setup(FeatureConfigurationContext context)
         {
-            // Register the Saga related behavior for incoming messages
+            // Register the Saga related behaviors for incoming messages
             context.Pipeline.Register<SagaPersistenceBehavior.Registration>();
+            context.Pipeline.Register<InvokeSagaNotFoundBehavior.Registration>();
 
             var typeBasedSagas = TypeBasedSagaMetaModel.Create(context.Settings.GetAvailableTypes(),conventions);
 

--- a/src/NServiceBus.Core/Unicast/Behaviors/InvokeSagaNotFoundBehavior.cs
+++ b/src/NServiceBus.Core/Unicast/Behaviors/InvokeSagaNotFoundBehavior.cs
@@ -1,0 +1,52 @@
+namespace NServiceBus
+{
+    using System;
+    using NServiceBus.Logging;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Pipeline.Contexts;
+    using NServiceBus.Saga;
+
+    class InvokeSagaNotFoundBehavior : IBehavior<IncomingContext>
+    {
+        static ILog logger = LogManager.GetLogger<InvokeSagaNotFoundBehavior>();
+
+        public void Invoke(IncomingContext context, Action next)
+        {
+            context.Set("Sagas.InvokeSagaNotFound", false);
+
+            next();
+
+            if (!context.Get<bool>("Sagas.InvokeSagaNotFound"))
+            {
+               return; 
+            }
+
+            bool result;
+            if (context.TryGet("Sagas.SagaWasInvoked", out result))
+            {
+                if (result)
+                {
+                    return;
+                }
+            }
+
+            logger.InfoFormat("Could not find a started saga for '{0}' message type. Going to invoke SagaNotFoundHandlers.", context.IncomingLogicalMessage.MessageType.FullName);
+
+            foreach (var handler in context.Builder.BuildAll<IHandleSagaNotFound>())
+            {
+                logger.DebugFormat("Invoking SagaNotFoundHandler ('{0}')", handler.GetType().FullName);
+                handler.Handle(context.IncomingLogicalMessage.Instance);
+            }
+        }
+
+        public class Registration : RegisterStep
+        {
+            public Registration()
+                : base("InvokeSagaNotFound", typeof(InvokeSagaNotFoundBehavior), "Invokes saga not found logic")
+            {
+                InsertBefore(WellKnownStep.LoadHandlers);
+                InsertAfter(WellKnownStep.MutateIncomingMessages);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Unicast/Behaviors/LoadHandlersBehavior.cs
+++ b/src/NServiceBus.Core/Unicast/Behaviors/LoadHandlersBehavior.cs
@@ -22,7 +22,6 @@
 
             // for now we cheat and pull it from the behavior context:
             var callbackInvoked = context.Get<bool>(CallbackInvocationBehavior.CallbackInvokedKey);
-
             var handlerTypedToInvoke = HandlerRegistry.GetHandlerTypes(messageToHandle.MessageType).ToList();
 
             if (!callbackInvoked && !handlerTypedToInvoke.Any())


### PR DESCRIPTION
This PR fixes both:
- IHandleSagaNotFound should only fire if no saga was invoked for the message
- IHandleSagaNotFound fires multiple times for a message that targets multiple sagas

