### PR TITLE
Introduced SubscriptionStorageOptions

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_from_sendonly.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_from_sendonly.cs
@@ -80,20 +80,13 @@
         {
             protected override void Setup(FeatureConfigurationContext context)
             {
-                context.Container.ConfigureComponent<HardCodedPersistenceImpl>(DependencyLifecycle.SingleInstance);
+                context.Container.ConfigureComponent<HardcodedSubscriptionQuery>(DependencyLifecycle.SingleInstance);
+                context.Container.ConfigureComponent<NoOpSubscriptionManager>(DependencyLifecycle.SingleInstance);
             }
         }
 
-        public class HardCodedPersistenceImpl : ISubscriptionStorage
+        public class HardcodedSubscriptionQuery : IQuerySubscriptions
         {
-            public void Subscribe(string client, IEnumerable<MessageType> messageTypes)
-            {
-            }
-
-            public void Unsubscribe(string client, IEnumerable<MessageType> messageTypes)
-            {
-            }
-
             public IEnumerable<string> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes)
             {
                 return new[]
@@ -101,8 +94,15 @@
                     "publishingfromsendonly.subscriber"
                 };
             }
+        }
 
-            public void Init()
+        public class NoOpSubscriptionManager : ISubscriptionStorage
+        {
+            public void Subscribe(string client, IEnumerable<MessageType> messageTypes, SubscriptionStorageOptions options)
+            {
+            }
+
+            public void Unsubscribe(string client, IEnumerable<MessageType> messageTypes, SubscriptionStorageOptions options)
             {
             }
         }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2770,12 +2770,23 @@ namespace NServiceBus.Unicast.Routing
 }
 namespace NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions
 {
-    public interface ISubscriptionStorage
+    public interface IInitializableSubscriptionStorage : NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.ISubscriptionStorage
+    {
+        void Init();
+    }
+    public interface IQuerySubscriptions
     {
         System.Collections.Generic.IEnumerable<string> GetSubscriberAddressesForMessage(System.Collections.Generic.IEnumerable<NServiceBus.Unicast.Subscriptions.MessageType> messageTypes);
-        void Init();
-        void Subscribe(string client, System.Collections.Generic.IEnumerable<NServiceBus.Unicast.Subscriptions.MessageType> messageTypes);
-        void Unsubscribe(string client, System.Collections.Generic.IEnumerable<NServiceBus.Unicast.Subscriptions.MessageType> messageTypes);
+    }
+    public interface ISubscriptionStorage
+    {
+        void Subscribe(string client, System.Collections.Generic.IEnumerable<NServiceBus.Unicast.Subscriptions.MessageType> messageTypes, NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.SubscriptionStorageOptions options);
+        void Unsubscribe(string client, System.Collections.Generic.IEnumerable<NServiceBus.Unicast.Subscriptions.MessageType> messageTypes, NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.SubscriptionStorageOptions options);
+    }
+    public class SubscriptionStorageOptions
+    {
+        public SubscriptionStorageOptions(NServiceBus.Extensibility.ContextBag context) { }
+        public NServiceBus.Extensibility.ReadOnlyContextBag Context { get; }
     }
 }
 namespace NServiceBus.Unicast.Subscriptions

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -199,10 +199,13 @@
     <Compile Include="Routing\DetermineRouteForPublishBehavior.cs" />
     <Compile Include="Routing\DetermineRouteForSendBehavior.cs" />
     <Compile Include="Routing\DirectToTargetDestination.cs" />
+    <Compile Include="Routing\MessageDrivenSubscriptions\IInitializableSubscriptionStorage.cs" />
+    <Compile Include="Routing\MessageDrivenSubscriptions\IQuerySubscriptions.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\MessageDrivenUnsubscribeTerminator.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\MessageDrivenSubscribeTerminator.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\MessageDrivenSubscriptions.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\SubscriptionRouter.cs" />
+    <Compile Include="Routing\MessageDrivenSubscriptions\SubscriptionStorageOptions.cs" />
     <Compile Include="Routing\MessageRouter.cs" />
     <Compile Include="Routing\MessagingBestPractices\BestPracticeEnforcement.cs" />
     <Compile Include="Routing\MessagingBestPractices\EnforceBestPracticesOptions.cs" />

