### PR TITLE
Pipeline is async

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
+++ b/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
@@ -17,7 +17,6 @@
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
     <NuGetPackageImportStamp>c9856eed</NuGetPackageImportStamp>
     <CreateDeploymentPackage>False</CreateDeploymentPackage>
-    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/NServiceBus.AcceptanceTesting/Support/ActiveRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ActiveRunner.cs
@@ -1,8 +1,11 @@
 ﻿namespace NServiceBus.AcceptanceTesting.Support
 {
+    using System.Threading.Tasks;
+
     class ActiveRunner
     {
         public EndpointRunner Instance { get; set; }
         public string EndpointName { get; set; }
+        public Task<EndpointRunner.Result> InitializeTask { get; set; }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_sendoptions.cs
+++ b/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_sendoptions.cs
@@ -37,8 +37,6 @@
             public string Secret { get; set; }
         }
 
-
-
         public class SendOptionsExtensions : EndpointConfigurationBuilder
         {
             public SendOptionsExtensions()
@@ -60,7 +58,7 @@
 
             public class TestingSendOptionsExtensionBehavior : Behavior<OutgoingContext>
             {
-                public override void Invoke(OutgoingContext context, Action next)
+                public override Task Invoke(OutgoingContext context, Func<Task> next)
                 {
                     Context data;
                     if (context.TryGet(out data))
@@ -68,7 +66,7 @@
                         context.UpdateMessageInstance(new SendMessage { Secret = data.SomeValue });
                     }
 
-                    next();
+                    return next();
                 }
 
                 public class Context

--- a/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_the_publish_api.cs
+++ b/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_the_publish_api.cs
@@ -64,7 +64,7 @@
 
             public class PublishExtensionBehavior : Behavior<OutgoingContext>
             {
-                public override void Invoke(OutgoingContext context, Action next)
+                public override Task Invoke(OutgoingContext context, Func<Task> next)
                 {
                     Context data;
 
@@ -77,7 +77,7 @@
                         Assert.Fail("Expected to find the data");
                     }
 
-                    next();
+                    return next();
                 }
 
                public  class Context

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultPublisher.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultPublisher.cs
@@ -26,9 +26,9 @@ namespace NServiceBus.AcceptanceTests.EndpointTemplates
         {
             public ScenarioContext Context { get; set; }
 
-            public override void Invoke(OutgoingContext context, Action next)
+            public override async Task Invoke(OutgoingContext context, Func<Task> next)
             {
-                next();
+                await next().ConfigureAwait(false);
 
                 SubscribersForEvent subscribersForEvent;
 

--- a/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_empty_id_header.cs
+++ b/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_empty_id_header.cs
@@ -26,14 +26,13 @@
         public class CorruptionBehavior : Behavior<DispatchContext>
         {
             public Context Context { get; set; }
-
-
-            public override void Invoke(DispatchContext context, Action next)
+            
+            public override Task Invoke(DispatchContext context, Func<Task> next)
             {
                 context.Get<OutgoingMessage>().Headers["ScenarioContextId"] = Context.Id.ToString();
                 context.Get<OutgoingMessage>().Headers[Headers.MessageId] = "";
 
-                next();
+                return next();
             }
         }
 
@@ -63,19 +62,21 @@
             {
                 public When_message_has_empty_id_header.Context ScenarioContext { get; set; }
 
-                public override void Invoke(Context ctx, Action next)
+                public override Task Invoke(Context ctx, Func<Task> next)
                 {
                     if (!ctx.GetPhysicalMessage().Headers.ContainsKey("ScenarioContextId"))
                     {
-                        return;
+                        return Task.FromResult(0);
                     }
                     var id = new Guid(ctx.GetPhysicalMessage().Headers["ScenarioContextId"]);
                     if (id != ScenarioContext.Id)
                     {
-                        return;
+                        return Task.FromResult(0);
                     }
                     ScenarioContext.MessageId = ctx.GetPhysicalMessage().Id;
                     ScenarioContext.MessageReceived = true;
+
+                    return Task.FromResult(0);
                 }
 
                 public class Registration : RegisterStep

--- a/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_no_id_header.cs
+++ b/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_no_id_header.cs
@@ -27,12 +27,12 @@
         {
             public Context Context { get; set; }
 
-            public override void Invoke(DispatchContext context, Action next)
+            public override Task Invoke(DispatchContext context, Func<Task> next)
             {
                 context.Get<OutgoingMessage>().Headers["ScenarioContextId"] = Context.Id.ToString();
                 context.Get<OutgoingMessage>().Headers[Headers.MessageId] = null;
 
-                next();
+                return next();
             }
         }
 
@@ -62,19 +62,21 @@
             {
                 public When_message_has_no_id_header.Context ScenarioContext { get; set; }
 
-                public override void Invoke(Context ctx, Action next)
+                public override Task Invoke(Context ctx, Func<Task> next)
                 {
                     if (!ctx.GetPhysicalMessage().Headers.ContainsKey("ScenarioContextId"))
                     {
-                        return;
+                        return Task.FromResult(0);
                     }
                     var id = new Guid(ctx.GetPhysicalMessage().Headers["ScenarioContextId"]);
                     if (id != ScenarioContext.Id)
                     {
-                        return;
+                        return Task.FromResult(0);
                     }
                     ScenarioContext.MessageId = ctx.GetPhysicalMessage().Id;
                     ScenarioContext.MessageReceived = true;
+
+                    return Task.FromResult(0);
                 }
 
                 public class Registration : RegisterStep

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -15,7 +15,6 @@
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>22d3799b</NuGetPackageImportStamp>
     <CreateDeploymentPackage>False</CreateDeploymentPackage>
-    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/NServiceBus.AcceptanceTests/PipelineExt/MutingHandlerExceptions.cs
+++ b/src/NServiceBus.AcceptanceTests/PipelineExt/MutingHandlerExceptions.cs
@@ -45,12 +45,12 @@ namespace NServiceBus.AcceptanceTests.PipelineExt
 
             class MyExceptionFilteringBehavior : PhysicalMessageProcessingStageBehavior
             {
-                public override void Invoke(Context context, Action next)
+                public override async Task Invoke(Context context, Func<Task> next)
                 {
                     try
                     {
                         //invoke the handler/rest of the pipeline
-                        next();
+                        await next().ConfigureAwait(false);
                     }
                     //catch specifix exceptions or
                     catch (Exception ex)

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_audited.cs
@@ -56,11 +56,11 @@
                     }
                 }
 
-                public override void Invoke(Context context, Action next)
+                public override async Task Invoke(Context context, Func<Task> next)
                 {
                     if (!context.GetPhysicalMessage().Headers[Headers.EnclosedMessageTypes].Contains(typeof(MessageToBeAudited).Name))
                     {
-                        next();
+                        await next().ConfigureAwait(false);
                         return;
                     }
 
@@ -71,12 +71,8 @@
                         return;
 
                     }
-                    else
-                    {
-                        next();
-                    }
-
-
+                    await next().ConfigureAwait(false);
+                    
                     called = true;
 
                     throw new SimulatedException();

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_blowing_up_just_after_dispatch.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_blowing_up_just_after_dispatch.cs
@@ -56,26 +56,22 @@
                     }
                 }
 
-                public override void Invoke(Context context, Action next)
+                public override async Task Invoke(Context context, Func<Task> next)
                 {
                     if (!context.GetPhysicalMessage().Headers[Headers.EnclosedMessageTypes].Contains(typeof(PlaceOrder).Name))
                     {
-                        next();
+                        await next().ConfigureAwait(false);
                         return;
                     }
-
-
+                    
                     if (called)
                     {
                         Console.Out.WriteLine("Called once, skipping next");
                         return;
 
                     }
-                    else
-                    {
-                        next();
-                    }
 
+                    await next().ConfigureAwait(false);
 
                     called = true;
 

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_dispatching_forwarded_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_dispatching_forwarded_messages.cs
@@ -56,11 +56,11 @@
                     }
                 }
 
-                public override void Invoke(Context context, Action next)
+                public override async Task Invoke(Context context, Func<Task> next)
                 {
                     if (!context.GetPhysicalMessage().Headers[Headers.EnclosedMessageTypes].Contains(typeof(MessageToBeForwarded).Name))
                     {
-                        next();
+                        await next().ConfigureAwait(false);
                         return;
                     }
 
@@ -71,11 +71,8 @@
                         return;
 
                     }
-                    else
-                    {
-                        next();
-                    }
 
+                    await next().ConfigureAwait(false);
 
                     called = true;
 

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga.cs
@@ -52,9 +52,9 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
                     this.testContext = testContext;
                 }
 
-                public override void Invoke(SubscribeContext context, Action next)
+                public override async Task Invoke(SubscribeContext context, Func<Task> next)
                 {
-                    next();
+                    await next().ConfigureAwait(false);
 
                     testContext.EventsSubscribedTo.Add(context.EventType);
                 }

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs
@@ -51,9 +51,9 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
                     this.testContext = testContext;
                 }
 
-                public override void Invoke(SubscribeContext context, Action next)
+                public override async Task Invoke(SubscribeContext context, Func<Task> next)
                 {
-                    next();
+                    await next().ConfigureAwait(false);
 
                     testContext.EventsSubscribedTo.Add(context.EventType);
                 }

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_autoSubscribe.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_autoSubscribe.cs
@@ -69,9 +69,9 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
                     this.testContext = testContext;
                 }
 
-                public override void Invoke(SubscribeContext context, Action next)
+                public override async Task Invoke(SubscribeContext context, Func<Task> next)
                 {
-                    next();
+                    await next().ConfigureAwait(false);
 
                     testContext.EventsSubscribedTo.Add(context.EventType);
                 }

--- a/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehavior.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehavior.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.Pipeline;
 
@@ -30,9 +31,9 @@
             this.scenarioContext = scenarioContext;
         }
 
