### PR TITLE
FeatureStartupTasks are not invoked for send only endpoint

### DIFF
--- a/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
@@ -11,7 +11,7 @@
     public class FeatureStartupTests
     {
         [Test]
-        public void Should_not_activate_features_with_unmet_dependencies()
+        public void Should_start_and_stop_features()
         {
             var feature = new FeatureWithStartupTask();
        
@@ -28,6 +28,25 @@
 
             Assert.True(FeatureWithStartupTask.Runner.Started);
             Assert.True(FeatureWithStartupTask.Runner.Stopped);
+        }
+
+        [Test]
+        public void Should_dispose_feature_when_they_implement_IDisposable()
+        {
+            var feature = new FeatureWithStartupTaskWhichIsDisposable();
+
+            var featureSettings = new FeatureActivator(new SettingsHolder());
+
+            featureSettings.Add(feature);
+
+            var builder = new FakeBuilder(typeof(FeatureWithStartupTaskWhichIsDisposable.Runner));
+
+            featureSettings.SetupFeatures(new FeatureConfigurationContext(null));
+
+            featureSettings.StartFeatures(builder);
+            featureSettings.StopFeatures(builder);
+
+            Assert.True(FeatureWithStartupTaskWhichIsDisposable.Runner.Disposed);
         }
 
         class FeatureWithStartupTask : TestFeature
@@ -50,8 +69,31 @@
                     Stopped = true;
                 }
 
-                public static bool Started { get; set; }
-                public static bool Stopped { get; set; }
+                public static bool Started { get; private set; }
+                public static bool Stopped { get; private set; }
+            }
+        }
+
+        class FeatureWithStartupTaskWhichIsDisposable : TestFeature
+        {
+            public FeatureWithStartupTaskWhichIsDisposable()
+            {
+                EnableByDefault();
+                RegisterStartupTask<Runner>();
+            }
+
+            public class Runner : FeatureStartupTask, IDisposable
+            {
+                protected override void OnStart()
+                {
+                }
+
+                public void Dispose()
+                {
+                    Disposed = true;
+                }
+
+                public static bool Disposed { get; private set; }
             }
         }
     }

--- a/src/NServiceBus.Core/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/AutomaticSubscriptions/AutoSubscribe.cs
@@ -1,10 +1,9 @@
 ﻿namespace NServiceBus.Features
 {
     using System.Linq;
-    using AutomaticSubscriptions;
-    using Logging;
-    using NServiceBus.Settings;
-    using Transports;
+    using NServiceBus.AutomaticSubscriptions;
+    using NServiceBus.Logging;
+    using NServiceBus.Transports;
 
     /// <summary>
     /// Used to configure auto subscriptions.

--- a/src/NServiceBus.Core/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/AutomaticSubscriptions/AutoSubscribe.cs
@@ -3,6 +3,7 @@
     using System.Linq;
     using AutomaticSubscriptions;
     using Logging;
+    using NServiceBus.Settings;
     using Transports;
 
     /// <summary>
@@ -13,7 +14,7 @@
         internal AutoSubscribe()
         {
             EnableByDefault();
-
+            Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"), "Send only endpoints can't autosubscribe.");
             RegisterStartupTask<ApplySubscriptions>();
         }
 

--- a/src/NServiceBus.Core/Configure.cs
+++ b/src/NServiceBus.Core/Configure.cs
@@ -120,12 +120,22 @@ namespace NServiceBus
 
             featureActivator.RegisterStartupTasks(container);
 
-            localAddress =Settings.LocalAddress();
+            localAddress = Settings.LocalAddress();
 
             foreach (var o in Builder.BuildAll<IWantToRunWhenConfigurationIsComplete>())
             {
                 o.Run(this);
             }
+
+            StartFeatures(featureActivator);
+        }
+
+        void StartFeatures(FeatureActivator featureActivator)
+        {
+            var featureRunner = new FeatureRunner(Builder, featureActivator);
+            container.RegisterSingleton(featureRunner);
+
+            featureRunner.Start();
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -154,7 +154,18 @@ namespace NServiceBus.Features
                     var task = (FeatureStartupTask) builder.Build(taskType);
 
                     task.PerformStop();
+
+                    DisposeIfNecessary(task);
                 }
