### PR TITLE
add SimulatedException for acceptance tests

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
+++ b/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Support\ScenarioDescriptor.cs" />
     <Compile Include="Support\ScenarioException.cs" />
     <Compile Include="Support\ScenarioRunner.cs" />
+    <Compile Include="Support\SimulatedException.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\NServiceBus.Core\NServiceBus.Core.csproj">

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -101,6 +101,11 @@ namespace NServiceBus.AcceptanceTesting
             return this;
         }
 
+        public IScenarioWithEndpointBehavior<TContext> AllowSimulatedExceptions()
+        {
+            return AllowExceptions(e => e is SimulatedException);
+        }
+
         public IAdvancedScenarioWithEndpointBehavior<TContext> MaxTestParallelism(int maxParallelism)
         {
             limitTestParallelismTo = maxParallelism;

--- a/src/NServiceBus.AcceptanceTesting/Support/IScenarioWithEndpointBehavior.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/IScenarioWithEndpointBehavior.cs
@@ -18,6 +18,8 @@
         IAdvancedScenarioWithEndpointBehavior<TContext> Repeat(Action<RunDescriptorsBuilder> runtimeDescriptor);
 
         IScenarioWithEndpointBehavior<TContext> AllowExceptions(Func<Exception,bool> filter = null);
+
+        IScenarioWithEndpointBehavior<TContext> AllowSimulatedExceptions();
     }
 
     public interface IAdvancedScenarioWithEndpointBehavior<TContext> where TContext : ScenarioContext

--- a/src/NServiceBus.AcceptanceTesting/Support/SimulatedException.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/SimulatedException.cs
@@ -1,0 +1,27 @@
+﻿namespace NServiceBus.AcceptanceTesting
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// A dummy exception to be used in acceptance tests for easier differentation from real exceptions.
+    /// </summary>
+    public class SimulatedException : Exception
+    {
+        public SimulatedException()
+        {
+        }
+
+        public SimulatedException(string message) : base(message)
+        {
+        }
+
+        public SimulatedException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        protected SimulatedException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/NonTx/When_sending_inside_ambient_tx.cs
+++ b/src/NServiceBus.AcceptanceTests/NonTx/When_sending_inside_ambient_tx.cs
@@ -19,7 +19,7 @@
                         bus.SendLocal(new MyMessage());
                         return Task.FromResult(0);
                     }))
-                    .AllowExceptions()
+                    .AllowSimulatedExceptions()
                     .Done(c => c.TestComplete)
                     .Repeat(r => r.For<AllDtcTransports>()) 
                     .Should(c => Assert.False(c.MessageEnlistedInTheAmbientTxReceived, "The enlisted bus.Send should not commit"))
@@ -57,7 +57,7 @@
                         Bus.SendLocal(new CompleteTest());
                     }
 
-                    throw new Exception("Simulated exception");
+                    throw new SimulatedException();
                 }
             }
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_default_settings.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_default_settings.cs
@@ -19,7 +19,7 @@
                         bus.SendLocal(new MessageToBeRetried { Id = context.Id, SecondMessage = true });
                         return Task.FromResult(0);
                     }))
-                    .AllowExceptions()
+                    .AllowSimulatedExceptions()
                     .Done(c => c.SecondMessageReceived || c.NumberOfTimesInvoked > 1)
                     .Repeat(r => r.For(Transports.Default))
                     .Should(c => Assert.AreEqual(1, c.NumberOfTimesInvoked, "No retries should be in use if transactions are off"))
@@ -60,7 +60,7 @@
 
                     Context.NumberOfTimesInvoked++;
 
-                    throw new Exception("Simulated exception");
+                    throw new SimulatedException();
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_dtc_on.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_dtc_on.cs
@@ -22,13 +22,13 @@
                        bus.SendLocal(new MessageToBeRetried { Id = context.Id });
                        return Task.FromResult(0);
                    }))
