### PR TITLE
Make SagaMetadata CorrelationProps distinct, validate other assumptions

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1976,7 +1976,7 @@ namespace NServiceBus.Saga
             where TSagaData : NServiceBus.Saga.IContainSagaData;
         TSagaData Get<TSagaData>(NServiceBus.Saga.SagaMetadata metadata, string propertyName, object propertyValue)
             where TSagaData : NServiceBus.Saga.IContainSagaData;
-        void Initialize(NServiceBus.Saga.SagaMetaModel model);
+        void Initialize(NServiceBus.Saga.SagaMetadataCollection allSagas);
         void Save(NServiceBus.Saga.SagaMetadata metadata, NServiceBus.Saga.IContainSagaData saga);
         void Update(NServiceBus.Saga.SagaMetadata metadata, NServiceBus.Saga.IContainSagaData saga);
     }
@@ -2046,9 +2046,9 @@ namespace NServiceBus.Saga
         public bool IsMessageAllowedToStartTheSaga(string messageType) { }
         public bool TryGetFinder(string messageType, out NServiceBus.Saga.SagaFinderDefinition finderDefinition) { }
     }
-    public class SagaMetaModel : System.Collections.Generic.IEnumerable<NServiceBus.Saga.SagaMetadata>, System.Collections.IEnumerable
+    public class SagaMetadataCollection : System.Collections.Generic.IEnumerable<NServiceBus.Saga.SagaMetadata>, System.Collections.IEnumerable
     {
-        public SagaMetaModel() { }
+        public SagaMetadataCollection() { }
         public NServiceBus.Saga.SagaMetadata Find(System.Type sagaType) { }
         public NServiceBus.Saga.SagaMetadata FindByEntity(System.Type entityType) { }
         public System.Collections.Generic.IEnumerator<NServiceBus.Saga.SagaMetadata> GetEnumerator() { }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1971,14 +1971,14 @@ namespace NServiceBus.Saga
     }
     public interface ISagaPersister
     {
-        void Complete(NServiceBus.Saga.IContainSagaData saga);
-        TSagaData Get<TSagaData>(System.Guid sagaId)
+        void Complete(NServiceBus.Saga.SagaMetadata metadata, NServiceBus.Saga.IContainSagaData saga);
+        TSagaData Get<TSagaData>(NServiceBus.Saga.SagaMetadata metadata, System.Guid sagaId)
             where TSagaData : NServiceBus.Saga.IContainSagaData;
-        TSagaData Get<TSagaData>(string propertyName, object propertyValue)
+        TSagaData Get<TSagaData>(NServiceBus.Saga.SagaMetadata metadata, string propertyName, object propertyValue)
             where TSagaData : NServiceBus.Saga.IContainSagaData;
         void Initialize(NServiceBus.Saga.SagaMetaModel model);
-        void Save(NServiceBus.Saga.IContainSagaData saga);
-        void Update(NServiceBus.Saga.IContainSagaData saga);
+        void Save(NServiceBus.Saga.SagaMetadata metadata, NServiceBus.Saga.IContainSagaData saga);
+        void Update(NServiceBus.Saga.SagaMetadata metadata, NServiceBus.Saga.IContainSagaData saga);
     }
     public abstract class Saga
     {

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2049,8 +2049,8 @@ namespace NServiceBus.Saga
     public class SagaMetaModel : System.Collections.Generic.IEnumerable<NServiceBus.Saga.SagaMetadata>, System.Collections.IEnumerable
     {
         public SagaMetaModel() { }
-        public NServiceBus.Saga.SagaMetadata FindByEntityName(string name) { }
-        public NServiceBus.Saga.SagaMetadata FindByName(string name) { }
+        public NServiceBus.Saga.SagaMetadata Find(System.Type sagaType) { }
+        public NServiceBus.Saga.SagaMetadata FindByEntity(System.Type entityType) { }
         public System.Collections.Generic.IEnumerator<NServiceBus.Saga.SagaMetadata> GetEnumerator() { }
         public void Initialize(System.Collections.Generic.IEnumerable<System.Type> availableTypes) { }
         public void Initialize(System.Collections.Generic.IEnumerable<System.Type> availableTypes, NServiceBus.Conventions conventions) { }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/InMemoryPersisterBuilder.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/InMemoryPersisterBuilder.cs
@@ -16,7 +16,7 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
         public static InMemorySagaPersister Build(params Type[] sagaTypes)
         {
             var inMemorySagaPersister = new InMemorySagaPersister();
-            var sagaMetaModel = new SagaMetaModel();
+            var sagaMetaModel = new SagaMetadataCollection();
             sagaMetaModel.Initialize(sagaTypes, new Conventions());
             inMemorySagaPersister.Initialize(sagaMetaModel);
             return inMemorySagaPersister;

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_completing_a_saga_with_the_InMemory_persister.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_completing_a_saga_with_the_InMemory_persister.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.SagaPersisters.InMemory.Tests
 {
     using System;
+    using NServiceBus.Saga;
     using NUnit.Framework;
 
     [TestFixture]
@@ -11,10 +12,11 @@
         {
             var saga = new TestSagaData { Id = Guid.NewGuid() };
             var persister = InMemoryPersisterBuilder.Build<TestSaga>();
-            persister.Save(saga);
-            Assert.NotNull(persister.Get<TestSagaData>(saga.Id));
-            persister.Complete(saga);
-            Assert.Null(persister.Get<TestSagaData>(saga.Id));
+            var metadata = SagaMetadata.Create(typeof(TestSaga));
+            persister.Save(metadata, saga);
+            Assert.NotNull(persister.Get<TestSagaData>(metadata, saga.Id));
+            persister.Complete(metadata, saga);
+            Assert.Null(persister.Get<TestSagaData>(metadata, saga.Id));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_completing_a_saga_with_unique_property_with_InMemory_persister.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_completing_a_saga_with_unique_property_with_InMemory_persister.cs
@@ -1,21 +1,30 @@
 ﻿namespace NServiceBus.SagaPersisters.InMemory.Tests
 {
     using System;
+    using NServiceBus.Saga;
     using NUnit.Framework;
     
     [TestFixture]
     class When_completing_a_saga_with_unique_property_with_InMemory_persister
     {
+        SagaMetadata metadata;
+
+        [SetUp]
+        public void SetUp()
+        {
+            metadata = SagaMetadata.Create(typeof(SagaWithUniqueProperty));
+        }
+
         [Test]
         public void Should_delete_the_saga()
         {
             var saga = new SagaWithUniquePropertyData { Id = Guid.NewGuid(), UniqueString = "whatever" };
 
             var persister = InMemoryPersisterBuilder.Build<SagaWithUniqueProperty>();
-            persister.Save(saga);
-            Assert.NotNull(persister.Get<SagaWithUniquePropertyData>(saga.Id));
-            persister.Complete(saga);
-            Assert.Null(persister.Get<SagaWithUniquePropertyData>(saga.Id));
+            persister.Save(metadata, saga);
+            Assert.NotNull(persister.Get<SagaWithUniquePropertyData>(metadata, saga.Id));
+            persister.Complete(metadata, saga);
+            Assert.Null(persister.Get<SagaWithUniquePropertyData>(metadata, saga.Id));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.SagaPersisters.InMemory.Tests
 {
     using System;
+    using NServiceBus.Saga;
     using NUnit.Framework;
 
     [TestFixture]
@@ -13,13 +14,14 @@
             var saga2 = new SagaWithUniquePropertyData { Id = Guid.NewGuid(), UniqueString = "whatever" };
 
             var persister = InMemoryPersisterBuilder.Build<SagaWithUniqueProperty>();
+            var metadata = SagaMetadata.Create(typeof(SagaWithUniqueProperty));
 
-            persister.Save(saga1);
-            persister.Complete(saga1);
-            persister.Save(saga2);
-            persister.Complete(saga2);
-            persister.Save(saga1);
-            persister.Complete(saga1);
+            persister.Save(metadata, saga1);
+            persister.Complete(metadata, saga1);
+            persister.Save(metadata, saga2);
+            persister.Complete(metadata, saga2);
+            persister.Save(metadata, saga1);
+            persister.Complete(metadata, saga1);
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.SagaPersisters.InMemory.Tests
 {
     using System;
+    using NServiceBus.Saga;
     using NUnit.Framework;
 
     [TestFixture]
@@ -10,11 +11,13 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
         public void It_should_enforce_uniqueness()
         {
             var saga1 = new SagaWithUniquePropertyData { Id = Guid.NewGuid(), UniqueString = "whatever"};
-            var saga2 = new SagaWithUniquePropertyData { Id = Guid.NewGuid(), UniqueString = "whatever"};
+            var saga2 = new SagaWithUniquePropertyData { Id = Guid.NewGuid(), UniqueString = "whatever" };
+
+            var metadata = SagaMetadata.Create(typeof(SagaWithUniqueProperty));
 
             var persister = InMemoryPersisterBuilder.Build(typeof(SagaWithUniqueProperty),typeof(SagaWithTwoUniqueProperties));
-            persister.Save(saga1);
-            Assert.Throws<InvalidOperationException>(() => persister.Save(saga2));
+            persister.Save(metadata, saga1);
+            Assert.Throws<InvalidOperationException>(() => persister.Save(metadata, saga2));
         }
         [Test]
         public void It_should_enforce_uniqueness_even_for_two_unique_properties()
@@ -23,10 +26,12 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
             var saga2 = new SagaWithTwoUniquePropertiesData { Id = Guid.NewGuid(), UniqueString = "whatever1", UniqueInt = 3};
             var saga3 = new SagaWithTwoUniquePropertiesData { Id = Guid.NewGuid(), UniqueString = "whatever3", UniqueInt = 3 };
 
+            var metadata = SagaMetadata.Create(typeof(SagaWithTwoUniqueProperties));
+
             var persister = InMemoryPersisterBuilder.Build(typeof(SagaWithUniqueProperty), typeof(SagaWithTwoUniqueProperties));
-            persister.Save(saga1);
-            persister.Save(saga2);
-            Assert.Throws<InvalidOperationException>(() => persister.Save(saga3));
+            persister.Save(metadata, saga1);
+            persister.Save(metadata, saga2);
+            Assert.Throws<InvalidOperationException>(() => persister.Save(metadata, saga3));
         }
 
     }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_the_same_unique_property_as_the_original_value_of_another_saga_before_updating.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_the_same_unique_property_as_the_original_value_of_another_saga_before_updating.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.SagaPersisters.InMemory.Tests
 {
     using System;
+    using NServiceBus.Saga;
     using NUnit.Framework;
 
     [TestFixture]
@@ -12,13 +13,15 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
             var saga1 = new SagaWithUniquePropertyData{Id = Guid.NewGuid(), UniqueString = "whatever"};
             var saga2 = new SagaWithUniquePropertyData{Id = Guid.NewGuid(), UniqueString = "whatever"};
 
-            var persister = InMemoryPersisterBuilder.Build<SagaWithUniqueProperty>();
-            persister.Save(saga1);
-            saga1 = persister.Get<SagaWithUniquePropertyData>(saga1.Id);
-            saga1.UniqueString = "whatever2";
-            persister.Update(saga1);
+            var metadata = SagaMetadata.Create(typeof(SagaWithUniqueProperty));
 
-            persister.Save(saga2);
+            var persister = InMemoryPersisterBuilder.Build<SagaWithUniqueProperty>();
+            persister.Save(metadata, saga1);
+            saga1 = persister.Get<SagaWithUniquePropertyData>(metadata, saga1.Id);
+            saga1.UniqueString = "whatever2";
+            persister.Update(metadata, saga1);
+
+            persister.Save(metadata, saga2);
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_different_sagas_with_unique_properties.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_different_sagas_with_unique_properties.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.SagaPersisters.InMemory.Tests
 {
     using System;
+    using NServiceBus.Saga;
     using NUnit.Framework;
 
     [TestFixture]
@@ -11,11 +12,14 @@
         {
             var saga1 = new SagaWithTwoUniquePropertiesData { Id = Guid.NewGuid(), UniqueString = "whatever", UniqueInt = 5 };
             var saga2 = new AnotherSagaWithTwoUniquePropertiesData { Id = Guid.NewGuid(), UniqueString = "whatever", UniqueInt = 5 };
-            var saga3 = new SagaWithUniquePropertyData {Id = Guid.NewGuid(), UniqueString = "whatever"};
+            var saga3 = new SagaWithUniquePropertyData { Id = Guid.NewGuid(), UniqueString = "whatever" };
+            var metadata1 = SagaMetadata.Create(typeof(SagaWithTwoUniqueProperties));
+            var metadata2 = SagaMetadata.Create(typeof(AnotherSagaWithTwoUniqueProperties));
+            var metadata3 = SagaMetadata.Create(typeof(SagaWithUniqueProperty));
             var persister = InMemoryPersisterBuilder.Build(typeof(SagaWithTwoUniqueProperties), typeof(AnotherSagaWithTwoUniqueProperties), typeof(SagaWithUniqueProperty));
-            persister.Save(saga1);
-            persister.Save(saga2);
-            persister.Save(saga3);
+            persister.Save(metadata1, saga1);
+            persister.Save(metadata2, saga2);
+            persister.Save(metadata3, saga3);
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_property_is_null.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_property_is_null.cs
@@ -18,10 +18,12 @@
                        };
 
             var persister = InMemoryPersisterBuilder.Build<Saga>();
-            persister.Save(saga);
+            var metadata = SagaMetadata.Create(typeof(Saga));
 
-            Assert.AreEqual(sagaId, persister.Get<SagaData>("Property", null).Id);
-            Assert.IsNull(persister.Get<SagaData>("Property", "a value"));
+            persister.Save(metadata, saga);
+
+            Assert.AreEqual(sagaId, persister.Get<SagaData>(metadata, "Property", null).Id);
+            Assert.IsNull(persister.Get<SagaData>(metadata, "Property", "a value"));
         }
 
         class Saga : Saga<SagaData>

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_saga_not_found_return_default.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_saga_not_found_return_default.cs
@@ -1,16 +1,25 @@
 ﻿namespace NServiceBus.SagaPersisters.InMemory.Tests
 {
     using System;
+    using NServiceBus.Saga;
     using NUnit.Framework;
 
     [TestFixture]
     class When_saga_not_found_return_default
     {
+        SagaMetadata metadata;
+
+        [SetUp]
+        public void SetUp()
+        {
+            metadata = SagaMetadata.Create(typeof(SimpleSagaEntitySaga));
+        }
+
         [Test]
         public void Should_return_default_when_using_finding_saga_with_property()
         {
             var persister = InMemoryPersisterBuilder.Build<SimpleSagaEntitySaga>();
-            var simpleSageEntity = persister.Get<SimpleSagaEntity>("propertyNotFound", null);
+            var simpleSageEntity = persister.Get<SimpleSagaEntity>(metadata, "propertyNotFound", null);
             Assert.IsNull(simpleSageEntity);
         }
 
@@ -18,7 +27,7 @@
         public void Should_return_default_when_using_finding_saga_with_id()
         {
             var persister = InMemoryPersisterBuilder.Build<SimpleSagaEntitySaga>();
-            var simpleSageEntity = persister.Get<SimpleSagaEntity>(Guid.Empty);
+            var simpleSageEntity = persister.Get<SimpleSagaEntity>(metadata, Guid.Empty);
             Assert.IsNull(simpleSageEntity);
         }
 
@@ -32,9 +41,9 @@
                 OrderSource = "CA"
             };
             var persister = InMemoryPersisterBuilder.Build<SimpleSagaEntitySaga>();
-            persister.Save(simpleSagaEntity);
+            persister.Save(metadata, simpleSagaEntity);
 
-            var anotherSagaEntity = persister.Get<AnotherSimpleSagaEntity>(id);
+            var anotherSagaEntity = persister.Get<AnotherSimpleSagaEntity>(metadata, id);
             Assert.IsNull(anotherSagaEntity);
         }
     }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_saving_a_null_unique_property.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_saving_a_null_unique_property.cs
@@ -18,7 +18,9 @@
                        };
 
             var persister = InMemoryPersisterBuilder.Build<Saga>();
-            var exception = Assert.Throws<InvalidOperationException>(() => persister.Save(saga));
+            var metadata = SagaMetadata.Create(typeof(Saga));
+
+            var exception = Assert.Throws<InvalidOperationException>(() => persister.Save(metadata, saga));
             Assert.AreEqual("Cannot store saga with id '895e60e0-7be3-490a-afca-fe69184474ca' since the unique property 'Property' has a null value.", exception.Message);
         }
 

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_updating_a_saga_with_the_same_unique_property_as_another_saga.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_updating_a_saga_with_the_same_unique_property_as_another_saga.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.SagaPersisters.InMemory.Tests
 {
     using System;
+    using NServiceBus.Saga;
     using NUnit.Framework;
 
     [TestFixture]
@@ -13,14 +14,16 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
             var saga2 = new SagaWithUniquePropertyData {Id = Guid.NewGuid(), UniqueString = "whatever"};
 
             var persister = InMemoryPersisterBuilder.Build(typeof(SagaWithUniqueProperty), typeof(SagaWithTwoUniqueProperties));
-            persister.Save(saga1);
-            persister.Save(saga2);
+            var metadata = SagaMetadata.Create(typeof(SagaWithUniqueProperty));
+
+            persister.Save(metadata, saga1);
+            persister.Save(metadata, saga2);
 
             Assert.Throws<InvalidOperationException>(() => 
             {
-                var saga = persister.Get<SagaWithUniquePropertyData>(saga2.Id);
+                var saga = persister.Get<SagaWithUniquePropertyData>(metadata, saga2.Id);
                 saga.UniqueString = "whatever1";
-                persister.Update(saga);
+                persister.Update(metadata, saga);
             });
         }
 
@@ -31,14 +34,16 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
             var saga2 = new SagaWithTwoUniquePropertiesData { Id = Guid.NewGuid(), UniqueString = "whatever", UniqueInt = 37};
 
             var persister = InMemoryPersisterBuilder.Build(typeof(SagaWithUniqueProperty), typeof(SagaWithTwoUniqueProperties));
-            persister.Save(saga1);
-            persister.Save(saga2);
+            var metadata = SagaMetadata.Create(typeof(SagaWithTwoUniqueProperties));
+
+            persister.Save(metadata, saga1);
+            persister.Save(metadata, saga2);
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                var saga = persister.Get<SagaWithTwoUniquePropertiesData>(saga2.Id);
+                var saga = persister.Get<SagaWithTwoUniquePropertiesData>(metadata, saga2.Id);
                 saga.UniqueInt = 5;
-                persister.Update(saga);
+                persister.Update(metadata, saga);
             });
         }
     }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_updating_a_saga_with_the_same_unique_property_value.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_updating_a_saga_with_the_same_unique_property_value.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.SagaPersisters.InMemory.Tests
 {
     using System;
+    using NServiceBus.Saga;
     using NUnit.Framework;
 
     [TestFixture]
@@ -15,9 +16,11 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
                     UniqueString = "whatever"
                 };
             var persister = InMemoryPersisterBuilder.Build<SagaWithUniqueProperty>();
-            persister.Save(saga1);
-            saga1 = persister.Get<SagaWithUniquePropertyData>(saga1.Id);
-            persister.Update(saga1);
+            var metadata = SagaMetadata.Create(typeof(SagaWithUniqueProperty));
+
+            persister.Save(metadata, saga1);
+            saga1 = persister.Get<SagaWithUniquePropertyData>(metadata, saga1.Id);
+            persister.Update(metadata, saga1);
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Sagas/SagaModelTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaModelTests.cs
@@ -10,9 +10,9 @@ namespace NServiceBus.Core.Tests.Sagas.TypeBasedSagas
     public class SagaModelTests
     {
 
-        SagaMetaModel GetModel(params Type[] types)
+        SagaMetadataCollection GetModel(params Type[] types)
         {
-            var sagaMetaModel = new SagaMetaModel();
+            var sagaMetaModel = new SagaMetadataCollection();
             sagaMetaModel.Initialize(types.ToList(), new Conventions());
             return sagaMetaModel;
         }

--- a/src/NServiceBus.Core.Tests/Sagas/SagaModelTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaModelTests.cs
@@ -22,7 +22,7 @@ namespace NServiceBus.Core.Tests.Sagas.TypeBasedSagas
         {
             var model = GetModel(typeof(MySaga));
 
-            var metadata = model.FindByName(typeof(MySaga).FullName);
+            var metadata = model.Find(typeof(MySaga));
 
 
             Assert.NotNull(metadata);
@@ -33,13 +33,37 @@ namespace NServiceBus.Core.Tests.Sagas.TypeBasedSagas
         {
             var model = GetModel(typeof(MySaga));
 
-            var metadata = model.FindByEntityName(typeof(MySaga.MyEntity).FullName);
+            var metadata = model.FindByEntity(typeof(MySaga.MyEntity));
 
 
             Assert.NotNull(metadata);
         }
 
-    
+        [Test]
+        public void ValidateAssumptionsAboutSagaMappings()
+        {
+            var model = GetModel(typeof(MySaga));
+
+            var metadata = model.Find(typeof(MySaga));
+
+            Assert.NotNull(metadata);
+
+            Assert.AreEqual(typeof(MySaga.MyEntity), metadata.SagaEntityType);
+            Assert.AreEqual(typeof(MySaga.MyEntity).FullName, metadata.EntityName);
+            Assert.AreEqual(typeof(MySaga), metadata.SagaType);
+            Assert.AreEqual(typeof(MySaga).FullName, metadata.Name);
+
+            Assert.AreEqual(2, metadata.AssociatedMessages.Count());
+            Assert.AreEqual(1, metadata.AssociatedMessages.Count(am => am.MessageType == typeof(Message1).FullName && am.IsAllowedToStartSaga == false));
+            Assert.AreEqual(1, metadata.AssociatedMessages.Count(am => am.MessageType == typeof(Message2).FullName && am.IsAllowedToStartSaga == false));
+
+            Assert.AreEqual(1, metadata.CorrelationProperties.Count);
+            Assert.AreEqual("UniqueProperty", metadata.CorrelationProperties[0].Name);
+
+            Assert.AreEqual(2, metadata.Finders.Count());
+            Assert.AreEqual(1, metadata.Finders.Count(f => f.MessageType == typeof(Message1).FullName));
+            Assert.AreEqual(1, metadata.Finders.Count(f => f.MessageType == typeof(Message2).FullName));
+        }
 
         [Test]
         public void FilterOutNonSagaTypes()

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -367,7 +367,7 @@
     <Compile Include="Sagas\SagaFinderDefinition.cs" />
     <Compile Include="Sagas\SagaMessage.cs" />
     <Compile Include="Sagas\SagaMetadata.cs" />
-    <Compile Include="Sagas\SagaMetaModel.cs" />
+    <Compile Include="Sagas\SagaMetadataCollection.cs" />
     <Compile Include="Sagas\SagaToMessageMap.cs" />
     <Compile Include="Pipeline\PipelineNotifications.cs" />
     <Compile Include="Pipeline\StepStarted.cs" />

--- a/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
@@ -23,8 +23,9 @@ namespace NServiceBus.InMemory.SagaPersister
             data.TryRemove(saga.Id, out value);
         }
 
-        public void Initialize(SagaMetaModel model)
+        public void Initialize(SagaMetadataCollection allSagas)
         {
+            // No special setup required for in-memory persistence
         }
 
         public TSagaData Get<TSagaData>(SagaMetadata metadata, string propertyName, object propertyValue) where TSagaData : IContainSagaData

--- a/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
@@ -85,7 +85,7 @@ namespace NServiceBus.InMemory.SagaPersister
         void ValidateUniqueProperties(IContainSagaData saga)
         {
             var sagaType = saga.GetType();
-            var sagaMetaData = sagaModel.FindByEntityName(sagaType.FullName);
+            var sagaMetaData = sagaModel.FindByEntity(sagaType);
             var existingSagas = (from s in data
                 where s.Value.SagaEntity.GetType() == sagaType && (s.Key != saga.Id)
                 select s.Value)

--- a/src/NServiceBus.Core/Saga/ISagaPersister.cs
+++ b/src/NServiceBus.Core/Saga/ISagaPersister.cs
@@ -10,33 +10,40 @@ namespace NServiceBus.Saga
     {
 		/// <summary>
 		/// Saves the saga entity to the persistence store.
-		/// </summary>
+        /// </summary>
+        /// <param name="metadata">Metadata describing the saga being saved.</param>
 		/// <param name="saga">The saga entity to save.</param>
-        void Save(IContainSagaData saga);
+        void Save(SagaMetadata metadata, IContainSagaData saga);
 
         /// <summary>
         /// Updates an existing saga entity in the persistence store.
         /// </summary>
+        /// <param name="metadata">Metadata describing the saga being updated.</param>
         /// <param name="saga">The saga entity to updated.</param>
-        void Update(IContainSagaData saga);
+        void Update(SagaMetadata metadata, IContainSagaData saga);
 
 		/// <summary>
 		/// Gets a saga entity from the persistence store by its Id.
-		/// </summary>
+        /// </summary>
+        /// <param name="metadata">Metadata describing the saga being retrieved.</param>
 		/// <param name="sagaId">The Id of the saga entity to get.</param>
-        TSagaData Get<TSagaData>(Guid sagaId) where TSagaData : IContainSagaData;
+        TSagaData Get<TSagaData>(SagaMetadata metadata, Guid sagaId) where TSagaData : IContainSagaData;
 
         /// <summary>
         /// Looks up a saga entity by a given property.
         /// </summary>
-        TSagaData Get<TSagaData>(string propertyName, object propertyValue) where TSagaData : IContainSagaData;
+        /// <param name="metadata">Metadata describing the saga being completed.</param>
+        /// <param name="propertyName">From the data store, analyze this property.</param>
+        /// <param name="propertyValue">From the data store, look for this value in the identified property.</param>
+        TSagaData Get<TSagaData>(SagaMetadata metadata, string propertyName, object propertyValue) where TSagaData : IContainSagaData;
 
 		/// <summary>
         /// Sets a saga as completed and removes it from the active saga list
 		/// in the persistence store.
 		/// </summary>
+		/// <param name="metadata">Metadata describing the saga being completed.</param>
 		/// <param name="saga">The saga to complete.</param>
-        void Complete(IContainSagaData saga);
+        void Complete(SagaMetadata metadata, IContainSagaData saga);
 
         /// <summary>
         /// Implementers can initialize the persistence with the given meta model.

--- a/src/NServiceBus.Core/Saga/ISagaPersister.cs
+++ b/src/NServiceBus.Core/Saga/ISagaPersister.cs
@@ -48,8 +48,8 @@ namespace NServiceBus.Saga
         /// <summary>
         /// Implementers can initialize the persistence with the given meta model.
         /// </summary>
-        /// <param name="model">The sagas meta model.</param>
-        void Initialize(SagaMetaModel model);
+        /// <param name="allSagas">Metadata for all saga types found.</param>
+        void Initialize(SagaMetadataCollection allSagas);
     }
 
 }

--- a/src/NServiceBus.Core/Sagas/LoadSagaByIdWrapper.cs
+++ b/src/NServiceBus.Core/Sagas/LoadSagaByIdWrapper.cs
@@ -6,14 +6,14 @@ namespace NServiceBus.Saga
     //this class in only here until we can move to a better saga persister api
     class LoadSagaByIdWrapper<T>:SagaLoader where T : IContainSagaData
     {
-        public IContainSagaData Load(ISagaPersister persister, string sagaId)
+        public IContainSagaData Load(ISagaPersister persister, SagaMetadata metadata, string sagaId)
         {
-            return persister.Get<T>(Guid.Parse(sagaId));
+            return persister.Get<T>(metadata, Guid.Parse(sagaId));
         }
     }
 
     interface SagaLoader
     {
-        IContainSagaData Load(ISagaPersister persister, string sagaId);
+        IContainSagaData Load(ISagaPersister persister, SagaMetadata metadata, string sagaId);
     }
 }

--- a/src/NServiceBus.Core/Sagas/PropertySagaFinder.cs
+++ b/src/NServiceBus.Core/Sagas/PropertySagaFinder.cs
@@ -9,12 +9,12 @@ namespace NServiceBus.Saga
     class PropertySagaFinder<TSagaData> : SagaFinder where TSagaData : IContainSagaData
     {
         ISagaPersister sagaPersister;
-        SagaMetaModel sagaMetaModel;
+        SagaMetadataCollection sagaMetadataCollection;
 
-        public PropertySagaFinder(ISagaPersister sagaPersister, SagaMetaModel sagaMetaModel)
+        public PropertySagaFinder(ISagaPersister sagaPersister, SagaMetadataCollection sagaMetadataCollection)
         {
             this.sagaPersister = sagaPersister;
-            this.sagaMetaModel = sagaMetaModel;
+            this.sagaMetadataCollection = sagaMetadataCollection;
         }
 
         internal override IContainSagaData Find(IBuilder builder,SagaFinderDefinition finderDefinition, object message)
@@ -23,7 +23,7 @@ namespace NServiceBus.Saga
             var propertyValue = propertyAccessor(message);
 
             var sagaPropertyName = (string)finderDefinition.Properties["saga-property-name"];
-            var sagaMetadata = sagaMetaModel.FindByEntity(typeof(TSagaData));
+            var sagaMetadata = sagaMetadataCollection.FindByEntity(typeof(TSagaData));
 
             if (sagaPropertyName.ToLower() == "id")
             {

--- a/src/NServiceBus.Core/Sagas/PropertySagaFinder.cs
+++ b/src/NServiceBus.Core/Sagas/PropertySagaFinder.cs
@@ -9,10 +9,12 @@ namespace NServiceBus.Saga
     class PropertySagaFinder<TSagaData> : SagaFinder where TSagaData : IContainSagaData
     {
         ISagaPersister sagaPersister;
+        SagaMetaModel sagaMetaModel;
 
-        public PropertySagaFinder(ISagaPersister sagaPersister)
+        public PropertySagaFinder(ISagaPersister sagaPersister, SagaMetaModel sagaMetaModel)
         {
             this.sagaPersister = sagaPersister;
+            this.sagaMetaModel = sagaMetaModel;
         }
 
         internal override IContainSagaData Find(IBuilder builder,SagaFinderDefinition finderDefinition, object message)
@@ -21,13 +23,14 @@ namespace NServiceBus.Saga
             var propertyValue = propertyAccessor(message);
 
             var sagaPropertyName = (string)finderDefinition.Properties["saga-property-name"];
+            var sagaMetadata = sagaMetaModel.FindByEntity(typeof(TSagaData));
 
             if (sagaPropertyName.ToLower() == "id")
             {
-                return sagaPersister.Get<TSagaData>((Guid)propertyValue);
+                return sagaPersister.Get<TSagaData>(sagaMetadata, (Guid)propertyValue);
             }
 
-            return sagaPersister.Get<TSagaData>(sagaPropertyName, propertyValue);
+            return sagaPersister.Get<TSagaData>(sagaMetadata, sagaPropertyName, propertyValue);
         }
     }
 }

--- a/src/NServiceBus.Core/Sagas/SagaMetaModel.cs
+++ b/src/NServiceBus.Core/Sagas/SagaMetaModel.cs
@@ -34,19 +34,19 @@ namespace NServiceBus.Saga
 
             foreach (var saga in foundSagas)
             {
-                byEntityName[saga.EntityName] = saga;
-                byName[saga.Name] = saga;
+                byEntity[saga.SagaEntityType] = saga;
+                byType[saga.SagaType] = saga;
             }
         }
 
         /// <summary>
         /// Returns a <see cref="SagaMetadata"/> for an entity by entity name.
         /// </summary>
-        /// <param name="name">Name of the entity.</param>
+        /// <param name="entityType">Type of the entity (saga data).</param>
         /// <returns>An instance of <see cref="SagaMetadata"/>.</returns>
-        public SagaMetadata FindByEntityName(string name)
+        public SagaMetadata FindByEntity(Type entityType)
         {
-            return byEntityName[name];
+            return byEntity[entityType];
         }
 
         /// <summary>
@@ -54,17 +54,17 @@ namespace NServiceBus.Saga
         /// </summary>
         public IEnumerator<SagaMetadata> GetEnumerator()
         {
-            return byEntityName.Values.GetEnumerator();
+            return byEntity.Values.GetEnumerator();
         }
 
         /// <summary>
         /// Returns a <see cref="SagaMetadata"/> for an entity by name.
         /// </summary>
-        /// <param name="name">Saga name.</param>
+        /// <param name="sagaType">Saga type.</param>
         /// <returns>An instance of <see cref="SagaMetadata"/>.</returns>
-        public SagaMetadata FindByName(string name)
+        public SagaMetadata Find(Type sagaType)
         {
-            return byName[name];
+            return byType[sagaType];
         }
 
         IEnumerator IEnumerable.GetEnumerator()
@@ -72,7 +72,7 @@ namespace NServiceBus.Saga
             return GetEnumerator();
         }
 
