### PR TITLE
More att framework improvements

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -166,13 +166,10 @@
 
                 runTimer.Stop();
 
-                Parallel.ForEach(runners, runner =>
+                foreach (var v in shoulds.Where(s => s.ContextType == runDescriptor.ScenarioContext.GetType()))
                 {
-                    foreach (var v in shoulds.Where(s => s.ContextType == runDescriptor.ScenarioContext.GetType()))
-                    {
-                        v.Verify(runDescriptor.ScenarioContext);
-                    }
-                });
+                    v.Verify(runDescriptor.ScenarioContext);
+                }
             }
             catch (Exception ex)
             {
@@ -221,7 +218,7 @@
             
             try
             {
-                Task.WaitAll(endpoints.Select(endpoint => Task.Factory.StartNew(() => SpinWait.SpinUntil(done, maxTime))).Cast<Task>().ToArray(), maxTime);
+                SpinWait.SpinUntil(done, maxTime);
 
                 if ((DateTime.UtcNow - startTime) > maxTime)
                 {

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
@@ -14,29 +14,7 @@
     public class When_Subscribing_to_errors : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_contain_exception_details()
-        {
-            Scenario.Define(() => new Context
-            {
-                Id = Guid.NewGuid()
-            })
-                .WithEndpoint<SLREndpoint>(b => b.Given((bus, c) => bus.SendLocal(new MessageToBeRetried
-                {
-                    Id = c.Id
-                })))
-                .AllowExceptions(e => e.Message.Contains("Simulated exception"))
-                .Done(c => c.MessageSentToError)
-                .Repeat(r => r.For<AllTransports>())
-                .Should(c =>
-                {
-                    Assert.IsInstanceOf<MySpecialException>(c.MessageSentToErrorException);
-                    Assert.True(c.Logs.Any(l => l.Level == "error" && l.Message.Contains("Simulated exception")), "The last exception should be logged as `error` before sending it to the error queue");
-                })
-                .Run();
-        }
-
-        [Test]
-        public void Should_receive_notifications()
+        public void Should_retain_exception_details_over_FLR_and_SLR()
         {
             var context = new Context
             {
@@ -46,7 +24,11 @@
                 .WithEndpoint<SLREndpoint>()
                 .AllowExceptions(e => e.Message.Contains("Simulated exception"))
                 .Done(c => c.MessageSentToError)
+                .Repeat(r => r.For<AllTransports>())
                 .Run();
+
+            Assert.IsInstanceOf<MySpecialException>(context.MessageSentToErrorException);
+            Assert.True(context.Logs.Any(l => l.Level == "error" && l.Message.Contains("Simulated exception")), "The last exception should be logged as `error` before sending it to the error queue");
 
             //FLR max retries = 3 means we will be processing 4 times. SLR max retries = 2 means we will do 3*FLR
             Assert.AreEqual(4 * 3, context.TotalNumberOfFLRTimesInvokedInHandler);

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
@@ -69,6 +69,7 @@
 
                 public void Handle(FinishMessage message)
                 {
+                    // This acts as a safe guard to abort the test earlier
                     Context.Done = true;
                 }
             }
@@ -128,6 +129,7 @@
                 public void Handle(object message)
                 {
                     Context.TimesFired++;
+                    Context.Done = true;
                 }
             }
         }
@@ -164,6 +166,7 @@
 
                 public void Handle(FinishMessage message)
                 {
+                    // This acts as a safe guard to abort the test earlier
                     Context.Done = true;
                 }
             }
@@ -193,6 +196,8 @@
 
             public class ReceiverWithOrderedSagasSaga2 : Saga<ReceiverWithOrderedSagasSaga2.ReceiverWithOrderedSagasSaga2Data>, IHandleMessages<StartSaga>, IAmStartedByMessages<MessageToSaga>
             {
+                public Context Context { get; set; }
+
                 public void Handle(StartSaga message)
                 {
                     Data.MessageId = message.Id;
@@ -200,6 +205,8 @@
 
                 public void Handle(MessageToSaga message)
                 {
+                    Data.MessageId = message.Id;
+                    Context.Done = true;
                 }
 
                 public class ReceiverWithOrderedSagasSaga2Data : ContainSagaData


### PR DESCRIPTION
As part of the async/await work I figured the ATT infrastructure is still a bit too complex and heavyweight regarding unnecessary parallelism. This PR introduces two changes. One change is the reduction of the parallel execution of the `should` verify and the `SpinWait` on the `done` delegate. This effectively reduces the number of background operations by the number of runners and endpoints. Therefore reducing the load on the thread pool and leading to less allocations and ramping up in the ThreadPool. 

Furthermore I changed `When_sagas_cant_be_found` to be a bit smarter regarding its execution. Before these ATTs just lasted each for over 10 seconds. Now they finish as soon as possible. To be honest I still think these tests are a bit weird but at least this improves the execution time. 

These changes had the following effect on my machine

### Before
ATT Execution time 3 min 58 s

### After
ATT Execution time 2 min 59 s

All in all 1 min less -> 25% perf improvement