### PR TITLE
Async acceptance testing framework

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
@@ -56,7 +56,7 @@
             return EndpointSetup<T>(c => { });
         }
 
-        public EndpointConfigurationBuilder EndpointSetup<T>(Action<BusConfiguration> configurationBuilderCustomization = null) where T : IEndpointSetupTemplate, new()
+        public EndpointConfigurationBuilder EndpointSetup<T>(Action<BusConfiguration> configurationBuilderCustomization) where T : IEndpointSetupTemplate, new()
         {
             if (configurationBuilderCustomization == null)
             {

--- a/src/NServiceBus.AcceptanceTesting/Scenario.cs
+++ b/src/NServiceBus.AcceptanceTesting/Scenario.cs
@@ -7,19 +7,12 @@
     {
         public static IScenarioWithEndpointBehavior<T> Define<T>() where T : ScenarioContext, new()
         {
-            Func<T> contextFactory = () => new T();
-            return new ScenarioWithContext<T>(contextFactory);
+            return new ScenarioWithContext<T>(c => { });
         }
 
-        public static IScenarioWithEndpointBehavior<T> Define<T>(T context) where T : ScenarioContext, new()
+        public static IScenarioWithEndpointBehavior<T> Define<T>(Action<T> contextInitializer) where T : ScenarioContext, new()
         {
-            return new ScenarioWithContext<T>(()=>context);
+            return new ScenarioWithContext<T>(contextInitializer);
         }
-
-        public static IScenarioWithEndpointBehavior<T> Define<T>(Func<T> contextFactory) where T : ScenarioContext, new()
-        {
-            return new ScenarioWithContext<T>(contextFactory);
-        }
-
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -62,22 +62,20 @@ namespace NServiceBus.AcceptanceTesting
                 return new List<TContext>();
             }
 
-            var scenarioContext = new TContext();
-            contextInitializer(scenarioContext);
             foreach (var runDescriptor in runDescriptors)
             {
+                var scenarioContext = new TContext();
+                contextInitializer(scenarioContext);
                 runDescriptor.ScenarioContext = scenarioContext;
                 runDescriptor.TestExecutionTimeout = settings.TestExecutionTimeout ?? TimeSpan.FromSeconds(90);
             }
 
             LogManager.UseFactory(new ContextAppender());
-            ContextAppender.SetContext(scenarioContext);
 
             var sw = new Stopwatch();
 
             sw.Start();
             await ScenarioRunner.Run(runDescriptors, behaviors, shoulds, done, limitTestParallelismTo, reports, allowedExceptions).ConfigureAwait(false);
-            ContextAppender.SetContext(null);
             sw.Stop();
 
             Console.WriteLine("Total time for testrun: {0}", sw.Elapsed);

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -11,9 +11,9 @@ namespace NServiceBus.AcceptanceTesting
 
     public class ScenarioWithContext<TContext> : IScenarioWithEndpointBehavior<TContext>, IAdvancedScenarioWithEndpointBehavior<TContext> where TContext : ScenarioContext, new()
     {
-        public ScenarioWithContext(Func<TContext> factory)
+        public ScenarioWithContext(Action<TContext> initializer)
         {
-            contextFactory = factory;
+            contextInitializer = initializer;
         }
 
         public IScenarioWithEndpointBehavior<TContext> WithEndpoint<T>() where T : EndpointConfigurationBuilder
@@ -62,7 +62,8 @@ namespace NServiceBus.AcceptanceTesting
                 return new List<TContext>();
             }
 
-            var scenarioContext = contextFactory();
+            var scenarioContext = new TContext();
+            contextInitializer(scenarioContext);
             foreach (var runDescriptor in runDescriptors)
             {
                 runDescriptor.ScenarioContext = scenarioContext;
@@ -146,7 +147,7 @@ namespace NServiceBus.AcceptanceTesting
         Action<RunDescriptorsBuilder> runDescriptorsBuilderAction = builder => builder.For(Conventions.DefaultRunDescriptor());
         IList<IScenarioVerification> shoulds = new List<IScenarioVerification>();
         Func<ScenarioContext, bool> done = context => true;
-        Func<TContext> contextFactory;
+        Action<TContext> contextInitializer;
         Action<RunSummary> reports;
         Func<Exception, bool> allowedExceptions = exception => false;
     }

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -113,13 +113,13 @@ namespace NServiceBus.AcceptanceTesting
             var contexts = await Run(new RunSettings
             {
                 TestExecutionTimeout = testExecutionTimeout
-            });
+            }).ConfigureAwait(false);
             return contexts.Single();
         }
 
         async Task<TContext> IScenarioWithEndpointBehavior<TContext>.Run(RunSettings settings)
         {
-            var contexts = await Run(settings);
+            var contexts = await Run(settings).ConfigureAwait(false);
             return contexts.Single();
         }
 

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointBehaviorBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointBehaviorBuilder.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     public class EndpointBehaviorBuilder<TContext> where TContext:ScenarioContext
     {
@@ -15,8 +16,7 @@
                 };
         }
 
-
-        public EndpointBehaviorBuilder<TContext> Given(Action<IBus> action)
+        public EndpointBehaviorBuilder<TContext> Given(Func<IBus, Task> action)
         {
             behavior.Givens.Add(new GivenDefinition<TContext>(action));
 
@@ -24,26 +24,26 @@
         }
 
 
-        public EndpointBehaviorBuilder<TContext> Given(Action<IBus,TContext> action)
+        public EndpointBehaviorBuilder<TContext> Given(Func<IBus, TContext, Task> action)
         {
             behavior.Givens.Add(new GivenDefinition<TContext>(action));
 
             return this;
         }
 
-        public EndpointBehaviorBuilder<TContext> When(Action<IBus> action)
+        public EndpointBehaviorBuilder<TContext> When(Func<IBus, Task> action)
         {
             return When(c => true, action);
         }
 
-        public EndpointBehaviorBuilder<TContext> When(Predicate<TContext> condition, Action<IBus> action)
+        public EndpointBehaviorBuilder<TContext> When(Predicate<TContext> condition, Func<IBus, Task> action)
         {
-            behavior.Whens.Add(new WhenDefinition<TContext>(condition,action));
+            behavior.Whens.Add(new WhenDefinition<TContext>(condition, action));
 
             return this;
         }
 
-        public EndpointBehaviorBuilder<TContext> When(Predicate<TContext> condition, Action<IBus,TContext> action)
+        public EndpointBehaviorBuilder<TContext> When(Predicate<TContext> condition, Func<IBus, TContext, Task> action)
         {
             behavior.Whens.Add(new WhenDefinition<TContext>(condition,action));
 

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -66,7 +66,7 @@
             }
         }
 
-        public Result Start()
+        public async Task<Result> Start()
         {
             try
             {
@@ -76,12 +76,11 @@
 
                     if (configuration.SendOnly)
                     {
-                        action(new IBusAdapter(sendOnlyBus));
+                        await action(new IBusAdapter(sendOnlyBus)).ConfigureAwait(false);
                     }
                     else
                     {
-
-                        action(bus);
+                        await action(bus).ConfigureAwait(false);
                     }
                 }
 
@@ -135,7 +134,7 @@
             }
         }
 
-        public Result Stop()
+        public Task<Result> Stop()
         {
             try
             {
@@ -152,13 +151,13 @@
 
                 Cleanup();
 
-                return Result.Success();
+                return Task.FromResult(Result.Success());
             }
             catch (Exception ex)
             {
                 Logger.Error("Failed to stop endpoint " + configuration.EndpointName, ex);
 
-                return Result.Failure(ex);
+                return Task.FromResult(Result.Failure(ex));
             }
         }
 

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -40,6 +40,7 @@
 
                 //apply custom config settings
                 busConfiguration = configuration.GetConfiguration(run, routingTable);
+                busConfiguration.GetSettings().Set<ScenarioContext>(scenarioContext);
 
                 endpointBehavior.CustomConfig.ForEach(customAction => customAction(busConfiguration));
 

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -40,7 +40,7 @@
 
                 //apply custom config settings
                 busConfiguration = configuration.GetConfiguration(run, routingTable);
-                busConfiguration.GetSettings().Set<ScenarioContext>(scenarioContext);
+                busConfiguration.GetSettings().Set(scenarioContext.GetType().FullName, scenarioContext);
 
                 endpointBehavior.CustomConfig.ForEach(customAction => customAction(busConfiguration));
 

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -91,7 +91,7 @@
 
                 if (behavior.Whens.Count != 0)
                 {
-                    Task.Factory.StartNew(() =>
+                    await Task.Run(async() =>
                     {
                         var executedWhens = new List<Guid>();
 
@@ -114,14 +114,13 @@
                                     continue;
                                 }
 
-                                if (when.ExecuteAction(scenarioContext, bus))
+                                if (await when.ExecuteAction(scenarioContext, bus))
                                 {
                                     executedWhens.Add(when.Id);
                                 }
                             }
                         }
-                    }, stopToken)
-                    .Wait(stopToken);
+                    }, stopToken);
                 }
 
                 return Result.Success();

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -121,7 +121,7 @@
                                 }
                             }
                         }
-                    }, stopToken);
+                    }, stopToken).ConfigureAwait(false);
                 }
 
                 return Result.Success();

--- a/src/NServiceBus.AcceptanceTesting/Support/GivenDefinition.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/GivenDefinition.cs
@@ -1,21 +1,22 @@
 namespace NServiceBus.AcceptanceTesting.Support
 {
     using System;
+    using System.Threading.Tasks;
 
     [Serializable]
     public class GivenDefinition<TContext> : IGivenDefinition where TContext : ScenarioContext
     {
-        public GivenDefinition(Action<IBus> action)
+        public GivenDefinition(Func<IBus, Task> action)
         {
             givenAction2 = action;
         }
 
-        public GivenDefinition(Action<IBus, TContext> action)
+        public GivenDefinition(Func<IBus, TContext, Task> action)
         {
             givenAction = action;
         }
 
-        public Action<IBus> GetAction(ScenarioContext context)
+        public Func<IBus, Task> GetAction(ScenarioContext context)
         {
             if (givenAction2 != null)
                 return bus => givenAction2(bus);
@@ -23,8 +24,7 @@ namespace NServiceBus.AcceptanceTesting.Support
             return bus => givenAction(bus, (TContext)context);
         }
 
-        Action<IBus, TContext> givenAction;
-        Action<IBus> givenAction2;
-
+        Func<IBus, TContext, Task> givenAction;
+        Func<IBus, Task> givenAction2;
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/Support/IScenarioWithEndpointBehavior.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/IScenarioWithEndpointBehavior.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     public interface IScenarioWithEndpointBehavior<TContext> where TContext : ScenarioContext
     {
@@ -11,8 +12,8 @@
 
         IScenarioWithEndpointBehavior<TContext> Done(Func<TContext, bool> func);
 
-        TContext Run(TimeSpan? testExecutionTimeout = null);
-        TContext Run(RunSettings settings);
+        Task<TContext> Run(TimeSpan? testExecutionTimeout = null);
+        Task<TContext> Run(RunSettings settings);
 
         IAdvancedScenarioWithEndpointBehavior<TContext> Repeat(Action<RunDescriptorsBuilder> runtimeDescriptor);
 
@@ -28,8 +29,8 @@
 
         IAdvancedScenarioWithEndpointBehavior<TContext> MaxTestParallelism(int maxParallelism);
 
-        IEnumerable<TContext> Run(TimeSpan? testExecutionTimeout = null);
+        Task<IEnumerable<TContext>> Run(TimeSpan? testExecutionTimeout = null);
 
-        IEnumerable<TContext> Run(RunSettings settings);
+        Task<IEnumerable<TContext>> Run(RunSettings settings);
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -68,7 +68,7 @@
                     }
                 }, cts.Token));
 
-                await Task.WhenAll(runs);
+                await Task.WhenAll(runs).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -223,9 +223,7 @@
             
             try
             {
-                // Let's use a blocking SpinWait for now
-                SpinWait.SpinUntil(done, maxTime);
-
+                // ReSharper disable once LoopVariableIsNeverChangedInsideLoop
                 while (!done())
                 {
                     if ((DateTime.UtcNow - startTime) > maxTime)
@@ -233,7 +231,7 @@
                         throw new ScenarioException(GenerateTestTimedOutMessage(maxTime));
                     }
 
-                    await Task.Delay(1);
+                    await Task.Delay(1).ConfigureAwait(false);
                 }
             }
             catch(Exception)
@@ -243,7 +241,7 @@
             }
 
             // With this version of C# we can't await in finally
-            await StopEndpoints(endpoints);
+            await StopEndpoints(endpoints).ConfigureAwait(false);
             
             var exceptions = runDescriptor.ScenarioContext.Exceptions
                         .Where(ex => !allowedExceptions(ex))
@@ -303,7 +301,7 @@
 
             var whenAll = Task.WhenAll(tasks);
             var timeoutTask = Task.Delay(TimeSpan.FromMinutes(2));
-            var completedTask = await Task.WhenAny(whenAll, timeoutTask);
+            var completedTask = await Task.WhenAny(whenAll, timeoutTask).ConfigureAwait(false);
 
             if (completedTask.Equals(timeoutTask))
             {

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -49,7 +49,9 @@
 
                     Console.WriteLine("{0} - Started @ {1}", runDescriptor.Key, DateTime.Now.ToString(CultureInfo.InvariantCulture));
 
+                    ContextAppender.SetContext(runDescriptor.ScenarioContext);
                     var runResult = await PerformTestRun(behaviorDescriptors, shoulds, runDescriptor, done, allowedExceptions).ConfigureAwait(false);
+                    ContextAppender.SetContext(null);
 
                     Console.WriteLine("{0} - Finished @ {1}", runDescriptor.Key, DateTime.Now.ToString(CultureInfo.InvariantCulture));
 

--- a/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_sendoptions.cs
+++ b/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_sendoptions.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.ApiExtension
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Extensibility;
@@ -25,6 +26,7 @@
                         options.RouteToLocalEndpointInstance();
 
                         bus.Send(new SendMessage(), options);
+                        return Task.FromResult(0);
                     }))
                     .Done(c => c.WasCalled)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_sendoptions.cs
+++ b/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_sendoptions.cs
@@ -13,11 +13,9 @@
     public class When_extending_sendoptions : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_be_able_to_set_context_items_and_retrieve_it_via_a_behavior()
+        public async Task Should_be_able_to_set_context_items_and_retrieve_it_via_a_behavior()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<SendOptionsExtensions>(b => b.Given((bus, c) =>
                     {
                         var options = new SendOptions();

--- a/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_the_publish_api.cs
+++ b/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_the_publish_api.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.ApiExtension
 {
     using System;
-    using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;

--- a/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_the_publish_api.cs
+++ b/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_the_publish_api.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.ApiExtension
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.Routing;
@@ -25,6 +26,7 @@
                             options.GetExtensions().Set(new Publisher.PublishExtensionBehavior.Context { SomeProperty = "ItWorks" });
 
                             bus.Publish(new MyEvent(), options);
+                            return Task.FromResult(0);
                         })
                      )
                     .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
@@ -33,6 +35,8 @@
 
                             if (context.HasNativePubSubSupport)
                                 context.Subscriber1Subscribed = true;
+
+                            return Task.FromResult(0);
                         }))
                     .Done(c => c.Subscriber1GotTheEvent)
                     .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_the_publish_api.cs
+++ b/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_the_publish_api.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.ApiExtension
 {
     using System;
+    using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -15,9 +16,9 @@
     public class When_extending_the_publish_api : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_make_the_context_available_to_behaviors()
+        public async Task Should_make_the_context_available_to_behaviors()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<Publisher>(b =>
                         b.When(c => c.Subscriber1Subscribed, bus =>
                         {
@@ -41,7 +42,6 @@
                     .Done(c => c.Subscriber1GotTheEvent)
                     .Repeat(r => r.For(Transports.Default))
                     .Should(c => Assert.True(c.Subscriber1GotTheEvent))
-
                     .Run();
         }
 

--- a/src/NServiceBus.AcceptanceTests/Audit/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_a_message_is_audited.cs
@@ -12,22 +12,18 @@
     {
       
         [Test]
-        public void Should_preserve_the_original_body()
+        public async Task Should_preserve_the_original_body()
         {
-            var context = new Context
-            {
-                RunId = Guid.NewGuid()
-            };
-
-            Scenario.Define(context)
-                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus =>
+            var context = await Scenario.Define<Context>(c => { c.RunId = Guid.NewGuid(); })
+                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given((bus, c) =>
                     {
-                        bus.SendLocal(new MessageToBeAudited { RunId = context.RunId });
+                        bus.SendLocal(new MessageToBeAudited { RunId = c.RunId });
                         return Task.FromResult(0);
                     }))
                     .WithEndpoint<AuditSpyEndpoint>()
                     .Done(c => c.Done)
                     .Run();
+
             Assert.AreEqual(context.OriginalBodyChecksum, context.AuditChecksum, "The body of the message sent to audit should be the same as the original message coming off the queue");
         }
 

--- a/src/NServiceBus.AcceptanceTests/Audit/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_a_message_is_audited.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using MessageMutator;
@@ -19,7 +20,11 @@
             };
 
             Scenario.Define(context)
-                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited { RunId = context.RunId })))
+                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new MessageToBeAudited { RunId = context.RunId });
+                        return Task.FromResult(0);
+                    }))
                     .WithEndpoint<AuditSpyEndpoint>()
                     .Done(c => c.Done)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/Audit/When_a_replymessage_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_a_replymessage_is_audited.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using MessageMutator;
@@ -17,7 +18,11 @@
 
             Scenario.Define(context)
                     .WithEndpoint<Server>()
-                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.Send(new Request())))
+                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus =>
+                    {
+                        bus.Send(new Request());
+                        return Task.FromResult(0);
+                    }))
                     .WithEndpoint<AuditSpyEndpoint>()
                     .Done(c => c.MessageAudited)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/Audit/When_a_replymessage_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_a_replymessage_is_audited.cs
@@ -12,11 +12,9 @@
     public class When_a_replymessage_is_audited : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_audit_the_message()
+        public async Task Should_audit_the_message()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Server>()
                     .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus =>
                     {

--- a/src/NServiceBus.AcceptanceTests/Audit/When_audit_is_overridden_in_code.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_audit_is_overridden_in_code.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Audit
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -12,7 +13,11 @@
         {
             var context = new Context();
             Scenario.Define(context)
-                .WithEndpoint<UserEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+                .WithEndpoint<UserEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new MessageToBeAudited());
+                    return Task.FromResult(0);
+                }))
                 .WithEndpoint<AuditSpy>()
                 .Done(c => c.MessageAudited)
                 .Run();

--- a/src/NServiceBus.AcceptanceTests/Audit/When_audit_is_overridden_in_code.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_audit_is_overridden_in_code.cs
@@ -9,10 +9,9 @@
     public class When_audit_is_overridden_in_code : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_audit_to_target_queue()
+        public async Task Should_audit_to_target_queue()
         {
-            var context = new Context();
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<UserEndpoint>(b => b.Given(bus =>
                 {
                     bus.SendLocal(new MessageToBeAudited());
@@ -21,6 +20,8 @@
                 .WithEndpoint<AuditSpy>()
                 .Done(c => c.MessageAudited)
                 .Run();
+
+            Assert.True(context.MessageAudited);
         }
 
         public class UserEndpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Audit/When_auditing.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_auditing.cs
@@ -10,10 +10,9 @@ namespace NServiceBus.AcceptanceTests.Audit
     public class When_auditing : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_not_be_forwarded_to_auditQueue_when_auditing_is_disabled()
+        public async Task Should_not_be_forwarded_to_auditQueue_when_auditing_is_disabled()
         {
-            var context = new Context();
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
             .WithEndpoint<EndpointWithAuditOff>(b => b.Given(bus =>
             {
                 bus.SendLocal(new MessageToBeAudited());
@@ -27,17 +26,16 @@ namespace NServiceBus.AcceptanceTests.Audit
         }
 
         [Test]
-        public void Should_be_forwarded_to_auditQueue_when_auditing_is_enabled()
+        public async Task Should_be_forwarded_to_auditQueue_when_auditing_is_enabled()
         {
-            var context = new Context();
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
             .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus =>
             {
                 bus.SendLocal(new MessageToBeAudited());
                 return Task.FromResult(0);
             }))
             .WithEndpoint<EndpointThatHandlesAuditMessages>()
-            .Done(c => c.IsMessageHandlingComplete && context.IsMessageHandledByTheAuditEndpoint)
+            .Done(c => c.IsMessageHandlingComplete && c.IsMessageHandledByTheAuditEndpoint)
             .Run();
 
             Assert.IsTrue(context.IsMessageHandledByTheAuditEndpoint);
@@ -51,7 +49,7 @@ namespace NServiceBus.AcceptanceTests.Audit
 
         public class EndpointWithAuditOff : EndpointConfigurationBuilder
         {
-           
+
             public EndpointWithAuditOff()
             {
                 // Although the AuditTo seems strange here, this test tries to fake the scenario where

--- a/src/NServiceBus.AcceptanceTests/Audit/When_auditing.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_auditing.cs
@@ -2,6 +2,7 @@
 namespace NServiceBus.AcceptanceTests.Audit
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NUnit.Framework;
@@ -13,7 +14,11 @@ namespace NServiceBus.AcceptanceTests.Audit
         {
             var context = new Context();
             Scenario.Define(context)
-            .WithEndpoint<EndpointWithAuditOff>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+            .WithEndpoint<EndpointWithAuditOff>(b => b.Given(bus =>
+            {
+                bus.SendLocal(new MessageToBeAudited());
+                return Task.FromResult(0);
+            }))
             .WithEndpoint<EndpointThatHandlesAuditMessages>()
             .Done(c => c.IsMessageHandlingComplete)
             .Run();
@@ -26,7 +31,11 @@ namespace NServiceBus.AcceptanceTests.Audit
         {
             var context = new Context();
             Scenario.Define(context)
-            .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+            .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus =>
+            {
+                bus.SendLocal(new MessageToBeAudited());
+                return Task.FromResult(0);
+            }))
             .WithEndpoint<EndpointThatHandlesAuditMessages>()
             .Done(c => c.IsMessageHandlingComplete && context.IsMessageHandledByTheAuditEndpoint)
             .Run();

--- a/src/NServiceBus.AcceptanceTests/Audit/When_auditing_message_with_TimeToBeReceived.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_auditing_message_with_TimeToBeReceived.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Audit
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -20,9 +21,13 @@
             Assert.IsTrue(context.IsMessageHandlingComplete);
         }
 
-        static Action<IBus> Send()
+        static Func<IBus, Task> Send()
         {
-            return bus => bus.SendLocal(new MessageToBeAudited());
+            return bus =>
+            {
+                bus.SendLocal(new MessageToBeAudited());
+                return Task.FromResult(0);
+            };
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Audit/When_auditing_message_with_TimeToBeReceived.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_auditing_message_with_TimeToBeReceived.cs
@@ -10,14 +10,14 @@
     {
 
         [Test]
-        public void Should_not_honor_TimeToBeReceived_for_audit_message()
+        public async Task Should_not_honor_TimeToBeReceived_for_audit_message()
         {
-            var context = new Context();
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
             .WithEndpoint<EndpointWithAuditOn>(b => b.Given(Send()))
             .WithEndpoint<EndpointThatHandlesAuditMessages>()
-            .Done(c => c.IsMessageHandlingComplete && context.TTBRHasExpiredAndMessageIsStillInAuditQueue)
+            .Done(c => c.IsMessageHandlingComplete && c.TTBRHasExpiredAndMessageIsStillInAuditQueue)
             .Run();
+
             Assert.IsTrue(context.IsMessageHandlingComplete);
         }
 

--- a/src/NServiceBus.AcceptanceTests/Basic/When_aborting_the_behavior_chain.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_aborting_the_behavior_chain.cs
@@ -9,11 +9,9 @@
     public class When_aborting_the_behavior_chain : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Subsequent_handlers_will_not_be_invoked()
+        public async Task Subsequent_handlers_will_not_be_invoked()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<MyEndpoint>(b => b.Given(bus =>
                 {
                     bus.SendLocal(new SomeMessage());

--- a/src/NServiceBus.AcceptanceTests/Basic/When_aborting_the_behavior_chain.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_aborting_the_behavior_chain.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Basic
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -13,7 +14,11 @@
             var context = new Context();
 
             Scenario.Define(context)
-                .WithEndpoint<MyEndpoint>(b => b.Given(bus => bus.SendLocal(new SomeMessage())))
+                .WithEndpoint<MyEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new SomeMessage());
+                    return Task.FromResult(0);
+                }))
                 .Done(c => c.FirstHandlerInvoked)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Basic/When_deferring_to_non_local.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_deferring_to_non_local.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Basic
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Features;
@@ -20,6 +21,7 @@
 
                         options.DelayDeliveryWith(TimeSpan.FromSeconds(3));
                         bus.Send(new MyMessage(), options);
+                        return Task.FromResult(0);
                     }))
                     .WithEndpoint<Receiver>()
                     .Done(c => c.WasCalled)

--- a/src/NServiceBus.AcceptanceTests/Basic/When_deferring_to_non_local.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_deferring_to_non_local.cs
@@ -10,11 +10,9 @@
     public class When_deferring_to_non_local : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Message_should_be_received()
+        public async Task Message_should_be_received()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         var options = new SendOptions();

--- a/src/NServiceBus.AcceptanceTests/Basic/When_handling_current_message_later.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_handling_current_message_later.cs
@@ -12,14 +12,9 @@
     public class When_handling_current_message_later : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_commit_unit_of_work_and_execute_subsequent_handlers()
+        public async Task Should_commit_unit_of_work_and_execute_subsequent_handlers()
         {
-            var context = new Context
-            {
-                Id = Guid.NewGuid()
-            };
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                 .WithEndpoint<MyEndpoint>(b => b.Given((bus, c) =>
                 {
                     bus.SendLocal(new SomeMessage{Id = c.Id});

--- a/src/NServiceBus.AcceptanceTests/Basic/When_handling_current_message_later.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_handling_current_message_later.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Basic
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Config;
@@ -19,7 +20,11 @@
             };
 
             Scenario.Define(context)
-                .WithEndpoint<MyEndpoint>(b => b.Given((bus, c) => bus.SendLocal(new SomeMessage{Id = c.Id})))
+                .WithEndpoint<MyEndpoint>(b => b.Given((bus, c) =>
+                {
+                    bus.SendLocal(new SomeMessage{Id = c.Id});
+                    return Task.FromResult(0);
+                }))
                 .Done(c => c.Done)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Basic/When_handling_message_with_several_messagehandlers.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_handling_message_with_several_messagehandlers.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Basic
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -13,10 +14,14 @@
             var context = new Context { Id = Guid.NewGuid() };
 
             Scenario.Define(context)
-                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage
+                    .WithEndpoint<Endpoint>(b => b.Given(bus =>
                     {
-                        Id = context.Id
-                    })))
+                        bus.SendLocal(new MyMessage
+                        {
+                            Id = context.Id
+                        });
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.FirstHandlerWasCalled)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Basic/When_handling_message_with_several_messagehandlers.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_handling_message_with_several_messagehandlers.cs
@@ -9,16 +9,14 @@
     public class When_handling_message_with_several_messagehandlers : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_call_all_handlers()
+        public async Task Should_call_all_handlers()
         {
-            var context = new Context { Id = Guid.NewGuid() };
-
-            Scenario.Define(context)
-                    .WithEndpoint<Endpoint>(b => b.Given(bus =>
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MyMessage
                         {
-                            Id = context.Id
+                            Id = c.Id
                         });
                         return Task.FromResult(0);
                     }))

--- a/src/NServiceBus.AcceptanceTests/Basic/When_incoming_headers_should_be_shared.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_incoming_headers_should_be_shared.cs
@@ -9,11 +9,9 @@
     public class When_incoming_headers_should_be_shared : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_expose_header_in_downstream_handlers()
+        public async Task Should_expose_header_in_downstream_handlers()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                 {
                     bus.SendLocal(new Message());

--- a/src/NServiceBus.AcceptanceTests/Basic/When_incoming_headers_should_be_shared.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_incoming_headers_should_be_shared.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Basic
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -13,7 +14,11 @@
             var context = new Context();
 
             Scenario.Define(context)
-                .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new Message())))
+                .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                {
+                    bus.SendLocal(new Message());
+                    return Task.FromResult(0);
+                }))
                 .Done(c => c.GotMessage)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Basic/When_injecting_handler_props.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_injecting_handler_props.cs
@@ -9,11 +9,9 @@
     public class When_injecting_handler_props : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Run()
