### PR TITLE
Introducing a "outgoing message" to improve the seam towards the transport

### DIFF
--- a/src/NServiceBus.Core.Tests/API/approvals/NServiceBus.Core.approved.cs
+++ b/src/NServiceBus.Core.Tests/API/approvals/NServiceBus.Core.approved.cs
@@ -1900,6 +1900,7 @@ namespace NServiceBus.Timeout.Core
     }
     public class TimeoutData
     {
+        [System.ObsoleteAttribute("Not used anymore. Will be removed in version 7.0.0.", true)]
         public const string OriginalReplyToAddress = "NServiceBus.Timeout.ReplyToAddress";
         public TimeoutData() { }
         public string Destination { get; set; }
@@ -1909,11 +1910,13 @@ namespace NServiceBus.Timeout.Core
         public System.Guid SagaId { get; set; }
         public byte[] State { get; set; }
         public System.DateTime Time { get; set; }
-        [System.ObsoleteAttribute("Please use `TimeoutData.ToSendOptions(string)` instead. Will be removed in versio" +
-            "n 7.0.0.", true)]
+        [System.ObsoleteAttribute("Use new SendOptions() instead. Will be removed in version 7.0.0.", true)]
         public NServiceBus.Unicast.SendOptions ToSendOptions(NServiceBus.Address replyToAddress) { }
+        [System.ObsoleteAttribute("Use new SendOptions() instead. Will be removed in version 7.0.0.", true)]
         public NServiceBus.Unicast.SendOptions ToSendOptions(string replyToAddress) { }
         public override string ToString() { }
+        [System.ObsoleteAttribute("Use new OutgoingMessage(timeoutData.State) instead. Will be removed in version 7." +
+            "0.0.", true)]
         public NServiceBus.TransportMessage ToTransportMessage() { }
     }
 }
@@ -1946,7 +1949,7 @@ namespace NServiceBus.Transports
     public interface IDeferMessages
     {
         void ClearDeferredMessages(string headerKey, string headerValue);
-        void Defer(NServiceBus.TransportMessage message, NServiceBus.Unicast.SendOptions sendOptions);
+        void Defer(NServiceBus.Transports.OutgoingMessage message, NServiceBus.Unicast.SendOptions sendOptions);
     }
     public interface IDequeueMessages : System.IObservable<NServiceBus.Transports.MessageAvailable>
     {
@@ -1959,35 +1962,41 @@ namespace NServiceBus.Transports
         void Subscribe(System.Type eventType, string publisherAddress);
         void Unsubscribe(System.Type eventType, string publisherAddress);
     }
+    public class IncomingMessage
+    {
+        public IncomingMessage(string messageId, System.Collections.Generic.Dictionary<string, string> headers, System.IO.Stream bodyStream) { }
+        public System.IO.Stream BodyStream { get; }
+        public System.Collections.Generic.Dictionary<string, string> Headers { get; }
+        public string MessageId { get; }
+    }
     public interface IPublishMessages
     {
-        void Publish(NServiceBus.TransportMessage message, NServiceBus.Unicast.PublishOptions publishOptions);
+        void Publish(NServiceBus.Transports.OutgoingMessage message, NServiceBus.Unicast.PublishOptions publishOptions);
     }
     public interface ISendMessages
     {
-        void Send(NServiceBus.TransportMessage message, NServiceBus.Unicast.SendOptions sendOptions);
+        void Send(NServiceBus.Transports.OutgoingMessage message, NServiceBus.Unicast.SendOptions sendOptions);
     }
     public class MessageAvailable
     {
         public MessageAvailable(string publicReceiveAddress, System.Action<NServiceBus.Pipeline.Contexts.IncomingContext> contextAction) { }
         public string PublicReceiveAddress { get; }
     }
+    public class OutgoingMessage
+    {
+        public OutgoingMessage(System.Collections.Generic.Dictionary<string, string> headers, byte[] body) { }
+        public byte[] Body { get; }
+        public System.Collections.Generic.Dictionary<string, string> Headers { get; }
+    }
     public abstract class ReceiveBehavior : NServiceBus.Pipeline.StageConnector<NServiceBus.Pipeline.Contexts.IncomingContext, NServiceBus.Pipeline.Contexts.TransportReceiveContext>
     {
         protected ReceiveBehavior() { }
         public override void Invoke(NServiceBus.Pipeline.Contexts.IncomingContext context, System.Action<NServiceBus.Pipeline.Contexts.TransportReceiveContext> next) { }
-        protected abstract void Invoke(NServiceBus.Pipeline.Contexts.IncomingContext context, System.Action<NServiceBus.Transports.ReceivedMessage> onMessage);
+        protected abstract void Invoke(NServiceBus.Pipeline.Contexts.IncomingContext context, System.Action<NServiceBus.Transports.IncomingMessage> onMessage);
         public class Registration : NServiceBus.Pipeline.RegisterStep
         {
             public Registration() { }
         }
-    }
-    public class ReceivedMessage
-    {
-        public ReceivedMessage(string messageId, System.Collections.Generic.Dictionary<string, string> headers, System.IO.Stream bodyStream) { }
-        public System.IO.Stream BodyStream { get; }
-        public System.Collections.Generic.Dictionary<string, string> Headers { get; }
-        public string MessageId { get; }
     }
     public class ReceiveOptions
     {
@@ -2032,7 +2041,7 @@ namespace NServiceBus.Transports.Msmq
         public MsmqMessageSender(NServiceBus.Pipeline.BehaviorContext context) { }
         public NServiceBus.Transports.Msmq.Config.MsmqSettings Settings { get; set; }
         public bool SuppressDistributedTransactions { get; set; }
-        public void Send(NServiceBus.TransportMessage message, NServiceBus.Unicast.SendOptions sendOptions) { }
+        public void Send(NServiceBus.Transports.OutgoingMessage message, NServiceBus.Unicast.SendOptions sendOptions) { }
     }
     public class MsmqUnitOfWork : System.IDisposable
     {
@@ -2079,6 +2088,8 @@ namespace NServiceBus.Unicast
         public bool EnforceMessagingBestPractices { get; set; }
         public bool EnlistInReceiveTransaction { get; set; }
         public System.Nullable<bool> NonDurable { get; set; }
+        [System.ObsoleteAttribute("Reply to address can be get/set using the `NServiceBus.ReplyToAddress` header. Wi" +
+            "ll be removed in version 7.0.0.", true)]
         public string ReplyToAddress { get; set; }
         public System.Nullable<System.TimeSpan> TimeToBeReceived { get; set; }
     }
@@ -2123,9 +2134,10 @@ namespace NServiceBus.Unicast
     }
     public class ReplyOptions : NServiceBus.Unicast.SendOptions
     {
-        [System.ObsoleteAttribute("Please use `ReplyOptions(string destination, string correlationId)` instead. Will" +
-            " be removed in version 7.0.0.", true)]
+        public ReplyOptions(string destination) { }
+        [System.ObsoleteAttribute("ReplyOptions(string destination). Will be removed in version 7.0.0.", true)]
         public ReplyOptions(NServiceBus.Address destination, string correlationId) { }
+        [System.ObsoleteAttribute("ReplyOptions(string destination). Will be removed in version 7.0.0.", true)]
         public ReplyOptions(string destination, string correlationId) { }
     }
     public class SendOptions : NServiceBus.Unicast.DeliveryOptions
