### PR TITLE
Batched dispatching

### DIFF
--- a/src/NServiceBus.AcceptanceTests/FakeTransport/FakeDispatcher.cs
+++ b/src/NServiceBus.AcceptanceTests/FakeTransport/FakeDispatcher.cs
@@ -1,11 +1,12 @@
 namespace NServiceBus.AcceptanceTests.FakeTransport
 {
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using NServiceBus.Transports;
 
     class FakeDispatcher : IDispatchMessages
     {
-        public Task Dispatch(OutgoingMessage message, DispatchOptions dispatchOptions)
+        public Task Dispatch(IEnumerable<TransportOperation> outgoingMessages)
         {
             return Task.FromResult(0);
         }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2499,7 +2499,7 @@ namespace NServiceBus.Transports
     }
     public interface IDispatchMessages
     {
-        System.Threading.Tasks.Task Dispatch(NServiceBus.Transports.OutgoingMessage message, NServiceBus.Transports.DispatchOptions dispatchOptions);
+        System.Threading.Tasks.Task Dispatch(System.Collections.Generic.IEnumerable<NServiceBus.Transports.TransportOperation> outgoingMessages);
     }
     public interface IManageSubscriptions
     {
@@ -2583,6 +2583,12 @@ namespace NServiceBus.Transports
         public abstract System.Collections.Generic.IEnumerable<System.Type> GetSupportedDeliveryConstraints();
         public abstract string ToTransportAddress(NServiceBus.LogicalAddress logicalAddress);
     }
+    public class TransportOperation
+    {
+        public TransportOperation(NServiceBus.Transports.OutgoingMessage message, NServiceBus.Transports.DispatchOptions dispatchOptions) { }
+        public NServiceBus.Transports.DispatchOptions DispatchOptions { get; }
+        public NServiceBus.Transports.OutgoingMessage Message { get; }
+    }
     public class TransportPublishOptions
     {
         public TransportPublishOptions(System.Type eventType, NServiceBus.ConsistencyGuarantees.ConsistencyGuarantee minimumConsistencyGuarantee, System.Collections.Generic.List<NServiceBus.DeliveryConstraints.DeliveryConstraint> deliveryConstraints, NServiceBus.Pipeline.BehaviorContext context) { }
@@ -2626,7 +2632,7 @@ namespace NServiceBus.Transports.Msmq
     public class MsmqMessageSender : NServiceBus.Transports.IDispatchMessages
     {
         public MsmqMessageSender(NServiceBus.Transports.Msmq.Config.MsmqSettings settings, NServiceBus.MsmqLabelGenerator messageLabelGenerator) { }
-        public System.Threading.Tasks.Task Dispatch(NServiceBus.Transports.OutgoingMessage message, NServiceBus.Transports.DispatchOptions dispatchOptions) { }
+        public System.Threading.Tasks.Task Dispatch(System.Collections.Generic.IEnumerable<NServiceBus.Transports.TransportOperation> transportOperations) { }
     }
     [System.ObsoleteAttribute("The msmq transaction is now available via the pipeline context. Will be removed i" +
         "n version 7.0.0.", true)]

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqMessageSenderTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqMessageSenderTests.cs
@@ -31,7 +31,7 @@
                 var headers = new Dictionary<string, string>();
                 var outgoingMessage = new OutgoingMessage("1", headers, bytes);
                 var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(queueName), new ContextBag());
-                messageSender.Dispatch(outgoingMessage, dispatchOptions);
+                messageSender.Dispatch(new [] { new TransportOperation(outgoingMessage, dispatchOptions)});
                 var messageLabel = ReadMessageLabel(path);
                 Assert.AreEqual("mylabel", messageLabel);
 
@@ -59,7 +59,7 @@
                 var headers = new Dictionary<string, string>();
                 var outgoingMessage = new OutgoingMessage("1", headers, bytes);
                 var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(queueName), new ContextBag());
-                messageSender.Dispatch(outgoingMessage, dispatchOptions);
+                messageSender.Dispatch(new [] { new TransportOperation(outgoingMessage, dispatchOptions)});
                 var messageLabel = ReadMessageLabel(path);
                 Assert.IsEmpty(messageLabel);
 

--- a/src/NServiceBus.Core.Tests/Timeout/FakeMessageDispatcher.cs
+++ b/src/NServiceBus.Core.Tests/Timeout/FakeMessageDispatcher.cs
@@ -1,5 +1,7 @@
 namespace NServiceBus.Core.Tests.Timeout
 {
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.Transports;
 
@@ -13,9 +15,9 @@ namespace NServiceBus.Core.Tests.Timeout
             set { messagesSent = value; }
         }
 