--- a/src/NServiceBus.Core/Persistence/InMemory/SubscriptionStorage/InMemorySubscriptionStorage.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/SubscriptionStorage/InMemorySubscriptionStorage.cs
@@ -9,9 +9,9 @@ namespace NServiceBus.InMemory.SubscriptionStorage
     /// <summary>
     ///     In memory implementation of the subscription storage
     /// </summary>
-    class InMemorySubscriptionStorage : ISubscriptionStorage
+    class InMemorySubscriptionStorage : ISubscriptionStorage, IQuerySubscriptions
     {
-        public void Subscribe(string address, IEnumerable<MessageType> messageTypes)
+        public void Subscribe(string address, IEnumerable<MessageType> messageTypes, SubscriptionStorageOptions options)
         {
             foreach (var m in messageTypes)
             {
@@ -21,7 +21,7 @@ namespace NServiceBus.InMemory.SubscriptionStorage
             }
         }
 
-        public void Unsubscribe(string address, IEnumerable<MessageType> messageTypes)
+        public void Unsubscribe(string address, IEnumerable<MessageType> messageTypes, SubscriptionStorageOptions options)
         {
             foreach (var m in messageTypes)
             {
@@ -46,10 +46,6 @@ namespace NServiceBus.InMemory.SubscriptionStorage
                 }
             }
             return result;
-        }
-
-        public void Init()
-        {
         }
 
         ConcurrentDictionary<MessageType, ConcurrentDictionary<string, object>> storage = new ConcurrentDictionary<MessageType, ConcurrentDictionary<string, object>>();

--- a/src/NServiceBus.Core/Persistence/Msmq/SubscriptionStorage/MsmqSubscriptionStorage.cs
+++ b/src/NServiceBus.Core/Persistence/Msmq/SubscriptionStorage/MsmqSubscriptionStorage.cs
@@ -15,7 +15,7 @@ namespace NServiceBus.Persistence.SubscriptionStorage
     /// Provides functionality for managing message subscriptions
     /// using MSMQ.
     /// </summary>
-    class MsmqSubscriptionStorage : ISubscriptionStorage, IDisposable
+    class MsmqSubscriptionStorage : IInitializableSubscriptionStorage, IQuerySubscriptions, IDisposable
     {
         public bool TransactionsEnabled { get; set; }
 
@@ -79,7 +79,7 @@ namespace NServiceBus.Persistence.SubscriptionStorage
             }
         }
 
-        public void Subscribe(string address, IEnumerable<MessageType> messageTypes)
+        public void Subscribe(string address, IEnumerable<MessageType> messageTypes, SubscriptionStorageOptions options)
         {
             lock (locker)
             {
@@ -113,7 +113,7 @@ namespace NServiceBus.Persistence.SubscriptionStorage
             }
         }
 
