### PR TITLE
ATT Framework Improvements

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointBehavior.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointBehavior.cs
@@ -5,8 +5,7 @@
     using System.Diagnostics;
     using System.Threading;
 
-    [Serializable]
-    public class EndpointBehavior : MarshalByRefObject
+    public class EndpointBehavior
     {
         public EndpointBehavior(Type builderType)
         {
@@ -22,7 +21,6 @@
         public List<Action<BusConfiguration>> CustomConfig { get; set; }
     }
 
-    [Serializable]
     public class WhenDefinition<TContext> : IWhenDefinition where TContext : ScenarioContext
     {
         public WhenDefinition(Predicate<TContext> condition, Action<IBus> action)

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Runtime.Remoting.Lifetime;
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Configuration.AdvanceExtensibility;
@@ -10,8 +9,7 @@
     using NServiceBus.Support;
     using NServiceBus.Transports;
 
-    [Serializable]
-    public class EndpointRunner : MarshalByRefObject
+    public class EndpointRunner
     {
         static ILog Logger = LogManager.GetLogger<EndpointRunner>();
         CancellationTokenSource stopSource = new CancellationTokenSource();
@@ -184,19 +182,6 @@
             return configuration.EndpointName;
         }
 
-        public override object InitializeLifetimeService()
-        {
-            var lease = (ILease)base.InitializeLifetimeService();
-            if (lease.CurrentState == LeaseState.Initial)
-            {
-                lease.InitialLeaseTime = TimeSpan.FromMinutes(2);
-                lease.SponsorshipTimeout = TimeSpan.FromMinutes(2);
-                lease.RenewOnCallTime = TimeSpan.FromSeconds(2);
-            }
-            return lease;
-        }
-
-        [Serializable]
         public class Result
         {
             public Exception Exception { get; set; }


### PR DESCRIPTION
As part of the Async/Await work we found out the the `Whens` are executed at the wrong place. Previously they were executed during the initialization phase of the endpoint. But they should be executed after the `Givens` during the startup phase of the endpoint.

Removed the unnecessary contextChanged semphare (no longer needed because of no more appdomains) and also the `[ Serializable]` attribute usage.

@Particular/nservicebus please review and merge