### PR TITLE
Timeout persistence options

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2298,10 +2298,13 @@ namespace NServiceBus.Timeout.Core
 {
     public interface IPersistTimeouts
     {
-        void Add(NServiceBus.Timeout.Core.TimeoutData timeout);
+        void Add(NServiceBus.Timeout.Core.TimeoutData timeout, NServiceBus.Timeout.Core.TimeoutPersistenceOptions options);
+        void RemoveTimeoutBy(System.Guid sagaId, NServiceBus.Timeout.Core.TimeoutPersistenceOptions options);
+        bool TryRemove(string timeoutId, NServiceBus.Timeout.Core.TimeoutPersistenceOptions options, out NServiceBus.Timeout.Core.TimeoutData timeoutData);
+    }
+    public interface IQueryTimeouts
+    {
         System.Collections.Generic.IEnumerable<System.Tuple<string, System.DateTime>> GetNextChunk(System.DateTime startSlice, out System.DateTime nextTimeToRunQuery);
-        void RemoveTimeoutBy(System.Guid sagaId);
-        bool TryRemove(string timeoutId, out NServiceBus.Timeout.Core.TimeoutData timeoutData);
     }
     public class TimeoutData
     {
@@ -2323,6 +2326,11 @@ namespace NServiceBus.Timeout.Core
         [System.ObsoleteAttribute("Use new OutgoingMessage(timeoutData.State) instead. Will be removed in version 7." +
             "0.0.", true)]
         public NServiceBus.TransportMessage ToTransportMessage() { }
+    }
+    public class TimeoutPersistenceOptions
+    {
+        public TimeoutPersistenceOptions(NServiceBus.Extensibility.ReadOnlyContextBag context) { }
+        public NServiceBus.Extensibility.ReadOnlyContextBag Context { get; set; }
     }
 }
 namespace NServiceBus.TransportDispatch

--- a/src/NServiceBus.Core.Tests/Timeout/InMemoryTimeoutPersisterTests.cs
+++ b/src/NServiceBus.Core.Tests/Timeout/InMemoryTimeoutPersisterTests.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Core.Tests.Timeout
 {
     using System;
     using System.Linq;
+    using NServiceBus.Extensibility;
     using NServiceBus.InMemory.TimeoutPersister;
     using NServiceBus.Timeout.Core;
     using NUnit.Framework;
@@ -23,16 +24,17 @@ namespace NServiceBus.Core.Tests.Timeout
         {
             DateTime nextTimeToRunQuery;
             var now = DateTime.UtcNow;
+            var options = new TimeoutPersistenceOptions(new ContextBag());
             var persister = new InMemoryTimeoutPersister();
             persister.Add(new TimeoutData
                           {
                               Time = DateTime.Now.AddDays(2)
-                          });
+                          }, options);
             var expectedDate = DateTime.Now.AddDays(1);
             persister.Add(new TimeoutData
                           {
                               Time = expectedDate
-                          });
+                          }, options);
             persister.GetNextChunk(now, out nextTimeToRunQuery);
             Assert.AreEqual(expectedDate, nextTimeToRunQuery);
         }
@@ -41,19 +43,20 @@ namespace NServiceBus.Core.Tests.Timeout
         public void When_multiple_future_are_returned()
         {
             DateTime nextTime;
+            var options = new TimeoutPersistenceOptions(new ContextBag());
             var persister = new InMemoryTimeoutPersister();
             persister.Add(new TimeoutData
                           {
                               Time = DateTime.Now.AddDays(-2)
-                          });
+                          }, options);
             persister.Add(new TimeoutData
                           {
                               Time = DateTime.Now.AddDays(-4)
-                          });
+                          }, options);
             persister.Add(new TimeoutData
                           {
                               Time = DateTime.Now.AddDays(-1)
-                          });
+                          }, options);
             var nextChunk = persister.GetNextChunk(DateTime.Now.AddDays(-3), out nextTime);
             Assert.AreEqual(2, nextChunk.Count());
         }