-        public void Unsubscribe(string address, IEnumerable<MessageType> messageTypes)
+        public void Unsubscribe(string address, IEnumerable<MessageType> messageTypes, SubscriptionStorageOptions options)
         {
             lock (locker)
             {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/IInitializableSubscriptionStorage.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/IInitializableSubscriptionStorage.cs
@@ -1,0 +1,14 @@
+namespace NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions
+{
+    /// <summary>
+    /// Defines an initializable storage for subscriptions.
+    /// </summary>
+    public interface IInitializableSubscriptionStorage : ISubscriptionStorage
+    {
+        /// <summary>
+        /// Notifies the subscription storage that now is the time to perform
+        /// any initialization work.
+        /// </summary>
+        void Init();
+    }
+}

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/IQuerySubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/IQuerySubscriptions.cs
@@ -1,0 +1,16 @@
+namespace NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Allows to query for subscriptions.
+    /// </summary>
+    public interface IQuerySubscriptions
+    {
+        /// <summary>
+        /// Returns a list of addresses of subscribers that previously requested to be notified
+        /// of messages of the given message types.
+        /// </summary>
+        IEnumerable<string> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes);
+    }
+}

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/ISubscriptionStorage.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/ISubscriptionStorage.cs
@@ -7,27 +7,14 @@ namespace NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions
 	/// </summary>
     public interface ISubscriptionStorage
     {
-
         /// <summary>
         /// Subscribes the given client address to messages of the given types.
         /// </summary>
-        void Subscribe(string client, IEnumerable<MessageType> messageTypes);
+        void Subscribe(string client, IEnumerable<MessageType> messageTypes, SubscriptionStorageOptions options);
 
         /// <summary>
         /// Unsubscribes the given client address from messages of the given types.
         /// </summary>
-        void Unsubscribe(string client, IEnumerable<MessageType> messageTypes);
-
-        /// <summary>
-        /// Returns a list of addresses of subscribers that previously requested to be notified
-        /// of messages of the given message types.
-        /// </summary>
-        IEnumerable<string> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes);
-
-        /// <summary>
-        /// Notifies the subscription storage that now is the time to perform
-        /// any initialization work.
-        /// </summary>
-        void Init();
+        void Unsubscribe(string client, IEnumerable<MessageType> messageTypes, SubscriptionStorageOptions options);
     }
 }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/StorageInitializer.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/StorageInitializer.cs
@@ -12,7 +12,7 @@
 
         class CallInit : FeatureStartupTask
         {
-            public ISubscriptionStorage SubscriptionStorage { get; set; }
+            public IInitializableSubscriptionStorage SubscriptionStorage { get; set; }
 
             protected override void OnStart()
             {
@@ -25,7 +25,6 @@
 
         protected internal override void Setup(FeatureConfigurationContext context)
         {
-            
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionReceiverBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionReceiverBehavior.cs
@@ -58,6 +58,7 @@
                 return;
             }
 
+            var options = new SubscriptionStorageOptions(context);
             if (transportMessage.MessageIntent == MessageIntentEnum.Subscribe)
             {
                 Logger.Info("Subscribing " + subscriberAddress + " to message type " + messageTypeString);
@@ -67,7 +68,7 @@
                 subscriptionStorage.Subscribe(transportMessage.ReplyToAddress, new[]
                 {
                     mt
-                });
+                }, options);
 
                 return;
             }
@@ -76,7 +77,7 @@
             subscriptionStorage.Unsubscribe(subscriberAddress, new[]
             {
                 new MessageType(messageTypeString)
-            });
+            }, options);
         }
 
 

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionStorageOptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionStorageOptions.cs
@@ -1,0 +1,24 @@
+namespace NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions
+{
+    using NServiceBus.Extensibility;
+
+    /// <summary>
+    /// Provides details about the current subscription storage operation.
+    /// </summary>
+    public class SubscriptionStorageOptions
+    {
+        /// <summary>
+        /// Creates a new instance of the SubscriptionStorageOptions class.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        public SubscriptionStorageOptions(ContextBag context)
+        {
+            Context = context;
+        }
+
+        /// <summary>
+        /// Access to the behavior context.
+        /// </summary>
+        public ReadOnlyContextBag Context { get; private set; }
+    }
+}

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -33,7 +33,7 @@
             }
             else
             {
-                context.Container.ConfigureComponent<DispatchStrategy>(b => new StorageDrivenDispatcher(b.Build<ISubscriptionStorage>(), b.Build<MessageMetadataRegistry>()), DependencyLifecycle.SingleInstance);
+                context.Container.ConfigureComponent<DispatchStrategy>(b => new StorageDrivenDispatcher(b.Build<IQuerySubscriptions>(), b.Build<MessageMetadataRegistry>()), DependencyLifecycle.SingleInstance);
             }
 
             context.Pipeline.Register("DetermineRouteForSend", typeof(DetermineRouteForSendBehavior), "Determines how the message being sent should be routed");

