### PR TITLE
Make OutboxSettings extensible for code only APIs

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1380,7 +1380,7 @@ namespace NServiceBus.InMemory.Outbox
 {
     public class static InMemoryOutboxSettingsExtensions
     {
-        public static NServiceBus.Outbox.OutboxSettings TimeToKeepDeduplicationData(this NServiceBus.Outbox.OutboxSettings cfg, System.TimeSpan time) { }
+        public static NServiceBus.Outbox.OutboxSettings TimeToKeepDeduplicationData(this NServiceBus.Outbox.OutboxSettings settings, System.TimeSpan time) { }
     }
 }
 namespace NServiceBus.Installation

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1376,6 +1376,13 @@ namespace NServiceBus.Hosting
         public System.Collections.Generic.Dictionary<string, string> Properties { get; }
     }
 }
+namespace NServiceBus.InMemory.Outbox
+{
+    public class static InMemoryOutboxSettingsExtensions
+    {
+        public static NServiceBus.Outbox.OutboxSettings TimeToKeepDeduplicationData(this NServiceBus.Outbox.OutboxSettings cfg, System.TimeSpan time) { }
+    }
+}
 namespace NServiceBus.Installation
 {
     public interface INeedToInstallSomething
@@ -1565,8 +1572,10 @@ namespace NServiceBus.Outbox
         public string MessageId { get; }
         public System.Collections.Generic.List<NServiceBus.Outbox.TransportOperation> TransportOperations { get; }
     }
-    public class OutboxSettings
+    public class OutboxSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
+        [System.ObsoleteAttribute("Please use `InMemoryOutboxSettingsExtensions.TimeToKeepDeduplicationData(TimeSpan" +
+            " time)` instead. Will be removed in version 7.0.0.", true)]
         public void TimeToKeepDeduplicationData(System.TimeSpan time) { }
     }
     public class TransportOperation

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -200,6 +200,10 @@
     <Compile Include="Routing\MessagingBestPractices\BestPracticesOptionExtensions.cs" />
     <Compile Include="Pipeline\Contexts\OutgoingContext.cs" />
     <Compile Include="PerformanceCounters\PerformanceCounterInstance.cs" />
+    <Compile Include="MessageMutator\IMutateOutgoingPhysicalContext.cs" />
+    <Compile Include="MessageMutator\OutgoingPhysicalMutatorContext.cs" />
+    <Compile Include="Persistence\InMemory\Outbox\InMemoryOutboxSettingsExtensions.cs" />
+    <Compile Include="Pipeline\Contexts\OutgoingLogicalMessageContext.cs" />
     <Compile Include="Pipeline\Contexts\PhysicalMessageProcessingStageBehavior.cs" />
     <Compile Include="Pipeline\BehaviorInvoker.cs" />
     <Compile Include="Pipeline\Contexts\IncomingContext.cs" />

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -200,10 +200,7 @@
     <Compile Include="Routing\MessagingBestPractices\BestPracticesOptionExtensions.cs" />
     <Compile Include="Pipeline\Contexts\OutgoingContext.cs" />
     <Compile Include="PerformanceCounters\PerformanceCounterInstance.cs" />
-    <Compile Include="MessageMutator\IMutateOutgoingPhysicalContext.cs" />
-    <Compile Include="MessageMutator\OutgoingPhysicalMutatorContext.cs" />
     <Compile Include="Persistence\InMemory\Outbox\InMemoryOutboxSettingsExtensions.cs" />
-    <Compile Include="Pipeline\Contexts\OutgoingLogicalMessageContext.cs" />
     <Compile Include="Pipeline\Contexts\PhysicalMessageProcessingStageBehavior.cs" />
     <Compile Include="Pipeline\BehaviorInvoker.cs" />
     <Compile Include="Pipeline\Contexts\IncomingContext.cs" />