-        Dictionary<string,SagaMetadata> byEntityName = new Dictionary<string, SagaMetadata>();
-        Dictionary<string, SagaMetadata> byName = new Dictionary<string, SagaMetadata>();
+        Dictionary<Type, SagaMetadata> byEntity = new Dictionary<Type, SagaMetadata>();
+        Dictionary<Type, SagaMetadata> byType = new Dictionary<Type, SagaMetadata>();
     }
 }

--- a/src/NServiceBus.Core/Sagas/SagaMetadata.cs
+++ b/src/NServiceBus.Core/Sagas/SagaMetadata.cs
@@ -163,7 +163,7 @@ namespace NServiceBus.Saga
 
             foreach (var mapping in mapper.Mappings)
             {
-                if (!mapping.HasCustomFinderMap)
+                if (!mapping.HasCustomFinderMap && correlationProperties.All(cp => cp.Name != mapping.SagaPropName))
                 {
                     correlationProperties.Add(new CorrelationProperty(mapping.SagaPropName));
                 }

--- a/src/NServiceBus.Core/Sagas/SagaMetadataCollection.cs
+++ b/src/NServiceBus.Core/Sagas/SagaMetadataCollection.cs
@@ -8,7 +8,7 @@ namespace NServiceBus.Saga
     /// <summary>
     /// Sagas metamodel.
     /// </summary>
-    public class SagaMetaModel : IEnumerable<SagaMetadata>
+    public class SagaMetadataCollection : IEnumerable<SagaMetadata>
     {
         /// <summary>
         /// Populates the model with saga metadata from the provided collection of types.

--- a/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
@@ -35,7 +35,7 @@
                 return;
             }
 
-            var sagaMetadata = SagaMetaModel.FindByName(context.MessageHandler.Instance.GetType().FullName);
+            var sagaMetadata = SagaMetaModel.Find(context.MessageHandler.Instance.GetType());
             var sagaInstanceState = new ActiveSagaInstance(saga, sagaMetadata);
 
             //so that other behaviors can access the saga

--- a/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
@@ -19,14 +19,14 @@
 
         public MessageHandlerRegistry MessageHandlerRegistry { get; private set; }
 
-        public SagaMetaModel SagaMetaModel { get; private set; }
+        public SagaMetadataCollection SagaMetadataCollection { get; private set; }
 
-        public SagaPersistenceBehavior(ISagaPersister persister, ICancelDeferredMessages timeoutCancellation, MessageHandlerRegistry handlerRegistry, SagaMetaModel sagaMetaModel)
+        public SagaPersistenceBehavior(ISagaPersister persister, ICancelDeferredMessages timeoutCancellation, MessageHandlerRegistry handlerRegistry, SagaMetadataCollection sagaMetadataCollection)
         {
             this.SagaPersister = persister;
             this.TimeoutCancellation = timeoutCancellation;
             this.MessageHandlerRegistry = handlerRegistry;
-            this.SagaMetaModel = sagaMetaModel;
+            this.SagaMetadataCollection = sagaMetadataCollection;
         }
 
         public override void Invoke(Context context, Action next)
@@ -43,7 +43,7 @@
                 return;
             }
 