@@ -61,11 +64,12 @@ namespace NServiceBus.Core.Tests.Timeout
         [Test]
         public void When_existing_is_removed_existing_is_outted()
         {
+            var options = new TimeoutPersistenceOptions(new ContextBag());
             var persister = new InMemoryTimeoutPersister();
             var inputTimeout = new TimeoutData();
-            persister.Add(inputTimeout);
+            persister.Add(inputTimeout, options);
             TimeoutData removedTimeout;
-            var removed = persister.TryRemove(inputTimeout.Id, out removedTimeout);
+            var removed = persister.TryRemove(inputTimeout.Id, options, out removedTimeout);
             Assert.IsTrue(removed);
             Assert.AreSame(inputTimeout, removedTimeout);
         }
@@ -73,17 +77,18 @@ namespace NServiceBus.Core.Tests.Timeout
         [Test]
         public void When_existing_is_removed_by_saga_id()
         {
+            var options = new TimeoutPersistenceOptions(new ContextBag());
             var persister = new InMemoryTimeoutPersister();
             var newGuid = Guid.NewGuid();
             var inputTimeout = new TimeoutData
                                {
                                    SagaId = newGuid
                                };
-            persister.Add(inputTimeout);
+            persister.Add(inputTimeout, options);
 
-            persister.RemoveTimeoutBy(newGuid);
+            persister.RemoveTimeoutBy(newGuid, options);
             TimeoutData removedTimeout;
-            var removed = persister.TryRemove(inputTimeout.Id, out removedTimeout);
+            var removed = persister.TryRemove(inputTimeout.Id, options, out removedTimeout);
             Assert.False(removed);
         }
 
@@ -92,19 +97,20 @@ namespace NServiceBus.Core.Tests.Timeout
         {
             DateTime nextTimeToRunQuery;
             var now = DateTime.UtcNow;
+            var options = new TimeoutPersistenceOptions(new ContextBag());
             var persister = new InMemoryTimeoutPersister();
             persister.Add(new TimeoutData
                           {
                               Time = DateTime.Now.AddDays(-1)
-                          });
+                          }, options);
             persister.Add(new TimeoutData
                           {
                               Time = DateTime.Now.AddDays(-3)
-                          });
+                          }, options);
             persister.Add(new TimeoutData
                           {
                               Time = DateTime.Now.AddDays(-2)
-                          });
+                          }, options);
             persister.GetNextChunk(now, out nextTimeToRunQuery);
             Assert.That(nextTimeToRunQuery, Is.EqualTo(now.AddMinutes(1)).Within(100).Milliseconds);
         }

--- a/src/NServiceBus.Core.Tests/Timeout/InMemoryTimeoutPersisterThreadTests.cs
+++ b/src/NServiceBus.Core.Tests/Timeout/InMemoryTimeoutPersisterThreadTests.cs
@@ -5,6 +5,7 @@ namespace NServiceBus.Core.Tests.Timeout
     using System.Diagnostics;
     using System.Linq;
     using System.Threading;
+    using NServiceBus.Extensibility;
     using NServiceBus.InMemory.TimeoutPersister;
     using NServiceBus.Timeout.Core;
     using NUnit.Framework;
@@ -20,11 +21,12 @@ namespace NServiceBus.Core.Tests.Timeout
         public void Run()
         {
             var stopwatch = Stopwatch.StartNew();
+            var options = new TimeoutPersistenceOptions(new ContextBag());
             var inMemoryTimeoutPersister = new InMemoryTimeoutPersister();
 
             for (var i = 0; i < 10; i++)
             {
-                var thread = new Thread(() => Runner(inMemoryTimeoutPersister));
+                var thread = new Thread(() => Runner(inMemoryTimeoutPersister, options));
                 thread.Start();
                 thread.Join();
             }
@@ -32,42 +34,42 @@ namespace NServiceBus.Core.Tests.Timeout
             Console.Out.WriteLine(stopwatch.ElapsedMilliseconds);
         }
 
-        void Runner(InMemoryTimeoutPersister inMemoryTimeoutPersister)
+        void Runner(InMemoryTimeoutPersister inMemoryTimeoutPersister, TimeoutPersistenceOptions options)
         {
             for (var i = 0; i < 10000; i++)
             {
                 GetNextChunk(inMemoryTimeoutPersister);
-                Add(inMemoryTimeoutPersister);
+                Add(inMemoryTimeoutPersister, options);
                 GetNextChunk(inMemoryTimeoutPersister);
-                TryRemove(inMemoryTimeoutPersister);
+                TryRemove(inMemoryTimeoutPersister, options);
                 GetNextChunk(inMemoryTimeoutPersister);
-                RemoveTimeoutBy(inMemoryTimeoutPersister);
+                RemoveTimeoutBy(inMemoryTimeoutPersister, options);
                 GetNextChunk(inMemoryTimeoutPersister);
             }
         }
 
