### PR TITLE
Acceptance test sagas/entities need unique names

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -153,7 +153,7 @@
     <Compile Include="Sagas\When_a_finder_exists.cs" />
     <Compile Include="ScenarioDescriptors\AllTransactionSettings.cs" />
     <Compile Include="ScenarioDescriptors\TransactionSettings.cs" />
-    <Compile Include="SelfVerification\When_running_acceptance_tests.cs" />
+    <Compile Include="SelfVerification\When_running_saga_tests.cs" />
     <Compile Include="Tx\Issue_2481.cs" />
     <Compile Include="Tx\When_receiving_with_native_multi_queue_transaction.cs" />
     <Compile Include="UnitOfWork\When_a_subscription_message_arrives.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_containing_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_containing_a_saga.cs
@@ -74,22 +74,22 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
                 }
             }
 
-            public class MySaga : Saga<MySaga.MySagaData>, IAmStartedByMessages<MyEvent>
+            public class AutoSubscriptionSaga : Saga<AutoSubscriptionSaga.AutoSubscriptionSagaData>, IAmStartedByMessages<MyEvent>
             {
                 public void Handle(MyEvent message)
                 {
                 }
 
-                public class MySagaData : ContainSagaData
+                public class AutoSubscriptionSagaData : ContainSagaData
                 {
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<AutoSubscriptionSagaData> mapper)
                 {
                 }
             }
 
-            public class MySagaThatReactsOnASuperClassEvent : Saga<MySagaThatReactsOnASuperClassEvent.MySagaData>, 
+            public class MySagaThatReactsOnASuperClassEvent : Saga<MySagaThatReactsOnASuperClassEvent.SuperClassEventSagaData>, 
                 IAmStartedByMessages<MyEventBase>
             {
                 public void Handle(MyEventBase message)
@@ -97,11 +97,11 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
                 }
 
 
-                public class MySagaData : ContainSagaData
+                public class SuperClassEventSagaData : ContainSagaData
                 {
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SuperClassEventSagaData> mapper)
                 {
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_base_class_message_hits_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_base_class_message_hits_a_saga.cs
@@ -43,7 +43,7 @@
                 EndpointSetup<DefaultServer>();
             }
 
-            public class TestSaga : Saga<TestSaga.SagaData>, IAmStartedByMessages<StartSagaMessageBase>
+            public class TestSaga04 : Saga<TestSaga04.SagaData04>, IAmStartedByMessages<StartSagaMessageBase>
             {
                 public Context Context { get; set; }
 
@@ -59,13 +59,13 @@
                     }
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData04> mapper)
                 {
                     mapper.ConfigureMapping<StartSagaMessageBase>(m => m.SomeId)
                         .ToSaga(s => s.SomeId);
                 }
 
-                public class SagaData : ContainSagaData
+                public class SagaData04 : ContainSagaData
                 {
                     public virtual Guid SomeId { get; set; }
                 }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_existing_saga_instance_exists.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_existing_saga_instance_exists.cs
@@ -44,7 +44,7 @@
                     builder => builder.Transactions().DoNotWrapHandlersExecutionInATransactionScope());
             }
 
-            public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartSagaMessage>
+            public class TestSaga05 : Saga<TestSagaData05>, IAmStartedByMessages<StartSagaMessage>
             {
                 public Context Context { get; set; }
                 public void Handle(StartSagaMessage message)
@@ -62,7 +62,7 @@
                     }
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData05> mapper)
                 {
                     mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
                         .ToSaga(s=>s.SomeId);
@@ -70,7 +70,7 @@
 
             }
 
