### PR TITLE
Configure pipelines using features

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_forwarded.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_forwarded.cs
@@ -68,7 +68,8 @@
 
                     if (called)
                     {
-                        Console.Out.WriteLine("Called once, skipping next");
+                        Console.Out.WriteLine("Called once, proceeding without exception");
+                        next();
                         return;
 
                     }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1190,7 +1190,7 @@ namespace NServiceBus.Features
         public NServiceBus.ObjectBuilder.IConfigureComponents Container { get; }
         public NServiceBus.Pipeline.PipelineSettings Pipeline { get; }
         public NServiceBus.Settings.ReadOnlySettings Settings { get; }
-        public NServiceBus.Pipeline.PipelineSettings AddSatellitePipeline(string name, string receiveAddress) { }
+        public NServiceBus.Features.SatelliteRegistration AddSatellitePipeline(string name, string receiveAddress, NServiceBus.Pipeline.RegisterStep pipelineBehaviorRegistration) { }
         public void RegisterReceiveBehavior(System.Func<NServiceBus.ObjectBuilder.IBuilder, NServiceBus.Transports.ReceiveBehavior> receiveBehaviorFactory) { }
     }
     public class FeatureDiagnosticData
@@ -1285,6 +1285,13 @@ namespace NServiceBus.Features
     public class Sagas : NServiceBus.Features.Feature
     {
         protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+    }
+    public class SatelliteRegistration
+    {
+        public NServiceBus.Pipeline.PipelineSettings SpecificBehaviors { get; }
+        public void EnableFeature(System.Type featureType) { }
+        public void EnableFeature<T>()
+            where T : NServiceBus.Features.Feature { }
     }
     public class Scheduler : NServiceBus.Features.Feature
     {

--- a/src/NServiceBus.Core.Tests/DataBus/When_nservicebus_is_initalizing.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_nservicebus_is_initalizing.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.Core.Tests.DataBus
     using NServiceBus.DataBus;
     using NServiceBus.DataBus.InMemory;
     using NServiceBus.Features;
+    using NServiceBus.Pipeline;
     using NUnit.Framework;
 
     [TestFixture]
@@ -22,7 +23,7 @@ namespace NServiceBus.Core.Tests.DataBus
             
             var config = builder.BuildConfiguration();
 
-            Assert.True(new DataBusFileBased().CheckPrerequisites(new FeatureConfigurationContext(config)).IsSatisfied);
+            Assert.True(new DataBusFileBased().CheckPrerequisites(new FeatureConfigurationContext(config.container, config.Settings, new PipelineModificationsBuilder())).IsSatisfied);
         }
 
         [Test]
@@ -42,8 +43,9 @@ namespace NServiceBus.Core.Tests.DataBus
             builder.Conventions().DefiningDataBusPropertiesAs(p => p.Name.EndsWith("DataBus"));
             
             var feature = new DataBusFileBased();
+            var configure = builder.BuildConfiguration();
 
-            Assert.Throws<InvalidOperationException>(() => feature.CheckPrerequisites(new FeatureConfigurationContext(builder.BuildConfiguration())));
+            Assert.Throws<InvalidOperationException>(() => feature.CheckPrerequisites(new FeatureConfigurationContext(configure.container, configure.Settings, new PipelineModificationsBuilder())));
         }
 
         [Test]
@@ -70,7 +72,7 @@ namespace NServiceBus.Core.Tests.DataBus
             var config = builder.BuildConfiguration();
             var feature = new DataBusFileBased();
 
-            Assert.DoesNotThrow(() => feature.CheckPrerequisites(new FeatureConfigurationContext(config)));
+            Assert.DoesNotThrow(() => feature.CheckPrerequisites(new FeatureConfigurationContext(config.container, config.Settings, new PipelineModificationsBuilder())));
         }
 
         class MyDataBusSerializer : IDataBusSerializer

--- a/src/NServiceBus.Core.Tests/Features/FeatureDefaultsTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDefaultsTests.cs
@@ -3,6 +3,8 @@
     using System.Collections.Generic;
     using System.Linq;
     using NServiceBus.Features;
+    using NServiceBus.ObjectBuilder.Common;
+    using NServiceBus.Pipeline;
     using NUnit.Framework;
     using Settings;
 
@@ -41,12 +43,13 @@
         {
             var featureThatIsEnabledByAnother = new FeatureThatIsEnabledByAnother();
             var settings = new SettingsHolder();
-            var featureSettings = new FeatureActivator(settings);
+            settings.Set<PipelineConfiguration>(new PipelineConfiguration(new PipelineModificationsBuilder()));
+            var featureSettings = new FeatureActivator(settings, new CommonObjectBuilder());
             //the orders matter here to expose a bug
             featureSettings.Add(featureThatIsEnabledByAnother);
             featureSettings.Add(new FeatureThatEnablesAnother());
 
-            featureSettings.SetupFeatures(new FeatureConfigurationContext(null));
+            featureSettings.SetupFeatures();
 
             Assert.True(featureThatIsEnabledByAnother.DefaultCalled, "FeatureThatIsEnabledByAnother wasn't activated");
         }
@@ -74,14 +77,15 @@
             };
 
             var settings = new SettingsHolder();
-            var featureSettings = new FeatureActivator(settings);
+            settings.Set<PipelineConfiguration>(new PipelineConfiguration(new PipelineModificationsBuilder()));
+            var featureSettings = new FeatureActivator(settings, new CommonObjectBuilder());
 
             //the orders matter here to expose a bug
             featureSettings.Add(level3);
             featureSettings.Add(level2);
             featureSettings.Add(level1);
 
-            featureSettings.SetupFeatures(new FeatureConfigurationContext(null));
+            featureSettings.SetupFeatures();
 
             Assert.True(level1.IsActive, "Activate1 wasn't activated");
             Assert.True(level2.IsActive, "Activate2 wasn't activated");
@@ -109,14 +113,15 @@
             };
 
             var settings = new SettingsHolder();
