### PR TITLE
Saga async

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas.cs
@@ -78,7 +78,7 @@
                     if (Context.ReplyFromTimeout)
                     {
                         Data.CorrIdForRequest = message.SomeIdThatTheResponseSagaCanCorrelateBackToUs; //wont be needed in the future
-                        RequestTimeout<DelayReply>(TimeSpan.FromSeconds(1));
+                        await RequestTimeout<DelayReply>(TimeSpan.FromSeconds(1));
                     }
 
                     Data.CorrIdForRequest = Guid.NewGuid();
@@ -106,20 +106,18 @@
 
                 public Task Timeout(DelayReply state)
                 {
-                    SendReply();
-                    return Task.FromResult(0);
+                    return SendReply();
                 }
 
                 public Task Handle(SendReplyFromNonInitiatingHandler message)
                 {
-                    SendReply();
-                    return Task.FromResult(0);
+                    return SendReply();
                 }
 
-                void SendReply()
+                Task SendReply()
                 {
                     //reply to originator must be used here since the sender of the incoming message the timeoutmanager and not the requesting saga
-                    ReplyToOriginator(new ResponseFromOtherSaga //change this line to Bus.ReplyAsync(new ResponseFromOtherSaga  and see it fail
+                    return ReplyToOriginator(new ResponseFromOtherSaga //change this line to Bus.ReplyAsync(new ResponseFromOtherSaga  and see it fail
                     {
                         SomeCorrelationId = Data.CorrIdForRequest //wont be needed in the future
                     });

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
@@ -41,8 +41,7 @@
                 public Task Handle(StartSaga1 message)
                 {
                     Data.DataId = message.DataId;
-                    RequestTimeout(TimeSpan.FromSeconds(1), new Saga1Timeout());
-                    return Task.FromResult(0);
+                    return RequestTimeout(TimeSpan.FromSeconds(1), new Saga1Timeout());
                 }
 
                 public async Task Timeout(Saga1Timeout state)

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_event_from_another_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_event_from_another_saga.cs
@@ -70,7 +70,7 @@
                     await Bus.PublishAsync<SomethingHappenedEvent>(m => { m.DataId = message.DataId; });
 
                     //Request a timeout
-                    RequestTimeout<Timeout1>(TimeSpan.FromSeconds(5));
+                    await RequestTimeout<Timeout1>(TimeSpan.FromSeconds(5));
                 }
 
                 public Task Timeout(Timeout1 state)
@@ -117,8 +117,7 @@
                 {
                     Data.DataId = message.DataId;
                     //Request a timeout
-                    RequestTimeout<Saga2Timeout>(TimeSpan.FromSeconds(5));
-                    return Task.FromResult(0);
+                    return RequestTimeout<Saga2Timeout>(TimeSpan.FromSeconds(5));
                 }
 
                 public Task Timeout(Saga2Timeout state)

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_timeout_hit_not_found_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_timeout_hit_not_found_saga.cs
@@ -48,7 +48,7 @@
                     Data.DataId = message.DataId;
 
                     //this will cause the message to be delivered right away
-                    RequestTimeout<MyTimeout>(TimeSpan.Zero);
+                    await RequestTimeout<MyTimeout>(TimeSpan.Zero);
                     await Bus.SendLocalAsync(new SomeOtherMessage { DataId = Guid.NewGuid() });
 
                     MarkAsComplete();

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_ReplyToOriginator.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_ReplyToOriginator.cs
@@ -50,11 +50,10 @@
                     });
                 }
 