-            public class TestSagaData : IContainSagaData
+            public class TestSagaData05 : IContainSagaData
             {
                 public virtual Guid Id { get; set; }
                 public virtual string Originator { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists.cs
@@ -31,17 +31,17 @@
                 EndpointSetup<DefaultServer>();
             }
 
-            class CustomFinder : IFindSagas<TestSaga.SagaData>.Using<StartSagaMessage>
+            class CustomFinder : IFindSagas<TestSaga06.SagaData06>.Using<StartSagaMessage>
             {
                 public Context Context { get; set; }
-                public TestSaga.SagaData FindBy(StartSagaMessage message, SagaPersistenceOptions options)
+                public TestSaga06.SagaData06 FindBy(StartSagaMessage message, SagaPersistenceOptions options)
                 {
                     Context.FinderUsed = true;
                     return null;
                 }
             }
 
-            public class TestSaga : Saga<TestSaga.SagaData>, IAmStartedByMessages<StartSagaMessage>
+            public class TestSaga06 : Saga<TestSaga06.SagaData06>, IAmStartedByMessages<StartSagaMessage>
             {
                 public Context Context { get; set; }
 
@@ -49,12 +49,12 @@
                 {
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData06> mapper)
                 {
                     // not required because of CustomFinder
                 }
 
-                public class SagaData : ContainSagaData
+                public class SagaData06 : ContainSagaData
                 {
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_context_information_added.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_context_information_added.cs
@@ -20,7 +20,7 @@ namespace NServiceBus.AcceptanceTests.Sagas
                 .Run();
 
             Assert.True(context.FinderUsed);
-            Assert.AreEqual(typeof(SagaEndpoint.TestSaga), context.Metadata.SagaType);
+            Assert.AreEqual(typeof(SagaEndpoint.TestSaga07), context.Metadata.SagaType);
             Assert.AreEqual("SomeData", context.ContextBag.Get<SagaEndpoint.BehaviorWhichAddsThingsToTheContext.State>().SomeData);
         }
 
@@ -38,10 +38,10 @@ namespace NServiceBus.AcceptanceTests.Sagas
                 EndpointSetup<DefaultServer>(c => c.Pipeline.Register<BehaviorWhichAddsThingsToTheContext.Registration>());
             }
 
-            class CustomFinder : IFindSagas<TestSaga.SagaData>.Using<StartSagaMessage>
+            class CustomFinder : IFindSagas<TestSaga07.SagaData07>.Using<StartSagaMessage>
             {
                 public Context Context { get; set; }
-                public TestSaga.SagaData FindBy(StartSagaMessage message, SagaPersistenceOptions options)
+                public TestSaga07.SagaData07 FindBy(StartSagaMessage message, SagaPersistenceOptions options)
                 {
                     Context.Metadata = options.Metadata;
                     Context.ContextBag = options.Context;
@@ -50,7 +50,7 @@ namespace NServiceBus.AcceptanceTests.Sagas
                 }
             }
 
-            public class TestSaga : Saga<TestSaga.SagaData>, IAmStartedByMessages<StartSagaMessage>
+            public class TestSaga07 : Saga<TestSaga07.SagaData07>, IAmStartedByMessages<StartSagaMessage>
             {
                 public Context Context { get; set; }
 
@@ -58,11 +58,11 @@ namespace NServiceBus.AcceptanceTests.Sagas
                 {
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData07> mapper)
                 {
                 }
 
-                public class SagaData : ContainSagaData
+                public class SagaData07 : ContainSagaData
                 {
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_found_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_found_saga.cs
@@ -32,22 +32,22 @@
                 EndpointSetup<DefaultServer>();
             }
 
-            public class CustomFinder : IFindSagas<TestSaga.SagaData>.Using<SomeOtherMessage>
+            public class CustomFinder : IFindSagas<TestSaga08.SagaData08>.Using<SomeOtherMessage>
             {
                 // ReSharper disable once MemberCanBePrivate.Global
                 public Context Context { get; set; }
 
-                public TestSaga.SagaData FindBy(SomeOtherMessage message, SagaPersistenceOptions options)
+                public TestSaga08.SagaData08 FindBy(SomeOtherMessage message, SagaPersistenceOptions options)
                 {
                     Context.FinderUsed = true;
-                    return new TestSaga.SagaData
+                    return new TestSaga08.SagaData08
                            {
                                Property = "jfbsjdfbsdjh"
                            };
                 }
             }
 
-            public class TestSaga : Saga<TestSaga.SagaData>,
+            public class TestSaga08 : Saga<TestSaga08.SagaData08>,
                 IAmStartedByMessages<StartSagaMessage>,
                 IHandleMessages<SomeOtherMessage>
             {
@@ -58,12 +58,12 @@
                     Bus.SendLocal(new SomeOtherMessage());
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData08> mapper)
                 {
                     // not required because of CustomFinder
                 }
 
-                public class SagaData : ContainSagaData
+                public class SagaData08 : ContainSagaData
                 {
                     public virtual string Property { get; set; }
                 }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
@@ -36,7 +36,7 @@
                 EndpointSetup<DefaultServer>();
             }
 
-            public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartSagaMessage>,IHandleMessages<SecondSagaMessage>
+            public class TestSaga09 : Saga<TestSagaData09>, IAmStartedByMessages<StartSagaMessage>,IHandleMessages<SecondSagaMessage>
             {
                 public Context Context { get; set; }
                 public void Handle(StartSagaMessage message)
@@ -49,7 +49,7 @@
                         });
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData09> mapper)
                 {
                     mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
                         .ToSaga(s=>s.SomeId);
@@ -70,7 +70,7 @@
 
             }
 
