### PR TITLE
Simplify the handle ordering API

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Basic/When_aborting_the_behavior_chain.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_aborting_the_behavior_chain.cs
@@ -34,15 +34,7 @@
         {
             public MyEndpoint()
             {
-                EndpointSetup<DefaultServer>();
-            }
-
-            class EnsureOrdering : ISpecifyMessageHandlerOrdering
-            {
-                public void SpecifyOrder(Order order)
-                {
-                    order.Specify(First<FirstHandler>.Then<SecondHandler>());
-                }
+                EndpointSetup<DefaultServer>(c => c.ExecuteTheseHandlersFirst(typeof(FirstHandler), typeof(SecondHandler)));
             }
 
             class FirstHandler : IHandleMessages<SomeMessage>

--- a/src/NServiceBus.AcceptanceTests/Basic/When_handling_current_message_later.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_handling_current_message_later.cs
@@ -46,19 +46,12 @@
                     b.RegisterComponents(r => r.ConfigureComponent<CheckUnitOfWorkOutcome>(DependencyLifecycle.InstancePerCall));
                     b.DisableFeature<TimeoutManager>();
                     b.DisableFeature<SecondLevelRetries>();
+                    b.ExecuteTheseHandlersFirst(typeof(FirstHandler), typeof(SecondHandler));
                 })
                     .WithConfig<TransportConfig>(c =>
                     {
                         c.MaxRetries = 0;
                     });
-            }
-
-            class EnsureOrdering : ISpecifyMessageHandlerOrdering
-            {
-                public void SpecifyOrder(Order order)
-                {
-                    order.Specify(First<FirstHandler>.Then<SecondHandler>());
-                }
             }
 
             class CheckUnitOfWorkOutcome : IManageUnitsOfWork

--- a/src/NServiceBus.AcceptanceTests/Basic/When_incoming_headers_should_be_shared.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_incoming_headers_should_be_shared.cs
@@ -30,17 +30,9 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>();
+                EndpointSetup<DefaultServer>(c => c.ExecuteTheseHandlersFirst(typeof(FirstHandler), typeof(SecondHandler)));
             }
 
-            class EnsureOrdering : ISpecifyMessageHandlerOrdering
-            {
-                public void SpecifyOrder(Order order)
-                {
-                    order.Specify(First<FirstHandler>.Then<SecondHandler>());
-                }
-            }
-       
             class FirstHandler : IHandleMessages<Message>
             {
                 public IBus Bus { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Sagas/Issue_1819.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/Issue_1819.cs
@@ -36,7 +36,7 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
+                EndpointSetup<DefaultServer>(c => c.ExecuteTheseHandlersFirst(typeof(CatchAllMessageHandler)));
             }
 
             public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleTimeouts<Saga1Timeout>, IHandleTimeouts<Saga2Timeout>
@@ -93,14 +93,6 @@
 
                 }
             }
-
-            public class Foo : ISpecifyMessageHandlerOrdering
-            {
-                public void SpecifyOrder(Order order)
-                {
-                    order.SpecifyFirst<CatchAllMessageHandler>();
-                }
-            }
         }
 
         [Serializable]
@@ -108,7 +100,6 @@
         {
             public Guid ContextId { get; set; }
         }