-        void RemoveTimeoutBy(InMemoryTimeoutPersister inMemoryTimeoutPersister)
+        void RemoveTimeoutBy(IPersistTimeouts inMemoryTimeoutPersister, TimeoutPersistenceOptions options)
         {
             var sagaId = sagaIdGuids.GetOrAdd(Thread.CurrentThread.ManagedThreadId, new Guid());
-            inMemoryTimeoutPersister.RemoveTimeoutBy(sagaId);
+            inMemoryTimeoutPersister.RemoveTimeoutBy(sagaId, options);
         }
 
-        void TryRemove(InMemoryTimeoutPersister inMemoryTimeoutPersister)
+        static void TryRemove(IPersistTimeouts inMemoryTimeoutPersister, TimeoutPersistenceOptions options)
         {
             TimeoutData timeout;
-            inMemoryTimeoutPersister.TryRemove(Thread.CurrentThread.Name, out timeout);
+            inMemoryTimeoutPersister.TryRemove(Thread.CurrentThread.Name, options, out timeout);
         }
 
-        void Add(InMemoryTimeoutPersister inMemoryTimeoutPersister)
+        static void Add(IPersistTimeouts inMemoryTimeoutPersister, TimeoutPersistenceOptions options)
         {
             inMemoryTimeoutPersister.Add(new TimeoutData
             {
                 Time = DateTime.Now,
                 Id = Thread.CurrentThread.Name
-            });
+            }, options);
         }
 
