### PR TITLE
log the original exception in ScenarioContext

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
+++ b/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
@@ -9,8 +9,6 @@
     /// </summary>
     class ContextAppender : ILoggerFactory, ILog
     {
-        static object contextLocker = new object();
-
         /// <summary>
         /// Because ILoggerFactory interface methods are only used in a static context. This is the only way to set the currently executing context.
         /// </summary>
@@ -41,23 +39,21 @@
 
         static void RecordLog(string message, string level)
         {
-            lock (contextLocker)
+            if (context != null)
             {
-                if (context != null)
+                context.Logs.Enqueue(new ScenarioContext.LogItem
                 {
-                    context.RecordEndpointLog(level, message);
-                }
+                    Level = level,
+                    Message = message
+                });
             }
         }
 
         static void AppendException(Exception exception)
         {
-            lock (contextLocker)
+            if (context != null)
             {
-                if (context != null)
-                {
-                    context.Exceptions += exception + Environment.NewLine;
-                }
+                context.Exceptions.Enqueue(exception);
             }
         }
 

--- a/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
@@ -6,7 +6,6 @@
     public abstract class ScenarioContext
     {
         public bool EndpointsStarted { get; set; }
-        public string Exceptions { get; set; }
 
         public bool HasNativePubSubSupport { get; set; }
 
@@ -17,14 +16,7 @@
             Trace += String.Format("{0:HH:mm:ss.ffffff} - {1}{2}", DateTime.Now, trace, Environment.NewLine);
         }
 
-        public void RecordEndpointLog(string level, string message)
-        {
-            Logs.Enqueue(new LogItem
-            {
-                Level = level,
-                Message = message
-            });
-        }
+        public ConcurrentQueue<Exception> Exceptions = new ConcurrentQueue<Exception>();
 
         public ConcurrentQueue<LogItem> Logs = new ConcurrentQueue<LogItem>();
 

--- a/src/NServiceBus.AcceptanceTesting/Support/ActiveRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ActiveRunner.cs
@@ -1,11 +1,8 @@
 ﻿namespace NServiceBus.AcceptanceTesting.Support
 {
-    using System;
-
     class ActiveRunner
     {
         public EndpointRunner Instance { get; set; }
         public string EndpointName { get; set; }
-        public AppDomain AppDomain { get; set; }
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -164,14 +164,15 @@
 
                 PerformScenarios(runDescriptor, runners, () =>
                 {
-                    if (!string.IsNullOrEmpty(runDescriptor.ScenarioContext.Exceptions))
+                    var exceptions = runDescriptor.ScenarioContext.Exceptions
+                        .Where(ex => !allowedExceptions(ex))
+                        .ToList();
+
+                    if (exceptions.Any())
                     {
-                        var ex = new Exception(runDescriptor.ScenarioContext.Exceptions);
-                        if (!allowedExceptions(ex))
-                        {
-                            throw new Exception("Failures in endpoints");
-                        }
+                        throw new AggregateException(exceptions);
                     }
+
                     return done(runDescriptor.ScenarioContext);
                 });
 


### PR DESCRIPTION
put the Exceptions into a list instead concatenating all exception's string representations. This should allow better assertions, filtering and logging.