+        public async Task Run()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Receiver>(c=>c.When(b =>
                     {
                         b.SendLocal(new MyMessage());

--- a/src/NServiceBus.AcceptanceTests/Basic/When_injecting_handler_props.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_injecting_handler_props.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Basic
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -13,7 +14,11 @@
             var context = new Context();
 
             Scenario.Define(context)
-                    .WithEndpoint<Receiver>(c=>c.When(b=>b.SendLocal(new MyMessage())))
+                    .WithEndpoint<Receiver>(c=>c.When(b =>
+                    {
+                        b.SendLocal(new MyMessage());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.WasCalled)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Basic/When_multiple_mappings_exists.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_multiple_mappings_exists.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Threading;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -14,7 +15,11 @@
             var context = new Context();
 
             Scenario.Define(context)
-                    .WithEndpoint<Sender>(b => b.Given((bus, c) => bus.Send(new MyCommand1())))
+                    .WithEndpoint<Sender>(b => b.Given((bus, c) =>
+                    {
+                        bus.Send(new MyCommand1());
+                        return Task.FromResult(0);
+                    }))
                     .WithEndpoint<Receiver1>()
                     .WithEndpoint<Receiver2>()
                     .Done(c => c.WasCalled1 || c.WasCalled2)

--- a/src/NServiceBus.AcceptanceTests/Basic/When_multiple_mappings_exists.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_multiple_mappings_exists.cs
@@ -10,11 +10,9 @@
     public class When_multiple_mappings_exists : NServiceBusAcceptanceTest
     {
         [Test]
-        public void First_registration_should_be_the_final_destination()
+        public async Task First_registration_should_be_the_final_destination()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Sender>(b => b.Given((bus, c) =>
                     {
                         bus.Send(new MyCommand1());

--- a/src/NServiceBus.AcceptanceTests/Basic/When_receiving_with_catch_all_handlers_registered.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_receiving_with_catch_all_handlers_registered.cs
@@ -9,16 +9,14 @@
     public class When_receiving_with_catch_all_handlers_registered : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_call_catch_all_handlers()
+        public async Task Should_call_catch_all_handlers()
         {
-            var context = new Context { Id = Guid.NewGuid() };
-
-            Scenario.Define(context)
-                    .WithEndpoint<Endpoint>(b => b.Given(bus =>
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MyMessage
                         {
-                            Id = context.Id
+                            Id = c.Id
                         });
                         return Task.FromResult(0);
                     }))
@@ -47,7 +45,7 @@
         }
 
         [Serializable]
-        public class MyMessage: IMessage
+        public class MyMessage : IMessage
         {
             public Guid Id { get; set; }
         }
@@ -83,10 +81,10 @@
         public class CatchAllHandler_IMessage : IHandleMessages<IMessage>
         {
             public Context Context { get; set; }
-            
+
             public void Handle(IMessage message)
             {
-                var myMessage = (MyMessage) message;
+                var myMessage = (MyMessage)message;
                 if (Context.Id != myMessage.Id)
                     return;
 

--- a/src/NServiceBus.AcceptanceTests/Basic/When_receiving_with_catch_all_handlers_registered.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_receiving_with_catch_all_handlers_registered.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Basic
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -13,10 +14,14 @@
             var context = new Context { Id = Guid.NewGuid() };
 
             Scenario.Define(context)
-                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage
+                    .WithEndpoint<Endpoint>(b => b.Given(bus =>
                     {
-                        Id = context.Id
-                    })))
+                        bus.SendLocal(new MyMessage
+                        {
+                            Id = context.Id
+                        });
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.ObjectHandlerWasCalled && c.DynamicHandlerWasCalled && c.IMessageHandlerWasCalled)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Basic/When_registering_additional_deserializers.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_registering_additional_deserializers.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.IO;
     using System.Runtime.Serialization.Formatters.Binary;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Features;
@@ -24,6 +25,7 @@
                         var sendOptions = new SendOptions();
                         sendOptions.SetHeader("ContentType", "MyCustomSerializer");
                         bus.Send(new MyRequest());
+                        return Task.FromResult(0);
                     }))
                 .WithEndpoint<XmlCustomSerializationReceiver>()
                 .Done(c => c.DeserializeCalled)

--- a/src/NServiceBus.AcceptanceTests/Basic/When_registering_additional_deserializers.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_registering_additional_deserializers.cs
@@ -14,11 +14,9 @@
     public class When_registering_additional_deserializers : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Two_endpoints_with_different_serializers_should_deserialize_the_message()
+        public async Task Two_endpoints_with_different_serializers_should_deserialize_the_message()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<CustomSerializationSender>(b => b.Given(
                     (bus, c) =>
                     {

--- a/src/NServiceBus.AcceptanceTests/Basic/When_registering_custom_serializer.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_registering_custom_serializer.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.IO;
     using System.Runtime.Serialization.Formatters.Binary;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Features;
@@ -19,7 +20,11 @@
 
             Scenario.Define(context)
                 .WithEndpoint<EndpointViaType>(b => b.Given(
-                    (bus, c) => bus.SendLocal(new MyRequest())))
+                    (bus, c) =>
+                    {
+                        bus.SendLocal(new MyRequest());
+                        return Task.FromResult(0);
+                    }))
                 .Done(c => c.HandlerGotTheRequest)
                 .Run();
 
@@ -34,7 +39,11 @@
 
             Scenario.Define(context)
                 .WithEndpoint<EndpointViaDefinition>(b => b.Given(
-                    (bus, c) => bus.SendLocal(new MyRequest())))
+                    (bus, c) =>
+                    {
+                        bus.SendLocal(new MyRequest());
+                        return Task.FromResult(0);
+                    }))
                 .Done(c => c.HandlerGotTheRequest)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Basic/When_registering_custom_serializer.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_registering_custom_serializer.cs
@@ -14,11 +14,9 @@
     public class When_registering_custom_serializer : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_register_via_type()
+        public async Task Should_register_via_type()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointViaType>(b => b.Given(
                     (bus, c) =>
                     {
@@ -33,11 +31,9 @@
         }
 
         [Test]
-        public void Should_register_via_definition()
+        public async Task Should_register_via_definition()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointViaDefinition>(b => b.Given(
                     (bus, c) =>
                     {

--- a/src/NServiceBus.AcceptanceTests/Basic/When_sending_from_a_send_only.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_sending_from_a_send_only.cs
@@ -10,13 +10,9 @@
     public class When_sending_from_a_send_only : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_receive_the_message()
+        public async Task Should_receive_the_message()
         {
-            var context = new Context
-            {
-                Id = Guid.NewGuid()
-            };
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<Sender>(b => b.Given((bus, c) =>
                     {
                         bus.Send(new MyMessage
@@ -33,13 +29,9 @@
         }
 
         [Test]
-        public void Should_not_need_audit_or_fault_forwarding_config_to_start()
+        public async Task Should_not_need_audit_or_fault_forwarding_config_to_start()
         {
-            var context = new Context
-            {
-                Id = Guid.NewGuid()
-            };
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<SendOnlyEndpoint>()
                     .Done(c => c.SendOnlyEndpointWasStarted)
                     .Run();
@@ -131,5 +123,5 @@
         }
     }
 
-    
+
 }

--- a/src/NServiceBus.AcceptanceTests/Basic/When_sending_from_a_send_only.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_sending_from_a_send_only.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Basic
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Features;
@@ -16,10 +17,14 @@
                 Id = Guid.NewGuid()
             };
             Scenario.Define(context)
-                    .WithEndpoint<Sender>(b => b.Given((bus, c) => bus.Send(new MyMessage
+                    .WithEndpoint<Sender>(b => b.Given((bus, c) =>
                     {
-                        Id = c.Id
-                    })))
+                        bus.Send(new MyMessage
+                        {
+                            Id = c.Id
+                        });
+                        return Task.FromResult(0);
+                    }))
                     .WithEndpoint<Receiver>()
                     .Done(c => c.WasCalled)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/Basic/When_sending_to_another_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_sending_to_another_endpoint.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -25,6 +26,7 @@
                         sendOptions.SetMessageId("MyMessageId");
                         
                         bus.Send(new MyMessage{Id = c.Id}, sendOptions);
+                        return Task.FromResult(0);
                     }))
                     .WithEndpoint<Receiver>()
                     .Done(c => c.WasCalled)

--- a/src/NServiceBus.AcceptanceTests/Basic/When_sending_to_another_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_sending_to_another_endpoint.cs
@@ -10,22 +10,17 @@
     public class When_sending_to_another_endpoint : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_receive_the_message()
+        public async Task Should_receive_the_message()
         {
-            var context = new Context
-            {
-                Id = Guid.NewGuid()
-            };
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<Sender>(b => b.Given((bus, c) =>
                     {
                         var sendOptions = new SendOptions();
 
                         sendOptions.SetHeader("MyHeader", "MyHeaderValue");
                         sendOptions.SetMessageId("MyMessageId");
-                        
-                        bus.Send(new MyMessage{Id = c.Id}, sendOptions);
+
+                        bus.Send(new MyMessage { Id = c.Id }, sendOptions);
                         return Task.FromResult(0);
                     }))
                     .WithEndpoint<Receiver>()
@@ -36,7 +31,7 @@
             Assert.AreEqual(1, context.TimesCalled, "The message handler should only be invoked once");
             Assert.AreEqual("StaticHeaderValue", context.ReceivedHeaders["MyStaticHeader"], "Static headers should be attached to outgoing messages");
             Assert.AreEqual("MyHeaderValue", context.MyHeader, "Static headers should be attached to outgoing messages");
-                       
+
         }
 
         public class Context : ScenarioContext
@@ -79,7 +74,7 @@
                     if (Context.Id != message.Id)
                         return;
 
-                    Assert.AreEqual(Bus.CurrentMessageContext.Id,"MyMessageId");
+                    Assert.AreEqual(Bus.CurrentMessageContext.Id, "MyMessageId");
 
                     Context.TimesCalled++;
 

--- a/src/NServiceBus.AcceptanceTests/Basic/When_sending_with_conventions.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_sending_with_conventions.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Basic
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -11,10 +12,14 @@
         public void Should_receive_the_message()
         {
             Scenario.Define(() => new Context { Id = Guid.NewGuid() })
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, context) => bus.SendLocal(new MyMessage
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, context) =>
                     {
-                        Id = context.Id
-                    })))
+                        bus.SendLocal(new MyMessage
+                        {
+                            Id = context.Id
+                        });
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.WasCalled)
                     .Run();
         }

--- a/src/NServiceBus.AcceptanceTests/Basic/When_sending_with_conventions.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_sending_with_conventions.cs
@@ -9,19 +9,21 @@
     public class When_sending_with_conventions : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_receive_the_message()
+        public async Task Should_receive_the_message()
         {
-            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, context) =>
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MyMessage
                         {
-                            Id = context.Id
+                            Id = c.Id
                         });
                         return Task.FromResult(0);
                     }))
                     .Done(c => c.WasCalled)
                     .Run();
+
+            Assert.True(context.WasCalled);
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Basic/When_setting_msmq_label_generator.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_setting_msmq_label_generator.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Messaging;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -23,10 +24,14 @@
                     Id = Guid.NewGuid()
                 };
                 Scenario.Define(context)
-                    .WithEndpoint<EndPoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage
+                    .WithEndpoint<EndPoint>(b => b.Given((bus, c) =>
                     {
-                        Id = c.Id
-                    })))
+                        bus.SendLocal(new MyMessage
+                        {
+                            Id = c.Id
+                        });
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.WasCalled && ReadMessageLabel() == "MyLabel")
                     .Repeat(r => r.For<MsmqOnly>())
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/Basic/When_setting_msmq_label_generator.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_setting_msmq_label_generator.cs
@@ -14,16 +14,12 @@
         const string auditQueue = @".\private$\labelAuditQueue";
 
         [Test]
-        public void Should_receive_the_message_and_label()
+        public async Task Should_receive_the_message_and_label()
         {
             DeleteAudit();
             try
             {
-                var context = new Context
-                {
-                    Id = Guid.NewGuid()
-                };
-                Scenario.Define(context)
+                await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<EndPoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MyMessage
@@ -34,9 +30,8 @@
                     }))
                     .Done(c => c.WasCalled && ReadMessageLabel() == "MyLabel")
                     .Repeat(r => r.For<MsmqOnly>())
+                    .Should(c => Assert.True(c.WasCalled, "The message handler should be called"))
                     .Run();
-
-                Assert.True(context.WasCalled, "The message handler should be called");
             }
             finally
             {
@@ -51,7 +46,6 @@
                 MessageQueue.Delete(auditQueue);
             }
         }
-
 
         static string ReadMessageLabel()
         {

--- a/src/NServiceBus.AcceptanceTests/Basic/When_starting_up_the_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_starting_up_the_endpoint.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -16,7 +17,7 @@
                 Id = Guid.NewGuid()
             };
             Scenario.Define(context)
-                .WithEndpoint<EndPoint>(b => b.Given((bus, c) => { }))
+                .WithEndpoint<EndPoint>(b => b.Given((bus, c) => Task.FromResult(0)))
                 .Run();
 
             var logItem = context.Logs.FirstOrDefault(item => item.Message.Contains(@"[Everyone] and [NT AUTHORITY\ANONYMOUS LOGON]"));

--- a/src/NServiceBus.AcceptanceTests/Basic/When_starting_up_the_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_starting_up_the_endpoint.cs
@@ -10,13 +10,9 @@
     public class When_starting_up_the_endpoint : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_log_warning_if_queue_is_configured_with_anon_and_everyone_permissions()
+        public async Task Should_log_warning_if_queue_is_configured_with_anon_and_everyone_permissions()
         {
-            var context = new Context
-            {
-                Id = Guid.NewGuid()
-            };
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                 .WithEndpoint<EndPoint>(b => b.Given((bus, c) => Task.FromResult(0)))
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Basic/When_using_INeedInitialization.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_using_INeedInitialization.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Basic
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -8,11 +9,9 @@
     public class When_using_INeedInitialization : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_be_able_to_set_endpoint_name()
+        public async Task Should_be_able_to_set_endpoint_name()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Sender>()
                     .WithEndpoint<Receiver>()
                     .Done(c => c.WasCalled)
@@ -50,7 +49,7 @@
                 }
             }
 
-            public class SendMessageToSender: IWantToRunWhenBusStartsAndStops
+            public class SendMessageToSender : IWantToRunWhenBusStartsAndStops
             {
                 public IBus Bus { get; set; }
 

--- a/src/NServiceBus.AcceptanceTests/Basic/When_using_a_greedy_convention.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_using_a_greedy_convention.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Basic
 {
     using System;
-    using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -13,7 +12,7 @@
         [Test]
         public async Task Should_receive_the_message()
         {
-            var contexts = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
+            await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<EndPoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MyMessage { Id = c.Id });

--- a/src/NServiceBus.AcceptanceTests/Basic/When_using_a_greedy_convention.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_using_a_greedy_convention.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Basic
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -12,7 +13,11 @@
         public void Should_receive_the_message()
         {
             Scenario.Define(() => new Context { Id = Guid.NewGuid() })
-                    .WithEndpoint<EndPoint>(b => b.Given((bus, context) => bus.SendLocal(new MyMessage { Id = context.Id })))
+                    .WithEndpoint<EndPoint>(b => b.Given((bus, context) =>
+                    {
+                        bus.SendLocal(new MyMessage { Id = context.Id });
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.WasCalled)
                     .Repeat(r => r
                         .For(Transports.Default)

--- a/src/NServiceBus.AcceptanceTests/Basic/When_using_a_greedy_convention.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_using_a_greedy_convention.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Basic
 {
     using System;
+    using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -10,12 +11,12 @@
     public class When_using_a_greedy_convention : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_receive_the_message()
+        public async Task Should_receive_the_message()
         {
-            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
-                    .WithEndpoint<EndPoint>(b => b.Given((bus, context) =>
+            var contexts = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
+                    .WithEndpoint<EndPoint>(b => b.Given((bus, c) =>
                     {
-                        bus.SendLocal(new MyMessage { Id = context.Id });
+                        bus.SendLocal(new MyMessage { Id = c.Id });
                         return Task.FromResult(0);
                     }))
                     .Done(c => c.WasCalled)
@@ -48,7 +49,7 @@
         }
 
         [Serializable]
-        public class MyMessage 
+        public class MyMessage
         {
             public Guid Id { get; set; }
         }

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_bestpractices_is_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_bestpractices_is_disabled.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.BestPractices
 {
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Features;
@@ -11,7 +12,11 @@
         public void Should_allow_subscribing_to_commands()
         {
             Scenario.Define<Context>()
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.Subscribe<MyCommand>()))
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                    {
+                        bus.Subscribe<MyCommand>();
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.EndpointsStarted)
                     .Run();
         }
@@ -20,7 +25,11 @@
         public void Should_allow_unsubscribing_to_commands()
         {
             Scenario.Define<Context>()
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.Unsubscribe<MyCommand>()))
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                    {
+                        bus.Unsubscribe<MyCommand>();
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.EndpointsStarted)
                     .Run();
         }
@@ -29,7 +38,11 @@
         public void Should_allow_publishing_commands()
         {
             Scenario.Define<Context>()
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.Publish(new MyCommand())))
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                    {
+                        bus.Publish(new MyCommand());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.EndpointsStarted)
                     .Run();
         }
@@ -38,7 +51,11 @@
         public void Should_allow_sending_events()
         {
             Scenario.Define<Context>()
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.Send(new MyEvent())))
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                    {
+                        bus.Send(new MyEvent());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.EndpointsStarted)
                     .Run();
         }

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_bestpractices_is_disabled_for_message.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_bestpractices_is_disabled_for_message.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.BestPractices
 {
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -18,6 +19,7 @@
                     publishOptions.DoNotEnforceBestPractices();
 
                     bus.Publish(new MyCommand(), publishOptions);
+                    return Task.FromResult(0);
                 }))
                 .Done(c => c.EndpointsStarted)
                 .Run();
@@ -36,6 +38,7 @@
                     sendOptions.DoNotEnforceBestPractices();
 
                     bus.Send(new MyEvent(), sendOptions);
+                    return Task.FromResult(0);
                 }))
                 .Done(c => c.EndpointsStarted)
                 .Run();

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_bestpractices_is_disabled_for_message.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_bestpractices_is_disabled_for_message.cs
@@ -8,11 +8,9 @@
     public class When_bestpractices_is_disabled_for_message : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_allow_publishing_commands()
+        public async Task Should_allow_publishing_commands()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                 {
                     var publishOptions = new PublishOptions();
@@ -24,14 +22,13 @@
                 .Done(c => c.EndpointsStarted)
                 .Run();
 
+            Assert.True(context.EndpointsStarted);
         }
 
         [Test]
-        public void Should_allow_sending_events()
+        public async Task Should_allow_sending_events()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                 {
                     var sendOptions = new SendOptions();
@@ -43,6 +40,7 @@
                 .Done(c => c.EndpointsStarted)
                 .Run();
 
+            Assert.True(context.EndpointsStarted);
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.BestPractices
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -24,6 +25,7 @@
                             c.Exception = ex;
                             c.GotTheException = true;
                         }
+                        return Task.FromResult(0);
                     }))
                     .Done(c => c.GotTheException)
                     .AllowExceptions()

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command.cs
@@ -9,11 +9,9 @@
     public class When_publishing_command : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_throw()
+        public async Task Should_throw()
         {
-            var context = new Context();
-            
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         try
@@ -37,7 +35,7 @@
         public class Context : ScenarioContext
         {
             public bool GotTheException { get; set; }
-            public Exception Exception{ get; set; }
+            public Exception Exception { get; set; }
         }
 
         public class Endpoint : EndpointConfigurationBuilder
@@ -47,6 +45,6 @@
                 EndpointSetup<DefaultServer>();
             }
         }
-        public class MyCommand : ICommand{}
+        public class MyCommand : ICommand { }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled.cs
@@ -1,0 +1,51 @@
+﻿namespace NServiceBus.AcceptanceTests.BestPractices
+{
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_publishing_command_bestpractices_disabled : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_allow_publishing_commands()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                {
+                    var publishOptions = new PublishOptions();
+                    publishOptions.DoNotEnforceBestPractices();
+
+                    bus.Publish(new MyCommand(), publishOptions);
+                    return Task.FromResult(0);
+                }))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.True(context.EndpointsStarted);
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<MyCommand>(typeof(Endpoint))
+                    .AddMapping<MyEvent>(typeof(Endpoint));
+            }
+
+            public class Handler : IHandleMessages<MyEvent>
+            {
+                public void Handle(MyEvent message)
+                {
+                }
+            }
+        }
+        public class MyCommand : ICommand { }
+        public class MyEvent : IEvent { }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled_on_endpoint.cs
@@ -9,9 +9,9 @@
     public class When_publishing_command_bestpractices_disabled_on_endpoint : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_allow_publishing_commands()
+        public async Task Should_allow_publishing_commands()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                 {
                     bus.Publish(new MyCommand());
@@ -22,9 +22,9 @@
         }
 
         [Test]
-        public void Should_allow_sending_events()
+        public async Task Should_allow_sending_events()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                 {
                     bus.Send(new MyEvent());

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled_on_endpoint.cs
@@ -1,0 +1,60 @@
+﻿namespace NServiceBus.AcceptanceTests.BestPractices
+{
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    public class When_publishing_command_bestpractices_disabled_on_endpoint : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_allow_publishing_commands()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                {
+                    bus.Publish(new MyCommand());
+                    return Task.FromResult(0);
+                }))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+        }
+
+        [Test]
+        public void Should_allow_sending_events()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                {
+                    bus.Send(new MyEvent());
+                    return Task.FromResult(0);
+                }))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<BestPracticeEnforcement>())
+                    .AddMapping<MyCommand>(typeof(Endpoint))
+                    .AddMapping<MyEvent>(typeof(Endpoint));
+            }
+
+            public class Handler : IHandleMessages<MyEvent>
+            {
+                public void Handle(MyEvent message)
+                {
+                }
+            }
+        }
+        public class MyCommand : ICommand { }
+        public class MyEvent : IEvent { }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_event.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_event.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.BestPractices
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -24,6 +25,7 @@
                             c.Exception = ex;
                             c.GotTheException = true;
                         }
+                        return Task.FromResult(0);
                     }))
                     .Done(c => c.GotTheException)
                     .AllowExceptions()

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_event.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_event.cs
@@ -9,11 +9,9 @@
     public class When_sending_event : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_throw()
+        public async Task Should_throw()
         {
-            var context = new Context();
-            
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         try
@@ -37,7 +35,7 @@
         public class Context : ScenarioContext
         {
             public bool GotTheException { get; set; }
-            public Exception Exception{ get; set; }
+            public Exception Exception { get; set; }
         }
 
         public class Endpoint : EndpointConfigurationBuilder
@@ -47,6 +45,6 @@
                 EndpointSetup<DefaultServer>();
             }
         }
-        public class MyEvent : IEvent{}
+        public class MyEvent : IEvent { }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled.cs
@@ -1,30 +1,12 @@
-﻿namespace NServiceBus.AcceptanceTests.BestPractices
+namespace NServiceBus.AcceptanceTests.BestPractices
 {
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
-    public class When_bestpractices_is_disabled_for_message : NServiceBusAcceptanceTest
+    public class When_sending_events_bestpractices_disabled : NServiceBusAcceptanceTest
     {
-        [Test]
-        public async Task Should_allow_publishing_commands()
-        {
-            var context = await Scenario.Define<Context>()
-                .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
-                {
-                    var publishOptions = new PublishOptions();
-                    publishOptions.DoNotEnforceBestPractices();
-
-                    bus.Publish(new MyCommand(), publishOptions);
-                    return Task.FromResult(0);
-                }))
-                .Done(c => c.EndpointsStarted)
-                .Run();
-
-            Assert.True(context.EndpointsStarted);
-        }
-
         [Test]
         public async Task Should_allow_sending_events()
         {

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled_on_endpoint.cs
@@ -9,9 +9,9 @@
     public class When_sending_events_bestpractices_disabled_on_endpoint : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_allow_sending_events()
+        public async Task Should_allow_sending_events()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                 {
                     bus.Send(new MyEvent());

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled_on_endpoint.cs
@@ -1,0 +1,47 @@
+﻿namespace NServiceBus.AcceptanceTests.BestPractices
+{
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    public class When_sending_events_bestpractices_disabled_on_endpoint : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_allow_sending_events()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                {
+                    bus.Send(new MyEvent());
+                    return Task.FromResult(0);
+                }))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<BestPracticeEnforcement>())
+                    .AddMapping<MyCommand>(typeof(Endpoint))
+                    .AddMapping<MyEvent>(typeof(Endpoint));
+            }
+
+            public class Handler : IHandleMessages<MyEvent>
+            {
+                public void Handle(MyEvent message)
+                {
+                }
+            }
+        }
+        public class MyCommand : ICommand { }
+        public class MyEvent : IEvent { }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command.cs
@@ -24,6 +24,7 @@
                             c.Exception = ex;
                             c.GotTheException = true;
                         }
+                        return Task.FromResult(0);
                     }))
                     .Done(c => c.GotTheException)
                     .AllowExceptions()

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.BestPractices
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command.cs
@@ -9,11 +9,9 @@
     public class When_subscribing_to_command : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_throw()
+        public async Task Should_throw()
         {
-            var context = new Context();
-            
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         try
@@ -37,7 +35,7 @@
         public class Context : ScenarioContext
         {
             public bool GotTheException { get; set; }
-            public Exception Exception{ get; set; }
+            public Exception Exception { get; set; }
         }
 
         public class Endpoint : EndpointConfigurationBuilder
@@ -47,6 +45,6 @@
                 EndpointSetup<DefaultServer>();
             }
         }
-        public class MyCommand : ICommand{}
+        public class MyCommand : ICommand { }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command_bestpractices_disabled_on_endpoint.cs
@@ -1,0 +1,73 @@
+﻿namespace NServiceBus.AcceptanceTests.BestPractices
+{
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    public class When_subscribing_to_command_bestpractices_disabled_on_endpoint : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_allow_subscribing_to_commands()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                {
+                    bus.Subscribe<MyCommand>();
+                    return Task.FromResult(0);
+                }))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+        }
+
+        [Test]
+        public void Should_allow_publishing_commands()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                {
+                    bus.Publish(new MyCommand());
+                    return Task.FromResult(0);
+                }))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+        }
+
+        [Test]
+        public void Should_allow_sending_events()
+        {
+            Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                {
+                    bus.Send(new MyEvent());
+                    return Task.FromResult(0);
+                }))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<BestPracticeEnforcement>())
+                    .AddMapping<MyCommand>(typeof(Endpoint))
+                    .AddMapping<MyEvent>(typeof(Endpoint));
+            }
+
+            public class Handler : IHandleMessages<MyEvent>
+            {
+                public void Handle(MyEvent message)
+                {
+                }
+            }
+        }
+        public class MyCommand : ICommand { }
+        public class MyEvent : IEvent { }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command_bestpractices_disabled_on_endpoint.cs
@@ -9,9 +9,9 @@
     public class When_subscribing_to_command_bestpractices_disabled_on_endpoint : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_allow_subscribing_to_commands()
+        public async Task Should_allow_subscribing_to_commands()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                 {
                     bus.Subscribe<MyCommand>();
@@ -22,9 +22,9 @@
         }
 
         [Test]
-        public void Should_allow_publishing_commands()
+        public async Task Should_allow_publishing_commands()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                 {
                     bus.Publish(new MyCommand());
@@ -35,9 +35,9 @@
         }
 
         [Test]
-        public void Should_allow_sending_events()
+        public async Task Should_allow_sending_events()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                 {
                     bus.Send(new MyEvent());

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command.cs
@@ -9,11 +9,9 @@
     public class When_unsubscribing_to_command : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_throw()
+        public async Task Should_throw()
         {
-            var context = new Context();
-            
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         try
@@ -37,7 +35,7 @@
         public class Context : ScenarioContext
         {
             public bool GotTheException { get; set; }
-            public Exception Exception{ get; set; }
+            public Exception Exception { get; set; }
         }
 
         public class Endpoint : EndpointConfigurationBuilder
@@ -47,6 +45,6 @@
                 EndpointSetup<DefaultServer>();
             }
         }
-        public class MyCommand : ICommand{}
+        public class MyCommand : ICommand { }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.BestPractices
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -24,6 +25,7 @@
                             c.Exception = ex;
                             c.GotTheException = true;
                         }
+                        return Task.FromResult(0);
                     }))
                     .Done(c => c.GotTheException)
                     .AllowExceptions()

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command_bestpractices_disabled_on_endpoint.cs
@@ -6,54 +6,15 @@
     using NServiceBus.Features;
     using NUnit.Framework;
 
