### PR TITLE
Hotfix 5.2.8: prevent timeout message loss when not using DTC

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -115,6 +115,15 @@
     <Compile Include="Sagas\When_a_finder_exists.cs" />
     <Compile Include="ScenarioDescriptors\AllTransactionSettings.cs" />
     <Compile Include="ScenarioDescriptors\TransactionSettings.cs" />
+    <Compile Include="NonDTC\When_dispatching_deferred_message_fails_without_dtc.cs" />
+    <Compile Include="Timeouts\OutdatedTimeoutPersister.cs" />
+    <Compile Include="Timeouts\TransportWithFakeQueues.cs" />
+    <Compile Include="Timeouts\UpdatedTimeoutPersister.cs" />
+    <Compile Include="Timeouts\When_dispatched_timeout_already_removed_from_timeout_storage.cs" />
+    <Compile Include="Timeouts\When_endpoint_uses_outdated_timeout_persistence_without_dtc.cs" />
+    <Compile Include="Timeouts\When_endpoint_uses_outdated_timeout_persistence_with_disabled_dtc.cs" />
+    <Compile Include="Timeouts\When_endpoint_uses_outdated_timeout_persistence_with_dtc.cs" />
+    <Compile Include="Timeouts\When_endpoint_uses_updated_timeout_persistence.cs" />
     <Compile Include="Tx\Issue_2481.cs" />
     <Compile Include="Volatile\When_sending_to_non_durable_endpoint.cs" />
     <Compile Include="Encryption\When_using_Rijndael_with_multikey.cs" />

