### PR TITLE
OutboxStorage is async

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_clearing_saga_timeouts.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_clearing_saga_timeouts.cs
@@ -1,8 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Reliability.Outbox
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -83,20 +81,20 @@
                 this.context = context;
             }
 
-            public bool TryGet(string messageId, OutboxStorageOptions options, out OutboxMessage message)
+            public Task<OutboxMessage> Get(string messageId, OutboxStorageOptions options)
             {
-                message = null;
-                return false;
+                return Task.FromResult(default(OutboxMessage));
             }
 
-            public void Store(string messageId, IEnumerable<TransportOperation> transportOperations, OutboxStorageOptions options)
+            public Task Store(OutboxMessage message, OutboxStorageOptions options)
             {
-                context.NumberOfOps = transportOperations.Count();
+                context.NumberOfOps = message.TransportOperations.Count;
+                return Task.FromResult(0);
             }
 
-            public void SetAsDispatched(string messageId, OutboxStorageOptions options)
+            public Task SetAsDispatched(string messageId, OutboxStorageOptions options)
             {
-
+                return Task.FromResult(0);
             }
         }
 

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1587,9 +1587,9 @@ namespace NServiceBus.Outbox
 {
     public interface IOutboxStorage
     {
-        void SetAsDispatched(string messageId, NServiceBus.Outbox.OutboxStorageOptions options);
-        void Store(string messageId, System.Collections.Generic.IEnumerable<NServiceBus.Outbox.TransportOperation> transportOperations, NServiceBus.Outbox.OutboxStorageOptions options);
-        bool TryGet(string messageId, NServiceBus.Outbox.OutboxStorageOptions options, out NServiceBus.Outbox.OutboxMessage message);
+        System.Threading.Tasks.Task<NServiceBus.Outbox.OutboxMessage> Get(string messageId, NServiceBus.Outbox.OutboxStorageOptions options);
+        System.Threading.Tasks.Task SetAsDispatched(string messageId, NServiceBus.Outbox.OutboxStorageOptions options);
+        System.Threading.Tasks.Task Store(NServiceBus.Outbox.OutboxMessage message, NServiceBus.Outbox.OutboxStorageOptions options);
     }
     public class OutboxMessage
     {

--- a/src/NServiceBus.Core.Tests/Reliability/Outbox/FakeOutboxStorage.cs
+++ b/src/NServiceBus.Core.Tests/Reliability/Outbox/FakeOutboxStorage.cs
@@ -1,37 +1,35 @@
 ﻿namespace NServiceBus.Core.Tests.Reliability.Outbox
 {
-    using System.Collections.Generic;
+    using System.Threading.Tasks;
     using NServiceBus.Outbox;
 
-    internal class FakeOutboxStorage : IOutboxStorage
+    class FakeOutboxStorage : IOutboxStorage
     {
         public OutboxMessage ExistingMessage { get; set; }
         public OutboxMessage StoredMessage { get; set; }
 
         public bool WasDispatched { get; set; }
 
-        public bool TryGet(string messageId, OutboxStorageOptions options, out OutboxMessage message)
+        public Task<OutboxMessage> Get(string messageId, OutboxStorageOptions options)
         {
-            message = null;
-
             if (ExistingMessage != null && ExistingMessage.MessageId == messageId)
             {
-                message = ExistingMessage;
-                return true;
+                return Task.FromResult(ExistingMessage);
             }
 
-            return false;
+            return Task.FromResult(default(OutboxMessage));
         }
 
-        public void Store(string messageId, IEnumerable<TransportOperation> transportOperations, OutboxStorageOptions options)
+        public Task Store(OutboxMessage message, OutboxStorageOptions options)
         {
-            StoredMessage = new OutboxMessage(messageId);
-            StoredMessage.TransportOperations.AddRange(transportOperations);
+            StoredMessage = message;
+            return Task.FromResult(0);
         }
 
-        public void SetAsDispatched(string messageId, OutboxStorageOptions options)
+        public Task SetAsDispatched(string messageId, OutboxStorageOptions options)
         {
             WasDispatched = true;
+            return Task.FromResult(0);
         }
     }
 }

--- a/src/NServiceBus.Core/Reliability/Outbox/IOutboxStorage.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/IOutboxStorage.cs
@@ -1,6 +1,6 @@
 ﻿namespace NServiceBus.Outbox
 {
-    using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Implemented by the persisters to provide outbox storage capabilities.
@@ -10,16 +10,17 @@
         /// <summary>
         /// Tries to find the given message in the outbox.
         /// </summary>
-        bool TryGet(string messageId, OutboxStorageOptions options, out OutboxMessage message);
+        /// <returns>If there is no <see cref="OutboxMessage"/> present for the given <paramref name="messageId"/> then null is returned.</returns>
+        Task<OutboxMessage> Get(string messageId, OutboxStorageOptions options);
 
         /// <summary>
         /// Stores.
         /// </summary>
-        void Store(string messageId, IEnumerable<TransportOperation> transportOperations, OutboxStorageOptions options);
+        Task Store(OutboxMessage message, OutboxStorageOptions options);
 
         /// <summary>
         /// Tells the storage that the message has been dispatched and its now safe to clean up the transport operations.
         /// </summary>
-        void SetAsDispatched(string messageId, OutboxStorageOptions options);
+        Task SetAsDispatched(string messageId, OutboxStorageOptions options);
     }
 }

--- a/src/NServiceBus.Core/Reliability/Outbox/OutboxDeduplicationBehavior.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/OutboxDeduplicationBehavior.cs
@@ -29,9 +29,9 @@
         {
             var options = new OutboxStorageOptions(context);
             var messageId = context.GetPhysicalMessage().Id;
-            OutboxMessage outboxMessage;
+            var outboxMessage = outboxStorage.Get(messageId, options).GetAwaiter().GetResult();
 
-            if (!outboxStorage.TryGet(messageId, options, out outboxMessage))
+            if (outboxMessage == null)
             {
                 outboxMessage = new OutboxMessage(messageId);
 
@@ -51,12 +51,12 @@
                     return;
                 }
 
-                outboxStorage.Store(messageId, outboxMessage.TransportOperations, options);
+                outboxStorage.Store(outboxMessage, options).GetAwaiter().GetResult();
             }
 
             DispatchOperationToTransport(outboxMessage.TransportOperations, context);
 
-            outboxStorage.SetAsDispatched(messageId, options);
+            outboxStorage.SetAsDispatched(messageId, options).GetAwaiter().GetResult();
         }
 
         void DispatchOperationToTransport(IEnumerable<TransportOperation> operations, Context context)


### PR DESCRIPTION
This PR is part of the work to make the core async enabled. For more background read [Async/Await: It's time!](http://particular.net/blog/async-await-its-time) blogpost

@timbussmann and I decided to streamline the API of the timeout persister and the outbox storage. Out parameters are not supported with async/await. For simplicity we went with returning null if nothing found. Here in this PR I also enforce that complete `OutboxMessage` needs to be passed into `Store`.

@Particular/tf-asyncawait Please review