-            public class TestSagaData : IContainSagaData
+            public class TestSagaData09 : IContainSagaData
             {
                 public virtual Guid Id { get; set; }
                 public virtual string Originator { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_an_endpoint_replies_to_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_an_endpoint_replies_to_a_saga.cs
@@ -76,7 +76,7 @@
             }
 
 
-            public class Saga2 : Saga<Saga2.MySaga2Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<DoSomethingResponse>
+            public class CorrelationTestSaga : Saga<CorrelationTestSaga.CorrelationTestSagaData>, IAmStartedByMessages<StartSaga>, IHandleMessages<DoSomethingResponse>
             {
                 public Context Context { get; set; }
 
@@ -93,13 +93,13 @@
                     MarkAsComplete();
                 }
                 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySaga2Data> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<CorrelationTestSagaData> mapper)
                 {
                     mapper.ConfigureMapping<StartSaga>(m => m.RunId).ToSaga(s => s.RunId);
                     mapper.ConfigureMapping<DoSomethingResponse>(m => m.RunId).ToSaga(s => s.RunId);
                 }
 
-                public class MySaga2Data : ContainSagaData
+                public class CorrelationTestSagaData : ContainSagaData
                 {
                     public virtual Guid RunId { get; set; }
                 }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas.cs
@@ -24,7 +24,7 @@ namespace NServiceBus.AcceptanceTests.Sagas
                 EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
             }
 
-            public class RequestingSaga : Saga<RequestingSaga.RequestingSagaData>,
+            public class RequestResponseRequestingSaga : Saga<RequestResponseRequestingSaga.RequestResponseRequestingSagaData>,
                 IAmStartedByMessages<InitiateRequestingSaga>,
                 IHandleMessages<ResponseFromOtherSaga>
             {
@@ -46,21 +46,21 @@ namespace NServiceBus.AcceptanceTests.Sagas
                     MarkAsComplete();
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RequestingSagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RequestResponseRequestingSagaData> mapper)
                 {
                     mapper.ConfigureMapping<InitiateRequestingSaga>(m => m.Id).ToSaga(s => s.CorrIdForResponse);
                     mapper.ConfigureMapping<ResponseFromOtherSaga>(m => m.SomeCorrelationId).ToSaga(s => s.CorrIdForResponse);
                 }
-                public class RequestingSagaData : ContainSagaData
+                public class RequestResponseRequestingSagaData : ContainSagaData
                 {
                     public virtual Guid CorrIdForResponse { get; set; } //wont be needed in the future
                 }
 
             }
 
-            public class RespondingSaga : Saga<RespondingSaga.RespondingSagaData>,
+            public class RequestResponseRespondingSaga : Saga<RequestResponseRespondingSaga.RequestResponseRespondingSagaData>,
                 IAmStartedByMessages<RequestToRespondingSaga>,
-                IHandleTimeouts<RespondingSaga.DelayReply>,
+                IHandleTimeouts<RequestResponseRespondingSaga.DelayReply>,
                 IHandleMessages<SendReplyFromNonInitiatingHandler>
             {
                 public Context Context { get; set; }
@@ -89,14 +89,14 @@ namespace NServiceBus.AcceptanceTests.Sagas
                     Bus.Reply(new ResponseFromOtherSaga());
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RespondingSagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RequestResponseRespondingSagaData> mapper)
                 {
                     mapper.ConfigureMapping<RequestToRespondingSaga>(m => m.SomeIdThatTheResponseSagaCanCorrelateBackToUs).ToSaga(s => s.CorrIdForRequest);
                     //this line is just needed so we can test the non initiating handler case
                     mapper.ConfigureMapping<SendReplyFromNonInitiatingHandler>(m => m.SagaIdSoWeCanCorrelate).ToSaga(s => s.Id);
                 }
 
-                public class RespondingSagaData : ContainSagaData
+                public class RequestResponseRespondingSagaData : ContainSagaData
                 {
                     public virtual Guid CorrIdForRequest { get; set; }
                 }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
@@ -18,7 +18,7 @@
                     var options = new SendOptions();
 
                     options.SetHeader(Headers.SagaId, Guid.NewGuid().ToString());
-                    options.SetHeader(Headers.SagaType, typeof(MySaga).AssemblyQualifiedName);
+                    options.SetHeader(Headers.SagaType, typeof(MessageWithSagaIdSaga).AssemblyQualifiedName);
                     options.RouteToLocalEndpointInstance();
                     bus.Send(message,options);
                 }))
@@ -31,17 +31,17 @@
             Assert.False(context.TimeoutHandlerCalled);
         }
 
