### PR TITLE
Saga persister options

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="MessageId\When_message_has_empty_id_header.cs" />
     <Compile Include="PubSub\When_publishing_an_event_implementing_two_unrelated_interfaces.cs" />
     <Compile Include="ApiExtension\When_extending_the_publish_api.cs" />
+    <Compile Include="Sagas\When_a_finder_exists_and_context_information_added.cs" />
     <Compile Include="Sagas\When_a_finder_exists_and_found_saga.cs" />
     <Compile Include="Recoverability\Retries\When_performing_slr_with_regular_exception.cs" />
     <Compile Include="Recoverability\Retries\When_performing_slr_with_serialization_exception.cs" />

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists.cs
@@ -34,7 +34,7 @@
             class CustomFinder : IFindSagas<TestSaga.SagaData>.Using<StartSagaMessage>
             {
                 public Context Context { get; set; }
-                public TestSaga.SagaData FindBy(StartSagaMessage message)
+                public TestSaga.SagaData FindBy(StartSagaMessage message, SagaPersistenceOptions options)
                 {
                     Context.FinderUsed = true;
                     return null;

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_context_information_added.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_context_information_added.cs
@@ -1,0 +1,100 @@
+namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Extensibility;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Saga;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_a_finder_exists_and_context_information_added
+    {
+        [Test]
+        public void Should_make_context_information_available()
+        {
+            var context = Scenario.Define<Context>()
+                .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage())))
+                .Done(c => c.FinderUsed)
+                .Run();
+
+            Assert.True(context.FinderUsed);
+            Assert.AreEqual(typeof(SagaEndpoint.TestSaga), context.Metadata.SagaType);
+            Assert.AreEqual("SomeData", context.ContextBag.Get<SagaEndpoint.BehaviorWhichAddsThingsToTheContext.State>().SomeData);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool FinderUsed { get; set; }
+            public SagaMetadata Metadata { get; set; }
+            public ContextBag ContextBag { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.Pipeline.Register<BehaviorWhichAddsThingsToTheContext.Registration>());
+            }
+
+            class CustomFinder : IFindSagas<TestSaga.SagaData>.Using<StartSagaMessage>
+            {
+                public Context Context { get; set; }
+                public TestSaga.SagaData FindBy(StartSagaMessage message, SagaPersistenceOptions options)
+                {
+                    Context.Metadata = options.Metadata;
+                    Context.ContextBag = options.Context;
+                    Context.FinderUsed = true;
+                    return null;
+                }
+            }
+
+            public class TestSaga : Saga<TestSaga.SagaData>, IAmStartedByMessages<StartSagaMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSagaMessage message)
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                {
+                }
+
+                public class SagaData : ContainSagaData
+                {
+                }
+            }
+
+            public class BehaviorWhichAddsThingsToTheContext : PhysicalMessageProcessingStageBehavior
+            {
+                public override void Invoke(Context context, Action next)
+                {
+                    context.Set(new State
+                    {
+                        SomeData = "SomeData"
+                    });
+
+                    next();
+                }
+
+                public class State
+                {
+                    public string SomeData { get; set; }
+                }
+
+                public class Registration : RegisterStep
+                {
+                    public Registration() : base("BehaviorWhichAddsThingsToTheContext", typeof(BehaviorWhichAddsThingsToTheContext), "BehaviorWhichAddsThingsToTheContext")
+                    {
+                    }
+                }
+            }
+        }
+
+        public class StartSagaMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_found_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_found_saga.cs
@@ -37,7 +37,7 @@
                 // ReSharper disable once MemberCanBePrivate.Global
                 public Context Context { get; set; }
 