-        public Task Dispatch(OutgoingMessage message, DispatchOptions dispatchOptions)
+        public Task Dispatch(IEnumerable<TransportOperation> outgoingMessages)
         {
-            MessagesSent++;
+            MessagesSent += outgoingMessages.Count();
             return Task.FromResult(0);
         }
     }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/DispatchTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/DispatchTimeoutBehavior.cs
@@ -31,7 +31,7 @@ namespace NServiceBus
             timeoutData.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
             timeoutData.Headers["NServiceBus.RelatedToTimeoutId"] = timeoutData.Id;
 
-            dispatcher.Dispatch(new OutgoingMessage(message.Id, timeoutData.Headers, timeoutData.State), sendOptions).GetAwaiter().GetResult();
+            dispatcher.Dispatch(new[] { new TransportOperation(new OutgoingMessage(message.Id, timeoutData.Headers, timeoutData.State), sendOptions)}).GetAwaiter().GetResult();
         }
 
         IDispatchMessages dispatcher;

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ExpiredTimeoutsPoller.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ExpiredTimeoutsPoller.cs
@@ -101,8 +101,8 @@ namespace NServiceBus.DelayedDelivery.TimeoutManager
 
                     dispatchRequest.Headers["Timeout.Id"] = timeoutData.Id;
 
-                    await dispatcher.Dispatch(dispatchRequest, new DispatchOptions(new DirectToTargetDestination(dispatcherAddress), new ContextBag()))
-                        .ConfigureAwait(false);
+                    var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(dispatcherAddress), new ContextBag());
+                    await dispatcher.Dispatch(new [] { new TransportOperation(dispatchRequest, dispatchOptions)}).ConfigureAwait(false);
                 }
 
                 lock (lockObject)

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
@@ -71,8 +71,9 @@ namespace NServiceBus
                 return;
             }
 
-            await dispatcher.Dispatch(new OutgoingMessage(message.Id, message.Headers, message.Body), new DispatchOptions(new DirectToTargetDestination(destination), context))
-                .ConfigureAwait(false);
+            var outgoingMessages = new OutgoingMessage(message.Id, message.Headers, message.Body);
+            var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(destination), context);
+            await dispatcher.Dispatch(new [] { new TransportOperation(outgoingMessages, dispatchOptions)}).ConfigureAwait(false);
         }
 
         async Task HandleInternal(TransportMessage message, PhysicalMessageProcessingStageBehavior.Context context)
@@ -123,7 +124,7 @@ namespace NServiceBus
                     var sendOptions = new DispatchOptions(new DirectToTargetDestination(data.Destination), context);
                     var outgoingMessage = new OutgoingMessage(data.Headers[Headers.MessageId], data.Headers, data.State);
 
-                    await dispatcher.Dispatch(outgoingMessage, sendOptions).ConfigureAwait(false);
+                    await dispatcher.Dispatch(new [] { new TransportOperation(outgoingMessage, sendOptions)}).ConfigureAwait(false);
                     return;
                 }
 

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -295,6 +295,7 @@
     <Compile Include="Transports\QueueBindings.cs" />
     <Compile Include="OutgoingPipeline\PhysicalOutgoingContextStageBehavior.cs" />
     <Compile Include="Transports\IncomingMessage.cs" />
+    <Compile Include="Transports\TransportOperation.cs" />
     <Compile Include="Transports\TransportPublishOptions.cs" />
     <Compile Include="Transports\DispatchOptions.cs" />
     <Compile Include="TransportDispatch\HeaderOptionExtensions.cs" />

--- a/src/NServiceBus.Core/Reliability/Outbox/OutboxDeduplicationBehavior.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/OutboxDeduplicationBehavior.cs
@@ -58,7 +58,7 @@
             outboxStorage.SetAsDispatched(messageId, options).GetAwaiter().GetResult();
         }
 
