### PR TITLE
Fix culture dependent tests

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Exceptions/Handler_throws.cs
+++ b/src/NServiceBus.AcceptanceTests/Exceptions/Handler_throws.cs
@@ -20,17 +20,16 @@
                     .AllowExceptions()
                     .Done(c => c.ExceptionReceived)
                     .Run();
-            Assert.AreEqual(typeof(HandlerException), context.ExceptionType);
+            Assert.AreEqual(typeof(HandlerException), context.Exception.GetType());
 
             StackTraceAssert.StartsWith(
-@"at NServiceBus.AcceptanceTests.Exceptions.Handler_throws.Endpoint.Handler.Handle(Message message)", context.StackTrace);
+@"at NServiceBus.AcceptanceTests.Exceptions.Handler_throws.Endpoint.Handler.Handle(Message message)", context.Exception);
         }
 
         public class Context : ScenarioContext
         {
             public bool ExceptionReceived { get; set; }
-            public string StackTrace { get; set; }
-            public Type ExceptionType { get; set; }
+            public Exception Exception { get; set; }
             public bool Subscribed { get; set; }
         }
 
@@ -61,8 +60,7 @@
                 {
                     BusNotifications.Errors.MessageSentToErrorQueue.Subscribe(e =>
                     {
-                        Context.ExceptionType = e.Exception.GetType();
-                        Context.StackTrace = e.Exception.StackTrace;
+                        Context.Exception = e.Exception;
                         Context.ExceptionReceived = true;
                     });
 

--- a/src/NServiceBus.AcceptanceTests/Exceptions/Uow_Begin_throws.cs
+++ b/src/NServiceBus.AcceptanceTests/Exceptions/Uow_Begin_throws.cs
@@ -22,16 +22,15 @@
                     .Done(c => c.ExceptionReceived)
                     .Run();
 
-            Assert.AreEqual(typeof(BeginException), context.ExceptionType);
+            Assert.AreEqual(typeof(BeginException), context.Exception.GetType());
             StackTraceAssert.StartsWith(
-@"at NServiceBus.AcceptanceTests.Exceptions.Uow_Begin_throws.Endpoint.UnitOfWorkThatThrowsInBegin.Begin()", context.StackTrace);
+@"at NServiceBus.AcceptanceTests.Exceptions.Uow_Begin_throws.Endpoint.UnitOfWorkThatThrowsInBegin.Begin()", context.Exception);
         }
 
         public class Context : ScenarioContext
         {
             public bool ExceptionReceived { get; set; }
-            public string StackTrace { get; set; }
-            public Type ExceptionType { get; set; }
+            public Exception Exception { get; set; }
             public bool Subscribed { get; set; }
         }
 
@@ -63,8 +62,7 @@
                 {
                     BusNotifications.Errors.MessageSentToErrorQueue.Subscribe(e =>
                     {
-                        Context.ExceptionType = e.Exception.GetType();
-                        Context.StackTrace = e.Exception.StackTrace;
+                        Context.Exception = e.Exception;
                         Context.ExceptionReceived = true;
                     });
 

--- a/src/NServiceBus.AcceptanceTests/Exceptions/Uow_End_throws.cs
+++ b/src/NServiceBus.AcceptanceTests/Exceptions/Uow_End_throws.cs
@@ -24,13 +24,13 @@
 
             Assert.AreEqual(typeof(EndException), context.ExceptionType);
             StackTraceAssert.StartsWith(
-@"at NServiceBus.AcceptanceTests.Exceptions.Uow_End_throws.Endpoint.UnitOfWorkThatThrowsInEnd.End(Exception ex)", context.StackTrace);
+@"at NServiceBus.AcceptanceTests.Exceptions.Uow_End_throws.Endpoint.UnitOfWorkThatThrowsInEnd.End(Exception ex)", context.Exception);
         }
 
         public class Context : ScenarioContext
         {
             public bool ExceptionReceived { get; set; }
-            public string StackTrace { get; set; }
+            public Exception Exception { get; set; }
             public Type ExceptionType { get; set; }
             public bool Subscribed { get; set; }
         }
@@ -63,7 +63,7 @@
                     BusNotifications.Errors.MessageSentToErrorQueue.Subscribe(e =>
                     {
                         Context.ExceptionType = e.Exception.GetType();
-                        Context.StackTrace = e.Exception.StackTrace;
+                        Context.Exception = e.Exception;
                         Context.ExceptionReceived = true;
                     });
 

--- a/src/NServiceBus.Core.Tests/Encryption/ConfigureRijndaelEncryptionServiceTests.cs
+++ b/src/NServiceBus.Core.Tests/Encryption/ConfigureRijndaelEncryptionServiceTests.cs
@@ -82,7 +82,8 @@
                 "key1"
             };
             var exception = Assert.Throws<ArgumentException>(() => ConfigureRijndaelEncryptionService.VerifyKeys(keys));
-            Assert.AreEqual("Overlapping keys defined. Please ensure that no keys overlap.\r\nParameter name: expiredKeys", exception.Message);
+            StringAssert.StartsWith("Overlapping keys defined. Please ensure that no keys overlap.", exception.Message);
+            Assert.AreEqual("expiredKeys", exception.ParamName);
         }
 
         [Test]
@@ -95,7 +96,8 @@
                 "key2"
             };
             var exception = Assert.Throws<ArgumentException>(() => ConfigureRijndaelEncryptionService.VerifyKeys(keys));