@@ -2133,6 +2145,8 @@ namespace NServiceBus.Unicast
         [System.ObsoleteAttribute("Please use `SendOptions(string)` instead. Will be removed in version 7.0.0.", true)]
         public SendOptions(NServiceBus.Address destination) { }
         public SendOptions(string destination) { }
+        [System.ObsoleteAttribute("Reply to address can be get/set using the `NServiceBus.CorrelationId` header. Wil" +
+            "l be removed in version 7.0.0.", true)]
         public string CorrelationId { get; set; }
         public System.Nullable<System.TimeSpan> DelayDeliveryWith { get; set; }
         public System.Nullable<System.DateTime> DeliverAt { get; set; }

--- a/src/NServiceBus.Core.Tests/Faults/ForwardFaultsToErrorQueueTests.cs
+++ b/src/NServiceBus.Core.Tests/Faults/ForwardFaultsToErrorQueueTests.cs
@@ -35,7 +35,7 @@ namespace NServiceBus.Core.Tests
 
             Assert.AreEqual(errorQueueAddress, sender.OptionsUsed.Destination);
 
-            Assert.AreEqual("someid", sender.MessageSent.Id);
+            Assert.AreEqual("someid", sender.MessageSent.Headers[Headers.MessageId]);
         }
         [Test]
         public void ShouldInvokeCriticalErrorIfForwardingFails()
@@ -114,7 +114,7 @@ namespace NServiceBus.Core.Tests
 
         PhysicalMessageProcessingStageBehavior.Context CreateContext(string messageId)
         {
-            var context = new PhysicalMessageProcessingStageBehavior.Context(new TransportReceiveContext(new ReceivedMessage(messageId, new Dictionary<string, string>(), new MemoryStream()), null));
+            var context = new PhysicalMessageProcessingStageBehavior.Context(new TransportReceiveContext(new IncomingMessage(messageId, new Dictionary<string, string>(), new MemoryStream()), null));
 
             context.SetPublicReceiveAddress("public-receive-address");
             return context;
@@ -136,12 +136,12 @@ namespace NServiceBus.Core.Tests
         }
         public class FakeSender : ISendMessages
         {
-            public TransportMessage MessageSent { get; set; }
+            public OutgoingMessage MessageSent { get; set; }
 
             public SendOptions OptionsUsed { get; set; }
             public bool ThrowOnSend { get; set; }
 
-            public void Send(TransportMessage message, SendOptions sendOptions)
+            public void Send(OutgoingMessage message, SendOptions sendOptions)
             {
                 MessageSent = message;
                 OptionsUsed = sendOptions;

--- a/src/NServiceBus.Core.Tests/FirstLevelRetriesTests.cs
+++ b/src/NServiceBus.Core.Tests/FirstLevelRetriesTests.cs
@@ -111,7 +111,7 @@
         }
         PhysicalMessageProcessingStageBehavior.Context CreateContext(string messageId)
         {
-            var context = new PhysicalMessageProcessingStageBehavior.Context(new TransportReceiveContext(new ReceivedMessage(messageId, new Dictionary<string, string>(), new MemoryStream()), null));
+            var context = new PhysicalMessageProcessingStageBehavior.Context(new TransportReceiveContext(new IncomingMessage(messageId, new Dictionary<string, string>(), new MemoryStream()), null));
             return context;
         }
     }

--- a/src/NServiceBus.Core.Tests/Outbox/OutboxDeduplicationBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Outbox/OutboxDeduplicationBehaviorTests.cs
@@ -19,7 +19,7 @@
         {
             fakeOutbox.ExistingMessage = new OutboxMessage("id");
 
-            var context = new PhysicalMessageProcessingStageBehavior.Context(new TransportReceiveContext(new ReceivedMessage("id", new Dictionary<string, string>(), new MemoryStream()), null));
+            var context = new PhysicalMessageProcessingStageBehavior.Context(new TransportReceiveContext(new IncomingMessage("id", new Dictionary<string, string>(), new MemoryStream()), null));
 
             Invoke(context);
 
@@ -29,7 +29,7 @@
         [Test]
         public void Should_not_dispatch_the_message_if_handle_current_message_later_was_called()
         {
-            var context = new PhysicalMessageProcessingStageBehavior.Context(new TransportReceiveContext(new ReceivedMessage("id", new Dictionary<string, string>(), new MemoryStream()), null))
+            var context = new PhysicalMessageProcessingStageBehavior.Context(new TransportReceiveContext(new IncomingMessage("id", new Dictionary<string, string>(), new MemoryStream()), null))
             {
                 handleCurrentMessageLaterWasCalled = true
             };

--- a/src/NServiceBus.Core.Tests/Outbox/OutboxRecordBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Outbox/OutboxRecordBehaviorTests.cs
@@ -13,7 +13,7 @@
         [Test]
         public void Should_not_store_the_message_if_handle_current_message_later_was_called()
         {
-            var context = new PhysicalMessageProcessingStageBehavior.Context(new TransportReceiveContext(new ReceivedMessage("id", new Dictionary<string, string>(), new MemoryStream()), null))
+            var context = new PhysicalMessageProcessingStageBehavior.Context(new TransportReceiveContext(new IncomingMessage("id", new Dictionary<string, string>(), new MemoryStream()), null))
             {
                 handleCurrentMessageLaterWasCalled = true
             };

--- a/src/NServiceBus.Core.Tests/Outbox/TransportOperationConverterTests.cs
+++ b/src/NServiceBus.Core.Tests/Outbox/TransportOperationConverterTests.cs
@@ -14,25 +14,21 @@
 
             var options = new SendOptions("destination")
             {
-                CorrelationId = "cid",
                 DelayDeliveryWith = TimeSpan.FromMinutes(1),
                 DeliverAt = DateTime.UtcNow.AddDays(1),
                 TimeToBeReceived = TimeSpan.FromMinutes(1),
                 NonDurable = true,
-                ReplyToAddress = "reply to",
                 EnlistInReceiveTransaction = false,
                 EnforceMessagingBestPractices = false
             };
 
             var converted = (SendOptions)options.ToTransportOperationOptions().ToDeliveryOptions();
 
-            Assert.AreEqual(converted.CorrelationId,options.CorrelationId);
             Assert.AreEqual(converted.DelayDeliveryWith, options.DelayDeliveryWith);
             Assert.AreEqual(converted.DeliverAt.ToString(), options.DeliverAt.ToString()); //the ticks will be off
             Assert.AreEqual(converted.Destination, options.Destination);
             Assert.AreEqual(converted.TimeToBeReceived, options.TimeToBeReceived); 
             Assert.AreEqual(converted.NonDurable, options.NonDurable);
-            Assert.AreEqual(converted.ReplyToAddress, options.ReplyToAddress);
             Assert.AreEqual(converted.EnforceMessagingBestPractices, options.EnforceMessagingBestPractices);
             Assert.AreEqual(converted.EnlistInReceiveTransaction, options.EnlistInReceiveTransaction);
         }
@@ -46,7 +42,6 @@
                 TimeToBeReceived = TimeSpan.FromMinutes(1),
                 NonDurable = true,
                 EnforceMessagingBestPractices = false,
-                ReplyToAddress = "reply to"
             };
 
             var converted = (PublishOptions)options.ToTransportOperationOptions().ToDeliveryOptions();
@@ -55,7 +50,6 @@
             Assert.AreEqual(typeof(MyMessage), options.EventType);
             Assert.AreEqual(converted.TimeToBeReceived, options.TimeToBeReceived);
             Assert.AreEqual(converted.NonDurable, options.NonDurable);
-            Assert.AreEqual(converted.ReplyToAddress, options.ReplyToAddress);
             Assert.AreEqual(converted.EnlistInReceiveTransaction, options.EnlistInReceiveTransaction);
             Assert.AreEqual(converted.EnforceMessagingBestPractices, options.EnforceMessagingBestPractices);
         }