-                public TestSaga.SagaData FindBy(SomeOtherMessage message)
+                public TestSaga.SagaData FindBy(SomeOtherMessage message, SagaPersistenceOptions options)
                 {
                     Context.FinderUsed = true;
                     return new TestSaga.SagaData

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_reply_from_a_finder.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_reply_from_a_finder.cs
@@ -46,7 +46,7 @@
                 public IBus Bus { get; set; }
                 public Context Context { get; set; }
 
-                public TestSagaWithCustomFinder.SagaData FindBy(StartSagaMessage message)
+                public TestSagaWithCustomFinder.SagaData FindBy(StartSagaMessage message, SagaPersistenceOptions options)
                 {
                     Bus.Reply(new SagaNotFoundMessage
                               {

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1966,7 +1966,6 @@ namespace NServiceBus.Saga
             where TSagaData : NServiceBus.Saga.IContainSagaData;
         TSagaData Get<TSagaData>(string propertyName, object propertyValue, NServiceBus.Saga.SagaPersistenceOptions options)
             where TSagaData : NServiceBus.Saga.IContainSagaData;
-        void Initialize(NServiceBus.Saga.SagaMetadataCollection allSagas);
         void Save(NServiceBus.Saga.IContainSagaData saga, NServiceBus.Saga.SagaPersistenceOptions options);
         void Update(NServiceBus.Saga.IContainSagaData saga, NServiceBus.Saga.SagaPersistenceOptions options);
     }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1961,14 +1961,14 @@ namespace NServiceBus.Saga
     }
     public interface ISagaPersister
     {
-        void Complete(NServiceBus.Saga.SagaMetadata metadata, NServiceBus.Saga.IContainSagaData saga);
-        TSagaData Get<TSagaData>(NServiceBus.Saga.SagaMetadata metadata, System.Guid sagaId)
+        void Complete(NServiceBus.Saga.IContainSagaData saga, NServiceBus.Saga.SagaPersistenceOptions options);
+        TSagaData Get<TSagaData>(System.Guid sagaId, NServiceBus.Saga.SagaPersistenceOptions options)
             where TSagaData : NServiceBus.Saga.IContainSagaData;
-        TSagaData Get<TSagaData>(NServiceBus.Saga.SagaMetadata metadata, string propertyName, object propertyValue)
+        TSagaData Get<TSagaData>(string propertyName, object propertyValue, NServiceBus.Saga.SagaPersistenceOptions options)
             where TSagaData : NServiceBus.Saga.IContainSagaData;
         void Initialize(NServiceBus.Saga.SagaMetadataCollection allSagas);
-        void Save(NServiceBus.Saga.SagaMetadata metadata, NServiceBus.Saga.IContainSagaData saga);
-        void Update(NServiceBus.Saga.SagaMetadata metadata, NServiceBus.Saga.IContainSagaData saga);
+        void Save(NServiceBus.Saga.IContainSagaData saga, NServiceBus.Saga.SagaPersistenceOptions options);
+        void Update(NServiceBus.Saga.IContainSagaData saga, NServiceBus.Saga.SagaPersistenceOptions options);
     }
     public abstract class Saga
     {
@@ -2044,6 +2044,12 @@ namespace NServiceBus.Saga
         public System.Collections.Generic.IEnumerator<NServiceBus.Saga.SagaMetadata> GetEnumerator() { }
         public void Initialize(System.Collections.Generic.IEnumerable<System.Type> availableTypes) { }
         public void Initialize(System.Collections.Generic.IEnumerable<System.Type> availableTypes, NServiceBus.Conventions conventions) { }
+    }
+    public class SagaPersistenceOptions
+    {
+        public SagaPersistenceOptions(NServiceBus.Saga.SagaMetadata sagaMetadata, NServiceBus.Extensibility.ContextBag context = null) { }
+        public NServiceBus.Extensibility.ContextBag Context { get; }
+        public NServiceBus.Saga.SagaMetadata Metadata { get; }
     }
     public class SagaPropertyMapper<TSagaData>
         where TSagaData : NServiceBus.Saga.IContainSagaData

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1948,7 +1948,7 @@ namespace NServiceBus.Saga
         public interface Using<T, M> : NServiceBus.Saga.IFinder
             where T : NServiceBus.Saga.IContainSagaData
         {
-            T FindBy(M message);
+            T FindBy(M message, NServiceBus.Saga.SagaPersistenceOptions options);
         }
     }
     public interface IHandleSagaNotFound

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/InMemoryPersisterBuilder.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/InMemoryPersisterBuilder.cs
@@ -18,7 +18,6 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
             var inMemorySagaPersister = new InMemorySagaPersister();
             var sagaMetaModel = new SagaMetadataCollection();
             sagaMetaModel.Initialize(sagaTypes, new Conventions());
-            inMemorySagaPersister.Initialize(sagaMetaModel);
             return inMemorySagaPersister;
         }
     }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_completing_a_saga_with_the_InMemory_persister.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_completing_a_saga_with_the_InMemory_persister.cs