-    public class When_bestpractices_is_disabled : NServiceBusAcceptanceTest
+    public class When_unsubscribing_to_command_bestpractices_disabled_on_endpoint : NServiceBusAcceptanceTest
     {
-        [Test]
-        public void Should_allow_subscribing_to_commands()
-        {
-            Scenario.Define<Context>()
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
-                    {
-                        bus.Subscribe<MyCommand>();
-                        return Task.FromResult(0);
-                    }))
-                    .Done(c => c.EndpointsStarted)
-                    .Run();
-        }
-
-        [Test]
+       [Test]
         public void Should_allow_unsubscribing_to_commands()
         {
             Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         bus.Unsubscribe<MyCommand>();
-                        return Task.FromResult(0);
-                    }))
-                    .Done(c => c.EndpointsStarted)
-                    .Run();
-        }
-
-        [Test]
-        public void Should_allow_publishing_commands()
-        {
-            Scenario.Define<Context>()
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
-                    {
-                        bus.Publish(new MyCommand());
-                        return Task.FromResult(0);
-                    }))
-                    .Done(c => c.EndpointsStarted)
-                    .Run();
-        }
-
-        [Test]
-        public void Should_allow_sending_events()
-        {
-            Scenario.Define<Context>()
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
-                    {
-                        bus.Send(new MyEvent());
                         return Task.FromResult(0);
                     }))
                     .Done(c => c.EndpointsStarted)

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command_bestpractices_disabled_on_endpoint.cs
@@ -9,16 +9,16 @@
     public class When_unsubscribing_to_command_bestpractices_disabled_on_endpoint : NServiceBusAcceptanceTest
     {
        [Test]
-        public void Should_allow_unsubscribing_to_commands()
+        public async Task Should_allow_unsubscribing_to_commands()
         {
-            Scenario.Define<Context>()
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
-                    {
-                        bus.Unsubscribe<MyCommand>();
-                        return Task.FromResult(0);
-                    }))
-                    .Done(c => c.EndpointsStarted)
-                    .Run();
+            await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                {
+                    bus.Unsubscribe<MyCommand>();
+                    return Task.FromResult(0);
+                }))
+                .Done(c => c.EndpointsStarted)
+                .Run();
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Causation/When_a_message_is_sent.cs
+++ b/src/NServiceBus.AcceptanceTests/Causation/When_a_message_is_sent.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Causation
 {
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -13,7 +14,11 @@
             var context = new Context();
 
             Scenario.Define(context)
-                    .WithEndpoint<CausationEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageSentOutsideOfHandler())))
+                    .WithEndpoint<CausationEndpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new MessageSentOutsideOfHandler());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.Done)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Causation/When_a_message_is_sent.cs
+++ b/src/NServiceBus.AcceptanceTests/Causation/When_a_message_is_sent.cs
@@ -7,13 +7,10 @@
 
     public class When_a_message_is_sent : NServiceBusAcceptanceTest
     {
-
         [Test]
-        public void Should_flow_causation_headers()
+        public async Task Should_flow_causation_headers()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<CausationEndpoint>(b => b.Given(bus =>
                     {
                         bus.SendLocal(new MessageSentOutsideOfHandler());
@@ -22,7 +19,7 @@
                     .Done(c => c.Done)
                     .Run();
 
-            Assert.AreEqual(context.FirstConversationId, context.ConversationIdReceived,"Conversation id should flow to outgoing messages");
+            Assert.AreEqual(context.FirstConversationId, context.ConversationIdReceived, "Conversation id should flow to outgoing messages");
             Assert.AreEqual(context.MessageIdOfFirstMessage, context.RelatedToReceived, "RelatedToId on outgoing messages should be set to the message id of the message causing it to be sent");
         }
 

--- a/src/NServiceBus.AcceptanceTests/Config/When_IWantToRunWhenBusStartsAndStops_Start_throws.cs
+++ b/src/NServiceBus.AcceptanceTests/Config/When_IWantToRunWhenBusStartsAndStops_Start_throws.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Config
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -8,11 +9,11 @@
     public class When_Start_throws : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_shutdown_bus_cleanly()
+        public async Task Should_shutdown_bus_cleanly()
         {
             Exception ex = null;
 
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<StartedEndpoint>(b => b.CustomConfig(c => c.DefineCriticalErrorAction((s, e) => ex = e)))
                     .AllowExceptions()
                     .Done(c => ex != null)

--- a/src/NServiceBus.AcceptanceTests/Config/When__startup_is_complete.cs
+++ b/src/NServiceBus.AcceptanceTests/Config/When__startup_is_complete.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Config
 {
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Settings;
@@ -8,9 +9,9 @@
     public class When__startup_is_complete : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Configure_and_setting_should_be_available_via_DI()
+        public async Task Configure_and_setting_should_be_available_via_DI()
         {
-            var context = Scenario.Define<Context>()
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<StartedEndpoint>()
                     .Done(c => c.IsDone)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/Config/When_a_config_override_is_found.cs
+++ b/src/NServiceBus.AcceptanceTests/Config/When_a_config_override_is_found.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Config
 {
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Config;
@@ -10,9 +11,9 @@
     {
 
         [Test]
-        public void Should_be_used_instead_of_pulling_the_settings_from_appconfig()
+        public async Task Should_be_used_instead_of_pulling_the_settings_from_appconfig()
         {
-            var context = Scenario.Define<Context>()
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<ConfigOverrideEndpoint>().Done(c =>c.ErrorQueueUsedByTheEndpoint != null)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Correlation/When_sending_with_no_correlation_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Correlation/When_sending_with_no_correlation_id.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Correlation
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -13,7 +14,11 @@
             var context = new Context();
 
             Scenario.Define(context)
-                    .WithEndpoint<CorrelationEndpoint>(b => b.Given(bus => bus.SendLocal(new MyRequest())))
+                    .WithEndpoint<CorrelationEndpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new MyRequest());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.GotRequest)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Correlation/When_sending_with_no_correlation_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Correlation/When_sending_with_no_correlation_id.cs
@@ -7,13 +7,11 @@
     using NUnit.Framework;
 
     public class When_sending_with_no_correlation_id : NServiceBusAcceptanceTest
-    {  
+    {
         [Test]
-        public void Should_use_the_message_id_as_the_correlation_id()
+        public async Task Should_use_the_message_id_as_the_correlation_id()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<CorrelationEndpoint>(b => b.Given(bus =>
                     {
                         bus.SendLocal(new MyRequest());

--- a/src/NServiceBus.AcceptanceTests/Correlation/When_using_a_custom_correlation_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Correlation/When_using_a_custom_correlation_id.cs
@@ -9,13 +9,11 @@
     public class When_using_a_custom_correlation_id : NServiceBusAcceptanceTest
     {
         static string CorrelationId = "my_custom_correlation_id";
-       
-        [Test]
-        public void Should_use_the_given_id_as_the_transport_level_correlation_id()
-        {
-            var context = new Context();
 
-            Scenario.Define(context)
+        [Test]
+        public async Task Should_use_the_given_id_as_the_transport_level_correlation_id()
+        {
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<CorrelationEndpoint>(b => b.Given(bus =>
                     {
                         var options = new SendOptions();
@@ -23,7 +21,7 @@
                         options.SetCorrelationId(CorrelationId);
                         options.RouteToLocalEndpointInstance();
 
-                        bus.Send(new MessageWithCustomCorrelationId(),options);
+                        bus.Send(new MessageWithCustomCorrelationId(), options);
                         return Task.FromResult(0);
                     }))
                     .Done(c => c.GotRequest)
@@ -60,7 +58,7 @@
             }
         }
 
-         [Serializable]
+        [Serializable]
         public class MessageWithCustomCorrelationId : IMessage
         {
         }

--- a/src/NServiceBus.AcceptanceTests/Correlation/When_using_a_custom_correlation_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Correlation/When_using_a_custom_correlation_id.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Correlation
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -23,6 +24,7 @@
                         options.RouteToLocalEndpointInstance();
 
                         bus.Send(new MessageWithCustomCorrelationId(),options);
+                        return Task.FromResult(0);
                     }))
                     .Done(c => c.GotRequest)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/CriticalError/When_registering_a_custom_criticalErrorHandler.cs
+++ b/src/NServiceBus.AcceptanceTests/CriticalError/When_registering_a_custom_criticalErrorHandler.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading.Tasks;
     using AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -15,7 +16,11 @@
         {
             Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithLocalCallback>(b => b.Given(
-                    (bus, context) => bus.SendLocal(new MyRequest())))
+                    (bus, context) =>
+                    {
+                        bus.SendLocal(new MyRequest());
+                        return Task.FromResult(0);
+                    }))
                 .AllowExceptions(exception => true)
                 .Done(c => c.ExceptionReceived)
                 .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/CriticalError/When_registering_a_custom_criticalErrorHandler.cs
+++ b/src/NServiceBus.AcceptanceTests/CriticalError/When_registering_a_custom_criticalErrorHandler.cs
@@ -1,12 +1,12 @@
 ﻿namespace NServiceBus.AcceptanceTests.CriticalError
 {
     using System;
-    using System.Diagnostics;
     using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Configuration.AdvanceExtensibility;
+    using NServiceBus.Settings;
     using NUnit.Framework;
     using ScenarioDescriptors;
     using IMessage = NServiceBus.IMessage;
@@ -14,9 +14,9 @@
     public class When_registering_a_custom_criticalErrorHandler : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Critical_error_should_be_raised_inside_delegate()
+        public async Task Critical_error_should_be_raised_inside_delegate()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithLocalCallback>(b => b.Given(
                     (bus, context) =>
                     {
@@ -31,7 +31,7 @@
                     Assert.AreEqual("Startup task failed to complete.", c.Message);
                     Assert.AreEqual("ExceptionInBusStarts", c.Exception.Message);
                 })
-                .Run(new TimeSpan(1, 1, 1));
+                .Run();
         }
 
         public class Context : ScenarioContext
@@ -67,6 +67,9 @@
             class AfterConfigIsComplete : IWantToRunWhenBusStartsAndStops
             {
                 public Context Context { get; set; }
+
+                public ReadOnlySettings Settings { get; set; }
+
                 public void Start()
                 {
                     throw new Exception("ExceptionInBusStarts");

--- a/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties.cs
+++ b/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties.cs
@@ -8,17 +8,17 @@
 
     public class When_sending_databus_properties:NServiceBusAcceptanceTest
     {
-        static byte[] PayloadToSend = new byte[1024 * 1024 * 10];
-
         [Test]
-        public async Task Should_receive_the_message_the_largeproperty_correctly()
+        public async Task Should_receive_messages_with_largepayload_correctly()
         {
+            var payloadToSend = new byte[1024 * 1024 * 10];
+
             var context = await Scenario.Define<Context>()
                     .WithEndpoint<Sender>(b => b.Given(bus=>
                     {
                         bus.Send(new MyMessageWithLargePayload
                         {
-                            Payload = new DataBusProperty<byte[]>(PayloadToSend)
+                            Payload = new DataBusProperty<byte[]>(payloadToSend)
                         });
                         return Task.FromResult(0);
                     }))
@@ -26,7 +26,7 @@
                     .Done(c => c.ReceivedPayload != null)
                     .Run();
 
-            Assert.AreEqual(PayloadToSend, context.ReceivedPayload, "The large payload should be marshalled correctly using the databus");
+            Assert.AreEqual(payloadToSend, context.ReceivedPayload, "The large payload should be marshalled correctly using the databus");
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties.cs
+++ b/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.DataBus
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NUnit.Framework;
@@ -10,13 +11,17 @@
         static byte[] PayloadToSend = new byte[1024 * 1024 * 10];
 
         [Test]
-        public void Should_receive_the_message_the_largeproperty_correctly()
+        public async Task Should_receive_the_message_the_largeproperty_correctly()
         {
-            var context = Scenario.Define<Context>()
-                    .WithEndpoint<Sender>(b => b.Given(bus=> bus.Send(new MyMessageWithLargePayload
+            var context = await Scenario.Define<Context>()
+                    .WithEndpoint<Sender>(b => b.Given(bus=>
+                    {
+                        bus.Send(new MyMessageWithLargePayload
                         {
-                            Payload = new DataBusProperty<byte[]>(PayloadToSend) 
-                        })))
+                            Payload = new DataBusProperty<byte[]>(PayloadToSend)
+                        });
+                        return Task.FromResult(0);
+                    }))
                     .WithEndpoint<Receiver>()
                     .Done(c => c.ReceivedPayload != null)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/DataBus/When_using_custom_IDataBus.cs
+++ b/src/NServiceBus.AcceptanceTests/DataBus/When_using_custom_IDataBus.cs
@@ -13,14 +13,9 @@
         static byte[] PayloadToSend = new byte[1024 * 10];
 
         [Test]
-        public void Should_be_able_to_register_via_fluent()
+        public async Task Should_be_able_to_register_via_fluent()
         {
-            var context = new Context
-            {
-                TempPath = Path.GetTempFileName()
-            };
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>(c => { c.TempPath = Path.GetTempFileName(); })
                     .WithEndpoint<SenderViaFluent>(b => b.Given(bus =>
                     {
                         bus.Send(new MyMessageWithLargePayload
@@ -99,5 +94,5 @@
         }
     }
 
-   
+
 }

--- a/src/NServiceBus.AcceptanceTests/DataBus/When_using_custom_IDataBus.cs
+++ b/src/NServiceBus.AcceptanceTests/DataBus/When_using_custom_IDataBus.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.IO;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NServiceBus.DataBus;
@@ -20,10 +21,14 @@
             };
 
             Scenario.Define(context)
-                    .WithEndpoint<SenderViaFluent>(b => b.Given(bus => bus.Send(new MyMessageWithLargePayload
+                    .WithEndpoint<SenderViaFluent>(b => b.Given(bus =>
                     {
-                        Payload = new DataBusProperty<byte[]>(PayloadToSend)
-                    })))
+                        bus.Send(new MyMessageWithLargePayload
+                        {
+                            Payload = new DataBusProperty<byte[]>(PayloadToSend)
+                        });
+                        return Task.FromResult(0);
+                    }))
                     .WithEndpoint<ReceiverViaFluent>()
                     .Done(c => c.ReceivedPayload != null)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_Deferring_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_Deferring_a_message.cs
@@ -10,12 +10,11 @@
     public class When_Deferring_a_message : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Delivery_should_be_delayed()
+        public async Task Delivery_should_be_delayed()
         {
-            var context = new Context();
             var delay = TimeSpan.FromSeconds(5);
 
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         var options = new SendOptions();

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_Deferring_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_Deferring_a_message.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.DelayedDelivery
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Features;
@@ -25,6 +26,7 @@
                         c.SentAt = DateTime.UtcNow;
 
                         bus.Send(new MyMessage(), options);
+                        return Task.FromResult(0);
                     }))
                     .Done(c => c.WasCalled)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/Encryption/EndpointTemplates/DefaultServer.cs
+++ b/src/NServiceBus.AcceptanceTests/Encryption/EndpointTemplates/DefaultServer.cs
@@ -96,6 +96,11 @@
 
         static IEnumerable<Type> GetNestedTypeRecursive(Type rootType, Type builderType)
         {
+            if (rootType == null)
+            {
+                throw new InvalidOperationException("Make sure you nest the endpoint infrastructure inside the TestFixture as nested classes");    
+            }
+
             yield return rootType;
 
             if (typeof(IEndpointConfigurationFactory).IsAssignableFrom(rootType) && rootType != builderType)

--- a/src/NServiceBus.AcceptanceTests/Encryption/When_using_Rijndael_with_config.cs
+++ b/src/NServiceBus.AcceptanceTests/Encryption/When_using_Rijndael_with_config.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NServiceBus.Config;
@@ -11,27 +12,34 @@
     public class When_using_Rijndael_with_config : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_receive_decrypted_message()
+        public async Task Should_receive_decrypted_message()
         {
-            var context = Scenario.Define<Context>()
-                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new MessageWithSecretData
+            var context = await Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new MessageWithSecretData
                         {
                             Secret = "betcha can't guess my secret",
-                            SubProperty = new MySecretSubProperty {Secret = "My sub secret"},
+                            SubProperty = new MySecretSubProperty
+                            {
+                                Secret = "My sub secret"
+                            },
                             CreditCards = new List<CreditCardDetails>
+                            {
+                                new CreditCardDetails
                                 {
-                                    new CreditCardDetails
-                                        {
-                                            ValidTo = DateTime.UtcNow.AddYears(1),
-                                            Number = "312312312312312"
-                                        },
-                                    new CreditCardDetails
-                                        {
-                                            ValidTo = DateTime.UtcNow.AddYears(2),
-                                            Number = "543645546546456"
-                                        }
+                                    ValidTo = DateTime.UtcNow.AddYears(1),
+                                    Number = "312312312312312"
+                                },
+                                new CreditCardDetails
+                                {
+                                    ValidTo = DateTime.UtcNow.AddYears(2),
+                                    Number = "543645546546456"
                                 }
-                        })))
+                            }
+                        });
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.GotTheMessage)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Encryption/When_using_Rijndael_with_custom.cs
+++ b/src/NServiceBus.AcceptanceTests/Encryption/When_using_Rijndael_with_custom.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NUnit.Framework;
@@ -9,27 +10,34 @@
     public class When_using_Rijndael_with_custom : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_receive_decrypted_message()
+        public async Task Should_receive_decrypted_message()
         {
-            var context = Scenario.Define<Context>()
-                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new MessageWithSecretData
+            var context = await Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new MessageWithSecretData
                         {
                             Secret = "betcha can't guess my secret",
-                            SubProperty = new MySecretSubProperty {Secret = "My sub secret"},
+                            SubProperty = new MySecretSubProperty
+                            {
+                                Secret = "My sub secret"
+                            },
                             CreditCards = new List<CreditCardDetails>
+                            {
+                                new CreditCardDetails
                                 {
-                                    new CreditCardDetails
-                                        {
-                                            ValidTo = DateTime.UtcNow.AddYears(1),
-                                            Number = "312312312312312"
-                                        },
-                                    new CreditCardDetails
-                                        {
-                                            ValidTo = DateTime.UtcNow.AddYears(2),
-                                            Number = "543645546546456"
-                                        }
+                                    ValidTo = DateTime.UtcNow.AddYears(1),
+                                    Number = "312312312312312"
+                                },
+                                new CreditCardDetails
+                                {
+                                    ValidTo = DateTime.UtcNow.AddYears(2),
+                                    Number = "543645546546456"
                                 }
-                        })))
+                            }
+                        });
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.GetTheMessage)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Encryption/When_using_Rijndael_with_multikey.cs
+++ b/src/NServiceBus.AcceptanceTests/Encryption/When_using_Rijndael_with_multikey.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
@@ -11,9 +12,9 @@
     public class When_using_Rijndael_with_multikey: NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_receive_decrypted_message()
+        public async Task Should_receive_decrypted_message()
         {
-            Scenario.Define<Context>()
+            var contexts = await Scenario.Define<Context>()
                     .WithEndpoint<Sender>(b => b.Given((bus, context) =>
                     {
                         bus.Send(new MessageWithSecretData

--- a/src/NServiceBus.AcceptanceTests/Encryption/When_using_Rijndael_with_multikey.cs
+++ b/src/NServiceBus.AcceptanceTests/Encryption/When_using_Rijndael_with_multikey.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NUnit.Framework;
@@ -13,10 +14,14 @@
         public void Should_receive_decrypted_message()
         {
             Scenario.Define<Context>()
-                    .WithEndpoint<Sender>(b => b.Given((bus, context) => bus.Send(new MessageWithSecretData
+                    .WithEndpoint<Sender>(b => b.Given((bus, context) =>
+                    {
+                        bus.Send(new MessageWithSecretData
                         {
                             Secret = "betcha can't guess my secret",
-                        })))
+                        });
+                        return Task.FromResult(0);
+                    }))
                     .WithEndpoint<Receiver>()
                     .Done(c => c.Done)
                     .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/Encryption/When_using_Rijndael_with_multikey.cs
+++ b/src/NServiceBus.AcceptanceTests/Encryption/When_using_Rijndael_with_multikey.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
@@ -14,7 +13,7 @@
         [Test]
         public async Task Should_receive_decrypted_message()
         {
-            var contexts = await Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<Sender>(b => b.Given((bus, context) =>
                     {
                         bus.Send(new MessageWithSecretData

--- a/src/NServiceBus.AcceptanceTests/Encryption/When_using_encryption_with_custom_service.cs
+++ b/src/NServiceBus.AcceptanceTests/Encryption/When_using_encryption_with_custom_service.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NServiceBus.Encryption;
@@ -11,27 +12,34 @@
     public class When_using_encryption_with_custom_service : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_receive_decrypted_message()
+        public async Task Should_receive_decrypted_message()
         {
-            var context = Scenario.Define<Context>()
-                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new MessageWithSecretData
+            var context = await Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new MessageWithSecretData
                         {
                             Secret = "betcha can't guess my secret",
-                            SubProperty = new MySecretSubProperty {Secret = "My sub secret"},
+                            SubProperty = new MySecretSubProperty
+                            {
+                                Secret = "My sub secret"
+                            },
                             CreditCards = new List<CreditCardDetails>
+                            {
+                                new CreditCardDetails
                                 {
-                                    new CreditCardDetails
-                                        {
-                                            ValidTo = DateTime.UtcNow.AddYears(1),
-                                            Number = "312312312312312"
-                                        },
-                                    new CreditCardDetails
-                                        {
-                                            ValidTo = DateTime.UtcNow.AddYears(2),
-                                            Number = "543645546546456"
-                                        }
+                                    ValidTo = DateTime.UtcNow.AddYears(1),
+                                    Number = "312312312312312"
+                                },
+                                new CreditCardDetails
+                                {
+                                    ValidTo = DateTime.UtcNow.AddYears(2),
+                                    Number = "543645546546456"
                                 }
-                        })))
+                            }
+                        });
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.GotTheMessage)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Forwarding/When_ForwardReceivedMessagesTo_is_set.cs
+++ b/src/NServiceBus.AcceptanceTests/Forwarding/When_ForwardReceivedMessagesTo_is_set.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Forwarding
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Config;
@@ -17,6 +18,7 @@
                     .WithEndpoint<EndpointThatForwards>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MessageToForward());
+                        return Task.FromResult(0);
                     }))
                     .WithEndpoint<ForwardReceiver>()
                     .Done(c => c.GotForwardedMessage)

--- a/src/NServiceBus.AcceptanceTests/Hosting/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Hosting/When_a_message_is_audited.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Hosting
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -13,7 +14,11 @@
             var context = new Context();
 
             Scenario.Define(context)
-                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new MessageToBeAudited());
+                        return Task.FromResult(0);
+                    }))
                     .WithEndpoint<AuditSpyEndpoint>()
                     .Done(c => c.Done)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/Hosting/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Hosting/When_a_message_is_audited.cs
@@ -9,12 +9,10 @@
     public class When_a_message_is_audited : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_add_host_related_headers()
+        public async Task Should_add_host_related_headers()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
-                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus =>
+            var context = await Scenario.Define<Context>()
+                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MessageToBeAudited());
                         return Task.FromResult(0);

