### PR TITLE
Add Data to exception headers

### DIFF
--- a/src/NServiceBus.Core.Tests/Utils/ExceptionHeaderHelperTests.cs
+++ b/src/NServiceBus.Core.Tests/Utils/ExceptionHeaderHelperTests.cs
@@ -103,6 +103,7 @@ namespace NServiceBus.Core.Tests.Utils
         {
             public override IDictionary Data
             {
+// ReSharper disable once AssignNullToNotNullAttribute
                 get { return null; }
             }
         }

--- a/src/NServiceBus.Core.Tests/Utils/ExceptionHeaderHelperTests.cs
+++ b/src/NServiceBus.Core.Tests/Utils/ExceptionHeaderHelperTests.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Core.Tests.Utils
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Runtime.CompilerServices;
     using NServiceBus.Faults;
@@ -82,6 +83,38 @@ namespace NServiceBus.Core.Tests.Utils
         void MethodThatThrows2()
         {
             throw new Exception("My Inner Exception");
+        }
+
+        [Test]
+        public void VerifyDataIsSet()
+        {
+            var exception = GetAnException();
+            exception.Data["TestKey"] = "MyValue";
+
+            var dictionary = new Dictionary<string, string>();
+
+            var failedQueue = new Address("TheErrorQueue", "TheErrorQueueMachine");
+            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, exception, failedQueue, "The reason", false);
+
+            Assert.AreEqual("MyValue", dictionary["NServiceBus.ExceptionInfo.Data.TestKey"]);
+        }
+
+        class NullDataException : Exception
+        {
+            public override IDictionary Data
+            {
+                get { return null; }
+            }
+        }
+
+        [Test]
+        public void VerifyNullDataDoesNotThrow()
+        {
+            var exception = new NullDataException();
+            var dictionary = new Dictionary<string, string>();
+
+            var failedQueue = new Address("TheErrorQueue", "TheErrorQueueMachine");
+            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, exception, failedQueue, "The reason", false);
         }
     }
 }

--- a/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
+++ b/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
@@ -43,7 +43,9 @@
             headers[FaultsHeaderKeys.FailedQ] = failedQueue.ToString();
             headers["NServiceBus.TimeOfFailure"] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
 
+// ReSharper disable once ConditionIsAlwaysTrueOrFalse
             if(e.Data == null)
+// ReSharper disable once HeuristicUnreachableCode
                 return;
 
             foreach (DictionaryEntry entry in e.Data)

--- a/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
+++ b/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Configuration;
     using NServiceBus.Faults;
@@ -41,6 +42,13 @@
             }
             headers[FaultsHeaderKeys.FailedQ] = failedQueue.ToString();
             headers["NServiceBus.TimeOfFailure"] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
+
+            foreach (DictionaryEntry entry in e.Data)
+            {
+                if (entry.Value == null)
+                    continue;
+                headers["NServiceBus.ExceptionInfo.Data." + entry.Key] = entry.Value.ToString();
+            }
         }
     }
 }

--- a/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
+++ b/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
@@ -43,6 +43,9 @@
             headers[FaultsHeaderKeys.FailedQ] = failedQueue.ToString();
             headers["NServiceBus.TimeOfFailure"] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
 
+            if(e.Data == null)
+                return;
+
             foreach (DictionaryEntry entry in e.Data)
             {
                 if (entry.Value == null)


### PR DESCRIPTION
When values are are added to an exception's "Data" property, they will be written to the exception headers of a failed message.
Fixes #2630