--- a/src/NServiceBus.AcceptanceTests/NonDTC/When_dispatching_deferred_message_fails_without_dtc.cs
+++ b/src/NServiceBus.AcceptanceTests/NonDTC/When_dispatching_deferred_message_fails_without_dtc.cs
@@ -1,0 +1,117 @@
+﻿namespace NServiceBus.AcceptanceTests.NonDTC
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NServiceBus.ObjectBuilder;
+    using NServiceBus.Transports;
+    using NServiceBus.Unicast;
+    using NUnit.Framework;
+
+    public class When_dispatching_deferred_message_fails_without_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Message_should_be_received()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                .WithEndpoint<TimeoutHandlingEndpoint>(b => b.Given((bus, c) =>
+                {
+                    bus.Defer(TimeSpan.FromSeconds(3), new MyMessage());
+                }))
+                .AllowExceptions()
+                .Done(c => c.MessageReceivedByHandler)
+                .Run();
+
+            Assert.IsTrue(context.SendingMessageFailedOnce, "Sending message attempt should fail once.");
+            Assert.IsTrue(context.MessageReceivedByHandler, "Message should be sent and received by handler on second attempt.");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageReceivedByHandler { get; set; }
+            public bool SendingMessageFailedOnce { get; set; }
+        }
+
+        public class TimeoutHandlingEndpoint : EndpointConfigurationBuilder
+        {
+            public TimeoutHandlingEndpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.EnableFeature<TimeoutManager>();
+                    config.Transactions().DisableDistributedTransactions();
+                });
+            }
+
+            public class DelayedMessageHandler : IHandleMessages<MyMessage>
+            {
+                Context context;
+
+                public DelayedMessageHandler(Context context)
+                {
+                    this.context = context;
+                }
+
+                public void Handle(MyMessage message)
+                {
+                    context.MessageReceivedByHandler = true;
+                }
+            }
+
+            public class EndpointConfiguration : IWantToRunBeforeConfigurationIsFinalized
+            {
+                public static IBuilder builder;
+
+                public void Run(Configure config)
+                {
+                    builder = config.Builder;
+                }
+            }
+
+            public class DispatcherInterceptor : Feature
+            {
+                public DispatcherInterceptor()
+                {
+                    EnableByDefault();
+                    DependsOn<MsmqTransportConfigurator>();
+                }
+
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                    var originalDispatcher = EndpointConfiguration.builder.Build<ISendMessages>();
+                    var ctx = EndpointConfiguration.builder.Build<Context>();
+                    context.Container.ConfigureComponent(() => new SenderWrapper(originalDispatcher, ctx), DependencyLifecycle.SingleInstance);
+                }
+            }
+
+            class SenderWrapper : ISendMessages
+            {
+                ISendMessages wrappedSender;
+                Context context;
+
+                public SenderWrapper(ISendMessages wrappedSender, Context context)
+                {
+                    this.wrappedSender = wrappedSender;
+                    this.context = context;
+                }
+
+                public void Send(TransportMessage message, SendOptions sendOptions)
+                {
+                    string relatedTimeoutId;
+                    if (message.Headers.TryGetValue("NServiceBus.RelatedToTimeoutId", out relatedTimeoutId) && !context.SendingMessageFailedOnce)
+                    {
+                        context.SendingMessageFailedOnce = true;
+                        throw new Exception("simulated exception");
+                    }
+
+                    wrappedSender.Send(message, sendOptions);
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : IMessage { }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Timeouts/OutdatedTimeoutPersister.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeouts/OutdatedTimeoutPersister.cs
@@ -1,0 +1,30 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using NServiceBus.Timeout.Core;
+
+    class OutdatedTimeoutPersister : IPersistTimeouts
+    {
+        public IEnumerable<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
+        {
+            nextTimeToRunQuery = DateTime.Now.AddYears(42);
+            return Enumerable.Empty<Tuple<string, DateTime>>().ToList();
+        }
+
+        public void Add(TimeoutData timeout)
+        {
+        }
+
+        public bool TryRemove(string timeoutId, out TimeoutData timeoutData)
+        {
+            timeoutData = null;
+            return false;
+        }
+
+        public void RemoveTimeoutBy(Guid sagaId)
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Timeouts/TransportWithFakeQueues.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeouts/TransportWithFakeQueues.cs
@@ -1,0 +1,47 @@
+﻿
+namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using NServiceBus.Transports;
+    using NServiceBus.Unicast;
+
+    public class TransportWithFakeQueues : TransportDefinition
+    {
+        protected override void Configure(BusConfiguration config)
+        {
+            config.RegisterComponents(c => c.ConfigureComponent<FakeDequeuer>(DependencyLifecycle.SingleInstance));
+            config.RegisterComponents(c => c.ConfigureComponent<FakeSender>(DependencyLifecycle.SingleInstance));
+            config.RegisterComponents(c => c.ConfigureComponent<FakeQueueCreator>(DependencyLifecycle.SingleInstance));
+        }
+    }
+
+    class FakeDequeuer : IDequeueMessages
+    {
+
+        public void Init(Address address, Unicast.Transport.TransactionSettings transactionSettings, Func<TransportMessage, bool> tryProcessMessage, Action<TransportMessage, Exception> endProcessMessage)
+        {
+        }
+
+        public void Start(int maximumConcurrencyLevel)
+        {
+        }
+
+        public void Stop()
+        {
+        }
+    }
+
+    class FakeQueueCreator : ICreateQueues
+    {
+        public void CreateQueueIfNecessary(Address address, string account)
+        {
+        }
+    }
+
+    class FakeSender : ISendMessages
+    {
+        public void Send(TransportMessage message, SendOptions sendOptions)
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Timeouts/UpdatedTimeoutPersister.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeouts/UpdatedTimeoutPersister.cs
@@ -1,0 +1,40 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using NServiceBus.Timeout.Core;
+
+    class UpdatedTimeoutPersister : IPersistTimeouts, IPersistTimeoutsV2
+    {
+        public IEnumerable<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
+        {
+            nextTimeToRunQuery = DateTime.Now.AddYears(42);
+            return Enumerable.Empty<Tuple<string, DateTime>>().ToList();
+        }
+
+        public void Add(TimeoutData timeout)
+        {
+        }
+
+        public bool TryRemove(string timeoutId, out TimeoutData timeoutData)
+        {
+            timeoutData = null;
+            return false;
+        }
+
+        public void RemoveTimeoutBy(Guid sagaId)
+        {
+        }
+
+        public TimeoutData Peek(string timeoutId)
+        {
+            return null;
+        }
+
+        public bool TryRemove(string timeoutId)
+        {
+            return true;
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Timeouts/When_dispatched_timeout_already_removed_from_timeout_storage.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeouts/When_dispatched_timeout_already_removed_from_timeout_storage.cs
@@ -1,0 +1,187 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Transactions;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NServiceBus.ObjectBuilder;
+    using NServiceBus.Timeout.Core;
+    using NUnit.Framework;
+
+    public class When_timeout_already_removed : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_rollback_and_not_deliver_timeout_when_using_dtc()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(b => b
+                    .CustomConfig(configure => configure.Transactions().EnableDistributedTransactions())
+                    .Given(bus =>
+                    {
+                        bus.Defer(TimeSpan.FromSeconds(5), new MyMessage());
+                    }))
+                .Done(c => c.AttemptedToRemoveTimeout || c.MessageReceived)
+                .Run();
+
+            Assert.IsFalse(context.MessageReceived, "Message should not be delivered using dtc.");
+            Assert.AreEqual(2, context.NumberOfProcessingAttempts, "The rollback should cause a retry.");
+            Assert.IsTrue(context.AttemptedToRemoveTimeout);
+        }
+
+        [Test]
+        public void Should_rollback_and_deliver_timeout_anyway_when_using_native_tx()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(b => b
+                    .CustomConfig(configure => configure.Transactions().DisableDistributedTransactions())
+                    .Given(bus =>
+                    {
+                        bus.Defer(TimeSpan.FromSeconds(5), new MyMessage());
+                    }))
+                .Done(c => c.AttemptedToRemoveTimeout && c.MessageReceived)
+                .Run();
+
+            Assert.IsTrue(context.MessageReceived, "Message should be delivered although transaction was aborted.");
+            Assert.AreEqual(2, context.NumberOfProcessingAttempts, "The rollback should cause a retry.");
+            Assert.IsTrue(context.AttemptedToRemoveTimeout);
+        }
+
+        [Test]
+        public void Should_deliver_timeout_anyway_when_using_no_tx()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(b => b
+                    .CustomConfig(configure => configure.Transactions().Disable())
+                    .Given(bus =>
+                    {
+                        bus.Defer(TimeSpan.FromSeconds(5), new MyMessage());
+                    }))
+                .Done(c => c.AttemptedToRemoveTimeout && c.MessageReceived)
+                .Run();
+
+            Assert.IsTrue(context.MessageReceived, "Message should be delivered although timeout processing fails.");
+            Assert.AreEqual(1, context.NumberOfProcessingAttempts, "Should not retry without transactions enabled.");
+            Assert.IsTrue(context.AttemptedToRemoveTimeout);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageReceived { get; set; }
+            public bool AttemptedToRemoveTimeout { get; set; }
+            public int NumberOfProcessingAttempts { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class DelayedMessageHandler : IHandleMessages<MyMessage>
+            {
+                Context context;
+
+                public DelayedMessageHandler(Context context)
+                {
+                    this.context = context;
+                }
+
+                public void Handle(MyMessage message)
+                {
+                    context.MessageReceived = true;
+                }
+            }
+
+            public class EndpointConfiguration : IWantToRunBeforeConfigurationIsFinalized
+            {
+                public static IBuilder builder;
+
+                public void Run(Configure config)
+                {
+                    builder = config.Builder;
+                }
+            }
+
+            public class DispatcherInterceptor : Feature
+            {
+                public DispatcherInterceptor()
+                {
+                    EnableByDefault();
+                }
+
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                    var originalPersister = EndpointConfiguration.builder.Build<IPersistTimeouts>();
+                    var ctx = EndpointConfiguration.builder.Build<Context>();
+                    context.Container.ConfigureComponent(() => new TimeoutPersistanceWrapper(originalPersister, originalPersister as IPersistTimeoutsV2, ctx), DependencyLifecycle.SingleInstance);
+                }
+            }
+
+            class TimeoutPersistanceWrapper : IPersistTimeouts, IPersistTimeoutsV2
+            {
+                IPersistTimeouts originalTimeoutPersister;
+                IPersistTimeoutsV2 originalTimeoutPersisterV2;
+                Context context;
+
+                public TimeoutPersistanceWrapper(IPersistTimeouts originalTimeoutPersister, IPersistTimeoutsV2 originalTimeoutPersisterV2, Context context)
+                {
+                    this.originalTimeoutPersister = originalTimeoutPersister;
+                    this.originalTimeoutPersisterV2 = originalTimeoutPersisterV2;
+                    this.context = context;
+                }
+
+                public IEnumerable<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
+                {
+                    return originalTimeoutPersister.GetNextChunk(startSlice, out nextTimeToRunQuery);
+                }
+
+                public void Add(TimeoutData timeout)
+                {
+                    originalTimeoutPersister.Add(timeout);
+                }
+
+                public bool TryRemove(string timeoutId, out TimeoutData timeoutData)
+                {
+                    return originalTimeoutPersister.TryRemove(timeoutId, out timeoutData);
+                }
+
+                public void RemoveTimeoutBy(Guid sagaId)
+                {
+                    originalTimeoutPersister.RemoveTimeoutBy(sagaId);
+                }
+
+                public TimeoutData Peek(string timeoutId)
+                {
+                    context.NumberOfProcessingAttempts++;
+                    return originalTimeoutPersisterV2.Peek(timeoutId);
+                }
+
+                public bool TryRemove(string timeoutId)
+                {
+                    context.AttemptedToRemoveTimeout = true;
+
+                    using (var tx = new TransactionScope(TransactionScopeOption.Suppress))
+                    { 
+                        // delete the timeout so it won't be available on retries
+                        originalTimeoutPersisterV2.TryRemove(timeoutId);
+                        tx.Complete();
+                    }
+
+                    return false;
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : IMessage { }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_with_disabled_dtc.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_with_disabled_dtc.cs
@@ -1,0 +1,69 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NServiceBus.Timeout.Core;
+    using NUnit.Framework;
+
+    class When_endpoint_uses_outdated_timeout_persistence_with_disabled_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_not_start_and_show_warning()
+        {
+            var context = new Context();
+            var scenarioException = Assert.Throws<AggregateException>(() => Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run())
+                .InnerException as ScenarioException;
+
+            Assert.IsFalse(context.EndpointsStarted);
+            Assert.IsNotNull(scenarioException);
+            StringAssert.Contains("You are using an outdated timeout persistence which can lead to message loss!", scenarioException.InnerException.Message);
+        }
+
+        [Test]
+        public void Endpoint_should_start_when_warning_suppressed()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(c => c.CustomConfig(b => b.SuppressOutdatedTimeoutPersistenceWarning()))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+
+        public class Context : ScenarioContext { }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.EnableFeature<TimeoutManager>();
+                    config.Transactions().DisableDistributedTransactions();
+                });
+            }
+        }
+
+        public class Initalizer : Feature
+        {
+            public Initalizer()
+            {
+                EnableByDefault();
+            }
+
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.Container.ConfigureComponent<OutdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_with_dtc.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_with_dtc.cs
@@ -1,0 +1,49 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_outdated_timeout_persistence_with_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_start()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        public class Context : ScenarioContext { }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.EnableFeature<TimeoutManager>();
+                    config.Transactions().EnableDistributedTransactions();
+                });
+            }
+        }
+
+        public class Initalizer : Feature
+        {
+            public Initalizer()
+            {
+                EnableByDefault();
+            }
+
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.Container.ConfigureComponent<OutdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_without_dtc.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_outdated_timeout_persistence_without_dtc.cs
@@ -1,0 +1,62 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    public class When_endpoint_uses_outdated_timeout_persistence_without_dtc
+    {
+        [Test]
+        public void Endpoint_should_not_start_and_show_warning()
+        {
+            var context = new Context();
+            var scenarioException = Assert.Throws<AggregateException>(() => Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run())
+                .InnerException as ScenarioException;
+
+            Assert.IsFalse(context.EndpointsStarted);
+            Assert.IsNotNull(scenarioException);
+            StringAssert.Contains("You are using an outdated timeout persistence which can lead to message loss!", scenarioException.InnerException.Message);
+        }
+
+        public class Context : ScenarioContext { }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.EnableFeature<TimeoutManager>();
+                    config.UseTransport<NonDtcTransportDefinition>();
+                    config.OverrideLocalAddress("FakeQueueName");
+                });
+            }
+        }
+        public class Initalizer : Feature
+        {
+            public Initalizer()
+            {
+                EnableByDefault();
+            }
+
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.Container.ConfigureComponent(() => new OutdatedTimeoutPersister(), DependencyLifecycle.SingleInstance);
+            }
+        }
+
+        public class NonDtcTransportDefinition : TransportWithFakeQueues
+        {
+            public NonDtcTransportDefinition()
+            {
+                HasSupportForDistributedTransactions = false;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_updated_timeout_persistence.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeouts/When_endpoint_uses_updated_timeout_persistence.cs
@@ -1,0 +1,49 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    class When_endpoint_uses_updated_timeout_persistence : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Endpoint_should_start()
+        {
+            var context = new Context();
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.EndpointsStarted);
+        }
+
+        public class Context : ScenarioContext { }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.EnableFeature<TimeoutManager>();
+                    config.Transactions().DisableDistributedTransactions();
+                });
+            }
+        }
+
+        public class Initalizer : Feature
+        {
+            public Initalizer()
+            {
+                EnableByDefault();
+            }
+
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.Container.ConfigureComponent<UpdatedTimeoutPersister>(DependencyLifecycle.SingleInstance);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -238,6 +238,9 @@
     <Compile Include="Serializers\XML\XmlSerializerCache.cs" />
     <Compile Include="Settings\DurableMessagesConfig.cs" />
     <Compile Include="Timeout\ConfigurationBuilderExtensions.cs" />
+    <Compile Include="Timeout\Core\IPersistTimeoutsV2.cs" />
+    <Compile Include="Timeout\Core\TimeoutPersistenceVersionCheck.cs" />
+    <Compile Include="Timeout\Core\TimeoutPersistenceVersionCheckExtension.cs" />
     <Compile Include="Transports\ConfigurePurging_Obsolete.cs" />
     <Compile Include="Unicast\Behaviors\FixSendIntentBehavior.cs" />
     <Compile Include="Unicast\Behaviors\ForwardReceivedMessages.cs" />

--- a/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
@@ -2,10 +2,11 @@ namespace NServiceBus.InMemory.TimeoutPersister
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using Timeout.Core;
 
-    class InMemoryTimeoutPersister : IPersistTimeouts
+    class InMemoryTimeoutPersister : IPersistTimeouts, IPersistTimeoutsV2
     {
         List<TimeoutData> storage = new List<TimeoutData>();
         ReaderWriterLockSlim readerWriterLock = new ReaderWriterLockSlim();
@@ -104,6 +105,26 @@ namespace NServiceBus.InMemory.TimeoutPersister
             {
                 readerWriterLock.ExitWriteLock();
             }
+        }
+
+        public TimeoutData Peek(string timeoutId)
+        {
+            try
+            {
+                readerWriterLock.EnterReadLock();
+                return storage.SingleOrDefault(t => t.Id == timeoutId);
+            }
+            finally
+            {
+                readerWriterLock.ExitReadLock();
+            }
+
+        }
+
+        public bool TryRemove(string timeoutId)
+        {
+            TimeoutData timeoutData;
+            return TryRemove(timeoutId, out timeoutData);
         }
     }
 }