-                public Task Handle(AnotherRequest message)
+                public async Task Handle(AnotherRequest message)
                 {
-                    ReplyToOriginator(new MyReplyToOriginator());
+                    await ReplyToOriginator(new MyReplyToOriginator());
                     MarkAsComplete();
-                    return Task.FromResult(0);
                 }
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RequestingSagaData> mapper)

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
@@ -41,8 +41,7 @@
                 public Task Handle(StartSagaMessage message)
                 {
                     Data.SomeId = message.SomeId;
-                    RequestTimeout(TimeSpan.FromMilliseconds(100), message);
-                    return Task.FromResult(0);
+                    return RequestTimeout(TimeSpan.FromMilliseconds(100), message);
                 }
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData01> mapper)

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_contain_saga_data.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_contain_saga_data.cs
@@ -43,9 +43,7 @@
                 {
                     Data.DataId = message.DataId;
 
-                    RequestTimeout(TimeSpan.FromSeconds(5), new TimeHasPassed());
-
-                    return Task.FromResult(0);
+                    return RequestTimeout(TimeSpan.FromSeconds(5), new TimeHasPassed());
                 }
 
                 public Task Timeout(TimeHasPassed state)

--- a/src/NServiceBus.AcceptanceTests/Sagas/when_receiving_multiple_timeouts.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/when_receiving_multiple_timeouts.cs
@@ -47,17 +47,15 @@
             {
                 public Context Context { get; set; }
 
-                public Task Handle(StartSaga1 message)
+                public async Task Handle(StartSaga1 message)
                 {
                     if (message.ContextId != Context.Id)
-                        return Task.FromResult(0);
+                        return;
 
                     Data.ContextId = message.ContextId;
 
-                    RequestTimeout(TimeSpan.FromSeconds(5), new Saga1Timeout { ContextId = Context.Id });
-                    RequestTimeout(TimeSpan.FromMilliseconds(10), new Saga2Timeout { ContextId = Context.Id });
-
-                    return Task.FromResult(0);
+                    await RequestTimeout(TimeSpan.FromSeconds(5), new Saga1Timeout { ContextId = Context.Id });
+                    await RequestTimeout(TimeSpan.FromMilliseconds(10), new Saga2Timeout { ContextId = Context.Id });
                 }
 
                 public Task Timeout(Saga1Timeout state)

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -736,27 +736,27 @@ namespace NServiceBus
         public NServiceBus.IContainSagaData Entity { get; set; }
         protected internal abstract void ConfigureHowToFindSaga(NServiceBus.IConfigureHowToFindSagaWithMessage sagaMessageFindingConfiguration);
         protected virtual void MarkAsComplete() { }
-        protected void ReplyToOriginator(object message) { }
+        protected System.Threading.Tasks.Task ReplyToOriginator(object message) { }
         [System.ObsoleteAttribute("Construct your message and pass it to the non Action overload. Please use `Saga.R" +
             "eplyToOriginator(object)` instead. Will be removed in version 7.0.0.", true)]
         protected virtual void ReplyToOriginator<TMessage>(System.Action<TMessage> messageConstructor)
             where TMessage : new() { }
-        protected void RequestTimeout<TTimeoutMessageType>(System.DateTime at)
+        protected System.Threading.Tasks.Task RequestTimeout<TTimeoutMessageType>(System.DateTime at)
             where TTimeoutMessageType : new() { }
         [System.ObsoleteAttribute("Construct your message and pass it to the non Action overload. Please use `Saga.R" +
             "equestTimeout<TTimeoutMessageType>(DateTime, TTimeoutMessageType)` instead. Will" +
             " be removed in version 7.0.0.", true)]
         protected void RequestTimeout<TTimeoutMessageType>(System.DateTime at, System.Action<TTimeoutMessageType> action)
             where TTimeoutMessageType : new() { }
-        protected void RequestTimeout<TTimeoutMessageType>(System.DateTime at, TTimeoutMessageType timeoutMessage) { }
-        protected void RequestTimeout<TTimeoutMessageType>(System.TimeSpan within)
+        protected System.Threading.Tasks.Task RequestTimeout<TTimeoutMessageType>(System.DateTime at, TTimeoutMessageType timeoutMessage) { }
+        protected System.Threading.Tasks.Task RequestTimeout<TTimeoutMessageType>(System.TimeSpan within)
             where TTimeoutMessageType : new() { }
         [System.ObsoleteAttribute("Construct your message and pass it to the non Action overload. Please use `Saga.R" +
             "equestTimeout<TTimeoutMessageType>(TimeSpan, TTimeoutMessageType)` instead. Will" +
             " be removed in version 7.0.0.", true)]
         protected void RequestTimeout<TTimeoutMessageType>(System.TimeSpan within, System.Action<TTimeoutMessageType> messageConstructor)
             where TTimeoutMessageType : new() { }
-        protected void RequestTimeout<TTimeoutMessageType>(System.TimeSpan within, TTimeoutMessageType timeoutMessage) { }
+        protected System.Threading.Tasks.Task RequestTimeout<TTimeoutMessageType>(System.TimeSpan within, TTimeoutMessageType timeoutMessage) { }
     }
     public abstract class Saga<TSagaData> : NServiceBus.Saga
         where TSagaData : NServiceBus.IContainSagaData, new ()

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -735,7 +735,7 @@ namespace NServiceBus
         public bool Completed { get; }
         public NServiceBus.IContainSagaData Entity { get; set; }
         protected internal abstract void ConfigureHowToFindSaga(NServiceBus.IConfigureHowToFindSagaWithMessage sagaMessageFindingConfiguration);
