### PR TITLE
IWantToRunWhenTheBusStartsAndStops Stop() method made async

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Basic/When_using_INeedInitialization.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_using_INeedInitialization.cs
@@ -58,8 +58,9 @@
                     Bus.Send(new SendMessage());
                 }
 
-                public void Stop()
+                public Task StopAsync()
                 {
+                    return Task.FromResult(0);
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Config/When_IWantToRunWhenBusStartsAndStops_Start_throws.cs
+++ b/src/NServiceBus.AcceptanceTests/Config/When_IWantToRunWhenBusStartsAndStops_Start_throws.cs
@@ -44,8 +44,9 @@
                     throw new Exception("Boom");
                 }
 
-                public void Stop()
+                public Task StopAsync()
                 {
+                    return Task.FromResult(0);
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Config/When__startup_is_complete.cs
+++ b/src/NServiceBus.AcceptanceTests/Config/When__startup_is_complete.cs
@@ -52,8 +52,9 @@
                     Context.IsDone = true;
                 }
 
-                public void Stop()
+                public Task StopAsync()
                 {
+                    return Task.FromResult(0);
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Config/When_a_config_override_is_found.cs
+++ b/src/NServiceBus.AcceptanceTests/Config/When_a_config_override_is_found.cs
@@ -52,8 +52,9 @@
                     context.ErrorQueueUsedByTheEndpoint = configure.Settings.GetConfigSection<MessageForwardingInCaseOfFaultConfig>().ErrorQueue;
                 }
 
-                public void Stop()
+                public Task StopAsync()
                 {
+                    return Task.FromResult(0);
                 }
             }
 

--- a/src/NServiceBus.AcceptanceTests/CriticalError/When_registering_a_custom_criticalErrorHandler.cs
+++ b/src/NServiceBus.AcceptanceTests/CriticalError/When_registering_a_custom_criticalErrorHandler.cs
@@ -76,8 +76,9 @@
                     throw new Exception("ExceptionInBusStarts");
                 }
 
-                public void Stop()
+                public Task StopAsync()
                 {
+                    return Task.FromResult(0);
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_empty_id_header.cs
+++ b/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_empty_id_header.cs
@@ -103,8 +103,9 @@
                     bus.SendLocal(new Message());
                 }
 
-                public void Stop()
+                public Task StopAsync()
                 {
+                    return Task.FromResult(0);
                 }
             }
 

--- a/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_no_id_header.cs
+++ b/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_no_id_header.cs
@@ -102,8 +102,9 @@
                     bus.SendLocal(new Message());
                 }
 
-                public void Stop()
+                public Task StopAsync()
                 {
+                    return Task.FromResult(0);
                 }
             }
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
@@ -124,12 +124,13 @@
                 });
             }
 
-            public void Stop()
+            public Task StopAsync()
             {
                 foreach (var unsubscribeStream in unsubscribeStreams)
                 {
                     unsubscribeStream.Dispose();
                 }
+                return Task.FromResult(0);
             }
 
             List<IDisposable> unsubscribeStreams = new List<IDisposable>();

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_dtc_on.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_dtc_on.cs
@@ -70,7 +70,10 @@
                     });
                 }
 
-                public void Stop() { }
+                public Task StopAsync()
+                {
+                    return Task.FromResult(0);
+                }
             }
 
             class MessageToBeRetriedHandler : IHandleMessages<MessageToBeRetried>

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
@@ -69,7 +69,10 @@
                     });
                 }
 
-                public void Stop() { }
+                public Task StopAsync()
+                {
+                    return Task.FromResult(0);
+                }
             }
 
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_with_retries_set_to_0.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_with_retries_set_to_0.cs
@@ -59,7 +59,10 @@
                     });
                 }
 
-                public void Stop() { }
+                public Task StopAsync()
+                {
+                    return Task.FromResult(0);
+                }
             }
 
             class MessageToBeRetriedHandler : IHandleMessages<MessageToBeRetried>

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
@@ -58,8 +58,9 @@
                     });
                 }
 
-                public void Stop()
+                public Task StopAsync()
                 {
+                    return Task.FromResult(0);
                 }
             }
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr.cs
@@ -92,8 +92,9 @@
                     });
                 }
 
-                public void Stop()
+                public Task StopAsync()
                 {
+                    return Task.FromResult(0);
                 }
             }
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
@@ -93,8 +93,9 @@
                     });
                 }
 
-                public void Stop()
+                public Task StopAsync()
                 {
+                    return Task.FromResult(0);
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/ScaleOut/When_individualization_is_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/ScaleOut/When_individualization_is_enabled.cs
@@ -45,8 +45,9 @@
                     Context.Address = Settings.LocalAddress();
                 }
 
-                public void Stop()
+                public Task StopAsync()
                 {
+                    return Task.FromResult(0);
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/ScaleOut/When_individualization_is_enabled_for_msmq.cs
+++ b/src/NServiceBus.AcceptanceTests/ScaleOut/When_individualization_is_enabled_for_msmq.cs
@@ -46,8 +46,9 @@
                     Context.EndpointName = ReadOnlySettings.EndpointName();
                 }
 
-                public void Stop()
+                public Task StopAsync()
                 {
+                    return Task.FromResult(0);
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Scheduling/When_scheduling_a_recurring_task.cs
+++ b/src/NServiceBus.AcceptanceTests/Scheduling/When_scheduling_a_recurring_task.cs
@@ -52,8 +52,9 @@
                     });
                 }
 
-                public void Stop()
+                public Task StopAsync()
                 {
+                    return Task.FromResult(0);
                 }
             }
         }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -524,7 +524,7 @@ namespace NServiceBus
     public interface IWantToRunWhenBusStartsAndStops
     {
         void Start();
-        void Stop();
+        System.Threading.Tasks.Task StopAsync();
     }
     public class JsonSerializer : NServiceBus.Serialization.SerializationDefinition
     {

--- a/src/NServiceBus.Core/IWantToRunWhenBusStartsAndStops.cs
+++ b/src/NServiceBus.Core/IWantToRunWhenBusStartsAndStops.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus
 {
+    using System.Threading.Tasks;
     using JetBrains.Annotations;
 
     /// <summary>
@@ -17,6 +18,6 @@
         /// <summary>
         /// Method called on shutdown.
         /// </summary>
-        void Stop();
+        Task StopAsync();
     }
 }


### PR DESCRIPTION
This PR is part of the work to make the core async enabled. For more background read [Async/Await: It's time!](http://particular.net/blog/async-await-its-time) blogpost

## Questions
- I used `Task.Run` instead of `StartNew` with `LongRunning` and `PreferFairness` because I think those two parameters are not necessary. The schedular is smart enough. Counter arguments?
- We currently don't have an explicit `Stop()` for the bus. We are using `Dispose()` for stopping the bus. The problem of dispose is that the signature is already predefined. I know we have other cards about starting and stopping the bus but I think in order to move to an asynchronous model we need to at least introduce a `StopAsync` method is part of our work here.

## Note
The behavior is preserved from V5.

@Particular/tf-asyncawait thoughts?
