### PR TITLE
make ScenarioContext.Logs threadsafe

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
@@ -1,7 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTesting
 {
     using System;
-    using System.Collections.Generic;
+    using System.Collections.Concurrent;
 
     public abstract class ScenarioContext
     {
@@ -19,14 +19,14 @@
 
         public void RecordEndpointLog(string level, string message)
         {
-            Logs.Add(new LogItem
+            Logs.Enqueue(new LogItem
             {
                 Level = level,
                 Message = message
             });
         }
 
-        public readonly List<LogItem> Logs = new List<LogItem>();
+        public ConcurrentQueue<LogItem> Logs = new ConcurrentQueue<LogItem>();
 
         public class LogItem
         {

--- a/src/NServiceBus.AcceptanceTests/Exceptions/TransportMessage/Cant_convert_NoTransactions.cs
+++ b/src/NServiceBus.AcceptanceTests/Exceptions/TransportMessage/Cant_convert_NoTransactions.cs
@@ -17,14 +17,12 @@
                     .AllowExceptions()
                     .Done(c =>
                     {
-                        var logs = c.Logs;
-                        return logs.Any(l => l.Level == "error");
+                        return c.Logs.Any(l => l.Level == "error");
                     })
                     .Repeat(r => r.For<MsmqOnly>())
                     .Should(c =>
                     {
-                        var logs = c.Logs;
-                        Assert.True(logs.Any(l => l.Message.Contains("is corrupt and will be moved to")));
+                        Assert.True(c.Logs.Any(l => l.Message.Contains("is corrupt and will be moved to")));
                     })
                     .Run();
         }

--- a/src/NServiceBus.AcceptanceTests/Exceptions/TransportMessage/Cant_convert_SuppressedDTC.cs
+++ b/src/NServiceBus.AcceptanceTests/Exceptions/TransportMessage/Cant_convert_SuppressedDTC.cs
@@ -19,8 +19,7 @@
                     .Repeat(r => r.For<MsmqOnly>())
                     .Should(c =>
                     {
-                        var logs = c.Logs;
-                        Assert.True(logs.Any(l => l.Message.Contains("is corrupt and will be moved to")));
+                        Assert.True(c.Logs.Any(l => l.Message.Contains("is corrupt and will be moved to")));
                     })
                     .Run();
         }


### PR DESCRIPTION
Acceptance Tests using the ScenarioContext.Logs collection to define *Done* conditions on acceptance tests may run into InvalidOperationExceptions due to concurrent access to the underlying List.