--- a/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostid.cs
+++ b/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostid.cs
@@ -11,12 +11,10 @@ namespace NServiceBus.AcceptanceTests.Hosting
 
     public class When_feature_overrides_hostid : NServiceBusAcceptanceTest
     {
-
-        static Context context = new Context();
         [Test]
-        public void MD5_should_not_be_used()
+        public async Task MD5_should_not_be_used()
         {
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<MyEndpoint>(e => e.Given(b =>
                 {
                     b.SendLocal(new MyMessage());
@@ -52,6 +50,7 @@ namespace NServiceBus.AcceptanceTests.Hosting
                     dictionary.TryRemove("NServiceBus.HostInformation.HostId", out s2);
 
                     // Try to get value, setting should not exist
+                    var context = (Context) s.Get<ScenarioContext>();
                     context.NotSet = !s.HasSetting("NServiceBus.HostInformation.HostId");
 
                     // Set override again so we have something

--- a/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostid.cs
+++ b/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostid.cs
@@ -50,7 +50,7 @@ namespace NServiceBus.AcceptanceTests.Hosting
                     dictionary.TryRemove("NServiceBus.HostInformation.HostId", out s2);
 
                     // Try to get value, setting should not exist
-                    var context = (Context) s.Get<ScenarioContext>();
+                    var context = s.Get<Context>();
                     context.NotSet = !s.HasSetting("NServiceBus.HostInformation.HostId");
 
                     // Set override again so we have something

--- a/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostid.cs
+++ b/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostid.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.AcceptanceTests.Hosting
     using System;
     using System.Collections.Concurrent;
     using System.Reflection;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Features;
@@ -16,7 +17,11 @@ namespace NServiceBus.AcceptanceTests.Hosting
         public void MD5_should_not_be_used()
         {
             Scenario.Define(context)
-                .WithEndpoint<MyEndpoint>(e => e.Given(b => b.SendLocal(new MyMessage())))
+                .WithEndpoint<MyEndpoint>(e => e.Given(b =>
+                {
+                    b.SendLocal(new MyMessage());
+                    return Task.FromResult(0);
+                }))
                 .Done(c => c.Done)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostinfo.cs
+++ b/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostinfo.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.AcceptanceTests.Hosting
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Features;
@@ -18,7 +19,11 @@ namespace NServiceBus.AcceptanceTests.Hosting
             var context = new Context();
 
             Scenario.Define(context)
-                .WithEndpoint<MyEndpoint>(e => e.Given(b => b.SendLocal(new MyMessage())))
+                .WithEndpoint<MyEndpoint>(e => e.Given(b =>
+                {
+                    b.SendLocal(new MyMessage());
+                    return Task.FromResult(0);
+                }))
                 .Done(c => c.OriginatingHostId != Guid.Empty)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostinfo.cs
+++ b/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostinfo.cs
@@ -14,11 +14,9 @@ namespace NServiceBus.AcceptanceTests.Hosting
         static string instanceName = "Foo";
 
         [Test]
-        public void HostInfo_is_changed()
+        public async Task HostInfo_is_changed()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<MyEndpoint>(e => e.Given(b =>
                 {
                     b.SendLocal(new MyMessage());

--- a/src/NServiceBus.AcceptanceTests/Hosting/When_sending_ensure_proper_headers.cs
+++ b/src/NServiceBus.AcceptanceTests/Hosting/When_sending_ensure_proper_headers.cs
@@ -10,25 +10,21 @@
     public class When_sending_ensure_proper_headers : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_have_proper_headers_for_the_originating_endpoint()
+        public async Task Should_have_proper_headers_for_the_originating_endpoint()
         {
-            var context = new Context
-            {
-                Id = Guid.NewGuid()
-            };
-
-            Scenario.Define(context)
-                                .WithEndpoint<Sender>(b => b.Given((bus, ctx) =>
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
+                                .WithEndpoint<Sender>(b => b.Given((bus, c) =>
                                 {
                                     bus.Send<MyMessage>(m =>
                                     {
-                                        m.Id = ctx.Id;
+                                        m.Id = c.Id;
                                     });
                                     return Task.FromResult(0);
                                 }))
                                 .WithEndpoint<Receiver>()
                                 .Done(c => c.WasCalled)
                                 .Run();
+
             Assert.True(context.WasCalled, "The message handler should be called");
             Assert.AreEqual("SenderForEnsureProperHeadersTest", context.ReceivedHeaders[Headers.OriginatingEndpoint], "Message should contain the Originating endpoint");
             Assert.IsNotNullOrEmpty(context.ReceivedHeaders[Headers.OriginatingHostId], "OriginatingHostId cannot be null or empty");

--- a/src/NServiceBus.AcceptanceTests/Hosting/When_sending_ensure_proper_headers.cs
+++ b/src/NServiceBus.AcceptanceTests/Hosting/When_sending_ensure_proper_headers.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -17,10 +18,14 @@
             };
 
             Scenario.Define(context)
-                                .WithEndpoint<Sender>(b => b.Given((bus, ctx) => bus.Send<MyMessage>(m =>
+                                .WithEndpoint<Sender>(b => b.Given((bus, ctx) =>
                                 {
-                                    m.Id = ctx.Id;
-                                })))
+                                    bus.Send<MyMessage>(m =>
+                                    {
+                                        m.Id = ctx.Id;
+                                    });
+                                    return Task.FromResult(0);
+                                }))
                                 .WithEndpoint<Receiver>()
                                 .Done(c => c.WasCalled)
                                 .Run();

--- a/src/NServiceBus.AcceptanceTests/Licensing/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Licensing/When_a_message_is_audited.cs
@@ -8,11 +8,9 @@
     public class When_a_message_is_audited : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_add_the_license_diagnostic_headers()
+        public async Task Should_add_the_license_diagnostic_headers()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus =>
                     {
                         bus.SendLocal(new MessageToBeAudited());
@@ -21,6 +19,7 @@
                     .WithEndpoint<AuditSpyEndpoint>()
                     .Done(c => c.HasDiagnosticLicensingHeaders)
                     .Run();
+
             Assert.IsTrue(context.HasDiagnosticLicensingHeaders);
         }
 

--- a/src/NServiceBus.AcceptanceTests/Licensing/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Licensing/When_a_message_is_audited.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Licensing
 {
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -12,7 +13,11 @@
             var context = new Context();
 
             Scenario.Define(context)
-                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new MessageToBeAudited());
+                        return Task.FromResult(0);
+                    }))
                     .WithEndpoint<AuditSpyEndpoint>()
                     .Done(c => c.HasDiagnosticLicensingHeaders)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_empty_id_header.cs
+++ b/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_empty_id_header.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.MessageId
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Config;
@@ -12,14 +13,9 @@
     public class When_message_has_empty_id_header : NServiceBusAcceptanceTest
     {
         [Test]
-        public void A_message_id_is_generated_by_the_transport_layer_on_receiving_side()
+        public async Task A_message_id_is_generated_by_the_transport_layer_on_receiving_side()
         {
-            var context = new Context
-            {
-                Id = Guid.NewGuid()
-            };
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<Endpoint>()
                     .Done(c => c.MessageReceived)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_no_id_header.cs
+++ b/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_no_id_header.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.MessageId
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Config;
@@ -12,14 +13,9 @@
     public class When_message_has_no_id_header : NServiceBusAcceptanceTest
     {
         [Test]
-        public void A_message_id_is_generated_by_the_transport_layer_on_receiving_side()
+        public async Task A_message_id_is_generated_by_the_transport_layer_on_receiving_side()
         {
-            var context = new Context
-            {
-                Id = Guid.NewGuid()
-            };
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<Endpoint>()
                     .Done(c => c.MessageReceived)
                     .Run();
@@ -30,7 +26,6 @@
         public class CorruptionBehavior : Behavior<DispatchContext>
         {
             public Context Context { get; set; }
-
 
             public override void Invoke(DispatchContext context, Action next)
             {

--- a/src/NServiceBus.AcceptanceTests/Mutators/Issue_1980.cs
+++ b/src/NServiceBus.AcceptanceTests/Mutators/Issue_1980.cs
@@ -10,10 +10,9 @@
     public class Issue_1980 : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Run()
+        public async Task Run()
         {
-            var testContext = new Context();
-            Scenario.Define(testContext)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new V1Message());
@@ -22,8 +21,8 @@
                     .Done(c => c.V2MessageReceived || c.V1MessageReceived)
                     .Run();
 
-            Assert.IsTrue(testContext.V2MessageReceived);
-            Assert.IsFalse(testContext.V1MessageReceived);
+            Assert.IsTrue(context.V2MessageReceived);
+            Assert.IsFalse(context.V1MessageReceived);
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Mutators/Issue_1980.cs
+++ b/src/NServiceBus.AcceptanceTests/Mutators/Issue_1980.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Mutators
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.MessageMutator;
@@ -13,7 +14,11 @@
         {
             var testContext = new Context();
             Scenario.Define(testContext)
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new V1Message())))
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                    {
+                        bus.SendLocal(new V1Message());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.V2MessageReceived || c.V1MessageReceived)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Mutators/When_defining_outgoing_message_mutators.cs
+++ b/src/NServiceBus.AcceptanceTests/Mutators/When_defining_outgoing_message_mutators.cs
@@ -15,7 +15,7 @@
             var context = await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given(bus =>
                     {
-                        bus.SendLocal(new MessageToBeMutated());
+                        bus.SendLocal(new Message());
                         return Task.FromResult(0);
                     }))
                     .Done(c => c.MessageProcessed)

--- a/src/NServiceBus.AcceptanceTests/Mutators/When_defining_outgoing_message_mutators.cs
+++ b/src/NServiceBus.AcceptanceTests/Mutators/When_defining_outgoing_message_mutators.cs
@@ -10,11 +10,10 @@
     public class When_defining_outgoing_message_mutators : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_be_applied_to_outgoing_messages()
+        public async Task Should_be_applied_to_outgoing_messages()
         {
-            var testContext = new Context();
-            Scenario.Define(testContext)
-                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new Message())))
+            var context = await Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given(bus =>
                     {
                         bus.SendLocal(new MessageToBeMutated());
                         return Task.FromResult(0);
@@ -22,8 +21,8 @@
                     .Done(c => c.MessageProcessed)
                     .Run();
 
-            Assert.True(testContext.TransportMutatorCalled);
-            Assert.True(testContext.MessageMutatorCalled);
+            Assert.True(context.TransportMutatorCalled);
+            Assert.True(context.MessageMutatorCalled);
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Mutators/When_defining_outgoing_message_mutators.cs
+++ b/src/NServiceBus.AcceptanceTests/Mutators/When_defining_outgoing_message_mutators.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Mutators
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.MessageMutator;
@@ -14,6 +15,10 @@
             var testContext = new Context();
             Scenario.Define(testContext)
                     .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new Message())))
+                    {
+                        bus.SendLocal(new MessageToBeMutated());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.MessageProcessed)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Mutators/When_mutating.cs
+++ b/src/NServiceBus.AcceptanceTests/Mutators/When_mutating.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.MessageMutator;
@@ -9,20 +10,20 @@
 
     public class When_mutating : NServiceBusAcceptanceTest
     {
-
         [Test]
-        public void Context_should_be_populated()
+        public async Task Context_should_be_populated()
         {
-            var testContext = new Context();
-            Scenario.Define(testContext)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Sender>(b => b.Given((bus, c) =>
                     {
                         bus.Send(new StartMessage());
+                        return Task.FromResult(0);
                     }))
                     .WithEndpoint<Receiver>()
                     .Done(c => c.WasCalled)
                     .Run(TimeSpan.FromHours(1));
-            Assert.True(testContext.WasCalled, "The message handler should be called");
+
+            Assert.True(context.WasCalled, "The message handler should be called");
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Mutators/When_outgoing_mutator_replaces_instance.cs
+++ b/src/NServiceBus.AcceptanceTests/Mutators/When_outgoing_mutator_replaces_instance.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Mutators
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.MessageMutator;
@@ -13,7 +14,11 @@
         {
             var testContext = new Context();
             Scenario.Define(testContext)
-                .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new V1Message())))
+                .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                {
+                    bus.SendLocal(new V1Message());
+                    return Task.FromResult(0);
+                }))
                 .Done(c => c.V2MessageReceived)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Mutators/When_outgoing_mutator_replaces_instance.cs
+++ b/src/NServiceBus.AcceptanceTests/Mutators/When_outgoing_mutator_replaces_instance.cs
@@ -10,10 +10,9 @@
     public class When_outgoing_mutator_replaces_instance : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Message_sent_should_be_new_instance()
+        public async Task Message_sent_should_be_new_instance()
         {
-            var testContext = new Context();
-            Scenario.Define(testContext)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                 {
                     bus.SendLocal(new V1Message());
@@ -22,8 +21,8 @@
                 .Done(c => c.V2MessageReceived)
                 .Run();
 
-            Assert.IsTrue(testContext.V2MessageReceived);
-            Assert.IsFalse(testContext.V1MessageReceived);
+            Assert.IsTrue(context.V2MessageReceived);
+            Assert.IsFalse(context.V1MessageReceived);
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Mutators/When_using_outgoing_tm_mutator.cs
+++ b/src/NServiceBus.AcceptanceTests/Mutators/When_using_outgoing_tm_mutator.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Mutators
 {
     using System.Text;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.MessageMutator;
@@ -14,6 +15,10 @@
             var testContext = new Context();
             Scenario.Define(testContext)
                     .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeMutated())))
+                    {
+                        bus.SendLocal(new MessageToBeMutated());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.MessageProcessed)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Mutators/When_using_outgoing_tm_mutator.cs
+++ b/src/NServiceBus.AcceptanceTests/Mutators/When_using_outgoing_tm_mutator.cs
@@ -10,11 +10,10 @@
     public class When_using_outgoing_tm_mutator : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_be_able_to_update_message()
+        public async Task Should_be_able_to_update_message()
         {
-            var testContext = new Context();
-            Scenario.Define(testContext)
-                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeMutated())))
+            var context = await Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.Given(bus =>
                     {
                         bus.SendLocal(new MessageToBeMutated());
                         return Task.FromResult(0);
@@ -22,7 +21,7 @@
                     .Done(c => c.MessageProcessed)
                     .Run();
 
-            Assert.True(testContext.CanAddHeaders);
+            Assert.True(context.CanAddHeaders);
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -118,7 +118,8 @@
     <Compile Include="Reliability\Outbox\When_dispatching_transport_operations.cs" />
     <Compile Include="PerfMon\CriticalTime\When_deferring_a_message.cs" />
     <Compile Include="Audit\When_audit_is_overridden_in_code.cs" />
-    <Compile Include="Routing\AutomaticSubscriptions\When_starting_an_endpoint_containing_a_saga.cs" />
+    <Compile Include="Routing\AutomaticSubscriptions\When_starting_an_endpoint_a_saga.cs" />
+    <Compile Include="Routing\AutomaticSubscriptions\When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs" />
     <Compile Include="Routing\AutomaticSubscriptions\When_starting_an_endpoint_with_autoSubscribe.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -118,7 +118,7 @@
     <Compile Include="Reliability\Outbox\When_dispatching_transport_operations.cs" />
     <Compile Include="PerfMon\CriticalTime\When_deferring_a_message.cs" />
     <Compile Include="Audit\When_audit_is_overridden_in_code.cs" />
-    <Compile Include="Routing\AutomaticSubscriptions\When_starting_an_endpoint_a_saga.cs" />
+    <Compile Include="Routing\AutomaticSubscriptions\When_starting_an_endpoint_with_a_saga.cs" />
     <Compile Include="Routing\AutomaticSubscriptions\When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs" />
     <Compile Include="Routing\AutomaticSubscriptions\When_starting_an_endpoint_with_autoSubscribe.cs">
       <SubType>Code</SubType>

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -73,11 +73,15 @@
     <Compile Include="Basic\When_deferring_to_non_local.cs" />
     <Compile Include="Basic\When_starting_up_the_endpoint.cs" />
     <Compile Include="Mutators\When_mutating.cs" />
+    <Compile Include="BestPractices\When_publishing_command_bestpractices_disabled_on_endpoint.cs" />
+    <Compile Include="BestPractices\When_sending_events_bestpractices_disabled_on_endpoint.cs" />
+    <Compile Include="BestPractices\When_sending_events_bestpractices_disabled.cs" />
+    <Compile Include="BestPractices\When_subscribing_to_command_bestpractices_disabled_on_endpoint.cs" />
     <Compile Include="Mutators\When_using_outgoing_tm_mutator.cs" />
     <Compile Include="Recoverability\Retries\When_message_fails_retries.cs" />
     <Compile Include="Recoverability\When_error_is_overridden_in_code.cs" />
-    <Compile Include="BestPractices\When_bestpractices_is_disabled_for_message.cs" />
-    <Compile Include="BestPractices\When_bestpractices_is_disabled.cs" />
+    <Compile Include="BestPractices\When_publishing_command_bestpractices_disabled.cs" />
+    <Compile Include="BestPractices\When_unsubscribing_to_command_bestpractices_disabled_on_endpoint.cs" />
     <Compile Include="BestPractices\When_unsubscribing_to_command.cs" />
     <Compile Include="BestPractices\When_subscribing_to_command.cs" />
     <Compile Include="BestPractices\When_publishing_command.cs" />

--- a/src/NServiceBus.AcceptanceTests/NonTx/When_sending_inside_ambient_tx.cs
+++ b/src/NServiceBus.AcceptanceTests/NonTx/When_sending_inside_ambient_tx.cs
@@ -11,10 +11,9 @@
     public class When_sending_inside_ambient_tx : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_not_roll_the_message_back_to_the_queue_in_case_of_failure()
+        public async Task Should_not_roll_the_message_back_to_the_queue_in_case_of_failure()
         {
-
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<NonTransactionalEndpoint>(b => b.Given(bus =>
                     {
                         bus.SendLocal(new MyMessage());

--- a/src/NServiceBus.AcceptanceTests/NonTx/When_sending_inside_ambient_tx.cs
+++ b/src/NServiceBus.AcceptanceTests/NonTx/When_sending_inside_ambient_tx.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.NonTx
 {
     using System;
+    using System.Threading.Tasks;
     using System.Transactions;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -14,7 +15,11 @@
         {
 
             Scenario.Define<Context>()
-                    .WithEndpoint<NonTransactionalEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .WithEndpoint<NonTransactionalEndpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new MyMessage());
+                        return Task.FromResult(0);
+                    }))
                     .AllowExceptions()
                     .Done(c => c.TestComplete)
                     .Repeat(r => r.For<AllDtcTransports>()) 

--- a/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_CriticalTime_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_CriticalTime_enabled.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.PerfMon.CriticalTime
 {
     using System.Diagnostics;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
@@ -14,13 +15,12 @@
 
         [Test]
         [Explicit("Since perf counters need to be enabled with powershell")]
-        public void Should_have_perf_counter_set()
+        public async Task Should_have_perf_counter_set()
         {
             using (var counter = new PerformanceCounter("NServiceBus", "Critical Time", "CriticaltimeEnabled.Endpoint", false))
             using (new Timer(state => CheckPerfCounter(counter), null, 0, 100))
             {
-                var context = new Context();
-                Scenario.Define(context)
+                var contexts = await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MyMessage());
@@ -63,7 +63,7 @@
         public class MyMessageHandler : IHandleMessages<MyMessage>
         {
             public Context Context { get; set; }
-            
+
             public void Handle(MyMessage message)
             {
                 Context.WasCalled = true;

--- a/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_CriticalTime_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_CriticalTime_enabled.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.PerfMon.CriticalTime
 {
     using System.Diagnostics;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
@@ -20,7 +19,7 @@
             using (var counter = new PerformanceCounter("NServiceBus", "Critical Time", "CriticaltimeEnabled.Endpoint", false))
             using (new Timer(state => CheckPerfCounter(counter), null, 0, 100))
             {
-                var contexts = await Scenario.Define<Context>()
+                await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MyMessage());

--- a/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_CriticalTime_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_CriticalTime_enabled.cs
@@ -2,6 +2,7 @@
 {
     using System.Diagnostics;
     using System.Threading;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -20,7 +21,11 @@
             {
                 var context = new Context();
                 Scenario.Define(context)
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage())))
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                    {
+                        bus.SendLocal(new MyMessage());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.WasCalled)
                     .Repeat(r => r.For(Transports.Default))
                     .Should(c => Assert.True(c.WasCalled, "The message handler should be called"))

--- a/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_deferring_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_deferring_a_message.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Diagnostics;
     using System.Threading;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -29,6 +30,7 @@
                         options.RouteToLocalEndpointInstance();
 
                         bus.Send(new MyMessage(), options);
+                        return Task.FromResult(0);
                     }))
                     .Done(c => c.WasCalled)
                     .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_deferring_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_deferring_a_message.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Diagnostics;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
@@ -15,13 +16,12 @@
 
         [Test]
         [Explicit("Since perf counters need to be enabled with powershell")]
-        public void Critical_time_should_not_include_the_time_message_was_waiting_in_the_timeout_store()
+        public async Task Critical_time_should_not_include_the_time_message_was_waiting_in_the_timeout_store()
         {
             using (var counter = new PerformanceCounter("NServiceBus", "Critical Time", "DeferringAMessage.Endpoint", false))
             using (new Timer(state => CheckPerfCounter(counter), null, 0, 100))
             {
-                var context = new Context();
-                Scenario.Define(context)
+                var contexts = await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         var options = new SendOptions();
@@ -71,7 +71,7 @@
         public class MyMessageHandler : IHandleMessages<MyMessage>
         {
             public Context Context { get; set; }
-            
+
             public void Handle(MyMessage message)
             {
                 Context.WasCalled = true;

--- a/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_deferring_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_deferring_a_message.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Diagnostics;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
@@ -21,7 +20,7 @@
             using (var counter = new PerformanceCounter("NServiceBus", "Critical Time", "DeferringAMessage.Endpoint", false))
             using (new Timer(state => CheckPerfCounter(counter), null, 0, 100))
             {
-                var contexts = await Scenario.Define<Context>()
+                await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         var options = new SendOptions();

--- a/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_slow_with_CriticalTime_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_slow_with_CriticalTime_enabled.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.PerfMon.CriticalTime
 {
     using System.Diagnostics;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
@@ -14,13 +15,12 @@
 
         [Test]
         [Explicit("Since perf counters need to be enabled with powershell")]
-        public void Should_have_perf_counter_set()
+        public async Task Should_have_perf_counter_set()
         {
             using (var counter = new PerformanceCounter("NServiceBus", "Critical Time", "SlowWithCriticaltimeEnabled.Endpoint", true))
             using (new Timer(state => CheckPerfCounter(counter), null, 0, 100))
             {
-                var context = new Context();
-                Scenario.Define(context)
+                await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MyMessage());

--- a/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_slow_with_CriticalTime_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_slow_with_CriticalTime_enabled.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.PerfMon.CriticalTime
 {
     using System.Diagnostics;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;

--- a/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_slow_with_CriticalTime_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/PerfMon/CriticalTime/When_slow_with_CriticalTime_enabled.cs
@@ -2,6 +2,7 @@
 {
     using System.Diagnostics;
     using System.Threading;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -20,7 +21,11 @@
             {
                 var context = new Context();
                 Scenario.Define(context)
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage())))
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                    {
+                        bus.SendLocal(new MyMessage());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.WasCalled)
                     .Repeat(r => r.For(Transports.Default))
                     .Should(c => Assert.True(c.WasCalled, "The message handler should be called"))

--- a/src/NServiceBus.AcceptanceTests/PerfMon/SLA/When_sending_slow_with_SLA_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/PerfMon/SLA/When_sending_slow_with_SLA_enabled.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Diagnostics;
     using System.Threading;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -21,7 +22,11 @@
             {
                 var context = new Context();
                 Scenario.Define(context)
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage())))
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                    {
+                        bus.SendLocal(new MyMessage());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.WasCalled)
                     .Repeat(r => r.For(Transports.Default))
                     .Should(c => Assert.True(c.WasCalled, "The message handler should be called"))

--- a/src/NServiceBus.AcceptanceTests/PerfMon/SLA/When_sending_slow_with_SLA_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/PerfMon/SLA/When_sending_slow_with_SLA_enabled.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Diagnostics;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
@@ -15,13 +16,12 @@
 
         [Test]
         [Explicit("Since perf counters need to be enabled with powershell")]
-        public void Should_have_perf_counter_set()
+        public async Task Should_have_perf_counter_set()
         {
             using (var counter = new PerformanceCounter("NServiceBus", "SLA violation countdown", "PerformanceMonitoring.Endpoint.WhenSendingSlowWithSLAEnabled." + Transports.Default.Key, true))
             using (new Timer(state => CheckPerfCounter(counter), null, 0, 100))
             {
-                var context = new Context();
-                Scenario.Define(context)
+                var contexts = await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MyMessage());
@@ -64,7 +64,7 @@
         public class MyMessageHandler : IHandleMessages<MyMessage>
         {
             public Context Context { get; set; }
-            
+
             public void Handle(MyMessage message)
             {
                 Thread.Sleep(1000);

--- a/src/NServiceBus.AcceptanceTests/PerfMon/SLA/When_sending_slow_with_SLA_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/PerfMon/SLA/When_sending_slow_with_SLA_enabled.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Diagnostics;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
@@ -21,7 +20,7 @@
             using (var counter = new PerformanceCounter("NServiceBus", "SLA violation countdown", "PerformanceMonitoring.Endpoint.WhenSendingSlowWithSLAEnabled." + Transports.Default.Key, true))
             using (new Timer(state => CheckPerfCounter(counter), null, 0, 100))
             {
-                var contexts = await Scenario.Define<Context>()
+                await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MyMessage());

--- a/src/NServiceBus.AcceptanceTests/PerfMon/SLA/When_sending_with_SLA_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/PerfMon/SLA/When_sending_with_SLA_enabled.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Diagnostics;
     using System.Threading;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -21,7 +22,11 @@
             {
                 var context = new Context();
                 Scenario.Define(context)
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage())))
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                    {
+                        bus.SendLocal(new MyMessage());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.WasCalled)
                     .Repeat(r => r.For(Transports.Default))
                     .Should(c => Assert.True(c.WasCalled, "The message handler should be called"))

--- a/src/NServiceBus.AcceptanceTests/PerfMon/SLA/When_sending_with_SLA_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/PerfMon/SLA/When_sending_with_SLA_enabled.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Diagnostics;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
@@ -21,7 +20,7 @@
             using (var counter = new PerformanceCounter("NServiceBus", "SLA violation countdown", "PerformanceMonitoring.Endpoint.WhenSendingWithSLAEnabled." + Transports.Default.Key, true))
             using (new Timer(state => CheckPerfCounter(counter), null, 0, 100))
             {
-                var contexts = await Scenario.Define<Context>()
+                await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MyMessage());

--- a/src/NServiceBus.AcceptanceTests/PerfMon/SLA/When_sending_with_SLA_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/PerfMon/SLA/When_sending_with_SLA_enabled.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Diagnostics;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
@@ -15,13 +16,12 @@
 
         [Test]
         [Explicit("Since perf counters need to be enabled with powershell")]
-        public void Should_have_perf_counter_set()
+        public async Task Should_have_perf_counter_set()
         {
             using (var counter = new PerformanceCounter("NServiceBus", "SLA violation countdown", "PerformanceMonitoring.Endpoint.WhenSendingWithSLAEnabled." + Transports.Default.Key, true))
             using (new Timer(state => CheckPerfCounter(counter), null, 0, 100))
             {
-                var context = new Context();
-                Scenario.Define(context)
+                var contexts = await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MyMessage());

--- a/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_sending_a_non_durable_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_sending_a_non_durable_message.cs
@@ -9,19 +9,18 @@
     public class When_sending_a_non_durable_message : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_be_available_as_a_header_on_receiver()
+        public async Task Should_be_available_as_a_header_on_receiver()
         {
-            var context = new Context();
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MyMessage());
                         return Task.FromResult(0);
                     }))
-                    .Done(c=>c.WasCalled)
+                    .Done(c => c.WasCalled)
                     .Run(TimeSpan.FromSeconds(10));
-        
-            Assert.IsTrue(context.NonDurabilityHeader,"Message should be flagged as non durable");
+
+            Assert.IsTrue(context.NonDurabilityHeader, "Message should be flagged as non durable");
         }
 
         public class Context : ScenarioContext
@@ -49,7 +48,7 @@
             }
         }
 
-      
+
         [Express]
         public class MyMessage : IMessage
         {

--- a/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_sending_a_non_durable_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_sending_a_non_durable_message.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Performance.MessageDurability
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -12,7 +13,11 @@
         {
             var context = new Context();
             Scenario.Define(context)
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage())))
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                    {
+                        bus.SendLocal(new MyMessage());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c=>c.WasCalled)
                     .Run(TimeSpan.FromSeconds(10));
         

--- a/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_expired.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_expired.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Performance.TimeToBeReceived
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -12,7 +13,11 @@
         {
             var context = new Context();
             Scenario.Define(context)
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage())))
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                    {
+                        bus.SendLocal(new MyMessage());
+                        return Task.FromResult(0);
+                    }))
                     .Run(TimeSpan.FromSeconds(10));
             Assert.IsFalse(context.WasCalled);
         }

--- a/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_expired.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_expired.cs
@@ -9,16 +9,16 @@
     public class When_TimeToBeReceived_has_expired : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Message_should_not_be_received()
+        public async Task Message_should_not_be_received()
         {
-            var context = new Context();
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MyMessage());
                         return Task.FromResult(0);
                     }))
                     .Run(TimeSpan.FromSeconds(10));
+
             Assert.IsFalse(context.WasCalled);
         }
 

--- a/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_expired_convention.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_expired_convention.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Performance.TimeToBeReceived
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -12,7 +13,11 @@
         {
             var context = new Context();
             Scenario.Define(context)
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage())))
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                    {
+                        bus.SendLocal(new MyMessage());
+                        return Task.FromResult(0);
+                    }))
                     .Run(TimeSpan.FromSeconds(10));
             Assert.IsFalse(context.WasCalled);
         }

--- a/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_expired_convention.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_expired_convention.cs
@@ -9,16 +9,16 @@
     public class When_TimeToBeReceived_has_expired_convention : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Message_should_not_be_received()
+        public async Task Message_should_not_be_received()
         {
-            var context = new Context();
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MyMessage());
                         return Task.FromResult(0);
                     }))
                     .Run(TimeSpan.FromSeconds(10));
+
             Assert.IsFalse(context.WasCalled);
         }
 

--- a/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_not_expired.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_not_expired.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Performance.TimeToBeReceived
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -13,7 +14,11 @@
             var context = new Context();
 
             Scenario.Define(context)
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new MyMessage())))
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                    {
+                        bus.SendLocal(new MyMessage());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.WasCalled)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_not_expired.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_not_expired.cs
@@ -9,11 +9,9 @@
     public class When_TimeToBeReceived_has_not_expired : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Message_should_be_received()
+        public async Task Message_should_be_received()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MyMessage());
@@ -23,7 +21,7 @@
                     .Run();
 
             Assert.IsTrue(context.WasCalled);
-            Assert.AreEqual(TimeSpan.FromSeconds(10),context.TTBROnIncomingMessage, "TTBR should be available as a header so receiving endpoints can know what value was used when the message was originally sent");
+            Assert.AreEqual(TimeSpan.FromSeconds(10), context.TTBROnIncomingMessage, "TTBR should be available as a header so receiving endpoints can know what value was used when the message was originally sent");
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Performance/When_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/When_message_is_audited.cs
@@ -11,18 +11,18 @@
     {
 
         [Test]
-        public void Should_contain_processing_stats_headers()
+        public async Task Should_contain_processing_stats_headers()
         {
-            var context = new Context();
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
             .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus =>
             {
                 bus.SendLocal(new MessageToBeAudited());
                 return Task.FromResult(0);
             }))
             .WithEndpoint<EndpointThatHandlesAuditMessages>()
-            .Done(c => context.IsMessageHandledByTheAuditEndpoint)
+            .Done(c => c.IsMessageHandledByTheAuditEndpoint)
             .Run();
+
             Assert.IsTrue(context.Headers.ContainsKey(Headers.ProcessingStarted));
             Assert.IsTrue(context.Headers.ContainsKey(Headers.ProcessingEnded));
             Assert.IsTrue(context.IsMessageHandledByTheAuditEndpoint);
@@ -31,7 +31,7 @@
         public class Context : ScenarioContext
         {
             public bool IsMessageHandledByTheAuditEndpoint { get; set; }
-            public IDictionary<string,string> Headers{ get; set; }
+            public IDictionary<string, string> Headers { get; set; }
         }
 
         public class EndpointWithAuditOn : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Performance/When_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/When_message_is_audited.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -14,7 +15,11 @@
         {
             var context = new Context();
             Scenario.Define(context)
-            .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+            .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus =>
+            {
+                bus.SendLocal(new MessageToBeAudited());
+                return Task.FromResult(0);
+            }))
             .WithEndpoint<EndpointThatHandlesAuditMessages>()
             .Done(c => context.IsMessageHandledByTheAuditEndpoint)
             .Run();

--- a/src/NServiceBus.AcceptanceTests/PipelineExt/FilteringWhatGetsAudited.cs
+++ b/src/NServiceBus.AcceptanceTests/PipelineExt/FilteringWhatGetsAudited.cs
@@ -16,10 +16,9 @@ namespace NServiceBus.AcceptanceTests.PipelineExt
     public class FilteringWhatGetsAudited : NServiceBusAcceptanceTest
     {
         [Test]
-        public void RunDemo()
+        public async Task RunDemo()
         {
-            var context = new Context();
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<UserEndpoint>(b => b.Given(bus =>
                 {
                     bus.SendLocal(new MessageToBeAudited());
@@ -89,7 +88,7 @@ namespace NServiceBus.AcceptanceTests.PipelineExt
                     next();
                 }
 
-              
+
             }
 
             class AuditFilterResult

--- a/src/NServiceBus.AcceptanceTests/PipelineExt/FilteringWhatGetsAudited.cs
+++ b/src/NServiceBus.AcceptanceTests/PipelineExt/FilteringWhatGetsAudited.cs
@@ -2,6 +2,7 @@
 namespace NServiceBus.AcceptanceTests.PipelineExt
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Audit;
@@ -19,7 +20,11 @@ namespace NServiceBus.AcceptanceTests.PipelineExt
         {
             var context = new Context();
             Scenario.Define(context)
-                .WithEndpoint<UserEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+                .WithEndpoint<UserEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new MessageToBeAudited());
+                    return Task.FromResult(0);
+                }))
                 .WithEndpoint<AuditSpy>()
                 .Done(c => c.Done)
                 .Run();

--- a/src/NServiceBus.AcceptanceTests/PipelineExt/MutingHandlerExceptions.cs
+++ b/src/NServiceBus.AcceptanceTests/PipelineExt/MutingHandlerExceptions.cs
@@ -2,6 +2,7 @@
 namespace NServiceBus.AcceptanceTests.PipelineExt
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Pipeline;
@@ -17,7 +18,11 @@ namespace NServiceBus.AcceptanceTests.PipelineExt
         {
             var context = new Context();
             Scenario.Define(context)
-                .WithEndpoint<EndpointWithCustomExceptionMuting>(b => b.Given(bus => bus.SendLocal(new MessageThatWillBlowUpButExWillBeMuted())))
+                .WithEndpoint<EndpointWithCustomExceptionMuting>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new MessageThatWillBlowUpButExWillBeMuted());
+                    return Task.FromResult(0);
+                }))
                 .WithEndpoint<AuditSpy>()
                 .Done(c => c.MessageAudited)
                 .Run();

