### PR TITLE
Changed callback code to use tasks

### DIFF
--- a/src/NServiceBus.Core.Tests/API/approvals/NServiceBus.Core.approved.cs
+++ b/src/NServiceBus.Core.Tests/API/approvals/NServiceBus.Core.approved.cs
@@ -42,6 +42,7 @@ namespace NServiceBus
         public static NServiceBus.IStartableBus Create(NServiceBus.BusConfiguration configuration) { }
         public static NServiceBus.ISendOnlyBus CreateSendOnly(NServiceBus.BusConfiguration configuration) { }
     }
+    [System.ObsoleteAttribute("Will be removed in version 7.0.0.", true)]
     public class BusAsyncResultEventArgs : System.EventArgs
     {
         public BusAsyncResultEventArgs() { }
@@ -2056,8 +2057,10 @@ namespace NServiceBus.Unicast
     {
         public static void ForEach<T>(this NServiceBus.ObjectBuilder.IBuilder builder, System.Action<T> action) { }
     }
+    [System.ObsoleteAttribute("Will be removed in version 7.0.0.", true)]
     public class BusAsyncResult : System.IAsyncResult
     {
+        [System.ObsoleteAttribute("Will be removed in version 7.0.0.", true)]
         public BusAsyncResult(System.AsyncCallback callback, object state) { }
         public object AsyncState { get; }
         public System.Threading.WaitHandle AsyncWaitHandle { get; }
@@ -2065,6 +2068,7 @@ namespace NServiceBus.Unicast
         public bool IsCompleted { get; }
         public void Complete(int errorCode, params object[] messages) { }
     }
+    [System.ObsoleteAttribute("Will be removed in version 7.0.0.", true)]
     public class CallbackMessageLookup
     {
         public CallbackMessageLookup() { }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -290,6 +290,7 @@
     <Compile Include="Unicast\Behaviors\MessageProcessingAbortedException.cs" />
     <Compile Include="Unicast\BusAsyncResultEventArgs.cs" />
     <Compile Include="Unicast\CallbackMessageLookup.cs" />
+    <Compile Include="Unicast\CallbackResultEventArgs.cs" />
     <Compile Include="Unicast\Config\RegisterHandlersInOrder.cs" />
     <Compile Include="Monitoring\SLA\SLABehavior.cs" />
     <Compile Include="Monitoring\CriticalTime\CriticalTimeBehavior.cs" />

--- a/src/NServiceBus.Core/Unicast/BusAsyncResult.cs
+++ b/src/NServiceBus.Core/Unicast/BusAsyncResult.cs
@@ -2,32 +2,20 @@ namespace NServiceBus.Unicast
 {
     using System;
     using System.Threading;
-    using System.Threading.Tasks;
-    using Logging;
 
     /// <summary>
     /// Implementation of IAsyncResult returned when registering a callback.
     /// </summary>
+    [ObsoleteEx(TreatAsErrorFromVersion = "6.0", RemoveInVersion = "7.0")]
     public class BusAsyncResult : IAsyncResult
     {
-        readonly AsyncCallback callback;
-        readonly CompletionResult result;
-        readonly TaskCompletionSource<CompletionResult> tcs;
-        readonly IAsyncResult internalAsyncResult;
-
         /// <summary>
         /// Creates a new object storing the given callback and state.
         /// </summary>
+        [ObsoleteEx(TreatAsErrorFromVersion = "6.0", RemoveInVersion = "7.0")]
         public BusAsyncResult(AsyncCallback callback, object state)
         {
-            this.callback = callback;
-            result = new CompletionResult
-            {
-                State = state
-            };
-
-            tcs = new TaskCompletionSource<CompletionResult>(result);
-            internalAsyncResult = tcs.Task;
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -37,31 +25,15 @@ namespace NServiceBus.Unicast
         /// </summary>
         public void Complete(int errorCode, params object[] messages)
         {
-            result.ErrorCode = errorCode;
-            result.Messages = messages;
-
-            if (callback != null)
-                try
-                {
-                    callback(this);
-                }
-                catch (Exception e)
-                {
-                    log.Error(callback.ToString(), e);
-                    tcs.SetException(e);
-                }
-
-            tcs.SetResult(result);
+            throw new NotImplementedException();
         }
-
-        static ILog log = LogManager.GetLogger<UnicastBus>();
 
         /// <summary>
         /// Returns a completion result containing the error code, messages, and state.
         /// </summary>
         public object AsyncState
         {
-            get { return internalAsyncResult.AsyncState; }
+            get { throw new NotImplementedException(); }
         }
 
         /// <summary>
@@ -69,7 +41,7 @@ namespace NServiceBus.Unicast
         /// </summary>
         public WaitHandle AsyncWaitHandle
         {
-            get { return internalAsyncResult.AsyncWaitHandle; }
+            get { throw new NotImplementedException(); }
         }
 
         /// <summary>
@@ -77,7 +49,7 @@ namespace NServiceBus.Unicast
         /// </summary>
         public bool CompletedSynchronously
         {
-            get { return internalAsyncResult.CompletedSynchronously; }
+            get { throw new NotImplementedException(); }
         }
 
         /// <summary>
@@ -85,12 +57,7 @@ namespace NServiceBus.Unicast
         /// </summary>
         public bool IsCompleted
         {
-            get { return internalAsyncResult.IsCompleted; }
-        }
-
-        internal Task<CompletionResult> Task
-        {
-            get { return tcs.Task; }
+            get { throw new NotImplementedException(); }
         }
     }
 }

--- a/src/NServiceBus.Core/Unicast/BusAsyncResultEventArgs.cs
+++ b/src/NServiceBus.Core/Unicast/BusAsyncResultEventArgs.cs
@@ -6,6 +6,7 @@ namespace NServiceBus
     /// <summary>
     /// Argument passed in the Registered event of the Callback object.
     /// </summary>
+    [ObsoleteEx(TreatAsErrorFromVersion = "6.0", RemoveInVersion = "7.0")]
     public class BusAsyncResultEventArgs : EventArgs
     {
         /// <summary>

--- a/src/NServiceBus.Core/Unicast/Callback.cs
+++ b/src/NServiceBus.Core/Unicast/Callback.cs
@@ -104,17 +104,7 @@ namespace NServiceBus
 
             if (callback != null)
             {
-                tcs.Task.ContinueWith(t =>
-                {
-                    try
-                    {
-                        callback(t);
-                    }
-                    catch (Exception e)
-                    {
-                        log.Error(callback.ToString(), e);
-                    }
-                });
+                tcs.Task.ContinueWith(t => callback(t));
             }
 
             var handler = Registered;
@@ -212,7 +202,7 @@ namespace NServiceBus
             var action = callback as Action<int>;
             if (action != null)
             {
-                action.Invoke(cr.ErrorCode);
+                action(cr.ErrorCode);
             }
             else
             {

--- a/src/NServiceBus.Core/Unicast/CallbackMessageLookup.cs
+++ b/src/NServiceBus.Core/Unicast/CallbackMessageLookup.cs
@@ -1,24 +1,27 @@
 namespace NServiceBus.Unicast
 {
     using System.Collections.Concurrent;
+    using System.Threading.Tasks;
 
     /// <summary>
-    /// 
+    ///
     /// </summary>
+    // Todo make internal in V7
+    [ObsoleteEx(TreatAsErrorFromVersion = "6.0", RemoveInVersion = "7.0")]
     public class CallbackMessageLookup
     {
         /// <summary>
         /// Map of message identifiers to Async Results - useful for cleanup in case of timeouts.
         /// </summary>
-        readonly ConcurrentDictionary<string, BusAsyncResult> messageIdToAsyncResultLookup = new ConcurrentDictionary<string, BusAsyncResult>();
+        readonly ConcurrentDictionary<string, TaskCompletionSource<CompletionResult>> messageIdToAsyncResultLookup = new ConcurrentDictionary<string, TaskCompletionSource<CompletionResult>>();
 
-        internal void RegisterResult(string messageId, BusAsyncResult result)
+        internal void RegisterResult(string messageId, TaskCompletionSource<CompletionResult> taskCompletionSource)
         {
             //TODO: what should we do if the key already exists?
-            messageIdToAsyncResultLookup[messageId] = result;
+            messageIdToAsyncResultLookup[messageId] = taskCompletionSource;
         }
 
-        internal bool TryGet(string messageId, out BusAsyncResult result)
+        internal bool TryGet(string messageId, out TaskCompletionSource<CompletionResult> result)
         {
             return messageIdToAsyncResultLookup.TryRemove(messageId, out result);
         }

--- a/src/NServiceBus.Core/Unicast/CallbackResultEventArgs.cs
+++ b/src/NServiceBus.Core/Unicast/CallbackResultEventArgs.cs
@@ -1,0 +1,11 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Threading.Tasks;
+
+    class CallbackResultEventArgs : EventArgs
+    {
+        public TaskCompletionSource<CompletionResult> TaskCompletionSource { get; set; }
+        public string MessageId { get; set; }
+    }
+}

--- a/src/NServiceBus.Core/Unicast/ContextualBus.cs
+++ b/src/NServiceBus.Core/Unicast/ContextualBus.cs
@@ -149,7 +149,7 @@ namespace NServiceBus.Unicast
         public Func<object, string, string> GetHeaderAction { get; internal set; }
 
         /// <summary>
-        /// Sets whether or not the return address of a received message 
+        /// Sets whether or not the return address of a received message
         /// should be propagated when the message is forwarded. This field is
         /// used primarily for the Distributor.
         /// </summary>
@@ -209,7 +209,6 @@ namespace NServiceBus.Unicast
 
             AssertHasLocalAddress();
 
-
             if (transportDefinition.HasSupportForCentralizedPubSub)
             {
                 // We are dealing with a brokered transport wired for auto pub/sub.
@@ -254,7 +253,6 @@ namespace NServiceBus.Unicast
             Unsubscribe(typeof(T));
         }
 
-
         /// <summary>
         /// <see cref="IBus.Unsubscribe(Type)"/>
         /// </summary>
@@ -269,7 +267,6 @@ namespace NServiceBus.Unicast
 
             AssertHasLocalAddress();
 
-
             if (transportDefinition.HasSupportForCentralizedPubSub)
             {
                 // We are dealing with a brokered transport wired for auto pub/sub.
@@ -283,7 +280,6 @@ namespace NServiceBus.Unicast
             {
                 subscriptionManager.Unsubscribe(messageType, destination);
             }
-
         }
 
         /// <summary>
@@ -418,7 +414,7 @@ namespace NServiceBus.Unicast
         {
             return SendMessage(new SendOptions(destination), messageFactory.Create(messageMapper.CreateInstance(messageConstructor)));
         }
-        
+
         /// <summary>
         /// <see cref="ISendOnlyBus.Send(string,object)"/>
         /// </summary>
@@ -426,7 +422,7 @@ namespace NServiceBus.Unicast
         {
             return SendMessage(new SendOptions(destination), messageFactory.Create(message));
         }
-        
+
         /// <summary>
         /// <see cref="ISendOnlyBus.Send{T}(string,string,Action{T})"/>
         /// </summary>
@@ -481,7 +477,6 @@ namespace NServiceBus.Unicast
             return SendMessage(options, messageFactory.Create(message));
         }
 
-
         ICallback SendMessage(SendOptions sendOptions, LogicalMessage message)
         {
             ApplyDefaultDeliveryOptionsIfNeeded(sendOptions,message);
@@ -508,11 +503,10 @@ namespace NServiceBus.Unicast
             return outgoing.Invoke(outgoingContext);
         }
 
-
         ICallback SetupCallback(string transportMessageId)
         {
             var result = new Callback(transportMessageId, sendOnlyMode);
-            result.Registered += (sender, args) => callbackMessageLookup.RegisterResult(args.MessageId, args.Result);
+            result.Registered += (sender, args) => callbackMessageLookup.RegisterResult(args.MessageId, args.TaskCompletionSource);
 
             return result;
         }
@@ -583,8 +577,6 @@ namespace NServiceBus.Unicast
             return destination;
         }
 
-
-
         TransportMessage MessageBeingProcessed
         {
             get
@@ -599,6 +591,5 @@ namespace NServiceBus.Unicast
                 return current;
             }
         }
-
     }
 }


### PR DESCRIPTION
Instead of implementing our own IAsyncResult this delegates to a task, and allows all the task based overrides to work with the task directly instead of wrapping the IAsyncResult.