-        public override void Invoke(Context context, Action next)
+        public override async Task Invoke(Context context, Func<Task> next)
         {
-            next();
+            await next().ConfigureAwait(false);
             var subscriptionMessageType = GetSubscriptionMessageTypeFrom(context.GetPhysicalMessage());
             if (subscriptionMessageType != null)
             {

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_context_information_added.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_context_information_added.cs
@@ -76,14 +76,14 @@ namespace NServiceBus.AcceptanceTests.Sagas
 
             public class BehaviorWhichAddsThingsToTheContext : PhysicalMessageProcessingStageBehavior
             {
-                public override void Invoke(Context context, Action next)
+                public override Task Invoke(Context context, Func<Task> next)
                 {
                     context.Set(new State
                     {
                         SomeData = "SomeData"
                     });
 
-                    next();
+                    return next();
                 }
 
                 public class State

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
@@ -4,7 +4,6 @@
     using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
-    using NServiceBus.Features;
     using NUnit.Framework;
 
     public class When_saga_is_mapped_to_complex_expression : NServiceBusAcceptanceTest
@@ -33,12 +32,7 @@
         {
             public SagaEndpoint()
             {
-                EndpointSetup<DefaultServer>(
-                    c =>
-                    {
-                        c.EnableFeature<TimeoutManager>();
-                        c.Transactions().DoNotWrapHandlersExecutionInATransactionScope();
-                    });
+                EndpointSetup<DefaultServer>();
             }
 
             public class TestSaga02 : Saga<TestSagaData02>,

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
@@ -6,26 +6,26 @@
     using AcceptanceTesting;
     using NServiceBus.Features;
     using NUnit.Framework;
-    using ScenarioDescriptors;
 
     public class When_saga_is_mapped_to_complex_expression : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_hydrate_and_invoke_the_existing_instance()
         {
-            await Scenario.Define<Context>()
-                    .WithEndpoint<SagaEndpoint>(b => b.Given(async bus =>
-                        {
-                            await bus.SendLocalAsync(new StartSagaMessage { Key = "Part1_Part2"});
-                            await bus.SendLocalAsync(new OtherMessage { Part1 = "Part1", Part2 = "Part2" });
-                        }))
+            var context = await Scenario.Define<Context>()
+                    .WithEndpoint<SagaEndpoint>(b => b
+                        .Given(bus => bus.SendLocalAsync(new StartSagaMessage { Key = "Part1_Part2"}))
+                        .When(c => c.FirstMessageReceived, bus =>  bus.SendLocalAsync(new OtherMessage { Part1 = "Part1", Part2 = "Part2" })))
+                    .AllowExceptions()
                     .Done(c => c.SecondMessageReceived)
-                    .Repeat(r => r.For(Persistence.Default))
                     .Run();
+
+            Assert.IsTrue(context.SecondMessageReceived);
         }
 
         public class Context : ScenarioContext
         {
+            public bool FirstMessageReceived { get; set; }
             public bool SecondMessageReceived { get; set; }
         }
 
@@ -42,12 +42,13 @@
             }
 
             public class TestSaga02 : Saga<TestSagaData02>,
-                IAmStartedByMessages<StartSagaMessage>, IHandleMessages<OtherMessage>
+                IAmStartedByMessages<StartSagaMessage>, IAmStartedByMessages<OtherMessage>
             {
                 public Context Context { get; set; }
                 public Task Handle(StartSagaMessage message)
                 {
                     Data.KeyValue = message.Key;
+                    Context.FirstMessageReceived = true;
                     return Task.FromResult(0);
                 }
 

--- a/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
+++ b/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
@@ -16,7 +16,6 @@
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>6b342a82</NuGetPackageImportStamp>
     <CreateDeploymentPackage>False</CreateDeploymentPackage>
-    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/NServiceBus.Core.Tests.x86/NServiceBus.Core.x86.Tests.csproj
+++ b/src/NServiceBus.Core.Tests.x86/NServiceBus.Core.x86.Tests.csproj
@@ -13,7 +13,6 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
-    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1869,8 +1869,8 @@ namespace NServiceBus.Pipeline
         protected NServiceBus.Unicast.Transport.PipelineInfo PipelineInfo { get; }
         public virtual System.Threading.Tasks.Task Cooldown() { }
         public void Initialize(NServiceBus.Unicast.Transport.PipelineInfo pipelineInfo) { }
-        public abstract void Invoke(TContext context, System.Action next);
-        public void Invoke(TContext context, System.Action<TContext> next) { }
+        public abstract System.Threading.Tasks.Task Invoke(TContext context, System.Func<System.Threading.Tasks.Task> next);
+        public System.Threading.Tasks.Task Invoke(TContext context, System.Func<TContext, System.Threading.Tasks.Task> next) { }
         public virtual System.Threading.Tasks.Task Warmup() { }
     }
     public abstract class BehaviorContext : NServiceBus.Extensibility.ContextBag
@@ -1888,7 +1888,7 @@ namespace NServiceBus.Pipeline
         where in TIn : NServiceBus.Pipeline.BehaviorContext
         where out TOut : NServiceBus.Pipeline.BehaviorContext
     {
-        void Invoke(TIn context, System.Action<TOut> next);
+        System.Threading.Tasks.Task Invoke(TIn context, System.Func<TOut, System.Threading.Tasks.Task> next);
     }
     public interface IPipelineTerminator { }
     public class PipelineNotifications : System.IDisposable
@@ -1912,8 +1912,8 @@ namespace NServiceBus.Pipeline
         where T : NServiceBus.Pipeline.BehaviorContext
     {
         protected PipelineTerminator() { }
-        public override void Invoke(T context, System.Action<NServiceBus.Pipeline.PipelineTerminator<T>.TerminatingContext> next) { }
-        public abstract void Terminate(T context);
+        public virtual System.Threading.Tasks.Task Invoke(T context, System.Func<NServiceBus.Pipeline.PipelineTerminator<T>.TerminatingContext, System.Threading.Tasks.Task> next) { }
+        protected abstract System.Threading.Tasks.Task Terminate(T context);
         public class TerminatingContext<T> : NServiceBus.Pipeline.BehaviorContext
             where T : NServiceBus.Pipeline.BehaviorContext
         {
@@ -1945,7 +1945,7 @@ namespace NServiceBus.Pipeline
         protected NServiceBus.Unicast.Transport.PipelineInfo PipelineInfo { get; }
         public virtual System.Threading.Tasks.Task Cooldown() { }
         public void Initialize(NServiceBus.Unicast.Transport.PipelineInfo pipelineInfo) { }
-        public abstract void Invoke(TFrom context, System.Action<TTo> next);
+        public abstract System.Threading.Tasks.Task Invoke(TFrom context, System.Func<TTo, System.Threading.Tasks.Task> next);
         public virtual System.Threading.Tasks.Task Warmup() { }
     }
     public struct StepEnded
@@ -2476,7 +2476,7 @@ namespace NServiceBus.Transports
     public interface IAuditMessages { }
     public interface ICancelDeferredMessages
     {
-        void CancelDeferredMessages(string messageKey, NServiceBus.Pipeline.BehaviorContext context);
+        System.Threading.Tasks.Task CancelDeferredMessages(string messageKey, NServiceBus.Pipeline.BehaviorContext context);
     }
     public interface ICreateQueues
     {
@@ -2503,8 +2503,17 @@ namespace NServiceBus.Transports
     }
     public interface IManageSubscriptions
     {
-        void Subscribe(System.Type eventType, NServiceBus.Extensibility.ContextBag context);
-        void Unsubscribe(System.Type eventType, NServiceBus.Extensibility.ContextBag context);
+        System.Threading.Tasks.Task SubscribeAsync(System.Type eventType, NServiceBus.Extensibility.ContextBag context);
+        System.Threading.Tasks.Task UnsubscribeAsync(System.Type eventType, NServiceBus.Extensibility.ContextBag context);
+    }
+    public class static IManageSubscriptionsExtensions_obsolete
+    {
+        [System.ObsoleteAttribute("Please use `SubscribeAsync(Type eventType, ContextBag context)` instead. Will be " +
+            "removed in version 7.0.0.", true)]
+        public static void Subscribe(this NServiceBus.Transports.IManageSubscriptions manage, System.Type eventType, NServiceBus.Extensibility.ContextBag context) { }
+        [System.ObsoleteAttribute("Please use `UnsubscribeAsync(Type eventType, ContextBag context)` instead. Will b" +
+            "e removed in version 7.0.0.", true)]
+        public static void Unsubscribe(NServiceBus.Transports.IManageSubscriptions manage, System.Type eventType, NServiceBus.Extensibility.ContextBag context) { }
     }
     public class IncomingMessage
     {

--- a/src/NServiceBus.Core.Tests/Causation/AttachCausationHeadersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Causation/AttachCausationHeadersBehaviorTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using NServiceBus.OutgoingPipeline;
     using NUnit.Framework;
 
@@ -9,19 +10,19 @@
     public class AttachCausationHeadersBehaviorTests
     {
         [Test]
-        public void Should_set_the_conversation_id_to_new_guid_when_not_sent_from_handler()
+        public async Task Should_set_the_conversation_id_to_new_guid_when_not_sent_from_handler()
         {
             var behavior = new AttachCausationHeadersBehavior();
             var context = InitializeContext();
 
-            behavior.Invoke(context,()=>{});
+            await behavior.Invoke(context, ()=> Task.FromResult(0));
 
             context.AssertHeaderWasSet(Headers.ConversationId,value=> value != Guid.Empty.ToString());
         }
 
         
         [Test]
-        public void Should_set_the_conversation_id_to_conversation_id_of_incoming_message()
+        public async Task Should_set_the_conversation_id_to_conversation_id_of_incoming_message()
         {
             var incomingConversationId = Guid.NewGuid().ToString();
 
@@ -31,14 +32,13 @@
             var transportMessage = new TransportMessage("xyz", new Dictionary<string, string> { { Headers.ConversationId, incomingConversationId } });
             context.Set(transportMessage);
 
-            behavior.Invoke(context, () => { });
-
+            await behavior.Invoke(context, () => Task.FromResult(0));
 
             context.AssertHeaderWasSet(Headers.ConversationId, value => value == incomingConversationId);
         }
 
         [Test,Ignore("Will be refactored to use a explicit override via options instead and not rely on the header being set")]
-        public void Should_not_override_a_conversation_id_specified_by_the_user()
+        public async Task Should_not_override_a_conversation_id_specified_by_the_user()
         {
             var userConversationId = Guid.NewGuid().ToString();
 
@@ -46,13 +46,13 @@
             var context = InitializeContext();
 
             
-            behavior.Invoke(context, () => { });
+            await behavior.Invoke(context, () => Task.FromResult(0));
 
             context.AssertHeaderWasSet(Headers.ConversationId, value => value == userConversationId);   
         }
 
         [Test]
-        public void Should_set_the_related_to_header_with_the_id_of_the_current_message()
+        public async Task Should_set_the_related_to_header_with_the_id_of_the_current_message()
         {
             
             var behavior = new AttachCausationHeadersBehavior();
@@ -60,7 +60,7 @@
 
             context.Set(new TransportMessage("the message id", new Dictionary<string, string>()));
 
-            behavior.Invoke(context, () => { });
+            await behavior.Invoke(context, () => Task.FromResult(0));
 
             context.AssertHeaderWasSet(Headers.RelatedTo, value => value == "the message id");   
         }
@@ -70,7 +70,5 @@
             var context = new PhysicalOutgoingContextStageBehavior.Context(null, ContextHelpers.GetOutgoingContext(new SendOptions()));
             return context;
         }
-
-    
     }
 }

--- a/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_incoming_messages.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_incoming_messages.cs
@@ -15,7 +15,7 @@ namespace NServiceBus.Core.Tests.DataBus
     class When_applying_the_databus_message_mutator_to_incoming_messages
     {
         [Test]
-        public void Incoming_databus_properties_should_be_hydrated()
+        public async Task Incoming_databus_properties_should_be_hydrated()
         {
             var propertyKey = Guid.NewGuid().ToString();
             var databusKey = Guid.NewGuid().ToString();
@@ -44,7 +44,7 @@ namespace NServiceBus.Core.Tests.DataBus
                 fakeDatabus.StreamsToReturn[databusKey] = stream;
 
               
-                receiveBehavior.Invoke(new LogicalMessageProcessingStageBehavior.Context(message,new Dictionary<string, string> { { "NServiceBus.DataBus." + propertyKey, databusKey } },null,null), () => { });
+                await receiveBehavior.Invoke(new LogicalMessageProcessingStageBehavior.Context(message,new Dictionary<string, string> { { "NServiceBus.DataBus." + propertyKey, databusKey } },null,null), () => Task.FromResult(0));
             }
 
             var instance = (MessageWithDataBusProperty)message.Instance;
@@ -52,9 +52,10 @@ namespace NServiceBus.Core.Tests.DataBus
             Assert.AreEqual(instance.DataBusProperty.Value, "test");
         }
 
-        class FakeDataBus:IDataBus
+        class FakeDataBus : IDataBus
         {
             public Dictionary<string,Stream> StreamsToReturn = new Dictionary<string, Stream>();
+
             public Task<Stream> Get(string key)
             {
                 return Task.FromResult(StreamsToReturn[key]);

--- a/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_null_properties.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_null_properties.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Core.Tests.DataBus
 {
     using System.IO;
     using System.Runtime.Serialization.Formatters.Binary;
+    using System.Threading.Tasks;
     using NUnit.Framework;
     using Conventions = NServiceBus.Conventions;
 
@@ -9,7 +10,7 @@ namespace NServiceBus.Core.Tests.DataBus
     class When_applying_the_databus_message_mutator_to_null_properties 
     {
         [Test]
-        public void Should_not_blow_up()
+        public async Task Should_not_blow_up()
         {
             var context = ContextHelpers.GetOutgoingContext(new MessageWithNullDataBusProperty());
             var sendBehavior = new DataBusSendBehavior
@@ -24,7 +25,7 @@ namespace NServiceBus.Core.Tests.DataBus
                 new BinaryFormatter().Serialize(stream, "test");
                 stream.Position = 0;
 
-                sendBehavior.Invoke(context, () => { });            
+                await sendBehavior.Invoke(context, () => Task.FromResult(0));            
             }
         }
 

--- a/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_outgoing_messages.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_outgoing_messages.cs
@@ -13,7 +13,7 @@ namespace NServiceBus.Core.Tests.DataBus
     class When_applying_the_databus_message_mutator_to_outgoing_messages
     {
         [Test]
-        public void Outgoing_databus_properties_should_be_dehydrated()
+        public async Task Outgoing_databus_properties_should_be_dehydrated()
         {
             var message = new MessageWithDataBusProperty
             {
@@ -30,13 +30,14 @@ namespace NServiceBus.Core.Tests.DataBus
                 Conventions = new Conventions(),
                 DataBusSerializer = new DefaultDataBusSerializer(),
             };
-            sendBehavior.Invoke(context, () => { });
+
+            await sendBehavior.Invoke(context, () => Task.FromResult(0));
 
             Assert.AreEqual(TimeSpan.MaxValue, fakeDatabus.TTBRUsed);
         }
 
         [Test]
-        public void Time_to_live_should_be_passed_on_the_databus()
+        public async Task Time_to_live_should_be_passed_on_the_databus()
         {
            var message = new MessageWithExplicitTimeToLive
             {
@@ -56,12 +57,12 @@ namespace NServiceBus.Core.Tests.DataBus
                DataBusSerializer = new DefaultDataBusSerializer(),
            };
 
-           sendBehavior.Invoke(context, () => { });
+           await sendBehavior.Invoke(context, () => Task.FromResult(0));
 
            Assert.AreEqual(TimeSpan.FromMinutes(1),fakeDatabus.TTBRUsed);
         }
 
-        class FakeDataBus:IDataBus
+        class FakeDataBus : IDataBus
         {
             public TimeSpan TTBRUsed;
 

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -134,6 +134,8 @@
     <Compile Include="Routing\ApplyReplyToAddressBehaviorTests.cs" />
     <Compile Include="Routing\DetermineRouteForPublishBehaviorTests.cs" />
     <Compile Include="Routing\DetermineRouteForSendBehaviorTests.cs" />
+    <Compile Include="Routing\MessageDrivenSubscribeTerminatorTests.cs" />
+    <Compile Include="Routing\MessageDrivenUnsubscribeTerminatorTests.cs" />
     <Compile Include="Routing\SubscriptionRouterTests.cs" />
     <Compile Include="Serializers\MessageDeserializerResolverTests.cs" />
     <Compile Include="Serializers\SerializationExtensionsTests.cs" />

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -16,7 +16,6 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>27189a06</NuGetPackageImportStamp>
-    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
@@ -4,6 +4,7 @@ namespace NServiceBus.Core.Tests.Pipeline
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
     using NUnit.Framework;
@@ -200,7 +201,7 @@ namespace NServiceBus.Core.Tests.Pipeline
         }
         class FakeBehavior: Behavior<IncomingContext>
         {
-            public override void Invoke(IncomingContext context, Action next)
+            public override Task Invoke(IncomingContext context, Func<Task> next)
             {
                 throw new NotImplementedException();
             }
@@ -209,7 +210,7 @@ namespace NServiceBus.Core.Tests.Pipeline
 
         class ReplacedBehavior : Behavior<IncomingContext>
         {
-            public override void Invoke(IncomingContext context, Action next)
+            public override Task Invoke(IncomingContext context, Func<Task> next)
             {
                 throw new NotImplementedException();
             }
@@ -217,7 +218,7 @@ namespace NServiceBus.Core.Tests.Pipeline
 
         class FakeStageConnector : StageConnector<IncomingContext,ChildContext>
         {
-            public override void Invoke(IncomingContext context, Action<ChildContext> next)
+            public override Task Invoke(IncomingContext context, Func<ChildContext, Task> next)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.Core.Tests/Pipeline/BehaviorTypeCheckerTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/BehaviorTypeCheckerTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Core.Tests.Pipeline
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
     using NUnit.Framework;
@@ -16,8 +17,9 @@
 
         class ValidBehavior : Behavior<RootContext>
         {
-            public override void Invoke(RootContext context, Action next)
+            public override Task Invoke(RootContext context, Func<Task> next)
             {
+                return Task.FromResult(0);
             }
         }
 
@@ -41,8 +43,9 @@
 
         class GenericBehavior<T> : Behavior<RootContext>
         {
-            public override void Invoke(RootContext context, Action next)
+            public override Task Invoke(RootContext context, Func<Task> next)
             {
+                return Task.FromResult(0);
             }
         }
     }

--- a/src/NServiceBus.Core.Tests/Pipeline/HandlerTransactionScopeWrapperBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/HandlerTransactionScopeWrapperBehaviorTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Core.Tests.Pipeline
 {
+    using System.Threading.Tasks;
     using System.Transactions;
     using NUnit.Framework;
 
@@ -7,7 +8,7 @@
     public class HandlerTransactionScopeWrapperBehaviorTests
     {
         [Test]
-        public void ShouldNotInterfereWithExistingScope()
+        public async Task ShouldNotInterfereWithExistingScope()
         {
             var behavior = new HandlerTransactionScopeWrapperBehavior(new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted });
 
@@ -16,17 +17,20 @@
                 IsolationLevel = IsolationLevel.Serializable
             }, TransactionScopeAsyncFlowOption.Enabled))
             {
-                behavior.Invoke(null, () => { });
+                await behavior.Invoke(null, () => Task.FromResult(0));
             }
         }
 
         [Test]
-        public void ShouldWrapInnerBehaviorsIfNoAmbientExists()
+        public async Task ShouldWrapInnerBehaviorsIfNoAmbientExists()
         {
             var behavior = new HandlerTransactionScopeWrapperBehavior(new TransactionOptions { IsolationLevel = IsolationLevel.ReadCommitted });
 
-            behavior.Invoke(null, () => Assert.NotNull(Transaction.Current));
-
+            await behavior.Invoke(null, () =>
+            {
+                Assert.NotNull(Transaction.Current);
+                return Task.FromResult(0);
+            });
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
 
@@ -58,8 +59,6 @@
             Assert.AreEqual(3, model.Count);
         }
 
-
-
         public class RootContext : BehaviorContext
         {
             public RootContext(BehaviorContext parentContext)
@@ -85,7 +84,7 @@
 
         public class RootToChildConnector : StageConnector<RootContext, ChildContext>
         {
-            public override void Invoke(RootContext context, Action<ChildContext> next)
+            public override Task Invoke(RootContext context, Func<ChildContext, Task> next)
             {
                 throw new NotImplementedException();
             }
@@ -93,14 +92,14 @@
 
         public class Terminator : PipelineTerminator<ChildContext>
         {
-            public override void Terminate(ChildContext context)
+            protected override Task Terminate(ChildContext context)
             {
                 throw new NotImplementedException();
             }
         }
         public class RootToChild2Connector : StageConnector<RootContext, ChildContextReachableButNotInheritingFromRootContext>
         {
-            public override void Invoke(RootContext context, Action<ChildContextReachableButNotInheritingFromRootContext> next)
+            public override Task Invoke(RootContext context, Func<ChildContextReachableButNotInheritingFromRootContext, Task> next)
             {
                 throw new NotImplementedException();
             }
@@ -108,7 +107,7 @@
 
         public class RootBehavior : Behavior<RootContext>
         {
-            public override void Invoke(RootContext context, Action next)
+            public override Task Invoke(RootContext context, Func<Task> next)
             {
                 throw new NotImplementedException();
             }
@@ -116,14 +115,14 @@
 
         public class ChildBehavior : Behavior<ChildContext>
         {
-            public override void Invoke(ChildContext context, Action next)
+            public override Task Invoke(ChildContext context, Func<Task> next)
             {
                 throw new NotImplementedException();
             }
         }
         public class NonReachableChildBehavior : Behavior<ChildContextReachableButNotInheritingFromRootContext>
         {
-            public override void Invoke(ChildContextReachableButNotInheritingFromRootContext context, Action next)
+            public override Task Invoke(ChildContextReachableButNotInheritingFromRootContext context, Func<Task> next)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.Core.Tests/Routing/ApplyReplyToAddressBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/ApplyReplyToAddressBehaviorTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Core.Tests.Routing
 {
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline.Contexts;
     using NUnit.Framework;
 
@@ -7,12 +8,12 @@
     public class ApplyReplyToAddressBehaviorTests
     {
         [Test]
-        public void Should_set_the_reply_to_header_to_configured_address()
+        public async Task Should_set_the_reply_to_header_to_configured_address()
         {
             var behavior = new ApplyReplyToAddressBehavior("MyAddress");
             var context = new OutgoingContext(new IncomingContext(null));
 
-            behavior.Invoke(context, () => { });
+            await behavior.Invoke(context, () => Task.FromResult(0));
 
             Assert.AreEqual("MyAddress", context.Get<DispatchMessageToTransportConnector.State>().Headers[Headers.ReplyToAddress]);
         }

--- a/src/NServiceBus.Core.Tests/Routing/DetermineRouteForPublishBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DetermineRouteForPublishBehaviorTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Core.Tests.Routing
 {
+    using System.Threading.Tasks;
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline.Contexts;
     using NServiceBus.Routing;
@@ -8,13 +9,13 @@
     public class DetermineRouteForPublishBehaviorTests
     {
         [Test]
-        public void Should_use_to_all_subscribers_strategy()
+        public async Task Should_use_to_all_subscribers_strategy()
         {
             var behavior = new DetermineRouteForPublishBehavior();
 
             var context = new OutgoingPublishContext(new RootContext(null), new OutgoingLogicalMessage(new MyEvent()), new PublishOptions());
 
-            behavior.Invoke(context, () => { });
+            await behavior.Invoke(context, () => Task.FromResult(0));
 
             var routingStrategy = (ToAllSubscribers)context.Get<RoutingStrategy>();
 

--- a/src/NServiceBus.Core.Tests/Routing/DetermineRouteForSendBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DetermineRouteForSendBehaviorTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Core.Tests.Routing
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline.Contexts;
     using NServiceBus.Routing;
@@ -10,7 +11,7 @@
     public class DetermineRouteForSendBehaviorTests
     {
         [Test]
-        public void Should_use_explicit_route_for_sends_if_present()
+        public async Task Should_use_explicit_route_for_sends_if_present()
         {
             var behavior = InitializeBehavior();
             var options = new SendOptions();
@@ -19,17 +20,15 @@
 
             var context = CreateContext(options);
 
-            behavior.Invoke(context, () => { });
+            await behavior.Invoke(context, () => Task.FromResult(0));
 
             var routingStrategy = (DirectToTargetDestination)context.Get<RoutingStrategy>();
 
             Assert.AreEqual("destination endpoint", routingStrategy.Destination);
         }
 
-
-
         [Test]
-        public void Should_route_to_local_endpoint_if_requested_so()
+        public async Task Should_route_to_local_endpoint_if_requested_so()
         {
             var behavior = InitializeBehavior("MyLocalAddress");
             var options = new SendOptions();
@@ -38,17 +37,15 @@
 
             var context = CreateContext(options);
 
-
-            behavior.Invoke(context, () => { });
+            await behavior.Invoke(context, () => Task.FromResult(0));
 
             var routingStrategy = (DirectToTargetDestination)context.Get<RoutingStrategy>();
-
 
             Assert.AreEqual("MyLocalAddress", routingStrategy.Destination);
         }
 
         [Test]
-        public void Should_route_using_the_mappings_if_no_destination_is_set()
+        public async Task Should_route_using_the_mappings_if_no_destination_is_set()
         {
             var router = new FakeRouter();
 
@@ -57,8 +54,7 @@
 
             var context = CreateContext(options);
 
-
-            behavior.Invoke(context, () => { });
+            await behavior.Invoke(context, () => Task.FromResult(0));
 
             var routingStrategy = (DirectToTargetDestination)context.Get<RoutingStrategy>();
 
@@ -75,8 +71,7 @@
 
             var context = CreateContext(options, new MessageWithoutRouting());
 
-
-            var ex = Assert.Throws<Exception>(() => behavior.Invoke(context, () => { }));
+            var ex = Assert.Throws<Exception>(async() => await behavior.Invoke(context, () => Task.FromResult(0)));
 
             Assert.True(ex.Message.Contains("No destination specified"));
         }

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
@@ -1,0 +1,113 @@
+﻿namespace NServiceBus.Core.Tests.Routing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Routing;
+    using NServiceBus.Routing.MessageDrivenSubscriptions;
+    using NServiceBus.Transports;
+    using NServiceBus.Unicast.Queuing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MessageDrivenSubscribeTerminatorTests
+    {
+        MessageDrivenSubscribeTerminator terminator;
+        SubscriptionRouter router;
+        StaticRoutes staticRoutes;
+        FakeDispatcher dispatcher;
+
+        [SetUp]
+        public void SetUp()
+        {
+            staticRoutes = new StaticRoutes();
+            SetupStaticRoutes();
+            router = new SubscriptionRouter(staticRoutes, new[] { typeof(object) });
+            dispatcher = new FakeDispatcher();
+            terminator = new MessageDrivenSubscribeTerminator(router, "replyToAddress", dispatcher);
+        }
+
+        [Test]
+        public async Task Should_Dispatch_for_all_publishers()
+        {
+            await terminator.Invoke(new SubscribeContext(new FakeContext(), typeof(object), new SubscribeOptions()), c => Task.FromResult(0));
+
+            Assert.AreEqual(1, dispatcher.DispatchedOperations.Count);
+        }
+
+        [Test]
+        public async Task Should_Dispatch_according_to_max_retries_when_dispatch_fails()
+        {
+            var options = new SubscribeOptions();
+            var state = options.GetExtensions().GetOrCreate<MessageDrivenSubscribeTerminator.State>();
+            state.MaxRetries = 10;
+            state.RetryDelay = TimeSpan.Zero;
+            dispatcher.FailDispatch(10);
+
+            await terminator.Invoke(new SubscribeContext(new FakeContext(), typeof(object), options), c => Task.FromResult(0));
+
+            Assert.AreEqual(1, dispatcher.DispatchedOperations.Count);
+            Assert.AreEqual(10, dispatcher.FailedNumberOfTimes);
+        }
+
+        [Test]
+        public void Should_Throw_when_max_retries_reached()
+        {
+            var options = new SubscribeOptions();
+            var state = options.GetExtensions().GetOrCreate<MessageDrivenSubscribeTerminator.State>();
+            state.MaxRetries = 10;
+            state.RetryDelay = TimeSpan.Zero;
+            dispatcher.FailDispatch(11);
+
+            Assert.Throws<QueueNotFoundException>(async () => await terminator.Invoke(new SubscribeContext(new FakeContext(), typeof(object), options), c => Task.FromResult(0)));
+
+            Assert.AreEqual(0, dispatcher.DispatchedOperations.Count);
+            Assert.AreEqual(11, dispatcher.FailedNumberOfTimes);
+        }
+
+        private void SetupStaticRoutes()
+        {
+            staticRoutes.Register(typeof(object), "publisher1");
+        }
+
+        class FakeDispatcher : IDispatchMessages
+        {
+            int? numberOfTimes;
+
+            public FakeDispatcher()
+            {
+                DispatchedOperations = new List<IEnumerable<TransportOperation>>();
+            }
+
+            public int FailedNumberOfTimes { get; private set; } = 0;
+
+            public List<IEnumerable<TransportOperation>> DispatchedOperations { get; }
+
+            public void FailDispatch(int times)
+            {
+                numberOfTimes = times;
+            }
+
+            public Task Dispatch(IEnumerable<TransportOperation> outgoingMessages)
+            {
+                if(numberOfTimes.HasValue && FailedNumberOfTimes < numberOfTimes.Value)
+                {
+                    FailedNumberOfTimes++;
+                    throw new QueueNotFoundException();
+                }
+
+                DispatchedOperations.Add(outgoingMessages);
+                return Task.FromResult(0);
+            }
+        }
+
+        class FakeContext : BehaviorContext
+        {
+            public FakeContext() : base(null)
+            {
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
@@ -41,7 +41,7 @@
         public async Task Should_Dispatch_according_to_max_retries_when_dispatch_fails()
         {
             var options = new SubscribeOptions();
-            var state = options.GetExtensions().GetOrCreate<MessageDrivenSubscribeTerminator.State>();
+            var state = options.GetExtensions().GetOrCreate<MessageDrivenSubscribeTerminator.Settings>();
             state.MaxRetries = 10;
             state.RetryDelay = TimeSpan.Zero;
             dispatcher.FailDispatch(10);
@@ -56,7 +56,7 @@
         public void Should_Throw_when_max_retries_reached()
         {
             var options = new SubscribeOptions();
-            var state = options.GetExtensions().GetOrCreate<MessageDrivenSubscribeTerminator.State>();
+            var state = options.GetExtensions().GetOrCreate<MessageDrivenSubscribeTerminator.Settings>();
             state.MaxRetries = 10;
             state.RetryDelay = TimeSpan.Zero;
             dispatcher.FailDispatch(11);

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
@@ -1,0 +1,113 @@
+﻿namespace NServiceBus.Core.Tests.Routing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Routing;
+    using NServiceBus.Routing.MessageDrivenSubscriptions;
+    using NServiceBus.Transports;
+    using NServiceBus.Unicast.Queuing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MessageDrivenUnsubscribeTerminatorTests
+    {
+        MessageDrivenUnsubscribeTerminator terminator;
+        SubscriptionRouter router;
+        StaticRoutes staticRoutes;
+        FakeDispatcher dispatcher;
+
+        [SetUp]
+        public void SetUp()
+        {
+            staticRoutes = new StaticRoutes();
+            SetupStaticRoutes();
+            router = new SubscriptionRouter(staticRoutes, new[] { typeof(object) });
+            dispatcher = new FakeDispatcher();
+            terminator = new MessageDrivenUnsubscribeTerminator(router, "replyToAddress", dispatcher);
+        }
+
+        [Test]
+        public async Task Should_Dispatch_for_all_publishers()
+        {
+            await terminator.Invoke(new UnsubscribeContext(new FakeContext(), typeof(object), new UnsubscribeOptions()), c => Task.FromResult(0));
+
+            Assert.AreEqual(1, dispatcher.DispatchedOperations.Count);
+        }
+
+        [Test]
+        public async Task Should_Dispatch_according_to_max_retries_when_dispatch_fails()
+        {
+            var options = new UnsubscribeOptions();
+            var state = options.GetExtensions().GetOrCreate<MessageDrivenUnsubscribeTerminator.State>();
+            state.MaxRetries = 10;
+            state.RetryDelay = TimeSpan.Zero;
+            dispatcher.FailDispatch(10);
+
+            await terminator.Invoke(new UnsubscribeContext(new FakeContext(), typeof(object), options), c => Task.FromResult(0));
+
+            Assert.AreEqual(1, dispatcher.DispatchedOperations.Count);
+            Assert.AreEqual(10, dispatcher.FailedNumberOfTimes);
+        }
+
+        [Test]
+        public void Should_Throw_when_max_retries_reached()
+        {
+            var options = new UnsubscribeOptions();
+            var state = options.GetExtensions().GetOrCreate<MessageDrivenUnsubscribeTerminator.State>();
+            state.MaxRetries = 10;
+            state.RetryDelay = TimeSpan.Zero;
+            dispatcher.FailDispatch(11);
+
+            Assert.Throws<QueueNotFoundException>(async () => await terminator.Invoke(new UnsubscribeContext(new FakeContext(), typeof(object), options), c => Task.FromResult(0)));
+
+            Assert.AreEqual(0, dispatcher.DispatchedOperations.Count);
+            Assert.AreEqual(11, dispatcher.FailedNumberOfTimes);
+        }
+
+        private void SetupStaticRoutes()
+        {
+            staticRoutes.Register(typeof(object), "publisher1");
+        }
+
+        class FakeDispatcher : IDispatchMessages
+        {
+            int? numberOfTimes;
+
+            public FakeDispatcher()
+            {
+                DispatchedOperations = new List<IEnumerable<TransportOperation>>();
+            }
+
+            public int FailedNumberOfTimes { get; private set; } = 0;
+
+            public List<IEnumerable<TransportOperation>> DispatchedOperations { get; }
+
+            public void FailDispatch(int times)
+            {
+                numberOfTimes = times;
+            }
+
+            public Task Dispatch(IEnumerable<TransportOperation> outgoingMessages)
+            {
+                if (numberOfTimes.HasValue && FailedNumberOfTimes < numberOfTimes.Value)
+                {
+                    FailedNumberOfTimes++;
+                    throw new QueueNotFoundException();
+                }
+
+                DispatchedOperations.Add(outgoingMessages);
+                return Task.FromResult(0);
+            }
+        }
+
+        class FakeContext : BehaviorContext
+        {
+            public FakeContext() : base(null)
+            {
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
@@ -41,7 +41,7 @@
         public async Task Should_Dispatch_according_to_max_retries_when_dispatch_fails()
         {
             var options = new UnsubscribeOptions();
-            var state = options.GetExtensions().GetOrCreate<MessageDrivenUnsubscribeTerminator.State>();
+            var state = options.GetExtensions().GetOrCreate<MessageDrivenUnsubscribeTerminator.Settings>();
             state.MaxRetries = 10;
             state.RetryDelay = TimeSpan.Zero;
             dispatcher.FailDispatch(10);
@@ -56,7 +56,7 @@
         public void Should_Throw_when_max_retries_reached()
         {
             var options = new UnsubscribeOptions();
-            var state = options.GetExtensions().GetOrCreate<MessageDrivenUnsubscribeTerminator.State>();
+            var state = options.GetExtensions().GetOrCreate<MessageDrivenUnsubscribeTerminator.Settings>();
             state.MaxRetries = 10;
             state.RetryDelay = TimeSpan.Zero;
             dispatcher.FailDispatch(11);

--- a/src/NServiceBus.Core.Tests/Serializers/SerializeMessagesBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/SerializeMessagesBehaviorTests.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Threading.Tasks;
     using NServiceBus.Serialization;
     using NServiceBus.Unicast.Messages;
     using NUnit.Framework;
@@ -11,7 +12,7 @@
     public class SerializeMessagesBehaviorTests
     {
         [Test]
-        public void Should_set_content_type_header()
+        public async Task Should_set_content_type_header()
         {
             var registry = new MessageMetadataRegistry(new Conventions());
 
@@ -20,7 +21,7 @@
             var context = ContextHelpers.GetOutgoingContext(new MyMessage());
             var behavior = new SerializeMessagesBehavior(new FakeSerializer("myContentType"), registry);
             
-            behavior.Invoke(context, c => { });
+            await behavior.Invoke(context, c => Task.FromResult(0));
 
             Assert.AreEqual("myContentType", context.GetOrCreate<DispatchMessageToTransportConnector.State>().Headers[Headers.ContentType]);
         }

--- a/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline.Contexts;
     using NServiceBus.Unicast.Messages;
     using NUnit.Framework;
@@ -17,7 +18,7 @@
             var context = new LogicalMessageProcessingStageBehavior.Context(
                 new LogicalMessage(new MessageMetadata(typeof(string)),null, null),new Dictionary<string, string>(),typeof(MyMessage),  null);
 
-            Assert.Throws<InvalidOperationException>(() => behavior.Invoke(context, c => { }));
+            Assert.Throws<InvalidOperationException>(async () => await behavior.Invoke(context, c => Task.FromResult(0)));
         }
 
         class MyMessage { }

--- a/src/NServiceBus.Core/Audit/AuditToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Audit/AuditToDispatchConnector.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using NServiceBus.Audit;
     using NServiceBus.DeliveryConstraints;
     using NServiceBus.Performance.TimeToBeReceived;
@@ -18,7 +19,7 @@ namespace NServiceBus
             this.timeToBeReceived = timeToBeReceived;
         }
 
-        public override void Invoke(AuditContext context, Action<DispatchContext> next)
+        public override Task Invoke(AuditContext context, Func<DispatchContext, Task> next)
         {
             var message = context.Get<OutgoingMessage>();
 
@@ -45,7 +46,7 @@ namespace NServiceBus
 
             dispatchContext.Set(deliveryConstraints);
 
-            next(dispatchContext);
+            return next(dispatchContext);
         }
 
         public class State

--- a/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Audit;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
@@ -14,9 +15,9 @@
             this.auditAddress = auditAddress;
         }
 
-        public override void Invoke(Context context, Action next)
+        public override async Task Invoke(Context context, Func<Task> next)
         {
-            next();
+            await next().ConfigureAwait(false);
 
             context.GetPhysicalMessage().RevertToOriginalBodyIfNeeded();
 
@@ -27,7 +28,7 @@
             context.Set(processedMessage);
             context.Set<RoutingStrategy>(new DirectToTargetDestination(auditAddress));
 
-            auditPipeline.Invoke(auditContext).GetAwaiter().GetResult();
+            await auditPipeline.Invoke(auditContext).ConfigureAwait(false);
         }
 
         PipelineBase<AuditContext> auditPipeline;

--- a/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
+++ b/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
@@ -1,17 +1,18 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
     using NServiceBus.TransportDispatch;
 
-    class AttachCausationHeadersBehavior :PhysicalOutgoingContextStageBehavior
+    class AttachCausationHeadersBehavior : PhysicalOutgoingContextStageBehavior
     {
-        public override void Invoke(Context context, Action next)
+        public override Task Invoke(Context context, Func<Task> next)
         {
             ApplyHeaders(context);
 
-            next();
+            return next();
          }
 
         void ApplyHeaders(Context context)

--- a/src/NServiceBus.Core/ConsistencyGuarantees/ApplyDefaultConsistencyGuaranteeBehavior.cs
+++ b/src/NServiceBus.Core/ConsistencyGuarantees/ApplyDefaultConsistencyGuaranteeBehavior.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.ConsistencyGuarantees;
     using NServiceBus.Pipeline;
     using NServiceBus.TransportDispatch;
@@ -13,7 +14,7 @@ namespace NServiceBus
             this.transportDefault = transportDefault;
         }
 
-        public override void Invoke(DispatchContext context, Action next)
+        public override Task Invoke(DispatchContext context, Func<Task> next)
         {
             ConsistencyGuarantee explicitGuarantee;
 
@@ -22,7 +23,7 @@ namespace NServiceBus
                 context.Set(transportDefault);
             }
 
-            next();
+            return next();
         }
 
         ConsistencyGuarantee transportDefault;

--- a/src/NServiceBus.Core/ConsistencyGuarantees/TransactionScopes/HandlerTransactionScopeWrapperBehavior.cs
+++ b/src/NServiceBus.Core/ConsistencyGuarantees/TransactionScopes/HandlerTransactionScopeWrapperBehavior.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using System.Transactions;
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
@@ -14,17 +15,17 @@ namespace NServiceBus
             this.transactionOptions = transactionOptions;
         }
 
-        public override void Invoke(Context context, Action next)
+        public override async Task Invoke(Context context, Func<Task> next)
         {
             if (Transaction.Current != null)
             {
-                next();
+                await next().ConfigureAwait(false);
                 return;
             }
 
             using (var tx = new TransactionScope(TransactionScopeOption.Required, transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
             {
-                next();
+                await next().ConfigureAwait(false);
 
                 tx.Complete();
             }

--- a/src/NServiceBus.Core/Correlation/AttachCorrelationIdBehavior.cs
+++ b/src/NServiceBus.Core/Correlation/AttachCorrelationIdBehavior.cs
@@ -1,13 +1,14 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
     using NServiceBus.TransportDispatch;
 
     class AttachCorrelationIdBehavior : Behavior<OutgoingContext>
     {
-        public override void Invoke(OutgoingContext context, Action next)
+        public override Task Invoke(OutgoingContext context, Func<Task> next)
         {
             var correlationId = context.GetOrCreate<State>().CustomCorrelationId;
        
@@ -35,7 +36,7 @@
             }
 
             context.SetHeader(Headers.CorrelationId, correlationId);
-            next();
+            return next();
         }
 
         public class State

--- a/src/NServiceBus.Core/DataBus/DataBusSendBehavior.cs
+++ b/src/NServiceBus.Core/DataBus/DataBusSendBehavior.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.IO;
+    using System.Threading.Tasks;
     using System.Transactions;
     using NServiceBus.DataBus;
     using NServiceBus.DeliveryConstraints;
@@ -19,7 +20,7 @@
 
         public Conventions Conventions { get; set; }
 
-        public override void Invoke(OutgoingContext context, Action next)
+        public override async Task Invoke(OutgoingContext context, Func<Task> next)
         {
             var timeToBeReceived = TimeSpan.MaxValue;
 
@@ -55,7 +56,7 @@
 
                     using (new TransactionScope(TransactionScopeOption.Suppress, TransactionScopeAsyncFlowOption.Enabled))
                     {
-                        headerValue = DataBus.Put(stream, timeToBeReceived).GetAwaiter().GetResult();
+                        headerValue = await DataBus.Put(stream, timeToBeReceived).ConfigureAwait(false);
                     }
 
                     string headerKey;
@@ -77,7 +78,7 @@
                 }
             }
 
-            next();
+            await next().ConfigureAwait(false);
         }
 
         public class Registration : RegisterStep

--- a/src/NServiceBus.Core/DelayedDelivery/ApplyDelayedDeliveryConstraintBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/ApplyDelayedDeliveryConstraintBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.DelayedDelivery;
     using NServiceBus.DeliveryConstraints;
     using NServiceBus.Pipeline;
@@ -8,7 +9,7 @@
 
     class ApplyDelayedDeliveryConstraintBehavior:Behavior<OutgoingContext>
     {
-        public override void Invoke(OutgoingContext context, Action next)
+        public override Task Invoke(OutgoingContext context, Func<Task> next)
         {
             State state;
 
@@ -17,7 +18,7 @@
                 context.AddDeliveryConstraint(state.RequestedDelay);
             }
 
-            next();
+            return next();
         }
 
         public class State

--- a/src/NServiceBus.Core/DelayedDelivery/NoOpCanceling.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/NoOpCanceling.cs
@@ -1,13 +1,15 @@
 ﻿namespace NServiceBus.DelayedDelivery
 {
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline;
     using NServiceBus.Transports;
 
     class NoOpCanceling : ICancelDeferredMessages
     {
-        public void CancelDeferredMessages(string messageKey, BehaviorContext context)
+        public Task CancelDeferredMessages(string messageKey, BehaviorContext context)
         {
-            //no-op       
+            //no-op
+            return TaskEx.Completed;
         }
     }
 }

--- a/src/NServiceBus.Core/DelayedDelivery/RequestCancelingOfDeferredMessagesFromTimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/RequestCancelingOfDeferredMessagesFromTimeoutManager.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.DelayedDelivery
 {
+    using System.Threading.Tasks;
     using NServiceBus.DelayedDelivery.TimeoutManager;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
@@ -16,7 +17,7 @@
             this.dispatchPipeline = dispatchPipeline;
         }
 
-        public void CancelDeferredMessages(string messageKey, BehaviorContext context)
+        public Task CancelDeferredMessages(string messageKey, BehaviorContext context)
         {
             var controlMessage = ControlMessageFactory.Create(MessageIntentEnum.Send);
 
@@ -27,7 +28,7 @@
 
             context.Set<RoutingStrategy>(new DirectToTargetDestination(timeoutManagerAddress));
 
-            dispatchPipeline.Invoke(dispatchContext).GetAwaiter().GetResult();
+            return dispatchPipeline.Invoke(dispatchContext);
         }
 
         string timeoutManagerAddress;

--- a/src/NServiceBus.Core/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehavior.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.DelayedDelivery;
     using NServiceBus.DelayedDelivery.TimeoutManager;
     using NServiceBus.DeliveryConstraints;
@@ -17,7 +18,7 @@ namespace NServiceBus
         }
 
 
-        public override void Invoke(DispatchContext context, Action next)
+        public override Task Invoke(DispatchContext context, Func<Task> next)
         {
             DelayedDeliveryConstraint constraint;
 
@@ -56,7 +57,7 @@ namespace NServiceBus
                 context.RemoveDeliveryConstaint(constraint);
             }
 
-            next();
+            return next();
         }
 
         string timeoutManagerAddress;

--- a/src/NServiceBus.Core/DelayedDelivery/ThrowIfCannotDeferMessageBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/ThrowIfCannotDeferMessageBehavior.cs
@@ -1,19 +1,20 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline;
     using NServiceBus.TransportDispatch;
 
     class ThrowIfCannotDeferMessageBehavior : Behavior<DispatchContext>
     {
-        public override void Invoke(DispatchContext context, Action next)
+        public override Task Invoke(DispatchContext context, Func<Task> next)
         {
             ApplyDelayedDeliveryConstraintBehavior.State delayState;
             if (context.TryGet(out delayState))
             {
                 throw new InvalidOperationException("Cannot delay delivery of messages when TimeoutManager is disabled or there is no infrastructure support for delayed messages.");
             }
-            next();
+            return next();
         }
 
         public class Registration : RegisterStep

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/DispatchTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/DispatchTimeoutBehavior.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
     using NServiceBus.Timeout.Core;
@@ -14,12 +15,12 @@ namespace NServiceBus
             this.persister = persister;
         }
 
-        public override void Terminate(PhysicalMessageProcessingStageBehavior.Context context)
+        protected override async Task Terminate(PhysicalMessageProcessingStageBehavior.Context context)
         {
             var message = context.GetPhysicalMessage();
             var timeoutId = message.Headers["Timeout.Id"];
 
-            var timeoutData = persister.Remove(timeoutId, new TimeoutPersistenceOptions(context)).GetAwaiter().GetResult();
+            var timeoutData = await persister.Remove(timeoutId, new TimeoutPersistenceOptions(context)).ConfigureAwait(false);
 
             if (timeoutData == null)
             {
@@ -31,7 +32,7 @@ namespace NServiceBus
             timeoutData.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
             timeoutData.Headers["NServiceBus.RelatedToTimeoutId"] = timeoutData.Id;
 
-            dispatcher.Dispatch(new[] { new TransportOperation(new OutgoingMessage(message.Id, timeoutData.Headers, timeoutData.State), sendOptions)}).GetAwaiter().GetResult();
+            await dispatcher.Dispatch(new[] { new TransportOperation(new OutgoingMessage(message.Id, timeoutData.Headers, timeoutData.State), sendOptions)}).ConfigureAwait(false);
         }
 
         IDispatchMessages dispatcher;

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
@@ -21,18 +21,18 @@ namespace NServiceBus
         // ReSharper disable once UnusedAutoPropertyAccessor.Global
         public EndpointName EndpointName { get; set; }
 
-        public override void Terminate(PhysicalMessageProcessingStageBehavior.Context context)
+        protected override async Task Terminate(PhysicalMessageProcessingStageBehavior.Context context)
         {
             var message = context.GetPhysicalMessage();
 
             //dispatch request will arrive at the same input so we need to make sure to call the correct handler
             if (message.Headers.ContainsKey(TimeoutIdToDispatchHeader))
             {
-                HandleBackwardsCompatibility(message, context).GetAwaiter().GetResult();
+                await HandleBackwardsCompatibility(message, context).ConfigureAwait(false);
             }
             else
             {
-                HandleInternal(message, context).GetAwaiter().GetResult();
+                await HandleInternal(message, context).ConfigureAwait(false);
             }
         }
 

--- a/src/NServiceBus.Core/Encryption/DecryptBehavior.cs
+++ b/src/NServiceBus.Core/Encryption/DecryptBehavior.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Encryption;
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
@@ -14,17 +15,17 @@ namespace NServiceBus
         {
             this.messageMutator = messageMutator;
         }
-        public override void Invoke(Context context, Action next)
+        public override async Task Invoke(Context context, Func<Task> next)
         {
             if (TransportMessageExtensions.IsControlMessage(context.Headers))
             {
-                next();
+                await next().ConfigureAwait(false);
                 return;
             }
             var current = context.GetLogicalMessage().Instance;
             current = messageMutator.MutateIncoming(current);
             context.GetLogicalMessage().UpdateMessageInstance(current);
-            next();
+            await next().ConfigureAwait(false);
         }
 
         public class DecryptRegistration : RegisterStep

--- a/src/NServiceBus.Core/Encryption/EncryptBehavior.cs
+++ b/src/NServiceBus.Core/Encryption/EncryptBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Encryption;
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
@@ -15,7 +16,7 @@
             this.messageMutator = messageMutator;
         }
 
-        public override void Invoke(OutgoingContext context, Action next)
+        public override Task Invoke(OutgoingContext context, Func<Task> next)
         {
             var currentMessageToSend = context.GetMessageInstance();
 
@@ -23,7 +24,7 @@
 
             context.UpdateMessageInstance(currentMessageToSend);
 
-            next();
+            return next();
         }
 
         public class EncryptRegistration : RegisterStep

--- a/src/NServiceBus.Core/Forwarding/ForwardingToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Forwarding/ForwardingToDispatchConnector.cs
@@ -1,16 +1,17 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Forwarding;
     using NServiceBus.Pipeline;
     using NServiceBus.TransportDispatch;
     using NServiceBus.Transports;
 
-    class ForwardingToDispatchConnector:StageConnector<ForwardingContext,DispatchContext>
+    class ForwardingToDispatchConnector : StageConnector<ForwardingContext,DispatchContext>
     {
-        public override void Invoke(ForwardingContext context, Action<DispatchContext> next)
+        public override Task Invoke(ForwardingContext context, Func<DispatchContext, Task> next)
         {
-            next(new DispatchContext(context.Get<OutgoingMessage>(),context));
+            return next(new DispatchContext(context.Get<OutgoingMessage>(),context));
         }
     }
 }

--- a/src/NServiceBus.Core/Forwarding/InvokeForwardingPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Forwarding/InvokeForwardingPipelineBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Forwarding;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
@@ -14,9 +15,9 @@
             this.forwardingAddress = forwardingAddress;
         }
 
-        public override void Invoke(Context context, Action next)
+        public override async Task Invoke(Context context, Func<Task> next)
         {
-            next();
+            await next().ConfigureAwait(false);
 
             context.GetPhysicalMessage().RevertToOriginalBodyIfNeeded();
 
@@ -26,7 +27,7 @@
 
             context.Set<RoutingStrategy>(new DirectToTargetDestination(forwardingAddress));
 
-            forwardingPipeline.Invoke(forwardingContext).GetAwaiter().GetResult();
+            await forwardingPipeline.Invoke(forwardingContext).ConfigureAwait(false);
         }
 
         IPipelineBase<ForwardingContext> forwardingPipeline;

--- a/src/NServiceBus.Core/Hosting/AddHostInfoHeadersBehavior.cs
+++ b/src/NServiceBus.Core/Hosting/AddHostInfoHeadersBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Hosting;
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
@@ -18,13 +19,13 @@
             this.endpointName = endpointName;
         }
 
-        public override void Invoke(OutgoingContext context, Action next)
+        public override Task Invoke(OutgoingContext context, Func<Task> next)
         {
             context.SetHeader(Headers.OriginatingMachine, RuntimeEnvironment.MachineName);
             context.SetHeader(Headers.OriginatingEndpoint, endpointName.ToString());
             context.SetHeader(Headers.OriginatingHostId, hostInformation.HostId.ToString("N"));
 
-            next();
+            return next();
         }
     }
 }

--- a/src/NServiceBus.Core/Hosting/AuditHostInformationBehavior.cs
+++ b/src/NServiceBus.Core/Hosting/AuditHostInformationBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Audit;
     using NServiceBus.Hosting;
     using NServiceBus.Pipeline;
@@ -14,7 +15,7 @@
             this.endpointName = endpointName;
         }
 
-        public override void Invoke(AuditContext context, Action next)
+        public override Task Invoke(AuditContext context, Func<Task> next)
         {
             context.AddAuditData(Headers.HostId, hostInfo.HostId.ToString("N"));
             context.AddAuditData(Headers.HostDisplayName, hostInfo.DisplayName);
@@ -22,7 +23,7 @@
             context.AddAuditData(Headers.ProcessingMachine, RuntimeEnvironment.MachineName);
             context.AddAuditData(Headers.ProcessingEndpoint, endpointName.ToString());
 
-            next();
+            return next();
         }
 
         HostInformation hostInfo;

--- a/src/NServiceBus.Core/Licensing/NotifyOnInvalidLicenseBehavior.cs
+++ b/src/NServiceBus.Core/Licensing/NotifyOnInvalidLicenseBehavior.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Diagnostics;
+    using System.Threading.Tasks;
     using Logging;
     using NServiceBus.Audit;
     using Pipeline;
@@ -13,11 +14,11 @@
             this.licenseExpired = licenseExpired;
         }
 
-        public override void Invoke(AuditContext context, Action next)
+        public override async Task Invoke(AuditContext context, Func<Task> next)
         {
             context.AddAuditData(Headers.HasLicenseExpired,licenseExpired.ToString().ToLower());
 
-            next();
+            await next().ConfigureAwait(false);
 
             if (licenseExpired && Debugger.IsAttached)
             {

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -17,7 +17,6 @@
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>59571a18</NuGetPackageImportStamp>
     <CreateDeploymentPackage>False</CreateDeploymentPackage>
-    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -108,6 +107,7 @@
     <Compile Include="Routing\DynamicRoutingConfigurationExtensions.cs" />
     <Compile Include="TaskEx.cs" />
     <Compile Include="Transports\DispatchConsistency.cs" />
+    <Compile Include="Transports\IManageSubscriptionsExtensions_obsolete.cs" />
     <Compile Include="Transports\Msmq\MsmqConnectionStringBuilder.cs" />
     <Compile Include="ConsistencyGuarantees\ApplyDefaultConsistencyGuaranteeBehavior.cs" />
     <Compile Include="ConsistencyGuarantees\ConsistencyGuaranteeContextExtensions.cs" />

--- a/src/NServiceBus.Core/OutgoingPipeline/PublishToOutgoingContextConnector.cs
+++ b/src/NServiceBus.Core/OutgoingPipeline/PublishToOutgoingContextConnector.cs
@@ -1,15 +1,16 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
 
-    class PublishToOutgoingContextConnector:StageConnector<OutgoingPublishContext,OutgoingContext>
+    class PublishToOutgoingContextConnector : StageConnector<OutgoingPublishContext,OutgoingContext>
     {
-        public override void Invoke(OutgoingPublishContext context, Action<OutgoingContext> next)
+        public override Task Invoke(OutgoingPublishContext context, Func<OutgoingContext, Task> next)
         {
-            next(new OutgoingContext(context));
+            return next(new OutgoingContext(context));
         }
     }
 }

--- a/src/NServiceBus.Core/OutgoingPipeline/ReplyToOutgoingContextConnector.cs
+++ b/src/NServiceBus.Core/OutgoingPipeline/ReplyToOutgoingContextConnector.cs
@@ -1,15 +1,16 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
 
     class ReplyToOutgoingContextConnector : StageConnector<OutgoingReplyContext, OutgoingContext>
     {
-        public override void Invoke(OutgoingReplyContext context, Action<OutgoingContext> next)
+        public override Task Invoke(OutgoingReplyContext context, Func<OutgoingContext, Task> next)
         {
-            next(new OutgoingContext(context));
+            return next(new OutgoingContext(context));
         }
     }
 }

--- a/src/NServiceBus.Core/OutgoingPipeline/SendToOutgoingContextConnector.cs
+++ b/src/NServiceBus.Core/OutgoingPipeline/SendToOutgoingContextConnector.cs
@@ -1,15 +1,16 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
 
     class SendToOutgoingContextConnector:StageConnector<OutgoingSendContext,OutgoingContext>
     {
-        public override void Invoke(OutgoingSendContext context, Action<OutgoingContext> next)
+        public override Task Invoke(OutgoingSendContext context, Func<OutgoingContext, Task> next)
         {
-            next(new OutgoingContext(context));
+            return next(new OutgoingContext(context));
         }
     }
 }

--- a/src/NServiceBus.Core/Performance/MessageDurability/DetermineMessageDurabilityBehavior.cs
+++ b/src/NServiceBus.Core/Performance/MessageDurability/DetermineMessageDurabilityBehavior.cs
@@ -2,13 +2,14 @@ namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using NServiceBus.DeliveryConstraints;
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
     using NServiceBus.TransportDispatch;
 
-    class DetermineMessageDurabilityBehavior:Behavior<OutgoingContext>
+    class DetermineMessageDurabilityBehavior : Behavior<OutgoingContext>
     {
         
         public DetermineMessageDurabilityBehavior(Dictionary<Type,bool> durabilitySettings)
@@ -16,7 +17,7 @@ namespace NServiceBus
             this.durabilitySettings = durabilitySettings;
         }
 
-        public override void Invoke(OutgoingContext context, Action next)
+        public override Task Invoke(OutgoingContext context, Func<Task> next)
         {
             bool isDurable;
             if (durabilitySettings.TryGetValue(context.GetMessageType(), out isDurable) && !isDurable)
@@ -26,7 +27,7 @@ namespace NServiceBus
                 context.SetHeader(Headers.NonDurableMessage,true.ToString());
             }
 
-            next();
+            return next();
         }
 
         Dictionary<Type, bool> durabilitySettings;

--- a/src/NServiceBus.Core/Performance/ReceiveStatisticsFeature.cs
+++ b/src/NServiceBus.Core/Performance/ReceiveStatisticsFeature.cs
@@ -1,11 +1,12 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Audit;
     using NServiceBus.Features;
     using NServiceBus.Pipeline;
 
-    class ReceiveStatisticsFeature:Feature
+    class ReceiveStatisticsFeature : Feature
     {
         public ReceiveStatisticsFeature()
         {
@@ -20,9 +21,9 @@
     }
 
 
-    class AuditProcessingStatisticsBehavior:Behavior<AuditContext>
+    class AuditProcessingStatisticsBehavior : Behavior<AuditContext>
     {
-        public override void Invoke(AuditContext context, Action next)
+        public override Task Invoke(AuditContext context, Func<Task> next)
         {
 
             ProcessingStatisticsBehavior.State state;
@@ -33,7 +34,7 @@
                 context.AddAuditData(Headers.ProcessingEnded, DateTimeExtensions.ToWireFormattedString(state.ProcessingEnded));
             }
 
-            next();
+            return next();
         }
     }
 }

--- a/src/NServiceBus.Core/Performance/Statistics/CriticalTime/CriticalTimeBehavior.cs
+++ b/src/NServiceBus.Core/Performance/Statistics/CriticalTime/CriticalTimeBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using Pipeline;
 
 
@@ -13,9 +14,9 @@
             this.criticalTimeCounter = criticalTimeCounter;
         }
 
-        public override void Invoke(Context context, Action next)
+        public override async Task Invoke(Context context, Func<Task> next)
         {
-            next();
+            await next().ConfigureAwait(false);
 
             ProcessingStatisticsBehavior.State state;
 

--- a/src/NServiceBus.Core/Performance/Statistics/ProcessingStatisticsBehavior.cs
+++ b/src/NServiceBus.Core/Performance/Statistics/ProcessingStatisticsBehavior.cs
@@ -1,11 +1,12 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline;
 
     class ProcessingStatisticsBehavior : PhysicalMessageProcessingStageBehavior
     {
-        public override void Invoke(Context context, Action next)
+        public override async Task Invoke(Context context, Func<Task> next)
         {
             var state = new State();
 
@@ -22,7 +23,7 @@
             context.Set(state);
             try
             {
-                next();
+                await next().ConfigureAwait(false);
             }
             finally
             {

--- a/src/NServiceBus.Core/Performance/Statistics/ReceivePerformanceDiagnosticsBehavior.cs
+++ b/src/NServiceBus.Core/Performance/Statistics/ReceivePerformanceDiagnosticsBehavior.cs
@@ -18,13 +18,13 @@ namespace NServiceBus
             return base.Warmup();
         }
 
-        public override void Invoke(Context context, Action next)
+        public override async Task Invoke(Context context, Func<Task> next)
         {
             messagesPulledFromQueueCounter.Increment();
 
             try
             {
-                next();
+                await next().ConfigureAwait(false);
             }
             catch (Exception)
             {

--- a/src/NServiceBus.Core/Performance/Statistics/SLA/SLABehavior.cs
+++ b/src/NServiceBus.Core/Performance/Statistics/SLA/SLABehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using Pipeline;
 
     class SLABehavior : PhysicalMessageProcessingStageBehavior
@@ -12,9 +13,9 @@
             this.breachCalculator = breachCalculator;
         }
 
-        public override void Invoke(Context context, Action next)
+        public override async Task Invoke(Context context, Func<Task> next)
         {
-            next();
+            await next().ConfigureAwait(false);
 
             ProcessingStatisticsBehavior.State state;
 

--- a/src/NServiceBus.Core/Performance/TimeToBeReceived/ApplyTimeToBeReceivedBehavior.cs
+++ b/src/NServiceBus.Core/Performance/TimeToBeReceived/ApplyTimeToBeReceivedBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.DeliveryConstraints;
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Performance.TimeToBeReceived;
@@ -8,14 +9,14 @@
     using NServiceBus.Pipeline.Contexts;
     using NServiceBus.TransportDispatch;
 
-    class ApplyTimeToBeReceivedBehavior:Behavior<OutgoingContext>
+    class ApplyTimeToBeReceivedBehavior : Behavior<OutgoingContext>
     {
         public ApplyTimeToBeReceivedBehavior(TimeToBeReceivedMappings timeToBeReceivedMappings)
         {
             this.timeToBeReceivedMappings = timeToBeReceivedMappings;
         }
         
-        public override void Invoke(OutgoingContext context, Action next)
+        public override Task Invoke(OutgoingContext context, Func<Task> next)
         {
             TimeSpan timeToBeReceived;
 
@@ -25,7 +26,7 @@
                 context.SetHeader(Headers.TimeToBeReceived, timeToBeReceived.ToString());
             }
 
-            next();
+            return next();
         }
 
         TimeToBeReceivedMappings timeToBeReceivedMappings;

--- a/src/NServiceBus.Core/Pipeline/Behavior.cs
+++ b/src/NServiceBus.Core/Pipeline/Behavior.cs
@@ -20,18 +20,18 @@
         /// </summary>
         /// <param name="context">The current context.</param>
         /// <param name="next">The next <see cref="!:IBehavior{TContext}" /> in the chain to execute.</param>
-        public abstract void Invoke(TContext context, Action next);
+        public abstract Task Invoke(TContext context, Func<Task> next);
 
         /// <summary>
         /// Called when the behavior is executed.
         /// </summary>
         /// <param name="context">The current context.</param>
         /// <param name="next">The next <see cref="IBehavior{TIn,TOut}"/> in the chain to execute.</param>
-        public void Invoke(TContext context, Action<TContext> next)
+        public Task Invoke(TContext context, Func<TContext, Task> next)
         {
             Guard.AgainstNull("context", context);
             Guard.AgainstNull("next", next);
-            Invoke(context, () => next(context));
+            return Invoke(context, () => next(context));
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Pipeline/BehaviorContext.cs
+++ b/src/NServiceBus.Core/Pipeline/BehaviorContext.cs
@@ -6,13 +6,13 @@
     /// <summary>
     /// Base class for a pipeline behavior.
     /// </summary>
-    public abstract class BehaviorContext:ContextBag
+    public abstract class BehaviorContext : ContextBag
     {
         /// <summary>
         /// Create an instance of <see cref="BehaviorContext"/>.
         /// </summary>
         /// <param name="parentContext">The parent context.</param>
-        protected BehaviorContext(BehaviorContext parentContext):base(parentContext)
+        protected BehaviorContext(BehaviorContext parentContext) : base(parentContext)
         {
           
         }

--- a/src/NServiceBus.Core/Pipeline/BehaviorInstance.cs
+++ b/src/NServiceBus.Core/Pipeline/BehaviorInstance.cs
@@ -30,11 +30,7 @@
 
         public Task Invoke(BehaviorContext context, Func<BehaviorContext, Task> next)
         {
-            invoker.Invoke(instance, context, ctx =>
-            {
-                next(ctx).GetAwaiter().GetResult();
-            });
-            return TaskEx.Completed;
+            return invoker.Invoke(instance, context, next);
         }
 
         public void Initialize(PipelineInfo pipelineInfo)

--- a/src/NServiceBus.Core/Pipeline/BehaviorInvoker.cs
+++ b/src/NServiceBus.Core/Pipeline/BehaviorInvoker.cs
@@ -1,14 +1,15 @@
 ﻿namespace NServiceBus.Pipeline
 {
     using System;
+    using System.Threading.Tasks;
 
     class BehaviorInvoker<TIn, TOut> : IBehaviorInvoker 
         where TOut : BehaviorContext
         where TIn : BehaviorContext
     {
-        public void Invoke(object behavior, BehaviorContext context, Action<BehaviorContext> next)
+        public Task Invoke(object behavior, BehaviorContext context, Func<BehaviorContext, Task> next)
         {
-            ((IBehavior<TIn, TOut>)behavior).Invoke((TIn)context, next);
+            return ((IBehavior<TIn, TOut>)behavior).Invoke((TIn)context, next);
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/IBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/IBehavior.cs
@@ -18,8 +18,7 @@ namespace NServiceBus.Pipeline
         /// </summary>
         /// <param name="context">The current context.</param>
         /// <param name="next">The next <see cref="IBehavior{TIn,TOut}"/> in the chain to execute.</param>
-        void Invoke(TIn context, Action<TOut> next);
-
+        Task Invoke(TIn context, Func<TOut, Task> next);
     }
 
     /// <summary>
@@ -27,7 +26,6 @@ namespace NServiceBus.Pipeline
     /// </summary>
     public interface IBehavior
     {
-
         /// <summary>
         /// Initialized the behavior with information about the just constructed pipeline.
         /// </summary>

--- a/src/NServiceBus.Core/Pipeline/IBehaviorInvoker.cs
+++ b/src/NServiceBus.Core/Pipeline/IBehaviorInvoker.cs
@@ -1,9 +1,10 @@
 ﻿namespace NServiceBus.Pipeline
 {
     using System;
+    using System.Threading.Tasks;
 
     interface IBehaviorInvoker
     {
-        void Invoke(object behavior, BehaviorContext context, Action<BehaviorContext> next);
+        Task Invoke(object behavior, BehaviorContext context, Func<BehaviorContext, Task> next);
     }
 }

--- a/src/NServiceBus.Core/Pipeline/PipelineTerminator.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineTerminator.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Pipeline
 {
     using System;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Marks the inner most behavior of the pipeline.
@@ -8,24 +9,22 @@
     /// <typeparam name="T">The pipeline context type to terminate.</typeparam>
     public abstract class PipelineTerminator<T> : StageConnector<T, PipelineTerminator<T>.TerminatingContext>, IPipelineTerminator where T : BehaviorContext
     {
-
         /// <summary>
         /// This method will be the final one to be called before the pipeline starts to travers back up the "stack".
         /// </summary>
         /// <param name="context">The current context.</param>
-        public abstract void Terminate(T context);
-
+        protected abstract Task Terminate(T context);
 
         /// <summary>
         /// Invokes the terminate method.
         /// </summary>
         /// <param name="context">Context object.</param>
         /// <param name="next">Ignored since there by definition is no next behavior to call.</param>
-        public override void Invoke(T context, Action<TerminatingContext> next)
+        public sealed override Task Invoke(T context, Func<TerminatingContext, Task> next)
         {
             Guard.AgainstNull("next", next);
 
-            Terminate(context);
+            return Terminate(context);
         }
 
         /// <summary>
@@ -40,7 +39,6 @@
             public TerminatingContext(BehaviorContext parentContext)
                 : base(parentContext)
             {
-
             }
         }
 

--- a/src/NServiceBus.Core/Pipeline/StageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/StageConnector.cs
@@ -17,7 +17,7 @@
         protected PipelineInfo PipelineInfo { get; private set; }
 
         /// <inheritdoc />
-        public abstract void Invoke(TFrom context, Action<TTo> next);
+        public abstract Task Invoke(TFrom context, Func<TTo, Task> next);
 
         /// <inheritdoc />
         public void Initialize(PipelineInfo pipelineInfo)
@@ -28,13 +28,13 @@
         /// <inheritdoc />
         public virtual Task Warmup()
         {
-            return Task.FromResult(true);
+            return TaskEx.Completed;
         }
 
         /// <inheritdoc />
         public virtual Task Cooldown()
         {
-            return Task.FromResult(true);
+            return TaskEx.Completed;
         }
     }
 }

--- a/src/NServiceBus.Core/Recoverability/FirstLevelRetries/FirstLevelRetriesBehavior.cs
+++ b/src/NServiceBus.Core/Recoverability/FirstLevelRetries/FirstLevelRetriesBehavior.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Features;
     using NServiceBus.Logging;
     using NServiceBus.Pipeline;
@@ -20,11 +21,11 @@ namespace NServiceBus
             this.notifications = notifications;
         }
 
-        public override void Invoke(Context context, Action next)
+        public override async Task Invoke(Context context, Func<Task> next)
         {
             try
             {
-                next();
+                await next().ConfigureAwait(false);
             }
             catch (MessageDeserializationException)
             {

--- a/src/NServiceBus.Core/Routing/ApplyReplyToAddressBehavior.cs
+++ b/src/NServiceBus.Core/Routing/ApplyReplyToAddressBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
     using NServiceBus.TransportDispatch;
@@ -13,11 +14,11 @@
             this.replyToAddress = replyToAddress;
         }
 
-        public override void Invoke(OutgoingContext context, Action next)
+        public override Task Invoke(OutgoingContext context, Func<Task> next)
         {
             context.SetHeader(Headers.ReplyToAddress, replyToAddress);
 
-            next();
+            return next();
         }
 
         string replyToAddress;

--- a/src/NServiceBus.Core/Routing/DetermineRouteForPublishBehavior.cs
+++ b/src/NServiceBus.Core/Routing/DetermineRouteForPublishBehavior.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
@@ -8,13 +9,13 @@ namespace NServiceBus
 
     class DetermineRouteForPublishBehavior : Behavior<OutgoingPublishContext>
     {
-        public override void Invoke(OutgoingPublishContext context, Action next)
+        public override Task Invoke(OutgoingPublishContext context, Func<Task> next)
         {
             context.SetHeader(Headers.MessageIntent, MessageIntentEnum.Publish.ToString());
 
             context.Set<RoutingStrategy>(new ToAllSubscribers(context.GetMessageType()));
 
-            next();
+            return next();
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/DetermineRouteForReplyBehavior.cs
+++ b/src/NServiceBus.Core/Routing/DetermineRouteForReplyBehavior.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
@@ -8,7 +9,7 @@ namespace NServiceBus
 
     class DetermineRouteForReplyBehavior : Behavior<OutgoingReplyContext>
     {
-        public override void Invoke(OutgoingReplyContext context, Action next)
+        public override Task Invoke(OutgoingReplyContext context, Func<Task> next)
         {
             var state = context.GetOrCreate<State>();
 
@@ -23,7 +24,7 @@ namespace NServiceBus
 
             context.Set<RoutingStrategy>(new DirectToTargetDestination(replyToAddress));
 
-            next();
+            return next();
         }
 
         static string GetReplyToAddressFromIncomingMessage(OutgoingReplyContext context)

--- a/src/NServiceBus.Core/Routing/DetermineRouteForSendBehavior.cs
+++ b/src/NServiceBus.Core/Routing/DetermineRouteForSendBehavior.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
@@ -18,7 +19,7 @@ namespace NServiceBus
             this.messageRouter = messageRouter;
         }
 
-        public override void Invoke(OutgoingSendContext context, Action next)
+        public override async Task Invoke(OutgoingSendContext context, Func<Task> next)
         {
             var messageType = context.GetMessageType();
             var state = context.GetOrCreate<State>();
@@ -44,7 +45,7 @@ namespace NServiceBus
 
             try
             {
-                next();
+                await next().ConfigureAwait(false);
             }
             catch (QueueNotFoundException ex)
             {

--- a/src/NServiceBus.Core/Routing/DynamicRoutingBehavior.cs
+++ b/src/NServiceBus.Core/Routing/DynamicRoutingBehavior.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
     using NServiceBus.Routing;
@@ -9,7 +10,7 @@ namespace NServiceBus
     {
         public DynamicRoutingProvider RoutingProvider { get; set; }
 
-        public override void Invoke(OutgoingContext context, Action next)
+        public override Task Invoke(OutgoingContext context, Func<Task> next)
         {
             //var sendOptions = context.DeliveryOptions as SendOptions; //TODO implement DYNAMIC routing after pipeline upgrade to V6
 
@@ -20,7 +21,7 @@ namespace NServiceBus
             //}
 
             //sendOptions.Destination = GetNextAddress(sendOptions.Destination);
-            next();
+            return next();
         }
 
         string GetNextAddress(string destination)

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Linq;
-    using System.Threading;
+    using System.Threading.Tasks;
     using NServiceBus.Extensibility;
     using NServiceBus.Logging;
     using NServiceBus.Pipeline;
@@ -21,7 +21,7 @@
             this.dispatcher = dispatcher;
         }
 
-        public override void Terminate(SubscribeContext context)
+        protected override async Task Terminate(SubscribeContext context)
         {
             var eventType = context.EventType;
 
@@ -44,24 +44,23 @@
 
                 var address = publisherAddress;
 
-                ThreadPool.QueueUserWorkItem(state =>
-                    SendSubscribeMessageWithRetries(address, subscriptionMessage, eventType.AssemblyQualifiedName, context));
+                await SendSubscribeMessageWithRetries(address, subscriptionMessage, eventType.AssemblyQualifiedName, context).ConfigureAwait(false);
             }
         }
 
-        void SendSubscribeMessageWithRetries(string destination, OutgoingMessage subscriptionMessage, string messageType, ContextBag context, int retriesCount = 0)
+        async Task SendSubscribeMessageWithRetries(string destination, OutgoingMessage subscriptionMessage, string messageType, ContextBag context, int retriesCount = 0)
         {
             try
             {
                 var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(destination), context);
-                dispatcher.Dispatch(new [] { new TransportOperation(subscriptionMessage, dispatchOptions)}).GetAwaiter().GetResult();
+                await dispatcher.Dispatch(new [] { new TransportOperation(subscriptionMessage, dispatchOptions)}).ConfigureAwait(false);
             }
             catch (QueueNotFoundException ex)
             {
                 if (retriesCount < 10)
                 {
-                    Thread.Sleep(TimeSpan.FromSeconds(2));
-                    SendSubscribeMessageWithRetries(destination, subscriptionMessage, messageType, context, ++retriesCount);
+                    await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+                    await SendSubscribeMessageWithRetries(destination, subscriptionMessage, messageType, context, ++retriesCount).ConfigureAwait(false);
                 }
                 else
                 {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -54,7 +54,7 @@
 
         async Task SendSubscribeMessageWithRetries(string destination, OutgoingMessage subscriptionMessage, string messageType, ContextBag context, int retriesCount = 0)
         {
-            var state = context.GetOrCreate<State>();
+            var state = context.GetOrCreate<Settings>();
             try
             {
                 var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(destination), context);
@@ -76,9 +76,9 @@
             }
         }
 
-        public class State
+        public class Settings
         {
-            public State()
+            public Settings()
             {
                 MaxRetries = 10;
                 RetryDelay = TimeSpan.FromSeconds(2);

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -54,16 +54,18 @@
 
         async Task SendUnsubscribeMessageWithRetries(string destination, OutgoingMessage unsubscribeMessage, string messageType, ContextBag context, int retriesCount = 0)
         {
+            var state = context.GetOrCreate<State>();
             try
             {
+                
                 var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(destination), context);
                 await dispatcher.Dispatch(new[] { new TransportOperation(unsubscribeMessage, dispatchOptions) }).ConfigureAwait(false);
             }
             catch (QueueNotFoundException ex)
             {
-                if (retriesCount < 10)
+                if (retriesCount < state.MaxRetries)
                 {
-                    await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+                    await Task.Delay(state.RetryDelay).ConfigureAwait(false);
                     await SendUnsubscribeMessageWithRetries(destination, unsubscribeMessage, messageType, context, ++retriesCount).ConfigureAwait(false);
                 }
                 else
@@ -73,6 +75,18 @@
                     throw new QueueNotFoundException(destination, message, ex);
                 }
             }
+        }
+
+        public class State
+        {
+            public State()
+            {
+                MaxRetries = 10;
+                RetryDelay = TimeSpan.FromSeconds(2);
+            }
+
+            public TimeSpan RetryDelay { get; set; }
+            public int MaxRetries { get; set; }
         }
 
         SubscriptionRouter subscriptionRouter;

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.Logging;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
@@ -18,7 +19,7 @@
             this.dispatcher = dispatcher;
         }
 
-        public override void Terminate(UnsubscribeContext context)
+        protected override async Task Terminate(UnsubscribeContext context)
         {
             var eventType = context.EventType;
 
@@ -39,9 +40,9 @@
                 subscriptionMessage.Headers[Headers.SubscriptionMessageType] = eventType.AssemblyQualifiedName;
                 subscriptionMessage.Headers[Headers.ReplyToAddress] = replyToAddress;
 
-
+                // Daniel: Why are we here not retrying?
                 var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(publisherAddress), context);
-                dispatcher.Dispatch(new [] { new TransportOperation(subscriptionMessage, dispatchOptions)}).GetAwaiter().GetResult();
+                await dispatcher.Dispatch(new [] { new TransportOperation(subscriptionMessage, dispatchOptions)}).ConfigureAwait(false);
             }
         }
 

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -54,7 +54,7 @@
 
         async Task SendUnsubscribeMessageWithRetries(string destination, OutgoingMessage unsubscribeMessage, string messageType, ContextBag context, int retriesCount = 0)
         {
-            var state = context.GetOrCreate<State>();
+            var state = context.GetOrCreate<Settings>();
             try
             {
                 
@@ -77,9 +77,9 @@
             }
         }
 
-        public class State
+        public class Settings
         {
-            public State()
+            public Settings()
             {
                 MaxRetries = 10;
                 RetryDelay = TimeSpan.FromSeconds(2);

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -1,13 +1,16 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
     using NServiceBus.Logging;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
     using NServiceBus.Routing.MessageDrivenSubscriptions;
     using NServiceBus.Transports;
+    using NServiceBus.Unicast.Queuing;
     using NServiceBus.Unicast.Transport;
 
     class MessageDrivenUnsubscribeTerminator : PipelineTerminator<UnsubscribeContext>
@@ -19,7 +22,7 @@
             this.dispatcher = dispatcher;
         }
 
-        protected override async Task Terminate(UnsubscribeContext context)
+        protected override Task Terminate(UnsubscribeContext context)
         {
             var eventType = context.EventType;
 
@@ -28,24 +31,49 @@
 
             if (!publisherAddresses.Any())
             {
-                throw new Exception(string.Format("No destination could be found for message type {0}. Check the <MessageEndpointMappings> section of the configuration of this endpoint for an entry either for this specific message type or for its assembly.", eventType));
+                throw new Exception($"No destination could be found for message type {eventType}. Check the <MessageEndpointMappings> section of the configuration of this endpoint for an entry either for this specific message type or for its assembly.");
             }
 
+            var unsubscribeTasks = new List<Task>();
             foreach (var publisherAddress in publisherAddresses)
             {
                 Logger.Debug("Unsubscribing to " + eventType.AssemblyQualifiedName + " at publisher queue " + publisherAddress);
 
-                var subscriptionMessage = ControlMessageFactory.Create(MessageIntentEnum.Unsubscribe);
+                var unsubscribeMessage = ControlMessageFactory.Create(MessageIntentEnum.Unsubscribe);
 
-                subscriptionMessage.Headers[Headers.SubscriptionMessageType] = eventType.AssemblyQualifiedName;
-                subscriptionMessage.Headers[Headers.ReplyToAddress] = replyToAddress;
+                unsubscribeMessage.Headers[Headers.SubscriptionMessageType] = eventType.AssemblyQualifiedName;
+                unsubscribeMessage.Headers[Headers.ReplyToAddress] = replyToAddress;
 
-                // Daniel: Why are we here not retrying?
-                var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(publisherAddress), context);
-                await dispatcher.Dispatch(new [] { new TransportOperation(subscriptionMessage, dispatchOptions)}).ConfigureAwait(false);
+                var address = publisherAddress;
+
+                unsubscribeTasks.Add(SendUnsubscribeMessageWithRetries(address, unsubscribeMessage, eventType.AssemblyQualifiedName, context));
             }
+
+            return Task.WhenAll(unsubscribeTasks.ToArray());
         }
 
+        async Task SendUnsubscribeMessageWithRetries(string destination, OutgoingMessage unsubscribeMessage, string messageType, ContextBag context, int retriesCount = 0)
+        {
+            try
+            {
+                var dispatchOptions = new DispatchOptions(new DirectToTargetDestination(destination), context);
+                await dispatcher.Dispatch(new[] { new TransportOperation(unsubscribeMessage, dispatchOptions) }).ConfigureAwait(false);
+            }
+            catch (QueueNotFoundException ex)
+            {
+                if (retriesCount < 10)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+                    await SendUnsubscribeMessageWithRetries(destination, unsubscribeMessage, messageType, context, ++retriesCount).ConfigureAwait(false);
+                }
+                else
+                {
+                    string message = $"Failed to unsubsribe for {messageType} at publisher queue {destination}, reason {ex.Message}";
+                    Logger.Error(message, ex);
+                    throw new QueueNotFoundException(destination, message, ex);
+                }
+            }
+        }
 
         SubscriptionRouter subscriptionRouter;
         string replyToAddress;

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforcePublishBestPracticesBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforcePublishBestPracticesBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.MessagingBestPractices;
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
@@ -15,7 +16,7 @@
             this.validations = validations;
         }
 
-        public override void Invoke(OutgoingPublishContext context, Action next)
+        public override Task Invoke(OutgoingPublishContext context, Func<Task> next)
         {
             EnforceBestPracticesOptions options;
 
@@ -24,7 +25,7 @@
                 validations.AssertIsValidForPubSub(context.GetMessageType());
             }
 
-            next();
+            return next();
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceReplyBestPracticesBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceReplyBestPracticesBehavior.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.MessagingBestPractices;
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
@@ -15,7 +16,7 @@ namespace NServiceBus
             this.validations = validations;
         }
 
-        public override void Invoke(OutgoingReplyContext context, Action next)
+        public override Task Invoke(OutgoingReplyContext context, Func<Task> next)
         {
             EnforceBestPracticesOptions options;
 
@@ -24,7 +25,7 @@ namespace NServiceBus
                 validations.AssertIsValidForReply(context.GetMessageType());
             }
 
-            next();
+            return next();
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceSendBestPracticesBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceSendBestPracticesBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.MessagingBestPractices;
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
@@ -15,7 +16,7 @@
             this.validations = validations;
         }
 
-        public override void Invoke(OutgoingSendContext context, Action next)
+        public override Task Invoke(OutgoingSendContext context, Func<Task> next)
         {
             EnforceBestPracticesOptions options;
 
@@ -24,7 +25,7 @@
                 validations.AssertIsValidForSend(context.GetMessageType());
             }
 
-            next();
+            return next();
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceSubscribeBestPracticesBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceSubscribeBestPracticesBehavior.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.MessagingBestPractices;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
@@ -13,7 +14,7 @@ namespace NServiceBus
             this.validations = validations;
         }
 
-        public override void Invoke(SubscribeContext context, Action next)
+        public override Task Invoke(SubscribeContext context, Func<Task> next)
         {
             EnforceBestPracticesOptions options;
 
@@ -22,7 +23,7 @@ namespace NServiceBus
                 validations.AssertIsValidForPubSub(context.EventType);
             }
 
-            next();
+            return next();
         }
 
         Validations validations;

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceUnsubscribeBestPracticesBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceUnsubscribeBestPracticesBehavior.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.MessagingBestPractices;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
@@ -13,7 +14,7 @@ namespace NServiceBus
             this.validations = validations;
         }
 
-        public override void Invoke(UnsubscribeContext context, Action next)
+        public override Task Invoke(UnsubscribeContext context, Func<Task> next)
         {
             EnforceBestPracticesOptions options;
 
@@ -22,7 +23,7 @@ namespace NServiceBus
                 validations.AssertIsValidForPubSub(context.EventType);
             }
 
-            next();
+            return next();
         }
 
         Validations validations;

--- a/src/NServiceBus.Core/Routing/NativeSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/NativeSubscribeTerminator.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus
 {
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
     using NServiceBus.Transports;
@@ -11,9 +12,9 @@ namespace NServiceBus
             this.subscriptionManager = subscriptionManager;
         }
 
-        public override void Terminate(SubscribeContext context)
+        protected override Task Terminate(SubscribeContext context)
         {
-            subscriptionManager.Subscribe(context.EventType, context);
+            return subscriptionManager.SubscribeAsync(context.EventType, context);
         }
 
         IManageSubscriptions subscriptionManager;

--- a/src/NServiceBus.Core/Routing/NativeUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/NativeUnsubscribeTerminator.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus
 {
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
     using NServiceBus.Transports;
@@ -11,9 +12,9 @@ namespace NServiceBus
             this.subscriptionManager = subscriptionManager;
         }
 
-        public override void Terminate(UnsubscribeContext context)
+        protected override Task Terminate(UnsubscribeContext context)
         {
-            subscriptionManager.Unsubscribe(context.EventType, context);
+            return subscriptionManager.UnsubscribeAsync(context.EventType, context);
         }
 
         IManageSubscriptions subscriptionManager;

--- a/src/NServiceBus.Core/Routing/StorageDrivenPublishing/StorageDrivenDispatcher.cs
+++ b/src/NServiceBus.Core/Routing/StorageDrivenPublishing/StorageDrivenDispatcher.cs
@@ -43,7 +43,7 @@
                 .Distinct()
                 .ToList();
 
-            var subscribers = querySubscriptions.GetSubscriberAddressesForMessage(eventTypesToPublish.Select(t => new MessageType(t))).GetAwaiter().GetResult()
+            var subscribers = (await querySubscriptions.GetSubscriberAddressesForMessage(eventTypesToPublish.Select(t => new MessageType(t))).ConfigureAwait(false))
                 .ToList();
 
             currentContext.Set(new SubscribersForEvent(subscribers, eventType));

--- a/src/NServiceBus.Core/Routing/SubscribeOptions.cs
+++ b/src/NServiceBus.Core/Routing/SubscribeOptions.cs
@@ -7,6 +7,5 @@
     /// </summary>
     public class SubscribeOptions : ExtendableOptions
     {
-
     }
 }

--- a/src/NServiceBus.Core/Sagas/AttachSagaDetailsToOutGoingMessageBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/AttachSagaDetailsToOutGoingMessageBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
     using NServiceBus.Sagas;
@@ -8,7 +9,7 @@
 
     class AttachSagaDetailsToOutGoingMessageBehavior : Behavior<OutgoingContext>
     {
-        public override void Invoke(OutgoingContext context, Action next)
+        public override Task Invoke(OutgoingContext context, Func<Task> next)
         {
             ActiveSagaInstance saga;
 
@@ -19,7 +20,7 @@
                 context.SetHeader(Headers.OriginatingSagaType, saga.Metadata.SagaType.AssemblyQualifiedName);
             }
 
-            next();
+            return next();
         }
 
 

--- a/src/NServiceBus.Core/Sagas/PopulateAutoCorrelationHeadersForRepliesBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/PopulateAutoCorrelationHeadersForRepliesBehavior.cs
@@ -1,17 +1,18 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
     using NServiceBus.TransportDispatch;
 
     class PopulateAutoCorrelationHeadersForRepliesBehavior : Behavior<OutgoingReplyContext>
     {
-        public override void Invoke(OutgoingReplyContext context, Action next)
+        public override Task Invoke(OutgoingReplyContext context, Func<Task> next)
         {
             FlowDetailsForRequestingSagaToOutgoingMessage(context);
 
-            next();
+            return next();
         }
 
         static void FlowDetailsForRequestingSagaToOutgoingMessage(OutgoingReplyContext context)

--- a/src/NServiceBus.Core/StaticHeaders/ApplyStaticHeadersBehavior.cs
+++ b/src/NServiceBus.Core/StaticHeaders/ApplyStaticHeadersBehavior.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
     using NServiceBus.StaticHeaders;
@@ -15,14 +16,14 @@ namespace NServiceBus
             this.currentStaticHeaders = currentStaticHeaders;
         }
 
-        public override void Invoke(OutgoingContext context, Action next)
+        public override Task Invoke(OutgoingContext context, Func<Task> next)
         {
             foreach (var staticHeader in currentStaticHeaders)
             {
                 context.SetHeader(staticHeader.Key,staticHeader.Value);
             }
 
-            next();
+            return next();
         }
     }
 }

--- a/src/NServiceBus.Core/TransportDispatch/DispatchMessageToTransportConnector.cs
+++ b/src/NServiceBus.Core/TransportDispatch/DispatchMessageToTransportConnector.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
     using NServiceBus.TransportDispatch;
@@ -9,15 +10,14 @@
 
     class DispatchMessageToTransportConnector : StageConnector<PhysicalOutgoingContextStageBehavior.Context,DispatchContext>
     {
-        public override void Invoke(PhysicalOutgoingContextStageBehavior.Context context, Action<DispatchContext> next)
+        public override Task Invoke(PhysicalOutgoingContextStageBehavior.Context context, Func<DispatchContext, Task> next)
         {
             var state = context.GetOrCreate<State>();
             state.Headers[Headers.MessageId] = state.MessageId;
 
             var message = new OutgoingMessage(state.MessageId, state.Headers, context.Body);
             
-            
-            next(new DispatchContext(message,context));
+            return next(new DispatchContext(message,context));
         }
      
         public class State

--- a/src/NServiceBus.Core/TransportDispatch/DispatchTerminator.cs
+++ b/src/NServiceBus.Core/TransportDispatch/DispatchTerminator.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus
 {
+    using System.Threading.Tasks;
     using NServiceBus.DeliveryConstraints;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
@@ -14,7 +15,7 @@
             this.defaultDispatchStrategy = defaultDispatchStrategy;
         }
 
-        public override void Terminate(DispatchContext context)
+        protected override Task Terminate(DispatchContext context)
         {
             DispatchStrategy dispatchStrategy;
 
@@ -24,7 +25,7 @@
             }
             var routingStrategy = context.GetRoutingStrategy();
 
-            dispatchStrategy.Dispatch(dispatcher, context.Get<OutgoingMessage>(), routingStrategy, context.GetDeliveryConstraints(), context, DispatchConsistency.Default).GetAwaiter().GetResult();
+            return dispatchStrategy.Dispatch(dispatcher, context.Get<OutgoingMessage>(), routingStrategy, context.GetDeliveryConstraints(), context, DispatchConsistency.Default);
         }
 
         IDispatchMessages dispatcher;

--- a/src/NServiceBus.Core/Transports/ICancelDeferredMessages.cs
+++ b/src/NServiceBus.Core/Transports/ICancelDeferredMessages.cs
@@ -1,15 +1,16 @@
 ﻿namespace NServiceBus.Transports
 {
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline;
 
     /// <summary>
-    /// Allows timeouts to be canceled by the key provided when set.
+    ///     Allows timeouts to be canceled by the key provided when set.
     /// </summary>
     public interface ICancelDeferredMessages
     {
         /// <summary>
-        /// Clears all timeouts for the given timeout key.
+        ///     Clears all timeouts for the given timeout key.
         /// </summary>
-        void CancelDeferredMessages(string messageKey,BehaviorContext context);
+        Task CancelDeferredMessages(string messageKey, BehaviorContext context);
     }
 }

--- a/src/NServiceBus.Core/Transports/IManageSubscriptions.cs
+++ b/src/NServiceBus.Core/Transports/IManageSubscriptions.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Transports
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Extensibility;
 
     /// <summary>
@@ -13,13 +14,13 @@
         /// </summary>
         /// <param name="eventType">The event type.</param>
         /// <param name="context">The current context.</param>
-        void Subscribe(Type eventType, ContextBag context);
+        Task SubscribeAsync(Type eventType, ContextBag context);
 
         /// <summary>
         /// Unsubscribes from the given event.
         /// </summary>
         /// <param name="eventType">The event type.</param>
         /// <param name="context">The current context.</param>
-        void Unsubscribe(Type eventType, ContextBag context);
+        Task UnsubscribeAsync(Type eventType, ContextBag context);
     }
 }

--- a/src/NServiceBus.Core/Transports/IManageSubscriptionsExtensions_obsolete.cs
+++ b/src/NServiceBus.Core/Transports/IManageSubscriptionsExtensions_obsolete.cs
@@ -1,0 +1,41 @@
+﻿namespace NServiceBus.Transports
+{
+    using System;
+    using NServiceBus.Extensibility;
+
+    /// <summary>
+    /// Syntactic suger <see cref="IManageSubscriptions"/>.
+    /// </summary>
+    public static class IManageSubscriptionsExtensions_obsolete
+    {
+        /// <summary>
+        /// Subscribes to the given event.
+        /// </summary>
+        /// <param name="manage">The manage subscriptions.</param>
+        /// <param name="eventType">The event type.</param>
+        /// <param name="context">The current context.</param>
+        [ObsoleteEx(
+            TreatAsErrorFromVersion = "6",
+            RemoveInVersion = "7",
+            ReplacementTypeOrMember = "SubscribeAsync(Type eventType, ContextBag context)")]
+        public static void Subscribe(this IManageSubscriptions manage, Type eventType, ContextBag context)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Unsubscribes from the given event.
+        /// </summary>
+        /// <param name="manage">The manage subscriptions.</param>
+        /// <param name="eventType">The event type.</param>
+        /// <param name="context">The current context.</param>
+        [ObsoleteEx(
+            TreatAsErrorFromVersion = "6",
+            RemoveInVersion = "7",
+            ReplacementTypeOrMember = "UnsubscribeAsync(Type eventType, ContextBag context)")]
+        public static void Unsubscribe(IManageSubscriptions manage, Type eventType, ContextBag context)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NServiceBus.Core/Unicast/Behaviors/InvokeHandlersBehavior.cs
+++ b/src/NServiceBus.Core/Unicast/Behaviors/InvokeHandlersBehavior.cs
@@ -1,25 +1,26 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using Pipeline.Contexts;
     using Sagas;
 
     class InvokeHandlersBehavior : HandlingStageBehavior
     {
-        public override void Invoke(Context context, Action next)
+        public override async Task Invoke(Context context, Func<Task> next)
         {
             ActiveSagaInstance saga;
 
             if (context.TryGet(out saga) && saga.NotFound && saga.Metadata.SagaType == context.MessageHandler.Instance.GetType())
             {
-                next();
+                await next().ConfigureAwait(false);
                 return;
             }
 
             var messageHandler = context.MessageHandler;
-            messageHandler.Invoke(context.MessageBeingHandled).GetAwaiter().GetResult();
+            await messageHandler.Invoke(context.MessageBeingHandled).ConfigureAwait(false);
 
-            next();
+            await next().ConfigureAwait(false);
         }
     }
 }

--- a/src/NServiceBus.Core/Unicast/Behaviors/LoadHandlersConnector.cs
+++ b/src/NServiceBus.Core/Unicast/Behaviors/LoadHandlersConnector.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading.Tasks;
     using Pipeline;
     using Pipeline.Contexts;
     using Unicast;
@@ -15,7 +16,7 @@
             this.messageHandlerRegistry = messageHandlerRegistry;
         }
 
-        public override void Invoke(LogicalMessageProcessingStageBehavior.Context context, Action<HandlingStageBehavior.Context> next)
+        public override async Task Invoke(LogicalMessageProcessingStageBehavior.Context context, Func<HandlingStageBehavior.Context, Task> next)
         {
             var handlersToInvoke = messageHandlerRegistry.GetHandlersFor(context.MessageType).ToList();
 
@@ -30,7 +31,7 @@
                 messageHandler.Instance = context.Builder.Build(messageHandler.HandlerType);
 
                 var handlingContext = new HandlingStageBehavior.Context(messageHandler, context);
-                next(handlingContext);
+                await next(handlingContext).ConfigureAwait(false);
 
                 if (handlingContext.HandlerInvocationAborted)
                 {

--- a/src/NServiceBus.Core/Unicast/Behaviors/TransportReceiveToPhysicalMessageProcessingConnector.cs
+++ b/src/NServiceBus.Core/Unicast/Behaviors/TransportReceiveToPhysicalMessageProcessingConnector.cs
@@ -1,18 +1,17 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
 
     class TransportReceiveToPhysicalMessageProcessingConnector : StageConnector<TransportReceiveContext, PhysicalMessageProcessingStageBehavior.Context>
     {
-
-
-        public override void Invoke(TransportReceiveContext context, Action<PhysicalMessageProcessingStageBehavior.Context> next)
+        public override async Task Invoke(TransportReceiveContext context, Func<PhysicalMessageProcessingStageBehavior.Context, Task> next)
         {
             var physicalMessageContext = new PhysicalMessageProcessingStageBehavior.Context(context);
 
-            next(physicalMessageContext);
+            await next(physicalMessageContext).ConfigureAwait(false);
 
             if (physicalMessageContext.AbortReceiveOperation)
             {

--- a/src/NServiceBus.Core/Unicast/ContextualBus.cs
+++ b/src/NServiceBus.Core/Unicast/ContextualBus.cs
@@ -61,6 +61,7 @@ namespace NServiceBus.Unicast
                 incomingContext,
                 eventType,
                 options);
+
             return pipeline.Invoke(subscribeContext);
         }
         

--- a/src/NServiceBus.Core/Unicast/Messages/DeserializeLogicalMessagesConnector.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/DeserializeLogicalMessagesConnector.cs
@@ -5,6 +5,7 @@
     using System.IO;
     using System.Linq;
     using System.Reflection;
+    using System.Threading.Tasks;
     using NServiceBus.Logging;
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
@@ -23,11 +24,11 @@
 
         public MessageMetadataRegistry MessageMetadataRegistry { get; set; }
 
-        public override void Invoke(PhysicalMessageProcessingStageBehavior.Context context, Action<LogicalMessagesProcessingStageBehavior.Context> next)
+        public override Task Invoke(PhysicalMessageProcessingStageBehavior.Context context, Func<LogicalMessagesProcessingStageBehavior.Context, Task> next)
         {
             var transportMessage = context.GetPhysicalMessage();
             var messages = ExtractWithExceptionHandling(transportMessage);
-            next(new LogicalMessagesProcessingStageBehavior.Context(messages, context));
+            return next(new LogicalMessagesProcessingStageBehavior.Context(messages, context));
         }
 
         List<LogicalMessage> ExtractWithExceptionHandling(TransportMessage transportMessage)

--- a/src/NServiceBus.Core/Unicast/Messages/ExecuteLogicalMessagesConnector.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/ExecuteLogicalMessagesConnector.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using System.Reflection;
+    using System.Threading.Tasks;
     using Logging;
     using NServiceBus.Unicast.Transport;
     using Pipeline;
@@ -10,13 +11,13 @@
 
     class ExecuteLogicalMessagesConnector : StageConnector<LogicalMessagesProcessingStageBehavior.Context, LogicalMessageProcessingStageBehavior.Context>
     {
-        public override void Invoke(LogicalMessagesProcessingStageBehavior.Context context, Action<LogicalMessageProcessingStageBehavior.Context> next)
+        public override async Task Invoke(LogicalMessagesProcessingStageBehavior.Context context, Func<LogicalMessageProcessingStageBehavior.Context, Task> next)
         {
             var logicalMessages = context.LogicalMessages;
 
             foreach (var message in logicalMessages)
             {
-                next(new LogicalMessageProcessingStageBehavior.Context(message, context.GetPhysicalMessage().Headers, message.MessageType, context));
+                await next(new LogicalMessageProcessingStageBehavior.Context(message, context.GetPhysicalMessage().Headers, message.MessageType, context)).ConfigureAwait(false);
             }
 
             if (!TransportMessageExtensions.IsControlMessage(context.GetPhysicalMessage().Headers))

--- a/src/NServiceBus.Core/UnitOfWork/UnitOfWorkBehavior.cs
+++ b/src/NServiceBus.Core/UnitOfWork/UnitOfWorkBehavior.cs
@@ -3,12 +3,13 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.UnitOfWork;
 
 
     class UnitOfWorkBehavior : PhysicalMessageProcessingStageBehavior
     {
-        public override void Invoke(Context context, Action next)
+        public override async Task Invoke(Context context, Func<Task> next)
         {
             try
             {
@@ -18,7 +19,7 @@
                     uow.Begin();
                 }
 
-                next();
+                await next().ConfigureAwait(false);
 
                 while (unitsOfWork.Count > 0)
                 {

--- a/src/NServiceBus.PerformanceTests/NServiceBus.PerformanceTests.csproj
+++ b/src/NServiceBus.PerformanceTests/NServiceBus.PerformanceTests.csproj
@@ -15,7 +15,6 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
     <CreateDeploymentPackage>False</CreateDeploymentPackage>
-    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/NServiceBus.sln.DotSettings
+++ b/src/NServiceBus.sln.DotSettings
@@ -1,6 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String>
+
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp60</s:String>
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/AutoCompleteBasicCompletion/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/CodeCompletion/IntelliSenseCompletingCharacters/IntelliSenseCompletingCharactersSettingCSharp/UpgradedFromVSSettings/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeEditing/Intellisense/LookupWindow/ShowSummary/@EntryValue">True</s:Boolean>
@@ -105,7 +105,6 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022SuggestUseVarKeywordEverywhere_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022TryStatementsCanBeMerged_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022UnknownCssVendorExtension_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CConfigurableSeverity_0020Id_003D_0022Xaml_002EBindingWithoutContextReferenceNotResolvedHighlighting_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/CodeIssueFilter/IssueTypesToHide/=_003CStaticSeverity_0020Severity_003D_00222_0022_0020Title_003D_0022Structural_0020Search_0020Hints_0022_0020GroupId_003D_0022StructuralSearch_0022_0020_002F_003E/@EntryIndexedValue">DoHide</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SealedMemberInSealedClass/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StaticFieldInGenericType/@EntryIndexedValue">ERROR</s:String>
@@ -130,16 +129,6 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ValueParameterNotUsed/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=VBPossibleMistakenCallToGetType_002E1/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=VBPossibleMistakenCallToGetType_002E2/@EntryIndexedValue">ERROR</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Xaml_002EBindingWithContextNotResolved/@EntryIndexedValue">ERROR</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Xaml_002EBindingWithoutContextNotResolved/@EntryIndexedValue">ERROR</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Xaml_002EPathError/@EntryIndexedValue">ERROR</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Xaml_002ERedundantCollectionProperty/@EntryIndexedValue">ERROR</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Xaml_002ERedundantModifiersAttribute/@EntryIndexedValue">ERROR</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Xaml_002ERedundantNamespaceAlias/@EntryIndexedValue">ERROR</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Xaml_002ERedundantPropertyTypeQualifier/@EntryIndexedValue">ERROR</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Xaml_002ERedundantResource/@EntryIndexedValue">ERROR</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Xaml_002ERedundantStyledValue/@EntryIndexedValue">ERROR</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Xaml_002EStaticResourceNotResolved/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=Format_0020My_0020Code_0020Using_0020_0022Particular_0022_0020conventions/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="Format My Code Using &amp;quot;Particular&amp;quot; conventions"&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;CSUseVar&gt;&lt;BehavourStyle&gt;CAN_CHANGE_TO_IMPLICIT&lt;/BehavourStyle&gt;&lt;LocalVariableStyle&gt;ALWAYS_IMPLICIT&lt;/LocalVariableStyle&gt;&lt;ForeachVariableStyle&gt;ALWAYS_IMPLICIT&lt;/ForeachVariableStyle&gt;&lt;/CSUseVar&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;True&lt;/OptimizeUsings&gt;&lt;EmbraceInRegion&gt;False&lt;/EmbraceInRegion&gt;&lt;RegionName&gt;&lt;/RegionName&gt;&lt;/CSOptimizeUsings&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;CSReorderTypeMembers&gt;True&lt;/CSReorderTypeMembers&gt;&lt;JsInsertSemicolon&gt;True&lt;/JsInsertSemicolon&gt;&lt;JsReformatCode&gt;True&lt;/JsReformatCode&gt;&lt;CssReformatCode&gt;True&lt;/CssReformatCode&gt;&lt;CSArrangeThisQualifier&gt;True&lt;/CSArrangeThisQualifier&gt;&lt;RemoveCodeRedundancies&gt;True&lt;/RemoveCodeRedundancies&gt;&lt;CSUseAutoProperty&gt;True&lt;/CSUseAutoProperty&gt;&lt;HtmlReformatCode&gt;True&lt;/HtmlReformatCode&gt;&lt;CSShortenReferences&gt;True&lt;/CSShortenReferences&gt;&lt;CSharpFormatDocComments&gt;True&lt;/CSharpFormatDocComments&gt;&lt;CssAlphabetizeProperties&gt;True&lt;/CssAlphabetizeProperties&gt;&lt;/Profile&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/RecentlyUsedProfile/@EntryValue">Default: Reformat Code</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeCleanup/SilentCleanupProfile/@EntryValue">Format My Code Using "Particular" conventions</s:String>
@@ -586,9 +575,6 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/WebNaming/UserRules/=ASP_005FHTML_005FCONTROL/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/WebNaming/UserRules/=ASP_005FTAG_005FNAME/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/WebNaming/UserRules/=ASP_005FTAG_005FPREFIX/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
-	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=NAMESPACE_005FALIAS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
-	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
-	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpFileLayoutPatternsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
This PR is part of the work to make the core async enabled. For more background read [Async/Await: It's time!](http://particular.net/blog/async-await-its-time) blogpost

Unfortunately I had to bundle a few things into this PR because making the pipeline async shed light into a few potential issues. Therefore this PR contains

* Makes the whole pipeline async and removes unnecessary `GetAwaiter().GetResult()` calls
* Behavior breaking change for auto subscriptions
* ATT framework improvements
* `When_saga_is_mapped_to_complex_expression` fix

## Behavior Breaking Change

### V5
The `AutoSubscription` feature uses `Bus.Suscribe` to send subscriptions to the publisher endpoint. This was done by using `ThreadPool.QueueUserWorkItem` in the background. If the publisher endpoint never created its queues this would silently fail in the background but the endpoint would still be running. Operators of such an endpoint would suprisingly never received events they subscribed to. Only deeper digging in the logfile would indicate that subscription was not possible. We optimized here for the best possible F5 debugger experience (in production you would setup your queues manually anyway).

### V6

The `Bus.Subscribe` and `Unsubscribe` have been aligned and do retries no longer in the background but asynchronously on the startup thread. Therefore in the case when a subscriber starts and the publisher has never created its queues the subscriber endpoint will not start and the user receives a `QueueNotFoundException` which the necessary indidcators what went wrong ( plus error log o course). Regarding the F5 behavior. With that change the F5 success story is still there. If you have a solution with subscribers and publishers and the subscribers start before the publisher the start of those subscribers will try to reach the publisher queues for 20 seconds (as before). This should be enough time for the publisher to come "online" and create its queues.

## Acceptance test framework

* Enables the ATT framework again to properly fail when a test times out
* Shortcuts the ATT execution pipeline if an endpoint fails to start
* Initialization of endpoint runner is done in parallel instead of sequentially, this influences `When_two_sagas_subscribe_to_the_same_event`

## When_saga_is_mapped_to_complex_expression
This test was making wrong assumptoins about the message order. With the new default concurrency settings in V6 it was very likely that `OtherMessage` arrived although the `StartMessageMessage` wasn't completed and therefore the `HandleSagaNotFound` was invoked. By sending the `OtherMessage` only after the first message was handled and allowing FLRs to happen with `AllowExceptions` this test works.