--- a/src/NServiceBus.Core.Tests/Timeout/FakeMessageSender.cs
+++ b/src/NServiceBus.Core.Tests/Timeout/FakeMessageSender.cs
@@ -13,7 +13,7 @@ namespace NServiceBus.Core.Tests.Timeout
             set { messagesSent = value; }
         }
 
-        public void Send(TransportMessage message, SendOptions sendOptions)
+        public void Send(OutgoingMessage message, SendOptions sendOptions)
         {
             MessagesSent++;
         }

--- a/src/NServiceBus.Core.Tests/Timeout/When_deferring_a_message.cs
+++ b/src/NServiceBus.Core.Tests/Timeout/When_deferring_a_message.cs
@@ -23,7 +23,7 @@
             var options = new SendOptions("destination");
             var deliverAt = DateTime.Now.AddDays(1);
             options.DeliverAt = deliverAt;
-            sut.Defer(new TransportMessage(), options);
+            sut.Defer(new OutgoingMessage(new Dictionary<string, string>(),new byte[0]), options);
 
             Assert.AreEqual(DateTimeExtensions.ToWireFormattedString(deliverAt), sender.Messages.First().Headers[TimeoutManagerHeaders.Expire]);
         }
@@ -38,7 +38,7 @@
             var options = new SendOptions("destination");
             var delay = TimeSpan.FromDays(1);
             options.DelayDeliveryWith = delay;
-            sut.Defer(new TransportMessage(), options);
+            sut.Defer(new OutgoingMessage(new Dictionary<string, string>(),new byte[0]), options);
 
             var expireAt = DateTimeExtensions.ToUtcDateTime(sender.Messages.First().Headers[TimeoutManagerHeaders.Expire]);
             Assert.IsTrue(expireAt <= DateTime.UtcNow + delay);
@@ -60,11 +60,13 @@
             Assert.AreEqual(1, sender.Messages.Count);
         }
 
-        private class FakeMessageSender : ISendMessages
+        class FakeMessageSender : ISendMessages
         {
-            public List<TransportMessage> Messages = new List<TransportMessage>();
 
-            public void Send(TransportMessage message, SendOptions sendOptions)
+            public List<OutgoingMessage> Messages = new List<OutgoingMessage>(); 
+            
+
+            public void Send(OutgoingMessage message, SendOptions sendOptions)
             {
                 Messages.Add(message);
             }

--- a/src/NServiceBus.Core.Tests/Unicast/ReplyOptionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/ReplyOptionsTests.cs
@@ -9,7 +9,7 @@
         [Test]
         public void Should_throw_if_destination_is_null()
         {
-            Assert.Throws<InvalidOperationException>(() => new ReplyOptions((string)null, "corr"));
+            Assert.Throws<InvalidOperationException>(() => new ReplyOptions(null));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Unicast/SubscriptionManagerTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/SubscriptionManagerTests.cs
@@ -28,13 +28,19 @@
             {
                 MessageAvailable = new AutoResetEvent(false);
             }
-            public TransportMessage MessageSent { get; private set; }
+
+
+            public OutgoingMessage MessageSent { get; private set; }
+
+            public SendOptions SendOptions { get; private set; }
 
             public AutoResetEvent MessageAvailable { get; private set; }
 
-            public void Send(TransportMessage message, SendOptions sendOptions)
+            public void Send(OutgoingMessage message, SendOptions sendOptions)
             {
                 MessageSent = message;
+
+                SendOptions = sendOptions;
 
                 MessageAvailable.Set();
             }

--- a/src/NServiceBus.Core.Tests/UnitOfWork/UnitOfWorkBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/UnitOfWork/UnitOfWorkBehaviorTests.cs
@@ -145,7 +145,7 @@
         {
             var runner = new UnitOfWorkBehavior();
 
-            var context = new PhysicalMessageProcessingStageBehavior.Context(new TransportReceiveContext(new ReceivedMessage("",new Dictionary<string, string>(),new MemoryStream() ), new IncomingContext(new RootContext(builder))));
+            var context = new PhysicalMessageProcessingStageBehavior.Context(new TransportReceiveContext(new IncomingMessage("",new Dictionary<string, string>(),new MemoryStream() ), new IncomingContext(new RootContext(builder))));
 
             runner.Invoke(context, () =>
             {

--- a/src/NServiceBus.Core/Audit/DefaultMessageAuditer.cs
+++ b/src/NServiceBus.Core/Audit/DefaultMessageAuditer.cs
@@ -50,9 +50,8 @@ namespace NServiceBus.Transports
             }
 
             // Send the newly created transport message to the queue
-            MessageSender.Send(messageToForward, new SendOptions(sendOptions.Destination)
+            MessageSender.Send(new OutgoingMessage(messageToForward.Headers,messageToForward.Body), new SendOptions(sendOptions.Destination)
             {
-                ReplyToAddress = Configure.PublicReturnAddress,
                 TimeToBeReceived = sendOptions.TimeToBeReceived
             });
         }

--- a/src/NServiceBus.Core/Faults/MoveFaultsToErrorQueueBehavior.cs
+++ b/src/NServiceBus.Core/Faults/MoveFaultsToErrorQueueBehavior.cs
@@ -41,7 +41,7 @@ namespace NServiceBus
                     message.Headers[Headers.HostId] = hostInformation.HostId.ToString("N");
                     message.Headers[Headers.HostDisplayName] = hostInformation.DisplayName;
 
-                    sender.Send(message,new SendOptions(errorQueueAddress));
+                    sender.Send(new OutgoingMessage(message.Headers,message.Body), new SendOptions(errorQueueAddress));
 
                     notifications.Errors.InvokeMessageHasBeenSentToErrorQueue(message,exception);
                 }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -131,9 +131,10 @@
     <Compile Include="Transports\Msmq\MsmqReceiveBehavior.cs" />
     <Compile Include="Transports\Msmq\MsmqReceiveWithNativeTransactionBehavior.cs" />
     <Compile Include="Transports\Msmq\MsmqReceiveWithNoTransactionBehavior.cs" />
+    <Compile Include="Transports\OutgoingMessage.cs" />
     <Compile Include="Transports\ReceiveBehavior.cs" />
     <Compile Include="Pipeline\Contexts\PhysicalOutgoingContext.cs" />
-    <Compile Include="Transports\ReceivedMessage.cs" />
+    <Compile Include="Transports\IncomingMessage.cs" />
     <Compile Include="Unicast\Behaviors\SagaInvocationResult.cs" />
     <Compile Include="Unicast\Behaviors\TransportReceiveToPhysicalMessageProcessingConnector.cs" />
     <Compile Include="Pipeline\Contexts\LogicalMessageProcessingStageBehavior.cs" />

--- a/src/NServiceBus.Core/Outbox/TransportOperationConverter.cs
+++ b/src/NServiceBus.Core/Outbox/TransportOperationConverter.cs
@@ -20,11 +20,6 @@ namespace NServiceBus.Outbox
                 result["NonDurable"] = true.ToString();
             }
 
-            if (options.ReplyToAddress != null)
-            {
-                result["ReplyToAddress"] = options.ReplyToAddress;
-            }
-
             result["EnlistInReceiveTransaction"] = options.EnlistInReceiveTransaction.ToString();
             result["EnforceMessagingBestPractices"] = options.EnforceMessagingBestPractices.ToString();
 
@@ -51,10 +46,6 @@ namespace NServiceBus.Outbox
                     result["DeliverAt"] = DateTimeExtensions.ToWireFormattedString(sendOptions.DeliverAt.Value);
                 }
 
-
-
-
-                result["CorrelationId"] = sendOptions.CorrelationId;
                 result["Destination"] = sendOptions.Destination;
             }
             else