-        class MySaga : Saga<MySaga.SagaData>, IAmStartedByMessages<MessageWithSagaId>,
+        class MessageWithSagaIdSaga : Saga<MessageWithSagaIdSaga.MessageWithSagaIdSagaData>, IAmStartedByMessages<MessageWithSagaId>,
             IHandleTimeouts<MessageWithSagaId>,
             IHandleSagaNotFound
         {
             public Context Context { get; set; }
 
-            public class SagaData : ContainSagaData
+            public class MessageWithSagaIdSagaData : ContainSagaData
             {
             }
 
-            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MessageWithSagaIdSagaData> mapper)
             {
             }
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_completes_the_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_completes_the_saga.cs
@@ -81,10 +81,10 @@
         {
             public SagaEndpoint()
             {
-                EndpointSetup<DefaultServer>(b => b.ExecuteTheseHandlersFirst(typeof(TestSaga)));
+                EndpointSetup<DefaultServer>(b => b.ExecuteTheseHandlersFirst(typeof(TestSaga10)));
             }
 
-            public class TestSaga : Saga<TestSagaData>, 
+            public class TestSaga10 : Saga<TestSagaData10>, 
                 IAmStartedByMessages<StartSagaMessage>, 
                 IHandleMessages<CompleteSagaMessage>, 
                 IHandleMessages<AnotherMessage>
@@ -113,7 +113,7 @@
                     Context.SagaReceivedAnotherMessage = true;
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData10> mapper)
                 {
                     mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
                         .ToSaga(s => s.SomeId);
@@ -124,7 +124,7 @@
                 }
             }
 
-            public class TestSagaData : IContainSagaData
+            public class TestSagaData10 : IContainSagaData
             {
                 public virtual Guid Id { get; set; }
                 public virtual string Originator { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_should_start_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_should_start_a_saga.cs
@@ -23,7 +23,7 @@
                 EndpointSetup<DefaultServer>(b => b.ExecuteTheseHandlersFirst(typeof(InterceptingHandler)));
             }
 
-            public class TestSaga : Saga<TestSaga.TestSagaData>, IAmStartedByMessages<StartSagaMessage>
+            public class TestSaga03 : Saga<TestSaga03.TestSagaData03>, IAmStartedByMessages<StartSagaMessage>
             {
                 public SagaEndpointContext Context { get; set; }
 
@@ -33,13 +33,13 @@
                     Data.SomeId = message.SomeId;
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData03> mapper)
                 {
                     mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
                         .ToSaga(s => s.SomeId);
                 }
 
-                public class TestSagaData : ContainSagaData
+                public class TestSagaData03 : ContainSagaData
                 {
                     public virtual string SomeId { get; set; }
                 }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_replies_to_message_published_by_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_replies_to_message_published_by_a_saga.cs
@@ -79,7 +79,7 @@
                 }));
             }
 
-            public class Saga2 : Saga<Saga2.MySaga2Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<DidSomethingResponse>
+            public class ReplyToPubMsgSaga : Saga<ReplyToPubMsgSaga.ReplyToPubMsgSagaData>, IAmStartedByMessages<StartSaga>, IHandleMessages<DidSomethingResponse>
             {
                 public Context Context { get; set; }
 
@@ -95,12 +95,12 @@
                     MarkAsComplete();
                 }
                 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySaga2Data> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ReplyToPubMsgSagaData> mapper)
                 {
                     mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
-                public class MySaga2Data : ContainSagaData
+                public class ReplyToPubMsgSagaData : ContainSagaData
                 {
                     public virtual Guid DataId { get; set; }
                 }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_reply_from_a_finder.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_reply_from_a_finder.cs
@@ -41,12 +41,12 @@
                 EndpointSetup<DefaultServer>();
             }
 