-            Assert.AreEqual("Empty encryption key detected in position 1.\r\nParameter name: expiredKeys", exception.Message);
+            StringAssert.StartsWith("Empty encryption key detected in position 1.", exception.Message);
+            Assert.AreEqual("expiredKeys", exception.ParamName);
         }
 
         [Test]
@@ -108,7 +110,8 @@
                 "key2"
             };
             var exception = Assert.Throws<ArgumentException>(() => ConfigureRijndaelEncryptionService.VerifyKeys(keys));
-            Assert.AreEqual("Empty encryption key detected in position 1.\r\nParameter name: expiredKeys", exception.Message);
+            StringAssert.StartsWith("Empty encryption key detected in position 1.", exception.Message);
+            Assert.AreEqual("expiredKeys", exception.ParamName);
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Utils/ExceptionHeaderHelperTests.cs
+++ b/src/NServiceBus.Core.Tests/Utils/ExceptionHeaderHelperTests.cs
@@ -17,12 +17,11 @@ namespace NServiceBus.Core.Tests.Utils
 
             var failedQueue = "TheErrorQueue@TheErrorQueueMachine";
             ExceptionHeaderHelper.SetExceptionHeaders(dictionary, exception, failedQueue, "The reason", false);
+
             Assert.AreEqual("The reason", dictionary["NServiceBus.ExceptionInfo.Reason"]);
             Assert.AreEqual("System.AggregateException", dictionary["NServiceBus.ExceptionInfo.ExceptionType"]);
-            var stackTrace = dictionary["NServiceBus.ExceptionInfo.StackTrace"];
-            Assert.IsTrue(stackTrace.StartsWith(@"System.AggregateException: My Exception ---> System.Exception: My Inner Exception
-   at NServiceBus.Core.Tests.Utils.ExceptionHeaderHelperTests.MethodThatThrows2() in "));
-            Assert.AreEqual("TheErrorQueue@TheErrorQueueMachine", dictionary[FaultsHeaderKeys.FailedQ]);
+            Assert.AreEqual(exception.ToString(), dictionary["NServiceBus.ExceptionInfo.StackTrace"]);
+            Assert.AreEqual(failedQueue, dictionary[FaultsHeaderKeys.FailedQ]);
             Assert.IsTrue(dictionary.ContainsKey("NServiceBus.TimeOfFailure"));
 
             Assert.AreEqual("System.Exception", dictionary["NServiceBus.ExceptionInfo.InnerExceptionType"]);
@@ -40,11 +39,11 @@ namespace NServiceBus.Core.Tests.Utils
 
             var failedQueue = "TheErrorQueue@TheErrorQueueMachine";
             ExceptionHeaderHelper.SetExceptionHeaders(dictionary, exception, failedQueue, "The reason", true);
+
             Assert.AreEqual("The reason", dictionary["NServiceBus.ExceptionInfo.Reason"]);
             Assert.AreEqual("System.AggregateException", dictionary["NServiceBus.ExceptionInfo.ExceptionType"]);
-            var stackTrace = dictionary["NServiceBus.ExceptionInfo.StackTrace"];
-            Assert.IsTrue(stackTrace.StartsWith(@"   at NServiceBus.Core.Tests.Utils.ExceptionHeaderHelperTests.MethodThatThrows1() in "));
-            Assert.AreEqual("TheErrorQueue@TheErrorQueueMachine", dictionary[FaultsHeaderKeys.FailedQ]);
+            Assert.AreEqual(exception.StackTrace, dictionary["NServiceBus.ExceptionInfo.StackTrace"]);
+            Assert.AreEqual(failedQueue, dictionary[FaultsHeaderKeys.FailedQ]);
             Assert.IsTrue(dictionary.ContainsKey("NServiceBus.TimeOfFailure"));
 
             Assert.AreEqual("System.Exception", dictionary["NServiceBus.ExceptionInfo.InnerExceptionType"]);

--- a/src/NServiceBus.Core.Tests/Utils/Reflection/ReflectTests.cs
+++ b/src/NServiceBus.Core.Tests/Utils/Reflection/ReflectTests.cs
@@ -51,11 +51,13 @@
                 var propertyInfo = Reflect<Target1>.GetProperty(target => target.Property1.Property2);
                 Assert.AreEqual("Property2", propertyInfo.Name);
             }
+
             [Test]
             public void Should_throw_when_dots_not_allowed()
             {
                 var argumentException = Assert.Throws<ArgumentException>(() => Reflect<Target1>.GetProperty(target => target.Property1.Property2, true));
-                Assert.AreEqual("Argument passed contains more than a single dot which is not allowed: target => target.Property1.Property2\r\nParameter name: member", argumentException.Message);
+                StringAssert.StartsWith("Argument passed contains more than a single dot which is not allowed: target => target.Property1.Property2", argumentException.Message);
+                Assert.AreEqual("member", argumentException.ParamName);
             }
 
             public class Target1


### PR DESCRIPTION
@SimonCropp you may want to have a look at the changes in `StackTraceAssert` helper.
I used the `StackTrace` class to get the localized stack traces without the file infos so we don't need to do that manually. As for the culture I decided to go with the minimal invasive way, which is setting the UICulture and accessing the Exception on a separate thread to avoid potential issues. This seems to work fine for the localization of the stack trace (although it won't work for certain exception messages like ArgumentNullException, but that doesn't matter here).

let me know what you think