--- a/src/NServiceBus.Core/Timeout/Core/IPersistTimeoutsV2.cs
+++ b/src/NServiceBus.Core/Timeout/Core/IPersistTimeoutsV2.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.Timeout.Core
+{
+    /// <summary>
+    /// Timeout persister contract.
+    /// </summary>
+    public interface IPersistTimeoutsV2
+    {
+        /// <summary>
+        /// Reads timeout data.
+        /// </summary>
+        /// <param name="timeoutId">The timeout id to read.</param>
+        /// <returns><see cref="TimeoutData"/> of the timeout if it was found. <c>null</c> otherwise.</returns>
+        TimeoutData Peek(string timeoutId);
+
+        /// <summary>
+        /// Removes the timeout if it hasn't been previously removed.
+        /// </summary>
+        /// <param name="timeoutId">The timeout id to remove.</param>
+        /// <returns><c>true</c> if the timeout has been successfully removed or <c>false</c> if there was no timeout to remove.</returns>
+        bool TryRemove(string timeoutId);
+    }
+}

--- a/src/NServiceBus.Core/Timeout/Core/TimeoutPersistenceVersionCheck.cs
+++ b/src/NServiceBus.Core/Timeout/Core/TimeoutPersistenceVersionCheck.cs
@@ -1,0 +1,87 @@
+﻿namespace NServiceBus.Timeout.Core
+{
+    using NServiceBus.Config;
+    using System;
+    using System.Configuration;
+    using NServiceBus.ObjectBuilder;
+    using NServiceBus.Settings;
+    using NServiceBus.Transports;
+
+    class TimeoutPersistenceVersionCheck : IWantToRunWhenConfigurationIsComplete
+    {
+        internal const string SuppressOutdatedTimeoutPersistenceWarning = "NServiceBus/suppress-outdated-timeout-persistence-warning";
+        
+        readonly IBuilder builder;
+        internal SettingsHolder settingsHolder;
+
+        public TimeoutPersistenceVersionCheck(IBuilder builder)
+        {
+            this.builder = builder;
+        }
+
+        public void Run(Configure config)
+        {
+            settingsHolder = config.Settings;
+            var suppressDtc = settingsHolder.Get<bool>("Transactions.SuppressDistributedTransactions");
+            if (IsTransportSupportingDtc() && !suppressDtc)
+            {
+                // there is no issue with the timeout persistence when using dtc
+                return;
+            }
+
+            var timeoutPersister = TryResolveTimeoutPersister();
+            if (timeoutPersister == null)
+            {
+                // no timeouts used
+                return;
+            }
+
+            if (!(timeoutPersister is IPersistTimeoutsV2) && !UserSuppressedTimeoutPersistenceWarning())
+            {
+                throw new Exception("You are using an outdated timeout persistence which can lead to message loss! Please update the configured timeout persistence. You can suppress this warning by configuring your bus using 'config.SuppressOutdatedTimeoutPersistenceWarning()' or by adding 'NServiceBus/suppress-outdated-timeout-persistence-warning' with value 'true' to the appSettings section of your application configuration file.");
+            }
+        }
+
+        IPersistTimeouts TryResolveTimeoutPersister()
+        {
+            IPersistTimeouts timeoutPersister = null;
+            try
+            {
+                timeoutPersister = builder.Build<IPersistTimeouts>();
+            }
+            catch (Exception)
+            {
+                // catch potential DI exception when interface not registered.
+            }
+
+            return timeoutPersister;
+        }
+
+        bool UserSuppressedTimeoutPersistenceWarning()
+        {
+            if (settingsHolder.HasSetting(SuppressOutdatedTimeoutPersistenceWarning))
+            {
+                return settingsHolder.GetOrDefault<bool>(SuppressOutdatedTimeoutPersistenceWarning);
+            }
+
+            var appSetting = ConfigurationManager.AppSettings[SuppressOutdatedTimeoutPersistenceWarning];
+            if (appSetting != null)
+            {
+                return bool.Parse(appSetting);
+            }
+
+            return false;
+        }
+
+        bool IsTransportSupportingDtc()
+        {
+            var selectedTransport = settingsHolder.GetOrDefault<TransportDefinition>("NServiceBus.Transports.TransportDefinition");
+            if (selectedTransport.HasSupportForDistributedTransactions.HasValue)
+            {
+                return selectedTransport.HasSupportForDistributedTransactions.Value;
+            }
+
+            return !selectedTransport.GetType().Name.Contains("RabbitMQ");
+        }
+    }
+} 