@@ -87,10 +78,7 @@ namespace NServiceBus.Outbox
             switch (operation)
             {
                 case "publish":
-                    result = new PublishOptions(Type.GetType(options["EventType"]))
-                    {
-                        ReplyToAddress = options["ReplyToAddress"]
-                    };
+                    result = new PublishOptions(Type.GetType(options["EventType"]));
                     break;
                 case "send":
                 case "audit":
@@ -101,10 +89,7 @@ namespace NServiceBus.Outbox
                     result = sendOptions;
                     break;
                 case "reply":
-                    var replyOptions = new ReplyOptions(options["Destination"], options["CorrelationId"])
-                    {
-                        ReplyToAddress = options["ReplyToAddress"]
-                    };
+                    var replyOptions = new ReplyOptions(options["Destination"]);
                     ApplySendOptionSettings(replyOptions, options);
 
                     result = replyOptions;
@@ -155,18 +140,6 @@ namespace NServiceBus.Outbox
             {
                 sendOptions.DeliverAt = DateTimeExtensions.ToUtcDateTime(deliverAt);
             }
-
-
-            sendOptions.CorrelationId = options["CorrelationId"];
-
-            string replyToAddress;
-            if (options.TryGetValue("ReplyToAddress", out replyToAddress))
-            {
-                sendOptions.ReplyToAddress = replyToAddress;
-            }
-
-
-            sendOptions.CorrelationId = options["CorrelationId"];
         }
 
     }

