### PR TITLE
Separate IOutboxStorage into IStoreOutboxMessages and IDeduplicateMessages

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1413,11 +1413,17 @@ namespace NServiceBus.ObjectBuilder
 }
 namespace NServiceBus.Outbox
 {
-    public interface IOutboxStorage
+    public interface IDeduplicateMessages
     {
         void SetAsDispatched(string messageId);
-        void Store(string messageId, System.Collections.Generic.IEnumerable<NServiceBus.Outbox.TransportOperation> transportOperations);
         bool TryGet(string messageId, out NServiceBus.Outbox.OutboxMessage message);
+    }
+    [System.ObsoleteAttribute("IOutboxStorage has been split into IStoreOutboxMessages and IDeduplicateMessages " +
+        "to segregate storage concerns. Will be removed in version 7.0.0.", true)]
+    public interface IOutboxStorage : NServiceBus.Outbox.IDeduplicateMessages, NServiceBus.Outbox.IStoreOutboxMessages { }
+    public interface IStoreOutboxMessages
+    {
+        void Store(string messageId, System.Collections.Generic.IEnumerable<NServiceBus.Outbox.TransportOperation> transportOperations);
     }
     public class OutboxMessage
     {

--- a/src/NServiceBus.Core.Tests/Outbox/FakeOutboxStorage.cs
+++ b/src/NServiceBus.Core.Tests/Outbox/FakeOutboxStorage.cs
@@ -3,7 +3,7 @@
     using System.Collections.Generic;
     using NServiceBus.Outbox;
 
-    internal class FakeOutboxStorage : IOutboxStorage
+    internal class FakeOutboxStorage : IStoreOutboxMessages, IDeduplicateMessages
     {
         public OutboxMessage ExistingMessage { get; set; }
         public OutboxMessage StoredMessage { get; set; }

--- a/src/NServiceBus.Core.Tests/Outbox/OutboxRecordBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Outbox/OutboxRecordBehaviorTests.cs
@@ -29,10 +29,7 @@
         {
             fakeOutbox = new FakeOutboxStorage();
 
-            behavior = new OutboxRecordBehavior
-            {
-                OutboxStorage = fakeOutbox
-            };
+            behavior = new OutboxRecordBehavior(fakeOutbox);
         }
 
         void Invoke(PhysicalMessageProcessingStageBehavior.Context context, bool shouldAbort = false)

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -131,6 +131,8 @@
     <Compile Include="Extensibility\OptionExtensionContext.cs" />
     <Compile Include="MessagingBestPractices\BestPracticeEnforcement.cs" />
     <Compile Include="MessagingBestPractices\OptionExtensions.cs" />
+    <Compile Include="Outbox\IDeduplicateMessages.cs" />
+    <Compile Include="Outbox\IStoreOutboxMessages.cs" />
     <Compile Include="Pipeline\Contexts\OutgoingContext.cs" />
     <Compile Include="Monitoring\PerformanceCounterInstance.cs" />
     <Compile Include="Pipeline\Contexts\PhysicalMessageProcessingStageBehavior.cs" />

--- a/src/NServiceBus.Core/Outbox/IDeduplicateMessages.cs
+++ b/src/NServiceBus.Core/Outbox/IDeduplicateMessages.cs
@@ -1,0 +1,18 @@
+﻿namespace NServiceBus.Outbox
+{
+    /// <summary>
+    /// Implemented by the persisters to message deduplication capabilities
+    /// </summary>
+    public interface IDeduplicateMessages
+    {
+        /// <summary>
+        /// Tries to find the given message in the outbox
+        /// </summary>
+        bool TryGet(string messageId, out OutboxMessage message);
+        
+        /// <summary>
+        /// Tells the storage that the message has been dispatched and its now safe to clean up the transport operations
+        /// </summary>
+        void SetAsDispatched(string messageId);
+    }
+}

--- a/src/NServiceBus.Core/Outbox/IOutboxStorage.cs
+++ b/src/NServiceBus.Core/Outbox/IOutboxStorage.cs
@@ -1,26 +1,11 @@
 ﻿namespace NServiceBus.Outbox
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// Implemented by the persisters to provide outbox storage capabilities
     /// </summary>
-    public interface IOutboxStorage
+    [ObsoleteEx(TreatAsErrorFromVersion = "6", RemoveInVersion = "7", 
+        Message = "IOutboxStorage has been split into IStoreOutboxMessages and IDeduplicateMessages to segregate storage concerns.")]
+    public interface IOutboxStorage : IStoreOutboxMessages, IDeduplicateMessages
     {
-        /// <summary>
-        /// Tries to find the given message in the outbox
-        /// </summary>
-        bool TryGet(string messageId, out OutboxMessage message);
-
-        /// <summary>
-        /// Stores 
-        /// </summary>
-        void Store(string messageId, IEnumerable<TransportOperation> transportOperations);
-        
-        
-        /// <summary>
-        /// Tells the storage that the message has been dispatched and its now safe to clean up the transport operations
-        /// </summary>
-        void SetAsDispatched(string messageId);
     }
 }

--- a/src/NServiceBus.Core/Outbox/IStoreOutboxMessages.cs
+++ b/src/NServiceBus.Core/Outbox/IStoreOutboxMessages.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus.Outbox
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Implemented by the persisters to provide outbox storage capabilities
+    /// </summary>
+    public interface IStoreOutboxMessages
+    {
+        /// <summary>
+        /// Stores 
+        /// </summary>
+        void Store(string messageId, IEnumerable<TransportOperation> transportOperations);
+    }
+}

--- a/src/NServiceBus.Core/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Outbox/Outbox.cs
@@ -80,7 +80,7 @@ The reason you need to do this is because we need to ensure that you have read a
             context.MainPipeline.Replace(WellKnownStep.DispatchMessageToTransport, typeof(OutboxSendBehavior), "Sending behavior with a delay sending until all business transactions are committed to the outbox storage");
 
             context.Container.ConfigureComponent(
-                b => new OutboxDeduplicationBehavior(b.Build<IOutboxStorage>(),
+                b => new OutboxDeduplicationBehavior(b.Build<IDeduplicateMessages>(),
                     b.Build<DispatchMessageToTransportBehavior>(), 
                     b.Build<DefaultMessageAuditer>(),
                     new TransactionSettings(context.Settings)), 

--- a/src/NServiceBus.Core/Outbox/OutboxRecordBehavior.cs
+++ b/src/NServiceBus.Core/Outbox/OutboxRecordBehavior.cs
@@ -6,7 +6,10 @@ namespace NServiceBus
 
     class OutboxRecordBehavior : PhysicalMessageProcessingStageBehavior
     {
-        public IStoreOutboxMessages OutboxStorage { get; set; }
+        public OutboxRecordBehavior(IStoreOutboxMessages outboxStorage)
+        {
+            this.storage = outboxStorage;
+        }
 
         public override void Invoke(Context context, Action next)
         {
@@ -19,7 +22,7 @@ namespace NServiceBus
 
             var outboxMessage = context.Get<OutboxMessage>();
 
-            OutboxStorage.Store(outboxMessage.MessageId, outboxMessage.TransportOperations);
+            storage.Store(outboxMessage.MessageId, outboxMessage.TransportOperations);
         }
 
         public class OutboxRecorderRegistration : RegisterStep
@@ -31,5 +34,7 @@ namespace NServiceBus
                 InsertAfter(WellKnownStep.ExecuteUnitOfWork);
             }
         }
+
+        IStoreOutboxMessages storage;
     }
 }

