### PR TITLE
Gateway message deduplication is async

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1368,7 +1368,7 @@ namespace NServiceBus.Gateway.Deduplication
 {
     public interface IDeduplicateMessages
     {
-        bool DeduplicateMessage(string clientId, System.DateTime timeReceived);
+        System.Threading.Tasks.Task<bool> DeduplicateMessage(string clientId, System.DateTime timeReceived);
     }
 }
 namespace NServiceBus.Hosting.Helpers

--- a/src/NServiceBus.Core/Gateway/IDeduplicateMessages.cs
+++ b/src/NServiceBus.Core/Gateway/IDeduplicateMessages.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Gateway.Deduplication
 {
     using System;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Defines the api for storages that wants to provide storage for gateway deduplication.
@@ -12,6 +13,6 @@
         /// </summary>
         /// <param name="clientId">The client id that defines the range of ids to check for duplicates.</param>
         /// <param name="timeReceived">The time received of the message to allow the storage to do cleanup.</param>
-        bool DeduplicateMessage(string clientId, DateTime timeReceived);
+        Task<bool> DeduplicateMessage(string clientId, DateTime timeReceived);
     }
 }

--- a/src/NServiceBus.Core/Persistence/InMemory/Gateway/InMemoryGatewayDeduplication.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Gateway/InMemoryGatewayDeduplication.cs
@@ -3,18 +3,19 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
 
     class InMemoryGatewayDeduplication : IDeduplicateMessages
     {
-        public bool DeduplicateMessage(string clientId, DateTime timeReceived)
+        public Task<bool> DeduplicateMessage(string clientId, DateTime timeReceived)
         {
             lock (persistence)
             {
                 var item = persistence.SingleOrDefault(m => m.Id == clientId);
                 if (item != null)
-                    return false;
+                    return Task.FromResult(false);
 
-                return persistence.Add(new GatewayMessage { Id = clientId, TimeReceived = timeReceived });
+                return Task.FromResult(persistence.Add(new GatewayMessage { Id = clientId, TimeReceived = timeReceived }));
             }
         }
 


### PR DESCRIPTION
This PR is part of the work to make the core async enabled. For more background read [Async/Await: It's time!](http://particular.net/blog/async-await-its-time) blogpost


The question is:

Should this still be in core?

@Particular/tf-asyncawait please review