--- a/src/NServiceBus.Core/Pipeline/Contexts/TransportReceiveContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Contexts/TransportReceiveContext.cs
@@ -9,7 +9,7 @@
     {
         internal const string IncomingPhysicalMessageKey = "NServiceBus.IncomingPhysicalMessage";
 
-        internal TransportReceiveContext(ReceivedMessage receivedMessage, BehaviorContext parentContext): base(parentContext)
+        internal TransportReceiveContext(IncomingMessage receivedMessage, BehaviorContext parentContext): base(parentContext)
         {
             PhysicalMessage = new TransportMessage(receivedMessage.MessageId, receivedMessage.Headers)
             {

--- a/src/NServiceBus.Core/SecondLevelRetries/SecondLevelRetriesBehavior.cs
+++ b/src/NServiceBus.Core/SecondLevelRetries/SecondLevelRetriesBehavior.cs
@@ -45,7 +45,7 @@ namespace NServiceBus
                     message.Headers[Headers.Retries] = currentRetry.ToString();
                     message.Headers[RetriesTimestamp] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
 
-                    deferer.Defer(message, new SendOptions(receiveAddress)
+                    deferer.Defer(new OutgoingMessage( message.Headers,message.Body), new SendOptions(receiveAddress)
                     {
                         DelayDeliveryWith = delay
                     });

--- a/src/NServiceBus.Core/Timeout/Core/DefaultTimeoutManager.cs
+++ b/src/NServiceBus.Core/Timeout/Core/DefaultTimeoutManager.cs
@@ -1,12 +1,13 @@
 namespace NServiceBus.Timeout.Core
 {
     using System;
+    using NServiceBus.Unicast;
     using Transports;
 
     class DefaultTimeoutManager
     {
         public IPersistTimeouts TimeoutsPersister { get; set; }
-       
+
         public ISendMessages MessageSender { get; set; }
 
         public Configure Configure { get; set; }
@@ -17,9 +18,13 @@ namespace NServiceBus.Timeout.Core
         {
             if (timeout.Time.AddSeconds(-1) <= DateTime.UtcNow)
             {
-                MessageSender.Send(timeout.ToTransportMessage(), timeout.ToSendOptions(Configure.LocalAddress));
+                var sendOptions = new SendOptions(timeout.Destination);
+                var message = new OutgoingMessage(timeout.Headers, timeout.State);
+
+                MessageSender.Send(message, sendOptions);
                 return;
             }
+
 
             TimeoutsPersister.Add(timeout);
 

--- a/src/NServiceBus.Core/Timeout/Core/TimeoutData.cs
+++ b/src/NServiceBus.Core/Timeout/Core/TimeoutData.cs
@@ -2,12 +2,11 @@ namespace NServiceBus.Timeout.Core
 {
     using System;
     using System.Collections.Generic;
-    using Unicast;
 
     /// <summary>
     /// Holds timeout information.
     /// </summary>
-    public class TimeoutData 
+    public partial class TimeoutData 
     {
         /// <summary>
         /// Id of this timeout
@@ -55,69 +54,5 @@ namespace NServiceBus.Timeout.Core
         {
             return string.Format("Timeout({0}) - Expires:{1}, SagaId:{2}", Id, Time, SagaId);
         }
-
-        /// <summary>
-        /// Transforms the timeout to a <see cref="TransportMessage"/>.
-        /// </summary>
-        /// <returns>Returns a <see cref="TransportMessage"/>.</returns>
-        public TransportMessage ToTransportMessage()
-        {
-            var transportMessage = new TransportMessage(Id,Headers)
-            {
-                Body = State
-            };
-
-
-            if (SagaId != Guid.Empty)
-            {
-                transportMessage.Headers[NServiceBus.Headers.SagaId] = SagaId.ToString();
-            }
-
-            transportMessage.Headers[NServiceBus.Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
-            transportMessage.Headers["NServiceBus.RelatedToTimeoutId"] = Id;
-
-            return transportMessage;
-        }
-
-        /// <summary>
-        /// Transforms the timeout to send options.
-        /// </summary>
-        /// <param name="replyToAddress">The reply address to use for outgoing messages</param>
-        [ObsoleteEx(
-            ReplacementTypeOrMember = "TimeoutData.ToSendOptions(string)", 
-            RemoveInVersion = "7.0", 
-            TreatAsErrorFromVersion = "6.0")]
-        // ReSharper disable once UnusedParameter.Global
-        public SendOptions ToSendOptions(Address replyToAddress)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// Transforms the timeout to send options.
-        /// </summary>
-        /// <param name="replyToAddress">The reply address to use for outgoing messages</param>
-        public SendOptions ToSendOptions(string replyToAddress)
-        {
-            if (Headers != null)
-            {
-                string originalReplyToAddressValue;
-                if (Headers.TryGetValue(OriginalReplyToAddress, out originalReplyToAddressValue))
-                {
-                    replyToAddress = originalReplyToAddressValue;
-                    Headers.Remove(OriginalReplyToAddress);
-                }
-            }
-
-            return new SendOptions(Destination)
-            {
-                ReplyToAddress = replyToAddress
-            };
-        }
-
-        /// <summary>
-        /// Original ReplyTo address header.
-        /// </summary>
-        public const string OriginalReplyToAddress = "NServiceBus.Timeout.ReplyToAddress";
     }
 }

--- a/src/NServiceBus.Core/Timeout/Core/TimeoutManagerDeferrer.cs
+++ b/src/NServiceBus.Core/Timeout/Core/TimeoutManagerDeferrer.cs
@@ -12,7 +12,7 @@
         public string TimeoutManagerAddress { get; set; }
         public Configure Configure { get; set; }
 
-        public void Defer(TransportMessage message, SendOptions sendOptions)
+        public void Defer(OutgoingMessage message, SendOptions sendOptions)
         {
             message.Headers[TimeoutManagerHeaders.RouteExpiredTimeoutTo] = sendOptions.Destination;
 
@@ -55,7 +55,7 @@
             controlMessage.Headers[headerKey] = headerValue;
             controlMessage.Headers[TimeoutManagerHeaders.ClearTimeouts] = Boolean.TrueString;
 
-            MessageSender.Send(controlMessage, new SendOptions(TimeoutManagerAddress) { ReplyToAddress = Configure.PublicReturnAddress });
+            MessageSender.Send(new OutgoingMessage(controlMessage.Headers,controlMessage.Body), new SendOptions(TimeoutManagerAddress));
         }
 
         static ILog Log = LogManager.GetLogger<TimeoutManagerDeferrer>();

--- a/src/NServiceBus.Core/Timeout/Hosting/Windows/TimeoutMessageProcessor.cs
+++ b/src/NServiceBus.Core/Timeout/Hosting/Windows/TimeoutMessageProcessor.cs
@@ -74,7 +74,7 @@ namespace NServiceBus.Timeout.Hosting.Windows
             }
 
             TimeoutManager.RemoveTimeout(timeoutId);
-            MessageSender.Send(message, new SendOptions(destination));
+            MessageSender.Send(new OutgoingMessage(message.Headers,message.Body), new SendOptions(destination));
         }
 
         void HandleInternal(TransportMessage message)
@@ -120,11 +120,7 @@ namespace NServiceBus.Timeout.Hosting.Windows
                     OwningTimeoutManager = EndpointName
                 };
 
-                //add a temp header so that we can make sure to restore the ReplyToAddress
-                if (message.ReplyToAddress != null)
-                {
-                    data.Headers[TimeoutData.OriginalReplyToAddress] = message.ReplyToAddress;
-                }
+            
 
                 TimeoutManager.PushTimeout(data);
             }

--- a/src/NServiceBus.Core/Timeout/Hosting/Windows/TimeoutPersisterReceiver.cs
+++ b/src/NServiceBus.Core/Timeout/Hosting/Windows/TimeoutPersisterReceiver.cs
@@ -93,8 +93,13 @@ namespace NServiceBus.Timeout.Hosting.Windows
                     {
                         startSlice = timeoutData.Item2;
                     }
+                    //use the dispatcher as the reply to address so that retries go back to the dispatcher q
+                    // instead of the main endpoint q
+                    var transportMessage = ControlMessage.Create();
 
-                    MessageSender.Send(CreateTransportMessage(timeoutData.Item1), new SendOptions(DispatcherAddress));
+                    transportMessage.Headers["Timeout.Id"] = timeoutData.Item1;
+
+                    MessageSender.Send(new OutgoingMessage(transportMessage.Headers,transportMessage.Body), new SendOptions(DispatcherAddress));
                 }
 
                 lock (lockObject)
@@ -129,16 +134,6 @@ namespace NServiceBus.Timeout.Hosting.Windows
             resetEvent.Set();
         }
 
-        static TransportMessage CreateTransportMessage(string timeoutId)
-        {
-            //use the dispatcher as the reply to address so that retries go back to the dispatcher q
-            // instead of the main endpoint q
-            var transportMessage = ControlMessage.Create();
-
-            transportMessage.Headers["Timeout.Id"] = timeoutId;
-
-            return transportMessage;
-        }
 
         void TimeoutsManagerOnTimeoutPushed(TimeoutData timeoutData)
         {

--- a/src/NServiceBus.Core/Transports/IDeferMessages.cs
+++ b/src/NServiceBus.Core/Transports/IDeferMessages.cs
@@ -10,7 +10,7 @@
         /// <summary>
         /// Defers the given message
         /// </summary>
-        void Defer(TransportMessage message, SendOptions sendOptions);
+        void Defer(OutgoingMessage message, SendOptions sendOptions);
 
         /// <summary>
         /// Clears all timeouts for the given header

--- a/src/NServiceBus.Core/Transports/IPublishMessages.cs
+++ b/src/NServiceBus.Core/Transports/IPublishMessages.cs
@@ -10,6 +10,6 @@ namespace NServiceBus.Transports
         /// <summary>
         /// Publishes the given messages to all known subscribers
         /// </summary>
-        void Publish(TransportMessage message,PublishOptions publishOptions);
+        void Publish(OutgoingMessage message,PublishOptions publishOptions);
     }
 }

--- a/src/NServiceBus.Core/Transports/ISendMessages.cs
+++ b/src/NServiceBus.Core/Transports/ISendMessages.cs
@@ -10,6 +10,6 @@ namespace NServiceBus.Transports
         /// <summary>
         /// Sends the given <paramref name="message"/>
         /// </summary>
-        void Send(TransportMessage message, SendOptions sendOptions);
+        void Send(OutgoingMessage message, SendOptions sendOptions);
     }
 }

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -6,7 +6,7 @@ namespace NServiceBus.Transports
     /// <summary>
     /// The raw message coming from the transport
     /// </summary>