@@ -12,11 +12,12 @@
         {
             var saga = new TestSagaData { Id = Guid.NewGuid() };
             var persister = InMemoryPersisterBuilder.Build<TestSaga>();
-            var metadata = SagaMetadata.Create(typeof(TestSaga));
-            persister.Save(metadata, saga);
-            Assert.NotNull(persister.Get<TestSagaData>(metadata, saga.Id));
-            persister.Complete(metadata, saga);
-            Assert.Null(persister.Get<TestSagaData>(metadata, saga.Id));
+            var options = new SagaPersistenceOptions(SagaMetadata.Create(typeof(TestSaga)));
+
+            persister.Save(saga, options);
+            Assert.NotNull(persister.Get<TestSagaData>(saga.Id, options));
+            persister.Complete(saga, options);
+            Assert.Null(persister.Get<TestSagaData>(saga.Id, options));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_completing_a_saga_with_unique_property_with_InMemory_persister.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_completing_a_saga_with_unique_property_with_InMemory_persister.cs
@@ -7,12 +7,12 @@
     [TestFixture]
     class When_completing_a_saga_with_unique_property_with_InMemory_persister
     {
-        SagaMetadata metadata;
+        SagaPersistenceOptions options;
 
         [SetUp]
         public void SetUp()
         {
-            metadata = SagaMetadata.Create(typeof(SagaWithUniqueProperty));
+            options = new SagaPersistenceOptions(SagaMetadata.Create(typeof(SagaWithUniqueProperty)));
         }
 
         [Test]
@@ -21,10 +21,10 @@
             var saga = new SagaWithUniquePropertyData { Id = Guid.NewGuid(), UniqueString = "whatever" };
 
             var persister = InMemoryPersisterBuilder.Build<SagaWithUniqueProperty>();
-            persister.Save(metadata, saga);
-            Assert.NotNull(persister.Get<SagaWithUniquePropertyData>(metadata, saga.Id));
-            persister.Complete(metadata, saga);
-            Assert.Null(persister.Get<SagaWithUniquePropertyData>(metadata, saga.Id));
+            persister.Save(saga, options);
+            Assert.NotNull(persister.Get<SagaWithUniquePropertyData>(saga.Id, options));
+            persister.Complete(saga, options);
+            Assert.Null(persister.Get<SagaWithUniquePropertyData>(saga.Id, options));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
@@ -14,14 +14,14 @@
             var saga2 = new SagaWithUniquePropertyData { Id = Guid.NewGuid(), UniqueString = "whatever" };
 
             var persister = InMemoryPersisterBuilder.Build<SagaWithUniqueProperty>();
-            var metadata = SagaMetadata.Create(typeof(SagaWithUniqueProperty));
+            var options = new SagaPersistenceOptions(SagaMetadata.Create(typeof(SagaWithUniqueProperty)));
 
-            persister.Save(metadata, saga1);
-            persister.Complete(metadata, saga1);
-            persister.Save(metadata, saga2);
-            persister.Complete(metadata, saga2);
-            persister.Save(metadata, saga1);
-            persister.Complete(metadata, saga1);
+            persister.Save(saga1, options);
+            persister.Complete(saga1, options);
+            persister.Save(saga2, options);
+            persister.Complete(saga2, options);
+            persister.Save(saga1, options);
+            persister.Complete(saga1, options);
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
@@ -13,11 +13,11 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
             var saga1 = new SagaWithUniquePropertyData { Id = Guid.NewGuid(), UniqueString = "whatever"};
             var saga2 = new SagaWithUniquePropertyData { Id = Guid.NewGuid(), UniqueString = "whatever" };
 
-            var metadata = SagaMetadata.Create(typeof(SagaWithUniqueProperty));
+            var options = new SagaPersistenceOptions(SagaMetadata.Create(typeof(SagaWithUniqueProperty)));
 
             var persister = InMemoryPersisterBuilder.Build(typeof(SagaWithUniqueProperty),typeof(SagaWithTwoUniqueProperties));
-            persister.Save(metadata, saga1);
-            Assert.Throws<InvalidOperationException>(() => persister.Save(metadata, saga2));
+            persister.Save(saga1, options);
+            Assert.Throws<InvalidOperationException>(() => persister.Save(saga2, options));
         }
         [Test]
         public void It_should_enforce_uniqueness_even_for_two_unique_properties()
@@ -26,12 +26,12 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
             var saga2 = new SagaWithTwoUniquePropertiesData { Id = Guid.NewGuid(), UniqueString = "whatever1", UniqueInt = 3};
             var saga3 = new SagaWithTwoUniquePropertiesData { Id = Guid.NewGuid(), UniqueString = "whatever3", UniqueInt = 3 };
 
-            var metadata = SagaMetadata.Create(typeof(SagaWithTwoUniqueProperties));
+            var options = new SagaPersistenceOptions(SagaMetadata.Create(typeof(SagaWithTwoUniqueProperties)));
 
             var persister = InMemoryPersisterBuilder.Build(typeof(SagaWithUniqueProperty), typeof(SagaWithTwoUniqueProperties));
-            persister.Save(metadata, saga1);
-            persister.Save(metadata, saga2);
-            Assert.Throws<InvalidOperationException>(() => persister.Save(metadata, saga3));
+            persister.Save(saga1, options);
+            persister.Save(saga2, options);
+            Assert.Throws<InvalidOperationException>(() => persister.Save(saga3, options));
         }
 
     }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_the_same_unique_property_as_the_original_value_of_another_saga_before_updating.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_the_same_unique_property_as_the_original_value_of_another_saga_before_updating.cs
@@ -13,15 +13,15 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
             var saga1 = new SagaWithUniquePropertyData{Id = Guid.NewGuid(), UniqueString = "whatever"};
             var saga2 = new SagaWithUniquePropertyData{Id = Guid.NewGuid(), UniqueString = "whatever"};
 
-            var metadata = SagaMetadata.Create(typeof(SagaWithUniqueProperty));
+            var options = new SagaPersistenceOptions(SagaMetadata.Create(typeof(SagaWithUniqueProperty)));
 
             var persister = InMemoryPersisterBuilder.Build<SagaWithUniqueProperty>();
-            persister.Save(metadata, saga1);
-            saga1 = persister.Get<SagaWithUniquePropertyData>(metadata, saga1.Id);
+            persister.Save(saga1, options);
+            saga1 = persister.Get<SagaWithUniquePropertyData>(saga1.Id, options);
             saga1.UniqueString = "whatever2";
-            persister.Update(metadata, saga1);
+            persister.Update(saga1, options);
 
-            persister.Save(metadata, saga2);
+            persister.Save(saga2, options);
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_different_sagas_with_unique_properties.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_different_sagas_with_unique_properties.cs
@@ -13,13 +13,13 @@
             var saga1 = new SagaWithTwoUniquePropertiesData { Id = Guid.NewGuid(), UniqueString = "whatever", UniqueInt = 5 };
             var saga2 = new AnotherSagaWithTwoUniquePropertiesData { Id = Guid.NewGuid(), UniqueString = "whatever", UniqueInt = 5 };
             var saga3 = new SagaWithUniquePropertyData { Id = Guid.NewGuid(), UniqueString = "whatever" };
