### PR TITLE
XmlSerializer now serializes properties of `object` type properly

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Config\When_users_override_the_configuration_source.cs" />
     <Compile Include="Config\When_using_convention_based_messages.cs" />
     <Compile Include="Conventions\MessageConventionSpecs.cs" />
+    <Compile Include="Serializers\XML\Issue_2796.cs" />
     <Compile Include="StandardsTests.cs" />
     <Compile Include="Encryption\ConfigureRijndaelEncryptionServiceTests.cs" />
     <Compile Include="Encryption\RijndaelEncryptionServiceTest.cs" />

--- a/src/NServiceBus.Core.Tests/Serializers/XML/Issue_2796.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/Issue_2796.cs
@@ -1,0 +1,41 @@
+﻿namespace NServiceBus.Core.Tests.Serializers.XML
+{
+    using System;
+    using System.IO;
+    using NServiceBus.Serializers.XML.Test;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class Issue_2796
+    {
+        [Test]
+        public void Object_property_with_primitive_or_struct_value_should_serialize_correctly()
+        {
+            var serializer = SerializerFactory.Create<SerializedPair>();
+            var message = new SerializedPair
+            {
+                Key = "AddressId",
+                Value = new Guid("{ebdeeb33-baa7-4100-b1aa-eb4d6816fd3d}")
+            };
+
+            object[] messageDeserialized;
+            using (Stream stream = new MemoryStream())
+            {
+                serializer.Serialize(message, stream);
+
+                stream.Position = 0;
+
+                messageDeserialized = serializer.Deserialize(stream, new[] { message.GetType() });
+            }
+
+            Assert.AreEqual(message.Key, ((SerializedPair)messageDeserialized[0]).Key);
+            Assert.AreEqual(message.Value, ((SerializedPair)messageDeserialized[0]).Value);
+        }
+
+        public class SerializedPair
+        {
+            public string Key { get; set; }
+            public object Value { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Features/DisplayDiagnosticsForFeatures.cs
+++ b/src/NServiceBus.Core/Features/DisplayDiagnosticsForFeatures.cs
@@ -27,7 +27,7 @@ namespace NServiceBus.Features
                     statusText.Append("Deactivation reason: ");
                     if (diagnosticData.PrerequisiteStatus != null && !diagnosticData.PrerequisiteStatus.IsSatisfied)
                     {
-                        statusText.AppendLine(string.Format("Did not fulfill its Prerequisites:"));
+                        statusText.AppendLine("Did not fulfill its Prerequisites:");
 
                         foreach (var reason in diagnosticData.PrerequisiteStatus.Reasons)
                         {

--- a/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
@@ -61,7 +61,7 @@
 
                         if (LicenseExpirationChecker.HasLicenseExpired(license))
                         {
-                            var message = string.Format("The license you provided has expired, please select another file.");
+                            var message = "The license you provided has expired, please select another file.";
                             Logger.Warn(message);
                             MessageBox.Show(this, message, "License expired", MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
                             return;


### PR DESCRIPTION
This PR duplicates the fix #2796 for the 5.0 branch.