-    public class ReceivedMessage
+    public class IncomingMessage
     {
         /// <summary>
         /// The native id of the message
@@ -29,7 +29,7 @@ namespace NServiceBus.Transports
         /// <param name="messageId">Native message id</param>
         /// <param name="headers">The message headers</param>
         /// <param name="bodyStream">The message body stream</param>
-        public ReceivedMessage(string messageId,Dictionary<string,string> headers,Stream bodyStream)
+        public IncomingMessage(string messageId,Dictionary<string,string> headers,Stream bodyStream)
         {
             MessageId = messageId;
             Headers = headers;

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqMessageSender.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqMessageSender.cs
@@ -3,10 +3,10 @@ namespace NServiceBus.Transports.Msmq
     using System;
     using System.Messaging;
     using System.Transactions;
-    using Config;
     using NServiceBus.Pipeline;
-    using Unicast;
-    using Unicast.Queuing;
+    using NServiceBus.Transports.Msmq.Config;
+    using NServiceBus.Unicast;
+    using NServiceBus.Unicast.Queuing;
 
     /// <summary>
     /// Default MSMQ <see cref="ISendMessages"/> implementation.
@@ -38,7 +38,7 @@ namespace NServiceBus.Transports.Msmq
         /// <summary>
         /// Sends the given <paramref name="message"/>
         /// </summary>
-        public void Send(TransportMessage message, SendOptions sendOptions)
+        public void Send(OutgoingMessage message, SendOptions sendOptions)
         {
             var destination = sendOptions.Destination;
             var destinationAddress = MsmqAddress.Parse(destination);
@@ -52,9 +52,9 @@ namespace NServiceBus.Transports.Msmq
                     toSend.UseJournalQueue = Settings.UseJournalQueue;
                     toSend.TimeToReachQueue = Settings.TimeToReachQueue;
 
-                    var replyToAddress = sendOptions.ReplyToAddress ?? message.ReplyToAddress;
+                    string replyToAddress;
 
-                    if (replyToAddress != null)
+                    if (message.Headers.TryGetValue(Headers.ReplyToAddress,out replyToAddress))
                     {
                         var returnAddress = MsmqUtilities.GetReturnAddress(replyToAddress, destinationAddress.Machine);
                         toSend.ResponseQueue = new MessageQueue(returnAddress);

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqReceiveWithNativeTransactionBehavior.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqReceiveWithNativeTransactionBehavior.cs
@@ -8,7 +8,7 @@ namespace NServiceBus
 
     class MsmqReceiveWithNativeTransactionBehavior : MsmqReceiveBehavior
     {
-        protected override void Invoke(IncomingContext context, Action<ReceivedMessage> onMessage)
+        protected override void Invoke(IncomingContext context, Action<IncomingMessage> onMessage)
         {
             var queue = context.Get<MessageQueue>();
 
@@ -44,7 +44,7 @@ namespace NServiceBus
                     
                     using (var bodyStream = message.BodyStream)
                     {
-                        onMessage(new ReceivedMessage(message.Id, headers, bodyStream));
+                        onMessage(new IncomingMessage(message.Id, headers, bodyStream));
                     }
 
                     msmqTransaction.Commit();

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqReceiveWithNoTransactionBehavior.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqReceiveWithNoTransactionBehavior.cs
@@ -8,7 +8,7 @@ namespace NServiceBus
 
     class MsmqReceiveWithNoTransactionBehavior : MsmqReceiveBehavior
     {
-        protected override void Invoke(IncomingContext context, Action<ReceivedMessage> onMessage)
+        protected override void Invoke(IncomingContext context, Action<IncomingMessage> onMessage)
         {
             var queue = context.Get<MessageQueue>();
 
@@ -33,7 +33,7 @@ namespace NServiceBus
 
             using (var bodyStream = message.BodyStream)
             {
-                onMessage(new ReceivedMessage(message.Id,headers,bodyStream));
+                onMessage(new IncomingMessage(message.Id,headers,bodyStream));
             }
         }
     }

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqReceiveWithTransactionScopeBehavior.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqReceiveWithTransactionScopeBehavior.cs
@@ -14,7 +14,7 @@ namespace NServiceBus
             this.transactionOptions = transactionOptions;
         }
 
-        protected override void Invoke(IncomingContext context, Action<ReceivedMessage> onMessage)
+        protected override void Invoke(IncomingContext context, Action<IncomingMessage> onMessage)
         {
             var queue = context.Get<MessageQueue>();
 
@@ -45,7 +45,7 @@ namespace NServiceBus
 
                 using (var bodyStream = message.BodyStream)
                 {
-                    onMessage(new ReceivedMessage(message.Id, headers, bodyStream));
+                    onMessage(new IncomingMessage(message.Id, headers, bodyStream));
                 }
 
                 scope.Complete();

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqUtilities.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqUtilities.cs
@@ -11,6 +11,7 @@ namespace NServiceBus
     using System.Xml;
     using NServiceBus.Logging;
     using NServiceBus.Support;
+    using NServiceBus.Transports;
     using NServiceBus.Transports.Msmq;
     using NServiceBus.Unicast;
 
@@ -204,7 +205,7 @@ namespace NServiceBus
         ///     Converts a TransportMessage to an Msmq message.
         ///     Doesn't set the ResponseQueue of the result.
         /// </summary>
-        public static Message Convert(TransportMessage message, SendOptions sendOptions)
+        public static Message Convert(OutgoingMessage message, DeliveryOptions deliveryOptions)
         {
             var result = new Message();
 
@@ -214,11 +215,11 @@ namespace NServiceBus
             }
 
 
-            AssignMsmqNativeCorrelationId(message, result);
+            AssignMsmqNativeCorrelationId(message.Headers, result);
 
-            if (sendOptions.NonDurable.HasValue)
+            if (deliveryOptions.NonDurable.HasValue)
             {
-                result.Recoverable = sendOptions.NonDurable.Value;
+                result.Recoverable = deliveryOptions.NonDurable.Value;
             }
             else
             {
@@ -226,9 +227,9 @@ namespace NServiceBus
                 result.Recoverable = true;
             }
       
-            if (sendOptions.TimeToBeReceived.HasValue &&  sendOptions.TimeToBeReceived.Value < MessageQueue.InfiniteTimeout)
+            if (deliveryOptions.TimeToBeReceived.HasValue &&  deliveryOptions.TimeToBeReceived.Value < MessageQueue.InfiniteTimeout)
             {
-                result.TimeToBeReceived = sendOptions.TimeToBeReceived.Value;
+                result.TimeToBeReceived = deliveryOptions.TimeToBeReceived.Value;
             }
 
             using (var stream = new MemoryStream())
@@ -241,45 +242,63 @@ namespace NServiceBus
                 result.Extension = stream.ToArray();
             }
 
-            result.AppSpecific = (int) message.MessageIntent;
+            var messageIntent = default(MessageIntentEnum);
+
+            string messageIntentString;
+
+            if (message.Headers.TryGetValue(Headers.MessageIntent, out messageIntentString))
+            {
+
+                Enum.TryParse(messageIntentString, true, out messageIntent);
+            }
+
+            result.AppSpecific = (int)messageIntent;
+           
 
             return result;
         }
 
-        static void AssignMsmqNativeCorrelationId(TransportMessage message, Message result)
+        static void AssignMsmqNativeCorrelationId(Dictionary<string,string> headers, Message result)
         {
-            if (string.IsNullOrEmpty(message.CorrelationId))
+            string correlationIdHeader;
+
+            if (!headers.TryGetValue(Headers.CorrelationId, out correlationIdHeader))
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(correlationIdHeader))
             {
                 return;
             }
 
             Guid correlationId;
 
-            if (Guid.TryParse(message.CorrelationId, out correlationId))
+            if (Guid.TryParse(correlationIdHeader, out correlationId))
             {
                 //msmq required the id's to be in the {guid}\{incrementing number} format so we need to fake a \0 at the end to make it compatible                
-                result.CorrelationId = message.CorrelationId + "\\0";
+                result.CorrelationId = correlationIdHeader + "\\0";
                 return;
             }
 
             try
             {
-                if (message.CorrelationId.Contains("\\"))
+                if (correlationIdHeader.Contains("\\"))
                 {
-                    var parts = message.CorrelationId.Split('\\');
+                    var parts = correlationIdHeader.Split('\\');
 
                     int number;
 
                     if (parts.Count() == 2 && Guid.TryParse(parts.First(), out correlationId) &&
                         int.TryParse(parts[1], out number))
                     {
-                        result.CorrelationId = message.CorrelationId;
+                        result.CorrelationId = correlationIdHeader;
                     }
                 }
             }
             catch (Exception ex)
             {
-                Logger.Warn("Failed to assign a native correlation id for message: " + message.Id, ex);
+                Logger.Warn("Failed to assign a native correlation id for message: " + headers[Headers.MessageId], ex);
             }
         }
 

--- a/src/NServiceBus.Core/Transports/OutgoingMessage.cs
+++ b/src/NServiceBus.Core/Transports/OutgoingMessage.cs
@@ -1,0 +1,32 @@
+namespace NServiceBus.Transports
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The message going out to the transport
+    /// </summary>
+    public class OutgoingMessage
+    {
+        /// <summary>
+        /// Constructs the message
+        /// </summary>
+        /// <param name="headers">The headers associated with this message</param>
+        /// <param name="body">The body of the message</param>
+        public OutgoingMessage(Dictionary<string, string> headers,byte[] body)
+        {
+            Headers = headers;
+            Body = body;
+        }
+
+        /// <summary>
+        /// The body to be sent
+        /// </summary>
+        public byte[] Body { get; private set; }
+
+
+        /// <summary>
+        /// The headers for the message
+        /// </summary>
+        public Dictionary<string, string> Headers { get; private set; }
+    }
+}

--- a/src/NServiceBus.Core/Transports/ReceiveBehavior.cs
+++ b/src/NServiceBus.Core/Transports/ReceiveBehavior.cs
@@ -25,7 +25,7 @@ namespace NServiceBus.Transports
         /// </summary>
         /// <param name="context"></param>
         /// <param name="onMessage"></param>
-        protected abstract void Invoke(IncomingContext context, Action<ReceivedMessage> onMessage);
+        protected abstract void Invoke(IncomingContext context, Action<IncomingMessage> onMessage);
 
         /// <summary>
         /// 

--- a/src/NServiceBus.Core/Unicast/Behaviors/CreatePhysicalMessageConnector.cs
+++ b/src/NServiceBus.Core/Unicast/Behaviors/CreatePhysicalMessageConnector.cs
@@ -16,22 +16,20 @@
 
         public override void Invoke(OutgoingContext context, Action<PhysicalOutgoingContextStageBehavior.Context> next)
         {
-            var deliveryOptions = context.DeliveryOptions;
 
-            var toSend = new TransportMessage { MessageIntent = MessageIntentEnum.Publish };
+            var intent = MessageIntentEnum.Publish;
 
-            var sendOptions = deliveryOptions as SendOptions;
-
-
-            if (sendOptions != null)
+            if (context.DeliveryOptions is SendOptions)
             {
-                toSend.MessageIntent = sendOptions is ReplyOptions ? MessageIntentEnum.Reply : MessageIntentEnum.Send;
-
-                if (sendOptions.CorrelationId != null)
-                {
-                    toSend.CorrelationId = sendOptions.CorrelationId;
-                }
+                intent = MessageIntentEnum.Send;   
             }
+
+            if (context.DeliveryOptions is ReplyOptions)
+            {
+                intent = MessageIntentEnum.Reply;
+            }
+     
+            var toSend = new TransportMessage { MessageIntent = intent };
 
             //apply static headers
             foreach (var kvp in configure.OutgoingHeaders)

--- a/src/NServiceBus.Core/Unicast/Behaviors/DispatchMessageToTransportBehavior.cs
+++ b/src/NServiceBus.Core/Unicast/Behaviors/DispatchMessageToTransportBehavior.cs
@@ -72,16 +72,18 @@
 
         void SendOrDefer(TransportMessage messageToSend, SendOptions sendOptions)
         {
+            var outgoingMessage = new OutgoingMessage(messageToSend.Headers,messageToSend.Body);
+
             if (sendOptions.DelayDeliveryWith.HasValue)
             {
                 if (sendOptions.DelayDeliveryWith > TimeSpan.Zero)
                 {
                     SetIsDeferredHeader(messageToSend);
-                    MessageDeferral.Defer(messageToSend, sendOptions);
+                    MessageDeferral.Defer(outgoingMessage, sendOptions);
                 }
                 else
                 {
-                    MessageSender.Send(messageToSend, sendOptions);
+                    MessageSender.Send(outgoingMessage, sendOptions);
                 }
 
                 return;
@@ -93,17 +95,17 @@
                 if (deliverAt > DateTime.UtcNow)
                 {
                     SetIsDeferredHeader(messageToSend);
-                    MessageDeferral.Defer(messageToSend, sendOptions);
+                    MessageDeferral.Defer(outgoingMessage, sendOptions);
                 }
                 else
                 {
-                    MessageSender.Send(messageToSend, sendOptions);
+                    MessageSender.Send(outgoingMessage, sendOptions);
                 }
 
                 return;
             }
 
-            MessageSender.Send(messageToSend, sendOptions);
+            MessageSender.Send(outgoingMessage, sendOptions);
         }
 
         static void SetIsDeferredHeader(TransportMessage messageToSend)
@@ -117,8 +119,7 @@
             {
                 throw new InvalidOperationException("No message publisher has been registered. If you're using a transport without native support for pub/sub please enable the message driven publishing feature by calling config.EnableFeature<MessageDrivenSubscriptions>() in your configuration");
             }
-
-            MessagePublisher.Publish(messageToSend, publishOptions);
+            MessagePublisher.Publish(new OutgoingMessage(messageToSend.Headers,messageToSend.Body), publishOptions);
         }
     }
 }

