### PR TITLE
SagaId passed into persister is no longer restricted to be a Guid

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1993,7 +1993,7 @@ namespace NServiceBus.Saga
     public interface ISagaPersister
     {
         void Complete(NServiceBus.Saga.IContainSagaData saga, NServiceBus.Saga.SagaPersistenceOptions options);
-        TSagaData Get<TSagaData>(System.Guid sagaId, NServiceBus.Saga.SagaPersistenceOptions options)
+        TSagaData Get<TSagaData>(string sagaId, NServiceBus.Saga.SagaPersistenceOptions options)
             where TSagaData : NServiceBus.Saga.IContainSagaData;
         TSagaData Get<TSagaData>(string propertyName, object propertyValue, NServiceBus.Saga.SagaPersistenceOptions options)
             where TSagaData : NServiceBus.Saga.IContainSagaData;

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_completing_a_saga_with_the_InMemory_persister.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_completing_a_saga_with_the_InMemory_persister.cs
@@ -15,9 +15,9 @@
             var options = new SagaPersistenceOptions(SagaMetadata.Create(typeof(TestSaga)));
 
             persister.Save(saga, options);
-            Assert.NotNull(persister.Get<TestSagaData>(saga.Id, options));
+            Assert.NotNull(persister.Get<TestSagaData>(saga.Id.ToString(), options));
             persister.Complete(saga, options);
-            Assert.Null(persister.Get<TestSagaData>(saga.Id, options));
+            Assert.Null(persister.Get<TestSagaData>(saga.Id.ToString(), options));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_completing_a_saga_with_unique_property_with_InMemory_persister.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_completing_a_saga_with_unique_property_with_InMemory_persister.cs
@@ -22,9 +22,9 @@
 
             var persister = InMemoryPersisterBuilder.Build<SagaWithUniqueProperty>();
             persister.Save(saga, options);
-            Assert.NotNull(persister.Get<SagaWithUniquePropertyData>(saga.Id, options));
+            Assert.NotNull(persister.Get<SagaWithUniquePropertyData>(saga.Id.ToString(), options));
             persister.Complete(saga, options);
-            Assert.Null(persister.Get<SagaWithUniquePropertyData>(saga.Id, options));
+            Assert.Null(persister.Get<SagaWithUniquePropertyData>(saga.Id.ToString(), options));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_multiple_workers_retrieve_same_saga.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_multiple_workers_retrieve_same_saga.cs
@@ -23,7 +23,7 @@
             var persister = InMemoryPersisterBuilder.Build<TestSaga>();
             persister.Save(saga, options);
 
-            var returnedSaga1 = persister.Get<TestSagaData>(saga.Id, options);
+            var returnedSaga1 = persister.Get<TestSagaData>(saga.Id.ToString(), options);
             var returnedSaga2 = persister.Get<TestSagaData>("Id", saga.Id, options);
             Assert.AreNotSame(returnedSaga2, returnedSaga1);
             Assert.AreNotSame(returnedSaga1, saga);
@@ -37,7 +37,7 @@
             var persister = InMemoryPersisterBuilder.Build<TestSaga>();
             persister.Save(saga, options);
 
-            var returnedSaga1 = Task<TestSagaData>.Factory.StartNew(() => persister.Get<TestSagaData>(saga.Id, options)).Result;
+            var returnedSaga1 = Task<TestSagaData>.Factory.StartNew(() => persister.Get<TestSagaData>(saga.Id.ToString(), options)).Result;
             var returnedSaga2 = persister.Get<TestSagaData>("Id", saga.Id, options);
 
             persister.Save(returnedSaga1, options);
@@ -52,7 +52,7 @@
             var persister = InMemoryPersisterBuilder.Build<TestSaga>();
             persister.Save(saga, options);
 
-            var record = persister.Get<TestSagaData>(saga.Id, options);
+            var record = persister.Get<TestSagaData>(saga.Id.ToString(), options);
             var staleRecord = persister.Get<TestSagaData>("Id", saga.Id, options);
 
             persister.Save(record, options);
@@ -67,7 +67,7 @@
             var persister = InMemoryPersisterBuilder.Build<TestSaga>();
             persister.Save(saga, options);
 
-            var returnedSaga1 = persister.Get<TestSagaData>(saga.Id, options);
+            var returnedSaga1 = persister.Get<TestSagaData>(saga.Id.ToString(), options);
             persister.Save(returnedSaga1, options);
 
             var exception = Assert.Throws<Exception>(() => persister.Save(returnedSaga1, options));
@@ -82,7 +82,7 @@
             var persister = InMemoryPersisterBuilder.Build<TestSaga>();
             persister.Save(saga, options);
 
-            var returnedSaga1 = Task<TestSagaData>.Factory.StartNew(() => persister.Get<TestSagaData>(saga.Id, options)).Result;
+            var returnedSaga1 = Task<TestSagaData>.Factory.StartNew(() => persister.Get<TestSagaData>(saga.Id.ToString(), options)).Result;
             var returnedSaga2 = persister.Get<TestSagaData>("Id", saga.Id, options);
 
             persister.Save(returnedSaga1, options);
@@ -90,7 +90,7 @@
             Assert.IsTrue(exceptionFromSaga2.Message.StartsWith(string.Format("InMemorySagaPersister concurrency violation: saga entity Id[{0}] already saved.", saga.Id)));
 
             var returnedSaga3 = Task<TestSagaData>.Factory.StartNew(() => persister.Get<TestSagaData>("Id", saga.Id, options)).Result;
-            var returnedSaga4 = persister.Get<TestSagaData>(saga.Id, options);
+            var returnedSaga4 = persister.Get<TestSagaData>(saga.Id.ToString(), options);
 
             persister.Save(returnedSaga4, options);
 

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_the_same_unique_property_as_the_original_value_of_another_saga_before_updating.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_the_same_unique_property_as_the_original_value_of_another_saga_before_updating.cs
@@ -17,7 +17,7 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
 
             var persister = InMemoryPersisterBuilder.Build<SagaWithUniqueProperty>();
             persister.Save(saga1, options);
-            saga1 = persister.Get<SagaWithUniquePropertyData>(saga1.Id, options);
+            saga1 = persister.Get<SagaWithUniquePropertyData>(saga1.Id.ToString(), options);
             saga1.UniqueString = "whatever2";
             persister.Update(saga1, options);
 

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_saga_not_found_return_default.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_saga_not_found_return_default.cs
@@ -27,7 +27,7 @@
         public void Should_return_default_when_using_finding_saga_with_id()
         {
             var persister = InMemoryPersisterBuilder.Build<SimpleSagaEntitySaga>();
-            var simpleSageEntity = persister.Get<SimpleSagaEntity>(Guid.Empty, options);
+            var simpleSageEntity = persister.Get<SimpleSagaEntity>(Guid.Empty.ToString(), options);
             Assert.IsNull(simpleSageEntity);
         }
 
@@ -43,7 +43,7 @@
             var persister = InMemoryPersisterBuilder.Build<SimpleSagaEntitySaga>();
             persister.Save(simpleSagaEntity, options);
 
-            var anotherSagaEntity = persister.Get<AnotherSimpleSagaEntity>(id, options);
+            var anotherSagaEntity = persister.Get<AnotherSimpleSagaEntity>(id.ToString(), options);
             Assert.IsNull(anotherSagaEntity);
         }
     }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_updating_a_saga_with_the_same_unique_property_as_another_saga.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_updating_a_saga_with_the_same_unique_property_as_another_saga.cs