-            var featureSettings = new FeatureActivator(settings);
+            settings.Set<PipelineConfiguration>(new PipelineConfiguration(new PipelineModificationsBuilder()));
+            var featureSettings = new FeatureActivator(settings, new CommonObjectBuilder());
 
             featureSettings.Add(dependingFeature);
             featureSettings.Add(feature);
 
             settings.EnableFeatureByDefault<MyFeature1>();
 
-            featureSettings.SetupFeatures(new FeatureConfigurationContext(null));
+            featureSettings.SetupFeatures();
 
             Assert.True(dependingFeature.IsActive);
 
@@ -146,7 +151,8 @@
             };
 
             var settings = new SettingsHolder();
-            var featureSettings = new FeatureActivator(settings);
+            settings.Set<PipelineConfiguration>(new PipelineConfiguration(new PipelineModificationsBuilder()));
+            var featureSettings = new FeatureActivator(settings, new CommonObjectBuilder());
 
             featureSettings.Add(dependingFeature);
             featureSettings.Add(feature);
@@ -157,7 +163,7 @@
             settings.EnableFeatureByDefault<MyFeature2>();
             settings.EnableFeatureByDefault<MyFeature3>();
 
-            featureSettings.SetupFeatures(new FeatureConfigurationContext(null));
+            featureSettings.SetupFeatures();
 
             Assert.True(dependingFeature.IsActive);
 
@@ -185,14 +191,15 @@
             };
 
             var settings = new SettingsHolder();
-            var featureSettings = new FeatureActivator(settings);
+            settings.Set<PipelineConfiguration>(new PipelineConfiguration(new PipelineModificationsBuilder()));
+            var featureSettings = new FeatureActivator(settings, new CommonObjectBuilder());
 
             //the orders matter here to expose a bug
             featureSettings.Add(level3);
             featureSettings.Add(level2);
             featureSettings.Add(level1);
 
-            featureSettings.SetupFeatures(new FeatureConfigurationContext(null));
+            featureSettings.SetupFeatures();
 
             Assert.True(level1.IsActive, "Level1 wasn't activated");
             Assert.True(level2.IsActive, "Level2 wasn't activated");

--- a/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
@@ -4,6 +4,8 @@
     using System.Collections.Generic;
     using System.Linq;
     using NServiceBus.Features;
+    using NServiceBus.ObjectBuilder.Common;
+    using NServiceBus.Pipeline;
     using NUnit.Framework;
     using Settings;
 
@@ -54,12 +56,14 @@
         [TestCaseSource("FeatureCombinationsForTests")]
         public void Should_only_activate_features_if_dependencies_are_met(FeatureCombinations setup)
         {
-            var featureSettings = new FeatureActivator(new SettingsHolder());
+            var settingsHolder = new SettingsHolder();
+            settingsHolder.Set<PipelineConfiguration>(new PipelineConfiguration(new PipelineModificationsBuilder()));
+            var featureSettings = new FeatureActivator(settingsHolder, new CommonObjectBuilder());
             var dependingFeature = setup.DependingFeature;
             featureSettings.Add(dependingFeature);
             Array.ForEach(setup.AvailableFeatures, featureSettings.Add);
 
-            featureSettings.SetupFeatures(new FeatureConfigurationContext(null));
+            featureSettings.SetupFeatures();
 
             Assert.AreEqual(setup.ShouldBeActive, dependingFeature.IsActive);
         }
@@ -79,14 +83,15 @@
             };
 
             var settings = new SettingsHolder();
-            var featureSettings = new FeatureActivator(settings);
+            settings.Set<PipelineConfiguration>(new PipelineConfiguration(new PipelineModificationsBuilder()));
+            var featureSettings = new FeatureActivator(settings, new CommonObjectBuilder());
 
             featureSettings.Add(dependingFeature);
             featureSettings.Add(feature);
 
             settings.EnableFeatureByDefault<MyFeature1>();
 
-            featureSettings.SetupFeatures(new FeatureConfigurationContext(null));
+            featureSettings.SetupFeatures();
 
             Assert.True(dependingFeature.IsActive);
 
@@ -116,7 +121,8 @@
             };
 
             var settings = new SettingsHolder();
-            var featureSettings = new FeatureActivator(settings);
+            settings.Set<PipelineConfiguration>(new PipelineConfiguration(new PipelineModificationsBuilder()));
+            var featureSettings = new FeatureActivator(settings, new CommonObjectBuilder());
 
             featureSettings.Add(dependingFeature);
             featureSettings.Add(feature);
@@ -127,7 +133,7 @@
             settings.EnableFeatureByDefault<MyFeature2>();
             settings.EnableFeatureByDefault<MyFeature3>();
 
-            featureSettings.SetupFeatures(new FeatureConfigurationContext(null));
+            featureSettings.SetupFeatures();
 
             Assert.True(dependingFeature.IsActive);
 
@@ -156,14 +162,15 @@
             };
 
             var settings = new SettingsHolder();
-            var featureSettings = new FeatureActivator(settings);
+            settings.Set<PipelineConfiguration>(new PipelineConfiguration(new PipelineModificationsBuilder()));
+            var featureSettings = new FeatureActivator(settings, new CommonObjectBuilder());
 
             //the orders matter here to expose a bug
             featureSettings.Add(level3);
             featureSettings.Add(level2);
             featureSettings.Add(level1);
 
-            featureSettings.SetupFeatures(new FeatureConfigurationContext(null));
+            featureSettings.SetupFeatures();
 
 
             Assert.True(level1.IsActive, "Level1 wasn't activated");

--- a/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
@@ -3,6 +3,8 @@
     using System;
     using System.Linq;
     using NServiceBus.Features;
+    using NServiceBus.ObjectBuilder.Common;
+    using NServiceBus.Pipeline;
     using NUnit.Framework;
     using Settings;
 
@@ -15,13 +17,15 @@
             var featureWithTrueCondition = new MyFeatureWithSatisfiedPrerequisite();
             var featureWithFalseCondition = new MyFeatureWithUnsatisfiedPrerequisite();
 