-            var metadata1 = SagaMetadata.Create(typeof(SagaWithTwoUniqueProperties));
-            var metadata2 = SagaMetadata.Create(typeof(AnotherSagaWithTwoUniqueProperties));
-            var metadata3 = SagaMetadata.Create(typeof(SagaWithUniqueProperty));
+            var options1 = new SagaPersistenceOptions(SagaMetadata.Create(typeof(SagaWithTwoUniqueProperties)));
+            var options2 = new SagaPersistenceOptions(SagaMetadata.Create(typeof(AnotherSagaWithTwoUniqueProperties)));
+            var options3 = new SagaPersistenceOptions(SagaMetadata.Create(typeof(SagaWithUniqueProperty)));
             var persister = InMemoryPersisterBuilder.Build(typeof(SagaWithTwoUniqueProperties), typeof(AnotherSagaWithTwoUniqueProperties), typeof(SagaWithUniqueProperty));
-            persister.Save(metadata1, saga1);
-            persister.Save(metadata2, saga2);
-            persister.Save(metadata3, saga3);
+            persister.Save(saga1, options1);
+            persister.Save(saga2, options2);
+            persister.Save(saga3, options3);
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_property_is_null.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_property_is_null.cs
@@ -18,12 +18,12 @@
                        };
 
             var persister = InMemoryPersisterBuilder.Build<Saga>();
-            var metadata = SagaMetadata.Create(typeof(Saga));
+            var options = new SagaPersistenceOptions(SagaMetadata.Create(typeof(Saga)));
 
-            persister.Save(metadata, saga);
+            persister.Save(saga, options);
 
-            Assert.AreEqual(sagaId, persister.Get<SagaData>(metadata, "Property", null).Id);
-            Assert.IsNull(persister.Get<SagaData>(metadata, "Property", "a value"));
+            Assert.AreEqual(sagaId, persister.Get<SagaData>("Property", null, options).Id);
+            Assert.IsNull(persister.Get<SagaData>("Property", "a value", options));
         }
 
         class Saga : Saga<SagaData>

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_saga_not_found_return_default.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_saga_not_found_return_default.cs
@@ -7,19 +7,19 @@
     [TestFixture]
     class When_saga_not_found_return_default
     {
-        SagaMetadata metadata;
+        SagaPersistenceOptions options;
 
         [SetUp]
         public void SetUp()
         {
-            metadata = SagaMetadata.Create(typeof(SimpleSagaEntitySaga));
+            options = new SagaPersistenceOptions(SagaMetadata.Create(typeof(SimpleSagaEntitySaga)));
         }
 
         [Test]
         public void Should_return_default_when_using_finding_saga_with_property()
         {
             var persister = InMemoryPersisterBuilder.Build<SimpleSagaEntitySaga>();
-            var simpleSageEntity = persister.Get<SimpleSagaEntity>(metadata, "propertyNotFound", null);
+            var simpleSageEntity = persister.Get<SimpleSagaEntity>("propertyNotFound", null, options);
             Assert.IsNull(simpleSageEntity);
         }
 
@@ -27,7 +27,7 @@
         public void Should_return_default_when_using_finding_saga_with_id()
         {
             var persister = InMemoryPersisterBuilder.Build<SimpleSagaEntitySaga>();
-            var simpleSageEntity = persister.Get<SimpleSagaEntity>(metadata, Guid.Empty);
+            var simpleSageEntity = persister.Get<SimpleSagaEntity>(Guid.Empty, options);
             Assert.IsNull(simpleSageEntity);
         }
 
@@ -41,9 +41,9 @@
                 OrderSource = "CA"
             };
             var persister = InMemoryPersisterBuilder.Build<SimpleSagaEntitySaga>();
-            persister.Save(metadata, simpleSagaEntity);
+            persister.Save(simpleSagaEntity, options);
 
-            var anotherSagaEntity = persister.Get<AnotherSimpleSagaEntity>(metadata, id);
+            var anotherSagaEntity = persister.Get<AnotherSimpleSagaEntity>(id, options);
             Assert.IsNull(anotherSagaEntity);
         }
     }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_saving_a_null_unique_property.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_saving_a_null_unique_property.cs
@@ -18,9 +18,9 @@
                        };
 
             var persister = InMemoryPersisterBuilder.Build<Saga>();
-            var metadata = SagaMetadata.Create(typeof(Saga));
+            var options = new SagaPersistenceOptions(SagaMetadata.Create(typeof(Saga)));
 
-            var exception = Assert.Throws<InvalidOperationException>(() => persister.Save(metadata, saga));
+            var exception = Assert.Throws<InvalidOperationException>(() => persister.Save(saga, options));
             Assert.AreEqual("Cannot store saga with id '895e60e0-7be3-490a-afca-fe69184474ca' since the unique property 'Property' has a null value.", exception.Message);
         }
 

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_updating_a_saga_with_the_same_unique_property_as_another_saga.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_updating_a_saga_with_the_same_unique_property_as_another_saga.cs
@@ -14,16 +14,16 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
             var saga2 = new SagaWithUniquePropertyData {Id = Guid.NewGuid(), UniqueString = "whatever"};
 
             var persister = InMemoryPersisterBuilder.Build(typeof(SagaWithUniqueProperty), typeof(SagaWithTwoUniqueProperties));
-            var metadata = SagaMetadata.Create(typeof(SagaWithUniqueProperty));
+            var options = new SagaPersistenceOptions(SagaMetadata.Create(typeof(SagaWithUniqueProperty)));
 