-
 
         public class Saga1Timeout
         {

--- a/src/NServiceBus.AcceptanceTests/Sagas/Issue_1819.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/Issue_1819.cs
@@ -36,7 +36,11 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>(c => c.ExecuteTheseHandlersFirst(typeof(CatchAllMessageHandler)));
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.EnableFeature<TimeoutManager>();
+                    c.ExecuteTheseHandlersFirst(typeof(CatchAllMessageHandler));
+                });
             }
 
             public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleTimeouts<Saga1Timeout>, IHandleTimeouts<Saga2Timeout>

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_completes_the_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_completes_the_saga.cs
@@ -81,7 +81,7 @@
         {
             public SagaEndpoint()
             {
-                EndpointSetup<DefaultServer>(b => b.LoadMessageHandlers<First<TestSaga>>());
+                EndpointSetup<DefaultServer>(b => b.ExecuteTheseHandlersFirst(typeof(TestSaga)));
             }
 
             public class TestSaga : Saga<TestSagaData>, 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_should_start_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_should_start_a_saga.cs
@@ -20,7 +20,7 @@
         {
             public SagaEndpoint()
             {
-                EndpointSetup<DefaultServer>(b => b.LoadMessageHandlers<First<InterceptingHandler>>());
+                EndpointSetup<DefaultServer>(b => b.ExecuteTheseHandlersFirst(typeof(InterceptingHandler)));
             }
 
             public class TestSaga : Saga<TestSaga.TestSagaData>, IAmStartedByMessages<StartSagaMessage>

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
@@ -128,7 +128,11 @@
         {
             public ReceiverWithOrderedSagas()
             {
-                EndpointSetup<DefaultServer>(c => c.ExecuteTheseHandlersFirst(typeof(Saga1), typeof(Saga2)));
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.EnableFeature<TimeoutManager>();
+                    c.ExecuteTheseHandlersFirst(typeof(Saga1), typeof(Saga2));
+                });
             }
             
             public class MessageToSagaHandler : IHandleMessages<MessageToSaga>

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
@@ -128,17 +128,9 @@
         {
             public ReceiverWithOrderedSagas()
             {
-                EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
+                EndpointSetup<DefaultServer>(c => c.ExecuteTheseHandlersFirst(typeof(Saga1), typeof(Saga2)));
             }
-
-            class EnsureOrdering : ISpecifyMessageHandlerOrdering
-            {
-                public void SpecifyOrder(Order order)
-                {
-                    order.Specify(First<Saga1>.Then<Saga2>());
-                }
-            }
-
+            
             public class MessageToSagaHandler : IHandleMessages<MessageToSaga>
             {
                 public IBus Bus { get; set; }
@@ -166,7 +158,6 @@
 
             public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
             {
-
                 public void Handle(StartSaga message)
                 {
                 }
@@ -186,7 +177,6 @@
 
             public class Saga2 : Saga<Saga2.Saga2Data>, IHandleMessages<StartSaga>, IAmStartedByMessages<MessageToSaga>
             {
-
                 public void Handle(StartSaga message)
                 {
                 }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -299,6 +299,8 @@ namespace NServiceBus
         public FileShareDataBus() { }
         protected internal override System.Type ProvidedByFeature() { }
     }
+    [System.ObsoleteAttribute("Please use `BusConfiguration.ExecuteTheseHandlersFirst` instead. Will be removed " +
+        "in version 7.0.0.", true)]
     public class First<T>
     {
         public First() { }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -499,6 +499,8 @@ namespace NServiceBus
         public static void Send(this NServiceBus.ISendOnlyBus bus, string destination, object message) { }
         public static void Send<T>(this NServiceBus.ISendOnlyBus bus, string destination, System.Action<T> messageConstructor) { }
     }
+    [System.ObsoleteAttribute("Please use `BusConfiguration.ExecuteTheseHandlersFirst` instead. Will be removed " +
+        "in version 7.0.0.", true)]
     public interface ISpecifyMessageHandlerOrdering
     {
         void SpecifyOrder(NServiceBus.Order order);
@@ -527,7 +529,13 @@ namespace NServiceBus
     }
     public class static LoadMessageHandlersExtentions
     {
+        public static void ExecuteTheseHandlersFirst(this NServiceBus.BusConfiguration config, System.Collections.Generic.IEnumerable<System.Type> handlerTypes) { }
+        public static void ExecuteTheseHandlersFirst(this NServiceBus.BusConfiguration config, params System.Type[] handlerTypes) { }
+        [System.ObsoleteAttribute("Please use `ExecuteTheseHandlersFirst` instead. Will be removed in version 7.0.0." +
+            "", true)]
         public static void LoadMessageHandlers<TFirst>(this NServiceBus.BusConfiguration config) { }
+        [System.ObsoleteAttribute("Please use `ExecuteTheseHandlersFirst` instead. Will be removed in version 7.0.0." +
+            "", true)]
         public static void LoadMessageHandlers<T>(this NServiceBus.BusConfiguration config, NServiceBus.First<T> order) { }
     }
     public class MessageDeserializationException : System.Runtime.Serialization.SerializationException
@@ -568,6 +576,8 @@ namespace NServiceBus
         public NonDurableDelivery() { }
         public override void Serialize(System.Collections.Generic.Dictionary<string, string> options) { }
     }
+    [System.ObsoleteAttribute("Please use `BusConfiguration.ExecuteTheseHandlersFirst` instead. Will be removed " +
+        "in version 7.0.0.", true)]
     public class Order
     {
         public Order() { }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -531,6 +531,7 @@ namespace NServiceBus
     }
     public class static LoadMessageHandlersExtentions
     {
+        public static void ExecuteTheseHandlersFirst(this NServiceBus.BusConfiguration config, System.Collections.Generic.IEnumerable<System.Type> handlerTypes) { }
         public static void ExecuteTheseHandlersFirst(this NServiceBus.BusConfiguration config, params System.Type[] handlerTypes) { }
         [System.ObsoleteAttribute("Please use `ExecuteTheseHandlersFirst` instead. Will be removed in version 7.0.0." +
             "", true)]

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -531,7 +531,6 @@ namespace NServiceBus
     }
     public class static LoadMessageHandlersExtentions
     {
-        public static void ExecuteTheseHandlersFirst(this NServiceBus.BusConfiguration config, System.Collections.Generic.IEnumerable<System.Type> handlerTypes) { }
         public static void ExecuteTheseHandlersFirst(this NServiceBus.BusConfiguration config, params System.Type[] handlerTypes) { }
         [System.ObsoleteAttribute("Please use `ExecuteTheseHandlersFirst` instead. Will be removed in version 7.0.0." +
             "", true)]

--- a/src/NServiceBus.Core/HandlerOrdering/First.cs
+++ b/src/NServiceBus.Core/HandlerOrdering/First.cs
@@ -9,6 +9,7 @@ namespace NServiceBus
     /// Not thread safe.
     /// </summary>
     /// <typeparam name="T">The type which will run first.</typeparam>
+    [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0", ReplacementTypeOrMember = "BusConfiguration.ExecuteTheseHandlersFirst")]
     public class First<T>
     {
         /// <summary>

--- a/src/NServiceBus.Core/HandlerOrdering/ISpecifyMessageHandlerOrdering.cs
+++ b/src/NServiceBus.Core/HandlerOrdering/ISpecifyMessageHandlerOrdering.cs
@@ -3,6 +3,7 @@
     /// <summary>
     /// Specify the order in which message handlers will be invoked.
     /// </summary>
+    [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0", ReplacementTypeOrMember = "BusConfiguration.ExecuteTheseHandlersFirst")]
     public interface ISpecifyMessageHandlerOrdering
     {
         /// <summary>

--- a/src/NServiceBus.Core/HandlerOrdering/Order.cs
+++ b/src/NServiceBus.Core/HandlerOrdering/Order.cs
@@ -6,6 +6,7 @@ namespace NServiceBus
     /// <summary>
     /// Used to specify the order in which message handlers will be activated.
     /// </summary>
+    [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0", ReplacementTypeOrMember = "BusConfiguration.ExecuteTheseHandlersFirst")]
     public class Order
     {
         ///<summary>

--- a/src/NServiceBus.Core/Unicast/Config/LoadMessageHandlersExtentions.cs
+++ b/src/NServiceBus.Core/Unicast/Config/LoadMessageHandlersExtentions.cs
@@ -40,7 +40,7 @@ namespace NServiceBus
         /// </summary>
         /// <param name="config">The <see cref="BusConfiguration"/> instance to apply the settings to.</param>
         /// <param name="handlerTypes">The handler types to execute first.</param>
-        public static void ExecuteTheseHandlersFirst(this BusConfiguration config, IEnumerable<Type> handlerTypes)
+        public static void ExecuteTheseHandlersFirst(this BusConfiguration config, params Type[] handlerTypes)
         {
             Guard.AgainstNull(config, "config");
             Guard.AgainstNull(handlerTypes, "handlerTypes");
@@ -66,21 +66,6 @@ namespace NServiceBus
 
                 list.Add(handlerType);
             }
-        }
-
-        /// <summary>
-        ///     Loads all message handler assemblies in the runtime directory
-        ///     and specifies that the handlers in the given 'order' are to
-        ///     run before all others and in the order specified.
-        /// </summary>
-        /// <param name="config">The <see cref="BusConfiguration"/> instance to apply the settings to.</param>
-        /// <param name="handlerTypes">The handler types to execute first.</param>
-        public static void ExecuteTheseHandlersFirst(this BusConfiguration config, params Type[] handlerTypes)
-        {
-            Guard.AgainstNull(config, "config");
-            Guard.AgainstNull(handlerTypes, "handlerTypes");
-
-            config.ExecuteTheseHandlersFirst((IEnumerable<Type>)handlerTypes);
         }
     }
 }

--- a/src/NServiceBus.Core/Unicast/Config/LoadMessageHandlersExtentions.cs
+++ b/src/NServiceBus.Core/Unicast/Config/LoadMessageHandlersExtentions.cs
@@ -1,6 +1,8 @@
 namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
+    using NServiceBus.Features;
 
     /// <summary>
     /// Provides configuration options to tune handler ordering
@@ -13,21 +15,57 @@ namespace NServiceBus
         ///     before all others.
         ///     Use First{T} to indicate the type to load from.
         /// </summary>
+        [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0", ReplacementTypeOrMember = "ExecuteTheseHandlersFirst")]
         /// <param name="config">The <see cref="BusConfiguration"/> instance to apply the settings to.</param>
         public static void LoadMessageHandlers<TFirst>(this BusConfiguration config)
         {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        ///     Loads all message handler assemblies in the runtime directory
+        ///     and specifies that the handlers in the given 'order' are to
+        ///     run before all others and in the order specified.
+        /// </summary>
+        [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0", ReplacementTypeOrMember = "ExecuteTheseHandlersFirst")]
+        public static void LoadMessageHandlers<T>(this BusConfiguration config, First<T> order)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        ///     Loads all message handler assemblies in the runtime directory
+        ///     and specifies that the handlers in the given 'order' are to
+        ///     run before all others and in the order specified.
+        /// </summary>
+        /// <param name="config">The configuration instance.</param>
+        /// <param name="handlerTypes">The handler types to execute first.</param>
+        public static void ExecuteTheseHandlersFirst(this BusConfiguration config, IEnumerable<Type> handlerTypes)
+        {
             Guard.AgainstNull(config, "config");
-            var args = typeof(TFirst).GetGenericArguments();
-            if (args.Length == 1)
+            Guard.AgainstNull(handlerTypes, "handlerTypes");
+
+            List<Type> list;
+            if (!config.Settings.TryGet("NServiceBus.ExecuteTheseHandlersFirst", out list))
             {
-                if (typeof(First<>).MakeGenericType(args[0]).IsAssignableFrom(typeof(TFirst)))
-                {
-                    config.Settings.Set("LoadMessageHandlers.Order.Types", new[] { args[0] });
-                    return;
-                }
+                list = new List<Type>();
+                config.Settings.Set("NServiceBus.ExecuteTheseHandlersFirst", list);
             }
 
-            throw new ArgumentException("TFirst should be of the type First<T> where T is the type to indicate as first.");
+            foreach (var handlerType in handlerTypes)
+            {
+                if (!RegisterHandlersInOrder.IsMessageHandler(handlerType))
+                {
+                    throw new ArgumentException(string.Format("'{0}' is not a handler type, please ensure that all types derive from IHandleMessages", handlerType));
+                }
+
+                if (list.Contains(handlerType))
+                {
+                    throw new ArgumentException(string.Format("The order in which the type '{0}' should be invoked was already specified by a previous call. You can only specify a handler type once.", handlerType));
+                }
+
+                list.Add(handlerType);
+            }
         }
 
         /// <summary>
@@ -36,12 +74,13 @@ namespace NServiceBus
         ///     run before all others and in the order specified.
         /// </summary>
         /// <param name="config">The <see cref="BusConfiguration"/> instance to apply the settings to.</param>
-        /// <param name="order">The first handler to execute.</param>
-        public static void LoadMessageHandlers<T>(this BusConfiguration config, First<T> order)
+        /// <param name="handlerTypes">The handler types to execute first.</param>
+        public static void ExecuteTheseHandlersFirst(this BusConfiguration config, params Type[] handlerTypes)
         {
             Guard.AgainstNull(config, "config");
-            Guard.AgainstNull(order, "order");
-            config.Settings.Set("LoadMessageHandlers.Order.Types", order.Types);
+            Guard.AgainstNull(handlerTypes, "handlerTypes");
+
+            config.ExecuteTheseHandlersFirst((IEnumerable<Type>)handlerTypes);
         }
     }
 }

--- a/src/NServiceBus.Core/Unicast/Config/LoadMessageHandlersExtentions.cs
+++ b/src/NServiceBus.Core/Unicast/Config/LoadMessageHandlersExtentions.cs
@@ -15,8 +15,8 @@ namespace NServiceBus
         ///     before all others.
         ///     Use First{T} to indicate the type to load from.
         /// </summary>
-        [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0", ReplacementTypeOrMember = "ExecuteTheseHandlersFirst")]
         /// <param name="config">The <see cref="BusConfiguration"/> instance to apply the settings to.</param>
+        [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0", ReplacementTypeOrMember = "ExecuteTheseHandlersFirst")]
         public static void LoadMessageHandlers<TFirst>(this BusConfiguration config)
         {
             throw new NotImplementedException();
@@ -38,7 +38,7 @@ namespace NServiceBus
         ///     and specifies that the handlers in the given 'order' are to
         ///     run before all others and in the order specified.
         /// </summary>
-        /// <param name="config">The configuration instance.</param>
+        /// <param name="config">The <see cref="BusConfiguration"/> instance to apply the settings to.</param>
         /// <param name="handlerTypes">The handler types to execute first.</param>
         public static void ExecuteTheseHandlersFirst(this BusConfiguration config, IEnumerable<Type> handlerTypes)
         {

--- a/src/NServiceBus.Core/Unicast/Config/LoadMessageHandlersExtentions.cs
+++ b/src/NServiceBus.Core/Unicast/Config/LoadMessageHandlersExtentions.cs
@@ -40,7 +40,7 @@ namespace NServiceBus
         /// </summary>
         /// <param name="config">The <see cref="BusConfiguration"/> instance to apply the settings to.</param>
         /// <param name="handlerTypes">The handler types to execute first.</param>
-        public static void ExecuteTheseHandlersFirst(this BusConfiguration config, params Type[] handlerTypes)
+        public static void ExecuteTheseHandlersFirst(this BusConfiguration config, IEnumerable<Type> handlerTypes)
         {
             Guard.AgainstNull(config, "config");
             Guard.AgainstNull(handlerTypes, "handlerTypes");
@@ -66,6 +66,21 @@ namespace NServiceBus
 
                 list.Add(handlerType);
             }
+        }
+
+        /// <summary>
+        ///     Loads all message handler assemblies in the runtime directory
+        ///     and specifies that the handlers in the given 'order' are to
+        ///     run before all others and in the order specified.
+        /// </summary>
+        /// <param name="config">The <see cref="BusConfiguration"/> instance to apply the settings to.</param>
+        /// <param name="handlerTypes">The handler types to execute first.</param>
+        public static void ExecuteTheseHandlersFirst(this BusConfiguration config, params Type[] handlerTypes)
+        {
+            Guard.AgainstNull(config, "config");
+            Guard.AgainstNull(handlerTypes, "handlerTypes");
+
+            config.ExecuteTheseHandlersFirst((IEnumerable<Type>)handlerTypes);
         }
     }
 }

--- a/src/NServiceBus.Core/Unicast/Config/RegisterHandlersInOrder.cs
+++ b/src/NServiceBus.Core/Unicast/Config/RegisterHandlersInOrder.cs
@@ -30,7 +30,7 @@ namespace NServiceBus.Features
             LoadMessageHandlers(context, order);
         }
 
-        static void LoadMessageHandlers(FeatureConfigurationContext context, IEnumerable<Type> orderedTypes)
+        static void LoadMessageHandlers(FeatureConfigurationContext context, List<Type> orderedTypes)
         {
             var types = new List<Type>(context.Settings.GetAvailableTypes());
 

--- a/src/NServiceBus.Core/Unicast/Config/RegisterHandlersInOrder.cs
+++ b/src/NServiceBus.Core/Unicast/Config/RegisterHandlersInOrder.cs
@@ -47,13 +47,11 @@ namespace NServiceBus.Features
         static void ConfigureMessageHandlersIn(FeatureConfigurationContext context, IEnumerable<Type> types)
         {
             var handlerRegistry = new MessageHandlerRegistry(context.Settings.Get<Conventions>());
-            var handlers = new List<Type>();
 
             foreach (var t in types.Where(IsMessageHandler))
             {
                 context.Container.ConfigureComponent(t, DependencyLifecycle.InstancePerUnitOfWork);
                 handlerRegistry.RegisterHandler(t);
-                handlers.Add(t);
             }
 
             List<Action<IConfigureComponents>> propertiesToInject;


### PR DESCRIPTION
### Problem description
At the moment we have a very IMO unintuitive API to specify message ordering.
1. The user needs to implement `ISpecifyMessageHandlerOrdering`, eg 
```c#
class EnsureOrdering : ISpecifyMessageHandlerOrdering
{
    public void SpecifyOrder(Order order)
    {
        order.Specify(First<H1>.Then<H2>());
    }
}
```
2. The user can also specify order via the `config.LoadMessageHandlers` overloads, eg:
```c#
config.LoadMessageHandlers(First<H1>.Then<H2>().AndThen<H3>().AndThen<H4>())
```

### Proposal
- [x] Deprecate all the above API;
- [x] Introduce a new simple api to specify ordering;
- [x] Doco (see https://github.com/Particular/docs.particular.net/pull/707)

#### New API
```c#
config.ExecuteTheseHandlersFirst(params Type[] handlerTypes)
```