--- a/src/NServiceBus.Core/Timeout/Core/TimeoutPersistenceVersionCheckExtension.cs
+++ b/src/NServiceBus.Core/Timeout/Core/TimeoutPersistenceVersionCheckExtension.cs
@@ -1,0 +1,19 @@
+namespace NServiceBus.Timeout.Core
+{
+    /// <summary>
+    /// Provides methods for suppressing startup checks regarding the selected TimeoutPersistance.
+    /// </summary>
+    public static class TimeoutPersistenceVersionCheckExtension
+    {
+        /// <summary>
+        /// Suppresses warning if selected TimeoutPersistance doesn't contain the hotfix preventing potential message loss.
+        /// </summary>
+        /// <param name="configure">The <see cref="Configure"/> instance.</param>
+        /// <returns></returns>
+        public static BusConfiguration SuppressOutdatedTimeoutPersistenceWarning(this BusConfiguration configure)
+        {
+            configure.Settings.Set(TimeoutPersistenceVersionCheck.SuppressOutdatedTimeoutPersistenceWarning, true);
+            return configure;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Timeout/Hosting/Windows/TimeoutDispatcherProcessor.cs
+++ b/src/NServiceBus.Core/Timeout/Hosting/Windows/TimeoutDispatcherProcessor.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Timeout.Hosting.Windows
 {
     using System;
     using Core;
+    using NServiceBus.Settings;
     using Satellites;
     using Transports;
     using Unicast.Transport;
@@ -18,21 +19,46 @@ namespace NServiceBus.Timeout.Hosting.Windows
         public IPersistTimeouts TimeoutsPersister { get; set; }
 
         public TimeoutPersisterReceiver TimeoutPersisterReceiver { get; set; }
-
+        
         public Configure Configure { get; set; }
       
         public Address InputAddress { get; set; }
+
+        public ReadOnlySettings Settings { get; set; }
 
         public bool Disabled { get; set; }
 
         public bool Handle(TransportMessage message)
         {
             var timeoutId = message.Headers["Timeout.Id"];
-            TimeoutData timeoutData;
 
-            if (TimeoutsPersister.TryRemove(timeoutId, out timeoutData))
+            var persisterV2 = TimeoutsPersister as IPersistTimeoutsV2;
+            if (persisterV2 != null)
             {
-                MessageSender.Send(timeoutData.ToTransportMessage(), timeoutData.ToSendOptions(Configure.LocalAddress));
+                var timeoutData = persisterV2.Peek(timeoutId);
+                if (timeoutData == null)
+                {
+                    return true;
+                }
+
+                var sendOptions = timeoutData.ToSendOptions(Configure.LocalAddress);
+                
+                if (ShouldSuppressTransaction())
+                {
+                    sendOptions.EnlistInReceiveTransaction = false;
+                }
+
+                MessageSender.Send(timeoutData.ToTransportMessage(), sendOptions);
+
+                return persisterV2.TryRemove(timeoutId);
+            }
+            else
+            {
+                TimeoutData timeoutData;
+                if (TimeoutsPersister.TryRemove(timeoutId, out timeoutData))
+                {
+                    MessageSender.Send(timeoutData.ToTransportMessage(), timeoutData.ToSendOptions(Configure.LocalAddress));
+                }
             }
 
             return true;
@@ -56,6 +82,23 @@ namespace NServiceBus.Timeout.Hosting.Windows
                 // transport.DisableSLR() or similar
                 receiver.FailureManager = new ManageMessageFailuresWithoutSlr(receiver.FailureManager, MessageSender, Configure);
             };
+        }
+
+        bool ShouldSuppressTransaction()
+        {
+            var suppressDtc = Settings.Get<bool>("Transactions.SuppressDistributedTransactions");
+            return !IsTransportSupportingDtc() || suppressDtc;
+        }
+
+        bool IsTransportSupportingDtc()
+        {
+            var selectedTransport = Settings.GetOrDefault<TransportDefinition>("NServiceBus.Transports.TransportDefinition");
+            if (selectedTransport.HasSupportForDistributedTransactions.HasValue)
+            {
+                return selectedTransport.HasSupportForDistributedTransactions.Value;
+            }
+
+            return !selectedTransport.GetType().Name.Contains("RabbitMQ");
         }
     }
 }

--- a/src/NServiceBus.Core/Timeout/Hosting/Windows/TimeoutMessageProcessor.cs
+++ b/src/NServiceBus.Core/Timeout/Hosting/Windows/TimeoutMessageProcessor.cs
@@ -76,8 +76,8 @@ namespace NServiceBus.Timeout.Hosting.Windows
                 destination = Address.Parse(routeExpiredTimeoutTo);
             }
 
-            TimeoutManager.RemoveTimeout(timeoutId);
             MessageSender.Send(message, new SendOptions(destination));
+            TimeoutManager.RemoveTimeout(timeoutId);
         }
 
         void HandleInternal(TransportMessage message)


### PR DESCRIPTION
## Who's affected

You might be affected if you are using one of the following transport configurations:
* RabbitMQ transport
* Azure transport 
* MSMQ or SQL transport with distributed transactions (DTC) **disabled**.

**and** you are using timeouts or deferred messages (e.g. `Bus.Defer(...)`)

## Symptoms

When experiencing connectivity issues with the transport there's a chance that a due timeout/deferred message is lost. Therefore the message will never arrive.

## What to do if you are affected

We highly recommend to update to the latest patch versions of your NServiceBus and optional persistence and transport packages. For more details see issue #2885

Connects to #2885