-            class CustomFinder : IFindSagas<TestSagaWithCustomFinder.SagaData>.Using<StartSagaMessage>
+            class CustomFinder : IFindSagas<TestSagaWithCustomFinder.TestSagaWithCustomFinderSagaData>.Using<StartSagaMessage>
             {
                 public IBus Bus { get; set; }
                 public Context Context { get; set; }
 
-                public TestSagaWithCustomFinder.SagaData FindBy(StartSagaMessage message, SagaPersistenceOptions options)
+                public TestSagaWithCustomFinder.TestSagaWithCustomFinderSagaData FindBy(StartSagaMessage message, SagaPersistenceOptions options)
                 {
                     Bus.Reply(new SagaNotFoundMessage
                               {
@@ -56,7 +56,7 @@
                 }
             }
 
-            public class TestSagaWithCustomFinder : Saga<TestSagaWithCustomFinder.SagaData>,
+            public class TestSagaWithCustomFinder : Saga<TestSagaWithCustomFinder.TestSagaWithCustomFinderSagaData>,
                 IAmStartedByMessages<StartSagaMessage>
             {
                 public Context Context { get; set; }
@@ -65,12 +65,12 @@
                 {
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaWithCustomFinderSagaData> mapper)
                 {
                     // not required because of CustomFinder
                 }
 
-                public class SagaData : ContainSagaData
+                public class TestSagaWithCustomFinderSagaData : ContainSagaData
                 {
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_has_a_non_empty_constructor.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_has_a_non_empty_constructor.cs
@@ -40,13 +40,13 @@
                     builder => builder.Transactions().DoNotWrapHandlersExecutionInATransactionScope());
             }
 
-            public class TestSaga : Saga<TestSagaData>,
+            public class TestSaga11 : Saga<TestSagaData11>,
                 IAmStartedByMessages<StartSagaMessage>, IHandleMessages<OtherMessage>
             {
                 Context context;
 
                 // ReSharper disable once UnusedParameter.Local
-                public TestSaga(IBus bus, Context context)
+                public TestSaga11(IBus bus, Context context)
                 {
                     this.context = context;
                 }
@@ -56,7 +56,7 @@
                     Data.SomeId = message.SomeId;
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData11> mapper)
                 {
                     mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
                         .ToSaga(s => s.SomeId);
@@ -70,7 +70,7 @@
                 }
             }
 
-            public class TestSagaData : IContainSagaData
+            public class TestSagaData11 : IContainSagaData
             {
                 public virtual Guid Id { get; set; }
                 public virtual string Originator { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
@@ -27,7 +27,7 @@
                 .Repeat(r => r.For(Transports.Default))
                 .Run();
 
-            Debug.WriteLine(context.ExceptionMessage, "A modification of IContainSagaData.Id has been detected. This property is for infrastructure purposes only and should not be modified. SagaType: " + typeof(Endpoint.MySaga));
+            Debug.WriteLine(context.ExceptionMessage, "A modification of IContainSagaData.Id has been detected. This property is for infrastructure purposes only and should not be modified. SagaType: " + typeof(Endpoint.SagaIdChangedSaga));
         }
 
         public class Context : ScenarioContext
@@ -47,7 +47,7 @@
                     });
             }
 
-            public class MySaga : Saga<MySaga.MySagaData>,
+            public class SagaIdChangedSaga : Saga<SagaIdChangedSaga.SagaIdChangedSagaData>,
                 IAmStartedByMessages<StartSaga>
             {
                 public Context Context { get; set; }
@@ -58,12 +58,12 @@
                     Data.Id = Guid.NewGuid();
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaIdChangedSagaData> mapper)
                 {
                     mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
-                public class MySagaData : ContainSagaData
+                public class SagaIdChangedSagaData : ContainSagaData
                 {
                     public virtual Guid DataId { get; set; }
                 }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
@@ -38,7 +38,7 @@
                     builder => builder.Transactions().DoNotWrapHandlersExecutionInATransactionScope());
             }
 
-            public class TestSaga : Saga<TestSagaData>,
+            public class TestSaga02 : Saga<TestSagaData02>,
                 IAmStartedByMessages<StartSagaMessage>, IHandleMessages<OtherMessage>
             {
                 public Context Context { get; set; }
@@ -47,7 +47,7 @@
                     Data.KeyValue = message.Key;
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData02> mapper)
                 {
                     mapper.ConfigureMapping<OtherMessage>(m => m.Part1 + "_" + m.Part2)
                         .ToSaga(s => s.KeyValue);
@@ -59,7 +59,7 @@
                 }
             }
 
-            public class TestSagaData : IContainSagaData
+            public class TestSagaData02 : IContainSagaData
             {
                 public virtual Guid Id { get; set; }
                 public virtual string Originator { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
@@ -73,7 +73,7 @@
                 }
             }
 
-            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
+            public class CantBeFoundSaga1 : Saga<CantBeFoundSaga1.CantBeFoundSaga1Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
             {
 
                 public void Handle(StartSaga message)
@@ -85,19 +85,19 @@
                 {
                 }
 
-                public class Saga1Data : ContainSagaData
+                public class CantBeFoundSaga1Data : ContainSagaData
                 {
                     public virtual Guid MessageId { get; set; }
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<CantBeFoundSaga1Data> mapper)
                 {
                     mapper.ConfigureMapping<StartSaga>(m => m.Id).ToSaga(s => s.MessageId);
                     mapper.ConfigureMapping<MessageToSaga>(m => m.Id).ToSaga(s => s.MessageId);
                 }
             }
 
-            public class Saga2 : Saga<Saga2.Saga2Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
+            public class CantBeFoundSaga2 : Saga<CantBeFoundSaga2.CantBeFoundSaga2Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
             {
 
                 public void Handle(StartSaga message)
@@ -109,12 +109,12 @@
                 {
                 }
 
-                public class Saga2Data : ContainSagaData
+                public class CantBeFoundSaga2Data : ContainSagaData
                 {
                     public virtual Guid MessageId { get; set; }
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga2Data> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<CantBeFoundSaga2Data> mapper)
                 {
                     mapper.ConfigureMapping<StartSaga>(m => m.Id).ToSaga(s => s.MessageId);
                     mapper.ConfigureMapping<MessageToSaga>(m => m.Id).ToSaga(s => s.MessageId);
@@ -139,7 +139,7 @@
                 EndpointSetup<DefaultServer>(c =>
                 {
                     c.EnableFeature<TimeoutManager>();
-                    c.ExecuteTheseHandlersFirst(typeof(Saga1), typeof(Saga2));
+                    c.ExecuteTheseHandlersFirst(typeof(ReceiverWithOrderedSagasSaga1), typeof(ReceiverWithOrderedSagasSaga2));
                 });
             }
 
@@ -168,7 +168,7 @@
                 }
             }
 