-                   .AllowExceptions()
+                   .AllowSimulatedExceptions()
                    .Done(c => c.GaveUpOnRetries)
                    .Repeat(r => r.For<AllDtcTransports>())
                    .Should(c =>
                    {
-                        //we add 1 since first call + X retries totals to X+1
-                        Assert.AreEqual(maxretries + 1, c.NumberOfTimesInvoked, string.Format("The FLR should by default retry {0} times", maxretries));
+                       //we add 1 since first call + X retries totals to X+1
+                       Assert.AreEqual(maxretries + 1, c.NumberOfTimesInvoked, string.Format("The FLR should by default retry {0} times", maxretries));
                        Assert.AreEqual(maxretries, c.Logs.Count(l => l.Message
                            .StartsWith(string.Format("First Level Retry is going to retry message '{0}' because of an exception:", c.PhysicalMessageId))));
                        Assert.AreEqual(1, c.Logs.Count(l => l.Message
@@ -87,7 +87,7 @@
                     Context.PhysicalMessageId = Bus.CurrentMessageContext.Id;
                     Context.NumberOfTimesInvoked++;
 
-                    throw new Exception("Simulated exception");
+                    throw new SimulatedException();
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
@@ -19,7 +19,7 @@
                         bus.SendLocal(new MessageToBeRetried { Id = context.Id });
                         return Task.FromResult(0);
                     }))
-                    .AllowExceptions()
+                    .AllowSimulatedExceptions()
                     .Done(c => c.ForwardedToErrorQueue)
                     .Repeat(r => r.For(Transports.Default))
                     .Should(c =>
@@ -87,7 +87,7 @@
                     Context.PhysicalMessageId = Bus.CurrentMessageContext.Id;
                     Context.NumberOfTimesInvoked++;
 
-                    throw new Exception("Simulated exception");
+                    throw new SimulatedException();
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_flr.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_flr.cs
@@ -22,7 +22,7 @@
                         bus.SendLocal(new MessageToBeRetried { Id = context.Id });
                         return Task.FromResult(0);
                     }))
-                    .AllowExceptions(e => e.Message.Contains("Simulated exception"))
+                    .AllowSimulatedExceptions()
                     .Done(c => c.NumberOfTimesInvoked >= 2)
                     .Repeat(r => r.For(Transports.Default))
                     .Should(context =>
@@ -95,7 +95,7 @@
                     }
 
 
-                    throw new Exception("Simulated exception");
+                    throw new SimulatedException();
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_with_retries_set_to_0.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_with_retries_set_to_0.cs
@@ -14,7 +14,7 @@
         {
             var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<RetryEndpoint>()
-                    .AllowExceptions()
+                    .AllowSimulatedExceptions()
                     .Done(c => c.GaveUp)
                     .Run();
 
@@ -72,7 +72,7 @@
                         return Task.FromResult(0);
                     }
                     Context.NumberOfTimesInvoked++;
-                    throw new Exception("Simulated exception");
+                    throw new SimulatedException();
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
@@ -19,7 +19,7 @@
                         bus.SendLocal(new MessageWhichFailsRetries());
                         return Task.FromResult(0);
                     }))
-                    .AllowExceptions(e => e is RetryEndpoint.SimulatedException)
+                    .AllowSimulatedExceptions()
                     .Done(c => c.ForwardedToErrorQueue)
                     .Run();
 
@@ -74,10 +74,6 @@
                     Context.PhysicalMessageId = Bus.CurrentMessageContext.Id;
                     throw new SimulatedException();
                 }
-            }
-
-            public class SimulatedException : Exception
-            {
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr.cs
@@ -115,9 +115,5 @@
         public class MessageToBeRetried : IMessage
         {
         }
-
-        public class SimulatedException : Exception
-        {
-        }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_regular_exception.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_regular_exception.cs
@@ -16,7 +16,7 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
                     bus.SendLocal(new MessageToBeRetried());
                     return Task.FromResult(0);
                 }))
-                .AllowExceptions(e => e is SimulatedException)
+                .AllowSimulatedExceptions()
                 .Done(c => c.SlrChecksum != default(byte))
                 .Run();
 
@@ -32,7 +32,7 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
                     bus.SendLocal(new MessageToBeRetried());
                     return Task.FromResult(0);
                 }))
-                .AllowExceptions(e => e is SimulatedException)
+                .AllowSimulatedExceptions()
                 .Done(c => c.ForwardedToErrorQueue)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_error_is_overridden_in_code.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_error_is_overridden_in_code.cs
@@ -19,7 +19,7 @@
                     return Task.FromResult(0);
                 }))
                 .WithEndpoint<ErrorSpy>()
-                .AllowExceptions()
+                .AllowSimulatedExceptions()
                 .Done(c => c.MessageReceived)
                 .Run();
 
@@ -45,7 +45,7 @@
             {
                 public Task Handle(Message message)
                 {
-                    throw new Exception();
+                    throw new SimulatedException();
                 }
             }
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_message_with_TimeToBeReceived_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_message_with_TimeToBeReceived_fails.cs
@@ -15,7 +15,7 @@
             var context = await Scenario.Define<Context>()
             .WithEndpoint<EndpointThatThrows>(b => b.Given(Send()))
             .WithEndpoint<EndpointThatHandlesErrorMessages>()
-            .AllowExceptions()
+            .AllowSimulatedExceptions()
             .Done(c => c.MessageFailed && c.TTBRHasExpiredAndMessageIsStillInErrorQueue)
             .Run();
 
@@ -66,7 +66,7 @@
                 public Task Handle(MessageThatFails message)
                 {
                     context.MessageFailed = true;
-                    throw new Exception("Simulated exception");
+                    throw new SimulatedException();
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_audited.cs
@@ -21,7 +21,7 @@
                         return Task.FromResult(0);
                     }))
                     .WithEndpoint<AuditSpyEndpoint>()