-            var sagaMetadata = SagaMetaModel.Find(context.MessageHandler.Instance.GetType());
+            var sagaMetadata = SagaMetadataCollection.Find(context.MessageHandler.Instance.GetType());
             var sagaInstanceState = new ActiveSagaInstance(saga, sagaMetadata);
 
             //so that other behaviors can access the saga

--- a/src/NServiceBus.Core/Sagas/Sagas.cs
+++ b/src/NServiceBus.Core/Sagas/Sagas.cs
@@ -26,7 +26,7 @@
                 }
             });
 
-            Defaults(s => s.Set<SagaMetaModel>(new SagaMetaModel()));
+            Defaults(s => s.Set<SagaMetadataCollection>(new SagaMetadataCollection()));
 
             Prerequisite(config => config.Settings.GetAvailableTypes().Any(IsSagaType), "No sagas was found in scanned types");
 
@@ -43,7 +43,7 @@
             context.Pipeline.Register<InvokeSagaNotFoundBehavior.Registration>();
             context.Pipeline.Register("AttachSagaDetailsToOutGoingMessage", typeof(AttachSagaDetailsToOutGoingMessageBehavior), "Makes sure that outgoing messages have saga info attached to them");
 
-            var sagaMetaModel = context.Settings.Get<SagaMetaModel>();
+            var sagaMetaModel = context.Settings.Get<SagaMetadataCollection>();
             sagaMetaModel.Initialize(context.Settings.GetAvailableTypes(), conventions);
 
             RegisterCustomFindersInContainer(context.Container, sagaMetaModel);