--- a/src/NServiceBus.AcceptanceTests/PipelineExt/MutingHandlerExceptions.cs
+++ b/src/NServiceBus.AcceptanceTests/PipelineExt/MutingHandlerExceptions.cs
@@ -14,10 +14,9 @@ namespace NServiceBus.AcceptanceTests.PipelineExt
     public class MutingHandlerExceptions : NServiceBusAcceptanceTest
     {
         [Test]
-        public void RunDemo()
+        public async Task RunDemo()
         {
-            var context = new Context();
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithCustomExceptionMuting>(b => b.Given(bus =>
                 {
                     bus.SendLocal(new MessageThatWillBlowUpButExWillBeMuted());

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_default_settings.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_default_settings.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Recoverability.Retries
 {
     using System;
-    using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -13,7 +12,7 @@
         [Test]
         public async Task Should_not_do_any_retries_if_transactions_are_off()
         {
-            var contexts = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
+            await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<RetryEndpoint>(b => b.Given((bus, context) =>
                     {
                         bus.SendLocal(new MessageToBeRetried { Id = context.Id });

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_default_settings.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_default_settings.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Recoverability.Retries
 {
     using System;
+    using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -10,9 +11,9 @@
     public class When_doing_flr_with_default_settings : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_not_do_any_retries_if_transactions_are_off()
+        public async Task Should_not_do_any_retries_if_transactions_are_off()
         {
-            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+            var contexts = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<RetryEndpoint>(b => b.Given((bus, context) =>
                     {
                         bus.SendLocal(new MessageToBeRetried { Id = context.Id });

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_default_settings.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_default_settings.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Recoverability.Retries
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -16,6 +17,7 @@
                     {
                         bus.SendLocal(new MessageToBeRetried { Id = context.Id });
                         bus.SendLocal(new MessageToBeRetried { Id = context.Id, SecondMessage = true });
+                        return Task.FromResult(0);
                     }))
                     .AllowExceptions()
                     .Done(c => c.SecondMessageReceived || c.NumberOfTimesInvoked > 1)

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_dtc_on.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_dtc_on.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -16,7 +17,11 @@
         public void Should_do_X_retries_by_default_with_dtc_on()
         {
             Scenario.Define(() => new Context { Id = Guid.NewGuid() })
-                    .WithEndpoint<RetryEndpoint>(b => b.Given((bus, context) => bus.SendLocal(new MessageToBeRetried{ Id = context.Id })))
+                    .WithEndpoint<RetryEndpoint>(b => b.Given((bus, context) =>
+                    {
+                        bus.SendLocal(new MessageToBeRetried{ Id = context.Id });
+                        return Task.FromResult(0);
+                    }))
                     .AllowExceptions()
                     .Done(c => c.GaveUpOnRetries)
                     .Repeat(r => r.For<AllDtcTransports>())

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -13,7 +14,11 @@
         public void Should_do_5_retries_by_default_with_native_transactions()
         {
             Scenario.Define(() => new Context { Id = Guid.NewGuid() })
-                    .WithEndpoint<RetryEndpoint>(b => b.Given((bus, context) => bus.SendLocal(new MessageToBeRetried { Id = context.Id })))
+                    .WithEndpoint<RetryEndpoint>(b => b.Given((bus, context) =>
+                    {
+                        bus.SendLocal(new MessageToBeRetried { Id = context.Id });
+                        return Task.FromResult(0);
+                    }))
                     .AllowExceptions()
                     .Done(c => c.ForwardedToErrorQueue)
                     .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
@@ -11,9 +11,9 @@
     public class When_doing_flr_with_native_transactions : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_do_5_retries_by_default_with_native_transactions()
+        public async Task Should_do_5_retries_by_default_with_native_transactions()
         {
-            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+            await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<RetryEndpoint>(b => b.Given((bus, context) =>
                     {
                         bus.SendLocal(new MessageToBeRetried { Id = context.Id });
@@ -31,7 +31,6 @@
                             .StartsWith(string.Format("Giving up First Level Retries for message '{0}'.", c.PhysicalMessageId))));
                     })
                     .Run();
-
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_flr.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_flr.cs
@@ -16,7 +16,7 @@
         [Test]
         public async Task Should_be_moved_to_slr()
         {
-            var contexts = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
+            await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<SLREndpoint>(b => b.Given((bus, context) =>
                     {
                         bus.SendLocal(new MessageToBeRetried { Id = context.Id });

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_flr.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_flr.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Recoverability.Retries
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -16,7 +17,11 @@
         public void Should_be_moved_to_slr()
         {
             Scenario.Define(() => new Context { Id = Guid.NewGuid() })
-                    .WithEndpoint<SLREndpoint>(b => b.Given((bus, context) => bus.SendLocal(new MessageToBeRetried { Id = context.Id })))
+                    .WithEndpoint<SLREndpoint>(b => b.Given((bus, context) =>
+                    {
+                        bus.SendLocal(new MessageToBeRetried { Id = context.Id });
+                        return Task.FromResult(0);
+                    }))
                     .AllowExceptions(e => e.Message.Contains("Simulated exception"))
                     .Done(c => c.NumberOfTimesInvoked >= 2)
                     .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_flr.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_flr.cs
@@ -14,9 +14,9 @@
         static TimeSpan SlrDelay = TimeSpan.FromSeconds(5);
 
         [Test]
-        public void Should_be_moved_to_slr()
+        public async Task Should_be_moved_to_slr()
         {
-            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+            var contexts = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<SLREndpoint>(b => b.Given((bus, context) =>
                     {
                         bus.SendLocal(new MessageToBeRetried { Id = context.Id });

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_with_retries_set_to_0.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_with_retries_set_to_0.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Recoverability.Retries
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Config;
@@ -9,20 +10,15 @@
     public class When_fails_with_retries_set_to_0 : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_not_retry_the_message_using_flr()
+        public async Task Should_not_retry_the_message_using_flr()
         {
-            var context = new Context
-            {
-                Id = Guid.NewGuid()
-            };
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<RetryEndpoint>()
                     .AllowExceptions()
                     .Done(c => c.GaveUp)
                     .Run();
 
-            Assert.AreEqual(1, context.NumberOfTimesInvoked,"No FLR should be in use if MaxRetries is set to 0");
+            Assert.AreEqual(1, context.NumberOfTimesInvoked, "No FLR should be in use if MaxRetries is set to 0");
         }
 
         public class Context : ScenarioContext
@@ -44,9 +40,9 @@
                     });
             }
 
-            class ErrorNotificationSpy: IWantToRunWhenBusStartsAndStops
+            class ErrorNotificationSpy : IWantToRunWhenBusStartsAndStops
             {
-                public Context  Context { get; set; }
+                public Context Context { get; set; }
 
                 public BusNotifications BusNotifications { get; set; }
                 public IBus Bus { get; set; }
@@ -63,10 +59,10 @@
                     });
                 }
 
-                public void Stop(){}
+                public void Stop() { }
             }
 
-            class MessageToBeRetriedHandler:IHandleMessages<MessageToBeRetried>
+            class MessageToBeRetriedHandler : IHandleMessages<MessageToBeRetried>
             {
                 public Context Context { get; set; }
                 public void Handle(MessageToBeRetried message)

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Features;
@@ -14,7 +15,11 @@
         {
             var context = new Context();
             Scenario.Define(() => context)
-                    .WithEndpoint<RetryEndpoint>(b => b.Given((bus, c) => bus.SendLocal(new MessageWhichFailsRetries())))
+                    .WithEndpoint<RetryEndpoint>(b => b.Given((bus, c) =>
+                    {
+                        bus.SendLocal(new MessageWhichFailsRetries());
+                        return Task.FromResult(0);
+                    }))
                     .AllowExceptions(e => e is RetryEndpoint.SimulatedException)
                     .Done(c => c.ForwardedToErrorQueue)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
@@ -11,10 +11,9 @@
     public class When_message_fails_retries : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_forward_message_to_error_queue()
+        public async Task Should_forward_message_to_error_queue()
         {
-            var context = new Context();
-            Scenario.Define(() => context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<RetryEndpoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MessageWhichFailsRetries());

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_regular_exception.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_regular_exception.cs
@@ -9,11 +9,9 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
     public class When_performing_slr_with_regular_exception : When_performing_slr
     {
         [Test]
-        public void Should_preserve_the_original_body_for_regular_exceptions()
+        public async Task Should_preserve_the_original_body_for_regular_exceptions()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<RetryEndpoint>(b => b.Given(bus =>
                 {
                     bus.SendLocal(new MessageToBeRetried());
@@ -27,11 +25,9 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
         }
 
         [Test]
-        public void Should_reschedule_message_three_times_by_default()
+        public async Task Should_reschedule_message_three_times_by_default()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<RetryEndpoint>(b => b.Given(bus =>
                 {
                     bus.SendLocal(new MessageToBeRetried());

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_regular_exception.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_regular_exception.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.AcceptanceTests.Recoverability.Retries
 {
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NUnit.Framework;
 
@@ -13,7 +14,11 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
             var context = new Context();
 
             Scenario.Define(context)
-                .WithEndpoint<RetryEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeRetried())))
+                .WithEndpoint<RetryEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new MessageToBeRetried());
+                    return Task.FromResult(0);
+                }))
                 .AllowExceptions(e => e is SimulatedException)
                 .Done(c => c.SlrChecksum != default(byte))
                 .Run();
@@ -27,7 +32,11 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
             var context = new Context();
 
             Scenario.Define(context)
-                .WithEndpoint<RetryEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeRetried())))
+                .WithEndpoint<RetryEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new MessageToBeRetried());
+                    return Task.FromResult(0);
+                }))
                 .AllowExceptions(e => e is SimulatedException)
                 .Done(c => c.ForwardedToErrorQueue)
                 .Run();

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_serialization_exception.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_serialization_exception.cs
@@ -8,14 +8,9 @@
     public class When_performing_slr_with_serialization_exception : When_performing_slr
     {
         [Test]
-        public void Should_preserve_the_original_body_for_serialization_exceptions()
+        public async Task Should_preserve_the_original_body_for_serialization_exceptions()
         {
-            var context = new Context
-            {
-                SimulateSerializationException = true
-            };
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>(c => { c.SimulateSerializationException = true; })
                 .WithEndpoint<RetryEndpoint>(b => b.Given(bus =>
                 {
                     bus.SendLocal(new MessageToBeRetried());

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_serialization_exception.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_serialization_exception.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Recoverability.Retries
 {
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NUnit.Framework;
 
@@ -15,7 +16,11 @@
             };
 
             Scenario.Define(context)
-                .WithEndpoint<RetryEndpoint>(b => b.Given(bus => bus.SendLocal(new MessageToBeRetried())))
+                .WithEndpoint<RetryEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new MessageToBeRetried());
+                    return Task.FromResult(0);
+                }))
                 .AllowExceptions(e => e is SimulatedException)
                 .Done(c => c.SlrChecksum != default(byte))
                 .Run();

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_error_is_overridden_in_code.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_error_is_overridden_in_code.cs
@@ -10,10 +10,9 @@
     public class When_error_is_overridden_in_code : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_error_to_target_queue()
+        public async Task Should_error_to_target_queue()
         {
-            var context = new Context();
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<UserEndpoint>(b => b.Given(bus =>
                 {
                     bus.SendLocal(new Message());
@@ -23,6 +22,8 @@
                 .AllowExceptions()
                 .Done(c => c.MessageReceived)
                 .Run();
+
+            Assert.True(context.MessageReceived);
         }
 
         public class UserEndpoint : EndpointConfigurationBuilder
@@ -74,7 +75,7 @@
         }
 
         [Serializable]
-        public class Message: IMessage
+        public class Message : IMessage
         {
         }
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_error_is_overridden_in_code.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_error_is_overridden_in_code.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Recoverability
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Config;
@@ -13,7 +14,11 @@
         {
             var context = new Context();
             Scenario.Define(context)
-                .WithEndpoint<UserEndpoint>(b => b.Given(bus => bus.SendLocal(new Message())))
+                .WithEndpoint<UserEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new Message());
+                    return Task.FromResult(0);
+                }))
                 .WithEndpoint<ErrorSpy>()
                 .AllowExceptions()
                 .Done(c => c.MessageReceived)

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_message_with_TimeToBeReceived_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_message_with_TimeToBeReceived_fails.cs
@@ -9,17 +9,16 @@
 
     public class When_message_with_TimeToBeReceived_fails : NServiceBusAcceptanceTest
     {
-
         [Test]
-        public void Should_not_honor_TimeToBeReceived_for_error_message()
+        public async Task Should_not_honor_TimeToBeReceived_for_error_message()
         {
-            var context = new Context();
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
             .WithEndpoint<EndpointThatThrows>(b => b.Given(Send()))
             .WithEndpoint<EndpointThatHandlesErrorMessages>()
             .AllowExceptions()
             .Done(c => c.MessageFailed && c.TTBRHasExpiredAndMessageIsStillInErrorQueue)
             .Run();
+
             Assert.IsTrue(context.MessageFailed);
             Assert.IsTrue(context.TTBRHasExpiredAndMessageIsStillInErrorQueue);
         }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_message_with_TimeToBeReceived_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_message_with_TimeToBeReceived_fails.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Recoverability
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Config;
@@ -23,9 +24,13 @@
             Assert.IsTrue(context.TTBRHasExpiredAndMessageIsStillInErrorQueue);
         }
 
-        static Action<IBus> Send()
+        static Func<IBus, Task> Send()
         {
-            return bus => bus.SendLocal(new MessageThatFails());
+            return bus =>
+            {
+                bus.SendLocal(new MessageThatFails());
+                return Task.FromResult(0);
+            };
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_audited.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Reliability.Outbox
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Configuration.AdvanceExtensibility;
@@ -16,7 +17,11 @@
             var context = new Context();
 
             Scenario.Define(context)
-                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeAudited())))
+                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new MessageToBeAudited());
+                        return Task.FromResult(0);
+                    }))
                     .WithEndpoint<AuditSpyEndpoint>()
                     .AllowExceptions(e => e is EndpointWithAuditOn.BlowUpAfterDispatchBehavior.FakeException)
                     .Done(c => c.Done)

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_audited.cs
@@ -12,11 +12,9 @@
     {
 
         [Test]
-        public void Should_audit_even_if_dispatch_blows_once()
+        public async Task Should_audit_even_if_dispatch_blows_once()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus =>
                     {
                         bus.SendLocal(new MessageToBeAudited());
@@ -26,6 +24,7 @@
                     .AllowExceptions(e => e is EndpointWithAuditOn.BlowUpAfterDispatchBehavior.FakeException)
                     .Done(c => c.Done)
                     .Run();
+
             Assert.True(context.Done);
         }
 

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_forwarded.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_forwarded.cs
@@ -13,11 +13,9 @@
     {
 
         [Test]
-        public void Should_forward_even_if_dispatch_blows_once()
+        public async Task Should_forward_even_if_dispatch_blows_once()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus =>
                     {
                         bus.SendLocal(new MessageToBeForwarded());
@@ -27,10 +25,9 @@
                     .AllowExceptions(e => e is EndpointWithAuditOn.BlowUpAfterDispatchBehavior.FakeException)
                     .Done(c => c.Done)
                     .Run();
+
             Assert.True(context.Done);
         }
-
-
 
         public class Context : ScenarioContext
         {

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_forwarded.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_forwarded.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Reliability.Outbox
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Config;
@@ -17,7 +18,11 @@
             var context = new Context();
 
             Scenario.Define(context)
-                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus => bus.SendLocal(new MessageToBeForwarded())))
+                    .WithEndpoint<EndpointWithAuditOn>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new MessageToBeForwarded());
+                        return Task.FromResult(0);
+                    }))
                     .WithEndpoint<ForwardingSpyEndpoint>()
                     .AllowExceptions(e => e is EndpointWithAuditOn.BlowUpAfterDispatchBehavior.FakeException)
                     .Done(c => c.Done)

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_blowing_up_just_after_dispatch.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_blowing_up_just_after_dispatch.cs
@@ -12,20 +12,19 @@
     public class When_blowing_up_just_after_dispatch : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_still_release_the_outgoing_messages_to_the_transport()
+        public async Task Should_still_release_the_outgoing_messages_to_the_transport()
         {
-          
-            Scenario.Define<Context>()
-                    .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus =>
-                    {
-                        bus.SendLocal(new PlaceOrder());
-                        return Task.FromResult(0);
-                    }))
-                    .AllowExceptions()
-                    .Done(c => c.OrderAckReceived == 1)
-                    .Repeat(r=>r.For<AllOutboxCapableStorages>())
-                    .Should(context => Assert.AreEqual(1, context.OrderAckReceived, "Order ack should have been received since outbox dispatch isn't part of the receive tx"))
-                    .Run(TimeSpan.FromSeconds(20));
+            await Scenario.Define<Context>()
+                .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new PlaceOrder());
+                    return Task.FromResult(0);
+                }))
+                .AllowExceptions()
+                .Done(c => c.OrderAckReceived == 1)
+                .Repeat(r=>r.For<AllOutboxCapableStorages>())
+                .Should(context => Assert.AreEqual(1, context.OrderAckReceived, "Order ack should have been received since outbox dispatch isn't part of the receive tx"))
+                .Run(TimeSpan.FromSeconds(20));
         }
 
 

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_blowing_up_just_after_dispatch.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_blowing_up_just_after_dispatch.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Reliability.Outbox
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -15,7 +16,11 @@
         {
           
             Scenario.Define<Context>()
-                    .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus => bus.SendLocal(new PlaceOrder())))
+                    .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new PlaceOrder());
+                        return Task.FromResult(0);
+                    }))
                     .AllowExceptions()
                     .Done(c => c.OrderAckReceived == 1)
                     .Repeat(r=>r.For<AllOutboxCapableStorages>())

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_clearing_saga_timeouts.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_clearing_saga_timeouts.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Configuration.AdvanceExtensibility;
@@ -19,7 +20,11 @@
             var context = new Context();
 
             Scenario.Define(context)
-                .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus => bus.SendLocal(new PlaceOrder { DataId = Guid.NewGuid() })))
+                .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new PlaceOrder { DataId = Guid.NewGuid() });
+                    return Task.FromResult(0);
+                }))
                 .AllowExceptions()
                 .Done(c => c.Done)
                 .Run();

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_clearing_saga_timeouts.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_clearing_saga_timeouts.cs
@@ -15,19 +15,17 @@
     public class When_clearing_saga_timeouts : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_record_the_request_to_clear_in_outbox()
+        public async Task Should_record_the_request_to_clear_in_outbox()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
-                .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus =>
-                {
-                    bus.SendLocal(new PlaceOrder { DataId = Guid.NewGuid() });
-                    return Task.FromResult(0);
-                }))
-                .AllowExceptions()
-                .Done(c => c.Done)
-                .Run();
+            var context = await Scenario.Define<Context>()
+            .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus =>
+            {
+                bus.SendLocal(new PlaceOrder { DataId = Guid.NewGuid() });
+                return Task.FromResult(0);
+            }))
+            .AllowExceptions()
+            .Done(c => c.Done)
+            .Run();
 
             Assert.AreEqual(1, context.NumberOfOps, "Request to clear should be in the outbox");
         }

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_dispatching_transport_operations.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_dispatching_transport_operations.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -15,7 +16,11 @@
         {
           
             Scenario.Define<Context>()
-                    .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus => bus.SendLocal(new PlaceOrder())))
+                    .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new PlaceOrder());
+                        return Task.FromResult(0);
+                    }))
                    .Done(c => c.DispatchedMessageReceived)
                     .Repeat(r=>r.For<AllOutboxCapableStorages>())
                     .Should(context =>

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_dispatching_transport_operations.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_dispatching_transport_operations.cs
@@ -12,23 +12,22 @@
     public class When_dispatching_transport_operations : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_honor_all_delivery_options()
+        public async Task Should_honor_all_delivery_options()
         {
-          
-            Scenario.Define<Context>()
-                    .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus =>
-                    {
-                        bus.SendLocal(new PlaceOrder());
-                        return Task.FromResult(0);
-                    }))
-                   .Done(c => c.DispatchedMessageReceived)
-                    .Repeat(r=>r.For<AllOutboxCapableStorages>())
-                    .Should(context =>
-                    {
-                        Assert.AreEqual(TimeSpan.FromMinutes(1), TimeSpan.Parse(context.HeadersOnDispatchedMessage[Headers.TimeToBeReceived]), "Should honor the TTBR");
-                        Assert.True(bool.Parse(context.HeadersOnDispatchedMessage[Headers.NonDurableMessage]), "Should honor the durability");
-                    })
-                    .Run(TimeSpan.FromSeconds(20));
+            await Scenario.Define<Context>()
+                .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new PlaceOrder());
+                    return Task.FromResult(0);
+                }))
+                .Done(c => c.DispatchedMessageReceived)
+                .Repeat(r=>r.For<AllOutboxCapableStorages>())
+                .Should(context =>
+                {
+                    Assert.AreEqual(TimeSpan.FromMinutes(1), TimeSpan.Parse(context.HeadersOnDispatchedMessage[Headers.TimeToBeReceived]), "Should honor the TTBR");
+                    Assert.True(bool.Parse(context.HeadersOnDispatchedMessage[Headers.NonDurableMessage]), "Should honor the durability");
+                })
+                .Run(TimeSpan.FromSeconds(20));
         }
 
 

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_receiving_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_receiving_a_message.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Reliability.Outbox
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTesting.Support;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -14,7 +15,11 @@
         public void Should_handle_it()
         {
             Scenario.Define<Context>()
-                    .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus => bus.SendLocal(new PlaceOrder())))
+                    .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new PlaceOrder());
+                        return Task.FromResult(0);
+                    }))
                     .AllowExceptions()
                     .Done(c => c.OrderAckReceived == 1)
                     .Repeat(r => r.For<AllOutboxCapableStorages>())
@@ -37,6 +42,8 @@
                         bus.Send(new PlaceOrder(), options);
                         bus.Send(new PlaceOrder(), options);
                         bus.SendLocal(new PlaceOrder());
+
+                        return Task.FromResult(0);
                     }))
                     .AllowExceptions()
                     .Done(c => c.OrderAckReceived >= 2)

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_receiving_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_receiving_a_message.cs
@@ -12,24 +12,24 @@
     public class When_receiving_a_message : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_handle_it()
+        public async Task Should_handle_it()
         {
-            Scenario.Define<Context>()
-                    .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus =>
-                    {
-                        bus.SendLocal(new PlaceOrder());
-                        return Task.FromResult(0);
-                    }))
-                    .AllowExceptions()
-                    .Done(c => c.OrderAckReceived == 1)
-                    .Repeat(r => r.For<AllOutboxCapableStorages>())
-                    .Run(new RunSettings { TestExecutionTimeout = TimeSpan.FromSeconds(20) });
+            await Scenario.Define<Context>()
+                .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new PlaceOrder());
+                    return Task.FromResult(0);
+                }))
+                .AllowExceptions()
+                .Done(c => c.OrderAckReceived == 1)
+                .Repeat(r => r.For<AllOutboxCapableStorages>())
+                .Run(new RunSettings { TestExecutionTimeout = TimeSpan.FromSeconds(20) });
         }
 
         [Test]
-        public void Should_discard_duplicates_using_the_outbox()
+        public async Task Should_discard_duplicates_using_the_outbox()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<NonDtcReceivingEndpoint>(b => b.Given(bus =>
                     {
                         var duplicateMessageId = Guid.NewGuid().ToString();

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_sending_from_a_non_dtc_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_sending_from_a_non_dtc_endpoint.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Reliability.Outbox
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -13,7 +14,11 @@
         public void Should_store_them_and_dispatch_them_from_the_outbox()
         {
             Scenario.Define<Context>()
-                    .WithEndpoint<NonDtcSalesEndpoint>(b => b.Given(bus => bus.SendLocal(new PlaceOrder())))
+                    .WithEndpoint<NonDtcSalesEndpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new PlaceOrder());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.OrderAckReceived)
                     .Repeat(r => r.For<AllOutboxCapableStorages>())
                     .Should(context => Assert.IsTrue(context.OrderAckReceived))

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_sending_from_a_non_dtc_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_sending_from_a_non_dtc_endpoint.cs
@@ -11,18 +11,18 @@
     public class When_sending_from_a_non_dtc_endpoint : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_store_them_and_dispatch_them_from_the_outbox()
+        public async Task Should_store_them_and_dispatch_them_from_the_outbox()
         {
-            Scenario.Define<Context>()
-                    .WithEndpoint<NonDtcSalesEndpoint>(b => b.Given(bus =>
-                    {
-                        bus.SendLocal(new PlaceOrder());
-                        return Task.FromResult(0);
-                    }))
-                    .Done(c => c.OrderAckReceived)
-                    .Repeat(r => r.For<AllOutboxCapableStorages>())
-                    .Should(context => Assert.IsTrue(context.OrderAckReceived))
-                    .Run(TimeSpan.FromSeconds(20));
+            await Scenario.Define<Context>()
+                .WithEndpoint<NonDtcSalesEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new PlaceOrder());
+                    return Task.FromResult(0);
+                }))
+                .Done(c => c.OrderAckReceived)
+                .Repeat(r => r.For<AllOutboxCapableStorages>())
+                .Should(context => Assert.IsTrue(context.OrderAckReceived))
+                .Run(TimeSpan.FromSeconds(20));
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_a_saga.cs
@@ -1,0 +1,108 @@
+namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Routing;
+    using NServiceBus.Saga;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_starting_an_endpoint_a_saga : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_autoSubscribe_the_saga_messageHandler_by_default()
+        {
+            var context = await Scenario.Define<Context>()
+                   .WithEndpoint<Subscriber>()
+                   .Done(c => c.EventsSubscribedTo.Count >= 2)
+                   .Run();
+
+            Assert.True(context.EventsSubscribedTo.Contains(typeof(MyEvent)), "Events only handled by sagas should be auto subscribed");
+            Assert.True(context.EventsSubscribedTo.Contains(typeof(MyEventBase)), "Sagas should be auto subscribed even when handling a base class event");
+        }
+
+        class Context : ScenarioContext
+        {
+            public Context()
+            {
+                EventsSubscribedTo = new List<Type>();
+            }
+            public List<Type> EventsSubscribedTo { get; set; }
+        }
+
+        class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>(c => c.Pipeline.Register("SubscriptionSpy", typeof(SubscriptionSpy), "Spies on subscriptions made"))
+                    .AddMapping<MyEventWithParent>(typeof(Subscriber)) //just map to our self for this test
+                    .AddMapping<MyEvent>(typeof(Subscriber)); //just map to our self for this test
+            }
+
+            public class SubscriptionSpy : Behavior<SubscribeContext>
+            {
+                Context testContext;
+
+                public SubscriptionSpy(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public override void Invoke(SubscribeContext context, Action next)
+                {
+                    next();
+
+                    testContext.EventsSubscribedTo.Add(context.EventType);
+                }
+            }
+
+            public class AutoSubscriptionSaga : Saga<AutoSubscriptionSaga.AutoSubscriptionSagaData>, IAmStartedByMessages<MyEvent>
+            {
+                public void Handle(MyEvent message)
+                {
+                }
+
+                public class AutoSubscriptionSagaData : ContainSagaData
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<AutoSubscriptionSagaData> mapper)
+                {
+                }
+            }
+
+            public class MySagaThatReactsOnASuperClassEvent : Saga<MySagaThatReactsOnASuperClassEvent.SuperClassEventSagaData>, 
+                IAmStartedByMessages<MyEventBase>
+            {
+                public void Handle(MyEventBase message)
+                {
+                }
+
+
+                public class SuperClassEventSagaData : ContainSagaData
+                {
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SuperClassEventSagaData> mapper)
+                {
+                }
+            }
+
+        }
+
+
+        public class MyEventBase : IEvent { }
+
+        public class MyEventWithParent : MyEventBase { }
+
+        public class MyMessage : IMessage { }
+
+        public class MyEvent : IEvent { }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_a_saga.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests;

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_containing_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_containing_a_saga.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -15,26 +16,24 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
     public class When_starting_an_endpoint_containing_a_saga : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_autoSubscribe_the_saga_messageHandler_by_default()
+        public async Task Should_autoSubscribe_the_saga_messageHandler_by_default()
         {
-            var context = Scenario.Define<Context>()
+            var context = await Scenario.Define<Context>()
                    .WithEndpoint<Subscriber>()
                    .Done(c => c.EventsSubscribedTo.Count >= 2)
                    .Run();
-
 
             Assert.True(context.EventsSubscribedTo.Contains(typeof(MyEvent)), "Events only handled by sagas should be auto subscribed");
             Assert.True(context.EventsSubscribedTo.Contains(typeof(MyEventBase)), "Sagas should be auto subscribed even when handling a base class event");
         }
 
         [Test]