--- a/src/NServiceBus.Core/Outbox/OutboxRecordBehavior.cs
+++ b/src/NServiceBus.Core/Outbox/OutboxRecordBehavior.cs
@@ -6,7 +6,7 @@ namespace NServiceBus
 
     class OutboxRecordBehavior : PhysicalMessageProcessingStageBehavior
     {
-        public IOutboxStorage OutboxStorage { get; set; }
+        public IStoreOutboxMessages OutboxStorage { get; set; }
 
         public override void Invoke(Context context, Action next)
         {

--- a/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxPersistence.cs
@@ -27,7 +27,10 @@
 
         class OutboxCleaner : FeatureStartupTask
         {
-            public InMemoryOutboxStorage InMemoryOutboxStorage { get; set; }
+            public OutboxCleaner(InMemoryOutboxStorage outboxStorage)
+            {
+                this.storage = outboxStorage;
+            }
 
             public TimeSpan TimeToKeepDeduplicationData { get; set; }
 
@@ -48,11 +51,12 @@
 
             void PerformCleanup(object state)
             {
-                InMemoryOutboxStorage.RemoveEntriesOlderThan(DateTime.UtcNow - TimeToKeepDeduplicationData);
+                storage.RemoveEntriesOlderThan(DateTime.UtcNow - TimeToKeepDeduplicationData);
             }
 
 // ReSharper disable once NotAccessedField.Local
             Timer cleanupTimer;
+            InMemoryOutboxStorage storage;
         }
     }
 }

--- a/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxStorage.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxStorage.cs
@@ -6,7 +6,7 @@
     using System.Linq;
     using NServiceBus.Outbox;
 
-    class InMemoryOutboxStorage : IOutboxStorage
+    class InMemoryOutboxStorage : IStoreOutboxMessages, IDeduplicateMessages
     {
         public bool TryGet(string messageId, out OutboxMessage message)
         {


### PR DESCRIPTION
For #2659 

Just the first piece of the puzzle - refactoring Raven & NH would come next.

@Particular/engineers would appreciate API feedback, especially:

1. Interface naming
2. OK to leave InMemoryPersister as a single class that implements both new interfaces? Splitting that as well would (likely) more closely mirror what will be done to Raven/NH, but then would likely need an additional internal shared class to act as the database, which seemed a bit too fancy unless absolutely necessary.