### PR TITLE
Make sure a Saga entity in acceptance tests always has virtual members

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Sagas\When_a_finder_exists.cs" />
     <Compile Include="ScenarioDescriptors\AllTransactionSettings.cs" />
     <Compile Include="ScenarioDescriptors\TransactionSettings.cs" />
+    <Compile Include="SelfVerification\When_running_acceptance_tests.cs" />
     <Compile Include="Tx\Issue_2481.cs" />
     <Compile Include="Tx\When_receiving_with_native_multi_queue_transaction.cs" />
     <Compile Include="UnitOfWork\When_a_subscription_message_arrives.cs" />

--- a/src/NServiceBus.AcceptanceTests/SelfVerification/When_running_acceptance_tests.cs
+++ b/src/NServiceBus.AcceptanceTests/SelfVerification/When_running_acceptance_tests.cs
@@ -1,0 +1,41 @@
+﻿namespace NServiceBus.AcceptanceTests.SelfVerification
+{
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using NServiceBus.Saga;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_running_acceptance_tests
+    {
+        [Test]
+        public void All_saga_entities_in_acceptance_tests_should_have_virtual_properties()
+        {
+            // Because otherwise NHibernate gets cranky!
+            var sagaEntities = Assembly.GetExecutingAssembly().GetTypes()
+                .Where(t => typeof(IContainSagaData).IsAssignableFrom(t) && !t.IsInterface)
+                .ToArray();
+
+            var offenders = 0;
+
+            foreach (var entity in sagaEntities)
+            {
+                foreach (var property in entity.GetProperties())
+                {
+                    if (property.GetGetMethod().IsVirtual)
+                    {
+                        Console.WriteLine("OK: {0}.{1}", entity.FullName, property.Name);
+                    }
+                    else
+                    {
+                        offenders++;
+                        Console.WriteLine("ERROR: {0}.{1} must be marked as virtual for NHibernate tests to succeed.", entity.FullName, property.Name);
+                    }
+                }
+            }
+
+            Assert.AreEqual(0, offenders);
+        }
+    }
+}


### PR DESCRIPTION
Just a little bit of reflection to make sure that when acceptance tests are run in the core, all saga entities must have virtual properties, so that we don't wait until we hit NHibernate to figure that out, and waste time in the process.