-            persister.Save(metadata, saga1);
-            persister.Save(metadata, saga2);
+            persister.Save(saga1, options);
+            persister.Save(saga2, options);
 
             Assert.Throws<InvalidOperationException>(() => 
             {
-                var saga = persister.Get<SagaWithUniquePropertyData>(metadata, saga2.Id);
+                var saga = persister.Get<SagaWithUniquePropertyData>(saga2.Id, options);
                 saga.UniqueString = "whatever1";
-                persister.Update(metadata, saga);
+                persister.Update(saga, options);
             });
         }
 
@@ -34,16 +34,16 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
             var saga2 = new SagaWithTwoUniquePropertiesData { Id = Guid.NewGuid(), UniqueString = "whatever", UniqueInt = 37};
 
             var persister = InMemoryPersisterBuilder.Build(typeof(SagaWithUniqueProperty), typeof(SagaWithTwoUniqueProperties));
-            var metadata = SagaMetadata.Create(typeof(SagaWithTwoUniqueProperties));
+            var options = new SagaPersistenceOptions(SagaMetadata.Create(typeof(SagaWithTwoUniqueProperties)));
 
-            persister.Save(metadata, saga1);
-            persister.Save(metadata, saga2);
+            persister.Save(saga1, options);
+            persister.Save(saga2, options);
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                var saga = persister.Get<SagaWithTwoUniquePropertiesData>(metadata, saga2.Id);
+                var saga = persister.Get<SagaWithTwoUniquePropertiesData>(saga2.Id, options);
                 saga.UniqueInt = 5;
-                persister.Update(metadata, saga);
+                persister.Update(saga, options);
             });
         }
     }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_updating_a_saga_with_the_same_unique_property_value.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_updating_a_saga_with_the_same_unique_property_value.cs
@@ -16,11 +16,11 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
                     UniqueString = "whatever"
                 };
             var persister = InMemoryPersisterBuilder.Build<SagaWithUniqueProperty>();
-            var metadata = SagaMetadata.Create(typeof(SagaWithUniqueProperty));
+            var options = new SagaPersistenceOptions(SagaMetadata.Create(typeof(SagaWithUniqueProperty)));
 
-            persister.Save(metadata, saga1);
-            saga1 = persister.Get<SagaWithUniquePropertyData>(metadata, saga1.Id);
-            persister.Update(metadata, saga1);
+            persister.Save(saga1, options);
+            saga1 = persister.Get<SagaWithUniquePropertyData>(saga1.Id, options);
+            persister.Update(saga1, options);
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
@@ -96,7 +96,7 @@
 
             public class Finder : IFindSagas<SagaData>.Using<StartSagaMessage>
             {
-                public SagaData FindBy(StartSagaMessage message)
+                public SagaData FindBy(StartSagaMessage message, SagaPersistenceOptions options)
                 {
                     return null;
                 }
@@ -143,7 +143,7 @@
 
             public class Finder : IFindSagas<SagaData>.Using<StartSagaMessage>
             {
-                public SagaData FindBy(StartSagaMessage message)
+                public SagaData FindBy(StartSagaMessage message, SagaPersistenceOptions options)
                 {
                     return null;
                 }
@@ -412,7 +412,7 @@
 
             internal class CustomFinder : IFindSagas<SagaData>.Using<SomeMessage>
             {
-                public SagaData FindBy(SomeMessage message)
+                public SagaData FindBy(SomeMessage message, SagaPersistenceOptions options)
                 {
                     return null;
                 }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -220,6 +220,7 @@
     <Compile Include="Routing\RoutingContextExtensions.cs" />
     <Compile Include="Sagas\AutoCorrelationFeature.cs" />
     <Compile Include="Sagas\PopulateAutoCorrelationHeadersForRepliesBehavior.cs" />
+    <Compile Include="Saga\SagaPersistenceOptions.cs" />
     <Compile Include="Satellites\IAdvancedSatellite.cs" />
     <Compile Include="Satellites\ISatellite.cs" />
     <Compile Include="Routing\DetermineRouteForReplyBehavior.cs" />

--- a/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
@@ -17,7 +17,7 @@ namespace NServiceBus.InMemory.SagaPersister
         JsonMessageSerializer serializer = new JsonMessageSerializer(null);
         ConcurrentDictionary<Guid, VersionedSagaEntity> data = new ConcurrentDictionary<Guid, VersionedSagaEntity>();
 
-        public void Complete(SagaMetadata metadata, IContainSagaData saga)
+        public void Complete(IContainSagaData saga, SagaPersistenceOptions options)
         {
             VersionedSagaEntity value;
             data.TryRemove(saga.Id, out value);
@@ -28,7 +28,7 @@ namespace NServiceBus.InMemory.SagaPersister
             // No special setup required for in-memory persistence
         }
 
-        public TSagaData Get<TSagaData>(SagaMetadata metadata, string propertyName, object propertyValue) where TSagaData : IContainSagaData
+        public TSagaData Get<TSagaData>(string propertyName, object propertyValue, SagaPersistenceOptions options) where TSagaData : IContainSagaData
         {
             var values = data.Values.Where(x => x.SagaEntity is TSagaData);
             foreach (var entity in values)
@@ -49,7 +49,7 @@ namespace NServiceBus.InMemory.SagaPersister
             return default(TSagaData);
         }
 
-        public TSagaData Get<TSagaData>(SagaMetadata metadata, Guid sagaId) where TSagaData : IContainSagaData
+        public TSagaData Get<TSagaData>(Guid sagaId, SagaPersistenceOptions options) where TSagaData : IContainSagaData
         {
             VersionedSagaEntity result;
             if (data.TryGetValue(sagaId, out result) && (result != null) && (result.SagaEntity is TSagaData))
@@ -61,9 +61,9 @@ namespace NServiceBus.InMemory.SagaPersister
             return default(TSagaData);
         }
 
-        public void Save(SagaMetadata metadata, IContainSagaData saga)
+        public void Save(IContainSagaData saga, SagaPersistenceOptions options)
         {
-            ValidateUniqueProperties(metadata, saga);
+            ValidateUniqueProperties(options.Metadata, saga);
 
             VersionedSagaEntity sagaEntity;
             if (data.TryGetValue(saga.Id, out sagaEntity))
@@ -76,9 +76,9 @@ namespace NServiceBus.InMemory.SagaPersister
             Interlocked.Increment(ref version);
         }
 
-        public void Update(SagaMetadata metadata, IContainSagaData saga)
+        public void Update(IContainSagaData saga, SagaPersistenceOptions options)
         {
-            Save(metadata, saga);
+            Save(saga, options);
         }
 
         void ValidateUniqueProperties(SagaMetadata sagaMetaData, IContainSagaData saga)

--- a/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
@@ -23,11 +23,6 @@ namespace NServiceBus.InMemory.SagaPersister
             data.TryRemove(saga.Id, out value);
         }
 
-        public void Initialize(SagaMetadataCollection allSagas)
-        {
-            // No special setup required for in-memory persistence
-        }
-
         public TSagaData Get<TSagaData>(string propertyName, object propertyValue, SagaPersistenceOptions options) where TSagaData : IContainSagaData
         {
             var values = data.Values.Where(x => x.SagaEntity is TSagaData);

--- a/src/NServiceBus.Core/Saga/IFindSagas.cs
+++ b/src/NServiceBus.Core/Saga/IFindSagas.cs
@@ -15,7 +15,7 @@ namespace NServiceBus.Saga
             /// <summary>
             /// Finds a saga entity of the type T using a message of type M.
             /// </summary>
-            T FindBy(M message);
+            T FindBy(M message, SagaPersistenceOptions options);
         }
     }
 }

