### PR TITLE
Misleading debug message logged for Unicast on endpoint shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ RavenDB is under both a OSS and a commercial license described [here](http://rav
 
 The commercial version can be used free of charge for NServiceBus specific storage needs like:
 
-Subscriptions, Sagas, Timeouts, etc 
+Subscriptions, Sagas, Timeouts, etc.
 
 Application specific use requires a paid RavenDB license
 


### PR DESCRIPTION
When `UnicastBus` is shutting down and executing all `IWantToRunWhenBusStartsAndStops.Stop()` [logged messages](https://github.com/Particular/NServiceBus/blob/97e3fee9c71bdc5d788108a69a3f0f2888e9ed02/src/NServiceBus.Core/Unicast/UnicastBus.cs#L687,L689), say it's executing `IWantToRunWhenBusStartsAndStops.Start()` 