-        public void Should_not_autoSubscribe_messages_handled_by_sagas_if_asked_to()
+        public async Task Should_not_autoSubscribe_messages_handled_by_sagas_if_asked_to()
         {
-            var context = Scenario.Define<Context>()
+            var context = await Scenario.Define<Context>()
                    .WithEndpoint<Subscriber>(g => g.CustomConfig(c => c.AutoSubscribe().DoNotAutoSubscribeSagas()))
                    .Done(c => c.EndpointsStarted)
                    .Run();
-
 
             Assert.False(context.EventsSubscribedTo.Any(), "Events only handled by sagas should not be auto subscribed");
         }

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_starting_an_endpoint_a_saga : NServiceBusAcceptanceTest
+    public class When_starting_an_endpoint_with_a_saga : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_autoSubscribe_the_saga_messageHandler_by_default()

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs
@@ -5,7 +5,6 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
@@ -13,27 +12,15 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_starting_an_endpoint_containing_a_saga : NServiceBusAcceptanceTest
+    public class When_starting_an_endpoint_with_a_saga_autosubscribe_disabled : NServiceBusAcceptanceTest
     {
-        [Test]
-        public async Task Should_autoSubscribe_the_saga_messageHandler_by_default()
-        {
-            var context = await Scenario.Define<Context>()
-                   .WithEndpoint<Subscriber>()
-                   .Done(c => c.EventsSubscribedTo.Count >= 2)
-                   .Run();
-
-            Assert.True(context.EventsSubscribedTo.Contains(typeof(MyEvent)), "Events only handled by sagas should be auto subscribed");
-            Assert.True(context.EventsSubscribedTo.Contains(typeof(MyEventBase)), "Sagas should be auto subscribed even when handling a base class event");
-        }
-
         [Test]
         public async Task Should_not_autoSubscribe_messages_handled_by_sagas_if_asked_to()
         {
             var context = await Scenario.Define<Context>()
-                   .WithEndpoint<Subscriber>(g => g.CustomConfig(c => c.AutoSubscribe().DoNotAutoSubscribeSagas()))
-                   .Done(c => c.EndpointsStarted)
-                   .Run();
+                .WithEndpoint<Subscriber>(g => g.CustomConfig(c => c.AutoSubscribe().DoNotAutoSubscribeSagas()))
+                .Done(c => c.EndpointsStarted)
+                .Run();
 
             Assert.False(context.EventsSubscribedTo.Any(), "Events only handled by sagas should not be auto subscribed");
         }
@@ -88,7 +75,7 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
                 }
             }
 
-            public class MySagaThatReactsOnASuperClassEvent : Saga<MySagaThatReactsOnASuperClassEvent.SuperClassEventSagaData>, 
+            public class MySagaThatReactsOnASuperClassEvent : Saga<MySagaThatReactsOnASuperClassEvent.SuperClassEventSagaData>,
                 IAmStartedByMessages<MyEventBase>
             {
                 public void Handle(MyEventBase message)

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs
@@ -60,22 +60,22 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
                 }
             }
 
-            public class AutoSubscriptionSaga : Saga<AutoSubscriptionSaga.AutoSubscriptionSagaData>, IAmStartedByMessages<MyEvent>
+            public class NotAutoSubscribedSaga : Saga<NotAutoSubscribedSaga.NotAutoSubscribedSagaSagaData>, IAmStartedByMessages<MyEvent>
             {
                 public void Handle(MyEvent message)
                 {
                 }
 
-                public class AutoSubscriptionSagaData : ContainSagaData
+                public class NotAutoSubscribedSagaSagaData : ContainSagaData
                 {
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<AutoSubscriptionSagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<NotAutoSubscribedSagaSagaData> mapper)
                 {
                 }
             }
 
-            public class MySagaThatReactsOnASuperClassEvent : Saga<MySagaThatReactsOnASuperClassEvent.SuperClassEventSagaData>,
+            public class NotAutosubsubscribedSagaThatReactsOnASuperClassEvent : Saga<NotAutosubsubscribedSagaThatReactsOnASuperClassEvent.NotAutosubscribeSuperClassEventSagaData>,
                 IAmStartedByMessages<MyEventBase>
             {
                 public void Handle(MyEventBase message)
@@ -83,11 +83,11 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
                 }
 
 
-                public class SuperClassEventSagaData : ContainSagaData
+                public class NotAutosubscribeSuperClassEventSagaData : ContainSagaData
                 {
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SuperClassEventSagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<NotAutosubscribeSuperClassEventSagaData> mapper)
                 {
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_autoSubscribe.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_autoSubscribe.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Pipeline;
@@ -12,13 +13,12 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
     public class When_starting_an_endpoint_with_autosubscribe : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_autosubscribe_to_relevant_messagetypes()
+        public async Task Should_autosubscribe_to_relevant_messagetypes()
         {
-            var context = Scenario.Define<Context>()
+            var context = await Scenario.Define<Context>()
                .WithEndpoint<Subscriber>()
                .Done(c => c.EventsSubscribedTo.Count >= 1)
                .Run();
-
 
             Assert.True(context.EventsSubscribedTo.Contains(typeof(MyEvent)), "Events should be auto subscribed");
             Assert.False(context.EventsSubscribedTo.Contains(typeof(MyEventWithNoRouting)), "Events without routing should not be auto subscribed");
@@ -28,13 +28,12 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
         }
 
         [Test]
-        public void Should_autosubscribe_plain_messages_if_asked_to()
+        public async Task Should_autosubscribe_plain_messages_if_asked_to()
         {
-            var context = Scenario.Define<Context>()
+            var context = await Scenario.Define<Context>()
                .WithEndpoint<Subscriber>(b => b.CustomConfig(c => c.AutoSubscribe().AutoSubscribePlainMessages()))
                .Done(c => c.EventsSubscribedTo.Count >= 2)
                .Run();
-
 
             Assert.True(context.EventsSubscribedTo.Contains(typeof(MyEvent)), "Events should be auto subscribed");
             Assert.False(context.EventsSubscribedTo.Contains(typeof(MyEventWithNoRouting)), "Events without routing should not be auto subscribed");

--- a/src/NServiceBus.AcceptanceTests/Routing/When_base_event_from_2_publishers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_base_event_from_2_publishers.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Routing
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -14,10 +15,18 @@
 
             Scenario.Define(cc)
                .WithEndpoint<Publisher1>(b =>
-                        b.When(c => c.SubscribedToPublisher1, bus => bus.Publish(new DerivedEvent1()))
+                        b.When(c => c.SubscribedToPublisher1, bus =>
+                        {
+                            bus.Publish(new DerivedEvent1());
+                            return Task.FromResult(0);
+                        })
                      )
                 .WithEndpoint<Publisher2>(b =>
-                        b.When(c => c.SubscribedToPublisher2, bus => bus.Publish(new DerivedEvent2()))
+                        b.When(c => c.SubscribedToPublisher2, bus =>
+                        {
+                            bus.Publish(new DerivedEvent2());
+                            return Task.FromResult(0);
+                        })
                      )
                .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
                {
@@ -29,6 +38,7 @@
                        context.SubscribedToPublisher1 = true;
                        context.SubscribedToPublisher2 = true;
                    }
+                   return Task.FromResult(0);
                }))
                .AllowExceptions(e => e.Message.Contains("Oracle.DataAccess.Client.OracleException: ORA-00001") || e.Message.Contains("System.Data.SqlClient.SqlException: Violation of PRIMARY KEY constraint"))
                .Done(c => c.GotTheEventFromPublisher1 && c.GotTheEventFromPublisher2)

--- a/src/NServiceBus.AcceptanceTests/Routing/When_base_event_from_2_publishers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_base_event_from_2_publishers.cs
@@ -9,11 +9,9 @@
     public class When_base_event_from_2_publishers : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_receive_events_from_all_publishers()
+        public async Task Should_receive_events_from_all_publishers()
         {
-            var cc = new Context();
-
-            Scenario.Define(cc)
+            var context = await Scenario.Define<Context>()
                .WithEndpoint<Publisher1>(b =>
                         b.When(c => c.SubscribedToPublisher1, bus =>
                         {
@@ -28,15 +26,15 @@
                             return Task.FromResult(0);
                         })
                      )
-               .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+               .WithEndpoint<Subscriber1>(b => b.Given((bus, c) =>
                {
                    bus.Subscribe<DerivedEvent1>();
                    bus.Subscribe<DerivedEvent2>();
 
-                   if (context.HasNativePubSubSupport)
+                   if (c.HasNativePubSubSupport)
                    {
-                       context.SubscribedToPublisher1 = true;
-                       context.SubscribedToPublisher2 = true;
+                       c.SubscribedToPublisher1 = true;
+                       c.SubscribedToPublisher2 = true;
                    }
                    return Task.FromResult(0);
                }))
@@ -44,8 +42,8 @@
                .Done(c => c.GotTheEventFromPublisher1 && c.GotTheEventFromPublisher2)
                .Run();
 
-            Assert.True(cc.GotTheEventFromPublisher1);
-            Assert.True(cc.GotTheEventFromPublisher2);
+            Assert.True(context.GotTheEventFromPublisher1);
+            Assert.True(context.GotTheEventFromPublisher2);
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/When_multi_subscribing_to_a_polymorphic_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_multi_subscribing_to_a_polymorphic_event.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Routing
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Features;
@@ -18,11 +19,13 @@
                 {
                     c.AddTrace("Publishing MyEvent1");
                     bus.Publish(new MyEvent1());
+                    return Task.FromResult(0);
                 }))
                 .WithEndpoint<Publisher2>(b => b.When(c => c.Publisher2HasDetectedASubscriberForEvent2, (bus, c) =>
                 {
                     c.AddTrace("Publishing MyEvent2");
                     bus.Publish(new MyEvent2());
+                    return Task.FromResult(0);
                 }))
                 .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
                 {
@@ -35,6 +38,7 @@
                         context.Publisher1HasASubscriberForIMyEvent = true;
                         context.Publisher2HasDetectedASubscriberForEvent2 = true;
                     }
+                    return Task.FromResult(0);
                 }))
                 .AllowExceptions(e => e.Message.Contains("Oracle.DataAccess.Client.OracleException: ORA-00001") || e.Message.Contains("System.Data.SqlClient.SqlException: Violation of PRIMARY KEY constraint"))
                 .Done(c => c.SubscriberGotIMyEvent && c.SubscriberGotMyEvent2)

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Routing
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -14,7 +15,11 @@
         {
             Scenario.Define<Context>()
                     .WithEndpoint<Publisher3>(b =>
-                        b.When(c => c.Subscriber3Subscribed, bus => bus.Publish<IFoo>())
+                        b.When(c => c.Subscriber3Subscribed, bus =>
+                        {
+                            bus.Publish<IFoo>();
+                            return Task.FromResult(0);
+                        })
                      )
                     .WithEndpoint<Subscriber3>(b => b.Given((bus, context) =>
                     {
@@ -24,6 +29,7 @@
                         {
                             context.Subscriber3Subscribed = true;
                         }
+                        return Task.FromResult(0);
                     }))
 
                     .Done(c => c.Subscriber3GotTheEvent)
@@ -45,6 +51,7 @@
 
                             options.SetHeader("MyHeader","SomeValue");
                             bus.Publish(new MyEvent(), options);
+                            return Task.FromResult(0);
                         })
                      )
                     .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
@@ -59,6 +66,7 @@
                             {
                                 context.AddTrace("Subscriber1 has now asked to be subscribed to MyEvent");
                             }
+                            return Task.FromResult(0);
                         }))
                       .WithEndpoint<Subscriber2>(b => b.Given((bus, context) =>
                       {
@@ -73,6 +81,7 @@
                           {
                               context.AddTrace("Subscriber2 has now asked to be subscribed to MyEvent");
                           }
+                          return Task.FromResult(0);
                       }))
                     .Done(c => c.Subscriber1GotTheEvent && c.Subscriber2GotTheEvent)
                     .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing.cs
@@ -11,37 +11,37 @@
     public class When_publishing : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Issue_1851()
+        public async Task Issue_1851()
         {
-            Scenario.Define<Context>()
-                    .WithEndpoint<Publisher3>(b =>
-                        b.When(c => c.Subscriber3Subscribed, bus =>
-                        {
-                            bus.Publish<IFoo>();
-                            return Task.FromResult(0);
-                        })
-                     )
-                    .WithEndpoint<Subscriber3>(b => b.Given((bus, context) =>
+            await Scenario.Define<Context>()
+                .WithEndpoint<Publisher3>(b =>
+                    b.When(c => c.Subscriber3Subscribed, bus =>
                     {
-                        bus.Subscribe<IFoo>();
-
-                        if (context.HasNativePubSubSupport)
-                        {
-                            context.Subscriber3Subscribed = true;
-                        }
+                        bus.Publish<IFoo>();
                         return Task.FromResult(0);
-                    }))
+                    })
+                    )
+                .WithEndpoint<Subscriber3>(b => b.Given((bus, context) =>
+                {
+                    bus.Subscribe<IFoo>();
 
-                    .Done(c => c.Subscriber3GotTheEvent)
-                    .Repeat(r => r.For(Transports.Default))
-                    .Should(c => Assert.True(c.Subscriber3GotTheEvent))
-                    .Run();
+                    if (context.HasNativePubSubSupport)
+                    {
+                        context.Subscriber3Subscribed = true;
+                    }
+                    return Task.FromResult(0);
+                }))
+
+                .Done(c => c.Subscriber3GotTheEvent)
+                .Repeat(r => r.For(Transports.Default))
+                .Should(c => Assert.True(c.Subscriber3GotTheEvent))
+                .Run();
         }
 
         [Test]
-        public void Should_be_delivered_to_all_subscribers()
+        public async Task Should_be_delivered_to_all_subscribers()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<Publisher>(b =>
                         b.When(c => c.Subscriber1Subscribed && c.Subscriber2Subscribed, (bus, c) =>
                         {
@@ -90,7 +90,6 @@
                         Assert.True(c.Subscriber1GotTheEvent);
                         Assert.True(c.Subscriber2GotTheEvent);
                     })
-
                     .Run(TimeSpan.FromSeconds(10));
         }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
@@ -11,9 +11,9 @@
     public class When_publishing_an_event_implementing_two_unrelated_interfaces : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Event_should_be_published_using_instance_type()
+        public async Task Event_should_be_published_using_instance_type()
         {
-            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+            await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<Publisher>(b =>
                         b.When(c => c.EventASubscribed && c.EventBSubscribed, (bus, ctx) =>
                         {

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Routing
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -21,6 +22,7 @@
                                 ContextId = ctx.Id
                             };
                             bus.Publish(message);
+                            return Task.FromResult(0);
                         }))
                     .WithEndpoint<Subscriber>(b => b.Given((bus, context) =>
                     {
@@ -32,6 +34,7 @@
                             context.EventASubscribed = true;
                             context.EventBSubscribed = true;
                         }
+                        return Task.FromResult(0);
                     }))
                     .Done(c => c.GotEventA && c.GotEventB)
                     .Repeat(r => r.For(Serializers.Xml))

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_from_sendonly.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_from_sendonly.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -19,7 +20,11 @@
             var context = new Context();
 
             Scenario.Define(context)
-                .WithEndpoint<SendOnlyPublisher>(b => b.Given((bus, c) => bus.Publish(new MyEvent())))
+                .WithEndpoint<SendOnlyPublisher>(b => b.Given((bus, c) =>
+                {
+                    bus.Publish(new MyEvent());
+                    return Task.FromResult(0);
+                }))
                 .WithEndpoint<Subscriber>()
                 .Done(c => c.SubscriberGotTheEvent)
                 .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_from_sendonly.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_from_sendonly.cs
@@ -15,11 +15,9 @@
     public class When_publishing_from_sendonly : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_be_delivered_to_all_subscribers()
+        public async Task Should_be_delivered_to_all_subscribers()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            await Scenario.Define<Context>()
                 .WithEndpoint<SendOnlyPublisher>(b => b.Given((bus, c) =>
                 {
                     bus.Publish(new MyEvent());

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_on_brokers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_on_brokers.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Routing
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -13,14 +14,20 @@
         {
             Scenario.Define<Context>()
                     .WithEndpoint<CentralizedPublisher>
-                    (b => b.When(c => c.IsSubscriptionProcessedForSub1 && c.IsSubscriptionProcessedForSub2, bus => bus.Publish(new MyEvent())))
+                    (b => b.When(c => c.IsSubscriptionProcessedForSub1 && c.IsSubscriptionProcessedForSub2, bus =>
+                    {
+                        bus.Publish(new MyEvent());
+                        return Task.FromResult(0);
+                    }))
                     .WithEndpoint<CentralizedSubscriber1>(b => b.Given((bus, context) =>
                     {
                       context.IsSubscriptionProcessedForSub1 = true;
+                        return Task.FromResult(0);
                     }))
                     .WithEndpoint<CentralizedSubscriber2>(b => b.Given((bus, context) =>
                     {
                         context.IsSubscriptionProcessedForSub2 = true;
+                        return Task.FromResult(0);
                     }))
                     .Done(c => c.Subscriber1GotTheEvent && c.Subscriber2GotTheEvent)
                     .Repeat(r => r.For<AllTransportsWithCentralizedPubSubSupport>())

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_on_brokers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_on_brokers.cs
@@ -10,34 +10,33 @@
     public class When_publishing_on_brokers : NServiceBusAcceptanceTest
     {
         [Test, Ignore] // Ignore because, test this test is unreliable. Passed on the build server without the core fix!
-        public void Should_be_delivered_to_allsubscribers_without_the_need_for_config()
+        public async Task Should_be_delivered_to_allsubscribers_without_the_need_for_config()
         {
-            Scenario.Define<Context>()
-                    .WithEndpoint<CentralizedPublisher>
-                    (b => b.When(c => c.IsSubscriptionProcessedForSub1 && c.IsSubscriptionProcessedForSub2, bus =>
-                    {
-                        bus.Publish(new MyEvent());
-                        return Task.FromResult(0);
-                    }))
-                    .WithEndpoint<CentralizedSubscriber1>(b => b.Given((bus, context) =>
-                    {
-                      context.IsSubscriptionProcessedForSub1 = true;
-                        return Task.FromResult(0);
-                    }))
-                    .WithEndpoint<CentralizedSubscriber2>(b => b.Given((bus, context) =>
-                    {
-                        context.IsSubscriptionProcessedForSub2 = true;
-                        return Task.FromResult(0);
-                    }))
-                    .Done(c => c.Subscriber1GotTheEvent && c.Subscriber2GotTheEvent)
-                    .Repeat(r => r.For<AllTransportsWithCentralizedPubSubSupport>())
-                    .Should(c =>
-                    {
-                        Assert.True(c.Subscriber1GotTheEvent);
-                        Assert.True(c.Subscriber2GotTheEvent);
-                    })
-
-                    .Run();
+            await Scenario.Define<Context>()
+                .WithEndpoint<CentralizedPublisher>
+                (b => b.When(c => c.IsSubscriptionProcessedForSub1 && c.IsSubscriptionProcessedForSub2, bus =>
+                {
+                    bus.Publish(new MyEvent());
+                    return Task.FromResult(0);
+                }))
+                .WithEndpoint<CentralizedSubscriber1>(b => b.Given((bus, context) =>
+                {
+                    context.IsSubscriptionProcessedForSub1 = true;
+                    return Task.FromResult(0);
+                }))
+                .WithEndpoint<CentralizedSubscriber2>(b => b.Given((bus, context) =>
+                {
+                    context.IsSubscriptionProcessedForSub2 = true;
+                    return Task.FromResult(0);
+                }))
+                .Done(c => c.Subscriber1GotTheEvent && c.Subscriber2GotTheEvent)
+                .Repeat(r => r.For<AllTransportsWithCentralizedPubSubSupport>())
+                .Should(c =>
+                {
+                    Assert.True(c.Subscriber1GotTheEvent);
+                    Assert.True(c.Subscriber2GotTheEvent);
+                })
+                .Run();
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_using_root_type.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_using_root_type.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Routing
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -19,6 +20,7 @@
                             IMyEvent message = new EventMessage();
 
                             bus.Publish(message);
+                            return Task.FromResult(0);
                         }))
                     .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
                     {
@@ -28,6 +30,7 @@
                         {
                             context.Subscriber1Subscribed = true;
                         }
+                        return Task.FromResult(0);
                     }))
                     .Done(c => c.Subscriber1GotTheEvent)
                     .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_using_root_type.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_using_root_type.cs
@@ -11,9 +11,9 @@
     public class When_publishing_using_root_type : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Event_should_be_published_using_instance_type()
+        public async Task Event_should_be_published_using_instance_type()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<Publisher>(b =>
                         b.When(c => c.Subscriber1Subscribed, bus =>
                         {

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_with_only_local_messagehandlers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_with_only_local_messagehandlers.cs
@@ -10,9 +10,9 @@
     public class When_publishing_with_only_local_messagehandlers : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_trigger_the_catch_all_handler_for_message_driven_subscriptions()
+        public async Task Should_trigger_the_catch_all_handler_for_message_driven_subscriptions()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                 .WithEndpoint<MessageDrivenPublisher>(b =>
                     b.When(c => c.LocalEndpointSubscribed, bus =>
                     {
@@ -26,26 +26,26 @@
         }
 
         [Test]
-        public void Should_trigger_the_catch_all_handler_for_publishers_with_centralized_pubsub()
+        public async Task Should_trigger_the_catch_all_handler_for_publishers_with_centralized_pubsub()
         {
-            Scenario.Define<Context>()
-                       .WithEndpoint<CentralizedStoragePublisher>(b =>
-                       {
-                           b.Given(bus =>
-                           {
-                               bus.Subscribe<EventHandledByLocalEndpoint>();
-                               return Task.FromResult(0);
-                           });
-                           b.When(c => c.EndpointsStarted, (bus, context) =>
-                           {
-                               bus.Publish(new EventHandledByLocalEndpoint());
-                               return Task.FromResult(0);
-                           });
-                       })
-                       .Done(c => c.CatchAllHandlerGotTheMessage)
-                       .Repeat(r => r.For<AllTransportsWithCentralizedPubSubSupport>())
-                       .Should(c => Assert.True(c.CatchAllHandlerGotTheMessage))
-                       .Run();
+            await Scenario.Define<Context>()
+                .WithEndpoint<CentralizedStoragePublisher>(b =>
+                {
+                    b.Given(bus =>
+                    {
+                        bus.Subscribe<EventHandledByLocalEndpoint>();
+                        return Task.FromResult(0);
+                    });
+                    b.When(c => c.EndpointsStarted, (bus, context) =>
+                    {
+                        bus.Publish(new EventHandledByLocalEndpoint());
+                        return Task.FromResult(0);
+                    });
+                })
+                .Done(c => c.CatchAllHandlerGotTheMessage)
+                .Repeat(r => r.For<AllTransportsWithCentralizedPubSubSupport>())
+                .Should(c => Assert.True(c.CatchAllHandlerGotTheMessage))
+                .Run();
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_with_overridden_local_address.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_with_overridden_local_address.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Routing
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -14,7 +15,11 @@
         {
             Scenario.Define<Context>()
                     .WithEndpoint<Publisher>(b =>
-                        b.When(c => c.Subscriber1Subscribed, bus => bus.Publish(new MyEvent()))
+                        b.When(c => c.Subscriber1Subscribed, bus =>
+                        {
+                            bus.Publish(new MyEvent());
+                            return Task.FromResult(0);
+                        })
                      )
                     .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
                         {
@@ -22,6 +27,7 @@
 
                             if (context.HasNativePubSubSupport)
                                 context.Subscriber1Subscribed = true;
+                            return Task.FromResult(0);
                         }))
                     .Done(c => c.Subscriber1GotTheEvent)
                     .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_with_overridden_local_address.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_with_overridden_local_address.cs
@@ -11,29 +11,28 @@
     public class When_publishing_with_overridden_local_address : NServiceBusAcceptanceTest
     {
         [Test, Explicit("This test fails against RabbitMQ")]
-        public void Should_be_delivered_to_all_subscribers()
+        public async Task Should_be_delivered_to_all_subscribers()
         {
-            Scenario.Define<Context>()
-                    .WithEndpoint<Publisher>(b =>
-                        b.When(c => c.Subscriber1Subscribed, bus =>
-                        {
-                            bus.Publish(new MyEvent());
-                            return Task.FromResult(0);
-                        })
-                     )
-                    .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
-                        {
-                            bus.Subscribe<MyEvent>();
+            await Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(b =>
+                    b.When(c => c.Subscriber1Subscribed, bus =>
+                    {
+                        bus.Publish(new MyEvent());
+                        return Task.FromResult(0);
+                    })
+                    )
+                .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+                    {
+                        bus.Subscribe<MyEvent>();
 
-                            if (context.HasNativePubSubSupport)
-                                context.Subscriber1Subscribed = true;
-                            return Task.FromResult(0);
-                        }))
-                    .Done(c => c.Subscriber1GotTheEvent)
-                    .Repeat(r => r.For(Transports.Default))
-                    .Should(c => Assert.True(c.Subscriber1GotTheEvent))
-
-                    .Run();
+                        if (context.HasNativePubSubSupport)
+                            context.Subscriber1Subscribed = true;
+                        return Task.FromResult(0);
+                    }))
+                .Done(c => c.Subscriber1GotTheEvent)
+                .Repeat(r => r.For(Transports.Default))
+                .Should(c => Assert.True(c.Subscriber1GotTheEvent))
+                .Run();
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/When_subscribing_to_a_polymorphic_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_subscribing_to_a_polymorphic_event.cs
@@ -10,37 +10,35 @@
     public class When_subscribing_to_a_polymorphic_event : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Event_should_be_delivered()
+        public async Task Event_should_be_delivered()
         {
-            var cc = new Context();
-
-            Scenario.Define(cc)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Publisher>(b => b.When(c => c.Subscriber1Subscribed && c.Subscriber2Subscribed, bus =>
                     {
                         bus.Publish(new MyEvent());
                         return Task.FromResult(0);
                     }))
-                    .WithEndpoint<Subscriber1>(b => b.Given((bus, context) =>
+                    .WithEndpoint<Subscriber1>(b => b.Given((bus, c) =>
                         {
                             bus.Subscribe<IMyEvent>();
 
-                            if (context.HasNativePubSubSupport)
-                                context.Subscriber1Subscribed = true;
+                            if (c.HasNativePubSubSupport)
+                                c.Subscriber1Subscribed = true;
                             return Task.FromResult(0);
                         }))
-                    .WithEndpoint<Subscriber2>(b => b.Given((bus, context) =>
+                    .WithEndpoint<Subscriber2>(b => b.Given((bus, c) =>
                         {
                             bus.Subscribe<MyEvent>();
 
-                            if (context.HasNativePubSubSupport)
-                                context.Subscriber2Subscribed = true;
+                            if (c.HasNativePubSubSupport)
+                                c.Subscriber2Subscribed = true;
                             return Task.FromResult(0);
                         }))
                     .Done(c => c.Subscriber1GotTheEvent && c.Subscriber2GotTheEvent)
                     .Run();
 
-            Assert.True(cc.Subscriber1GotTheEvent);
-            Assert.True(cc.Subscriber2GotTheEvent);
+            Assert.True(context.Subscriber1GotTheEvent);
+            Assert.True(context.Subscriber2GotTheEvent);
         }
 
         public class Context : ScenarioContext
@@ -66,7 +64,7 @@
                     {
                         context.Subscriber1Subscribed = true;
                     }
-                    
+
                     if (args.SubscriberReturnAddress.Contains("Subscriber2"))
                     {
                         context.Subscriber2Subscribed = true;
@@ -112,7 +110,7 @@
                 }
             }
         }
-        
+
         [Serializable]
         public class MyEvent : IMyEvent
         {

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_base_class_message_hits_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_base_class_message_hits_a_saga.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Saga;
@@ -10,10 +11,10 @@
     public class When_a_base_class_message_hits_a_saga
     {
         [Test]
-        public void Should_find_existing_instance()
+        public async Task Should_find_existing_instance()
         {
             var correlationId = Guid.NewGuid();
-            var context = Scenario.Define<Context>()
+            var context = await Scenario.Define<Context>()
                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
                    {
                        bus.SendLocal(new StartSagaMessage
@@ -24,6 +25,7 @@
                        {
                            SomeId = correlationId
                        });
+                       return Task.FromResult(0);
                    }))
                    .Done(c => c.SecondMessageFoundExistingSaga)
                    .Run(TimeSpan.FromSeconds(20));

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_existing_saga_instance_exists.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_existing_saga_instance_exists.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NUnit.Framework;
@@ -18,7 +19,8 @@
                     .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
                         {
                             bus.SendLocal(new StartSagaMessage { SomeId = IdThatSagaIsCorrelatedOn });
-                            bus.SendLocal(new StartSagaMessage { SomeId = IdThatSagaIsCorrelatedOn, SecondMessage = true });                                    
+                            bus.SendLocal(new StartSagaMessage { SomeId = IdThatSagaIsCorrelatedOn, SecondMessage = true });
+                            return Task.FromResult(0);
                         }))
                     .Done(c => c.SecondMessageReceived)
                     .Repeat(r => r.For(Persistence.Default))

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_existing_saga_instance_exists.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_existing_saga_instance_exists.cs
@@ -13,20 +13,19 @@
         static Guid IdThatSagaIsCorrelatedOn = Guid.NewGuid();
 
         [Test]
-        public void Should_hydrate_and_invoke_the_existing_instance()
+        public async Task Should_hydrate_and_invoke_the_existing_instance()
         {
-            Scenario.Define<Context>()
-                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
-                        {
-                            bus.SendLocal(new StartSagaMessage { SomeId = IdThatSagaIsCorrelatedOn });
-                            bus.SendLocal(new StartSagaMessage { SomeId = IdThatSagaIsCorrelatedOn, SecondMessage = true });
-                            return Task.FromResult(0);
-                        }))
-                    .Done(c => c.SecondMessageReceived)
-                    .Repeat(r => r.For(Persistence.Default))
-                    .Should(c => Assert.AreEqual(c.FirstSagaInstance, c.SecondSagaInstance, "The same saga instance should be invoked invoked for both messages"))
-
-                    .Run();
+            await Scenario.Define<Context>()
+                .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new StartSagaMessage { SomeId = IdThatSagaIsCorrelatedOn });
+                        bus.SendLocal(new StartSagaMessage { SomeId = IdThatSagaIsCorrelatedOn, SecondMessage = true });
+                        return Task.FromResult(0);
+                    }))
+                .Done(c => c.SecondMessageReceived)
+                .Repeat(r => r.For(Persistence.Default))
+                .Should(c => Assert.AreEqual(c.FirstSagaInstance, c.SecondSagaInstance, "The same saga instance should be invoked invoked for both messages"))
+                .Run();
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Saga;
@@ -9,10 +10,14 @@
     public class When_a_finder_exists
     {
         [Test]
-        public void Should_use_it_to_find_saga()
+        public async Task Should_use_it_to_find_saga()
         {
-            var context = Scenario.Define<Context>()
-                   .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage())))
+            var context = await Scenario.Define<Context>()
+                   .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                   {
+                       bus.SendLocal(new StartSagaMessage());
+                       return Task.FromResult(0);
+                   }))
                    .Done(c => c.FinderUsed)
                    .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_context_information_added.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_context_information_added.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Extensibility;
