### PR TITLE
Cleanup and Configuration phase of ATTs is async as well

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointConfiguration.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointConfiguration.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     public class EndpointConfiguration
     {
@@ -18,7 +19,7 @@
 
         public IList<Type> TypesToInclude { get; set; }
 
-        public Func<RunDescriptor, IDictionary<Type, string>, BusConfiguration> GetConfiguration { get; set; }
+        public Func<RunDescriptor, IDictionary<Type, string>, Task<BusConfiguration>> GetConfiguration { get; set; }
 
         public string EndpointName
         {

--- a/src/NServiceBus.AcceptanceTesting/Support/IEndpointSetupTemplate.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/IEndpointSetupTemplate.cs
@@ -1,10 +1,11 @@
 ﻿namespace NServiceBus.AcceptanceTesting.Support
 {
     using System;
+    using System.Threading.Tasks;
     using Config.ConfigurationSource;
 
     public interface IEndpointSetupTemplate
     {
-        BusConfiguration GetConfiguration(RunDescriptor runDescriptor, EndpointConfiguration endpointConfiguration, IConfigurationSource configSource, Action<BusConfiguration> configurationBuilderCustomization);
+        Task<BusConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointConfiguration endpointConfiguration, IConfigurationSource configSource, Action<BusConfiguration> configurationBuilderCustomization);
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -163,7 +163,7 @@
 
             try
             {
-                var runners = InitializeRunners(runDescriptor, behaviorDescriptors);
+                var runners = await InitializeRunners(runDescriptor, behaviorDescriptors).ConfigureAwait(false);
 
                 runResult.ActiveEndpoints = runners.Select(r => r.EndpointName).ToList();
 
@@ -276,7 +276,7 @@
 
             var whenAll = Task.WhenAll(tasks);
             var timeoutTask = Task.Delay(TimeSpan.FromMinutes(2));
-            var completedTask = await Task.WhenAny(whenAll, timeoutTask);
+            var completedTask = await Task.WhenAny(whenAll, timeoutTask).ConfigureAwait(false);
 
             if (completedTask.Equals(timeoutTask))
                 throw new Exception("Starting endpoints took longer than 2 minutes");
@@ -309,7 +309,7 @@
             }
         }
 
-        static List<ActiveRunner> InitializeRunners(RunDescriptor runDescriptor, IList<EndpointBehavior> behaviorDescriptors)
+        static async Task<List<ActiveRunner>> InitializeRunners(RunDescriptor runDescriptor, IList<EndpointBehavior> behaviorDescriptors)
         {
             var runners = new List<ActiveRunner>();
             var routingTable = CreateRoutingTable(behaviorDescriptors);
@@ -328,7 +328,7 @@
                     Instance = new EndpointRunner(),
                     EndpointName = endpointName
                 };
-                var result = runner.Instance.Initialize(runDescriptor, behaviorDescriptor, routingTable, endpointName);
+                var result = await runner.Instance.Initialize(runDescriptor, behaviorDescriptor, routingTable, endpointName).ConfigureAwait(false);
 
                 if (result.Failed)
                 {

--- a/src/NServiceBus.AcceptanceTests/ConfigureMsmqTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureMsmqTransport.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Messaging;
+using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.Configuration.AdvanceExtensibility;
 
@@ -8,12 +9,13 @@ public class ConfigureMsmqTransport
 {
     BusConfiguration busConfiguration;
 
-    public void Configure(BusConfiguration configuration)
+    public Task Configure(BusConfiguration configuration)
     {
         busConfiguration = configuration;
+        return Task.FromResult(0);
     }
 
-    public void Cleanup()
+    public Task Cleanup()
     {
         var name = busConfiguration.GetSettings().EndpointName();
         var nameFilter = @"private$\" + name;
@@ -38,5 +40,7 @@ public class ConfigureMsmqTransport
         }
 
         MessageQueue.ClearConnectionCache();
+
+        return Task.FromResult(0);
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Encryption/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/Encryption/EndpointTemplates/ConfigureExtensions.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Reflection;
+    using System.Threading.Tasks;
     using NServiceBus.Configuration.AdvanceExtensibility;
     using ScenarioDescriptors;
 
@@ -18,7 +19,7 @@
             return dictionary[key];
         }
 
-        public static void DefineTransport(this BusConfiguration config, IDictionary<string, string> settings, Type endpointBuilderType)
+        public static async Task DefineTransport(this BusConfiguration config, IDictionary<string, string> settings, Type endpointBuilderType)
         {
             if (!settings.ContainsKey("Transport"))
             {
@@ -39,7 +40,7 @@
 
                 dynamic dc = configurer;
 
-                dc.Configure(config);
+                await dc.Configure(config);
                 var cleanupMethod = configurer.GetType().GetMethod("Cleanup", BindingFlags.Public | BindingFlags.Instance);
                 config.GetSettings().Set("CleanupTransport", cleanupMethod != null ? configurer : new Cleaner());
                 return;
@@ -60,7 +61,7 @@
             }
         }
 
-        public static void DefinePersistence(this BusConfiguration config, IDictionary<string, string> settings)
+        public static async Task DefinePersistence(this BusConfiguration config, IDictionary<string, string> settings)
         {
             if (!settings.ContainsKey("Persistence"))
             { 
@@ -80,7 +81,7 @@
 
                 dynamic dc = configurer;
 
-                dc.Configure(config);
+                await dc.Configure(config);
 
                 var cleanupMethod = configurer.GetType().GetMethod("Cleanup", BindingFlags.Public | BindingFlags.Instance);
                 config.GetSettings().Set("CleanupPersistence", cleanupMethod != null ? configurer : new Cleaner());
@@ -92,8 +93,9 @@
 
         class Cleaner
         {
-            public void Cleanup()
+            public Task Cleanup()
             {
+                return Task.FromResult(0);
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Encryption/EndpointTemplates/DefaultPublisher.cs
+++ b/src/NServiceBus.AcceptanceTests/Encryption/EndpointTemplates/DefaultPublisher.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.AcceptanceTests.EndpointTemplates
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTesting.Support;
     using NServiceBus.Config.ConfigurationSource;
@@ -12,7 +13,7 @@ namespace NServiceBus.AcceptanceTests.EndpointTemplates
 
     public class DefaultPublisher : IEndpointSetupTemplate
     {
-        public BusConfiguration GetConfiguration(RunDescriptor runDescriptor, EndpointConfiguration endpointConfiguration, IConfigurationSource configSource, Action<BusConfiguration> configurationBuilderCustomization)
+        public Task<BusConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointConfiguration endpointConfiguration, IConfigurationSource configSource, Action<BusConfiguration> configurationBuilderCustomization)
         {
             return new DefaultServer(new List<Type> { typeof(SubscriptionTracer), typeof(SubscriptionTracer.Registration) }).GetConfiguration(runDescriptor, endpointConfiguration, configSource, b =>
             {

--- a/src/NServiceBus.AcceptanceTests/Encryption/EndpointTemplates/DefaultServer.cs
+++ b/src/NServiceBus.AcceptanceTests/Encryption/EndpointTemplates/DefaultServer.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using System.Threading.Tasks;
     using AcceptanceTesting.Support;
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
@@ -27,7 +28,7 @@
             this.typesToInclude = typesToInclude;
         }
 
-        public BusConfiguration GetConfiguration(RunDescriptor runDescriptor, EndpointConfiguration endpointConfiguration, IConfigurationSource configSource, Action<BusConfiguration> configurationBuilderCustomization)
+        public async Task<BusConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointConfiguration endpointConfiguration, IConfigurationSource configSource, Action<BusConfiguration> configurationBuilderCustomization)
         {
             var settings = runDescriptor.Settings;            
 
@@ -45,7 +46,7 @@
             // TimeoutManager is currently required by Sagas
             builder.EnableFeature<TimeoutManager>();
             builder.DisableFeature<SecondLevelRetries>();
-            builder.DefineTransport(settings, endpointConfiguration.BuilderType);
+            await builder.DefineTransport(settings, endpointConfiguration.BuilderType);
             builder.DefineTransactions(settings);
             builder.DefineBuilder(settings);
             builder.RegisterComponents(r =>
@@ -63,7 +64,7 @@
             {
                 builder.UseSerialization(Type.GetType(serializer));
             }
-            builder.DefinePersistence(settings);
+            await builder.DefinePersistence(settings);
 
             builder.GetSettings().SetDefault("ScaleOut.UseSingleBrokerQueue", true);
             configurationBuilderCustomization(builder);


### PR DESCRIPTION
This PR is part of the work to make the core async enabled. For more background read [Async/Await: It's time!](http://particular.net/blog/async-await-its-time) blogpost

`Configure` and `Cleanup` phase for persistence and transport are now async as well.

@Particular/tf-asyncawait please review