### PR TITLE
Allows disabling main message processing feature.

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="FakeTransport\FakeTransportContext.cs" />
     <Compile Include="Performance\ProcessingOptimizations\When_limiting_concurrency_via_both_api_and_config.cs" />
     <Compile Include="Performance\ProcessingOptimizations\When_using_concurrency_limit.cs" />
+    <Compile Include="PipelineExt\When_disabling_message_processing_feature.cs" />
     <Compile Include="Recoverability\Retries\When_message_fails_retries.cs" />
     <Compile Include="Recoverability\When_error_is_overridden_in_code.cs" />
     <Compile Include="BestPractices\When_publishing_command_bestpractices_disabled.cs" />

--- a/src/NServiceBus.AcceptanceTests/PipelineExt/When_disabling_message_processing_feature.cs
+++ b/src/NServiceBus.AcceptanceTests/PipelineExt/When_disabling_message_processing_feature.cs
@@ -1,0 +1,57 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Pipeline.Contexts;
+    using NUnit.Framework;
+
+    public class When_disabling_message_processing_feature : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task It_should_process_the_raw_message_via_spcialized_behavior()
+        {
+            var context = await Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.When((bus, c) => bus.SendLocalAsync(new MyMessage())))
+                    .Done(c => c.WasCalled)
+                    .Run();
+
+            Assert.IsTrue(context.WasCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.DisableMainProcessingPipeline();
+                    config.Pipeline.Register("RawMessageProcessingBehavior", typeof(RawMessageProcessingBehavior), "RawMessageProcessingBehavior");
+                });
+            }
+
+            public class RawMessageProcessingBehavior : PipelineTerminator<TransportReceiveContext>
+            {
+                public Context Context { get; set; }
+
+                protected override Task Terminate(TransportReceiveContext context)
+                {
+                    Context.WasCalled = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+        
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1896,6 +1896,10 @@ namespace NServiceBus.Pipeline
         System.Threading.Tasks.Task Invoke(TIn context, System.Func<TOut, System.Threading.Tasks.Task> next);
     }
     public interface IPipelineTerminator { }
+    public class static MessageProcessingBusConfigurationExtensions
+    {
+        public static void DisableMainProcessingPipeline(this NServiceBus.BusConfiguration busConfiguration) { }
+    }
     public class PipelineNotifications : System.IDisposable
     {
         public PipelineNotifications() { }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -105,11 +105,12 @@
     <Compile Include="IWantToRunWhenBusStartsAndStopsExtensions_obsoletes.cs" />
     <Compile Include="Pipeline\Incoming\InvokeHandlerContext.cs" />
     <Compile Include="Pipeline\Incoming\LogicalMessageProcessingContext.cs" />
+    <Compile Include="Pipeline\Incoming\MessageProcessingBusConfigurationExtensions.cs" />
     <Compile Include="Pipeline\Incoming\PendingTransportOperations.cs" />
     <Compile Include="Pipeline\Incoming\PhysicalMessageProcessingContext.cs" />
     <Compile Include="Pipeline\Outgoing\BatchDispatchContext.cs" />
     <Compile Include="Pipeline\Outgoing\BatchToDispatchConnector.cs" />
-    <Compile Include="Pipeline\Incoming\ReceiveFeature.cs" />
+    <Compile Include="Pipeline\Incoming\MessageProcessingFeature.cs" />
     <Compile Include="Pipeline\Outgoing\ForceImmediateDispatchForOperationsInSupressedScopeBehavior.cs" />
     <Compile Include="Pipeline\Outgoing\ImmediateDispatchOptionExtensions.cs" />
     <Compile Include="Pipeline\Outgoing\OutgoingPhysicalMessageContext.cs" />

--- a/src/NServiceBus.Core/Pipeline/Incoming/MessageProcessingBusConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/MessageProcessingBusConfigurationExtensions.cs
@@ -1,0 +1,19 @@
+﻿namespace NServiceBus.Pipeline
+{
+    using NServiceBus.Features;
+
+    /// <summary>
+    /// Allows configuring of the message processing feature.
+    /// </summary>
+    public static class MessageProcessingBusConfigurationExtensions
+    {
+        /// <summary>
+        /// Disables the main processing pipeline (by removing all the standard pipeline behaviors). 
+        /// </summary>
+        public static void DisableMainProcessingPipeline(this BusConfiguration busConfiguration)
+        {
+            busConfiguration.DisableFeature<MessageProcessingFeature>();
+            busConfiguration.DisableFeature<FirstLevelRetries>();
+        }
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/Incoming/MessageProcessingFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/MessageProcessingFeature.cs
@@ -4,13 +4,19 @@
     using NServiceBus.Outbox;
     using NServiceBus.Pipeline;
 
-    class ReceiveFeature : Feature
+    /// <summary>
+    /// The main NServiceBus message processing pipeline.
+    /// </summary>
+    internal class MessageProcessingFeature : Feature
     {
-        public ReceiveFeature()
+        internal MessageProcessingFeature()
         {
             EnableByDefault();
         }
 
+        /// <summary>
+        ///     Called when the features is activated.
+        /// </summary>
         protected internal override void Setup(FeatureConfigurationContext context)
         {
             context.Pipeline.RegisterConnector<TransportReceiveToPhysicalMessageProcessingConnector>("Allows to abort processing the message");


### PR DESCRIPTION
 * Renamed `ReceiveFeature` to `MessageProcessingFeature`
 * Made `MessageProcessingFeature` public so it can be disabled via `DisableFeature<T>`

Usage scenario: an endpoint (e.g. gateway or bridge) that does low-level processing of raw messages.