### PR TITLE
SettingsExtensions should not try to instantiate abstract classes

### DIFF
--- a/src/NServiceBus.Core/SettingsExtentions.cs
+++ b/src/NServiceBus.Core/SettingsExtentions.cs
@@ -21,7 +21,8 @@ namespace NServiceBus
             var configurationSource = settings.Get<IConfigurationSource>();
 
             // ReSharper disable HeapView.SlowDelegateCreation
-            var sectionOverrideType = typesToScan.FirstOrDefault(t => typeof(IProvideConfiguration<T>).IsAssignableFrom(t));
+            var sectionOverrideType = typesToScan.Where(t => !t.IsAbstract)
+                .FirstOrDefault(t => typeof(IProvideConfiguration<T>).IsAssignableFrom(t));
             // ReSharper restore HeapView.SlowDelegateCreation
 
             if (sectionOverrideType == null)


### PR DESCRIPTION

SettingsExtensions.GetConfigSection method should filter out abstract classes, to prevent passing them to Activator.CreateInstance. Problem is described at https://github.com/Particular/NServiceBus/issues/2809