-            var featureSettings = new FeatureActivator(new SettingsHolder());
+            var settings = new SettingsHolder();
+            settings.Set<PipelineConfiguration>(new PipelineConfiguration(new PipelineModificationsBuilder()));
+            var featureSettings = new FeatureActivator(settings, new CommonObjectBuilder());
 
             featureSettings.Add(featureWithTrueCondition);
             featureSettings.Add(featureWithFalseCondition);
 
 
-            featureSettings.SetupFeatures(new FeatureConfigurationContext(null));
+            featureSettings.SetupFeatures();
 
             Assert.True(featureWithTrueCondition.IsActive);
             Assert.False(featureWithFalseCondition.IsActive);
@@ -33,11 +37,12 @@
         public void Should_register_defaults_if_feature_is_activated()
         {
             var settings = new SettingsHolder();
-            var featureSettings = new FeatureActivator(settings);
+            settings.Set<PipelineConfiguration>(new PipelineConfiguration(new PipelineModificationsBuilder()));
+            var featureSettings = new FeatureActivator(settings, new CommonObjectBuilder());
 
             featureSettings.Add(new MyFeatureWithDefaults());
 
-            featureSettings.SetupFeatures(new FeatureConfigurationContext(null));
+            featureSettings.SetupFeatures();
 
             Assert.True(settings.HasSetting("Test1"));
         }
