### PR TITLE
Added a case that removes "at lambda_method" from clean stack trace when asserting

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Exceptions/StackTraceAssert.cs
+++ b/src/NServiceBus.AcceptanceTests/Exceptions/StackTraceAssert.cs
@@ -63,7 +63,10 @@ namespace NServiceBus.AcceptanceTests.Exceptions
                     {
                         break;
                     }
-
+                    if (line.StartsWith("at lambda_method("))
+                    {
+                        continue;
+                    }
                     stringBuilder.AppendLine(line.Split(new[]
                     {
                         " in "


### PR DESCRIPTION
@Particular/nservicebus @SimonCropp can you review?