### PR TITLE
Less info logging

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
+++ b/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
@@ -32,7 +32,7 @@
             return this;
         }
 
-        public bool IsDebugEnabled { get { return true; } }
+        public bool IsDebugEnabled { get { return false; } }
         public bool IsInfoEnabled { get { return true; } }
         public bool IsWarnEnabled { get { return true; } }
         public bool IsErrorEnabled { get { return true; } }
@@ -63,23 +63,17 @@
 
         public void Debug(string message)
         {
-            Trace.WriteLine(message);
-            RecordLog(message, "debug");
+            //we don't care about debug logs
         }
 
         public void Debug(string message, Exception exception)
         {
-            var fullMessage = string.Format("{0} {1}", message, exception);
-            Trace.WriteLine(fullMessage);
             AppendException(exception);
-            RecordLog(fullMessage, "debug");
         }
 
         public void DebugFormat(string format, params object[] args)
         {
-            var fullMessage = string.Format(format, args);
-            Trace.WriteLine(fullMessage);
-            RecordLog(fullMessage, "debug");
+            //we don't care about debug logs
         }
 
         public void Info(string message)

--- a/src/NServiceBus.Core/Faults/MoveFaultsToErrorQueueBehavior.cs
+++ b/src/NServiceBus.Core/Faults/MoveFaultsToErrorQueueBehavior.cs
@@ -71,7 +71,6 @@ namespace NServiceBus
             public Registration()
                 : base("MoveFaultsToErrorQueue", typeof(MoveFaultsToErrorQueueBehavior), "Moved failing messages to the configured error queue")
             {
-                InsertBeforeIfExists("HandlerTransactionScopeWrapper");
                 InsertBeforeIfExists("FirstLevelRetries");
                 InsertBeforeIfExists("SecondLevelRetries");
             }

--- a/src/NServiceBus.Core/Features/DisplayDiagnosticsForFeatures.cs
+++ b/src/NServiceBus.Core/Features/DisplayDiagnosticsForFeatures.cs
@@ -50,7 +50,7 @@ namespace NServiceBus.Features
                 statusText.AppendLine();
             }
 
-            Logger.Info(statusText.ToString());
+            Logger.Debug(statusText.ToString());
         }
 
         static ILog Logger = LogManager.GetLogger<DisplayDiagnosticsForFeatures>();

--- a/src/NServiceBus.Core/Persistence/PersistenceStartup.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceStartup.cs
@@ -39,7 +39,7 @@
 
                 foreach (var storageType in definition.SelectedStorages)
                 {
-                    Logger.InfoFormat("Activating persistence '{0}' to provide storage for '{1}' storage.", definition.DefinitionType.Name, storageType);
+                    Logger.DebugFormat("Activating persistence '{0}' to provide storage for '{1}' storage.", definition.DefinitionType.Name, storageType);
                     persistenceDefinition.ApplyActionForStorage(storageType, settings);
                     resultingSupportedStorages.Add(storageType);
                 }

--- a/src/NServiceBus.Core/Pipeline/PipelineCollection.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineCollection.cs
@@ -24,7 +24,7 @@ namespace NServiceBus.Pipeline
                 try
                 {
                     await pipeline.Start();
-                    Logger.InfoFormat("Started {0} pipeline", pipeline.Id);
+                    Logger.DebugFormat("Started {0} pipeline", pipeline.Id);
                 }
                 catch (Exception ex)
                 {
@@ -40,7 +40,7 @@ namespace NServiceBus.Pipeline
             {
                 Logger.DebugFormat("Stopping {0} pipeline", pipeline.Id);
                 await pipeline.Stop();
-                Logger.InfoFormat("Stopped {0} pipeline", pipeline.Id);
+                Logger.DebugFormat("Stopped {0} pipeline", pipeline.Id);
             }
         }
 