--- a/src/NServiceBus.Core/Unicast/DeliveryOptions.cs
+++ b/src/NServiceBus.Core/Unicast/DeliveryOptions.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Unicast
     /// <summary>
     /// Base class for options to deliver messages.
     /// </summary>
-    public abstract class DeliveryOptions
+    public abstract partial class DeliveryOptions
     {
         /// <summary>
         /// Creates an instance of <see cref="DeliveryOptions"/>.
@@ -26,11 +26,7 @@ namespace NServiceBus.Unicast
         /// This is enabled by default
         /// </summary>
         public bool EnlistInReceiveTransaction { get; set; }
-        
-        /// <summary>
-        /// The reply address to use for outgoing messages
-        /// </summary>
-        public string ReplyToAddress { get; set; }
+
 
 
         /// <summary>

--- a/src/NServiceBus.Core/Unicast/Publishing/StorageDrivenPublisher.cs
+++ b/src/NServiceBus.Core/Unicast/Publishing/StorageDrivenPublisher.cs
@@ -24,7 +24,7 @@
         }
 
 
-        public void Publish(TransportMessage message, PublishOptions publishOptions)
+        public void Publish(OutgoingMessage message, PublishOptions publishOptions)
         {
             var eventTypesToPublish = messageMetadataRegistry.GetMessageMetadata(publishOptions.EventType.FullName)
                 .MessageHierarchy
@@ -44,13 +44,11 @@
             foreach (var subscriber in subscribers)
             {
                 //this is unicast so we give the message a unique ID
-                message.ChangeMessageId(CombGuid.Generate().ToString());
+                message.Headers[Headers.MessageId] = CombGuid.Generate().ToString();
 
                 messageSender.Send(message, new SendOptions(subscriber)
                 {
-                    ReplyToAddress = publishOptions.ReplyToAddress,
-                    EnforceMessagingBestPractices = publishOptions.EnforceMessagingBestPractices,
-                    EnlistInReceiveTransaction = publishOptions.EnlistInReceiveTransaction,
+                    EnforceMessagingBestPractices = publishOptions.EnforceMessagingBestPractices
                 });
             }
         }

--- a/src/NServiceBus.Core/Unicast/ReplyOptions.cs
+++ b/src/NServiceBus.Core/Unicast/ReplyOptions.cs
@@ -5,32 +5,18 @@ namespace NServiceBus.Unicast
     /// <summary>
     /// Additional options that only apply for reply messages
     /// </summary>