--- a/src/NServiceBus.Core/Saga/ISagaPersister.cs
+++ b/src/NServiceBus.Core/Saga/ISagaPersister.cs
@@ -8,48 +8,44 @@ namespace NServiceBus.Saga
     /// </summary>
     public interface ISagaPersister
     {
-		/// <summary>
-		/// Saves the saga entity to the persistence store.
+        /// <summary>
+        /// Saves the saga entity to the persistence store.
         /// </summary>
-        /// <param name="metadata">Metadata describing the saga being saved.</param>
-		/// <param name="saga">The saga entity to save.</param>
-        void Save(SagaMetadata metadata, IContainSagaData saga);
+        /// <param name="saga">The saga entity to save.</param>
+        /// <param name="options">The saga persistence options.</param>
+        void Save(IContainSagaData saga, SagaPersistenceOptions options);
 
         /// <summary>
         /// Updates an existing saga entity in the persistence store.
         /// </summary>
-        /// <param name="metadata">Metadata describing the saga being updated.</param>
         /// <param name="saga">The saga entity to updated.</param>
-        void Update(SagaMetadata metadata, IContainSagaData saga);
+        /// <param name="options">The saga persistence options.</param>
+        void Update(IContainSagaData saga, SagaPersistenceOptions options);
 
-		/// <summary>
-		/// Gets a saga entity from the persistence store by its Id.
+        /// <summary>
+        /// Gets a saga entity from the persistence store by its Id.
         /// </summary>
-        /// <param name="metadata">Metadata describing the saga being retrieved.</param>
-		/// <param name="sagaId">The Id of the saga entity to get.</param>
-        TSagaData Get<TSagaData>(SagaMetadata metadata, Guid sagaId) where TSagaData : IContainSagaData;
+        /// <param name="sagaId">The Id of the saga entity to get.</param>
+        /// <param name="options">The saga persistence options.</param>
+        TSagaData Get<TSagaData>(Guid sagaId, SagaPersistenceOptions options) where TSagaData : IContainSagaData;
 
         /// <summary>
         /// Looks up a saga entity by a given property.
         /// </summary>
-        /// <param name="metadata">Metadata describing the saga being completed.</param>
         /// <param name="propertyName">From the data store, analyze this property.</param>
         /// <param name="propertyValue">From the data store, look for this value in the identified property.</param>
-        TSagaData Get<TSagaData>(SagaMetadata metadata, string propertyName, object propertyValue) where TSagaData : IContainSagaData;
-
-		/// <summary>
-        /// Sets a saga as completed and removes it from the active saga list
-		/// in the persistence store.
-		/// </summary>
-		/// <param name="metadata">Metadata describing the saga being completed.</param>
-		/// <param name="saga">The saga to complete.</param>
-        void Complete(SagaMetadata metadata, IContainSagaData saga);
+        /// <param name="options">The saga persistence options.</param>
+        TSagaData Get<TSagaData>(string propertyName, object propertyValue, SagaPersistenceOptions options) where TSagaData : IContainSagaData;
 
         /// <summary>
         /// Implementers can initialize the persistence with the given meta model.
+        /// Sets a saga as completed and removes it from the active saga list
+        /// in the persistence store.
         /// </summary>
         /// <param name="allSagas">Metadata for all saga types found.</param>
         void Initialize(SagaMetadataCollection allSagas);
+        /// <param name="saga">The saga to complete.</param>
+        /// <param name="options">The saga persistence options.</param>
+        void Complete(IContainSagaData saga, SagaPersistenceOptions options);
     }
