### PR TITLE
Allow headers to be set from outgoing mutators

### DIFF
--- a/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_empty_id_header.cs
+++ b/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_empty_id_header.cs
@@ -4,6 +4,7 @@
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Config;
+    using NServiceBus.MessageMutator;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
 
@@ -25,11 +26,11 @@
             Assert.IsFalse(string.IsNullOrWhiteSpace(context.MessageId));
         }
 
-        public class CorruptionMutator : IMutateOutgoingPhysicalContext
+        public class CorruptionMutator : IMutateOutgoingPhysicalMessages
         {
             public Context ScenarioContext { get; set; }
 
-            public void MutateOutgoing(OutgoingPhysicalMutatorContext context)
+            public void MutateOutgoing(MutateOutgoingPhysicalMessageContext context)
             {
                 context.SetHeader("ScenarioContextId",ScenarioContext.Id.ToString());
                 context.SetHeader(Headers.MessageId,"");

--- a/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_no_id_header.cs
+++ b/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_no_id_header.cs
@@ -4,6 +4,7 @@
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Config;
+    using NServiceBus.MessageMutator;
     using NServiceBus.Pipeline;
     using NServiceBus.Unicast.Messages;
     using NUnit.Framework;
@@ -26,7 +27,7 @@
             Assert.IsFalse(string.IsNullOrWhiteSpace(context.MessageId));
         }
 
-        public class CorruptionMutator : IMutateOutgoingPhysicalContext
+        public class CorruptionMutator : IMutateOutgoingPhysicalMessages
         {
             public Context ScenarioContext { get; set; }
 
@@ -35,7 +36,7 @@
              
             }
 
-            public void MutateOutgoing(OutgoingPhysicalMutatorContext context)
+            public void MutateOutgoing(MutateOutgoingPhysicalMessageContext context)
             {
                 context.SetHeader(Headers.MessageId,null);
                 context.SetHeader("ScenarioContextId",ScenarioContext.Id.ToString());

--- a/src/NServiceBus.AcceptanceTests/Mutators/When_defining_outgoing_message_mutators.cs
+++ b/src/NServiceBus.AcceptanceTests/Mutators/When_defining_outgoing_message_mutators.cs
@@ -37,12 +37,12 @@
             }
 
 
-            class MyTransportMessageMutator : IMutateOutgoingPhysicalContext, INeedInitialization
+            class MyTransportMessageMutator : IMutateOutgoingPhysicalMessages, INeedInitialization
             {
 
                 public Context Context { get; set; }
 
-                public void MutateOutgoing(OutgoingPhysicalMutatorContext context)
+                public void MutateOutgoing(MutateOutgoingPhysicalMessageContext context)
                 {
                     Context.TransportMutatorCalled = true;
                 }

--- a/src/NServiceBus.AcceptanceTests/Mutators/When_defining_outgoing_message_mutators.cs
+++ b/src/NServiceBus.AcceptanceTests/Mutators/When_defining_outgoing_message_mutators.cs
@@ -59,18 +59,15 @@
 
                 public Context Context { get; set; }
 
-                public object MutateOutgoing(object message)
+                public void MutateOutgoing(MutateOutgoingMessagesContext context)
                 {
                     Context.MessageMutatorCalled = true;
-
-                    return message;
                 }
 
                 public void Customize(BusConfiguration configuration)
                 {
                     configuration.RegisterComponents(c => c.ConfigureComponent<MyMessageMutator>(DependencyLifecycle.InstancePerCall));
                 }
-
             }
 
             class MessageToBeMutatedHandler : IHandleMessages<MessageToBeMutated>

--- a/src/NServiceBus.AcceptanceTests/Mutators/When_outgoing_mutator_replaces_instance.cs
+++ b/src/NServiceBus.AcceptanceTests/Mutators/When_outgoing_mutator_replaces_instance.cs
@@ -38,14 +38,12 @@
 
             class MutateOutgoingMessages : IMutateOutgoingMessages
             {
-                public object MutateOutgoing(object message)
+                public void MutateOutgoing(MutateOutgoingMessagesContext context)
                 {
-                    if (message is V1Message)
+                    if (context.MessageInstance is V1Message)
                     {
-                        return new V2Message();
+                        context.MessageInstance = new V2Message();
                     }
-
-                    return message;
                 }
             }
 

--- a/src/NServiceBus.AcceptanceTests/Retries/When_performing_slr.cs
+++ b/src/NServiceBus.AcceptanceTests/Retries/When_performing_slr.cs
@@ -32,7 +32,7 @@
                     });
             }
    