-        void DispatchOperationToTransport(IEnumerable<TransportOperation> operations, Context context)
+        void DispatchOperationToTransport(IEnumerable<Outbox.TransportOperation> operations, Context context)
         {
             foreach (var transportOperation in operations)
             {

--- a/src/NServiceBus.Core/Reliability/Outbox/OutboxDispatchStrategy.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/OutboxDispatchStrategy.cs
@@ -9,6 +9,7 @@ namespace NServiceBus
     using NServiceBus.Routing;
     using NServiceBus.TransportDispatch;
     using NServiceBus.Transports;
+    using TransportOperation = NServiceBus.Outbox.TransportOperation;
 
     class OutboxDispatchStrategy : DispatchStrategy
     {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -53,7 +53,8 @@
         {
             try
             {
-                dispatcher.Dispatch(subscriptionMessage, new DispatchOptions(new DirectToTargetDestination(destination), context)).GetAwaiter().GetResult();
+                var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(destination), context);
+                dispatcher.Dispatch(new [] { new TransportOperation(subscriptionMessage, dispatchOptions)}).GetAwaiter().GetResult();
             }
             catch (QueueNotFoundException ex)
             {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -40,7 +40,8 @@
                 subscriptionMessage.Headers[Headers.ReplyToAddress] = replyToAddress;
 
 
-                dispatcher.Dispatch(subscriptionMessage, new DispatchOptions(new DirectToTargetDestination(publisherAddress), context)).GetAwaiter().GetResult();
+                var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(publisherAddress), context);
+                dispatcher.Dispatch(new [] { new TransportOperation(subscriptionMessage, dispatchOptions)}).GetAwaiter().GetResult();
             }
         }
 

--- a/src/NServiceBus.Core/Routing/StorageDrivenPublishing/StorageDrivenDispatcher.cs
+++ b/src/NServiceBus.Core/Routing/StorageDrivenPublishing/StorageDrivenDispatcher.cs
@@ -27,11 +27,11 @@
 
             if (toAllSubscribersStrategy == null)
             {
-                await dispatcher.Dispatch(message, new DispatchOptions(routingStrategy,
+                var dispatchOptions = new DispatchOptions(routingStrategy,
                     currentContext,
                     currentConstraints,
-                    dispatchConsistency)).ConfigureAwait(false);
-
+                    dispatchConsistency);
+                await dispatcher.Dispatch(new [] {new TransportOperation(message, dispatchOptions)}).ConfigureAwait(false);
                 return;
             }
 
@@ -55,10 +55,11 @@
 
             foreach (var subscriber in subscribers)
             {
-                await dispatcher.Dispatch(message, new DispatchOptions(new DirectToTargetDestination(subscriber),
+                var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(subscriber),
                     currentContext,
                     currentConstraints,
-                    dispatchConsistency)).ConfigureAwait(false);
+                    dispatchConsistency);
+                await dispatcher.Dispatch(new [] { new TransportOperation(message, dispatchOptions)}).ConfigureAwait(false);
             }
         }
 