--- a/src/NServiceBus.Core/Routing/StorageDrivenPublishing/StorageDrivenDispatcher.cs
+++ b/src/NServiceBus.Core/Routing/StorageDrivenPublishing/StorageDrivenDispatcher.cs
@@ -13,12 +13,11 @@
 
     class StorageDrivenDispatcher : DispatchStrategy
     {
-        public StorageDrivenDispatcher(ISubscriptionStorage subscriptionStorage, MessageMetadataRegistry messageMetadataRegistry)
+        public StorageDrivenDispatcher(IQuerySubscriptions querySubscriptions, MessageMetadataRegistry messageMetadataRegistry)
         {
-            this.subscriptionStorage = subscriptionStorage;
+            this.querySubscriptions = querySubscriptions;
             this.messageMetadataRegistry = messageMetadataRegistry;
         }
-
 
         public override void Dispatch(IDispatchMessages dispatcher, OutgoingMessage message, RoutingStrategy routingStrategy, ConsistencyGuarantee minimumConsistencyGuarantee, IEnumerable<DeliveryConstraint> constraints, BehaviorContext currentContext)
         {
@@ -44,7 +43,7 @@
                 .Distinct()
                 .ToList();
 
-            var subscribers = subscriptionStorage.GetSubscriberAddressesForMessage(eventTypesToPublish.Select(t => new MessageType(t))).ToList();
+            var subscribers = querySubscriptions.GetSubscriberAddressesForMessage(eventTypesToPublish.Select(t => new MessageType(t))).ToList();
 
 
             currentContext.Set(new SubscribersForEvent(subscribers, eventType));
@@ -64,7 +63,7 @@
             }
         }
 
-        readonly ISubscriptionStorage subscriptionStorage;
+        readonly IQuerySubscriptions querySubscriptions;
         readonly MessageMetadataRegistry messageMetadataRegistry;
     }
 }

--- a/src/NServiceBus.PerformanceTests/PubSub/PubSubTestCase.cs
+++ b/src/NServiceBus.PerformanceTests/PubSub/PubSubTestCase.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Transactions;
 using NServiceBus;
 using NServiceBus.Configuration.AdvanceExtensibility;
+using NServiceBus.Extensibility;
 using NServiceBus.Features;
 using NServiceBus.Settings;
 using NServiceBus.Transports.Msmq;
@@ -65,7 +66,7 @@ public class PubSubTestCase : TestCase
                 break;
         }
 
-        
+
         using (var bus = Bus.Create(configuration))
         {
             Parallel.For(
@@ -108,9 +109,9 @@ public class PrimeSubscriptionStorage : Feature
 
         public ReadOnlySettings Settings { get; set; }
 
-        public ISubscriptionStorage SubscriptionStorage { get; set; }
+        public IInitializableSubscriptionStorage SubscriptionStorage { get; set; }
 
-        void PrimeSubscriptionStorage(ISubscriptionStorage subscriptionStorage)
+        void PrimeSubscriptionStorage(IInitializableSubscriptionStorage subscriptionStorage)
         {
             var testEventMessage = new MessageType(typeof(TestEvent));
 
@@ -135,7 +136,7 @@ public class PrimeSubscriptionStorage : Feature
                     subscriptionStorage.Subscribe(subscriberAddress, new List<MessageType>
                 {
                     testEventMessage
-                });
+                }, new SubscriptionStorageOptions(new ContextBag()));
 
                     tx.Complete();
                 }


### PR DESCRIPTION
This PR is part of https://github.com/Particular/FeatureDevelopment/issues/324 and addresses the following:

* It introduces `SubscriptionStorageOptions`
* Split the `ISubscriptionStorage` into `IQuerySubscriptions`, `ISubscriptionStorage` and `IInitializableSubscriptionStorage`

We can debate whether we still need the `Init()` and therefore the `IInitializableSubscriptionStorage` I quickly checked and at least `MsmqSubscriptionStorage` and `NHibernate` needs it. We could also say that initializing the storage itself is a concern of the persister and no longer of the core. I'm fine with that as well. Thoughts?

@Particular/nservicebus please review.