-            class BodyMutator : IMutateOutgoingPhysicalContext,IMutateIncomingTransportMessages, INeedInitialization
+            class BodyMutator : IMutateOutgoingPhysicalMessages,IMutateIncomingTransportMessages, INeedInitialization
             {
                 public Context Context { get; set; }
 
@@ -66,7 +66,7 @@
                     configuration.RegisterComponents(c => c.ConfigureComponent<BodyMutator>(DependencyLifecycle.InstancePerCall));
                 }
 
-                public void MutateOutgoing(OutgoingPhysicalMutatorContext context)
+                public void MutateOutgoing(MutateOutgoingPhysicalMessageContext context)
                 {
                     context.Body[0]--;
                 }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -267,6 +267,20 @@ namespace NServiceBus
     {
         public ExpressAttribute() { }
     }
+    [System.ObsoleteAttribute("Headers are not managed via the send, reply and publishoptions. Will be removed i" +
+        "n version 7.0.0.", true)]
+    public class static ExtensionMethods
+    {
+        [System.ObsoleteAttribute("Use a incoming behavior to get access to the current message. Will be removed in " +
+            "version 7.0.0.", true)]
+        public static object CurrentMessageBeingHandled { get; set; }
+        [System.ObsoleteAttribute("Headers are not \'set\' only on the outgoing pipeline. Will be removed in version 7" +
+            ".0.0.", true)]
+        public static string GetMessageHeader(this NServiceBus.IBus bus, object msg, string key) { }
+        [System.ObsoleteAttribute("Headers can be set using the ``.SetHeader` method on the context object passed in" +
+            "to your behavior or mutator. Will be removed in version 7.0.0.", true)]
+        public static void SetMessageHeader(this NServiceBus.ISendOnlyBus bus, object msg, string key, string value) { }
+    }
     public class FileShareDataBus : NServiceBus.DataBus.DataBusDefinition
     {
         public FileShareDataBus() { }
@@ -422,10 +436,6 @@ namespace NServiceBus
         T CreateInstance<T>(System.Action<T> action);
         object CreateInstance(System.Type messageType);
     }