@@ -21,7 +21,7 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
 
             Assert.Throws<InvalidOperationException>(() => 
             {
-                var saga = persister.Get<SagaWithUniquePropertyData>(saga2.Id, options);
+                var saga = persister.Get<SagaWithUniquePropertyData>(saga2.Id.ToString(), options);
                 saga.UniqueString = "whatever1";
                 persister.Update(saga, options);
             });
@@ -41,7 +41,7 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
 
             Assert.Throws<InvalidOperationException>(() =>
             {
-                var saga = persister.Get<SagaWithTwoUniquePropertiesData>(saga2.Id, options);
+                var saga = persister.Get<SagaWithTwoUniquePropertiesData>(saga2.Id.ToString(), options);
                 saga.UniqueInt = 5;
                 persister.Update(saga, options);
             });

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_updating_a_saga_with_the_same_unique_property_value.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_updating_a_saga_with_the_same_unique_property_value.cs
@@ -19,7 +19,7 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
             var options = new SagaPersistenceOptions(SagaMetadata.Create(typeof(SagaWithUniqueProperty)));
 
             persister.Save(saga1, options);
-            saga1 = persister.Get<SagaWithUniquePropertyData>(saga1.Id, options);
+            saga1 = persister.Get<SagaWithUniquePropertyData>(saga1.Id.ToString(), options);
             persister.Update(saga1, options);
         }
     }

--- a/src/NServiceBus.Core/Saga/ISagaPersister.cs
+++ b/src/NServiceBus.Core/Saga/ISagaPersister.cs
@@ -1,7 +1,5 @@
 namespace NServiceBus.Saga
 {
-    using System;
-
     /// <summary>
     /// Defines the basic functionality of a persister for storing 
 	/// and retrieving a saga.
@@ -27,7 +25,7 @@ namespace NServiceBus.Saga
         /// </summary>
         /// <param name="sagaId">The Id of the saga entity to get.</param>
         /// <param name="options">The saga persistence options.</param>
-        TSagaData Get<TSagaData>(Guid sagaId, SagaPersistenceOptions options) where TSagaData : IContainSagaData;
+        TSagaData Get<TSagaData>(string sagaId, SagaPersistenceOptions options) where TSagaData : IContainSagaData;
 
         /// <summary>
         /// Looks up a saga entity by a given property.

--- a/src/NServiceBus.Core/Sagas/LoadSagaByIdWrapper.cs
+++ b/src/NServiceBus.Core/Sagas/LoadSagaByIdWrapper.cs
@@ -1,14 +1,11 @@
 namespace NServiceBus.Saga
 {
-    using System;
-
- 
     //this class in only here until we can move to a better saga persister api
     class LoadSagaByIdWrapper<T>:SagaLoader where T : IContainSagaData
     {
         public IContainSagaData Load(ISagaPersister persister, string sagaId, SagaPersistenceOptions options)
         {
-            return persister.Get<T>(Guid.Parse(sagaId), options);
+            return persister.Get<T>(sagaId, options);
         }
     }
 

--- a/src/NServiceBus.Core/Sagas/PropertySagaFinder.cs
+++ b/src/NServiceBus.Core/Sagas/PropertySagaFinder.cs
@@ -24,7 +24,7 @@ namespace NServiceBus.Saga
 
             if (sagaPropertyName.ToLower() == "id")
             {
-                return sagaPersister.Get<TSagaData>((Guid)propertyValue, options);
+                return sagaPersister.Get<TSagaData>(propertyValue.ToString(), options);
             }
 
             return sagaPersister.Get<TSagaData>(sagaPropertyName, propertyValue, options);


### PR DESCRIPTION
Discussed with @andreasohlund 

I assumed `IContainsSagaData` should still be the same for the moment.