--- a/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxPersistence.cs
@@ -9,6 +9,8 @@
     /// </summary>
     public class InMemoryOutboxPersistence : Feature
     {
+        internal const string TimeToKeepDeduplicationEntries = "Outbox.TimeToKeepDeduplicationEntries";
+
         internal InMemoryOutboxPersistence()
         {
             DependsOn<Outbox>();
@@ -22,7 +24,7 @@
         {
             context.Container.ConfigureComponent<InMemoryOutboxStorage>(DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent<OutboxCleaner>(DependencyLifecycle.SingleInstance)
-                .ConfigureProperty(t => t.TimeToKeepDeduplicationData, context.Settings.Get<TimeSpan>(Outbox.TimeToKeepDeduplicationEntries));
+                .ConfigureProperty(t => t.TimeToKeepDeduplicationData, context.Settings.Get<TimeSpan>(TimeToKeepDeduplicationEntries));
         }
 
         class OutboxCleaner : FeatureStartupTask

--- a/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxSettingsExtensions.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxSettingsExtensions.cs
@@ -1,0 +1,24 @@
+namespace NServiceBus.InMemory.Outbox
+{
+    using System;
+    using NServiceBus.Configuration.AdvanceExtensibility;
+    using NServiceBus.Outbox;
+
+    /// <summary>
+    /// Contains InMemoryOutbox related settings extensions.
+    /// </summary>
+    public static class InMemoryOutboxSettingsExtensions
+    {
+        /// <summary>
+        /// Specifies how long the outbox should keep message data in storage to be able to deduplicate.
+        /// </summary>
+        /// <param name="cfg">The outbox settings</param>
+        /// <param name="time">The new duration to be used </param>
+        public static OutboxSettings TimeToKeepDeduplicationData(this OutboxSettings cfg, TimeSpan time)
+        {
+            Guard.AgainstNegativeAndZero(time, "time");
+            cfg.GetSettings().Set(Features.InMemoryOutboxPersistence.TimeToKeepDeduplicationEntries, time);
+            return cfg;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxSettingsExtensions.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxSettingsExtensions.cs
@@ -12,13 +12,15 @@ namespace NServiceBus.InMemory.Outbox
         /// <summary>
         /// Specifies how long the outbox should keep message data in storage to be able to deduplicate.
         /// </summary>
-        /// <param name="cfg">The outbox settings</param>
-        /// <param name="time">The new duration to be used </param>
-        public static OutboxSettings TimeToKeepDeduplicationData(this OutboxSettings cfg, TimeSpan time)
+        /// <param name="settings">The outbox settings</param>
+        /// <param name="time">Defines the timespan which indicates how long the outbox deduplication entries should be kept. 
+        /// i.ex if <code>TimeSpan.FromDays(1)</code> is used the deduplication entries are kept for no longer than one day.
+        /// It is not possible to use a negative or zero TimeSpan value.</param>
+        public static OutboxSettings TimeToKeepDeduplicationData(this OutboxSettings settings, TimeSpan time)
         {
             Guard.AgainstNegativeAndZero(time, "time");
-            cfg.GetSettings().Set(Features.InMemoryOutboxPersistence.TimeToKeepDeduplicationEntries, time);
-            return cfg;
+            settings.GetSettings().Set(Features.InMemoryOutboxPersistence.TimeToKeepDeduplicationEntries, time);
+            return settings;
         }
     }
 }

--- a/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
@@ -18,7 +18,7 @@
     {
         internal Outbox()
         {
-            Defaults(s => s.SetDefault(TimeToKeepDeduplicationEntries, TimeSpan.FromDays(5)));
+            Defaults(s => s.SetDefault(InMemoryOutboxPersistence.TimeToKeepDeduplicationEntries, TimeSpan.FromDays(5)));
 
             Prerequisite(c => c.Settings.Get<bool>("Transactions.Enabled"), "Outbox isn't needed since the receive transactions has been turned off");
 
@@ -64,7 +64,7 @@ The reason you need to do this is because we need to ensure that you have read a
             return result;
         }
 
-        internal const string TimeToKeepDeduplicationEntries = "Outbox.TimeToKeepDeduplicationEntries";
+       
 
         /// <summary>
         /// See <see cref="Feature.Setup"/>

--- a/src/NServiceBus.Core/Reliability/Outbox/OutboxSettings.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/OutboxSettings.cs
@@ -1,28 +1,27 @@
 ﻿namespace NServiceBus.Outbox
 {
     using System;
+    using NServiceBus.Configuration.AdvanceExtensibility;
     using Settings;
 
     /// <summary>
     /// Custom settings related to the outbox feature
     /// </summary>
-    public class OutboxSettings
+    public class OutboxSettings : ExposeSettings
     {
-        SettingsHolder settings;
-
-        internal OutboxSettings(SettingsHolder settings)
+        internal OutboxSettings(SettingsHolder settings) : base(settings)
         {
-            this.settings = settings;
         }
 
         /// <summary>
         /// Specifies how long the outbox should keep message data in storage to be able to deduplicate.
         /// </summary>
-        /// <param name="time">The new duration to be used</param>
+        /// <param name="time">The new duration to be used </param>
+        [ObsoleteEx(ReplacementTypeOrMember = "InMemoryOutboxSettingsExtensions.TimeToKeepDeduplicationData(TimeSpan time)", TreatAsErrorFromVersion = "6.0", RemoveInVersion = "7.0")]
+        // ReSharper disable once UnusedParameter.Global
         public void TimeToKeepDeduplicationData(TimeSpan time)
         {
-            Guard.AgainstNegativeAndZero(time, "time");
-            settings.Set(Features.Outbox.TimeToKeepDeduplicationEntries,time);
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
For code only APIs we need to make `OutboxSettings` extensible so that for example RavenDB persistence and NH persistence can write extension methods on top of `OutboxSettings`. This also cleans up the `TimeToKeepDeduplicationData` which was exposed on the `OutboxSettings` but in reality only belongs to the InMemoryOutbox.

@andreasohlund That's what I wanted to talk about today. Without this there is no proper way to expose code only settings for outbox