### PR TITLE
Making context bag mandatory and exposed as readonly

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2366,9 +2366,9 @@ namespace NServiceBus.Transports
     }
     public class DispatchOptions
     {
-        public DispatchOptions(NServiceBus.Routing.RoutingStrategy routingStrategy, NServiceBus.ConsistencyGuarantees.ConsistencyGuarantee minimumConsistencyGuarantee, System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> deliveryConstraints, NServiceBus.Extensibility.ContextBag context = null) { }
-        public DispatchOptions(string destination, NServiceBus.ConsistencyGuarantees.ConsistencyGuarantee minimumConsistencyGuarantee, System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> deliveryConstraints, NServiceBus.Extensibility.ContextBag context = null) { }
-        public NServiceBus.Extensibility.ContextBag Context { get; }
+        public DispatchOptions(NServiceBus.Routing.RoutingStrategy routingStrategy, NServiceBus.ConsistencyGuarantees.ConsistencyGuarantee minimumConsistencyGuarantee, System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> deliveryConstraints, NServiceBus.Extensibility.ContextBag context) { }
+        public DispatchOptions(string destination, NServiceBus.ConsistencyGuarantees.ConsistencyGuarantee minimumConsistencyGuarantee, System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> deliveryConstraints, NServiceBus.Extensibility.ContextBag context) { }
+        public NServiceBus.Extensibility.ReadOnlyContextBag Context { get; }
         public System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> DeliveryConstraints { get; }
         public NServiceBus.ConsistencyGuarantees.ConsistencyGuarantee MinimumConsistencyGuarantee { get; }
         public NServiceBus.Routing.RoutingStrategy RoutingStrategy { get; set; }

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqMessageSenderTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqMessageSenderTests.cs
@@ -5,6 +5,7 @@
     using System.Messaging;
     using NServiceBus.ConsistencyGuarantees;
     using NServiceBus.DeliveryConstraints;
+    using NServiceBus.Extensibility;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
     using NServiceBus.Transports;
@@ -40,7 +41,7 @@
                 };
                 var headers = new Dictionary<string, string>();
                 var outgoingMessage = new OutgoingMessage("1", headers, bytes);
-                var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(queueName),new AtomicWithReceiveOperation(), new List<DeliveryConstraint>() );
+                var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(queueName),new AtomicWithReceiveOperation(), new List<DeliveryConstraint>(), new ContextBag());
                 messageSender.Dispatch(outgoingMessage, dispatchOptions);
                 var messageLabel = ReadMessageLabel(path);
                 Assert.AreEqual("mylabel", messageLabel);
@@ -68,7 +69,7 @@
                 };
                 var headers = new Dictionary<string, string>();
                 var outgoingMessage = new OutgoingMessage("1", headers, bytes);
-                var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(queueName), new AtomicWithReceiveOperation(), new List<DeliveryConstraint>());
+                var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(queueName), new AtomicWithReceiveOperation(), new List<DeliveryConstraint>(), new ContextBag());
                 messageSender.Dispatch(outgoingMessage, dispatchOptions);
                 var messageLabel = ReadMessageLabel(path);
                 Assert.IsEmpty(messageLabel);

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqUtilitiesTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqUtilitiesTests.cs
@@ -9,6 +9,7 @@
     using System.Net.Sockets;
     using NServiceBus.ConsistencyGuarantees;
     using NServiceBus.DeliveryConstraints;
+    using NServiceBus.Extensibility;
     using NServiceBus.Performance.TimeToBeReceived;
     using NServiceBus.Transports;
     using NUnit.Framework;