@@ -12,10 +13,14 @@ namespace NServiceBus.AcceptanceTests.Sagas
     public class When_a_finder_exists_and_context_information_added
     {
         [Test]
-        public void Should_make_context_information_available()
+        public async Task Should_make_context_information_available()
         {
-            var context = Scenario.Define<Context>()
-                .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage())))
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new StartSagaMessage());
+                    return Task.FromResult(0);
+                }))
                 .Done(c => c.FinderUsed)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_found_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_found_saga.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Saga;
@@ -9,10 +10,14 @@
     public class When_a_finder_exists_and_found_saga
     {
         [Test]
-        public void Should_find_saga_and_not_correlate()
+        public async Task Should_find_saga_and_not_correlate()
         {
-            var context = Scenario.Define<Context>()
-                .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage())))
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new StartSagaMessage());
+                    return Task.FromResult(0);
+                }))
                 .Done(c => c.Completed)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
@@ -12,9 +12,9 @@
     public class When_a_saga_message_goes_through_the_slr : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_invoke_the_correct_handle_methods_on_the_saga()
+        public async Task Should_invoke_the_correct_handle_methods_on_the_saga()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
                     {
                         bus.SendLocal(new StartSagaMessage { SomeId = Guid.NewGuid() });

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NUnit.Framework;
@@ -14,7 +15,11 @@
         public void Should_invoke_the_correct_handle_methods_on_the_saga()
         {
             Scenario.Define<Context>()
-                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage { SomeId = Guid.NewGuid() })))
+                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new StartSagaMessage { SomeId = Guid.NewGuid() });
+                        return Task.FromResult(0);
+                    }))
                     .AllowExceptions()
                     .Done(c => c.SecondMessageProcessed)
                     .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_an_endpoint_replies_to_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_an_endpoint_replies_to_a_saga.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NUnit.Framework;
@@ -19,7 +20,11 @@
             };
 
             Scenario.Define(context)
-                    .WithEndpoint<EndpointThatHostsASaga>(b => b.Given((bus, ctx) => bus.SendLocal(new StartSaga { RunId = ctx.RunId })))
+                    .WithEndpoint<EndpointThatHostsASaga>(b => b.Given((bus, ctx) =>
+                    {
+                        bus.SendLocal(new StartSaga { RunId = ctx.RunId });
+                        return Task.FromResult(0);
+                    }))
                     .WithEndpoint<EndpointThatRepliesToSagaMessage>()
                     .Done(c => c.Done)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_an_endpoint_replies_to_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_an_endpoint_replies_to_a_saga.cs
@@ -12,14 +12,9 @@
     public class When_an_endpoint_replies_to_a_saga : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_correlate_all_saga_messages_properly()
+        public async Task Should_correlate_all_saga_messages_properly()
         {
-            var context = new Context
-            {
-                RunId = Guid.NewGuid()
-            };
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>(c => { c.RunId = Guid.NewGuid(); })
                     .WithEndpoint<EndpointThatHostsASaga>(b => b.Given((bus, ctx) =>
                     {
                         bus.SendLocal(new StartSaga { RunId = ctx.RunId });
@@ -62,7 +57,7 @@
             public EndpointThatHostsASaga()
             {
                 EndpointSetup<DefaultServer>()
-                    .AddMapping<DoSomething>(typeof (EndpointThatRepliesToSagaMessage));
+                    .AddMapping<DoSomething>(typeof(EndpointThatRepliesToSagaMessage));
 
             }
 
@@ -97,7 +92,7 @@
                     Context.DidSagaReplyMessageGetCorrelated = message.RunId == Data.RunId;
                     MarkAsComplete();
                 }
-                
+
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<CorrelationTestSagaData> mapper)
                 {
                     mapper.ConfigureMapping<StartSaga>(m => m.RunId).ToSaga(s => s.RunId);
@@ -110,7 +105,7 @@
                 }
             }
         }
-        
+
 
         [Serializable]
         public class StartSaga : ICommand

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas_first_handler_responding.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas_first_handler_responding.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.AcceptanceTests.Sagas
 {
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NUnit.Framework;
 
@@ -11,7 +12,11 @@ namespace NServiceBus.AcceptanceTests.Sagas
             var context = new Context();
 
             Scenario.Define(context)
-                .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new InitiateRequestingSaga())))
+                .WithEndpoint<Endpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new InitiateRequestingSaga());
+                    return Task.FromResult(0);
+                }))
                 .Done(c => c.DidRequestingSagaGetTheResponse)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas_first_handler_responding.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas_first_handler_responding.cs
@@ -7,11 +7,9 @@ namespace NServiceBus.AcceptanceTests.Sagas
     public class When_doing_request_response_between_sagas_first_handler_responding : When_doing_request_response_between_sagas
     {
         [Test]
-        public void Should_autocorrelate_the_response_back_to_the_requesting_saga_from_the_first_handler()
+        public async Task Should_autocorrelate_the_response_back_to_the_requesting_saga_from_the_first_handler()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.Given(bus =>
                 {
                     bus.SendLocal(new InitiateRequestingSaga());

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas_response_from_noninitiating.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas_response_from_noninitiating.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.AcceptanceTests.Sagas
 {
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NUnit.Framework;
 
@@ -14,7 +15,11 @@ namespace NServiceBus.AcceptanceTests.Sagas
             };
 
             Scenario.Define(context)
-                .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new InitiateRequestingSaga())))
+                .WithEndpoint<Endpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new InitiateRequestingSaga());
+                    return Task.FromResult(0);
+                }))
                 .Done(c => c.DidRequestingSagaGetTheResponse)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas_response_from_noninitiating.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas_response_from_noninitiating.cs
@@ -7,14 +7,9 @@ namespace NServiceBus.AcceptanceTests.Sagas
     public class When_doing_request_response_between_sagas_response_from_noninitiating : When_doing_request_response_between_sagas
     {
         [Test]
-        public void Should_autocorrelate_the_response_back_to_the_requesting_saga_from_handler_other_than_the_initiating_one()
+        public async Task Should_autocorrelate_the_response_back_to_the_requesting_saga_from_handler_other_than_the_initiating_one()
         {
-            var context = new Context
-            {
-                ReplyFromNonInitiatingHandler = true
-            };
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>(c => { c.ReplyFromNonInitiatingHandler = true; })
                 .WithEndpoint<Endpoint>(b => b.Given(bus =>
                 {
                     bus.SendLocal(new InitiateRequestingSaga());

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas_with_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas_with_timeout.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTesting.Support;
     using NUnit.Framework;
@@ -16,7 +17,11 @@ namespace NServiceBus.AcceptanceTests.Sagas
             };
 
             Scenario.Define(context)
-                .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new InitiateRequestingSaga())))
+                .WithEndpoint<Endpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new InitiateRequestingSaga());
+                    return Task.FromResult(0);
+                }))
                 .Done(c => c.DidRequestingSagaGetTheResponse)
                 .Run(new RunSettings { TestExecutionTimeout = TimeSpan.FromSeconds(15) });
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas_with_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas_with_timeout.cs
@@ -9,14 +9,9 @@ namespace NServiceBus.AcceptanceTests.Sagas
     public class When_doing_request_response_between_sagas_with_timeout : When_doing_request_response_between_sagas
     {
         [Test]
-        public void Should_autocorrelate_the_response_back_to_the_requesting_saga_from_timeouts()
+        public async Task Should_autocorrelate_the_response_back_to_the_requesting_saga_from_timeouts()
         {
-            var context = new Context
-            {
-                ReplyFromTimeout = true
-            };
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>(c => { c.ReplyFromTimeout = true; })
                 .WithEndpoint<Endpoint>(b => b.Given(bus =>
                 {
                     bus.SendLocal(new InitiateRequestingSaga());

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Saga;
@@ -9,9 +10,9 @@
     public class When_message_has_a_saga_id : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_not_start_a_new_saga_if_not_found()
+        public async Task Should_not_start_a_new_saga_if_not_found()
         {
-            var context = Scenario.Define<Context>()
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
                 {
                     var message = new MessageWithSagaId();
@@ -21,6 +22,7 @@
                     options.SetHeader(Headers.SagaType, typeof(MessageWithSagaIdSaga).AssemblyQualifiedName);
                     options.RouteToLocalEndpointInstance();
                     bus.Send(message, options);
+                    return Task.FromResult(0);
                 }))
                 .Done(c => c.OtherSagaStarted)
                 .Run();

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_completes_the_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_completes_the_saga.cs
@@ -11,9 +11,9 @@
     public class When_receiving_that_completes_the_saga : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_hydrate_and_complete_the_existing_instance()
+        public async Task Should_hydrate_and_complete_the_existing_instance()
         {
-            Scenario.Define(() => new Context { Id = Guid.NewGuid() })
+            await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<SagaEndpoint>(b =>
                         {
                             b.Given((bus, context) =>
@@ -39,12 +39,9 @@
         }
 
         [Test]
-        public void Should_ignore_messages_afterwards()
+        public async Task Should_ignore_messages_afterwards()
         {
-            Scenario.Define(new Context
-            {
-                Id = Guid.NewGuid()
-            })
+            await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                 .WithEndpoint<SagaEndpoint>(b =>
                 {
                     b.Given((bus, c) =>
@@ -99,9 +96,9 @@
                 EndpointSetup<DefaultServer>(b => b.ExecuteTheseHandlersFirst(typeof(TestSaga10)));
             }
 
-            public class TestSaga10 : Saga<TestSagaData10>, 
-                IAmStartedByMessages<StartSagaMessage>, 
-                IHandleMessages<CompleteSagaMessage>, 
+            public class TestSaga10 : Saga<TestSagaData10>,
+                IAmStartedByMessages<StartSagaMessage>,
+                IHandleMessages<CompleteSagaMessage>,
                 IHandleMessages<AnotherMessage>
             {
                 public Context Context { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_completes_the_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_completes_the_saga.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NUnit.Framework;
@@ -41,10 +42,14 @@
             })
                 .WithEndpoint<SagaEndpoint>(b =>
                 {
-                    b.Given((bus, c) => bus.SendLocal(new StartSagaMessage
+                    b.Given((bus, c) =>
                     {
-                        SomeId = c.Id
-                    }));
+                        bus.SendLocal(new StartSagaMessage
+                        {
+                            SomeId = c.Id
+                        });
+                        return Task.FromResult(0);
+                    });
                     b.When(c => c.StartSagaMessageReceived, (bus, c) =>
                     {
                         c.AddTrace("CompleteSagaMessage sent");
@@ -52,11 +57,16 @@
                         {
                             SomeId = c.Id
                         });
+                        return Task.FromResult(0);
                     });
-                    b.When(c => c.SagaCompleted, (bus, c) => bus.SendLocal(new AnotherMessage
+                    b.When(c => c.SagaCompleted, (bus, c) =>
                     {
-                        SomeId = c.Id
-                    }));
+                        bus.SendLocal(new AnotherMessage
+                        {
+                            SomeId = c.Id
+                        });
+                        return Task.FromResult(0);
+                    });
                 })
                 .Done(c => c.AnotherMessageReceived)
                 .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_completes_the_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_completes_the_saga.cs
@@ -16,7 +16,11 @@
             Scenario.Define(() => new Context { Id = Guid.NewGuid() })
                     .WithEndpoint<SagaEndpoint>(b =>
                         {
-                            b.Given((bus, context) => bus.SendLocal(new StartSagaMessage { SomeId = context.Id }));
+                            b.Given((bus, context) =>
+                            {
+                                bus.SendLocal(new StartSagaMessage { SomeId = context.Id });
+                                return Task.FromResult(0);
+                            });
                             b.When(context => context.StartSagaMessageReceived, (bus, context) =>
                             {
                                 context.AddTrace("CompleteSagaMessage sent");
@@ -25,6 +29,7 @@
                                 {
                                     SomeId = context.Id
                                 });
+                                return Task.FromResult(0);
                             });
                         })
                     .Done(c => c.SagaCompleted)

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_should_start_a_saga_with_interception.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_should_start_a_saga_with_interception.cs
@@ -9,9 +9,9 @@
     public class When_receiving_that_should_start_a_saga_with_interception : When_receiving_that_should_start_a_saga
     {
         [Test]
-        public void Should_not_start_saga_if_a_interception_handler_has_been_invoked()
+        public async Task Should_not_start_saga_if_a_interception_handler_has_been_invoked()
         {
-            Scenario.Define(() => new SagaEndpointContext { InterceptSaga = true })
+            await Scenario.Define< SagaEndpointContext>(c => { c.InterceptSaga = true; })
                 .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
                 {
                     bus.SendLocal(new StartSagaMessage { SomeId = Guid.NewGuid().ToString() });

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_should_start_a_saga_with_interception.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_should_start_a_saga_with_interception.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
     using NUnit.Framework;
@@ -11,7 +12,11 @@
         public void Should_not_start_saga_if_a_interception_handler_has_been_invoked()
         {
             Scenario.Define(() => new SagaEndpointContext { InterceptSaga = true })
-                .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage { SomeId = Guid.NewGuid().ToString() })))
+                .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new StartSagaMessage { SomeId = Guid.NewGuid().ToString() });
+                    return Task.FromResult(0);
+                }))
                 .Done(context => context.InterceptingHandlerCalled)
                 .Repeat(r => r.For(Transports.Default))
                 .Should(c =>

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_should_start_a_saga_without_interception.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_should_start_a_saga_without_interception.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
     using NUnit.Framework;
@@ -11,7 +12,11 @@
         public void Should_start_the_saga_and_call_messagehandlers()
         {
             Scenario.Define<SagaEndpointContext>()
-                .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage { SomeId = Guid.NewGuid().ToString() })))
+                .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new StartSagaMessage { SomeId = Guid.NewGuid().ToString() });
+                    return Task.FromResult(0);
+                }))
                 .Done(context => context.InterceptingHandlerCalled && context.SagaStarted)
                 .Repeat(r => r.For(Transports.Default))
                 .Should(c =>

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_should_start_a_saga_without_interception.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_should_start_a_saga_without_interception.cs
@@ -9,9 +9,9 @@
     public class When_receiving_that_should_start_a_saga_without_interception : When_receiving_that_should_start_a_saga
     {
         [Test]
-        public void Should_start_the_saga_and_call_messagehandlers()
+        public async Task Should_start_the_saga_and_call_messagehandlers()
         {
-            Scenario.Define<SagaEndpointContext>()
+            await Scenario.Define<SagaEndpointContext>()
                 .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
                 {
                     bus.SendLocal(new StartSagaMessage { SomeId = Guid.NewGuid().ToString() });

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_replies_to_message_published_by_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_replies_to_message_published_by_a_saga.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using Features;
@@ -17,10 +18,14 @@
         {
             Scenario.Define<Context>()
                 .WithEndpoint<SagaEndpoint>
-                (b => b.When(c => c.Subscribed, bus => bus.SendLocal(new StartSaga
+                (b => b.When(c => c.Subscribed, bus =>
                 {
-                    DataId = Guid.NewGuid()
-                }))
+                    bus.SendLocal(new StartSaga
+                    {
+                        DataId = Guid.NewGuid()
+                    });
+                    return Task.FromResult(0);
+                })
                 )
                 .WithEndpoint<ReplyEndpoint>(b => b.Given((bus, context) =>
                 {
@@ -29,6 +34,7 @@
                     {
                         context.Subscribed = true;
                     }
+                    return Task.FromResult(0);
                 }))
                 .Done(c => c.DidSagaReplyMessageGetCorrelated)
                 .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_replies_to_message_published_by_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_replies_to_message_published_by_a_saga.cs
@@ -14,9 +14,9 @@
     public class When_replies_to_message_published_by_a_saga : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_reply_to_a_message_published_by_a_saga()
+        public async Task Should_reply_to_a_message_published_by_a_saga()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                 .WithEndpoint<SagaEndpoint>
                 (b => b.When(c => c.Subscribed, bus =>
                 {

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_reply_from_a_finder.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_reply_from_a_finder.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Saga;
@@ -18,10 +19,11 @@
             };
 
             Scenario.Define(context)
-                .WithEndpoint<SagaEndpoint>(b => b.Given(bus => bus.SendLocal(new StartSagaMessage
-                                                                              {
-                                                                                  Id = context.Id
-                                                                              })))
+                .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new StartSagaMessage { Id = context.Id });
+                    return Task.FromResult(0);
+                }))
                 .Done(c => c.HandlerFired)
                 .Run();
 
@@ -49,9 +51,9 @@
                 public TestSagaWithCustomFinder.TestSagaWithCustomFinderSagaData FindBy(StartSagaMessage message, SagaPersistenceOptions options)
                 {
                     Bus.Reply(new SagaNotFoundMessage
-                              {
-                                  Id = Context.Id
-                              });
+                    {
+                        Id = Context.Id
+                    });
                     return null;
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_reply_from_a_finder.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_reply_from_a_finder.cs
@@ -11,17 +11,12 @@
     public class When_reply_from_a_finder
     {
         [Test]
-        public void Should_be_received_by_handler()
+        public async Task Should_be_received_by_handler()
         {
-            var context = new Context
-            {
-                Id = Guid.NewGuid()
-            };
-
-            Scenario.Define(context)
-                .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
+                .WithEndpoint<SagaEndpoint>(b => b.Given((bus, c) =>
                 {
-                    bus.SendLocal(new StartSagaMessage { Id = context.Id });
+                    bus.SendLocal(new StartSagaMessage { Id = c.Id });
                     return Task.FromResult(0);
                 }))
                 .Done(c => c.HandlerFired)

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_has_a_non_empty_constructor.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_has_a_non_empty_constructor.cs
@@ -13,9 +13,9 @@
         static Guid IdThatSagaIsCorrelatedOn = Guid.NewGuid();
 
         [Test]
-        public void Should_hydrate_and_invoke_the_existing_instance()
+        public async Task Should_hydrate_and_invoke_the_existing_instance()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
                         {
                             bus.SendLocal(new StartSagaMessage { SomeId = IdThatSagaIsCorrelatedOn });

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_has_a_non_empty_constructor.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_has_a_non_empty_constructor.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NUnit.Framework;
@@ -19,6 +20,7 @@
                         {
                             bus.SendLocal(new StartSagaMessage { SomeId = IdThatSagaIsCorrelatedOn });
                             bus.SendLocal(new OtherMessage { SomeId = IdThatSagaIsCorrelatedOn });
+                            return Task.FromResult(0);
                         }))
                     .Done(c => c.SecondMessageReceived)
                     .Repeat(r => r.For(Persistence.Default))

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
@@ -10,6 +10,7 @@
     using Saga;
     using ScenarioDescriptors;
 
+    [TestFixture]
     public class When_saga_id_changed : NServiceBusAcceptanceTest
     {
         [Test]

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
@@ -32,69 +32,72 @@
                 .Should(c => { Assert.AreEqual(c.ExceptionMessage, "A modification of IContainSagaData.Id has been detected. This property is for infrastructure purposes only and should not be modified. SagaType: " + typeof(Endpoint.SagaIdChangedSaga)); })
                 .Run();
         }
-    }
 
-    public class Context : ScenarioContext
-    {
-        public bool MessageFailed { get; set; }
-        public string ExceptionMessage { get; set; }
-    }
-
-    public class Endpoint : EndpointConfigurationBuilder
-    {
-        public Endpoint()
+        public class Context : ScenarioContext
         {
-            EndpointSetup<DefaultServer>(b => b.DisableFeature<TimeoutManager>())
-                .WithConfig<TransportConfig>(c =>
+            public bool MessageFailed { get; set; }
+            public string ExceptionMessage { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(b => b.DisableFeature<TimeoutManager>())
+                    .WithConfig<TransportConfig>(c =>
+                    {
+                        c.MaxRetries = 0;
+                    });
+            }
+
+            public class SagaIdChangedSaga : Saga<SagaIdChangedSaga.SagaIdChangedSagaData>,
+                IAmStartedByMessages<StartSaga>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(StartSaga message)
                 {
-                    c.MaxRetries = 0;
-                });
-        }
+                    Data.DataId = message.DataId;
+                    Data.Id = Guid.NewGuid();
+                }
 
-        public class SagaIdChangedSaga : Saga<SagaIdChangedSaga.SagaIdChangedSagaData>,
-            IAmStartedByMessages<StartSaga>
-        {
-            public Context Context { get; set; }
-
-            public void Handle(StartSaga message)
-            {
-                Data.DataId = message.DataId;
-                Data.Id = Guid.NewGuid();
-            }
-
-            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaIdChangedSagaData> mapper)
-            {
-                mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
-            }
-
-            public class SagaIdChangedSagaData : ContainSagaData
-            {
-                public virtual Guid DataId { get; set; }
-            }
-
-        }
-        class ErrorNotificationSpy : IWantToRunWhenBusStartsAndStops
-        {
-            public Context Context { get; set; }
-
-            public BusNotifications BusNotifications { get; set; }
-
-            public void Start()
-            {
-                BusNotifications.Errors.MessageSentToErrorQueue.Subscribe(e =>
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaIdChangedSagaData> mapper)
                 {
-                    Context.MessageFailed = true;
-                    Context.ExceptionMessage = e.Exception.Message;
-                });
+                    mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
+                }
+
+                public class SagaIdChangedSagaData : ContainSagaData
+                {
+                    public virtual Guid DataId { get; set; }
+                }
+
             }
 
-            public void Stop() { }
-        }
-    }
+            class ErrorNotificationSpy : IWantToRunWhenBusStartsAndStops
+            {
+                public Context Context { get; set; }
 
-    [Serializable]
-    public class StartSaga : ICommand
-    {
-        public Guid DataId { get; set; }
+                public BusNotifications BusNotifications { get; set; }
+
+                public void Start()
+                {
+                    BusNotifications.Errors.MessageSentToErrorQueue.Subscribe(e =>
+                    {
+                        Context.MessageFailed = true;
+                        Context.ExceptionMessage = e.Exception.Message;
+                    });
+                }
+
+                public void Stop()
+                {
+                }
+            }
+        }
+
+        [Serializable]
+        public class StartSaga : ICommand
+        {
+            public Guid DataId { get; set; }
+        }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Diagnostics;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NServiceBus.Config;
@@ -18,10 +19,14 @@
             var context = new Context();
             Scenario.Define(context)
                 .WithEndpoint<Endpoint>(
-                    b => b.Given(bus => bus.SendLocal(new StartSaga
+                    b => b.Given(bus =>
                     {
-                        DataId = Guid.NewGuid()
-                    })))
+                        bus.SendLocal(new StartSaga
+                        {
+                            DataId = Guid.NewGuid()
+                        });
+                        return Task.FromResult(0);
+                    }))
                     .AllowExceptions()
                 .Done(c => c.MessageFailed)
                 .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NUnit.Framework;
@@ -17,7 +18,8 @@
                     .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
                         {
                             bus.SendLocal(new StartSagaMessage { Key = "Part1_Part2"});
-                            bus.SendLocal(new OtherMessage { Part1 = "Part1", Part2 = "Part2" });                                    
+                            bus.SendLocal(new OtherMessage { Part1 = "Part1", Part2 = "Part2" });
+                            return Task.FromResult(0);
                         }))
                     .Done(c => c.SecondMessageReceived)
                     .Repeat(r => r.For(Persistence.Default))

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
@@ -10,11 +10,10 @@
 
     public class When_saga_is_mapped_to_complex_expression : NServiceBusAcceptanceTest
     {
-
         [Test]
-        public void Should_hydrate_and_invoke_the_existing_instance()
+        public async Task Should_hydrate_and_invoke_the_existing_instance()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
                         {
                             bus.SendLocal(new StartSagaMessage { Key = "Part1_Part2"});

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
@@ -11,11 +11,9 @@
     public class When_sagas_cant_be_found : NServiceBusAcceptanceTest
     {
         [Test]
-        public void IHandleSagaNotFound_only_called_once()
+        public async Task IHandleSagaNotFound_only_called_once()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<ReceiverWithSagas>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new MessageToSaga { Id = Guid.NewGuid() });
@@ -28,18 +26,16 @@
         }
 
         [Test]
-        public void IHandleSagaNotFound_not_called_if_second_saga_is_executed()
+        public async Task IHandleSagaNotFound_not_called_if_second_saga_is_executed()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
-                    .WithEndpoint<ReceiverWithOrderedSagas>(b => b.Given((bus, c) =>
-                    {
-                        bus.SendLocal(new MessageToSaga { Id = Guid.NewGuid() });
-                        return Task.FromResult(0);
-                    }))
-                    .Done(c => c.Done)
-                    .Run();
+            var context = await Scenario.Define<Context>()
+                     .WithEndpoint<ReceiverWithOrderedSagas>(b => b.Given((bus, c) =>
+                     {
+                         bus.SendLocal(new MessageToSaga { Id = Guid.NewGuid() });
+                         return Task.FromResult(0);
+                     }))
+                     .Done(c => c.Done)
+                     .Run();
 
             Assert.AreEqual(0, context.TimesFired);
         }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NServiceBus.Features;
@@ -15,7 +16,11 @@
             var context = new Context();
 
             Scenario.Define(context)
-                    .WithEndpoint<ReceiverWithSagas>(b => b.Given((bus, c) => bus.SendLocal(new MessageToSaga { Id = Guid.NewGuid() })))
+                    .WithEndpoint<ReceiverWithSagas>(b => b.Given((bus, c) =>
+                    {
+                        bus.SendLocal(new MessageToSaga { Id = Guid.NewGuid() });
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.Done)
                     .Run();
 
@@ -28,7 +33,11 @@
             var context = new Context();
 
             Scenario.Define(context)
-                    .WithEndpoint<ReceiverWithOrderedSagas>(b => b.Given((bus, c) => bus.SendLocal(new MessageToSaga { Id = Guid.NewGuid() })))
+                    .WithEndpoint<ReceiverWithOrderedSagas>(b => b.Given((bus, c) =>
+                    {
+                        bus.SendLocal(new MessageToSaga { Id = Guid.NewGuid() });
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.Done)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_handle.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_handle.cs
@@ -2,6 +2,7 @@
 namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NServiceBus.Features;
@@ -15,7 +16,11 @@ namespace NServiceBus.AcceptanceTests.Sagas
         public void Should_match_different_saga()
         {
             Scenario.Define<Context>()
-                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new StartSaga1 { DataId = Guid.NewGuid() })))
+                    .WithEndpoint<Endpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new StartSaga1 { DataId = Guid.NewGuid() });
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.DidSaga2ReceiveMessage)
                     .Repeat(r => r.For(Transports.Default))
                     .Should(c => Assert.True(c.DidSaga2ReceiveMessage))

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_handle.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_handle.cs
@@ -13,18 +13,18 @@ namespace NServiceBus.AcceptanceTests.Sagas
     public class When_sending_from_a_saga_handle : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_match_different_saga()