-            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
+            public class ReceiverWithOrderedSagasSaga1 : Saga<ReceiverWithOrderedSagasSaga1.ReceiverWithOrderedSagasSaga1Data>, IAmStartedByMessages<StartSaga>, IHandleMessages<MessageToSaga>
             {
                 public void Handle(StartSaga message)
                 {
@@ -179,19 +179,19 @@
                 {
                 }
 
-                public class Saga1Data : ContainSagaData
+                public class ReceiverWithOrderedSagasSaga1Data : ContainSagaData
                 {
                     public virtual Guid MessageId { get; set; }
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ReceiverWithOrderedSagasSaga1Data> mapper)
                 {
                     mapper.ConfigureMapping<StartSaga>(m => m.Id).ToSaga(s => s.MessageId);
                     mapper.ConfigureMapping<MessageToSaga>(m => m.Id).ToSaga(s => s.MessageId);
                 }
             }
 
-            public class Saga2 : Saga<Saga2.Saga2Data>, IHandleMessages<StartSaga>, IAmStartedByMessages<MessageToSaga>
+            public class ReceiverWithOrderedSagasSaga2 : Saga<ReceiverWithOrderedSagasSaga2.ReceiverWithOrderedSagasSaga2Data>, IHandleMessages<StartSaga>, IAmStartedByMessages<MessageToSaga>
             {
                 public void Handle(StartSaga message)
                 {
@@ -202,12 +202,12 @@
                 {
                 }
 
-                public class Saga2Data : ContainSagaData
+                public class ReceiverWithOrderedSagasSaga2Data : ContainSagaData
                 {
                     public virtual Guid MessageId { get; set; }
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga2Data> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ReceiverWithOrderedSagasSaga2Data> mapper)
                 {
                     mapper.ConfigureMapping<StartSaga>(m => m.Id).ToSaga(s => s.MessageId);
                     mapper.ConfigureMapping<MessageToSaga>(m => m.Id).ToSaga(s => s.MessageId);

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_handle.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_handle.cs
@@ -35,7 +35,7 @@ namespace NServiceBus.AcceptanceTests.Sagas
                 EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
             }
 
-            public class Saga1 : Saga<Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleMessages<MessageSaga1WillHandle>
+            public class TwoSaga1Saga1 : Saga<TwoSaga1Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleMessages<MessageSaga1WillHandle>
             {
                 public Context Context { get; set; }
 
@@ -55,7 +55,7 @@ namespace NServiceBus.AcceptanceTests.Sagas
                     MarkAsComplete();
                 }
                 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TwoSaga1Saga1Data> mapper)
                 {
                     mapper.ConfigureMapping<MessageSaga1WillHandle>(m => m.DataId).ToSaga(s => s.DataId);
                     mapper.ConfigureMapping<StartSaga1>(m => m.DataId).ToSaga(s => s.DataId);
@@ -63,13 +63,13 @@ namespace NServiceBus.AcceptanceTests.Sagas
 
             }
 
-            public class Saga1Data : ContainSagaData
+            public class TwoSaga1Saga1Data : ContainSagaData
             {
                 public virtual Guid DataId { get; set; }
             }
 
 
-            public class Saga2 : Saga<Saga2.Saga2Data>, IAmStartedByMessages<StartSaga2>
+            public class TwoSaga1Saga2 : Saga<TwoSaga1Saga2.TwoSaga1Saga2Data>, IAmStartedByMessages<StartSaga2>
             {
                 public Context Context { get; set; }
 
@@ -78,12 +78,12 @@ namespace NServiceBus.AcceptanceTests.Sagas
                     Context.DidSaga2ReceiveMessage = true;
                 }
 
-                public class Saga2Data : ContainSagaData
+                public class TwoSaga1Saga2Data : ContainSagaData
                 {
                     public virtual Guid DataId { get; set; }
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga2Data> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TwoSaga1Saga2Data> mapper)
                 {
                     mapper.ConfigureMapping<StartSaga2>(m => m.DataId).ToSaga(s => s.DataId);
                 }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
@@ -34,7 +34,7 @@
                 EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
             }
 
-            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleTimeouts<Saga1Timeout>
+            public class SendFromTimeoutSaga1 : Saga<SendFromTimeoutSaga1.SendFromTimeoutSaga1Data>, IAmStartedByMessages<StartSaga1>, IHandleTimeouts<Saga1Timeout>
             {
                 public Context Context { get; set; }
 
@@ -50,18 +50,18 @@
                     MarkAsComplete();
                 }
 
-                public class Saga1Data : ContainSagaData
+                public class SendFromTimeoutSaga1Data : ContainSagaData
                 {
                     public virtual Guid DataId { get; set; }
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SendFromTimeoutSaga1Data> mapper)
                 {
                     mapper.ConfigureMapping<StartSaga1>(m => m.DataId).ToSaga(s => s.DataId);
                 }
             }
 