-        void GetNextChunk(InMemoryTimeoutPersister inMemoryTimeoutPersister)
+        static void GetNextChunk(IQueryTimeouts inMemoryTimeoutPersister)
         {
             for (var i = 0; i < 10; i++)
             {

--- a/src/NServiceBus.Core.Tests/Timeout/When_receiving_timeouts.cs
+++ b/src/NServiceBus.Core.Tests/Timeout/When_receiving_timeouts.cs
@@ -2,6 +2,8 @@ namespace NServiceBus.Core.Tests.Timeout
 {
     using System;
     using System.Collections.Generic;
+    using NServiceBus.Extensibility;
+    using NServiceBus.InMemory.TimeoutPersister;
     using NServiceBus.Timeout.Core;
     using NUnit.Framework;
 
@@ -12,19 +14,17 @@ namespace NServiceBus.Core.Tests.Timeout
         [Test]
         public void Should_dispatch_timeout_if_is_due_now()
         {
+            var options = new TimeoutPersistenceOptions(new ContextBag());
            var  messageSender = new FakeMessageSender();
 
-            var manager = new DefaultTimeoutManager
-            {
-                MessageSender = messageSender
-            };
+            var manager = new DefaultTimeoutManager(new InMemoryTimeoutPersister(), messageSender);
 
             manager.PushTimeout(new TimeoutData
                 {
                     Time = DateTime.UtcNow,
                     Destination = "local",
                     Headers = new Dictionary<string, string> { {Headers.MessageId,"msg id"}}
-                });
+                }, options);
 
             Assert.AreEqual(1, messageSender.MessagesSent);
         }

--- a/src/NServiceBus.Core.Tests/Timeout/When_removing_timeouts_from_the_storage.cs
+++ b/src/NServiceBus.Core.Tests/Timeout/When_removing_timeouts_from_the_storage.cs
@@ -4,51 +4,44 @@
     using System.Collections.Generic;
     using System.Linq;
     using InMemory.TimeoutPersister;
+    using NServiceBus.Extensibility;
     using NServiceBus.Timeout.Core;
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_removing_timeouts_from_the_storage_with_inMemory : When_removing_timeouts_from_the_storage
+    public class When_removing_timeouts_from_the_storage_with_inMemory
     {
-        protected override IPersistTimeouts CreateTimeoutPersister()
-        {
-            return new InMemoryTimeoutPersister();
-        }
-    }
-
-    public abstract class When_removing_timeouts_from_the_storage
-    {
-        protected IPersistTimeouts persister;
-
-        protected abstract IPersistTimeouts CreateTimeoutPersister();
+        InMemoryTimeoutPersister persister;
+        TimeoutPersistenceOptions options;
 
         [SetUp]
         public void Setup()
         {
-            persister = CreateTimeoutPersister();
+            options = new TimeoutPersistenceOptions(new ContextBag());
+            persister = new InMemoryTimeoutPersister();
         }
 
         [Test]
         public void Should_remove_timeouts_by_id()
         {
-            var t1 = new TimeoutData {Id = "1", Time = DateTime.UtcNow.AddHours(-1)};
-            persister.Add(t1);
+            var t1 = new TimeoutData { Id = "1", Time = DateTime.UtcNow.AddHours(-1) };
+            persister.Add(t1, options);
 
-            var t2 = new TimeoutData {Id = "2", Time = DateTime.UtcNow.AddHours(-1)};
-            persister.Add(t2);
+            var t2 = new TimeoutData { Id = "2", Time = DateTime.UtcNow.AddHours(-1) };
+            persister.Add(t2, options);
 
             var timeouts = GetNextChunk();
 
             foreach (var timeout in timeouts)
             {
                 TimeoutData timeoutData;
-                persister.TryRemove(timeout.Item1, out timeoutData);
+                persister.TryRemove(timeout.Item1, options, out timeoutData);
             }
 
             Assert.AreEqual(0, GetNextChunk().Count());
         }
 
-        protected IEnumerable<Tuple<string, DateTime>> GetNextChunk()
+        IEnumerable<Tuple<string, DateTime>> GetNextChunk()
         {
             DateTime nextTimeToRunQuery;
             return persister.GetNextChunk(DateTime.UtcNow.AddYears(-3), out nextTimeToRunQuery);

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Core/IPersistTimeouts.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Core/IPersistTimeouts.cs
@@ -13,27 +13,31 @@ namespace NServiceBus.Timeout.Core
         /// </summary>
         /// <param name="startSlice">The time where to start retrieving the next slice, the slice should exclude this date.</param>
         /// <param name="nextTimeToRunQuery">Returns the next time we should query again.</param>
+        /// <param name="options">The timeout persistence options</param>
         /// <returns>Returns the next range of timeouts that are due.</returns>
-        IEnumerable<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery);
+        IEnumerable<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, TimeoutPersistenceOptions options, out DateTime nextTimeToRunQuery);
 
         /// <summary>
         /// Adds a new timeout.
         /// </summary>
         /// <param name="timeout">Timeout data.</param>
-        void Add(TimeoutData timeout);
+        /// <param name="options">The timeout persistence options</param>
+        void Add(TimeoutData timeout, TimeoutPersistenceOptions options);
 
         /// <summary>
         /// Removes the timeout if it hasn't been previously removed.
         /// </summary>
         /// <param name="timeoutId">The timeout id to remove.</param>
         /// <param name="timeoutData">The timeout data of the removed timeout.</param>
+        /// <param name="options">The timeout persistence options</param>
         /// <returns><c>true</c> it the timeout was successfully removed.</returns>
-        bool TryRemove(string timeoutId, out TimeoutData timeoutData);
+        bool TryRemove(string timeoutId, TimeoutPersistenceOptions options, out TimeoutData timeoutData);
 
         /// <summary>
         /// Removes the time by saga id.
         /// </summary>
         /// <param name="sagaId">The saga id of the timeouts to remove.</param>
-        void RemoveTimeoutBy(Guid sagaId);
+        /// <param name="options">The timeout persistence options</param>
+        void RemoveTimeoutBy(Guid sagaId, TimeoutPersistenceOptions options);
     }
 }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Core/IPersistTimeouts.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Core/IPersistTimeouts.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Timeout.Core
 {
     using System;
-    using System.Collections.Generic;
 
     /// <summary>
     /// Timeout persister contract.
@@ -9,19 +8,10 @@ namespace NServiceBus.Timeout.Core
     public interface IPersistTimeouts
     {
         /// <summary>
-        /// Retrieves the next range of timeouts that are due.
-        /// </summary>
-        /// <param name="startSlice">The time where to start retrieving the next slice, the slice should exclude this date.</param>
-        /// <param name="nextTimeToRunQuery">Returns the next time we should query again.</param>
-        /// <param name="options">The timeout persistence options</param>
-        /// <returns>Returns the next range of timeouts that are due.</returns>
-        IEnumerable<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, TimeoutPersistenceOptions options, out DateTime nextTimeToRunQuery);
-
-        /// <summary>
         /// Adds a new timeout.
         /// </summary>
         /// <param name="timeout">Timeout data.</param>
-        /// <param name="options">The timeout persistence options</param>
+        /// <param name="options">The timeout persistence options.</param>
         void Add(TimeoutData timeout, TimeoutPersistenceOptions options);
 
         /// <summary>
@@ -29,7 +19,7 @@ namespace NServiceBus.Timeout.Core
         /// </summary>
         /// <param name="timeoutId">The timeout id to remove.</param>
         /// <param name="timeoutData">The timeout data of the removed timeout.</param>
-        /// <param name="options">The timeout persistence options</param>
+        /// <param name="options">The timeout persistence options.</param>
         /// <returns><c>true</c> it the timeout was successfully removed.</returns>
         bool TryRemove(string timeoutId, TimeoutPersistenceOptions options, out TimeoutData timeoutData);
 
@@ -37,7 +27,7 @@ namespace NServiceBus.Timeout.Core
         /// Removes the time by saga id.
         /// </summary>
         /// <param name="sagaId">The saga id of the timeouts to remove.</param>
-        /// <param name="options">The timeout persistence options</param>
+        /// <param name="options">The timeout persistence options.</param>
         void RemoveTimeoutBy(Guid sagaId, TimeoutPersistenceOptions options);
     }
 }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Core/IQueryTimeouts.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Core/IQueryTimeouts.cs