--- a/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
@@ -199,7 +199,7 @@ namespace NServiceBus.Pipeline
 
                             if (!beforeReference.Enforce)
                             {
-                                Logger.Info(message);
+                                Logger.Debug(message);
                             }
                             else
                             {
@@ -224,7 +224,7 @@ namespace NServiceBus.Pipeline
 
                             if (!afterReference.Enforce)
                             {
-                                Logger.Info(message);
+                                Logger.Debug(message);
                             }
                             else
                             {

--- a/src/NServiceBus.Core/Unicast/Config/UnicastBus.cs
+++ b/src/NServiceBus.Core/Unicast/Config/UnicastBus.cs
@@ -104,7 +104,7 @@ namespace NServiceBus.Features
 
             var messageDefinitions = messageRegistry.GetAllMessages().ToList();
 
-            Logger.InfoFormat("Number of messages found: {0}", messageDefinitions.Count());
+            Logger.DebugFormat("Number of messages found: {0}", messageDefinitions.Count());
 
             if (!Logger.IsDebugEnabled)
             {


### PR DESCRIPTION
@SimonCropp first pass on dialing back the logging. Please review.

After this the acpt tests output:


```
smqTransport - Started @ 2015-08-26 16:18:30
Trial for Particular Service Platform is still active, trial expires on 2016-06-25.
Queue ANDREAS2015\private$\StartupIsComplete.StartedEndpoint does not exist.
Did not attempt to add user 'Andreas2015\andreas.ohlund' to group 'Performance Monitor Users' since process is not running with elevate privileges. Processing will continue. To manually perform this action run the following command from an admin console:
net localgroup "Performance Monitor Users" "Andreas2015\andreas.ohlund" /add
Queue [private$\StartupIsComplete.StartedEndpoint] is running with [Everyone] and [NT AUTHORITY\ANONYMOUS LOGON] permissions. Consider setting appropriate permissions, if required by your organization. For more information, please consult the documentation.
Queue [private$\error] is running with [Everyone] and [NT AUTHORITY\ANONYMOUS LOGON] permissions. Consider setting appropriate permissions, if required by your organization. For more information, please consult the documentation.
Registration 'HandlerTransactionScopeWrapper' specified in the insertbefore of the 'MoveFaultsToErrorQueue' step does not exist in this stage!
Registration 'SecondLevelRetries' specified in the insertbefore of the 'MoveFaultsToErrorQueue' step does not exist in this stage!
Registration 'InvokeAuditPipeline' specified in the insertafter of the 'ProcessingStatistics' step does not exist!
NServiceBus performance counter for '# of msgs pulled from the input queue /sec' is not set up correctly. To rectify this problem download the latest powershell commandlets from http://www.particular.net downloads page.
NServiceBus performance counter for '# of msgs successfully processed / sec' is not set up correctly. To rectify this problem download the latest powershell commandlets from http://www.particular.net downloads page.
NServiceBus performance counter for '# of msgs failures / sec' is not set up correctly. To rectify this problem download the latest powershell commandlets from http://www.particular.net downloads page.
Stopping endpoint: StartupIsComplete.StartedEndpoint
Initiating shutdown.
Shutdown complete.
Deleted 'FormatName:DIRECT=OS:andreas2015\private$\startupiscomplete.startedendpoint' queue
Endpoint: StartupIsComplete.StartedEndpoint stopped (00:00:00.0670591s)
MsmqTransport - Finished @ 2015-08-26 16:18:32
------------------------------------------------------
Test summary for: MsmqTransport


Using settings:
   Transport: NServiceBus.MsmqTransport, NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c
   Transport.ConnectionString: cacheSendConnection=false;journal=false;


Endpoints:
     - StartupIsComplete.StartedEndpoint
Result: Successful - Duration: 00:00:02.1998083

Context:
IsDone = True
ConfigureIsAvailable = True
SettingIsAvailable = True
EndpointsStarted = True
Exceptions = 
HasNativePubSubSupport = False

Trace:

------------------------------------------------------
Total time for testrun: 00:00:02.2197037


```

Which all seems fair to me?