### PR TITLE
XmlSerializer now serializes properties of `object` type properly

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Persistence\PersistenceStorageMergerTests.cs" />
     <Compile Include="Sagas\SagaModelTests.cs" />
     <Compile Include="Sagas\TypeBasedSagaMetaModelTests.cs" />
+    <Compile Include="Serializers\XML\Issue_2796.cs" />
     <Compile Include="StandardsTests.cs" />
     <Compile Include="Encryption\ConfigureRijndaelEncryptionServiceTests.cs" />
     <Compile Include="Encryption\RijndaelEncryptionServiceTest.cs" />
@@ -300,7 +301,7 @@
       <Project>{dd48b2d0-e996-412d-9157-821ed8b17a9d}</Project>
       <Name>NServiceBus.Core</Name>
     </ProjectReference>
-  </ItemGroup> 
+  </ItemGroup>
   <ItemGroup>
     <Content Include="TestDlls\dotNet.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/NServiceBus.Core.Tests/Serializers/XML/Issue_2796.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/Issue_2796.cs
@@ -1,0 +1,41 @@
+﻿namespace NServiceBus.Core.Tests.Serializers.XML
+{
+    using System;
+    using System.IO;
+    using NServiceBus.Serializers.XML.Test;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class Issue_2796
+    {
+        [Test]
+        public void Object_property_with_primitive_or_struct_value_should_serialize_correctly()
+        {
+            var serializer = SerializerFactory.Create<SerializedPair>();
+            var message = new SerializedPair
+            {
+                Key = "AddressId",
+                Value = new Guid("{ebdeeb33-baa7-4100-b1aa-eb4d6816fd3d}")
+            };
+
+            object[] messageDeserialized;
+            using (Stream stream = new MemoryStream())
+            {
+                serializer.Serialize(message, stream);
+
+                stream.Position = 0;
+
+                messageDeserialized = serializer.Deserialize(stream, new[] { message.GetType() });
+            }
+
+            Assert.AreEqual(message.Key, ((SerializedPair)messageDeserialized[0]).Key);
+            Assert.AreEqual(message.Value, ((SerializedPair)messageDeserialized[0]).Value);
+        }
+
+        public class SerializedPair
+        {
+            public string Key { get; set; }
+            public object Value { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
## Who's affected

Users with V5.X endpoints configured to use XML message serialization, when using fields of type `System.Object` that are assigned primitive or simple (e.g. Guid, DateTime) types.

## Symptoms

Serialization will not generate namespaces for simple types, and deserialization will fail, since the message element does not have all the appropriate namespaces.

## Steps to reproduce

Trying to serialize, then deserialize the following type fill fail, when the `Value` property is assigned a simple type, e.g. Guid:

    public class SerializedPair
    {
        public string Key { get; set; }
        public object Value { get; set; }
    }


## Workaround

none

### Original bug report

I'm currently upgrading from NServiceBus 4.7.5 to NServiceBus 5.2.4, and when using the XmlSerializer, I noticed that it generates an invalid XML message when I try to serialize a message - 
the namespaces for the simple types are no longer declared, but they're still used in the document.

For example, if I try to serialize a message that exposes a SerializedPair property that is defined as follows:

    public class SerializedPair
    {
        public string Key { get; set; }
        public object Value { get; set; }
    }

in 4.7.5 it would be serialized as:

    <?xml version="1.0"?>
    <Messages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
              xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
              xmlns="http://tempuri.net/xxx.Crm.ServiceBusMessages" 
              xmlns:guid="Guid" xmlns:int32="Int32" 
              xmlns:string="String" 
              xmlns:datetime="DateTime" 
              xmlns:boolean="Boolean" 
              xmlns:decimal="Decimal">
        <UpdateContact>
            <SerializedPair>
                <Key>AddressId</Key>
                <guid:Value>ebdeeb33-baa7-4100-b1aa-eb4d6816fd3d</guid:Value>
            </SerializedPair>
           ....

In 5.2.4, it gets serialized as:

    <?xml version="1.0" ?>
    <UpdateContact xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
                   xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
                   xmlns="http://tempuri.net/xxx.Crm.ServiceBusMessages">
        <SerializedPair>
            <Key>AddressId</Key>
            <guid:Value>70a22cd7-64fd-4d6d-ab13-2ad7800addc7</guid:Value>
        </SerializedPair>
        ....
        

Note that the "Messages" element is no longer present, and the "xmlns:guid" namespace declaration is also missing, which makes this invalid XML.
How do I get NServiceBus to generate valid xml again?
        
For completeness, my BusConfiguration looks like:

    BusConfiguration busConfiguration = new BusConfiguration();
    busConfiguration.UseSerialization<XmlSerializer>();
    busConfiguration.UseTransport<MsmqTransport>();
    ISendOnlyBus bus = Bus.CreateSendOnly(busConfiguration);


This was originally posted in http://stackoverflow.com/q/31943814/90882