@@ -1,0 +1,19 @@
+namespace NServiceBus.Timeout.Core
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Allows to query for timeouts.
+    /// </summary>
+    public interface IQueryTimeouts
+    {
+        /// <summary>
+        /// Retrieves the next range of timeouts that are due.
+        /// </summary>
+        /// <param name="startSlice">The time where to start retrieving the next slice, the slice should exclude this date.</param>
+        /// <param name="nextTimeToRunQuery">Returns the next time we should query again.</param>
+        /// <returns>Returns the next range of timeouts that are due.</returns>
+        IEnumerable<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery);
+    }
+}

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Core/TimeoutPersistenceOptions.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Core/TimeoutPersistenceOptions.cs
@@ -1,0 +1,24 @@
+namespace NServiceBus.Timeout.Core
+{
+    using NServiceBus.Extensibility;
+
+    /// <summary>
+    /// Contains details about the to be persisted timeouts.
+    /// </summary>
+    public class TimeoutPersistenceOptions
+    {
+        /// <summary>
+        /// Creates a new instance of the TimeoutPersistenceOptions class.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        public TimeoutPersistenceOptions(ReadOnlyContextBag context)
+        {
+            Context = context;
+        }
+
+        /// <summary>
+        /// Access to the behavior context.
+        /// </summary>
+        public ReadOnlyContextBag Context { get; set; }
+    }
+}

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutDispatcherProcessorBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutDispatcherProcessorBehavior.cs
@@ -13,10 +13,18 @@ namespace NServiceBus
 
     class TimeoutDispatcherProcessorBehavior : SatelliteBehavior
     {
-        public IDispatchMessages MessageSender { get; set; }
-        public IPersistTimeouts TimeoutsPersister { get; set; }
-        public TimeoutPersisterReceiver TimeoutPersisterReceiver { get; set; }
-        public Configure Configure { get; set; }
+        readonly IDispatchMessages dispatchMessages;
+        readonly IPersistTimeouts persistTimeouts;
+        readonly TimeoutPersisterReceiver timeoutPersisterReceiver;
+
+        public TimeoutDispatcherProcessorBehavior(IDispatchMessages dispatcher, IPersistTimeouts persister, TimeoutPersisterReceiver receiver)
+        {
+            timeoutPersisterReceiver = receiver;
+            persistTimeouts = persister;
+            dispatchMessages = dispatcher;
+        }
+
+        // ReSharper disable once UnusedAutoPropertyAccessor.Global
         public string InputAddress { get; set; }
 
         public override void Terminate(PhysicalMessageProcessingStageBehavior.Context context)
@@ -25,27 +33,28 @@ namespace NServiceBus
             var timeoutId = message.Headers["Timeout.Id"];
             var options = new TimeoutPersistenceOptions(context);
             TimeoutData timeoutData;
-
-            if (TimeoutsPersister.TryRemove(timeoutId, options, out timeoutData))
+            if (!persistTimeouts.TryRemove(timeoutId, options, out timeoutData))
             {
-                var sendOptions = new DispatchOptions(timeoutData.Destination,new AtomicWithReceiveOperation(), new List<DeliveryConstraint>(), new ContextBag());
-
-                timeoutData.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
-                timeoutData.Headers["NServiceBus.RelatedToTimeoutId"] = timeoutData.Id;
-
-                MessageSender.Dispatch(new OutgoingMessage(message.Id, timeoutData.Headers, timeoutData.State), sendOptions);
+                return;
             }
+
+            var sendOptions = new DispatchOptions(timeoutData.Destination, new AtomicWithReceiveOperation(), new List<DeliveryConstraint>(), new ContextBag());
+
+            timeoutData.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
+            timeoutData.Headers["NServiceBus.RelatedToTimeoutId"] = timeoutData.Id;
+
+            dispatchMessages.Dispatch(new OutgoingMessage(message.Id, timeoutData.Headers, timeoutData.State), sendOptions);
         }
 
         public override Task Warmup()
         {
-            TimeoutPersisterReceiver.Start();
+            timeoutPersisterReceiver.Start();
             return base.Warmup();
         }
 
         public override Task Cooldown()
         {
-            TimeoutPersisterReceiver.Stop();
+            timeoutPersisterReceiver.Stop();
             return base.Cooldown();
         }
 

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutDispatcherProcessorBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutDispatcherProcessorBehavior.cs
@@ -23,6 +23,7 @@ namespace NServiceBus
         {
             var message = context.GetPhysicalMessage();
             var timeoutId = message.Headers["Timeout.Id"];
+            var options = new TimeoutPersistenceOptions();
             TimeoutData timeoutData;
 
             if (TimeoutsPersister.TryRemove(timeoutId, out timeoutData))

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutDispatcherProcessorBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutDispatcherProcessorBehavior.cs
@@ -23,8 +23,7 @@ namespace NServiceBus
         {
             var message = context.GetPhysicalMessage();
             var timeoutId = message.Headers["Timeout.Id"];
-            // TODO Daniel; Change when SatelliteTerminator PR is merged
-            var options = new TimeoutPersistenceOptions(new ContextBag());
+            var options = new TimeoutPersistenceOptions(context);
             TimeoutData timeoutData;
 
             if (TimeoutsPersister.TryRemove(timeoutId, options, out timeoutData))

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutDispatcherProcessorBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutDispatcherProcessorBehavior.cs
@@ -23,10 +23,11 @@ namespace NServiceBus
         {
             var message = context.GetPhysicalMessage();
             var timeoutId = message.Headers["Timeout.Id"];
-            var options = new TimeoutPersistenceOptions();
+            // TODO Daniel; Change when SatelliteTerminator PR is merged
+            var options = new TimeoutPersistenceOptions(new ContextBag());
             TimeoutData timeoutData;
 
-            if (TimeoutsPersister.TryRemove(timeoutId, out timeoutData))
+            if (TimeoutsPersister.TryRemove(timeoutId, options, out timeoutData))
             {
                 var sendOptions = new DispatchOptions(timeoutData.Destination,new AtomicWithReceiveOperation(), new List<DeliveryConstraint>(), new ContextBag());
 

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutMessageProcessorBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutMessageProcessorBehavior.cs
@@ -25,8 +25,7 @@ namespace NServiceBus
         public override void Terminate(PhysicalMessageProcessingStageBehavior.Context context)
         {
             var message = context.GetPhysicalMessage();         
-            // TODO Daniel; Change when SatelliteTerminator PR is merged
-            var options = new TimeoutPersistenceOptions(new ContextBag());
+            var options = new TimeoutPersistenceOptions(context);
             //dispatch request will arrive at the same input so we need to make sure to call the correct handler
             if (message.Headers.ContainsKey(TimeoutIdToDispatchHeader))
             {

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutPersisterReceiver.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutPersisterReceiver.cs
@@ -111,7 +111,7 @@ namespace NServiceBus.Timeout.Hosting.Windows
 
                     dispatchRequest.Headers["Timeout.Id"] = timeoutData.Item1;
 
-                    messageSender.Dispatch(dispatchRequest, new DispatchOptions(DispatcherAddress, new AtomicWithReceiveOperation(), new List<DeliveryConstraint>()));
+                    messageSender.Dispatch(dispatchRequest, new DispatchOptions(DispatcherAddress, new AtomicWithReceiveOperation(), new List<DeliveryConstraint>(), new ContextBag()));
                 }
 
                 lock (lockObject)

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutPersisterReceiver.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutPersisterReceiver.cs
@@ -15,11 +15,20 @@ namespace NServiceBus.Timeout.Hosting.Windows
 
     class TimeoutPersisterReceiver : IDisposable
     {
-        public IPersistTimeouts TimeoutsPersister { get; set; }
-        public IDispatchMessages MessageSender { get; set; }
-        public int SecondsToSleepBetweenPolls { get; set; }
-        public DefaultTimeoutManager TimeoutManager { get; set; }
+        IQueryTimeouts timeoutsQuery;
+        DefaultTimeoutManager timeoutManager;
+        IDispatchMessages messageSender;
+
         public CriticalError CriticalError { get; set; }
+
+        public TimeoutPersisterReceiver(IQueryTimeouts queryTimeouts, IDispatchMessages dispatchMessages, DefaultTimeoutManager timeoutManager, CriticalError criticalError)
+        {
+            timeoutsQuery = queryTimeouts;
+            messageSender = dispatchMessages;
+            this.timeoutManager = timeoutManager;
+        }
+
+        public int SecondsToSleepBetweenPolls { get; set; }
         public string DispatcherAddress { get; set; }
         public TimeSpan TimeToWaitBeforeTriggeringCriticalError { get; set; }
 
@@ -34,7 +43,7 @@ namespace NServiceBus.Timeout.Hosting.Windows
                 ex =>
                     CriticalError.Raise("Repeated failures when fetching timeouts from storage, endpoint will be terminated.", ex));
 
-            TimeoutManager.TimeoutPushed = TimeoutsManagerOnTimeoutPushed;
+            timeoutManager.TimeoutPushed = TimeoutsManagerOnTimeoutPushed;
 
             SecondsToSleepBetweenPolls = 1;
 
@@ -45,7 +54,7 @@ namespace NServiceBus.Timeout.Hosting.Windows
 
         public void Stop()
         {
-            TimeoutManager.TimeoutPushed = null;
+            timeoutManager.TimeoutPushed = null;
             tokenSource.Cancel();
             resetEvent.WaitOne();
         }
@@ -88,7 +97,7 @@ namespace NServiceBus.Timeout.Hosting.Windows
                 Logger.DebugFormat("Polling for timeouts at {0}.", DateTime.Now);
 
                 DateTime nextExpiredTimeout;
-                var timeoutDatas = TimeoutsPersister.GetNextChunk(startSlice, out nextExpiredTimeout);
+                var timeoutDatas = timeoutsQuery.GetNextChunk(startSlice, out nextExpiredTimeout);
 
                 foreach (var timeoutData in timeoutDatas)
                 {
@@ -102,7 +111,7 @@ namespace NServiceBus.Timeout.Hosting.Windows
 
                     dispatchRequest.Headers["Timeout.Id"] = timeoutData.Item1;
 
-                    MessageSender.Dispatch(dispatchRequest, new DispatchOptions(DispatcherAddress, new AtomicWithReceiveOperation(), new List<DeliveryConstraint>(), new ContextBag()));
+                    messageSender.Dispatch(dispatchRequest, new DispatchOptions(DispatcherAddress, new AtomicWithReceiveOperation(), new List<DeliveryConstraint>()));
                 }
 
                 lock (lockObject)

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -127,6 +127,7 @@
     <Compile Include="DelayedDelivery\NoOpCanceling.cs" />
     <Compile Include="DelayedDelivery\RequestCancelingOfDeferredMessagesFromTimeoutManager.cs" />
     <Compile Include="DelayedDelivery\RouteDeferredMessageToTimeoutManagerBehavior.cs" />
+    <Compile Include="DelayedDelivery\TimeoutManager\Core\IQueryTimeouts.cs" />
     <Compile Include="DelayedDelivery\TimeoutManager\Core\TimeoutPersistenceOptions.cs" />
     <Compile Include="DeliveryConstraints\DeliveryConstraintContextExtensions.cs" />
     <Compile Include="Encryption\DecryptBehavior.cs" />

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -127,6 +127,7 @@
     <Compile Include="DelayedDelivery\NoOpCanceling.cs" />
     <Compile Include="DelayedDelivery\RequestCancelingOfDeferredMessagesFromTimeoutManager.cs" />
     <Compile Include="DelayedDelivery\RouteDeferredMessageToTimeoutManagerBehavior.cs" />
+    <Compile Include="DelayedDelivery\TimeoutManager\Core\TimeoutPersistenceOptions.cs" />
     <Compile Include="DeliveryConstraints\DeliveryConstraintContextExtensions.cs" />
     <Compile Include="Encryption\DecryptBehavior.cs" />
     <Compile Include="Encryption\EncryptBehavior.cs" />

--- a/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
@@ -5,12 +5,12 @@ namespace NServiceBus.InMemory.TimeoutPersister
     using System.Threading;
     using Timeout.Core;
 
-    class InMemoryTimeoutPersister : IPersistTimeouts, IDisposable
+    class InMemoryTimeoutPersister : IPersistTimeouts, IQueryTimeouts, IDisposable
     {
         List<TimeoutData> storage = new List<TimeoutData>();
         ReaderWriterLockSlim readerWriterLock = new ReaderWriterLockSlim();
 
-        public IEnumerable<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, TimeoutPersistenceOptions options, out DateTime nextTimeToRunQuery)
+        public IEnumerable<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
         {
             var now = DateTime.UtcNow;
             nextTimeToRunQuery = DateTime.MaxValue;

--- a/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.InMemory.TimeoutPersister
         List<TimeoutData> storage = new List<TimeoutData>();
         ReaderWriterLockSlim readerWriterLock = new ReaderWriterLockSlim();
 
-        public IEnumerable<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
+        public IEnumerable<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, TimeoutPersistenceOptions options, out DateTime nextTimeToRunQuery)
         {
             var now = DateTime.UtcNow;
             nextTimeToRunQuery = DateTime.MaxValue;
@@ -44,7 +44,7 @@ namespace NServiceBus.InMemory.TimeoutPersister
             return tuples;
         }
 
-        public void Add(TimeoutData timeout)
+        public void Add(TimeoutData timeout, TimeoutPersistenceOptions options)
         {
             timeout.Id = Guid.NewGuid().ToString();
             try
@@ -58,7 +58,7 @@ namespace NServiceBus.InMemory.TimeoutPersister
             }
         }
 
-        public bool TryRemove(string timeoutId, out TimeoutData timeoutData)
+        public bool TryRemove(string timeoutId, TimeoutPersistenceOptions options, out TimeoutData timeoutData)
         {
             try
             {
@@ -84,7 +84,7 @@ namespace NServiceBus.InMemory.TimeoutPersister
             }
         }
 
-        public void RemoveTimeoutBy(Guid sagaId)
+        public void RemoveTimeoutBy(Guid sagaId, TimeoutPersistenceOptions options)
         {
             try
             {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/ISubscriptionStorage.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/ISubscriptionStorage.cs
@@ -7,7 +7,6 @@ namespace NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions
 	/// </summary>
     public interface ISubscriptionStorage
     {
-
         /// <summary>
         /// Subscribes the given client address to messages of the given types.
         /// </summary>


### PR DESCRIPTION
This PR is part of https://github.com/Particular/FeatureDevelopment/issues/324 and addresses the following:

We want to be able to float context information into the timeout persister. This makes this possible. This splits also the `IPersistTimeouts` interface into two concerns. One is the timeout querying `IQueryTimeouts` and the other one is the timeout storage operations `IPersistTimeouts`.

@andreasohlund I also removed a few of the timeout persister base tests (which were only ever used with the `InMemoryTimeoutPersister`. I quickly checked and I didn't see that we deploy them with any kind of nuget package or so.

~~Please see there are still two TODO left~~

~~https://github.com/Particular/NServiceBus/pull/2802/files#diff-f71f998dbe767ca05a306b7567d9bccaR27~~

~~I will update this as soon as we have #2801 merged~~

@Particular/nservicebus please review.