### PR TITLE
Guarantee uniqueness for saga entity declaring classes as well, for NH

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_existing_saga_instance_exists.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_existing_saga_instance_exists.cs
@@ -12,7 +12,7 @@
         public async Task Should_hydrate_and_invoke_the_existing_instance()
         {
             var context = await Scenario.Define<Context>()
-                .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                .WithEndpoint<ExistingSagaInstanceEndpt>(b => b.Given(bus =>
                     {
                         bus.SendLocal(new StartSagaMessage { SomeId = Guid.NewGuid() });
                         return Task.FromResult(0);
@@ -31,9 +31,9 @@
             public Guid SecondSagaId { get; set; }
         }
 
-        public class SagaEndpoint : EndpointConfigurationBuilder
+        public class ExistingSagaInstanceEndpt : EndpointConfigurationBuilder
         {
-            public SagaEndpoint()
+            public ExistingSagaInstanceEndpt()
             {
                 EndpointSetup<DefaultServer>();
             }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
@@ -14,7 +14,7 @@
         public async Task Should_invoke_the_correct_handle_methods_on_the_saga()
         {
             await Scenario.Define<Context>()
-                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                    .WithEndpoint<SagaMsgThruSlrEndpt>(b => b.Given(bus =>
                     {
                         bus.SendLocal(new StartSagaMessage { SomeId = Guid.NewGuid() });
                         return Task.FromResult(0);
@@ -33,9 +33,9 @@
             public int NumberOfTimesInvoked { get; set; }
         }
 
-        public class SagaEndpoint : EndpointConfigurationBuilder
+        public class SagaMsgThruSlrEndpt : EndpointConfigurationBuilder
         {
-            public SagaEndpoint()
+            public SagaMsgThruSlrEndpt()
             {
                 EndpointSetup<DefaultServer>();
             }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_completes_the_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_completes_the_saga.cs
@@ -13,7 +13,7 @@
         public async Task Should_hydrate_and_complete_the_existing_instance()
         {
             await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
-                    .WithEndpoint<SagaEndpoint>(b =>
+                    .WithEndpoint<RecvCompletesSagaEndpt>(b =>
                         {
                             b.Given((bus, context) =>
                             {
@@ -41,7 +41,7 @@
         public async Task Should_ignore_messages_afterwards()
         {
             await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
-                .WithEndpoint<SagaEndpoint>(b =>
+                .WithEndpoint<RecvCompletesSagaEndpt>(b =>
                 {
                     b.Given((bus, c) =>
                     {
@@ -88,9 +88,9 @@
             public bool SagaReceivedAnotherMessage { get; set; }
         }
 
-        public class SagaEndpoint : EndpointConfigurationBuilder
+        public class RecvCompletesSagaEndpt : EndpointConfigurationBuilder
         {
-            public SagaEndpoint()
+            public RecvCompletesSagaEndpt()
             {
                 EndpointSetup<DefaultServer>(b => b.ExecuteTheseHandlersFirst(typeof(TestSaga10)));
             }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_has_a_non_empty_constructor.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_has_a_non_empty_constructor.cs
@@ -15,7 +15,7 @@
         public async Task Should_hydrate_and_invoke_the_existing_instance()
         {
             await Scenario.Define<Context>()
-                    .WithEndpoint<SagaEndpoint>(b => b.Given(bus =>
+                    .WithEndpoint<NonEmptySagaCtorEndpt>(b => b.Given(bus =>
                         {
                             bus.SendLocal(new StartSagaMessage { SomeId = IdThatSagaIsCorrelatedOn });
                             return Task.FromResult(0);
@@ -31,9 +31,9 @@
 
         }
 
-        public class SagaEndpoint : EndpointConfigurationBuilder
+        public class NonEmptySagaCtorEndpt : EndpointConfigurationBuilder
         {
-            public SagaEndpoint()
+            public NonEmptySagaCtorEndpt()
             {
                 EndpointSetup<DefaultServer>();
             }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
@@ -13,7 +13,7 @@
         public async Task Timeout_should_be_received_after_expiration()
         {
             await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
-                    .WithEndpoint<SagaEndpoint>(g => g.Given(bus =>
+                    .WithEndpoint<RecvMsgForTimeoutEndpt>(g => g.Given(bus =>
                     {
                         bus.SendLocal(new StartSagaMessage());
                         return Task.FromResult(0);
@@ -31,9 +31,9 @@
             public bool TimeoutReceived { get; set; }
         }
 
-        public class SagaEndpoint : EndpointConfigurationBuilder
+        public class RecvMsgForTimeoutEndpt : EndpointConfigurationBuilder
         {
-            public SagaEndpoint()
+            public RecvMsgForTimeoutEndpt()
             {
                 EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
             }

--- a/src/NServiceBus.AcceptanceTests/SelfVerification/When_running_saga_tests.cs
+++ b/src/NServiceBus.AcceptanceTests/SelfVerification/When_running_saga_tests.cs
@@ -47,11 +47,16 @@
             var sagaEntities = allTypes.Where(t => typeof(IContainSagaData).IsAssignableFrom(t) && !t.IsInterface)
                .ToArray();
 
+            var nestedSagaEntityParents = sagaEntities
+                .Where(t => t.DeclaringType != null)
+                .Select(t => t.DeclaringType)
+                .ToArray();
+
             var usedNames = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
             var offenders = 0;
 
             Console.WriteLine("Sagas / Saga Entities with non-unique names:");
-            foreach (var cls in sagas.Union(sagaEntities))
+            foreach (var cls in sagas.Union(sagaEntities).Union(nestedSagaEntityParents))
             {
                 if (usedNames.Contains(cls.Name))
                 {


### PR DESCRIPTION
Similar to #2814 - more ensuring names are unique. But this time, the target is declaring classes when saga entities are nested types, because NHibernate (for historical reasons, I think) will use the declaring type (one direct parent relationship, not all the way to the top) to determine the table name.

One acceptance test guarantees uniqueness via reflection, and the rest of the changes fix it for the acceptance tests in core.