--- a/src/NServiceBus.Core/TransportDispatch/DefaultDispatchStrategy.cs
+++ b/src/NServiceBus.Core/TransportDispatch/DefaultDispatchStrategy.cs
@@ -11,7 +11,8 @@
     {
         public override Task Dispatch(IDispatchMessages dispatcher, OutgoingMessage message, RoutingStrategy routingStrategy, IEnumerable<DeliveryConstraint> constraints, BehaviorContext currentContext, DispatchConsistency dispatchConsistency)
         {
-            return dispatcher.Dispatch(message, new DispatchOptions(routingStrategy, currentContext, constraints, dispatchConsistency));
+            var dispatchOptions = new DispatchOptions(routingStrategy, currentContext, constraints, dispatchConsistency);
+            return dispatcher.Dispatch(new [] { new TransportOperation(message, dispatchOptions)});
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/IDispatchMessages.cs
+++ b/src/NServiceBus.Core/Transports/IDispatchMessages.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Transports
 {
     using System.Threading.Tasks;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Abstraction of the capability to dispatch messages.
@@ -8,8 +9,8 @@ namespace NServiceBus.Transports
     public interface IDispatchMessages
     {
         /// <summary>
-        /// Sends the given <paramref name="message"/>.
+        /// Dispatches the given operations to the transport.
         /// </summary>
-        Task Dispatch(OutgoingMessage message, DispatchOptions dispatchOptions);
+        Task Dispatch(IEnumerable<TransportOperation> outgoingMessages);
     }
 }

--- a/src/NServiceBus.Core/Transports/TransportOperation.cs
+++ b/src/NServiceBus.Core/Transports/TransportOperation.cs
@@ -5,32 +5,23 @@ namespace NServiceBus.Transports
     /// </summary>
     public class TransportOperation
     {
-        OutgoingMessage message;
-        DispatchOptions dispatchOptions;
-
         /// <summary>
         /// Creates a new transport operation.
         /// </summary>
         public TransportOperation(OutgoingMessage message, DispatchOptions dispatchOptions)
         {
-            this.message = message;
-            this.dispatchOptions = dispatchOptions;
+            this.Message = message;
+            this.DispatchOptions = dispatchOptions;
         }
 
         /// <summary>
         /// Gets the message.
         /// </summary>
-        public OutgoingMessage Message
-        {
-            get { return message; }
-        }
+        public OutgoingMessage Message { get; private set; }
 
         /// <summary>
         /// Gets the dispatch options.
         /// </summary>
-        public DispatchOptions DispatchOptions
-        {
-            get { return dispatchOptions; }
-        }
+        public DispatchOptions DispatchOptions { get; private set; }
     }
 }

--- a/src/NServiceBus.Core/Transports/TransportOperation.cs
+++ b/src/NServiceBus.Core/Transports/TransportOperation.cs
@@ -1,0 +1,36 @@
+namespace NServiceBus.Transports
+{
+    /// <summary>
+    /// Defines the transport operations including the message and information how to send it.
+    /// </summary>
+    public class TransportOperation
+    {
+        OutgoingMessage message;
+        DispatchOptions dispatchOptions;
+
+        /// <summary>
+        /// Creates a new transport operation.
+        /// </summary>
+        public TransportOperation(OutgoingMessage message, DispatchOptions dispatchOptions)
+        {
+            this.message = message;
+            this.dispatchOptions = dispatchOptions;
+        }
+
+        /// <summary>
+        /// Gets the message.
+        /// </summary>
+        public OutgoingMessage Message
+        {
+            get { return message; }
+        }
+
+        /// <summary>
+        /// Gets the dispatch options.
+        /// </summary>
+        public DispatchOptions DispatchOptions
+        {
+            get { return dispatchOptions; }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Unicast/ContextualBus.cs
+++ b/src/NServiceBus.Core/Unicast/ContextualBus.cs
@@ -112,7 +112,9 @@ namespace NServiceBus.Unicast
                 return;
             }
 
-            await dispatcher.Dispatch(new OutgoingMessage(MessageBeingProcessed.Id, MessageBeingProcessed.Headers, MessageBeingProcessed.Body), new DispatchOptions(new DirectToTargetDestination(sendLocalAddress), new ContextBag())).ConfigureAwait(false);
+            var outgoingMessages = new OutgoingMessage(MessageBeingProcessed.Id, MessageBeingProcessed.Headers, MessageBeingProcessed.Body);
+            var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(sendLocalAddress), new ContextBag());
+            await dispatcher.Dispatch(new [] { new TransportOperation(outgoingMessages, dispatchOptions)});
 
             incomingContext.handleCurrentMessageLaterWasCalled = true;
 
@@ -124,7 +126,9 @@ namespace NServiceBus.Unicast
         /// </summary>
         public Task ForwardCurrentMessageToAsync(string destination)
         {
-            return dispatcher.Dispatch(new OutgoingMessage(MessageBeingProcessed.Id, MessageBeingProcessed.Headers, MessageBeingProcessed.Body), new DispatchOptions(new DirectToTargetDestination(destination), new ContextBag()));
+            var outgoingMessages = new OutgoingMessage(MessageBeingProcessed.Id, MessageBeingProcessed.Headers, MessageBeingProcessed.Body);
+            var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(destination), new ContextBag());
+            await dispatcher.Dispatch(new [] { new TransportOperation(outgoingMessages, dispatchOptions)});
         }
 
         public Task SendAsync<T>(Action<T> messageConstructor, NServiceBus.SendOptions options)

--- a/src/NServiceBus.Core/Unicast/ContextualBus.cs
+++ b/src/NServiceBus.Core/Unicast/ContextualBus.cs
@@ -124,7 +124,7 @@ namespace NServiceBus.Unicast
         /// <summary>
         /// <see cref="IBus.ForwardCurrentMessageToAsync"/>
         /// </summary>
-        public Task ForwardCurrentMessageToAsync(string destination)
+        public async Task ForwardCurrentMessageToAsync(string destination)
         {
             var outgoingMessages = new OutgoingMessage(MessageBeingProcessed.Id, MessageBeingProcessed.Headers, MessageBeingProcessed.Body);
             var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(destination), new ContextBag());


### PR DESCRIPTION
 Changed the API of `IDispatchMessages` to be able to pass a collection of `TransportOperation`s to be dispatched to the transport. Rationale:
 * It allows for batching sends which can improve performance of certain transports
 * It allows to get rid of `StorageDrivenDispatcher`
 * It makes the concept of the transport operation explicit