@@ -46,12 +51,12 @@
         public void Should_not_register_defaults_if_feature_is_not_activated()
         {
             var settings = new SettingsHolder();
-            var featureSettings = new FeatureActivator(settings);
+            var featureSettings = new FeatureActivator(settings, new CommonObjectBuilder());
 
             featureSettings.Add(new MyFeatureWithDefaultsNotActive());
             featureSettings.Add(new MyFeatureWithDefaultsNotActiveDueToUnsatisfiedPrerequisite());
 
-            featureSettings.SetupFeatures(new FeatureConfigurationContext(null));
+            featureSettings.SetupFeatures();
 
             Assert.False(settings.HasSetting("Test1"));
             Assert.False(settings.HasSetting("Test2"));

--- a/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
@@ -3,6 +3,8 @@
     using System;
     using System.Collections.Generic;
     using NServiceBus.Features;
+    using NServiceBus.ObjectBuilder.Common;
+    using NServiceBus.Pipeline;
     using NUnit.Framework;
     using ObjectBuilder;
     using Settings;
@@ -14,14 +16,16 @@
         public void Should_start_and_stop_features()
         {
             var feature = new FeatureWithStartupTask();
-       
-            var featureSettings = new FeatureActivator(new SettingsHolder());
+
+            var settings = new SettingsHolder();
+            settings.Set<PipelineConfiguration>(new PipelineConfiguration(new PipelineModificationsBuilder()));
+            var featureSettings = new FeatureActivator(settings, new CommonObjectBuilder());
 
             featureSettings.Add(feature);
 
             var builder = new FakeBuilder(typeof(FeatureWithStartupTask.Runner));
 
-            featureSettings.SetupFeatures(new FeatureConfigurationContext(null));
+            featureSettings.SetupFeatures();
 
             featureSettings.StartFeatures(builder);
             featureSettings.StopFeatures(builder);
@@ -35,13 +39,15 @@
         {
             var feature = new FeatureWithStartupTaskWhichIsDisposable();
 
-            var featureSettings = new FeatureActivator(new SettingsHolder());
+            var settings = new SettingsHolder();
+            settings.Set<PipelineConfiguration>(new PipelineConfiguration(new PipelineModificationsBuilder()));
+            var featureSettings = new FeatureActivator(settings, new CommonObjectBuilder());
 
             featureSettings.Add(feature);
 
             var builder = new FakeBuilder(typeof(FeatureWithStartupTaskWhichIsDisposable.Runner));
 
-            featureSettings.SetupFeatures(new FeatureConfigurationContext(null));
+            featureSettings.SetupFeatures();
 
             featureSettings.StartFeatures(builder);
             featureSettings.StopFeatures(builder);

--- a/src/NServiceBus.Core.Tests/Serializers/Json/When_not_overriding_stream_encoding.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/When_not_overriding_stream_encoding.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Serializers.Json.Tests
 {
     using System.Text;
     using Features;
+    using NServiceBus.Pipeline;
     using NUnit.Framework;
 
     [TestFixture]
@@ -17,7 +18,7 @@ namespace NServiceBus.Serializers.Json.Tests
 
             var config = builder.BuildConfiguration();
 
-            var context = new FeatureConfigurationContext(config);
+            var context = new FeatureConfigurationContext(config.container, config.Settings, new PipelineModificationsBuilder());
             new JsonSerialization().SetupFeature(context);
    
             var serializer = config.Builder.Build<JsonMessageSerializer>();

--- a/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Serializers.Json.Tests
 {
     using System.Text;
     using Features;
+    using NServiceBus.Pipeline;
     using NUnit.Framework;
 
     [TestFixture]
@@ -16,7 +17,7 @@ namespace NServiceBus.Serializers.Json.Tests
 
             var config = builder.BuildConfiguration();
 
-            var context = new FeatureConfigurationContext(config);
+            var context = new FeatureConfigurationContext(config.container, config.Settings, new PipelineModificationsBuilder());
             new JsonSerialization().SetupFeature(context);
 
             var serializer = config.Builder.Build<JsonMessageSerializer>();

--- a/src/NServiceBus.Core/Audit/Audit.cs
+++ b/src/NServiceBus.Core/Audit/Audit.cs
@@ -28,7 +28,7 @@
             context.Container.ConfigureComponent(b =>
             {
                 var pipelinesCollection = context.Settings.Get<PipelineConfiguration>();
-                var auditPipeline = new PipelineBase<AuditContext>(b, context.Settings, pipelinesCollection.MainPipeline);
+                var auditPipeline = new PipelineBase<AuditContext>(b, context.Settings, pipelinesCollection.CreateMainPipeline());
 
                 return new InvokeAuditPipelineBehavior(auditPipeline,auditConfig.Address);
             }, DependencyLifecycle.InstancePerCall);

--- a/src/NServiceBus.Core/BusConfiguration.cs
+++ b/src/NServiceBus.Core/BusConfiguration.cs
@@ -33,9 +33,13 @@ namespace NServiceBus
         {
             configurationSourceToUse = new DefaultConfigurationSource();
 
-            pipelineCollection = new PipelineConfiguration();
+            var userDefinedBehaviors = new PipelineModificationsBuilder();
+            pipelineCollection = new PipelineConfiguration(userDefinedBehaviors);
             Settings.Set<PipelineConfiguration>(pipelineCollection);
-            Pipeline = new PipelineSettings(pipelineCollection.MainPipeline);
+            Pipeline = new PipelineSettings(userDefinedBehaviors);
+
+            var satellites = new SatelliteCollection();
+            Settings.Set<SatelliteCollection>(satellites);
 
             Settings.Set<QueueBindings>(new QueueBindings());
 

--- a/src/NServiceBus.Core/BusConfiguration.cs
+++ b/src/NServiceBus.Core/BusConfiguration.cs
@@ -246,7 +246,7 @@ namespace NServiceBus
 
             Settings.SetDefault<Conventions>(conventionsBuilder.Conventions);
 
-            return new Configure(Settings, container, registrations, Pipeline, pipelineCollection);
+            return new Configure(Settings, container, registrations, pipelineCollection);
         }
 
         List<Type> GetAllowedTypes(string path)

--- a/src/NServiceBus.Core/Configure.cs
+++ b/src/NServiceBus.Core/Configure.cs
@@ -84,7 +84,7 @@ namespace NServiceBus
         {
             WireUpConfigSectionOverrides();
 
-            var featureActivator = new FeatureActivator(Settings);
+            var featureActivator = new FeatureActivator(Settings, container);
 
             container.RegisterSingleton(featureActivator);
 
@@ -94,7 +94,7 @@ namespace NServiceBus
 
             ActivateAndInvoke<IWantToRunBeforeConfigurationIsFinalized>(TypesToScan, t => t.Run(this));
 
-            var featureStats = featureActivator.SetupFeatures(new FeatureConfigurationContext(this));
+            var featureStats = featureActivator.SetupFeatures();
 
             pipelineConfiguration.RegisterBehaviorsInContainer(Settings, container);
 

--- a/src/NServiceBus.Core/Configure.cs
+++ b/src/NServiceBus.Core/Configure.cs
@@ -19,10 +19,9 @@ namespace NServiceBus
         /// <summary>
         ///     Creates a new instance of <see cref="Configure"/>.
         /// </summary>
-        internal Configure(SettingsHolder settings, IContainer container, List<Action<IConfigureComponents>> registrations, PipelineSettings pipelineSettings, PipelineConfiguration pipelineConfiguration)
+        internal Configure(SettingsHolder settings, IContainer container, List<Action<IConfigureComponents>> registrations, PipelineConfiguration pipelineConfiguration)
         {
             Settings = settings;
-            this.pipelineSettings = pipelineSettings;
             this.pipelineConfiguration = pipelineConfiguration;
 
             RegisterContainerAdapter(container);
@@ -159,7 +158,6 @@ namespace NServiceBus
         }
 
         internal IConfigureComponents container;
-        internal PipelineSettings pipelineSettings;
         PipelineConfiguration pipelineConfiguration;
     }
 }

--- a/src/NServiceBus.Core/DelayedDelivery/DelayedDeliveryFeature.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/DelayedDeliveryFeature.cs
@@ -29,7 +29,7 @@
                 {
                     var pipelinesCollection = context.Settings.Get<PipelineConfiguration>();
 
-                    var dispatchPipeline = new PipelineBase<DispatchContext>(b, context.Settings, pipelinesCollection.MainPipeline);
+                    var dispatchPipeline = new PipelineBase<DispatchContext>(b, context.Settings, pipelinesCollection.CreateMainPipeline());
 
                     return new RequestCancelingOfDeferredMessagesFromTimeoutManager(timeoutManagerAddress, dispatchPipeline);
                 }, DependencyLifecycle.SingleInstance);

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
@@ -44,19 +44,17 @@
             var dispatcherAddress = selectedTransportDefinition.GetSubScope(localAddress,"TimeoutsDispatcher");
             var inputAddress = selectedTransportDefinition.GetSubScope(localAddress, "Timeouts");
 
-            var messageProcessorPipeline = context.AddSatellitePipeline("Timeout Message Processor", inputAddress);
-            messageProcessorPipeline.Register<MoveFaultsToErrorQueueBehavior.Registration>();
-            messageProcessorPipeline.Register<FirstLevelRetriesBehavior.Registration>();
-            messageProcessorPipeline.Register<TimeoutMessageProcessorBehavior.Registration>();
+            var messageProcessorPipeline = context.AddSatellitePipeline("Timeout Message Processor", inputAddress, new TimeoutMessageProcessorBehavior.Registration());
+            messageProcessorPipeline.EnableFeature<StoreFaultsInErrorQueue>();
+            messageProcessorPipeline.EnableFeature<FirstLevelRetries>();
 
             context.Container.ConfigureComponent<TimeoutMessageProcessorBehavior>(DependencyLifecycle.SingleInstance)
                 .ConfigureProperty(t => t.InputAddress, inputAddress)
                 .ConfigureProperty(t => t.EndpointName, context.Settings.EndpointName());
 
-            var dispatcherProcessorPipeline = context.AddSatellitePipeline("Timeout Dispatcher Processor", dispatcherAddress);
-            dispatcherProcessorPipeline.Register<MoveFaultsToErrorQueueBehavior.Registration>();
-            dispatcherProcessorPipeline.Register<FirstLevelRetriesBehavior.Registration>();
-            dispatcherProcessorPipeline.Register<TimeoutDispatcherProcessorBehavior.Registration>();
+            var dispatcherProcessorPipeline = context.AddSatellitePipeline("Timeout Dispatcher Processor", dispatcherAddress, new TimeoutDispatcherProcessorBehavior.Registration());
+            dispatcherProcessorPipeline.EnableFeature<StoreFaultsInErrorQueue>();
+            dispatcherProcessorPipeline.EnableFeature<FirstLevelRetries>();
 
             context.Container.ConfigureComponent<TimeoutDispatcherProcessorBehavior>(DependencyLifecycle.SingleInstance)
                 .ConfigureProperty(t => t.InputAddress, dispatcherAddress);

--- a/src/NServiceBus.Core/Faults/StoreFaultsInErrorQueue.cs
+++ b/src/NServiceBus.Core/Faults/StoreFaultsInErrorQueue.cs
@@ -23,7 +23,7 @@ namespace NServiceBus.Features
             {
                 var pipelinesCollection = context.Settings.Get<PipelineConfiguration>();
 
-                var dispatchPipeline = new PipelineBase<DispatchContext>(b, context.Settings, pipelinesCollection.MainPipeline);
+                var dispatchPipeline = new PipelineBase<DispatchContext>(b, context.Settings, pipelinesCollection.CreateMainPipeline());
 
                 return new MoveFaultsToErrorQueueBehavior(
                     b.Build<CriticalError>(),

--- a/src/NServiceBus.Core/Features/SatelliteRegistration.cs
+++ b/src/NServiceBus.Core/Features/SatelliteRegistration.cs
@@ -1,0 +1,45 @@
+﻿namespace NServiceBus.Features
+{
+    using System;
+    using NServiceBus.Pipeline;
+
+    /// <summary>
+    /// Allows to customize satellite registration.
+    /// </summary>
+    public class SatelliteRegistration
+    {
+        readonly Satellite satellite;
+
+        internal SatelliteRegistration(Satellite satellite)
+        {
+            this.satellite = satellite;
+        }
+
+        /// <summary>
+        /// Allows to register satellite-specific behaviors that belong only to this satellite.
+        /// </summary>
+        public PipelineSettings SpecificBehaviors
+        {
+            get { return new PipelineSettings(satellite.SpecificFeaturesRegistration); }
+        }
+
+        /// <summary>
+        /// Enables feature <paramref name="featureType"/> for this satellite by registering this feature's behaviors in the satellite pipeline.
+        /// </summary>
+        /// <param name="featureType">The feature to enable.</param>
+        public void EnableFeature(Type featureType)
+        {
+            satellite.EnableFeature(featureType);
+        }
+
+        /// <summary>
+        /// Enables feature <typeparamref name="T"/> for this satellite by registering this feature's behaviors in the satellite pipeline.
+        /// </summary>
+        /// <typeparam name="T">The feature to enable.</typeparam>
+        public void EnableFeature<T>() where T : Feature
+        {
+            satellite.EnableFeature(typeof(T));
+        }
+
+    }
+}

--- a/src/NServiceBus.Core/Forwarding/ForwardReceivedMessages.cs
+++ b/src/NServiceBus.Core/Forwarding/ForwardReceivedMessages.cs
@@ -33,7 +33,7 @@
             context.Container.ConfigureComponent(b =>
             {
                 var pipelinesCollection = context.Settings.Get<PipelineConfiguration>();
-                var pipeline = new PipelineBase<ForwardingContext>(b, context.Settings, pipelinesCollection.MainPipeline);
+                var pipeline = new PipelineBase<ForwardingContext>(b, context.Settings, pipelinesCollection.CreateMainPipeline());
 
                 return new InvokeForwardingPipelineBehavior(pipeline, forwardReceivedMessagesQueue);
             }, DependencyLifecycle.InstancePerCall);

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Faults\ErrorSubscribers.cs" />
     <Compile Include="Features\FeatureRunner.cs" />
     <Compile Include="Features\FeatureState.cs" />
+    <Compile Include="Features\SatelliteRegistration.cs" />
     <Compile Include="FirstLevelRetries\FirstLevelRetry.cs" />
     <Compile Include="Faults\ErrorQueueSettings.cs" />
     <Compile Include="Faults\StoreFaultsInErrorQueue.cs" />
@@ -176,9 +177,14 @@
     <Compile Include="Pipeline\Contexts\LogicalMessagesContextExtensions.cs" />
     <Compile Include="OutgoingPipeline\OutgoingPublishContext.cs" />
     <Compile Include="Pipeline\Contexts\TransportMessageContextExtensions.cs" />
+    <Compile Include="Pipeline\FeatureBehaviorsRegistration.cs" />
     <Compile Include="Pipeline\IPipelineTerminator.cs" />
     <Compile Include="Pipeline\IStageConnector.cs" />
     <Compile Include="Pipeline\PipelineDiagnostics.cs" />
+    <Compile Include="Pipeline\PipelineModifications.cs" />
+    <Compile Include="Pipeline\PipelineModificationsComposer.cs" />
+    <Compile Include="Pipeline\Satellite.cs" />
+    <Compile Include="Pipeline\SatelliteCollection.cs" />
     <Compile Include="Reliability\Outbox\DeliveryConstraintsFactory.cs" />
     <Compile Include="Reliability\Outbox\OutboxDispatchStrategy.cs" />
     <Compile Include="Performance\ReceiveStatisticsFeature.cs" />
@@ -359,7 +365,7 @@
     <Compile Include="Persistence\Storage.cs" />
     <Compile Include="Persistence\StorageType.cs" />
     <Compile Include="Pipeline\HardcodedPipelineSteps.cs" />
-    <Compile Include="Pipeline\PipelineModifications.cs" />
+    <Compile Include="Pipeline\PipelineModificationsBuilder.cs" />
     <Compile Include="Sagas\CorrelationProperty.cs" />
     <Compile Include="Sagas\CustomFinderAdapter.cs" />
     <Compile Include="Sagas\LoadSagaByIdWrapper.cs" />

--- a/src/NServiceBus.Core/Pipeline/FeatureBehaviorsRegistration.cs
+++ b/src/NServiceBus.Core/Pipeline/FeatureBehaviorsRegistration.cs
@@ -1,0 +1,26 @@
+﻿namespace NServiceBus.Pipeline
+{
+    using System;
+
+    class FeatureBehaviorsRegistration
+    {
+        readonly Type featureType;
+        readonly PipelineModificationsBuilder registration;
+
+        public FeatureBehaviorsRegistration(Type featureType, PipelineModificationsBuilder registration)
+        {
+            this.featureType = featureType;
+            this.registration = registration;
+        }
+
+        public Type FeatureType
+        {
+            get { return featureType; }
+        }
+
+        public PipelineModificationsBuilder Registration
+        {
+            get { return registration; }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/PipelineConfiguration.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineConfiguration.cs
@@ -1,14 +1,49 @@
 ﻿namespace NServiceBus.Pipeline
 {
+    using System;
     using System.Collections.Generic;
+    using System.Linq;
     using NServiceBus.ObjectBuilder;
     using NServiceBus.Settings;
 
     class PipelineConfiguration
     {
-        public readonly PipelineModifications MainPipeline = new PipelineModifications();
-        public readonly List<SatellitePipelineModifications> SatellitePipelines = new List<SatellitePipelineModifications>();
+        readonly List<FeatureBehaviorsRegistration> featureBehaviorsRegistrations = new List<FeatureBehaviorsRegistration>();
+        readonly PipelineModificationsBuilder userDefinedBehaviors;
+
+        public PipelineConfiguration(PipelineModificationsBuilder userDefinedBehaviors)
+        {
+            this.userDefinedBehaviors = userDefinedBehaviors;
+        }
+
+        public void RegisterFeatureBehaviors(Type featureType, PipelineModificationsBuilder registrations)
+        {
+            featureBehaviorsRegistrations.Add(new FeatureBehaviorsRegistration(featureType, registrations));
+        }
+
         public RegisterStep ReceiveBehavior { get; set; }
+
+        public PipelineModifications CreateSatellitePipeline(Satellite satellite)
+        {
+            var composer = new PipelineModificationsComposer();
+            foreach (var registration in featureBehaviorsRegistrations.Where(x => satellite.IsEnabled(x.FeatureType)))
+            {
+                composer.AddSource(registration.Registration);
+            }
+            composer.AddSource(satellite.SpecificFeaturesRegistration);
+            return composer.Compose();
+        }
+
+        public PipelineModifications CreateMainPipeline()
+        {
+            var composer = new PipelineModificationsComposer();
+            foreach (var registration in featureBehaviorsRegistrations)
+            {
+                composer.AddSource(registration.Registration);
+            }
+            composer.AddSource(userDefinedBehaviors);
+            return composer.Compose();
+        }
 
         public void RegisterBehaviorsInContainer(SettingsHolder settings, IConfigureComponents container)
         {
@@ -16,14 +51,10 @@
             {
                 ReceiveBehavior.ApplyContainerRegistration(settings, container);
             }
-            RegisterBehaviorsInContainer(MainPipeline, settings, container);
-            foreach (var satellitePipeline in SatellitePipelines)
-            {
-                RegisterBehaviorsInContainer(satellitePipeline, settings, container);
-            }
+            RegisterBehaviorsInContainer(CreateMainPipeline(), settings, container);
         }
 
-        void RegisterBehaviorsInContainer(PipelineModifications pipeline, SettingsHolder settings, IConfigureComponents container)
+        static void RegisterBehaviorsInContainer(PipelineModifications pipeline, SettingsHolder settings, IConfigureComponents container)
         {
             foreach (var registeredBehavior in pipeline.Replacements)
             {

--- a/src/NServiceBus.Core/Pipeline/PipelineModifications.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModifications.cs
@@ -1,23 +1,31 @@
 ﻿namespace NServiceBus.Pipeline
 {
-    using System.Collections.Generic;
-
     class PipelineModifications
     {
-        public List<RegisterStep> Additions = new List<RegisterStep>();
-        public List<RemoveStep> Removals = new List<RemoveStep>();
-        public List<ReplaceBehavior> Replacements = new List<ReplaceBehavior>();
-    }
+        readonly RegisterStep[] additions;
+        readonly RemoveStep[] removals;
+        readonly ReplaceBehavior[] replacements;
 
-    class SatellitePipelineModifications : PipelineModifications
-    {
-        public readonly string Name;
-        public readonly string ReceiveAddress;
-
-        public SatellitePipelineModifications(string name, string receiveAddress)
+        public PipelineModifications(RegisterStep[] additions, RemoveStep[] removals, ReplaceBehavior[] replacements)
         {
-            Name = name;
-            ReceiveAddress = receiveAddress;
+            this.additions = additions;
+            this.removals = removals;
+            this.replacements = replacements;
+        }
+
+        public RegisterStep[] Additions
+        {
+            get { return additions; }
+        }
+
+        public RemoveStep[] Removals
+        {
+            get { return removals; }
+        }
+
+        public ReplaceBehavior[] Replacements
+        {
+            get { return replacements; }
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/PipelineModificationsBuilder.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModificationsBuilder.cs
@@ -1,0 +1,30 @@
+﻿namespace NServiceBus.Pipeline
+{
+    using System.Collections.Generic;
+
+    class PipelineModificationsBuilder
+    {
+        readonly List<RegisterStep> additions = new List<RegisterStep>();
+        readonly List<RemoveStep> removals = new List<RemoveStep>();
+        readonly List<ReplaceBehavior> replacements = new List<ReplaceBehavior>();
+
+        public void AddRemoval(RemoveStep removeStep)
+        {
+            removals.Add(removeStep);
+        }
+
+        public void AddReplacement(ReplaceBehavior replaceBehavior)
+        {
+            replacements.Add(replaceBehavior);
+        }
+
+        public void AddAddition(RegisterStep step)
+        {
+            additions.Add(step);
+        }
+
+        public IEnumerable<RegisterStep> Additions { get { return additions; }}
+        public IEnumerable<RemoveStep> Removals { get { return removals; }}
+        public IEnumerable<ReplaceBehavior> Replacements { get { return replacements; }}
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/PipelineModificationsComposer.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModificationsComposer.cs
@@ -1,0 +1,24 @@
+﻿namespace NServiceBus.Pipeline
+{
+    using System.Collections.Generic;
+    using System.Linq;
+
+    class PipelineModificationsComposer
+    {
+        readonly List<PipelineModificationsBuilder> sources = new List<PipelineModificationsBuilder>();
+
+        public void AddSource(PipelineModificationsBuilder source)
+        {
+            sources.Add(source);
+        }
+
+        public PipelineModifications Compose()
+        {
+            return new PipelineModifications(
+                sources.SelectMany(x => x.Additions).ToArray(),
+                sources.SelectMany(x => x.Removals).ToArray(),
+                sources.SelectMany(x => x.Replacements).ToArray()
+                );
+        }
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
@@ -13,7 +13,7 @@ namespace NServiceBus.Pipeline
         /// <summary>
         /// Initializes a new instance of <see cref="PipelineSettings"/>.
         /// </summary>
-        internal PipelineSettings(PipelineModifications modifications)
+        internal PipelineSettings(PipelineModificationsBuilder modifications)
         {
             this.modifications = modifications;
         }
@@ -27,7 +27,7 @@ namespace NServiceBus.Pipeline
             // I can only remove a behavior that is registered and other behaviors do not depend on, eg InsertBefore/After
             Guard.AgainstNullAndEmpty("stepId", stepId);
 
-            modifications.Removals.Add(new RemoveStep(stepId));
+            modifications.AddRemoval(new RemoveStep(stepId));
         }
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace NServiceBus.Pipeline
             Guard.AgainstNullAndEmpty("stepId", stepId);
 
             registeredBehaviors.Add(newBehavior);
-            modifications.Replacements.Add(new ReplaceBehavior(stepId, newBehavior, description));
+            modifications.AddReplacement(new ReplaceBehavior(stepId, newBehavior, description));
         }
 
         /// <summary>
@@ -138,13 +138,13 @@ namespace NServiceBus.Pipeline
         {
             registeredSteps.Add(step);
 
-            modifications.Additions.Add(step);
+            modifications.AddAddition(step);
         }
 
         List<RegisterStep> registeredSteps = new List<RegisterStep>();
         List<Type> registeredBehaviors = new List<Type>();
 
-        PipelineModifications modifications;
+        PipelineModificationsBuilder modifications;
 
 
         internal void RegisterConnector<T>(string description) where T : IStageConnector

--- a/src/NServiceBus.Core/Pipeline/Satellite.cs
+++ b/src/NServiceBus.Core/Pipeline/Satellite.cs
@@ -1,0 +1,46 @@
+namespace NServiceBus.Pipeline
+{
+    using System;
+    using System.Collections.Generic;
+
+    class Satellite
+    {
+        readonly HashSet<Type> enabledFeatures = new HashSet<Type>();
+        readonly string name;
+        readonly string receiveAddress;
+        readonly PipelineModificationsBuilder specificFeaturesRegistration = new PipelineModificationsBuilder();
+
+        public Satellite(string name, string receiveAddress, RegisterStep pipelineBehavior)
+        {
+            this.name = name;
+            this.receiveAddress = receiveAddress;
+            specificFeaturesRegistration.AddAddition(pipelineBehavior);
+            new PipelineSettings(specificFeaturesRegistration).RegisterConnector<TransportReceiveToPhysicalMessageProcessingConnector>("Allows to abort processing the message");
+        }
+
+        public string Name
+        {
+            get { return name; }
+        }
+
+        public string ReceiveAddress
+        {
+            get { return receiveAddress; }
+        }
+
+        public PipelineModificationsBuilder SpecificFeaturesRegistration
+        {
+            get { return specificFeaturesRegistration; }
+        }
+
+        public void EnableFeature(Type featureType)
+        {
+            enabledFeatures.Add(featureType);
+        }
+
+        public bool IsEnabled(Type featureType)
+        {
+            return enabledFeatures.Contains(featureType);
+        }
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/SatelliteCollection.cs
+++ b/src/NServiceBus.Core/Pipeline/SatelliteCollection.cs
@@ -1,0 +1,25 @@
+namespace NServiceBus.Pipeline
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    class SatelliteCollection
+    {
+        readonly List<Satellite> satellites = new List<Satellite>();
+
+        public void Register(Satellite satellite)
+        {
+            if (satellites.Any(x => x.Name == satellite.Name || x.ReceiveAddress == satellite.ReceiveAddress))
+            {
+                throw new InvalidOperationException("The given satellite name or receive address is already taken by another satellite.");
+            }
+            satellites.Add(satellite);
+        }
+
+        public IEnumerable<Satellite> Satellites
+        {
+            get { return satellites; }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/StepRegistrationsCoordinator.cs
+++ b/src/NServiceBus.Core/Pipeline/StepRegistrationsCoordinator.cs
@@ -6,7 +6,7 @@ namespace NServiceBus.Pipeline
 
     class StepRegistrationsCoordinator
     {
-        public StepRegistrationsCoordinator(List<RemoveStep> removals, List<ReplaceBehavior> replacements)
+        public StepRegistrationsCoordinator(IList<RemoveStep> removals, IList<ReplaceBehavior> replacements)
         {
             this.removals = removals;
             this.replacements = replacements;
@@ -38,7 +38,7 @@ namespace NServiceBus.Pipeline
             return piplineModelBuilder.Build();
         }
 
-        static IEnumerable<Type> ContextsReachableFrom<TRootContext>(List<RegisterStep> registerSteps)
+        static IEnumerable<Type> ContextsReachableFrom<TRootContext>(IEnumerable<RegisterStep> registerSteps)
         {
             var stageConnectors = registerSteps.Where(s => s.IsStageConnector())
                 .ToList();
@@ -58,20 +58,14 @@ namespace NServiceBus.Pipeline
             }
         }
 
-        static Type GetInputType(Type behaviorType)
-        {
-            var behaviorInterface = GetBehaviorInterface(behaviorType);
-            return behaviorInterface.GetGenericArguments()[0];
-        }
-
         static Type GetBehaviorInterface(Type behaviorType)
         {
             var behaviorInterface = behaviorType.GetInterfaces().First(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IBehavior<,>));
             return behaviorInterface;
         }
 
-        List<RegisterStep> additions = new List<RegisterStep>();
-        List<RemoveStep> removals;
-        List<ReplaceBehavior> replacements;
+        IList<RegisterStep> additions = new List<RegisterStep>();
+        IList<RemoveStep> removals;
+        IList<ReplaceBehavior> replacements;
     }
 }

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetries.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetries.cs
@@ -38,7 +38,7 @@ namespace NServiceBus.Features
             {
                 var pipelinesCollection = context.Settings.Get<PipelineConfiguration>();
              
-                var dispatchPipeline = new PipelineBase<DispatchContext>(b, context.Settings, pipelinesCollection.MainPipeline);
+                var dispatchPipeline = new PipelineBase<DispatchContext>(b, context.Settings, pipelinesCollection.CreateMainPipeline());
                 return new SecondLevelRetriesBehavior(dispatchPipeline,retryPolicy,b.Build<BusNotifications>());
             }, DependencyLifecycle.InstancePerCall);
         }

--- a/src/NServiceBus.Core/Unicast/ContextualBus.cs
+++ b/src/NServiceBus.Core/Unicast/ContextualBus.cs
@@ -56,7 +56,7 @@ namespace NServiceBus.Unicast
         /// </summary>
         public void Publish(object message, NServiceBus.PublishOptions options)
         {
-            var pipeline = new PipelineBase<OutgoingPublishContext>(builder, settings, settings.Get<PipelineConfiguration>().MainPipeline);
+            var pipeline = new PipelineBase<OutgoingPublishContext>(builder, settings, settings.Get<PipelineConfiguration>().CreateMainPipeline());
          
             var publishContext = new OutgoingPublishContext(
                 incomingContext,
@@ -149,7 +149,7 @@ namespace NServiceBus.Unicast
         /// </summary>
         public void Reply(object message, NServiceBus.ReplyOptions options)
         {
-            var pipeline = new PipelineBase<OutgoingReplyContext>(builder, settings, settings.Get<PipelineConfiguration>().MainPipeline);
+            var pipeline = new PipelineBase<OutgoingReplyContext>(builder, settings, settings.Get<PipelineConfiguration>().CreateMainPipeline());
 
             var outgoingContext = new OutgoingReplyContext(
                 incomingContext,
@@ -213,7 +213,7 @@ namespace NServiceBus.Unicast
 
         void SendMessage(Type messageType, object message, NServiceBus.SendOptions options)
         {
-            var pipeline = new PipelineBase<OutgoingSendContext>(builder, settings, settings.Get<PipelineConfiguration>().MainPipeline);
+            var pipeline = new PipelineBase<OutgoingSendContext>(builder, settings, settings.Get<PipelineConfiguration>().CreateMainPipeline());
 
             var outgoingContext = new OutgoingSendContext(
                 incomingContext,

--- a/src/NServiceBus.Core/Unicast/UnicastBusInternal.cs
+++ b/src/NServiceBus.Core/Unicast/UnicastBusInternal.cs
@@ -102,13 +102,15 @@ namespace NServiceBus.Unicast
 
         IEnumerable<TransportReceiver> BuildPipelines()
         {
-            var pipelinesCollection = settings.Get<PipelineConfiguration>();
+            var pipelineConfiguration = settings.Get<PipelineConfiguration>();
+            var satelliteCollection = settings.Get<SatelliteCollection>();
 
-            yield return BuildPipelineInstance(pipelinesCollection.MainPipeline, pipelinesCollection.ReceiveBehavior, "Main", settings.LocalAddress());
+            yield return BuildPipelineInstance(pipelineConfiguration.CreateMainPipeline(), pipelineConfiguration.ReceiveBehavior, "Main", settings.LocalAddress());
 
-            foreach (var satellite in pipelinesCollection.SatellitePipelines)
+            foreach (var satellite in satelliteCollection.Satellites)
             {
-                yield return BuildPipelineInstance(satellite, pipelinesCollection.ReceiveBehavior, satellite.Name, satellite.ReceiveAddress);
+                var pipeline = pipelineConfiguration.CreateSatellitePipeline(satellite);
+                yield return BuildPipelineInstance(pipeline, pipelineConfiguration.ReceiveBehavior, satellite.Name, satellite.ReceiveAddress);
             }
         }
 


### PR DESCRIPTION
The old V6 pipeline API was based on individual behaviors. If you wanted to add a pipeline, you would write code like this:

```
var messageProcessorPipeline = context.AddSatellitePipeline("Timeout Message Processor", inputAddress);
messageProcessorPipeline.Register<MoveFaultsToErrorQueueBehavior.Registration>();
messageProcessorPipeline.Register<FirstLevelRetriesBehavior.Registration>();
messageProcessorPipeline.Register<TimeoutMessageProcessorBehavior.Registration>();
```

the problem with this API is that it adds `FirstLevelRetriesBehavior` and `TimeoutMessageProcessorBehavior` breaching feature encapsulation. Other features (`TimeoutManager` in this example) should not know the behaviors of other features.

This PR proposes a better API:

```
var messageProcessorPipeline = context.AddSatellitePipeline("Timeout Message Processor", inputAddress, new TimeoutMessageProcessorBehavior.Registration());
messageProcessorPipeline.EnableFeature<StoreFaultsInErrorQueue>();
messageProcessorPipeline.EnableFeature<FirstLevelRetries>();
```

The responsibility of a feature is to register its behaviors. All the enabled features' behaviors form the main pipeline. Satellite pipelines are composed of behaviors registered by features that are explicitly registered with a given satellite.