+        public async Task Should_match_different_saga()
         {
-            Scenario.Define<Context>()
-                    .WithEndpoint<Endpoint>(b => b.Given(bus =>
-                    {
-                        bus.SendLocal(new StartSaga1 { DataId = Guid.NewGuid() });
-                        return Task.FromResult(0);
-                    }))
-                    .Done(c => c.DidSaga2ReceiveMessage)
-                    .Repeat(r => r.For(Transports.Default))
-                    .Should(c => Assert.True(c.DidSaga2ReceiveMessage))
-                    .Run();
+            await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new StartSaga1 { DataId = Guid.NewGuid() });
+                    return Task.FromResult(0);
+                }))
+                .Done(c => c.DidSaga2ReceiveMessage)
+                .Repeat(r => r.For(Transports.Default))
+                .Should(c => Assert.True(c.DidSaga2ReceiveMessage))
+                .Run();
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NServiceBus.Features;
@@ -14,7 +15,11 @@
         public void Should_match_different_saga()
         {
             Scenario.Define<Context>()
-                    .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new StartSaga1 { DataId = Guid.NewGuid() })))
+                    .WithEndpoint<Endpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new StartSaga1 { DataId = Guid.NewGuid() });
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.DidSaga2ReceiveMessage)
                     .Repeat(r => r.For(Transports.Default))
                     .Should(c => Assert.True(c.DidSaga2ReceiveMessage))

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
@@ -12,9 +12,9 @@
     public class When_sending_from_a_saga_timeout : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_match_different_saga()
+        public async Task Should_match_different_saga()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.Given(bus =>
                     {
                         bus.SendLocal(new StartSaga1 { DataId = Guid.NewGuid() });

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_base_event_from_other_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_base_event_from_other_saga.cs
@@ -15,9 +15,9 @@
     {
 
         [Test]
-        public void Should_start_the_saga_when_set_up_to_start_for_the_base_event()
+        public async Task Should_start_the_saga_when_set_up_to_start_for_the_base_event()
         {
-            Scenario.Define<SagaContext>()
+            await Scenario.Define<SagaContext>()
                 .WithEndpoint<Publisher>(b =>
                     b.When(c => c.IsEventSubscriptionReceived,
                         bus =>

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_base_event_from_other_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_base_event_from_other_saga.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using Features;
@@ -20,7 +21,10 @@
                 .WithEndpoint<Publisher>(b =>
                     b.When(c => c.IsEventSubscriptionReceived,
                         bus =>
-                            bus.Publish<SomethingHappenedEvent>(m => { m.DataId = Guid.NewGuid(); }))
+                        {
+                            bus.Publish<SomethingHappenedEvent>(m => { m.DataId = Guid.NewGuid(); });
+                            return Task.FromResult(0);
+                        })
                 )
                 .WithEndpoint<SagaThatIsStartedByABaseEvent>(
                     b => b.Given((bus, context) =>
@@ -29,6 +33,7 @@
 
                         if (context.HasNativePubSubSupport)
                             context.IsEventSubscriptionReceived = true;
+                        return Task.FromResult(0);
                     }))
                 .Done(c => c.DidSagaComplete)
                 .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_event_from_another_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_event_from_another_saga.cs
@@ -14,9 +14,9 @@
     public class When_started_by_event_from_another_saga : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_start_the_saga_and_request_a_timeout()
+        public async Task Should_start_the_saga_and_request_a_timeout()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                 .WithEndpoint<SagaThatPublishesAnEvent>(b =>
                     b.When(c => c.IsEventSubscriptionReceived,
                             bus =>

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_event_from_another_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_event_from_another_saga.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using Features;
@@ -19,10 +20,13 @@
                 .WithEndpoint<SagaThatPublishesAnEvent>(b =>
                     b.When(c => c.IsEventSubscriptionReceived,
                             bus =>
+                            {
                                 bus.SendLocal(new StartSaga
                                 {
                                     DataId = Guid.NewGuid()
-                                }))
+                                });
+                                return Task.FromResult(0);
+                            })
                 )
                 .WithEndpoint<SagaThatIsStartedByTheEvent>(
                     b => b.Given((bus, context) =>
@@ -31,6 +35,7 @@
 
                         if (context.HasNativePubSubSupport)
                             context.IsEventSubscriptionReceived = true;
+                        return Task.FromResult(0);
                     }))
                 .Done(c => c.DidSaga1Complete && c.DidSaga2Complete)
                 .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_timeout_hit_not_found_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_timeout_hit_not_found_saga.cs
@@ -11,9 +11,9 @@
     public class When_timeout_hit_not_found_saga : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_not_fire_notfound_for_tm()
+        public async Task Should_not_fire_notfound_for_tm()
         {
-            var context = Scenario.Define<Context>()
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.Given(bus =>
                 {
                     bus.SendLocal(new StartSaga());

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_timeout_hit_not_found_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_timeout_hit_not_found_saga.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NServiceBus.Features;
@@ -13,7 +14,11 @@
         public void Should_not_fire_notfound_for_tm()
         {
             var context = Scenario.Define<Context>()
-                .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new StartSaga())))
+                .WithEndpoint<Endpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new StartSaga());
+                    return Task.FromResult(0);
+                }))
                 .Done(c => c.NotFoundHandlerCalledForRegularMessage)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_two_sagas_subscribe_to_the_same_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_two_sagas_subscribe_to_the_same_event.cs
@@ -14,9 +14,9 @@ namespace NServiceBus.AcceptanceTests.Sagas
     public class When_two_sagas_subscribe_to_the_same_event : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_invoke_all_handlers_on_all_sagas()
+        public async Task Should_invoke_all_handlers_on_all_sagas()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<SagaEndpoint>(b =>
                         b.When(c => c.Subscribed, bus =>
                         {

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_ReplyToOriginator.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_ReplyToOriginator.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.Features;
@@ -15,7 +16,11 @@
             var context = new Context();
 
             Scenario.Define(context)
-                .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new InitiateRequestingSaga { SomeCorrelationId = Guid.NewGuid() })))
+                .WithEndpoint<Endpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new InitiateRequestingSaga { SomeCorrelationId = Guid.NewGuid() });
+                    return Task.FromResult(0);
+                }))
                 .Done(c => c.Done)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_ReplyToOriginator.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_ReplyToOriginator.cs
@@ -11,11 +11,9 @@
     public class When_using_ReplyToOriginator : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_set_Reply_as_messageintent()
+        public async Task Should_set_Reply_as_messageintent()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.Given(bus =>
                 {
                     bus.SendLocal(new InitiateRequestingSaga { SomeCorrelationId = Guid.NewGuid() });

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NServiceBus.Features;
@@ -13,7 +14,11 @@
         public void Timeout_should_be_received_after_expiration()
         {
             Scenario.Define(() => new Context {Id = Guid.NewGuid()})
-                    .WithEndpoint<SagaEndpoint>(g => g.Given(bus=>bus.SendLocal(new StartSagaMessage())))
+                    .WithEndpoint<SagaEndpoint>(g => g.Given(bus =>
+                    {
+                        bus.SendLocal(new StartSagaMessage());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.TimeoutReceived)
                     .Run();
         }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
@@ -11,9 +11,9 @@
     public class When_using_a_received_message_for_timeout : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Timeout_should_be_received_after_expiration()
+        public async Task Timeout_should_be_received_after_expiration()
         {
-            Scenario.Define(() => new Context {Id = Guid.NewGuid()})
+            await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<SagaEndpoint>(g => g.Given(bus =>
                     {
                         bus.SendLocal(new StartSagaMessage());

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_contain_saga_data.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_contain_saga_data.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Features;
@@ -14,7 +15,11 @@
         {
             var context = Scenario.Define<Context>()
                     .WithEndpoint<EndpointThatHostsASaga>(
-                        b => b.Given(bus => bus.SendLocal(new StartSaga {DataId = Guid.NewGuid()})))
+                        b => b.Given(bus =>
+                        {
+                            bus.SendLocal(new StartSaga {DataId = Guid.NewGuid()});
+                            return Task.FromResult(0);
+                        }))
                     .Done(c => c.TimeoutReceived)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_contain_saga_data.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_contain_saga_data.cs
@@ -11,9 +11,9 @@
     public class When_using_contain_saga_data : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_handle_timeouts_properly()
+        public async Task Should_handle_timeouts_properly()
         {
-            var context = Scenario.Define<Context>()
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<EndpointThatHostsASaga>(
                         b => b.Given(bus =>
                         {

--- a/src/NServiceBus.AcceptanceTests/Sagas/when_receiving_multiple_timeouts.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/when_receiving_multiple_timeouts.cs
@@ -12,11 +12,9 @@
     {
         // realted to NSB issue #1819
         [Test]
-        public void It_should_not_invoke_SagaNotFound_handler()
+        public async Task It_should_not_invoke_SagaNotFound_handler()
         {
-            var context = new Context { Id = Guid.NewGuid() };
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
                     {
                         bus.SendLocal(new StartSaga1 { ContextId = c.Id });

--- a/src/NServiceBus.AcceptanceTests/Sagas/when_receiving_multiple_timeouts.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/when_receiving_multiple_timeouts.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NServiceBus.Features;
@@ -16,7 +17,11 @@
             var context = new Context { Id = Guid.NewGuid() };
 
             Scenario.Define(context)
-                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new StartSaga1 { ContextId = c.Id })))
+                    .WithEndpoint<Endpoint>(b => b.Given((bus, c) =>
+                    {
+                        bus.SendLocal(new StartSaga1 { ContextId = c.Id });
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => (c.Saga1TimeoutFired && c.Saga2TimeoutFired) || c.SagaNotFound)
                     .Run(TimeSpan.FromSeconds(20));
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/when_reply_from_saga_not_found_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/when_reply_from_saga_not_found_handler.cs
@@ -11,11 +11,9 @@
     {
         // related to NSB issue #2044
         [Test]
-        public void It_should_invoke_message_handler()
+        public async Task It_should_invoke_message_handler()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<Sender>(b => b.Given((bus, c) =>
                     {
                         bus.Send(new MessageToSaga());

--- a/src/NServiceBus.AcceptanceTests/Sagas/when_reply_from_saga_not_found_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/when_reply_from_saga_not_found_handler.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NUnit.Framework;
@@ -15,7 +16,11 @@
             var context = new Context();
 
             Scenario.Define(context)
-                    .WithEndpoint<Sender>(b => b.Given((bus, c) => bus.Send(new MessageToSaga())))
+                    .WithEndpoint<Sender>(b => b.Given((bus, c) =>
+                    {
+                        bus.Send(new MessageToSaga());
+                        return Task.FromResult(0);
+                    }))
                     .WithEndpoint<ReceiverWithSaga>()
                     .Done(c => c.ReplyReceived)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/ScaleOut/When_individualization_is_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/ScaleOut/When_individualization_is_enabled.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.ScaleOut
 {
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Settings;
@@ -9,14 +10,12 @@
     {
         const string discriminator = "-something";
 
-
         [Test]
-        public void Should_use_the_configured_differentiator()
+        public async Task Should_use_the_configured_differentiator()
         {
-            var context = Scenario.Define<Context>()
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<IndividualizedEndpoint>().Done(c => c.EndpointsStarted)
                     .Run();
-
 
             Assert.True(context.Address.Contains("-something"), context.Address + " should contain the discriminator " + discriminator);
 

--- a/src/NServiceBus.AcceptanceTests/ScaleOut/When_individualization_is_enabled_for_msmq.cs
+++ b/src/NServiceBus.AcceptanceTests/ScaleOut/When_individualization_is_enabled_for_msmq.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.ScaleOut
 {
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -10,9 +11,9 @@
     public class When_individualization_is_enabled_for_msmq : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_be_a_no_op_discriminator()
+        public async Task Should_be_a_no_op_discriminator()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<IndividualizedEndpoint>().Done(c => c.EndpointsStarted)
                     .Repeat(r => r.For<MsmqOnly>())
                     .Should(c => Assert.AreEqual(c.EndpointName, c.Address.Split('@').First()))

--- a/src/NServiceBus.AcceptanceTests/ScaleOut/When_no_discriminator_is_available.cs
+++ b/src/NServiceBus.AcceptanceTests/ScaleOut/When_no_discriminator_is_available.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.ConsistencyGuarantees;
@@ -14,18 +15,26 @@
     public class When_no_discriminator_is_available : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_blow_up()
+        public async Task Should_blow_up()
         {
-            var ex = Assert.Throws<AggregateException>(()=> Scenario.Define<Context>()
-                    .WithEndpoint<IndividualizedEndpoint>().Done(c =>c.EndpointsStarted)
+            AggregateException ex = null;
+            try
+            {
+                await Scenario.Define<Context>()
+                    .WithEndpoint<IndividualizedEndpoint>().Done(c => c.EndpointsStarted)
                     .AllowExceptions()
-                    .Run());
+                    .Run();
+
+            }
+            catch (AggregateException e)
+            {
+                ex = e;
+            }
 
             var configEx = ex.InnerExceptions.First()
                 .InnerException;
 
             Assert.True(configEx.Message.StartsWith("No endpoint instance discriminator found"));
-
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Scheduling/When_scheduling_a_recurring_task.cs
+++ b/src/NServiceBus.AcceptanceTests/Scheduling/When_scheduling_a_recurring_task.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Scheduling
 {
     using System;
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NServiceBus.Features;
@@ -10,9 +11,9 @@
     public class When_scheduling_a_recurring_task : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_execute_the_task()
+        public async Task Should_execute_the_task()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<SchedulingEndpoint>()
                     .Done(c => c.InvokedAt.HasValue)
                     .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/Tx/Issue_2481.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/Issue_2481.cs
@@ -11,9 +11,9 @@
     public class Issue_2481 : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_enlist_the_receive_in_the_dtc_tx()
+        public async Task Should_enlist_the_receive_in_the_dtc_tx()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<DTCEndpoint>(b => b.Given(bus =>
                     {
                         bus.SendLocal(new MyMessage());

--- a/src/NServiceBus.AcceptanceTests/Tx/Issue_2481.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/Issue_2481.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Tx
 {
     using System;
+    using System.Threading.Tasks;
     using System.Transactions;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -13,7 +14,11 @@
         public void Should_enlist_the_receive_in_the_dtc_tx()
         {
             Scenario.Define<Context>()
-                    .WithEndpoint<DTCEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .WithEndpoint<DTCEndpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new MyMessage());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.HandlerInvoked)
                     .Repeat(r => r.For<AllDtcTransports>())
                     .Should(c => Assert.False(c.CanEnlistPromotable, "There should exists a DTC tx"))

--- a/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_dtc_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_dtc_disabled.cs
@@ -11,10 +11,9 @@
     public class When_receiving_with_dtc_disabled : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_not_escalate_a_single_durable_rm_to_dtc_tx()
+        public async Task Should_not_escalate_a_single_durable_rm_to_dtc_tx()
         {
-
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<NonDTCEndpoint>(b => b.Given(bus =>
                     {
                         bus.SendLocal(new MyMessage());

--- a/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_dtc_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_dtc_disabled.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Tx
 {
     using System;
+    using System.Threading.Tasks;
     using System.Transactions;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -14,7 +15,11 @@
         {
 
             Scenario.Define<Context>()
-                    .WithEndpoint<NonDTCEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .WithEndpoint<NonDTCEndpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new MyMessage());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.HandlerInvoked)
                     .Repeat(r => r.For<AllDtcTransports>())
                     .Should(c =>

--- a/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_dtc_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_dtc_enabled.cs
@@ -11,18 +11,18 @@
     public class When_receiving_with_dtc_enabled : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_enlist_the_receive_in_the_dtc_tx()
+        public async Task Should_enlist_the_receive_in_the_dtc_tx()
         {
-            Scenario.Define<Context>()
-                    .WithEndpoint<DTCEndpoint>(b => b.Given(bus =>
-                    {
-                        bus.SendLocal(new MyMessage());
-                        return Task.FromResult(0);
-                    }))
-                    .Done(c => c.HandlerInvoked)
-                    .Repeat(r => r.For<AllDtcTransports>())
-                    .Should(c => Assert.False(c.CanEnlistPromotable, "There should exists a DTC tx"))
-                    .Run();
+            await Scenario.Define<Context>()
+                .WithEndpoint<DTCEndpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new MyMessage());
+                    return Task.FromResult(0);
+                }))
+                .Done(c => c.HandlerInvoked)
+                .Repeat(r => r.For<AllDtcTransports>())
+                .Should(c => Assert.False(c.CanEnlistPromotable, "There should exists a DTC tx"))
+                .Run();
         }
 
         [Test]
@@ -50,7 +50,6 @@
                 tx.Complete();
             }
         }
-
 
         public class Context : ScenarioContext
         {

--- a/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_dtc_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_dtc_enabled.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Tx
 {
     using System;
+    using System.Threading.Tasks;
     using System.Transactions;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -13,7 +14,11 @@
         public void Should_enlist_the_receive_in_the_dtc_tx()
         {
             Scenario.Define<Context>()
-                    .WithEndpoint<DTCEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .WithEndpoint<DTCEndpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new MyMessage());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.HandlerInvoked)
                     .Repeat(r => r.For<AllDtcTransports>())
                     .Should(c => Assert.False(c.CanEnlistPromotable, "There should exists a DTC tx"))

--- a/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_native_multi_queue_transaction.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_native_multi_queue_transaction.cs
@@ -10,27 +10,23 @@
     public class When_receiving_with_native_multi_queue_transaction : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_not_send_outgoing_messages_if_receiving_transaction_is_rolled_back()
+        public async Task Should_not_send_outgoing_messages_if_receiving_transaction_is_rolled_back()
         {
-            var context = new Context
-            {
-                FirstAttempt = true
-            };
-            Scenario.Define(context)
-                .WithEndpoint<Endpoint>(b => b.Given(bus =>
-                {
-                    bus.SendLocal(new MyMessage());
-                    return Task.FromResult(0);
-                }))
-                .Done(c => c.MessageHandled)
-                .AllowExceptions(e => e is Endpoint.FakeException)
-                .Repeat(r => r.For<AllNativeMultiQueueTransactionTransports>())
-                .Should(c =>
-                {
-                    Assert.IsFalse(c.HasFailed);
-                    Assert.IsTrue(c.MessageHandled);
-                })
-                .Run();
+            await Scenario.Define<Context>(c => { c.FirstAttempt = true; })
+                 .WithEndpoint<Endpoint>(b => b.Given(bus =>
+                 {
+                     bus.SendLocal(new MyMessage());
+                     return Task.FromResult(0);
+                 }))
+                 .Done(c => c.MessageHandled)
+                 .AllowExceptions(e => e is Endpoint.FakeException)
+                 .Repeat(r => r.For<AllNativeMultiQueueTransactionTransports>())
+                 .Should(c =>
+                 {
+                     Assert.IsFalse(c.HasFailed);
+                     Assert.IsTrue(c.MessageHandled);
+                 })
+                 .Run();
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_native_multi_queue_transaction.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_native_multi_queue_transaction.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Tx
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -16,7 +17,11 @@
                 FirstAttempt = true
             };
             Scenario.Define(context)
-                .WithEndpoint<Endpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                .WithEndpoint<Endpoint>(b => b.Given(bus =>
+                {
+                    bus.SendLocal(new MyMessage());
+                    return Task.FromResult(0);
+                }))
                 .Done(c => c.MessageHandled)
                 .AllowExceptions(e => e is Endpoint.FakeException)
                 .Repeat(r => r.For<AllNativeMultiQueueTransactionTransports>())

--- a/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_the_default_settings.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_the_default_settings.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Tx
 {
     using System;
+    using System.Threading.Tasks;
     using System.Transactions;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -13,7 +14,11 @@
         public void Should_wrap_the_handler_pipeline_with_a_transactionscope()
         {
             Scenario.Define<Context>()
-                    .WithEndpoint<TransactionalEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .WithEndpoint<TransactionalEndpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new MyMessage());
+                        return Task.FromResult(0);
+                    }))
                     .Done(c => c.HandlerInvoked)
                     .Repeat(r => r.For(Transports.Default))
                     .Should(c => Assert.True(c.AmbientTransactionExists, "There should exist an ambient transaction"))

--- a/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_the_default_settings.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_the_default_settings.cs
@@ -11,9 +11,9 @@
     public class When_receiving_with_the_default_settings : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_wrap_the_handler_pipeline_with_a_transactionscope()
+        public async Task Should_wrap_the_handler_pipeline_with_a_transactionscope()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<TransactionalEndpoint>(b => b.Given(bus =>
                     {
                         bus.SendLocal(new MyMessage());

--- a/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_transactions_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_transactions_disabled.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Tx
 {
     using System;
+    using System.Threading.Tasks;
     using System.Transactions;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -14,7 +15,11 @@
         {
 
             Scenario.Define<Context>()
-                    .WithEndpoint<NonTransactionalEndpoint>(b => b.Given(bus => bus.SendLocal(new MyMessage())))
+                    .WithEndpoint<NonTransactionalEndpoint>(b => b.Given(bus =>
+                    {
+                        bus.SendLocal(new MyMessage());
+                        return Task.FromResult(0);
+                    }))
                     .AllowExceptions()
                     .Done(c => c.TestComplete)
                     .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_transactions_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_transactions_disabled.cs
@@ -11,10 +11,9 @@
     public class When_receiving_with_transactions_disabled : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_not_roll_the_message_back_to_the_queue_in_case_of_failure()
+        public async Task Should_not_roll_the_message_back_to_the_queue_in_case_of_failure()
         {
-
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<NonTransactionalEndpoint>(b => b.Given(bus =>
                     {
                         bus.SendLocal(new MyMessage());

--- a/src/NServiceBus.AcceptanceTests/Tx/When_sending_within_an_ambient_transaction.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_sending_within_an_ambient_transaction.cs
@@ -11,9 +11,9 @@
     public class When_sending_within_an_ambient_transaction : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_not_deliver_them_until_the_commit_phase()
+        public async Task Should_not_deliver_them_until_the_commit_phase()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<TransactionalEndpoint>(b => b.Given((bus, context) =>
                         {
                             using (var tx = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
@@ -38,9 +38,9 @@
         }
 
         [Test]
-        public void Should_not_deliver_them_on_rollback()
+        public async Task Should_not_deliver_them_on_rollback()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<TransactionalEndpoint>(b => b.Given(bus =>
                         {
                             using (new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))

--- a/src/NServiceBus.AcceptanceTests/Tx/When_sending_within_an_ambient_transaction.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_sending_within_an_ambient_transaction.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Tx
 {
     using System;
+    using System.Threading.Tasks;
     using System.Transactions;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -28,6 +29,7 @@
 
                                 tx.Complete();
                             }
+                            return Task.FromResult(0);
                         }))
                     .Done(c => c.MessageThatIsNotEnlistedHandlerWasCalled && c.TimesCalled >= 2)
                     .Repeat(r => r.For<AllDtcTransports>())
@@ -49,7 +51,7 @@
                             }
 
                             bus.Send(new MessageThatIsNotEnlisted());
-
+                            return Task.FromResult(0);
                         }))
                     .Done(c => c.MessageThatIsNotEnlistedHandlerWasCalled)
                     .Repeat(r => r.For<AllDtcTransports>())

--- a/src/NServiceBus.AcceptanceTests/UnitOfWork/When_a_subscription_message_arrives.cs
+++ b/src/NServiceBus.AcceptanceTests/UnitOfWork/When_a_subscription_message_arrives.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.UnitOfWork
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.UnitOfWork;
@@ -9,11 +10,9 @@
     public class When_a_subscription_message_arrives
     {
         [Test]
-        public void Should_invoke_uow()
+        public async Task Should_invoke_uow()
         {
-            var context = new Context();
-
-            Scenario.Define(context)
+            var context = await Scenario.Define<Context>()
                     .WithEndpoint<UOWEndpoint>()
                     .Done(c => c.UowWasCalled)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
+++ b/src/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
@@ -10,9 +10,9 @@
     public class When_multiple_versions_of_a_message_is_published : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_deliver_is_to_both_v1_and_vX_subscribers()
+        public async Task Should_deliver_is_to_both_v1_and_vX_subscribers()
         {
-            Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<V2Publisher>(b =>
                         b.When(c => c.V1Subscribed && c.V2Subscribed, (bus, c) =>
                         {

--- a/src/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
+++ b/src/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Versioning
 {
+    using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
     using NServiceBus.AcceptanceTests.Routing;
@@ -13,22 +14,28 @@
         {
             Scenario.Define<Context>()
                     .WithEndpoint<V2Publisher>(b =>
-                        b.When(c => c.V1Subscribed && c.V2Subscribed, (bus, c) => bus.Publish<V2Event>(e =>
-                                 {
-                                     e.SomeData = 1;
-                                     e.MoreInfo = "dasd";
-                                 })))
+                        b.When(c => c.V1Subscribed && c.V2Subscribed, (bus, c) =>
+                        {
+                            bus.Publish<V2Event>(e =>
+                            {
+                                e.SomeData = 1;
+                                e.MoreInfo = "dasd";
+                            });
+                            return Task.FromResult(0);
+                        }))
                     .WithEndpoint<V1Subscriber>(b => b.Given((bus,c) =>
                         {
                             bus.Subscribe<V1Event>();
                             if (c.HasNativePubSubSupport)
                                 c.V1Subscribed = true;
+                            return Task.FromResult(0);
                         }))
                     .WithEndpoint<V2Subscriber>(b => b.Given((bus,c) =>
                         {
                             bus.Subscribe<V2Event>();
                             if (c.HasNativePubSubSupport)
                                 c.V2Subscribed = true;
+                            return Task.FromResult(0);
                         }))
                     .Done(c => c.V1SubscriberGotTheMessage && c.V2SubscriberGotTheMessage)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/Volatile/When_sending_to_non_durable_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Volatile/When_sending_to_non_durable_endpoint.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Volatile
 {
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
@@ -12,7 +13,11 @@
         {
             var context = new Context();
             Scenario.Define(context)
-                    .WithEndpoint<Sender>(b => b.Given((bus, c) => bus.Send(new MyMessage())))
+                    .WithEndpoint<Sender>(b => b.Given((bus, c) =>
+                    {
+                        bus.Send(new MyMessage());
+                        return Task.FromResult(0);
+                    }))
                     .WithEndpoint<Receiver>()
                     .Done(c => c.WasCalled)
                     .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/Volatile/When_sending_to_non_durable_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Volatile/When_sending_to_non_durable_endpoint.cs
@@ -9,10 +9,9 @@
     public class When_sending_to_non_durable_endpoint: NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_receive_the_message()
+        public async Task Should_receive_the_message()
         {
-            var context = new Context();
-            Scenario.Define(context)
+            await Scenario.Define<Context>()
                     .WithEndpoint<Sender>(b => b.Given((bus, c) =>
                     {
                         bus.Send(new MyMessage());

--- a/src/NServiceBus.Core/CriticalError/ConfigureCriticalErrorAction.cs
+++ b/src/NServiceBus.Core/CriticalError/ConfigureCriticalErrorAction.cs
@@ -20,6 +20,5 @@ namespace NServiceBus
             Guard.AgainstNull("onCriticalError", onCriticalError);
             busConfiguration.Settings.Set("onCriticalErrorAction", onCriticalError);
         }
-
     }
 }

--- a/src/NServiceBus.Core/Unicast/UnicastBusInternal_RemoveInV7.cs
+++ b/src/NServiceBus.Core/Unicast/UnicastBusInternal_RemoveInV7.cs
@@ -43,7 +43,7 @@ namespace NServiceBus.Unicast
         {
             throw new NotImplementedException();
         }
-
+ 
         public void Return<T>(T errorEnum)
         {
             throw new NotImplementedException();

--- a/src/NServiceBus.sln
+++ b/src/NServiceBus.sln
@@ -114,7 +114,4 @@ Global
 		{758357F6-CD31-4337-80C4-BA377FC257AF} = {2904B75F-8F07-4C07-BABC-BC42533B3E75}
 		{2F2FBB64-FE67-4204-8E27-E1DB39ED843D} = {2904B75F-8F07-4C07-BABC-BC42533B3E75}
 	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		EnterpriseLibraryConfigurationToolBinariesPath = packages\Unity.2.1.505.2\lib\NET35;packages\Unity.2.1.505.0\lib\NET35
-	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This PR is part of the work to make the core async enabled. For more background read [Async/Await: It's time!](http://particular.net/blog/async-await-its-time) blogpost

* Complete ATT framework async aware
* No more SpinWaiting
* Fixed a bug in the original ATT framework where we didn't recreate the ScenarioContext per RunDescriptor

@Particular/tf-asyncawait can you please start reviewing and tripple check if my changes made sense also watch for potential missing `ConfigureAwait(false)`

@Particular/nservicebus is it possible to treat this as "should go in before all other ATT changes"? 

In my machine I have a few failing tests because messages from old tests seem to suddendly being dispatch via FLR on other tests. Can someone help hunting this? 