### PR TITLE
New message best practice for deferring messages

### DIFF
--- a/src/NServiceBus.Core.Tests/Unicast/MessagingBestPracticesTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/MessagingBestPracticesTests.cs
@@ -7,6 +7,24 @@
     public class MessagingBestPracticesTests
     {
         [TestFixture]
+        public class When_defering
+        {
+            [Test]
+            public void Should_throw_for_TimeToBeReceived_set()
+            {
+                var invalidOperationException = Assert.Throws<InvalidOperationException>(() => MessagingBestPractices.AssertIsValidForDefer(typeof(MyDeferredMessage), new Conventions()));
+                Assert.AreEqual("Defering messages with TimeToBeReceived set is not supported. Remove the TimeToBeReceived attribute to defer messages of this type.", invalidOperationException.Message);
+            }
+
+            [Test]
+            public void Should_not_throw_for_TimeToBeReceived_no_set()
+            {
+                MessagingBestPractices.AssertIsValidForDefer(typeof(MyMessage), new Conventions());
+            }
+        }
+
+
+        [TestFixture]
         public class When_replying
         {
             [Test]
@@ -54,6 +72,11 @@
             }
 
      
+        }
+
+        [TimeToBeReceived("00:00:01")]
+        public class MyDeferredMessage : IMessage
+        {
         }
 
         public class MyMessage : IMessage

--- a/src/NServiceBus.Core/Unicast/ContextualBus.cs
+++ b/src/NServiceBus.Core/Unicast/ContextualBus.cs
@@ -466,6 +466,8 @@ namespace NServiceBus.Unicast
         /// </summary>
         public ICallback Defer(TimeSpan delay, object message)
         {
+            MessagingBestPractices.AssertIsValidForDefer(message.GetType(), builder.Build<Conventions>());
+
             var options = new SendOptions(sendLocalAddress)
             {
                 DelayDeliveryWith = delay,
@@ -480,6 +482,8 @@ namespace NServiceBus.Unicast
         /// </summary>
         public ICallback Defer(DateTime processAt, object message)
         {
+            MessagingBestPractices.AssertIsValidForDefer(message.GetType(), builder.Build<Conventions>());
+
             var options = new SendOptions(sendLocalAddress)
             {
                 DeliverAt = processAt,

--- a/src/NServiceBus.Core/Unicast/MessagingBestPractices.cs
+++ b/src/NServiceBus.Core/Unicast/MessagingBestPractices.cs
@@ -34,6 +34,14 @@ namespace NServiceBus.Unicast
             }
         }
 
+        public static void AssertIsValidForDefer(Type messageType, Conventions conventions)
+        {
+            if (conventions.GetTimeToBeReceived(messageType) < TimeSpan.MaxValue)
+            {
+                throw new InvalidOperationException("Defering messages with TimeToBeReceived set is not supported. Remove the TimeToBeReceived attribute to defer messages of this type.");
+            }
+        }
+
         static ILog Log = LogManager.GetLogger<MessagingBestPractices>();
     }
 }


### PR DESCRIPTION
Implemented a new message best practice check to make sure users don't defer messages that have a TimeToBeReceived attribute. 

Putting a TimeToBeReceived attribute on the message might lead to message loss if a struggling timeout manager does not pick up the message before the TTBR runs out.

@andreasohlund and I could not come up with a reasonable scenario where you would need both defer and TTBR set. The suggestion is to throw if the user tries to do this.