### PR TITLE
Correct unit test names for generic handlers

### DIFF
--- a/src/NServiceBus.Core.Tests/Unicast/Config/ConfigurationSettings.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/Config/ConfigurationSettings.cs
@@ -44,13 +44,13 @@
         }
 
         [Test]
-        public void Specific_generic_type_definition_handler_should_not_be_classified_as_a_handler()
+        public void Specific_generic_type_definition_handler_should_be_classified_as_a_handler()
         {
             Assert.IsTrue(RegisterHandlersInOrder.IsMessageHandler(typeof(GenericTypeDefinitionHandler<string>)));
         }
 
         [Test]
-        public void Generic_implemented_type_definition_handler_should_not_be_classified_as_a_handler()
+        public void Generic_implemented_type_definition_handler_should_be_classified_as_a_handler()
         {
             Assert.IsTrue(RegisterHandlersInOrder.IsMessageHandler(typeof(GenericImplementedHandler)));
         }


### PR DESCRIPTION
Some while ago generic message handlers were re-enabled in version 4 
and the tests were modified accordingly. However, the test method names
were never changed. This commit corrects that omission.