-
 }

--- a/src/NServiceBus.Core/Saga/ISagaPersister.cs
+++ b/src/NServiceBus.Core/Saga/ISagaPersister.cs
@@ -38,12 +38,9 @@ namespace NServiceBus.Saga
         TSagaData Get<TSagaData>(string propertyName, object propertyValue, SagaPersistenceOptions options) where TSagaData : IContainSagaData;
 
         /// <summary>
-        /// Implementers can initialize the persistence with the given meta model.
         /// Sets a saga as completed and removes it from the active saga list
         /// in the persistence store.
         /// </summary>
-        /// <param name="allSagas">Metadata for all saga types found.</param>
-        void Initialize(SagaMetadataCollection allSagas);
         /// <param name="saga">The saga to complete.</param>
         /// <param name="options">The saga persistence options.</param>
         void Complete(IContainSagaData saga, SagaPersistenceOptions options);

--- a/src/NServiceBus.Core/Saga/SagaPersistenceOptions.cs
+++ b/src/NServiceBus.Core/Saga/SagaPersistenceOptions.cs
@@ -15,6 +15,7 @@ namespace NServiceBus.Saga
         public SagaPersistenceOptions(SagaMetadata sagaMetadata, ContextBag context = null)
         {
             Metadata = sagaMetadata;
+            Context = context;
 
             if (context == null)
             {

--- a/src/NServiceBus.Core/Saga/SagaPersistenceOptions.cs
+++ b/src/NServiceBus.Core/Saga/SagaPersistenceOptions.cs
@@ -3,7 +3,7 @@ namespace NServiceBus.Saga
     using NServiceBus.Extensibility;
 
     /// <summary>
-    /// Contains details about the to be persisted saga
+    /// Contains details about the to be persisted saga.
     /// </summary>
     public class SagaPersistenceOptions
     {

--- a/src/NServiceBus.Core/Saga/SagaPersistenceOptions.cs
+++ b/src/NServiceBus.Core/Saga/SagaPersistenceOptions.cs
@@ -1,0 +1,35 @@
+namespace NServiceBus.Saga
+{
+    using NServiceBus.Extensibility;
+
+    /// <summary>
+    /// Contains details about the to be persisted saga
+    /// </summary>
+    public class SagaPersistenceOptions
+    {
+        /// <summary>
+        /// Creates a new instance of the SagaPersistenceOptions class.
+        /// </summary>
+        /// <param name="sagaMetadata">The saga metadata representing the to be persisted saga.</param>
+        /// <param name="context">The context.</param>
+        public SagaPersistenceOptions(SagaMetadata sagaMetadata, ContextBag context = null)
+        {
+            Metadata = sagaMetadata;
+
+            if (context == null)
+            {
+                Context = new ContextBag();
+            }
+        }
+
+        /// <summary>
+        /// The saga metadata representing the to be persisted saga.
+        /// </summary>
+        public SagaMetadata Metadata { get; private set; }
+
+        /// <summary>
+        /// Access to the behavior context.
+        /// </summary>
+        public ContextBag Context { get; private set; }
+    }
+}

--- a/src/NServiceBus.Core/Sagas/CustomFinderAdapter.cs
+++ b/src/NServiceBus.Core/Sagas/CustomFinderAdapter.cs
@@ -5,12 +5,13 @@ namespace NServiceBus.Saga
 
     class CustomFinderAdapter<TSagaData,TMessage> : SagaFinder where TSagaData : IContainSagaData
     {
-        internal override IContainSagaData Find(IBuilder builder,SagaFinderDefinition finderDefinition, object message)
+        internal override IContainSagaData Find(IBuilder builder, SagaFinderDefinition finderDefinition, SagaPersistenceOptions options, object message)
         {
             var customFinderType = (Type)finderDefinition.Properties["custom-finder-clr-type"];
 
             var finder = (IFindSagas<TSagaData>.Using<TMessage>)builder.Build(customFinderType);
 
+            // TODO Daniel: The options might also need to flow into the user's finders?
             return finder.FindBy((TMessage) message);
         }
     }

--- a/src/NServiceBus.Core/Sagas/CustomFinderAdapter.cs
+++ b/src/NServiceBus.Core/Sagas/CustomFinderAdapter.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Saga
             var finder = (IFindSagas<TSagaData>.Using<TMessage>)builder.Build(customFinderType);
 
             // TODO Daniel: The options might also need to flow into the user's finders?
-            return finder.FindBy((TMessage) message);
+            return finder.FindBy((TMessage) message, options);
         }
     }
 }

--- a/src/NServiceBus.Core/Sagas/CustomFinderAdapter.cs
+++ b/src/NServiceBus.Core/Sagas/CustomFinderAdapter.cs
@@ -11,7 +11,6 @@ namespace NServiceBus.Saga
 
             var finder = (IFindSagas<TSagaData>.Using<TMessage>)builder.Build(customFinderType);
 
-            // TODO Daniel: The options might also need to flow into the user's finders?
             return finder.FindBy((TMessage) message, options);
         }
     }

