### PR TITLE
Include loaded AppDomain assemblies

### DIFF
--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_directory__with_non_dot_net_dll_is_scanned.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_directory__with_non_dot_net_dll_is_scanned.cs
@@ -23,10 +23,7 @@
             var directoryName = Path.GetDirectoryName(path);
 
             var testDllDirectory = Path.Combine(directoryName, "TestDlls");
-            var assemblyScanner = new AssemblyScanner(testDllDirectory)
-                {
-                    IncludeAppDomainAssemblies = false
-                };
+            var assemblyScanner = new AssemblyScanner(testDllDirectory);
             assemblyScanner.MustReferenceAtLeastOneAssembly.Add(typeof(IHandleMessages<>).Assembly);
 
             results = assemblyScanner

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_directory_with_handler_dll_is_scanned.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_directory_with_handler_dll_is_scanned.cs
@@ -12,10 +12,7 @@
         [SetUp]
         public void Context()
         {
-            var assemblyScanner = new AssemblyScanner(AssemblyLocation.CurrentDirectory)
-                {
-                    IncludeAppDomainAssemblies = false
-                };
+            var assemblyScanner = new AssemblyScanner(AssemblyLocation.CurrentDirectory);
             assemblyScanner.MustReferenceAtLeastOneAssembly.Add(typeof(IHandleMessages<>).Assembly);
 
             results = assemblyScanner

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_directory_with_no_reference_dlls_is_scanned.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_directory_with_no_reference_dlls_is_scanned.cs
@@ -22,10 +22,7 @@
             var directoryName = Path.GetDirectoryName(path);
 
             var testDllDirectory = Path.Combine(directoryName, "TestDlls");
-            var assemblyScanner = new AssemblyScanner(testDllDirectory)
-                {
-                    IncludeAppDomainAssemblies = false
-                };
+            var assemblyScanner = new AssemblyScanner(testDllDirectory);
             assemblyScanner.MustReferenceAtLeastOneAssembly.Add(typeof(IHandleMessages<>).Assembly);
 
             var results = assemblyScanner

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_inclusion_predicate_is_used.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_inclusion_predicate_is_used.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Core.Tests.AssemblyScanner
 {
     using System.Collections.Generic;
-    using System.Linq;
     using Hosting.Helpers;
     using NUnit.Framework;
 
@@ -25,10 +24,9 @@ namespace NServiceBus.Core.Tests.AssemblyScanner
         }
 
         [Test]
-        public void only_files_explicitly_included_are_returned()
+        public void includes_explicitly_included_file()
         {
-            Assert.That(results.Assemblies, Has.Count.EqualTo(1));
-            Assert.That(results.Assemblies.Single().GetName().Name, Is.EqualTo("NServiceBus.Core.Tests"));
+            Assert.IsTrue(results.Assemblies.Exists(a => a.GetName().Name == "NServiceBus.Core.Tests"));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_for_dlls_only.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_for_dlls_only.cs
@@ -22,7 +22,6 @@ namespace NServiceBus.Core.Tests.AssemblyScanner
 
             results = new AssemblyScanner(BaseDirectoryToScan)
                 {
-                    IncludeAppDomainAssemblies = true,
                     IncludeExesInScan = false,
                 }
                 .GetScannableAssemblies();

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_top_level_only.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_top_level_only.cs
@@ -24,7 +24,6 @@ namespace NServiceBus.Core.Tests.AssemblyScanner
 
             results = new AssemblyScanner(baseDirectoryToScan)
                 {
-                    IncludeAppDomainAssemblies = true,
                     ScanNestedDirectories = false
                 }
                 .GetScannableAssemblies();

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_told_to_scan_app_domain.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_told_to_scan_app_domain.cs
@@ -17,9 +17,6 @@ namespace NServiceBus.Core.Tests.AssemblyScanner
             Directory.CreateDirectory(someDir);
 
             results = new AssemblyScanner(someDir)
-                {
-                    IncludeAppDomainAssemblies = true,
-                }
                 .GetScannableAssemblies();
         }
 

--- a/src/NServiceBus.Core/AllAssemblies.cs
+++ b/src/NServiceBus.Core/AllAssemblies.cs
@@ -79,7 +79,6 @@ namespace NServiceBus
         {
             var assemblyScanner = new AssemblyScanner(directory)
             {
-                IncludeAppDomainAssemblies = true,
                 AssembliesToInclude = assembliesToInclude,
                 AssembliesToSkip = assembliesToExclude
             };

--- a/src/NServiceBus.Core/BusConfiguration.cs
+++ b/src/NServiceBus.Core/BusConfiguration.cs
@@ -3,7 +3,6 @@ namespace NServiceBus
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.IO;
     using System.Linq;
     using System.Reflection;
     using System.Transactions;
@@ -86,7 +85,6 @@ namespace NServiceBus
         /// </summary>
         public void ScanAssembliesInDirectory(string probeDirectory)
         {
-            directory = probeDirectory;
             AssembliesToScan(GetAssembliesInDirectory(probeDirectory));
         }
 
@@ -190,17 +188,10 @@ namespace NServiceBus
 
                 ScanAssembliesInDirectory(directoryToScan);
             }
-
-            scannedTypes = scannedTypes.Union(Configure.GetAllowedTypes(Assembly.GetExecutingAssembly())).ToList();
-
-            if (HttpRuntime.AppDomainAppId == null)
+            else
             {
-                var baseDirectory = directory ?? AppDomain.CurrentDomain.BaseDirectory;
-                var hostPath = Path.Combine(baseDirectory, "NServiceBus.Host.exe");
-                if (File.Exists(hostPath))
-                {
-                    scannedTypes = scannedTypes.Union(Configure.GetAllowedTypes(Assembly.LoadFrom(hostPath))).ToList();
-                }
+                var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(a => !AssemblyScanner.IsInDefaultAssemblyExclusions(a.GetName().Name)).ToArray();
+                scannedTypes = scannedTypes.Union(Configure.GetAllowedTypes(assemblies)).ToList();
             }
 
             Settings.SetDefault("TypesToScan", scannedTypes);
@@ -256,7 +247,6 @@ namespace NServiceBus
         ConventionsBuilder conventionsBuilder = new ConventionsBuilder();
         List<Action<IConfigureComponents>> registrations = new List<Action<IConfigureComponents>>();
         IContainer customBuilder;
-        string directory;
         string endpointName;
         string endpointVersion;
         IList<Type> scannedTypes;


### PR DESCRIPTION
If assemblies are already loaded in the AppDomain then their types should be included in the scanned types list.
This is required otherwise a user can:
```c#
var config = new BusConfiguration();
config.AssembliesToScan(typeof(Program).Assembly);
config.UsePersistence<RavenDBPersistence>();
```
and the RavenDBPersistence would not be included!

Fixes #2561
Fixes part of #2572