-                    .AllowExceptions(e => e is EndpointWithAuditOn.BlowUpAfterDispatchBehavior.FakeException)
+                    .AllowSimulatedExceptions()
                     .Done(c => c.Done)
                     .Run();
 
@@ -84,11 +84,7 @@
 
                     called = true;
 
-                    throw new FakeException();
-                }
-
-                public class FakeException : Exception
-                {
+                    throw new SimulatedException();
                 }
 
                 static bool called;

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_forwarded.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_forwarded.cs
@@ -22,7 +22,7 @@
                         return Task.FromResult(0);
                     }))
                     .WithEndpoint<ForwardingSpyEndpoint>()
-                    .AllowExceptions(e => e is EndpointWithAuditOn.BlowUpAfterDispatchBehavior.FakeException)
+                    .AllowSimulatedExceptions()
                     .Done(c => c.Done)
                     .Run();
 
@@ -83,11 +83,7 @@
 
                     called = true;
 
-                    throw new FakeException();
-                }
-
-                public class FakeException : Exception
-                {
+                    throw new SimulatedException();
                 }
 
                 static bool called;

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_blowing_up_just_after_dispatch.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_blowing_up_just_after_dispatch.cs
@@ -20,7 +20,7 @@
                     bus.SendLocal(new PlaceOrder());
                     return Task.FromResult(0);
                 }))
-                .AllowExceptions()
+                .AllowSimulatedExceptions()
                 .Done(c => c.OrderAckReceived == 1)
                 .Repeat(r=>r.For<AllOutboxCapableStorages>())
                 .Should(context => Assert.AreEqual(1, context.OrderAckReceived, "Order ack should have been received since outbox dispatch isn't part of the receive tx"))
@@ -83,7 +83,7 @@
 
                     called = true;
 
-                    throw new Exception("Fake ex after dispatch");
+                    throw new SimulatedException();
                 }
 
                 static bool called;

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
@@ -19,7 +19,7 @@
                         bus.SendLocal(new StartSagaMessage { SomeId = Guid.NewGuid() });
                         return Task.FromResult(0);
                     }))
-                    .AllowExceptions()
+                    .AllowSimulatedExceptions()
                     .Done(c => c.SecondMessageProcessed)
                     .Repeat(r => r.For(Transports.Default))
                     .Run();
@@ -69,7 +69,7 @@
                     var shouldFail = Context.NumberOfTimesInvoked < 2; //1 FLR and 1 SLR
 
                     if(shouldFail)
-                        throw new Exception("Simulated exception");
+                        throw new SimulatedException();
 
                     Context.SecondMessageProcessed = true;
 

--- a/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_native_multi_queue_transaction.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_native_multi_queue_transaction.cs
@@ -19,7 +19,7 @@
                      return Task.FromResult(0);
                  }))
                  .Done(c => c.MessageHandled)
-                 .AllowExceptions(e => e is Endpoint.FakeException)
+                 .AllowSimulatedExceptions()
                  .Repeat(r => r.For<AllNativeMultiQueueTransactionTransports>())
                  .Should(c =>
                  {
@@ -58,7 +58,7 @@
                             HasFailed = true
                         });
                         Context.FirstAttempt = false;
-                        throw new FakeException();
+                        throw new SimulatedException();
                     }
 
                     Bus.SendLocal(new MessageHandledEvent());
@@ -78,10 +78,6 @@
                     Context.HasFailed |= @event.HasFailed;
                     return Task.FromResult(0);
                 }
-            }
-
-            public class FakeException : Exception
-            {
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_transactions_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_transactions_disabled.cs
@@ -19,7 +19,7 @@
                         bus.SendLocal(new MyMessage());
                         return Task.FromResult(0);
                     }))
-                    .AllowExceptions()
+                    .AllowSimulatedExceptions()
                     .Done(c => c.TestComplete)
                     .Repeat(r => r.For(Transports.Default))
                     .Should(c => Assert.AreEqual(1, c.TimesCalled, "Should not retry the message"))
@@ -54,7 +54,7 @@
                         Bus.SendLocal(new CompleteTest());
                     }
 
-                    throw new Exception("Simulated exception");
+                    throw new SimulatedException();
                 }
             }
 


### PR DESCRIPTION
* adds a `SimulatedException` for acceptance tests to use instead of `Exception`
* allows a more fine grained `AllowExceptions()` configuration which should avoid allowing all Exceptions and possibly miss a non-expected exception
* adds a `AllowSimulatedExceptions()` configuration option for Scenario.Define which is a shortcut to `AllowExceptions(e => e is SimulatedException)`
* replaced all test specific fake/simulated exception classes