--- a/src/NServiceBus.Core/Sagas/LoadSagaByIdWrapper.cs
+++ b/src/NServiceBus.Core/Sagas/LoadSagaByIdWrapper.cs
@@ -6,14 +6,14 @@ namespace NServiceBus.Saga
     //this class in only here until we can move to a better saga persister api
     class LoadSagaByIdWrapper<T>:SagaLoader where T : IContainSagaData
     {
-        public IContainSagaData Load(ISagaPersister persister, SagaMetadata metadata, string sagaId)
+        public IContainSagaData Load(ISagaPersister persister, string sagaId, SagaPersistenceOptions options)
         {
-            return persister.Get<T>(metadata, Guid.Parse(sagaId));
+            return persister.Get<T>(Guid.Parse(sagaId), options);
         }
     }
 
     interface SagaLoader
     {
-        IContainSagaData Load(ISagaPersister persister, SagaMetadata metadata, string sagaId);
+        IContainSagaData Load(ISagaPersister persister, string sagaId, SagaPersistenceOptions options);
     }
 }

--- a/src/NServiceBus.Core/Sagas/PropertySagaFinder.cs
+++ b/src/NServiceBus.Core/Sagas/PropertySagaFinder.cs
@@ -9,28 +9,25 @@ namespace NServiceBus.Saga
     class PropertySagaFinder<TSagaData> : SagaFinder where TSagaData : IContainSagaData
     {
         ISagaPersister sagaPersister;
-        SagaMetadataCollection sagaMetadataCollection;
 
-        public PropertySagaFinder(ISagaPersister sagaPersister, SagaMetadataCollection sagaMetadataCollection)
+        public PropertySagaFinder(ISagaPersister sagaPersister)
         {
             this.sagaPersister = sagaPersister;
-            this.sagaMetadataCollection = sagaMetadataCollection;
         }
 
-        internal override IContainSagaData Find(IBuilder builder,SagaFinderDefinition finderDefinition, object message)
+        internal override IContainSagaData Find(IBuilder builder, SagaFinderDefinition finderDefinition, SagaPersistenceOptions options, object message)
         {
             var propertyAccessor = (Func<object,object>)finderDefinition.Properties["property-accessor"];
             var propertyValue = propertyAccessor(message);
 
             var sagaPropertyName = (string)finderDefinition.Properties["saga-property-name"];
-            var sagaMetadata = sagaMetadataCollection.FindByEntity(typeof(TSagaData));
 
             if (sagaPropertyName.ToLower() == "id")
             {
-                return sagaPersister.Get<TSagaData>(sagaMetadata, (Guid)propertyValue);
+                return sagaPersister.Get<TSagaData>((Guid)propertyValue, options);
             }
 
-            return sagaPersister.Get<TSagaData>(sagaMetadata, sagaPropertyName, propertyValue);
+            return sagaPersister.Get<TSagaData>(sagaPropertyName, propertyValue, options);
         }
     }
 }

--- a/src/NServiceBus.Core/Sagas/SagaFinder.cs
+++ b/src/NServiceBus.Core/Sagas/SagaFinder.cs
@@ -5,6 +5,6 @@
 
     abstract class SagaFinder
     {
-        internal abstract IContainSagaData Find(IBuilder builder,SagaFinderDefinition finderDefinition, object message);
+        internal abstract IContainSagaData Find(IBuilder builder,SagaFinderDefinition finderDefinition, SagaPersistenceOptions options, object message);
     }
 }

--- a/src/NServiceBus.Core/Sagas/Sagas.cs
+++ b/src/NServiceBus.Core/Sagas/Sagas.cs
@@ -29,8 +29,6 @@
             Defaults(s => s.Set<SagaMetadataCollection>(new SagaMetadataCollection()));
 
             Prerequisite(config => config.Settings.GetAvailableTypes().Any(IsSagaType), "No sagas was found in scanned types");
-
-            RegisterStartupTask<CallISagaPersisterInitializeMethod>();
         }
 
         /// <summary>
@@ -98,22 +96,5 @@
         }
 
         Conventions conventions;
-
-        class CallISagaPersisterInitializeMethod : FeatureStartupTask
-        {
-            ISagaPersister persister;
-            SagaMetadataCollection model;
-
-            public CallISagaPersisterInitializeMethod(ISagaPersister persister, SagaMetadataCollection model)
-            {
-                this.persister = persister;
-                this.model = model;
-            }
-
-            protected override void OnStart()
-            {
-                persister.Initialize(model);
-            }
-        }
     }
 }


### PR DESCRIPTION
This PR is part of https://github.com/Particular/FeatureDevelopment/issues/324 and addresses the following two issues:

- The `Initialize` method is not useful on the saga persister interface. It is currently not envisioned to be used by NH and RavenDB. If it is needed in the future the `SagaMetadataCollection` is already present in the settings dictionary.
- Introduces `SagaPersistenceOptions` which allow to float `BehaviorContext` information into the persister, thus enabling the persister to retrieve the initialized sessions, transactions, connections etc. directly from the context bag.

~~There is a `TODO` left~~

https://github.com/Particular/NServiceBus/pull/2794/files#diff-e050e3190aac0540961a4da77f6f46c2R14

Wasn't sure if we should already float the options into the user`s finders.

@particular/nservicebus thoughts? // cc @davidboike