-        protected virtual void MarkAsComplete() { }
+        protected void MarkAsComplete() { }
         protected System.Threading.Tasks.Task ReplyToOriginator(object message) { }
         [System.ObsoleteAttribute("Construct your message and pass it to the non Action overload. Please use `Saga.R" +
             "eplyToOriginator(object)` instead. Will be removed in version 7.0.0.", true)]

--- a/src/NServiceBus.Core/Sagas/Saga.cs
+++ b/src/NServiceBus.Core/Sagas/Saga.cs
@@ -100,7 +100,7 @@ namespace NServiceBus
             var canHandleTimeoutMessage = this is IHandleTimeouts<TTimeoutMessageType>;
             if (!canHandleTimeoutMessage)
             {
-                var message = string.Format("The type '{0}' cannot request timeouts for '{1}' because it does not implement 'IHandleTimeouts<{2}>'", GetType().Name, timeoutMessage, typeof(TTimeoutMessageType).FullName);
+                var message = $"The type '{GetType().Name}' cannot request timeouts for '{timeoutMessage}' because it does not implement 'IHandleTimeouts<{typeof(TTimeoutMessageType).FullName}>'";
                 throw new Exception(message);
             }
         }
@@ -202,7 +202,7 @@ namespace NServiceBus
         /// Marks the saga as complete.
         /// This may result in the sagas state being deleted by the persister.
         /// </summary>
-        protected virtual void MarkAsComplete()
+        protected void MarkAsComplete()
         {
             Completed = true;
         }

--- a/src/NServiceBus.Core/Sagas/Saga.cs
+++ b/src/NServiceBus.Core/Sagas/Saga.cs
@@ -1,6 +1,8 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
 
     /// <summary>
     /// This class is used to define sagas containing data and handling a message.
@@ -49,9 +51,9 @@ namespace NServiceBus
         /// Request for a timeout to occur at the given <see cref="DateTime"/>.
         /// </summary>
         /// <param name="at"><see cref="DateTime"/> to send timeout <typeparamref name="TTimeoutMessageType"/>.</param>
-        protected void RequestTimeout<TTimeoutMessageType>(DateTime at) where TTimeoutMessageType : new()
+        protected Task RequestTimeout<TTimeoutMessageType>(DateTime at) where TTimeoutMessageType : new()
         {
-            RequestTimeout(at, new TTimeoutMessageType());
+            return RequestTimeout(at, new TTimeoutMessageType());
         }
 
         /// <summary>