@@ -21,7 +22,7 @@
         {
             var expected = String.Format("Can u see this '{0}' character!", (char)0x19);
             
-            var options = new DispatchOptions("destination", new AtomicWithReceiveOperation(), new List<DeliveryConstraint>());
+            var options = new DispatchOptions("destination", new AtomicWithReceiveOperation(), new List<DeliveryConstraint>(), new ContextBag());
 
 
             var message = MsmqUtilities.Convert(new OutgoingMessage("message id",new Dictionary<string, string> { { "NServiceBus.ExceptionInfo.Message" ,expected} }, new byte[0]), options);
@@ -34,7 +35,7 @@
         public void Should_convert_message_headers_that_contain_nulls_at_the_end()
         {
             var expected = "Hello World!";
-            var options = new DispatchOptions("destination", new AtomicWithReceiveOperation(), new List<DeliveryConstraint>());
+            var options = new DispatchOptions("destination", new AtomicWithReceiveOperation(), new List<DeliveryConstraint>(), new ContextBag());
 
             Console.Out.WriteLine(sizeof(char));
             var message = MsmqUtilities.Convert(new OutgoingMessage("message id",new Dictionary<string, string> { { "NServiceBus.ExceptionInfo.Message", expected } }, new byte[0]), options);
@@ -52,7 +53,7 @@
         [Test]
         public void Should_fetch_the_replytoaddress_from_responsequeue_for_backwards_compatibility()
         {
-            var message = MsmqUtilities.Convert(new OutgoingMessage("message id", new Dictionary<string, string>(), new byte[0]), new DispatchOptions("destination", new AtomicWithReceiveOperation(), new List<DeliveryConstraint>()));
+            var message = MsmqUtilities.Convert(new OutgoingMessage("message id", new Dictionary<string, string>(), new byte[0]), new DispatchOptions("destination", new AtomicWithReceiveOperation(), new List<DeliveryConstraint>(), new ContextBag()));
 
             message.ResponseQueue = new MessageQueue(MsmqUtilities.GetReturnAddress("local", Environment.MachineName));
             var headers = MsmqUtilities.ExtractHeaders(message);
@@ -63,7 +64,7 @@
         [Test]
         public void Should_use_the_TTBR_in_the_send_options_if_set()
         {
-            var options = new DispatchOptions("destination", new AtomicWithReceiveOperation(), new List<DeliveryConstraint>{new DiscardIfNotReceivedBefore(TimeSpan.FromDays(1))});
+            var options = new DispatchOptions("destination", new AtomicWithReceiveOperation(), new List<DeliveryConstraint>{new DiscardIfNotReceivedBefore(TimeSpan.FromDays(1))}, new ContextBag());
 
             var message = MsmqUtilities.Convert(new OutgoingMessage("message id",new Dictionary<string, string>(),  new byte[0]), options);
 
@@ -74,11 +75,11 @@
         [Test]
         public void Should_use_the_non_durable_setting()
         {
-            var options = new DispatchOptions("destination", new AtomicWithReceiveOperation(), new List<DeliveryConstraint> { new NonDurableDelivery() });
+            var options = new DispatchOptions("destination", new AtomicWithReceiveOperation(), new List<DeliveryConstraint> { new NonDurableDelivery() }, new ContextBag());
 
       
             Assert.False(MsmqUtilities.Convert(new OutgoingMessage("message id", new Dictionary<string, string>(), new byte[0]), options).Recoverable);
-            Assert.True(MsmqUtilities.Convert(new OutgoingMessage("message id", new Dictionary<string, string>(), new byte[0]), new DispatchOptions("destination", new AtomicWithReceiveOperation(), new List<DeliveryConstraint>())).Recoverable);
+            Assert.True(MsmqUtilities.Convert(new OutgoingMessage("message id", new Dictionary<string, string>(), new byte[0]), new DispatchOptions("destination", new AtomicWithReceiveOperation(), new List<DeliveryConstraint>(), new ContextBag())).Recoverable);
         }
 
   

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Core/DefaultTimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Core/DefaultTimeoutManager.cs
@@ -4,6 +4,7 @@ namespace NServiceBus.Timeout.Core
     using System.Collections.Generic;
     using NServiceBus.ConsistencyGuarantees;
     using NServiceBus.DeliveryConstraints;
+    using NServiceBus.Extensibility;
     using NServiceBus.Transports;
 
     class DefaultTimeoutManager
@@ -18,7 +19,7 @@ namespace NServiceBus.Timeout.Core
         {
             if (timeout.Time.AddSeconds(-1) <= DateTime.UtcNow)
             {
-                var sendOptions = new DispatchOptions(timeout.Destination,new AtomicWithReceiveOperation(), new List<DeliveryConstraint>());
+                var sendOptions = new DispatchOptions(timeout.Destination,new AtomicWithReceiveOperation(), new List<DeliveryConstraint>(), new ContextBag());
                 var message = new OutgoingMessage(timeout.Headers[Headers.MessageId],timeout.Headers, timeout.State);
 
                 MessageSender.Dispatch(message, sendOptions);

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutDispatcherProcessorBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutDispatcherProcessorBehavior.cs
@@ -5,6 +5,7 @@ namespace NServiceBus
     using System.Threading.Tasks;
     using NServiceBus.ConsistencyGuarantees;
     using NServiceBus.DeliveryConstraints;
+    using NServiceBus.Extensibility;
     using NServiceBus.Pipeline;
     using NServiceBus.Timeout.Core;
     using NServiceBus.Timeout.Hosting.Windows;
@@ -26,7 +27,7 @@ namespace NServiceBus
 
             if (TimeoutsPersister.TryRemove(timeoutId, out timeoutData))
             {
-                var sendOptions = new DispatchOptions(timeoutData.Destination, new AtomicWithReceiveOperation(), new List<DeliveryConstraint>());
+                var sendOptions = new DispatchOptions(timeoutData.Destination,new AtomicWithReceiveOperation(), new List<DeliveryConstraint>(), new ContextBag());
 
                 timeoutData.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
                 timeoutData.Headers["NServiceBus.RelatedToTimeoutId"] = timeoutData.Id;

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutMessageProcessorBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutMessageProcessorBehavior.cs
@@ -4,6 +4,7 @@ namespace NServiceBus
     using System.Collections.Generic;
     using NServiceBus.ConsistencyGuarantees;
     using NServiceBus.DeliveryConstraints;
+    using NServiceBus.Extensibility;
     using NServiceBus.Pipeline;
     using NServiceBus.Timeout;
     using NServiceBus.Timeout.Core;
@@ -52,7 +53,7 @@ namespace NServiceBus
             }
 
             TimeoutManager.RemoveTimeout(timeoutId);
-            MessageSender.Dispatch(new OutgoingMessage(message.Id, message.Headers, message.Body), new DispatchOptions(destination, new AtomicWithReceiveOperation(), new List<DeliveryConstraint>()));
+            MessageSender.Dispatch(new OutgoingMessage(message.Id,message.Headers, message.Body), new DispatchOptions(destination,new AtomicWithReceiveOperation(), new List<DeliveryConstraint>(), new ContextBag()));
         }
 
         void HandleInternal(TransportMessage message)

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutPersisterReceiver.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Hosting/Windows/TimeoutPersisterReceiver.cs
@@ -7,6 +7,7 @@ namespace NServiceBus.Timeout.Hosting.Windows
     using NServiceBus.CircuitBreakers;
     using NServiceBus.ConsistencyGuarantees;
     using NServiceBus.DeliveryConstraints;
+    using NServiceBus.Extensibility;
     using NServiceBus.Logging;
     using NServiceBus.Timeout.Core;
     using NServiceBus.Transports;
@@ -101,7 +102,7 @@ namespace NServiceBus.Timeout.Hosting.Windows
 
                     dispatchRequest.Headers["Timeout.Id"] = timeoutData.Item1;
 
-                    MessageSender.Dispatch(dispatchRequest, new DispatchOptions(DispatcherAddress, new AtomicWithReceiveOperation(), new List<DeliveryConstraint>()));
+                    MessageSender.Dispatch(dispatchRequest, new DispatchOptions(DispatcherAddress, new AtomicWithReceiveOperation(), new List<DeliveryConstraint>(), new ContextBag()));
                 }
 
                 lock (lockObject)

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -6,6 +6,7 @@
     using System.Threading;
     using NServiceBus.ConsistencyGuarantees;
     using NServiceBus.DeliveryConstraints;
+    using NServiceBus.Extensibility;
     using NServiceBus.Logging;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
@@ -55,7 +56,7 @@
         {
             try
             {
-                dispatcher.Dispatch(subscriptionMessage, new DispatchOptions(destination, new AtLeastOnce(), new List<DeliveryConstraint>()));
+                dispatcher.Dispatch(subscriptionMessage, new DispatchOptions(destination, new AtLeastOnce(), new List<DeliveryConstraint>(), new ContextBag()));
             }
             catch (QueueNotFoundException ex)
             {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using NServiceBus.ConsistencyGuarantees;
     using NServiceBus.DeliveryConstraints;
+    using NServiceBus.Extensibility;
     using NServiceBus.Logging;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
@@ -43,7 +44,7 @@
                 subscriptionMessage.Headers[Headers.ReplyToAddress] = replyToAddress;
 
 
-                dispatcher.Dispatch(subscriptionMessage, new DispatchOptions(publisherAddress, new AtLeastOnce(), new List<DeliveryConstraint>()));
+                dispatcher.Dispatch(subscriptionMessage, new DispatchOptions(publisherAddress, new AtLeastOnce(), new List<DeliveryConstraint>(), new ContextBag()));
             }
         }
 

--- a/src/NServiceBus.Core/Transports/DispatchOptions.cs
+++ b/src/NServiceBus.Core/Transports/DispatchOptions.cs
@@ -18,17 +18,12 @@ namespace NServiceBus.Transports
         /// <param name="minimumConsistencyGuarantee">The level of consistency that's required for this operation.</param>
         /// <param name="deliveryConstraints">The delivery constraints that must be honored by the transport.</param>
         /// <param name="context">The pipeline context if present.</param>
-        public DispatchOptions(RoutingStrategy routingStrategy, ConsistencyGuarantee minimumConsistencyGuarantee, IEnumerable<DeliveryConstraint> deliveryConstraints, ContextBag context = null)
+        public DispatchOptions(RoutingStrategy routingStrategy, ConsistencyGuarantee minimumConsistencyGuarantee, IEnumerable<DeliveryConstraint> deliveryConstraints, ContextBag context)
         {
             RoutingStrategy = routingStrategy;
             MinimumConsistencyGuarantee = minimumConsistencyGuarantee;
             DeliveryConstraints = deliveryConstraints;
             Context = context;
-
-            if (context == null)
-            {
-                Context = new ContextBag();
-            }
         }
 
         /// <summary>
@@ -38,11 +33,11 @@ namespace NServiceBus.Transports
         /// <param name="minimumConsistencyGuarantee">The level of consistency that's required for this operation.</param>
         /// <param name="deliveryConstraints">The delivery constraints that must be honored by the transport.</param>
         /// <param name="context">The pipeline context if present.</param>
-        public DispatchOptions(string destination, ConsistencyGuarantee minimumConsistencyGuarantee, IEnumerable<DeliveryConstraint> deliveryConstraints, ContextBag context = null)
+        public DispatchOptions(string destination, ConsistencyGuarantee minimumConsistencyGuarantee, IEnumerable<DeliveryConstraint> deliveryConstraints, ContextBag context)
             : this(new DirectToTargetDestination(destination), minimumConsistencyGuarantee,deliveryConstraints,context)
         {
-          
         }
+
         /// <summary>
         /// The strategy to use when routing this message.
         /// </summary>
@@ -61,6 +56,6 @@ namespace NServiceBus.Transports
         /// <summary>
         /// Access to the behavior context.
         /// </summary>
-        public ContextBag Context { get; private set; }
+        public ReadOnlyContextBag Context { get; private set; }
     }
 }

--- a/src/NServiceBus.Core/Unicast/ContextualBus.cs
+++ b/src/NServiceBus.Core/Unicast/ContextualBus.cs
@@ -5,6 +5,7 @@ namespace NServiceBus.Unicast
     using Janitor;
     using NServiceBus.ConsistencyGuarantees;
     using NServiceBus.DeliveryConstraints;
+    using NServiceBus.Extensibility;
     using NServiceBus.MessageInterfaces;
     using NServiceBus.ObjectBuilder;
     using NServiceBus.OutgoingPipeline;
@@ -118,7 +119,7 @@ namespace NServiceBus.Unicast
                 return;
             }
 
-            dispatcher.Dispatch(new OutgoingMessage(MessageBeingProcessed.Id, MessageBeingProcessed.Headers, MessageBeingProcessed.Body), new DispatchOptions(sendLocalAddress, new AtomicWithReceiveOperation(), new List<DeliveryConstraint>()));
+            dispatcher.Dispatch(new OutgoingMessage(MessageBeingProcessed.Id, MessageBeingProcessed.Headers, MessageBeingProcessed.Body), new DispatchOptions(sendLocalAddress, new AtomicWithReceiveOperation(), new List<DeliveryConstraint>(), new ContextBag()));
 
             incomingContext.handleCurrentMessageLaterWasCalled = true;
 
@@ -130,7 +131,7 @@ namespace NServiceBus.Unicast
         /// </summary>
         public void ForwardCurrentMessageTo(string destination)
         {
-            dispatcher.Dispatch(new OutgoingMessage(MessageBeingProcessed.Id, MessageBeingProcessed.Headers, MessageBeingProcessed.Body), new DispatchOptions(destination, new AtomicWithReceiveOperation(), new List<DeliveryConstraint>()));
+            dispatcher.Dispatch(new OutgoingMessage(MessageBeingProcessed.Id, MessageBeingProcessed.Headers, MessageBeingProcessed.Body), new DispatchOptions(destination, new AtomicWithReceiveOperation(), new List<DeliveryConstraint>(), new ContextBag()));
         }
 
         public void Send<T>(Action<T> messageConstructor, NServiceBus.SendOptions options)


### PR DESCRIPTION
This PR is part of https://github.com/Particular/FeatureDevelopment/issues/324 and addresses the following:

It aligns the `DispatchOptions` with the newly introduced options

@Particular/nservicebus please review.