+            }
+        }
+
+        static void DisposeIfNecessary(FeatureStartupTask task)
+        {
+            var disposableTask = task as IDisposable;
+            if (disposableTask != null)
+            {
+                disposableTask.Dispose();
             }
         }
 

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -298,23 +298,5 @@ namespace NServiceBus.Features
             internal List<Node> previous = new List<Node>();
             bool visited;
         }
-
-        class Runner : IWantToRunWhenBusStartsAndStops
-        {
-            public IBuilder Builder { get; set; }
-
-            public FeatureActivator FeatureActivator { get; set; }
-
-
-            public void Start()
-            {
-                FeatureActivator.StartFeatures(Builder);
-            }
-
-            public void Stop()
-            {
-                FeatureActivator.StopFeatures(Builder);
-            }
-        }
     }
 }

--- a/src/NServiceBus.Core/Features/FeatureRunner.cs
+++ b/src/NServiceBus.Core/Features/FeatureRunner.cs
@@ -1,0 +1,29 @@
+namespace NServiceBus.Features
+{
+    using NServiceBus.ObjectBuilder;
+
+    /// <summary>
+    /// Running everything on the calling thread for now. Features shouldn't be doing anything heavy inside the start and stop.
+    /// </summary>
+    class FeatureRunner
+    {
+        readonly FeatureActivator featureActivator;
+        readonly IBuilder builder;
+
+        public FeatureRunner(IBuilder builder, FeatureActivator featureActivator)
+        {
+            this.builder = builder;
+            this.featureActivator = featureActivator;
+        }
+
+        public void Start()
+        {
+            featureActivator.StartFeatures(builder);
+        }
+
+        public void Stop()
+        {
+            featureActivator.StopFeatures(builder);
+        }
+    }
+}

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Faults\FailedMessage.cs" />
     <Compile Include="Faults\ErrorsNotifications.cs" />
     <Compile Include="Faults\ErrorSubscribers.cs" />
+    <Compile Include="Features\FeatureRunner.cs" />
     <Compile Include="FirstLevelRetries\FirstLevelRetry.cs" />
     <Compile Include="Faults\ErrorQueueSettings.cs" />
     <Compile Include="Faults\StoreFaultsInErrorQueue.cs" />

--- a/src/NServiceBus.Core/Unicast/UnicastBus.cs
+++ b/src/NServiceBus.Core/Unicast/UnicastBus.cs
@@ -10,6 +10,7 @@ namespace NServiceBus.Unicast
     using Hosting;
     using Licensing;
     using Logging;
+    using NServiceBus.Features;
     using NServiceBus.MessageInterfaces;
     using NServiceBus.Transports;
     using NServiceBus.Unicast.Messages;
@@ -167,6 +168,8 @@ namespace NServiceBus.Unicast
 
         void InnerShutdown()
         {
+            StopFeatures();
+
             if (!started)
             {
                 return;
@@ -180,6 +183,14 @@ namespace NServiceBus.Unicast
             Log.Info("Shutdown complete.");
 
             started = false;
+        }
+
+        void StopFeatures()
+        {
+            // Pull the feature  runner singleton out of the container
+            // features are always stopped
+            var featureRunner = Builder.Build<FeatureRunner>();
+            featureRunner.Stop();
         }
 
 


### PR DESCRIPTION
We should not drive them from `IWantToRunWhenTheBusStartsAndStops`

We should also support the startup tasks to implement `IDisposable`

Closes #2672

Decided to not execute the feature startup on separate task. Because features are now started and stopped all the time it is the feature's responsibility to check whether it makes sense to run. Especially if it is enabled by default. That's why this Pull also changes the `AutoSubscribe` feature

@Particular/engineers please review