@@ -74,7 +76,7 @@ namespace NServiceBus
         /// </summary>
         /// <param name="at"><see cref="DateTime"/> to send timeout <paramref name="timeoutMessage"/>.</param>
         /// <param name="timeoutMessage">The message to send after <paramref name="at"/> is reached.</param>
-        protected void RequestTimeout<TTimeoutMessageType>(DateTime at, TTimeoutMessageType timeoutMessage)
+        protected Task RequestTimeout<TTimeoutMessageType>(DateTime at, TTimeoutMessageType timeoutMessage)
         {
             if (at.Kind == DateTimeKind.Unspecified)
             {
@@ -90,7 +92,7 @@ namespace NServiceBus
 
             SetTimeoutHeaders(options);
 
-            Bus.SendAsync(timeoutMessage, options).GetAwaiter().GetResult();
+            return Bus.SendAsync(timeoutMessage, options);
         }
 
         void VerifySagaCanHandleTimeout<TTimeoutMessageType>(TTimeoutMessageType timeoutMessage)
@@ -107,9 +109,9 @@ namespace NServiceBus
         /// Request for a timeout to occur within the give <see cref="TimeSpan"/>.
         /// </summary>
         /// <param name="within">Given <see cref="TimeSpan"/> to delay timeout message by.</param>
-        protected void RequestTimeout<TTimeoutMessageType>(TimeSpan within) where TTimeoutMessageType : new()
+        protected Task RequestTimeout<TTimeoutMessageType>(TimeSpan within) where TTimeoutMessageType : new()
         {
-            RequestTimeout(within, new TTimeoutMessageType());
+            return RequestTimeout(within, new TTimeoutMessageType());
         }
 
         /// <summary>
@@ -132,7 +134,7 @@ namespace NServiceBus
         /// </summary>
         /// <param name="within">Given <see cref="TimeSpan"/> to delay timeout message by.</param>
         /// <param name="timeoutMessage">The message to send after <paramref name="within"/> expires.</param>
-        protected void RequestTimeout<TTimeoutMessageType>(TimeSpan within, TTimeoutMessageType timeoutMessage)
+        protected Task RequestTimeout<TTimeoutMessageType>(TimeSpan within, TTimeoutMessageType timeoutMessage)
         {
             VerifySagaCanHandleTimeout(timeoutMessage);
 
@@ -143,10 +145,10 @@ namespace NServiceBus
 
             SetTimeoutHeaders(context);
 
-            Bus.SendAsync(timeoutMessage, context).GetAwaiter().GetResult();
+            return Bus.SendAsync(timeoutMessage, context);
         }
 
-        void SetTimeoutHeaders(SendOptions options)
+        void SetTimeoutHeaders(ExtendableOptions options)
         {
             options.SetHeader(Headers.SagaId, Entity.Id.ToString());
             options.SetHeader(Headers.IsSagaTimeoutMessage, bool.TrueString);
@@ -156,7 +158,7 @@ namespace NServiceBus
         /// <summary>
         /// Sends the <paramref name="message"/> using the bus to the endpoint that caused this saga to start.
         /// </summary>
-        protected void ReplyToOriginator(object message)
+        protected Task ReplyToOriginator(object message)
         {
             if (string.IsNullOrEmpty(Entity.Originator))
             {
@@ -177,7 +179,7 @@ namespace NServiceBus
                 SagaIdToUse = null
             });
 
-            Bus.ReplyAsync(message, options).GetAwaiter().GetResult();
+            return Bus.ReplyAsync(message, options);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR is part of the work to make the core async enabled. For more background read [Async/Await: It's time!](http://particular.net/blog/async-await-its-time) blogpost

Makes the reminders of the Saga infrastructure async. 

Discussed with @andreasohlund and @johnsimons that `MarkAsComplete` doesn't need to be virtual. I removed it here.

@udidahan do you see any reasons why `MarkAsComplete` should be virtual?