-    public class ReplyOptions : SendOptions
+    public partial class ReplyOptions : SendOptions
     {
 
         /// <summary>
         /// Both a destination and a correlation id is required when replying
         /// </summary>
-        [ObsoleteEx(
-            ReplacementTypeOrMember = "ReplyOptions(string destination, string correlationId)",
-            RemoveInVersion = "7.0")]
-        // ReSharper disable once UnusedParameter.Local
-        public ReplyOptions(Address destination, string correlationId) : base(destination)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        /// Both a destination and a correlation id is required when replying
-        /// </summary>
-        public ReplyOptions(string destination, string correlationId):base(destination)
+        public ReplyOptions(string destination):base(destination)
         {
             if (destination == null)
             {
                 throw new InvalidOperationException("Can't reply with null reply-to-address field. It can happen if you are using a SendOnly client.");
             }
-
-            CorrelationId = correlationId;
         }
     }
 }

--- a/src/NServiceBus.Core/Unicast/SendOptions.cs
+++ b/src/NServiceBus.Core/Unicast/SendOptions.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Unicast
     /// <summary>
     /// Controls how a message will be sent by the transport
     /// </summary>
-    public class SendOptions : DeliveryOptions
+    public partial class SendOptions : DeliveryOptions
     {
         TimeSpan? delayDeliveryWith;
 
@@ -33,11 +33,6 @@ namespace NServiceBus.Unicast
         }
 
         /// <summary>
-        /// The correlation id to be used on the message. Mostly used when doing Bus.Reply
-        /// </summary>
-        public string CorrelationId { get; set; }
-
-        /// <summary>
         /// The time when the message should be delivered to the destination
         /// </summary>
         public DateTime? DeliverAt { get; set; }
@@ -63,5 +58,8 @@ namespace NServiceBus.Unicast
         /// Address where to send this message
         /// </summary>
         public string Destination { get; set; }
+
+
+
     }
 }

--- a/src/NServiceBus.Core/v6-obsoletes.cs
+++ b/src/NServiceBus.Core/v6-obsoletes.cs
@@ -7,8 +7,8 @@ namespace NServiceBus
     {
 
         [ObsoleteEx(
-            Message = "For sending purposes use DeliveryOptions.NonDurable (note the negation). When receiving look at the new 'NServiceBus.NonDurableMessage' header", 
-            RemoveInVersion = "7.0", 
+            Message = "For sending purposes use DeliveryOptions.NonDurable (note the negation). When receiving look at the new 'NServiceBus.NonDurableMessage' header",
+            RemoveInVersion = "7.0",
             TreatAsErrorFromVersion = "6.0")]
         public bool Recoverable { get { throw new NotImplementedException(); } set { throw new NotImplementedException(); } }
 
@@ -17,5 +17,111 @@ namespace NServiceBus
             RemoveInVersion = "7.0",
             TreatAsErrorFromVersion = "6.0")]
         public TimeSpan TimeToBeReceived { get { throw new NotImplementedException(); } set { throw new NotImplementedException(); } }
+    }
+}
+
+
+namespace NServiceBus.Unicast
+{
+    using System;
+
+    public abstract partial class DeliveryOptions
+    {
+        [ObsoleteEx(
+           Message = "Reply to address can be get/set using the `NServiceBus.ReplyToAddress` header",
+           RemoveInVersion = "7.0",
+           TreatAsErrorFromVersion = "6.0")]
+        public string ReplyToAddress { get { throw new NotImplementedException(); } set { throw new NotImplementedException(); } }
+    }
+}
+
+
+namespace NServiceBus.Unicast
+{
+    using System;
+
+    public partial class SendOptions
+    {
+
+        [ObsoleteEx(
+    Message = "Reply to address can be get/set using the `NServiceBus.CorrelationId` header",
+    RemoveInVersion = "7.0",
+    TreatAsErrorFromVersion = "6.0")]
+        public string CorrelationId { get { throw new NotImplementedException(); } set { throw new NotImplementedException(); } }
+
+    }
+}
+
+namespace NServiceBus.Timeout.Core
+{
+    using System;
+    using NServiceBus.Unicast;
+
+    public partial class TimeoutData
+    {
+
+
+        [ObsoleteEx(Message = "Use new OutgoingMessage(timeoutData.State) instead", RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0")]
+        public TransportMessage ToTransportMessage()
+        {
+            throw new NotImplementedException();
+        }
+
+        [ObsoleteEx(
+            Message = "Use new SendOptions() instead",
+            RemoveInVersion = "7.0",
+            TreatAsErrorFromVersion = "6.0")]
+        public SendOptions ToSendOptions(Address replyToAddress)
+        {
+            throw new NotImplementedException();
+        }
+
+        [ObsoleteEx(
+            Message = "Use new SendOptions() instead",
+            RemoveInVersion = "7.0",
+            TreatAsErrorFromVersion = "6.0")]
+        public SendOptions ToSendOptions(string replyToAddress)
+        {
+            throw new NotImplementedException();
+        }
+
+
+
+        [ObsoleteEx(
+            Message = "Not used anymore",
+            RemoveInVersion = "7.0",
+            TreatAsErrorFromVersion = "6.0")]
+        public const string OriginalReplyToAddress = "NServiceBus.Timeout.ReplyToAddress";
+    }
+}
+
+
+namespace NServiceBus.Unicast
+{
+    using System;
+
+   
+    public partial class ReplyOptions
+    {
+
+           [ObsoleteEx(
+            Message = "ReplyOptions(string destination)",
+            RemoveInVersion = "7.0",
+            TreatAsErrorFromVersion = "6.0")]
+        public ReplyOptions(Address destination, string correlationId)
+            : base(destination)
+        {
+            throw new NotImplementedException();
+        }
+
+         [ObsoleteEx(
+            Message = "ReplyOptions(string destination)",
+            RemoveInVersion = "7.0",
+            TreatAsErrorFromVersion = "6.0")]
+        public ReplyOptions(string destination, string correlationId)
+            : base(destination)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
This pull does the following:

* Adds a `OutgoingMessage` that is passed to the transport when sending messages. This new abstraction only contains things that the transport should care about and not the entire TransportMessage

* Renames the recently added `ReceivedMessage` to `IncomingMessage` to be more consistent

* Removes a few properties from the delivery options that the transports shouldn't care about. We need to remove more (like `EnforceMessagingBestPractices` but that can go in a separate pull

If we decided to go with a `Stream` instead of `byte[]` that will be a different pull

## Breaking changes


### NServiceBus.Transports.IDeferMessages  

#### Methods Removed

  - `void Defer(NServiceBus.TransportMessage, NServiceBus.Unicast.SendOptions)` 


### NServiceBus.Transports.IPublishMessages  

#### Methods Removed

  - `void Publish(NServiceBus.TransportMessage, NServiceBus.Unicast.PublishOptions)` 


### NServiceBus.Transports.ISendMessages  

#### Methods Removed

  - `void Send(NServiceBus.TransportMessage, NServiceBus.Unicast.SendOptions)` 


### NServiceBus.Transports.Msmq.MsmqMessageSender  [ [old](tbdsrc/NServiceBus.Core/Transports/Msmq/MsmqMessageSender.cs) | [new](tbdNServiceBus.Core/Transports/Msmq/MsmqMessageSender.cs) ]

#### Methods Removed

  - `void Send(NServiceBus.TransportMessage, NServiceBus.Unicast.SendOptions)` [ [link](tbdsrc/NServiceBus.Core/Transports/Msmq/MsmqMessageSender.cs#L43) ]
