### PR TITLE
Interface for readonly context bag

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_context_information_added.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_context_information_added.cs
@@ -28,7 +28,7 @@ namespace NServiceBus.AcceptanceTests.Sagas
         {
             public bool FinderUsed { get; set; }
             public SagaMetadata Metadata { get; set; }
-            public ContextBag ContextBag { get; set; }
+            public ReadOnlyContextBag ContextBag { get; set; }
         }
 
         public class SagaEndpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1072,7 +1072,7 @@ namespace NServiceBus.Encryption
 }
 namespace NServiceBus.Extensibility
 {
-    public class ContextBag : NServiceBus.Extensibility.ReadonlyContextBag
+    public class ContextBag : NServiceBus.Extensibility.ReadOnlyContextBag
     {
         public ContextBag(NServiceBus.Extensibility.ContextBag parentBag = null) { }
         public T Get<T>() { }
@@ -1091,7 +1091,7 @@ namespace NServiceBus.Extensibility
     {
         public static NServiceBus.Extensibility.ContextBag GetExtensions(this NServiceBus.Extensibility.ExtendableOptions options) { }
     }
-    public interface ReadonlyContextBag
+    public interface ReadOnlyContextBag
     {
         T Get<T>();
         bool TryGet<T>(out T result);

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1072,7 +1072,7 @@ namespace NServiceBus.Encryption
 }
 namespace NServiceBus.Extensibility
 {
-    public class ContextBag
+    public class ContextBag : NServiceBus.Extensibility.ReadonlyContextBag
     {
         public ContextBag(NServiceBus.Extensibility.ContextBag parentBag = null) { }
         public T Get<T>() { }
@@ -1090,6 +1090,11 @@ namespace NServiceBus.Extensibility
     public class static ExtendableOptionsExtensions
     {
         public static NServiceBus.Extensibility.ContextBag GetExtensions(this NServiceBus.Extensibility.ExtendableOptions options) { }
+    }
+    public interface ReadonlyContextBag
+    {
+        T Get<T>();
+        bool TryGet<T>(out T result);
     }
 }
 namespace NServiceBus.Faults

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1582,8 +1582,8 @@ namespace NServiceBus.Outbox
     }
     public class OutboxStorageOptions
     {
-        public OutboxStorageOptions(NServiceBus.Extensibility.ContextBag context) { }
-        public NServiceBus.Extensibility.ContextBag Context { get; set; }
+        public OutboxStorageOptions(NServiceBus.Extensibility.ReadOnlyContextBag context) { }
+        public NServiceBus.Extensibility.ReadOnlyContextBag Context { get; set; }
     }
     public class TransportOperation
     {
@@ -2056,8 +2056,8 @@ namespace NServiceBus.Saga
     }
     public class SagaPersistenceOptions
     {
-        public SagaPersistenceOptions(NServiceBus.Saga.SagaMetadata sagaMetadata, NServiceBus.Extensibility.ContextBag context = null) { }
-        public NServiceBus.Extensibility.ContextBag Context { get; }
+        public SagaPersistenceOptions(NServiceBus.Saga.SagaMetadata sagaMetadata, NServiceBus.Extensibility.ReadOnlyContextBag context = null) { }
+        public NServiceBus.Extensibility.ReadOnlyContextBag Context { get; }
         public NServiceBus.Saga.SagaMetadata Metadata { get; }
     }
     public class SagaPropertyMapper<TSagaData>

--- a/src/NServiceBus.Core/Extensibility/ContextBag.cs
+++ b/src/NServiceBus.Core/Extensibility/ContextBag.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Extensibility
     /// <summary>
     /// A string object bag of context objects.
     /// </summary>
-    public class ContextBag
+    public class ContextBag : ReadonlyContextBag
     {
         /// <summary>
         /// Initialized a new instance of <see cref="ContextBag"/>.

--- a/src/NServiceBus.Core/Extensibility/ContextBag.cs
+++ b/src/NServiceBus.Core/Extensibility/ContextBag.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Extensibility
     /// <summary>
     /// A string object bag of context objects.
     /// </summary>
-    public class ContextBag : ReadonlyContextBag
+    public class ContextBag : ReadOnlyContextBag
     {
         /// <summary>
         /// Initialized a new instance of <see cref="ContextBag"/>.

--- a/src/NServiceBus.Core/Extensibility/ReadonlyContextBag.cs
+++ b/src/NServiceBus.Core/Extensibility/ReadonlyContextBag.cs
@@ -1,7 +1,7 @@
 namespace NServiceBus.Extensibility
 {
     /// <summary>
-    /// Context bag which is readonly
+    /// Context bag which is readonly.
     /// </summary>
     public interface ReadonlyContextBag
     {

--- a/src/NServiceBus.Core/Extensibility/ReadonlyContextBag.cs
+++ b/src/NServiceBus.Core/Extensibility/ReadonlyContextBag.cs
@@ -1,0 +1,23 @@
+namespace NServiceBus.Extensibility
+{
+    /// <summary>
+    /// Context bag which is readonly
+    /// </summary>
+    public interface ReadonlyContextBag
+    {
+        /// <summary>
+        /// Retrieves the specified type from the context.
+        /// </summary>
+        /// <typeparam name="T">The type to retrieve.</typeparam>
+        /// <returns>The type instance.</returns>
+        T Get<T>();
+
+        /// <summary>
+        /// Tries to retrieves the specified type from the context.
+        /// </summary>
+        /// <typeparam name="T">The type to retrieve.</typeparam>
+        /// <param name="result">The type instance.</param>
+        /// <returns><code>true</code> if found, otherwise <code>false</code>.</returns>
+        bool TryGet<T>(out T result);
+    }
+}

--- a/src/NServiceBus.Core/Extensibility/ReadonlyContextBag.cs
+++ b/src/NServiceBus.Core/Extensibility/ReadonlyContextBag.cs
@@ -3,7 +3,7 @@ namespace NServiceBus.Extensibility
     /// <summary>
     /// Context bag which is readonly.
     /// </summary>
-    public interface ReadonlyContextBag
+    public interface ReadOnlyContextBag
     {
         /// <summary>
         /// Retrieves the specified type from the context.

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -138,7 +138,7 @@
     <Compile Include="BusNotifications.cs" />
     <Compile Include="Extensibility\ExtendableOptions.cs" />
     <Compile Include="Extensibility\ExtendableOptionsExtensions.cs" />
-    <Compile Include="Extensibility\ReadonlyContextBag.cs" />
+    <Compile Include="Extensibility\ReadOnlyContextBag.cs" />
     <Compile Include="Faults\ConfigureError.cs" />
     <Compile Include="Faults\FailedMessage.cs" />
     <Compile Include="Faults\ErrorsNotifications.cs" />

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -138,6 +138,7 @@
     <Compile Include="BusNotifications.cs" />
     <Compile Include="Extensibility\ExtendableOptions.cs" />
     <Compile Include="Extensibility\ExtendableOptionsExtensions.cs" />
+    <Compile Include="Extensibility\ReadonlyContextBag.cs" />
     <Compile Include="Faults\ConfigureError.cs" />
     <Compile Include="Faults\FailedMessage.cs" />
     <Compile Include="Faults\ErrorsNotifications.cs" />

--- a/src/NServiceBus.Core/Reliability/Outbox/OutboxStorageOptions.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/OutboxStorageOptions.cs
@@ -11,7 +11,7 @@
         /// Creates a new instance of the OutboxStorageOptions class.
         /// </summary>
         /// <param name="context">The context.</param>
-        public OutboxStorageOptions(ContextBag context)
+        public OutboxStorageOptions(ReadOnlyContextBag context)
         {
             Context = context;
         }
@@ -19,6 +19,6 @@
         /// <summary>
         /// Access to the behavior context.
         /// </summary>
-        public ContextBag Context { get; set; }
+        public ReadOnlyContextBag Context { get; set; }
     }
 }

--- a/src/NServiceBus.Core/Saga/SagaPersistenceOptions.cs
+++ b/src/NServiceBus.Core/Saga/SagaPersistenceOptions.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Saga
         /// </summary>
         /// <param name="sagaMetadata">The saga metadata representing the to be persisted saga.</param>
         /// <param name="context">The context.</param>
-        public SagaPersistenceOptions(SagaMetadata sagaMetadata, ContextBag context = null)
+        public SagaPersistenceOptions(SagaMetadata sagaMetadata, ReadOnlyContextBag context = null)
         {
             Metadata = sagaMetadata;
             Context = context;
@@ -31,6 +31,6 @@ namespace NServiceBus.Saga
         /// <summary>
         /// Access to the behavior context.
         /// </summary>
-        public ContextBag Context { get; private set; }
+        public ReadOnlyContextBag Context { get; private set; }
     }
 }


### PR DESCRIPTION
This PR is part of https://github.com/Particular/FeatureDevelopment/issues/324 and addresses the following:

Introduces a readonly view onto the `ContextBag`. While working on the saga persister, outbox persister and such I realized that when we pass the `ContextBag` into the persister they should probably not be allowed to modify this bag. 

@Particular/nservicebus thoughts?