@@ -102,9 +102,9 @@
         class CallISagaPersisterInitializeMethod : FeatureStartupTask
         {
             ISagaPersister persister;
-            SagaMetaModel model;
+            SagaMetadataCollection model;
 
-            public CallISagaPersisterInitializeMethod(ISagaPersister persister, SagaMetaModel model)
+            public CallISagaPersisterInitializeMethod(ISagaPersister persister, SagaMetadataCollection model)
             {
                 this.persister = persister;
                 this.model = model;


### PR DESCRIPTION
As @danielmarbach and I started to apply SataMetadata to the NH and RavenDB persisters, some usability concerns came up. So I added a test to validate all my assumptions about what a SagaMetadata should look like based on the Saga under test, and made a few modifications.

First, where `[Unique]` had always been distinct before because of how reflection works, CorrelationProperties were not. Two message mappings pointing to the same saga property would create duplicate correlation properties, which is a mess for a persister to have to deal with. The persister should be able to make the assumption they are already distinct. So I changed that.

Side note: We have a problem with how RavenDB handles this because Raven always assumed one and only one `[Unique]`, and having multiple would necessitate multiple pointer docs, and the Saga storage document to point to a collection of pointer doc ids rather than a single property. Backwards compatibility would be a mess, so we may have to throw in Raven if the CorrelationProperties collection is > 1. For NHibernate it's no big deal.

Second, it seems onerous to force the consumer of SagaMetaModel to know to use a type's FullName (either the saga's or the saga entity's) to find the SagaMetadata. The only reason I could think of would be if a message came in with one of the types in a header and you had to find the saga metadata based on that, but the Core does no such thing anywhere. So I changed the API to do lookups by a Type, and changed the underlying dictionaries as well.

@johnsimons do these changes seem reasonable?

/cc @Particular/nservicebus 