-            public class Saga2 : Saga<Saga2.Saga2Data>, IAmStartedByMessages<StartSaga2>
+            public class SendFromTimeoutSaga2 : Saga<SendFromTimeoutSaga2.SendFromTimeoutSaga2Data>, IAmStartedByMessages<StartSaga2>
             {
                 public Context Context { get; set; }
 
@@ -71,12 +71,12 @@
                     Context.DidSaga2ReceiveMessage = true;
                 }
 
-                public class Saga2Data : ContainSagaData
+                public class SendFromTimeoutSaga2Data : ContainSagaData
                 {
                     public virtual Guid DataId { get; set; }
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga2Data> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SendFromTimeoutSaga2Data> mapper)
                 {
                     mapper.ConfigureMapping<StartSaga2>(m => m.DataId).ToSaga(s => s.DataId);
                 }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_base_event_from_other_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_base_event_from_other_saga.cs
@@ -62,7 +62,7 @@
                     .AddMapping<BaseEvent>(typeof(Publisher));
             }
 
-            public class SagaStartedByBaseEvent : Saga<SagaStartedByBaseEvent.SagaData>, IAmStartedByMessages<BaseEvent>
+            public class SagaStartedByBaseEvent : Saga<SagaStartedByBaseEvent.SagaStartedByBaseEventSagaData>, IAmStartedByMessages<BaseEvent>
             {
                 public SagaContext Context { get; set; }
 
@@ -73,12 +73,12 @@
                     Context.DidSagaComplete = true;
                 }
 
-                public class SagaData : ContainSagaData
+                public class SagaStartedByBaseEventSagaData : ContainSagaData
                 {
                     public virtual Guid DataId { get; set; }
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaStartedByBaseEventSagaData> mapper)
                 {
                     mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
                 }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_event_from_another_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_event_from_another_saga.cs
@@ -59,7 +59,7 @@
                 });
             }
 
-            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga>, IHandleTimeouts<Saga1.Timeout1>
+            public class EventFromOtherSaga1 : Saga<EventFromOtherSaga1.EventFromOtherSaga1Data>, IAmStartedByMessages<StartSaga>, IHandleTimeouts<EventFromOtherSaga1.Timeout1>
             {
                 public Context Context { get; set; }
 
@@ -80,7 +80,7 @@
                     Context.DidSaga1Complete = true;
                 }
 
-                public class Saga1Data : ContainSagaData
+                public class EventFromOtherSaga1Data : ContainSagaData
                 {
                     public virtual Guid DataId { get; set; }
                 }
@@ -89,7 +89,7 @@
                 {
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<EventFromOtherSaga1Data> mapper)
                 {
                     mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
                 }
@@ -109,7 +109,7 @@
 
             }
 
-            public class Saga2 : Saga<Saga2.Saga2Data>, IAmStartedByMessages<SomethingHappenedEvent>, IHandleTimeouts<Saga2.Saga2Timeout>
+            public class EventFromOtherSaga2 : Saga<EventFromOtherSaga2.EventFromOtherSaga2Data>, IAmStartedByMessages<SomethingHappenedEvent>, IHandleTimeouts<EventFromOtherSaga2.Saga2Timeout>
             {
                 public Context Context { get; set; }
 
@@ -126,7 +126,7 @@
                     Context.DidSaga2Complete = true;
                 }
 
-                public class Saga2Data : ContainSagaData
+                public class EventFromOtherSaga2Data : ContainSagaData
                 {
                     public virtual Guid DataId { get; set; }
                 }
@@ -135,7 +135,7 @@
                 {
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga2Data> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<EventFromOtherSaga2Data> mapper)
                 {
                     mapper.ConfigureMapping<SomethingHappenedEvent>(m => m.DataId).ToSaga(s => s.DataId);
                 }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_timeout_hit_not_found_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_timeout_hit_not_found_saga.cs
@@ -34,9 +34,9 @@
                 EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
             }
 
-            public class MySaga : Saga<MySaga.MySagaData>,
+            public class TimeoutHitsNotFoundSaga : Saga<TimeoutHitsNotFoundSaga.TimeoutHitsNotFoundSagaData>,
                 IAmStartedByMessages<StartSaga>, IHandleSagaNotFound,