-    public interface IMutateOutgoingPhysicalContext
-    {
-        void MutateOutgoing(NServiceBus.OutgoingPhysicalMutatorContext context);
-    }
     public class IndividualThrottlingSettings
     {
         public NServiceBus.IndividualThrottlingSettings DoNotLimit(string satelliteId) { }
@@ -554,12 +564,6 @@ namespace NServiceBus
     public class static OutboxConfigExtensions
     {
         public static NServiceBus.Outbox.OutboxSettings EnableOutbox(this NServiceBus.BusConfiguration config) { }
-    }
-    public class OutgoingPhysicalMutatorContext
-    {
-        public OutgoingPhysicalMutatorContext(byte[] body, System.Collections.Generic.Dictionary<string, string> headers) { }
-        public byte[] Body { get; set; }
-        public void SetHeader(string key, string value) { }
     }
     public class static PersistenceConfig
     {
@@ -1394,10 +1398,14 @@ namespace NServiceBus.MessageMutator
     }
     public interface IMutateOutgoingMessages
     {
-        object MutateOutgoing(object message);
+        void MutateOutgoing(NServiceBus.MessageMutator.MutateOutgoingMessagesContext context);
     }
-    [System.ObsoleteAttribute("Please use `IMutateOutgoingPhysicalContext` instead. Will be removed in version 7" +
-        ".0.0.", true)]
+    public interface IMutateOutgoingPhysicalMessages
+    {
+        void MutateOutgoing(NServiceBus.MessageMutator.MutateOutgoingPhysicalMessageContext context);
+    }
+    [System.ObsoleteAttribute("Please use `IMutateOutgoingPhysicalMessages` instead. Will be removed in version " +
+        "7.0.0.", true)]
     public interface IMutateOutgoingTransportMessages
     {
         void MutateOutgoing(NServiceBus.Unicast.Messages.LogicalMessage logicalMessage, NServiceBus.TransportMessage transportMessage);
@@ -1405,6 +1413,18 @@ namespace NServiceBus.MessageMutator
     [System.ObsoleteAttribute("Just have your mutator implement both IMutateIncomingTransportMessages and IMutat" +
         "eOutgoingPhysicalContext. Will be removed in version 7.0.0.", true)]
     public interface IMutateTransportMessages : NServiceBus.MessageMutator.IMutateIncomingTransportMessages, NServiceBus.MessageMutator.IMutateOutgoingTransportMessages { }
+    public class MutateOutgoingMessagesContext
+    {
+        public MutateOutgoingMessagesContext(object messageInstance) { }
+        public object MessageInstance { get; set; }
+        public void SetHeader(string key, string value) { }
+    }
+    public class MutateOutgoingPhysicalMessageContext
+    {
+        public MutateOutgoingPhysicalMessageContext(byte[] body, System.Collections.Generic.Dictionary<string, string> headers) { }
+        public byte[] Body { get; set; }
+        public void SetHeader(string key, string value) { }
+    }
 }
 namespace NServiceBus.ObjectBuilder.Common
 {

--- a/src/NServiceBus.Core/Impersonation/Windows/WindowsIdentityEnricher.cs
+++ b/src/NServiceBus.Core/Impersonation/Windows/WindowsIdentityEnricher.cs
@@ -2,11 +2,12 @@ namespace NServiceBus.Impersonation.Windows
 {
     using System.Security.Principal;
     using System.Threading;
+    using NServiceBus.MessageMutator;
 
-    class WindowsIdentityEnricher : IMutateOutgoingPhysicalContext
+    class WindowsIdentityEnricher : IMutateOutgoingPhysicalMessages
     {
 
-        public void MutateOutgoing(OutgoingPhysicalMutatorContext context)
+        public void MutateOutgoing(MutateOutgoingPhysicalMessageContext context)
         {
             if (Thread.CurrentPrincipal != null && Thread.CurrentPrincipal.Identity != null && !string.IsNullOrEmpty(Thread.CurrentPrincipal.Identity.Name))
             {

--- a/src/NServiceBus.Core/MessageMutator/IMutateOutgoingMessages.cs
+++ b/src/NServiceBus.Core/MessageMutator/IMutateOutgoingMessages.cs
@@ -11,6 +11,6 @@ namespace NServiceBus.MessageMutator
         /// <summary>
         /// Mutates the given message just before it's serialized
         /// </summary>
-        object MutateOutgoing(object message);
+        void MutateOutgoing(MutateOutgoingMessagesContext context);
     }
 }

--- a/src/NServiceBus.Core/MessageMutator/IMutateOutgoingPhysicalMessages.cs
+++ b/src/NServiceBus.Core/MessageMutator/IMutateOutgoingPhysicalMessages.cs
@@ -1,4 +1,4 @@
-namespace NServiceBus
+namespace NServiceBus.MessageMutator
 {
     using JetBrains.Annotations;
 
@@ -6,12 +6,12 @@ namespace NServiceBus
     /// Provides a way to mutate the context for outgoing messages in the physical stage
     /// </summary>
     [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
-    public interface IMutateOutgoingPhysicalContext
+    public interface IMutateOutgoingPhysicalMessages
     {
         /// <summary>
         /// Performs the mutation
         /// </summary>
         /// <param name="context">Contains the available properties that can be mutated</param>
-        void MutateOutgoing(OutgoingPhysicalMutatorContext context);
+        void MutateOutgoing(MutateOutgoingPhysicalMessageContext context);
     }
 }

--- a/src/NServiceBus.Core/MessageMutator/MutateOutgoingMessagesContext.cs
+++ b/src/NServiceBus.Core/MessageMutator/MutateOutgoingMessagesContext.cs
@@ -1,0 +1,54 @@
+namespace NServiceBus.MessageMutator
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Provides ways to mutate the outgoing message instance
+    /// </summary>
+    public class MutateOutgoingMessagesContext
+    {
+        /// <summary>
+        /// The current message instance being sent
+        /// </summary>
+        public object MessageInstance
+        {
+            get
+            {
+                return instance;
+            }
+            set
+            {
+                MessageInstanceChanged = true;
+                instance = value;
+
+            }
+        }
+
+        /// <summary>
+        /// Initializes the context
+        /// </summary>
+        /// <param name="messageInstance"></param>
+        public MutateOutgoingMessagesContext(object messageInstance)
+        {
+            Headers = new Dictionary<string, string>();
+            MessageInstance = messageInstance;
+        }
+
+
+        /// <summary>
+        /// Allows headers to be set
+        /// </summary>
+        /// <param name="key">The header key</param>
+        /// <param name="value">The header value</param>
+        public void SetHeader(string key, string value)
+        {
+            Headers[key] = value;
+        }
+
+        internal readonly Dictionary<string, string> Headers;
+
+        internal bool MessageInstanceChanged; 
+        
+        object instance;
+    }
+}

--- a/src/NServiceBus.Core/MessageMutator/MutateOutgoingPhysicalMessageBehavior.cs
+++ b/src/NServiceBus.Core/MessageMutator/MutateOutgoingPhysicalMessageBehavior.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using NServiceBus.MessageMutator;
     using NServiceBus.Pipeline.Contexts;
 
     class MutateOutgoingPhysicalMessageBehavior : PhysicalOutgoingContextStageBehavior
@@ -10,9 +11,9 @@
         {
             var headersSetByMutators = new Dictionary<string,string>();
 
-            foreach (var mutator in context.Builder.BuildAll<IMutateOutgoingPhysicalContext>())
+            foreach (var mutator in context.Builder.BuildAll<IMutateOutgoingPhysicalMessages>())
             {
-                mutator.MutateOutgoing(new OutgoingPhysicalMutatorContext(context.Body, headersSetByMutators));
+                mutator.MutateOutgoing(new MutateOutgoingPhysicalMessageContext(context.Body, headersSetByMutators));
             }
 
             foreach (var header in headersSetByMutators)

--- a/src/NServiceBus.Core/MessageMutator/MutateOutgoingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Core/MessageMutator/MutateOutgoingPhysicalMessageContext.cs
@@ -1,11 +1,11 @@
-namespace NServiceBus
+namespace NServiceBus.MessageMutator
 {
     using System.Collections.Generic;
 
     /// <summary>
     /// Context class for IMutateOutgoingPhysicalContext
     /// </summary>
-    public class OutgoingPhysicalMutatorContext
+    public class MutateOutgoingPhysicalMessageContext
     {
 
         /// <summary>
@@ -13,7 +13,7 @@ namespace NServiceBus
         /// </summary>
         /// <param name="body"></param>
         /// <param name="headers"></param>
-        public OutgoingPhysicalMutatorContext(byte[] body, Dictionary<string, string> headers)
+        public MutateOutgoingPhysicalMessageContext(byte[] body, Dictionary<string, string> headers)
         {
             this.headers = headers;
             Body = body;

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -131,9 +131,9 @@
     <Compile Include="Faults\StoreFaultsInErrorQueue.cs" />
     <Compile Include="IBusExtensions.cs" />
     <Compile Include="ISendOnlyBusExtensions.cs" />
-    <Compile Include="MessageMutator\IMutateOutgoingPhysicalContext.cs" />
+    <Compile Include="MessageMutator\IMutateOutgoingPhysicalMessages.cs" />
     <Compile Include="MessageMutator\MutateOutgoingMessagesContext.cs" />
-    <Compile Include="MessageMutator\OutgoingPhysicalMutatorContext.cs" />
+    <Compile Include="MessageMutator\MutateOutgoingPhysicalMessageContext.cs" />
     <Compile Include="Extensibility\OptionExtensionContext.cs" />
     <Compile Include="MessagingBestPractices\BestPracticeEnforcement.cs" />
     <Compile Include="MessagingBestPractices\OptionExtensions.cs" />

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -132,6 +132,7 @@
     <Compile Include="IBusExtensions.cs" />
     <Compile Include="ISendOnlyBusExtensions.cs" />
     <Compile Include="MessageMutator\IMutateOutgoingPhysicalContext.cs" />
+    <Compile Include="MessageMutator\MutateOutgoingMessagesContext.cs" />
     <Compile Include="MessageMutator\OutgoingPhysicalMutatorContext.cs" />
     <Compile Include="Extensibility\OptionExtensionContext.cs" />
     <Compile Include="MessagingBestPractices\BestPracticeEnforcement.cs" />

--- a/src/NServiceBus.Core/v6-obsoletes.cs
+++ b/src/NServiceBus.Core/v6-obsoletes.cs
@@ -152,7 +152,7 @@ namespace NServiceBus.Unicast
            Message = "Turn best practices check off using configuration.DisableFeature<BestPracticeEnforcement>()",
            RemoveInVersion = "7.0",
            TreatAsErrorFromVersion = "6.0")]
-        public bool EnforceMessagingBestPractices { get { throw new NotImplementedException(); } set { throw new NotImplementedException(); } } 
+        public bool EnforceMessagingBestPractices { get { throw new NotImplementedException(); } set { throw new NotImplementedException(); } }
     }
 
     [ObsoleteEx(
@@ -466,3 +466,22 @@ namespace NServiceBus.Unicast
         }
     }
 }
+
+namespace NServiceBus
+{
+    using System;
+
+    [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0", Message = "Headers are not managed via the send, reply and publishoptions")]
+    public static class ExtensionMethods
+    {
+        [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0", Message = "Headers are not 'set' only on the outgoing pipeline")]
+        public static string GetMessageHeader(this IBus bus, object msg, string key){throw new NotImplementedException();}
+
+        [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0", Message = "Headers can be set using the ``.SetHeader` method on the context object passed into your behavior or mutator")]
+        public static void SetMessageHeader(this ISendOnlyBus bus, object msg, string key, string value){throw new NotImplementedException();}
+
+        [ObsoleteEx(RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0", Message = "Use a incoming behavior to get access to the current message")]
+        public static object CurrentMessageBeingHandled { get { throw new NotImplementedException(); } set { throw new NotImplementedException(); } }
+    }
+}
+

--- a/src/NServiceBus.Core/v6-obsoletes.cs
+++ b/src/NServiceBus.Core/v6-obsoletes.cs
@@ -269,7 +269,7 @@ namespace NServiceBus.MessageMutator
     public interface IMutateTransportMessages : IMutateIncomingTransportMessages, IMutateOutgoingTransportMessages { }
 
     [ObsoleteEx(
-                ReplacementTypeOrMember = "IMutateOutgoingPhysicalContext",
+                ReplacementTypeOrMember = "IMutateOutgoingPhysicalMessages",
                 RemoveInVersion = "7.0",
                 TreatAsErrorFromVersion = "6.0")]
     public interface IMutateOutgoingTransportMessages


### PR DESCRIPTION
* adds obsoletes for the old Bus.Get|SetMessageHeader methods

* introduces a context for the outgoingmessagemutator
* renames the transport message mutator to physical message mutator


@SimonCropp please give this a once over before I fix the doco and upgrade guide