### PR TITLE
use streamwriter for XML

### DIFF
--- a/src/NServiceBus.Core.Tests/Serializers/XML/SerializerTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/SerializerTests.cs
@@ -704,16 +704,22 @@ namespace NServiceBus.Serializers.XML.Test
 
             watch.Reset();
 
-            var s = new MemoryStream();
-            serializer.Serialize(message, s);
-            var buffer = s.GetBuffer();
-            s.Dispose();
+            byte[] buffer;
+            using (var s = new MemoryStream())
+            {
+                serializer.Serialize(message, s);
+                buffer = s.ToArray();
+            }
 
             watch.Start();
 
             for (var i = 0; i < numberOfIterations; i++)
+            {
                 using (var forDeserializing = new MemoryStream(buffer))
+                {
                     serializer.Deserialize(forDeserializing);
+                }
+            }
 
             watch.Stop();
             Debug.WriteLine("Deserializing: " + watch.Elapsed);

--- a/src/NServiceBus.Core/Serializers/XML/Serializer.cs
+++ b/src/NServiceBus.Core/Serializers/XML/Serializer.cs
@@ -498,7 +498,7 @@
 
         public void Dispose()
         {
-            
+            //Injected at compile time   
         }
     }
 }

--- a/src/NServiceBus.Core/Serializers/XML/Serializer.cs
+++ b/src/NServiceBus.Core/Serializers/XML/Serializer.cs
@@ -12,25 +12,25 @@
     using NServiceBus.MessageInterfaces;
     using NServiceBus.Utils.Reflection;
 
-    class Serializer
+    class Serializer:IDisposable
     {
         const string BaseType = "baseType";
 
         const string DefaultNamespace = "http://tempuri.net";
 
-        readonly List<Type> namespacesToAdd = new List<Type>();
-        readonly IMessageMapper mapper;
-        readonly StreamWriter writer;
-        readonly object message;
-        readonly Conventions conventions;
-        readonly XmlSerializerCache cache;
-        readonly bool skipWrappingRawXml;
-        readonly string @namespace;
+        List<Type> namespacesToAdd = new List<Type>();
+        IMessageMapper mapper;
+        StreamWriter writer;
+        object message;
+        Conventions conventions;
+        XmlSerializerCache cache;
+        bool skipWrappingRawXml;
+        string @namespace;
 
         public Serializer(IMessageMapper mapper, Stream stream, object message, Conventions conventions, XmlSerializerCache cache, bool skipWrappingRawXml, string @namespace = DefaultNamespace)
         {
             this.mapper = mapper;
-            writer = new StreamWriter(stream);
+            writer = new StreamWriter(stream, Encoding.UTF8, 1024,true);
             this.message = message;
             this.conventions = conventions;
             this.cache = cache;
@@ -45,7 +45,6 @@
 
             WriteObject(t.SerializationFriendlyName(), t, message, true);
             writer.Flush();
-            
         }
 
         string GetNamespace(object target)
@@ -495,6 +494,11 @@
             }
 
             writer.WriteLine(">");
+        }
+
+        public void Dispose()
+        {
+            
         }
     }
 }

--- a/src/NServiceBus.Core/Serializers/XML/XmlMessageSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlMessageSerializer.cs
@@ -70,8 +70,10 @@ namespace NServiceBus.Serializers.XML
         /// </summary>
         public void Serialize(object message, Stream stream)
         {
-            var serializer = new Serializer(mapper,stream,message, conventions, cache, SkipWrappingRawXml, Namespace);
-            serializer.Serialize();
+            using (var serializer = new Serializer(mapper, stream, message, conventions, cache, SkipWrappingRawXml, Namespace))
+            {
+                serializer.Serialize();
+            }
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Serializers/XML/XmlMessageSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlMessageSerializer.cs
@@ -70,9 +70,8 @@ namespace NServiceBus.Serializers.XML
         /// </summary>
         public void Serialize(object message, Stream stream)
         {
-            var serializer = new Serializer(mapper, conventions, cache, SkipWrappingRawXml, Namespace);
-            var buffer = serializer.Serialize(message);
-            stream.Write(buffer, 0, buffer.Length);
+            var serializer = new Serializer(mapper,stream,message, conventions, cache, SkipWrappingRawXml, Namespace);
+            serializer.Serialize();
         }
 
         /// <summary>


### PR DESCRIPTION
So the current XML Serialize does 3 steps

1. write the entire xml to a string
2. UTF8 encode the entire string to a byte array
3. write the whole byte array to the target stream

So we loose the entire memory for the serialization **twice**. this makes @johnsimons angry

This PR changes it over to a streamwriter so we just stream each small text chunk to the target stream.