-                IHandleTimeouts<MySaga.MyTimeout>,
+                IHandleTimeouts<TimeoutHitsNotFoundSaga.MyTimeout>,
                 IHandleMessages<SomeOtherMessage>
             {
                 public Context Context { get; set; }
@@ -52,13 +52,13 @@
                     MarkAsComplete();
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TimeoutHitsNotFoundSagaData> mapper)
                 {
                     mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
                     mapper.ConfigureMapping<SomeOtherMessage>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
-                public class MySagaData : ContainSagaData
+                public class TimeoutHitsNotFoundSagaData : ContainSagaData
                 {
                     public virtual Guid DataId { get; set; }
                 }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
@@ -34,7 +34,7 @@
                 EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
             }
 
-            public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartSagaMessage>, IHandleTimeouts<StartSagaMessage>
+            public class TestSaga01 : Saga<TestSagaData01>, IAmStartedByMessages<StartSagaMessage>, IHandleTimeouts<StartSagaMessage>
             {
                 public Context Context { get; set; }
 
@@ -44,7 +44,7 @@
                     RequestTimeout(TimeSpan.FromMilliseconds(100), message);
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData01> mapper)
                 {
                     mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
                         .ToSaga(s => s.SomeId);
@@ -57,7 +57,7 @@
                 }
             }
 
-            public class TestSagaData : IContainSagaData
+            public class TestSagaData01 : IContainSagaData
             {
                 public virtual Guid Id { get; set; }
                 public virtual string Originator { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Sagas/when_receiving_multiple_timeouts.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/when_receiving_multiple_timeouts.cs
@@ -44,7 +44,7 @@
                 });
             }
 
-            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleTimeouts<Saga1Timeout>, IHandleTimeouts<Saga2Timeout>
+            public class MultTimeoutsSaga1 : Saga<MultTimeoutsSaga1.MultTimeoutsSaga1Data>, IAmStartedByMessages<StartSaga1>, IHandleTimeouts<Saga1Timeout>, IHandleTimeouts<Saga2Timeout>
             {
                 public Context Context { get; set; }
 
@@ -72,12 +72,12 @@
                     Context.Saga2TimeoutFired = true;
                 }
 
-                public class Saga1Data : ContainSagaData
+                public class MultTimeoutsSaga1Data : ContainSagaData
                 {
                     public virtual Guid ContextId { get; set; }
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MultTimeoutsSaga1Data> mapper)
                 {
                     mapper.ConfigureMapping<StartSaga1>(m => m.ContextId)
                         .ToSaga(s => s.Id);

--- a/src/NServiceBus.AcceptanceTests/Sagas/when_reply_from_saga_not_found_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/when_reply_from_saga_not_found_handler.cs
@@ -55,7 +55,7 @@
                 EndpointSetup<DefaultServer>();
             }
 
-            public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleMessages<MessageToSaga>
+            public class NotFoundHandlerSaga1 : Saga<NotFoundHandlerSaga1.NotFoundHandlerSaga1Data>, IAmStartedByMessages<StartSaga1>, IHandleMessages<MessageToSaga>
             {
 
                 public void Handle(StartSaga1 message)
@@ -67,12 +67,12 @@
                 {
                 }
 
-                public class Saga1Data : ContainSagaData
+                public class NotFoundHandlerSaga1Data : ContainSagaData
                 {
                     public virtual Guid ContextId { get; set; }
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<NotFoundHandlerSaga1Data> mapper)
                 {
                     mapper.ConfigureMapping<StartSaga1>(m => m.ContextId)
                         .ToSaga(s => s.ContextId);


### PR DESCRIPTION
We're awful at naming things. There are more names available than TestSaga, MySaga, Saga1, Saga2, etc. NHibernate mapping conventions (although not necessarily a unique problem for NHibernate) maps saga names based on the class names (not full names, so namespace doesn't matter!) of the Saga and SagaEntity. If not unique, then the same SQL table is shared between the tests, even if their structure is radically different, introducing subtle testing bugs based on which tests run first and get the opportunity to create the table.

Ideally, all sagas would be well named so that they described, in some way, what was under test. But that takes more time and energy than I have available today.

This PR introduces a reflection test to ensure that all Sagas and SagaEntities have unique names, at the very least. In some I tried to come up with unique, useful names, but many of the tests are so abstract that I just renamed them to TestSaga01 through TestSaga11.

Further renaming can happen in the future to make the names actually meaningful, but this much is required to get me unstuck in NHibernate.

All changes to tests were made with Resharper. Assuming the acceptance tests still pass here, this should be fairly low risk even though a lot of files have been touched.

If you're looking for the reflection test, that's isolated in its own commit.