### PR TITLE
DefaultScheduler uses `Task.Run` + minor cleanups

### DIFF
--- a/src/NServiceBus.Core/Scheduling/DefaultScheduler.cs
+++ b/src/NServiceBus.Core/Scheduling/DefaultScheduler.cs
@@ -3,7 +3,6 @@ namespace NServiceBus.Scheduling
     using System;
     using System.Collections.Concurrent;
     using System.Diagnostics;
-    using System.Threading;
     using System.Threading.Tasks;
     using Logging;
 
@@ -41,8 +40,7 @@ namespace NServiceBus.Scheduling
             var sw = new Stopwatch();
             sw.Start();
 
-            Task.Factory
-                .StartNew(taskDefinition.Task, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default)
+            Task.Run(taskDefinition.Task)
                 .ContinueWith(task =>
                 {
                     sw.Stop();
@@ -51,7 +49,7 @@ namespace NServiceBus.Scheduling
                     {
                         task.Exception.Handle(ex =>
                         {
-                            logger.Error(String.Format("Failed to execute scheduled task '{0}'.", taskDefinition.Name), ex);
+                            logger.Error($"Failed to execute scheduled task '{taskDefinition.Name}'.", ex);
                             return true;
                         });
                     }
@@ -59,7 +57,7 @@ namespace NServiceBus.Scheduling
                     {
                         logger.InfoFormat("Scheduled task '{0}' run for {1}", taskDefinition.Name, sw.Elapsed.ToString());
                     }
-                });
+                }, TaskContinuationOptions.ExecuteSynchronously);
         }
 
         void DeferTask(TaskDefinition taskDefinition)

--- a/src/NServiceBus.Core/Unicast/StartAndStoppablesRunner.cs
+++ b/src/NServiceBus.Core/Unicast/StartAndStoppablesRunner.cs
@@ -30,7 +30,7 @@
                 }, TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously);
                 task.ContinueWith(t =>
                 {
-                    Log.Error(string.Format("Startup task {0} failed to complete.", startable1.GetType().AssemblyQualifiedName), t.Exception);
+                    Log.Error($"Startup task {startable1.GetType().AssemblyQualifiedName} failed to complete.", t.Exception);
                 }, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
 
                 startableTasks.Add(task);
@@ -63,7 +63,7 @@
                     .Ignore();
                     task.ContinueWith(t =>
                     {
-                        Log.Fatal(string.Format("Startup task {0} failed to stop.", stoppable1.GetType().AssemblyQualifiedName), t.Exception);
+                        Log.Fatal($"Startup task {stoppable1.GetType().AssemblyQualifiedName} failed to stop.", t.Exception);
                         t.Exception.Flatten().Handle(e => true);
                     }, TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously)
                     .Ignore();


### PR DESCRIPTION
@ramonsmits I checked the current continuations in the core. They should be fine regarding `ContinueWith`

@Particular/nservicebus please review