### PR TITLE
Saga.ReplyToOriginator sets the wrong MessageIntent

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Sagas\When_a_finder_exists_and_found_saga.cs" />
     <Compile Include="Retries\When_performing_slr_with_regular_exception.cs" />
     <Compile Include="Retries\When_performing_slr_with_serialization_exception.cs" />
+    <Compile Include="Sagas\When_using_ReplyToOriginator.cs" />
     <Compile Include="Sagas\When_doing_request_response_between_sagas_first_handler_responding.cs" />
     <Compile Include="Sagas\When_doing_request_response_between_sagas_response_from_noninitiating.cs" />
     <Compile Include="Sagas\When_doing_request_response_between_sagas_with_timeout.cs" />

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_ReplyToOriginator.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_ReplyToOriginator.cs
@@ -1,0 +1,98 @@
+﻿
+namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using EndpointTemplates;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+    using Saga;
+
+    public class When_using_ReplyToOriginator : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_set_Reply_as_messageintent()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new InitiateRequestingSaga())))
+                .Done(c => c.Done)
+                .Run();
+
+            Assert.AreEqual(MessageIntentEnum.Reply, context.Intent);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public MessageIntentEnum Intent { get; set; }
+            public bool Done { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class RequestingSaga : Saga<RequestingSaga.RequestingSagaData>,
+                IAmStartedByMessages<InitiateRequestingSaga>,
+                IHandleMessages<AnotherRequest>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(InitiateRequestingSaga message)
+                {
+                    Data.CorrIdForResponse = Guid.NewGuid(); //wont be needed in the future
+
+                    Bus.SendLocal(new AnotherRequest
+                    {
+                        SomeCorrelationId = Data.CorrIdForResponse //wont be needed in the future
+                    });
+                }
+
+                public void Handle(AnotherRequest message)
+                {
+                    ReplyToOriginator(new MyReplyToOriginator());
+                    MarkAsComplete();
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RequestingSagaData> mapper)
+                {
+                    //if this line is un-commented the timeout and secondary handler tests will start to fail
+                    // for more info and discussion see TBD
+                    mapper.ConfigureMapping<AnotherRequest>(m => m.SomeCorrelationId).ToSaga(s => s.CorrIdForResponse);
+                }
+                public class RequestingSagaData : ContainSagaData
+                {
+                    public virtual Guid CorrIdForResponse { get; set; } //wont be needed in the future
+                }
+            }
+
+            class MyReplyToOriginatorHandler:IHandleMessages<MyReplyToOriginator>
+            {
+                public Context Context { get; set; }
+                public IBus Bus { get; set; }
+
+                public void Handle(MyReplyToOriginator message)
+                {
+                    Context.Intent = (MessageIntentEnum)Enum.Parse(typeof(MessageIntentEnum), Bus.CurrentMessageContext.Headers[Headers.MessageIntent]);
+                    Context.Done = true;
+                }
+            }
+        }
+
+        public class InitiateRequestingSaga : ICommand { }
+
+        public class AnotherRequest : ICommand
+        {
+            public Guid SomeCorrelationId { get; set; }
+        }
+
+        public class MyReplyToOriginator : IMessage
+        {
+            public Guid SomeCorrelationId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Saga/Saga.cs
+++ b/src/NServiceBus.Core/Saga/Saga.cs
@@ -157,7 +157,20 @@ namespace NServiceBus.Saga
                 throw new Exception("Entity.Originator cannot be null. Perhaps the sender is a SendOnly endpoint.");
             }
 
-            Bus.Send(message, new SendOptions(Entity.Originator, Entity.OriginalMessageId));
+            var sendOptions = new SendOptions(correlationId: Entity.OriginalMessageId);
+            sendOptions.AsReplyTo(Entity.Originator);
+            sendOptions.ExtensionContext.Set(new WrapperForReplyToOriginator(true));
+            Bus.Send(message, sendOptions);
+        }
+
+        internal class WrapperForReplyToOriginator
+        {
+            internal bool ReplyToOriginator;
+
+            public WrapperForReplyToOriginator(bool replyToOriginator)
+            {
+                ReplyToOriginator = replyToOriginator;
+            }
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Sagas/PopulateAutoCorrelationHeadersForRepliesBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/PopulateAutoCorrelationHeadersForRepliesBehavior.cs
@@ -22,6 +22,12 @@
 
             if (context.TryGet(TransportReceiveContext.IncomingPhysicalMessageKey, out incomingMessage))
             {
+                Saga.Saga.WrapperForReplyToOriginator flagContainer;
+                if (context.Extensions.TryGet(out flagContainer) && flagContainer.ReplyToOriginator)
+                {
+                    return;
+                }
+
                 //flow the the saga id of the calling saga (if any) to outgoing message in order to support autocorrelation
                 if (context.Intent == MessageIntentEnum.Reply)
                 {


### PR DESCRIPTION
When a reply is done the `MessageIntent` for  should be set to `Reply`.

`Saga.ReplyToOriginator` is incorrectly assigning it to `Send`.