### PR TITLE
Added send-via capability

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
@@ -72,6 +72,22 @@
             return this;
         }
 
+        public EndpointConfigurationBuilder EndpointSetup<T>(Action<BusConfiguration, IDictionary<Type, string>> configurationBuilderCustomization) where T : IEndpointSetupTemplate, new()
+        {
+            if (configurationBuilderCustomization == null)
+            {
+                configurationBuilderCustomization = (b, r) => { };
+            }
+            configuration.GetConfiguration = (settings, routingTable) =>
+            {
+                var endpointSetupTemplate = new T();
+                var scenarioConfigSource = new ScenarioConfigSource(configuration, routingTable);
+                return endpointSetupTemplate.GetConfiguration(settings, configuration, scenarioConfigSource, b => configurationBuilderCustomization(b, routingTable));
+            };
+
+            return this;
+        }
+
         EndpointConfiguration IEndpointConfigurationFactory.Get()
         {
             return CreateScenario();

--- a/src/NServiceBus.AcceptanceTests/Basic/When_deferring_to_non_local_via_a_proxy.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_deferring_to_non_local_via_a_proxy.cs
@@ -1,0 +1,97 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    public class When_deferring_to_non_local_via_a_proxy : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Message_should_be_received_by_proxy()
+        {
+            var context = await Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b => b.When((bus, c) =>
+                    {
+                        var options = new SendOptions();
+
+                        options.DelayDeliveryWith(TimeSpan.FromSeconds(3));
+                        return bus.SendAsync(new MyMessage(), options);
+                    }))
+                    .WithEndpoint<Receiver>()
+                    .WithEndpoint<Proxy>()
+                    .Done(c => c.MessagedDeliveredToProxy)
+                    .Run();
+
+            Assert.IsTrue(context.MessagedDeliveredToProxy);
+            Assert.IsNotNull(context.UltimateDestination);
+            Assert.IsNull(context.Route1);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessagedDeliveredToProxy { get; set; }
+            public string UltimateDestination { get; set; }
+            public string Route1 { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>((config, rt) =>
+                {
+                    config.EnableFeature<TimeoutManager>();
+                    config.Routing().UnicastRoutingTable.AddStatic(typeof(MyMessage), rt[typeof(Receiver)], rt[typeof(Proxy)]);
+                });
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyMessage message)
+                {
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Proxy : EndpointConfigurationBuilder
+        {
+            public Proxy()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+            public class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Context Context { get; set; }
+                public IBus Bus { get; set; }
+
+                public Task Handle(MyMessage message)
+                {
+                    Context.MessagedDeliveredToProxy = true;
+                    Context.UltimateDestination = Bus.CurrentMessageContext.Headers[Headers.UltimateDestination];
+                    string route1;
+                    Bus.CurrentMessageContext.Headers.TryGetValue(Headers.SendVia+".1", out route1);
+                    Context.Route1 = route1;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        [Serializable]
+        public class MyMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -67,6 +67,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Basic\When_deferring_to_non_local_via_a_proxy.cs" />
     <Compile Include="Basic\When_registering_additional_deserializers.cs" />
     <Compile Include="Basic\When_setting_msmq_label_generator.cs" />
     <Compile Include="Basic\When_deferring_to_non_local.cs" />
@@ -137,6 +138,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Routing\When_distributing_an_event.cs" />
+    <Compile Include="Routing\When_sending_a_command_via_a_proxy.cs" />
     <Compile Include="Routing\When_publishing_from_sendonly.cs" />
     <Compile Include="MessageId\When_message_has_empty_id_header.cs" />
     <Compile Include="Routing\When_publishing_an_event_implementing_two_unrelated_interfaces.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/When_sending_a_command_via_a_proxy.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_sending_a_command_via_a_proxy.cs
@@ -1,0 +1,175 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Pipeline.Contexts;
+    using NServiceBus.Routing;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    public class When_sending_a_command_via_a_proxy : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_send_via_a_proxy_but_reply_directly()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(b => b.When(c => c.ReceiverReady && c.ProxyReady, (bus, c) => bus.SendAsync(new Request())))
+                .WithEndpoint<Receiver>()
+                .WithEndpoint<Proxy>()
+                .Done(c => c.SenderGotResponse)
+                .Run();
+
+            Assert.IsTrue(context.SenderGotResponse);
+            Assert.IsTrue(context.ReceiverGotRequest);
+            Assert.IsTrue(context.ProxyGotRequest);
+            Assert.IsFalse(context.ProxyGotResponse);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool ProxyGotRequest { get; set; }
+            public bool ReceiverGotRequest { get; set; }
+            public bool ProxyGotResponse { get; set; }
+            public bool SenderGotResponse { get; set; }
+
+            public bool ProxyReady { get; set; }
+            public bool ReceiverReady { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    var receiverEndpoint = new EndpointName("SendingACommandViaAProxy.Receiver");
+                    var proxyEndpoint = new EndpointName("SendingACommandViaAProxy.Proxy");
+                    c.Routing().UnicastRoutingTable.AddStatic(typeof(Request), receiverEndpoint, new EndpointInstanceName(proxyEndpoint, null, null));
+                    c.Routing().EndpointInstances.AddStatic(receiverEndpoint, new EndpointInstanceName(receiverEndpoint, null, null));
+                });
+            }
+
+
+            public class ResponseHandler : IHandleMessages<Response>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(Response message)
+                {
+                    Context.SenderGotResponse = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                });
+            }
+
+            public class ReadyNotification : IWantToRunWhenBusStartsAndStops
+            {
+                public Context Context { get; set; }
+
+                public Task StartAsync()
+                {
+                    Context.ReceiverReady = true;
+                    return Task.FromResult(0);
+                }
+
+                public Task StopAsync()
+                {
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class MyMessageHandler : IHandleMessages<Request>
+            {
+                public IBus Bus { get; set; }
+                public Context Context { get; set; }
+
+                public Task Handle(Request message)
+                {
+                    Context.ReceiverGotRequest = true;
+                    return Bus.ReplyAsync(new Response());
+                }
+            }
+        }
+
+        public class Proxy : EndpointConfigurationBuilder
+        {
+            public Proxy()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.Pipeline.Register("Proxy", typeof(ProxyBehavior), "Proxy");
+                });
+            }
+
+            public class ReadyNotification : IWantToRunWhenBusStartsAndStops
+            {
+                public Context Context { get; set; }
+
+                public Task StartAsync()
+                {
+                    Context.ProxyReady = true;
+                    return Task.FromResult(0);
+                }
+
+                public Task StopAsync()
+                {
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class ProxyBehavior : Behavior<TransportReceiveContext>
+            {
+                public Context Context { get; set; }
+                public IDispatchMessages Dispatcher { get; set; }
+                
+                public override async Task Invoke(TransportReceiveContext context, Func<Task> next)
+                {
+                    var itinerary = Itinerary.ExtractFrom(context.Message.Headers);
+                    string destination;
+                    itinerary.Advance(out destination);
+                    var outgoingMessage = new OutgoingMessage(context.Message.MessageId, context.Message.Headers, context.Message.Body);
+                    var addressLabel = new UnicastAddressTag(destination);
+                    await Dispatcher.Dispatch(new[]
+                    {
+                        new TransportOperation(outgoingMessage, new DispatchOptions(addressLabel, DispatchConsistency.Default))
+                    }, context);
+                    await next().ConfigureAwait(false);
+                }
+            }
+
+            public class MessageDetector : IHandleMessages<IMessage>
+            {
+                public Context Context { get; set; }
+
+
+                public Task Handle(IMessage message)
+                {
+                    Context.ProxyGotRequest |= message is Request;
+                    Context.ProxyGotResponse |= message is Response;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Request : ICommand
+        {
+        }
+
+        public class Response : IMessage
+        {
+        }
+
+    }
+}

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -377,9 +377,11 @@ namespace NServiceBus
         public const string RouteTo = "NServiceBus.Header.RouteTo";
         public const string SagaId = "NServiceBus.SagaId";
         public const string SagaType = "NServiceBus.SagaType";
+        public const string SendVia = "NServiceBus.SendVia";
         public const string SubscriptionMessageType = "SubscriptionMessageType";
         public const string TimeSent = "NServiceBus.TimeSent";
         public const string TimeToBeReceived = "NServiceBus.TimeToBeReceived";
+        public const string UltimateDestination = "NServiceBus.UltimateDestination";
         public const string WindowsIdentityName = "WinIdName";
     }
     public class static HostInfoConfigurationExtensions
@@ -2098,6 +2100,13 @@ namespace NServiceBus.Routing
         public AllInstancesDistributionStrategy() { }
         public override System.Collections.Generic.IEnumerable<NServiceBus.EndpointInstanceName> SelectDestination(System.Collections.Generic.IEnumerable<NServiceBus.EndpointInstanceName> allInstances) { }
     }
+    public sealed class DirectRoutingImmediateDestination
+    {
+        public DirectRoutingImmediateDestination(NServiceBus.EndpointInstanceName instanceName) { }
+        public DirectRoutingImmediateDestination(string physicalAddress) { }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
+    }
     public class DistributionPolicy
     {
         public DistributionPolicy() { }
@@ -2108,12 +2117,29 @@ namespace NServiceBus.Routing
         protected DistributionStrategy() { }
         public abstract System.Collections.Generic.IEnumerable<NServiceBus.EndpointInstanceName> SelectDestination(System.Collections.Generic.IEnumerable<NServiceBus.EndpointInstanceName> allInstances);
     }
+    public class EndpointInstanceData
+    {
+        public EndpointInstanceData(NServiceBus.EndpointInstanceName name) { }
+        public System.Collections.Generic.Dictionary<string, object> ExtensionData { get; }
+        public NServiceBus.EndpointInstanceName Name { get; }
+    }
     public class EndpointInstances
     {
         public EndpointInstances() { }
+        public void AddDynamic(System.Func<NServiceBus.EndpointName, System.Collections.Generic.IEnumerable<NServiceBus.Routing.EndpointInstanceData>> dynamicRule) { }
         public void AddDynamic(System.Func<NServiceBus.EndpointName, System.Collections.Generic.IEnumerable<NServiceBus.EndpointInstanceName>> dynamicRule) { }
+        public void AddStatic(NServiceBus.EndpointName endpoint, params NServiceBus.Routing.EndpointInstanceData[] instances) { }
         public void AddStatic(NServiceBus.EndpointName endpoint, params NServiceBus.EndpointInstanceName[] instances) { }
         public void AddStaticUsingTransportDiscriminators(NServiceBus.EndpointName endpoint, params string[] transportDiscriminators) { }
+    }
+    public class Itinerary
+    {
+        public Itinerary(string ultimateDestination, params string[] sendVia) { }
+        public bool IsEmpty { get; }
+        public NServiceBus.Routing.Itinerary Advance(out string immediateDestination) { }
+        public static NServiceBus.Routing.Itinerary Empty() { }
+        public static NServiceBus.Routing.Itinerary ExtractFrom(System.Collections.Generic.IDictionary<string, string> headers) { }
+        public void Store(System.Collections.Generic.IDictionary<string, string> headers) { }
     }
     public class MulticastAddressTag : NServiceBus.Routing.AddressTag
     {
@@ -2146,24 +2172,38 @@ namespace NServiceBus.Routing
         public UnicastAddressTag(string destination) { }
         public string Destination { get; }
     }
-    public class UnicastRoutingDestination
+    public sealed class UnicastRoutingDestination
     {
         public UnicastRoutingDestination(NServiceBus.EndpointName endpointName) { }
         public UnicastRoutingDestination(NServiceBus.EndpointInstanceName instanceName) { }
         public UnicastRoutingDestination(string physicalAddress) { }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
+    }
+    public sealed class UnicastRoutingRoute
+    {
+        public UnicastRoutingRoute(NServiceBus.Routing.UnicastRoutingDestination ultimateDestination, NServiceBus.Routing.DirectRoutingImmediateDestination immediateDestination = null) { }
+        public override bool Equals(object obj) { }
+        public override int GetHashCode() { }
     }
     public class UnicastRoutingStrategy : NServiceBus.Routing.RoutingStrategy
     {
-        public UnicastRoutingStrategy(string destination) { }
+        public UnicastRoutingStrategy(string ultimateDestination, params string[] route) { }
         public override NServiceBus.Routing.AddressTag Apply(System.Collections.Generic.Dictionary<string, string> headers) { }
+        public NServiceBus.Routing.UnicastRoutingStrategy SendVia(string next) { }
     }
     public class UnicastRoutingTable
     {
         public UnicastRoutingTable() { }
+        public void AddDynamic(System.Func<System.Type, NServiceBus.Extensibility.ContextBag, System.Collections.Generic.IEnumerable<NServiceBus.Routing.UnicastRoutingRoute>> dynamicRule) { }
         public void AddDynamic(System.Func<System.Type, NServiceBus.Extensibility.ContextBag, System.Collections.Generic.IEnumerable<NServiceBus.Routing.UnicastRoutingDestination>> dynamicRule) { }
+        public void AddStatic(System.Type messageType, NServiceBus.Routing.UnicastRoutingRoute route) { }
         public void AddStatic(System.Type messageType, NServiceBus.EndpointName destination) { }
+        public void AddStatic(System.Type messageType, NServiceBus.EndpointName destination, NServiceBus.EndpointInstanceName sendVia) { }
+        public void AddStatic(System.Type messageType, NServiceBus.EndpointName destination, string sendVia) { }
         public void AddStatic(System.Type messageType, NServiceBus.EndpointInstanceName destination) { }
         public void AddStatic(System.Type messageType, string destinationAddress) { }
+        public void AddStatic(System.Type messageType, string destinationAddress, string sendVia) { }
     }
     public class UnsubscribeContext : NServiceBus.Pipeline.BehaviorContext
     {

--- a/src/NServiceBus.Core.Tests/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehaviorTests.cs
@@ -28,9 +28,11 @@
 
             await behavior.Invoke(context, () => Task.FromResult(0));
 
-            Assert.AreEqual("tm", ((UnicastAddressTag)context.RoutingStrategies.First().Apply(new Dictionary<string, string>())).Destination);
+            var headers = new Dictionary<string, string>();
+            var addressLabel = context.RoutingStrategies.First().Apply(headers);
+            Assert.AreEqual("tm", ((UnicastAddressTag)addressLabel).Destination);
 
-            Assert.AreEqual(message.Headers[TimeoutManagerHeaders.RouteExpiredTimeoutTo], "target");
+            Assert.AreEqual(headers[Headers.UltimateDestination], "target");
         }
 
 

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -135,6 +135,7 @@
     <Compile Include="Routing\ApplyReplyToAddressBehaviorTests.cs" />
     <Compile Include="Routing\DetermineRouteForPublishBehaviorTests.cs" />
     <Compile Include="Routing\DetermineRouteForSendBehaviorTests.cs" />
+    <Compile Include="Routing\ItineraryTests.cs" />
     <Compile Include="Routing\MessageDrivenSubscribeTerminatorTests.cs" />
     <Compile Include="Routing\MessageDrivenUnsubscribeTerminatorTests.cs" />
     <Compile Include="Routing\SubscriptionRouterTests.cs" />

--- a/src/NServiceBus.Core.Tests/Routing/DetermineRouteForPublishBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DetermineRouteForPublishBehaviorTests.cs
@@ -13,7 +13,7 @@
         [Test]
         public async Task Should_use_to_all_subscribers_strategy()
         {
-            var behavior = new MulticastPublishRouterBehavior();
+            var behavior = new MulticastPublishRouterConnector();
 
             var context = new OutgoingPublishContext(new OutgoingLogicalMessage(new MyEvent()), new PublishOptions(), new RootContext(null));
 

--- a/src/NServiceBus.Core.Tests/Routing/ItineraryTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/ItineraryTests.cs
@@ -1,0 +1,95 @@
+﻿namespace NServiceBus.Core.Tests.Routing
+{
+    using System.Collections.Generic;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    class ItineraryTests
+    {
+        [Test]
+        public void Empty_itinerary_is_empty()
+        {
+            var empty = Itinerary.Empty();
+            Assert.IsTrue(empty.IsEmpty);
+        }
+
+        [Test]
+        public void Advancing_an_empty_itinerary_retuns_an_empty_itinerary()
+        {
+            string immediateDestination;
+            var empty = Itinerary.Empty();
+            var advanced = empty.Advance(out immediateDestination);
+
+            Assert.IsTrue(advanced.IsEmpty);
+            Assert.IsNull(immediateDestination);
+        }
+
+        [Test]
+        public void Advancing_an_itinerary_without_send_via_returns_an_empty_itinerary()
+        {
+            string immediateDestination;
+            var itinerary = new Itinerary("Ultimate");
+            var advanced = itinerary.Advance(out immediateDestination);
+
+            Assert.IsTrue(advanced.IsEmpty);
+            Assert.AreEqual("Ultimate", immediateDestination);
+        }
+
+        [Test]
+        public void Advancing_an_itinerary_with_send_via_hops_returns_a_non_empty_itinerary()
+        {
+            string immediateDestination;
+            var itinerary = new Itinerary("Ultimate","Hop-1","Hop-2");
+
+            var advanced = itinerary.Advance(out immediateDestination);
+            Assert.IsFalse(advanced.IsEmpty);
+            Assert.AreEqual("Hop-1", immediateDestination);
+
+            advanced = advanced.Advance(out immediateDestination);
+            Assert.IsFalse(advanced.IsEmpty);
+            Assert.AreEqual("Hop-2", immediateDestination);
+
+            advanced = advanced.Advance(out immediateDestination);
+            Assert.IsTrue(advanced.IsEmpty);
+            Assert.AreEqual("Ultimate", immediateDestination);
+        }
+
+        [Test]
+        public void Storing_empty_itinerary_is_noop()
+        {
+            var itinerary = Itinerary.Empty();
+            var store = new Dictionary<string, string>();
+
+            itinerary.Store(store);
+
+            Assert.IsEmpty(store);
+        }
+
+        [Test]
+        public void Storing_a_no_hop_itinerary_stores_only_ultimate_destination_header()
+        {
+            var itinerary = new Itinerary("Ultimate");
+            var store = new Dictionary<string, string>();
+
+            itinerary.Store(store);
+
+            Assert.AreEqual(1, store.Count);
+            Assert.AreEqual("Ultimate", store[Headers.UltimateDestination]);
+        }
+
+        [Test]
+        public void Storing_a_multi_hop_itinerary_stores_the_send_via_headers()
+        {
+            var itinerary = new Itinerary("Ultimate", "Hop-1", "Hop-2");
+            var store = new Dictionary<string, string>();
+
+            itinerary.Store(store);
+
+            Assert.AreEqual(3, store.Count);
+            Assert.AreEqual("Ultimate", store[Headers.UltimateDestination]);
+            Assert.AreEqual("Hop-1", store[Headers.SendVia + ".1"]);
+            Assert.AreEqual("Hop-2", store[Headers.SendVia + ".2"]);
+        }
+    }
+}

--- a/src/NServiceBus.Core/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehavior.cs
@@ -42,13 +42,8 @@ namespace NServiceBus
                     throw new Exception("Postponed delivery of messages with TimeToBeReceived set is not supported. Remove the TimeToBeReceived attribute to postpone messages of this type.");
                 }
 
-                //Hack 133
-                var ultimateDestination = ((UnicastAddressTag)context.RoutingStrategies.First().Apply(new Dictionary<string, string>())).Destination;
-                context.Message.Headers[TimeoutManagerHeaders.RouteExpiredTimeoutTo] = ultimateDestination;
-                context.RoutingStrategies = new[]
-                {
-                    new UnicastRoutingStrategy(timeoutManagerAddress)
-                }; 
+                var newRoutingStrategies = context.RoutingStrategies.Cast<UnicastRoutingStrategy>().Select(s => s.SendVia(timeoutManagerAddress)).ToArray();
+                context.RoutingStrategies = newRoutingStrategies;
 
                 DateTime deliverAt;
                 var delayConstraint = constraint as DelayDeliveryWith;

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
@@ -45,9 +45,15 @@ namespace NServiceBus
                 }
 
                 var destination = message.GetReplyToAddress();
-
                 string routeExpiredTimeoutTo;
-                if (message.Headers.TryGetValue(TimeoutManagerHeaders.RouteExpiredTimeoutTo, out routeExpiredTimeoutTo))
+
+                var itinerary = Itinerary.ExtractFrom(message.Headers);
+                if (!itinerary.IsEmpty)
+                {
+                    var newItinerary = itinerary.Advance(out destination);
+                    newItinerary.Store(message.Headers);
+                }
+                else if (message.Headers.TryGetValue(TimeoutManagerHeaders.RouteExpiredTimeoutTo, out routeExpiredTimeoutTo))
                 {
                     destination = routeExpiredTimeoutTo;
                 }

--- a/src/NServiceBus.Core/Headers.cs
+++ b/src/NServiceBus.Core/Headers.cs
@@ -217,5 +217,15 @@
         /// Indicates that the message was sent as a non durable message.
         /// </summary>
         public const string NonDurableMessage = "NServiceBus.NonDurableMessage";
+
+        /// <summary>
+        /// Indicates the ultimate destination of a message.
+        /// </summary>
+        public const string UltimateDestination = "NServiceBus.UltimateDestination";
+
+        /// <summary>
+        /// Indicates where to send the message next.
+        /// </summary>
+        public const string SendVia = "NServiceBus.SendVia";
     }
 }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -118,10 +118,14 @@
     <Compile Include="Pipeline\Outgoing\OutgoingPhysicalMessageContext.cs" />
     <Compile Include="Reliability\Outbox\ForceBatchDispatchToBeIsolatedBehavior.cs" />
     <Compile Include="Reliability\Outbox\OutboxTransaction.cs" />
+    <Compile Include="Routing\Itinerary.cs" />
     <Compile Include="Routing\MulticastRoutingStrategy.cs" />
     <Compile Include="Routing\RoutingStrategy.cs" />
     <Compile Include="Routing\UnicastRoutingStrategy.cs" />
     <Compile Include="Sagas\SagaLoader.cs" />
+    <Compile Include="Routing\DirectRoutingImmediateDestination.cs" />
+    <Compile Include="Routing\UnicastRoutingRoute.cs" />
+    <Compile Include="Routing\EndpointInstanceData.cs" />
     <Compile Include="Sagas\Saga_obsoletes.cs" />
     <Compile Include="Routing\AllInstancesDistributionStrategy.cs" />
     <Compile Include="Routing\UnicastRoutingDestination.cs" />
@@ -243,6 +247,7 @@
     <Compile Include="DelayedDelivery\DelayDeliveryWith.cs" />
     <Compile Include="Features\RootFeature.cs" />
     <Compile Include="Routing\Routers\MulticastPublishRouterBehavior.cs" />
+    <Compile Include="Routing\Routers\MulticastPublishRouterConnector.cs" />
     <Compile Include="Routing\Routers\UnicastSendRouterConnector.cs" />
     <Compile Include="Routing\UnicastAddressTag.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\IInitializableSubscriptionStorage.cs" />

--- a/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
@@ -21,7 +21,7 @@
                 {
                     var headers = new Dictionary<string, string>(context.Message.Headers);
                     var addressLabel = rs.Apply(headers);
-                    var message = new OutgoingMessage(context.Message.MessageId, context.Message.Headers, context.Message.Body);
+                    var message = new OutgoingMessage(context.Message.MessageId, headers, context.Message.Body);
                     return new TransportOperation(message, new DispatchOptions(addressLabel, dispatchConsistency, context.GetDeliveryConstraints()));
                 });            
 

--- a/src/NServiceBus.Core/Recoverability/Faults/MoveFaultsToErrorQueueBehavior.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/MoveFaultsToErrorQueueBehavior.cs
@@ -49,7 +49,7 @@ namespace NServiceBus
                     message.Headers[Headers.HostId] = hostInformation.HostId.ToString("N");
                     message.Headers[Headers.HostDisplayName] = hostInformation.DisplayName;
 
-
+            
                     var dispatchContext = new RoutingContext(new OutgoingMessage(message.MessageId, message.Headers, message.Body), 
                         new UnicastRoutingStrategy(errorQueueAddress), 
                         context);

--- a/src/NServiceBus.Core/Routing/DirectRoutingImmediateDestination.cs
+++ b/src/NServiceBus.Core/Routing/DirectRoutingImmediateDestination.cs
@@ -1,0 +1,111 @@
+namespace NServiceBus.Routing
+{
+    using System;
+
+    /// <summary>
+    /// An immediate destination of direct routing.
+    /// </summary>
+    public sealed class DirectRoutingImmediateDestination
+    {
+        EndpointInstanceName instanceName;
+        string physicalAddress;
+        static string[] emptyRoute = new string[0];
+
+        private DirectRoutingImmediateDestination()
+        {
+        }
+
+        internal static DirectRoutingImmediateDestination None()
+        {
+            return new DirectRoutingImmediateDestination();
+        }
+
+        /// <summary>
+        /// Creates a destination based on the name of the endpoint instance.
+        /// </summary>
+        /// <param name="instanceName">Destination instance name.</param>
+        public DirectRoutingImmediateDestination(EndpointInstanceName instanceName)
+        {
+            Guard.AgainstNull(nameof(instanceName), instanceName);
+            this.instanceName = instanceName;
+        }
+
+        /// <summary>
+        /// Creates a destination based on the physical address.
+        /// </summary>
+        /// <param name="physicalAddress">Destination physical address.</param>
+        public DirectRoutingImmediateDestination(string physicalAddress)
+        {
+            Guard.AgainstNullAndEmpty(nameof(physicalAddress), physicalAddress);
+            this.physicalAddress = physicalAddress;
+        }
+
+        internal string[] Resolve(Func<EndpointInstanceName, string> addressResolver)
+        {
+            if (physicalAddress != null)
+            {
+                return new[] {physicalAddress};
+            }
+            if (instanceName != null)
+            {
+                return new []{ addressResolver(instanceName)};
+            }
+            return emptyRoute;
+        }
+
+        bool Equals(DirectRoutingImmediateDestination other)
+        {
+            return Equals(instanceName, other.instanceName) && string.Equals(physicalAddress, other.physicalAddress);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <returns>
+        /// true if the specified object  is equal to the current object; otherwise, false.
+        /// </returns>
+        /// <param name="obj">The object to compare with the current object. </param>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+            return obj is DirectRoutingImmediateDestination && Equals((DirectRoutingImmediateDestination) obj);
+        }
+
+        /// <summary>
+        /// Serves as a hash function for a particular type. 
+        /// </summary>
+        /// <returns>
+        /// A hash code for the current object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((instanceName != null ? instanceName.GetHashCode() : 0)*397) ^ (physicalAddress != null ? physicalAddress.GetHashCode() : 0);
+            }
+        }
+
+        /// <summary>
+        /// Checks for equality.
+        /// </summary>
+        public static bool operator ==(DirectRoutingImmediateDestination left, DirectRoutingImmediateDestination right)
+        {
+            return Equals(left, right);
+        }
+
+        /// <summary>
+        /// Checks for inequality.
+        /// </summary>
+        public static bool operator !=(DirectRoutingImmediateDestination left, DirectRoutingImmediateDestination right)
+        {
+            return !Equals(left, right);
+        }
+    }
+}

--- a/src/NServiceBus.Core/Routing/DistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionPolicy.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Routing
         List<Tuple<Func<Type, bool>,DistributionStrategy>> strategies = new List<Tuple<Func<Type, bool>, DistributionStrategy>>();
 
         /// <summary>
-        /// Creates a new distribution policy.
+        /// Creates a new distribution policy object.
         /// </summary>
         public DistributionPolicy()
         {

--- a/src/NServiceBus.Core/Routing/EndpointInstanceData.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstanceData.cs
@@ -1,7 +1,5 @@
 namespace NServiceBus.Routing
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// Contains information about the endpoint instance.
     /// </summary>
@@ -13,18 +11,12 @@ namespace NServiceBus.Routing
         public EndpointInstanceName Name { get; }
 
         /// <summary>
-        /// The extension data.
-        /// </summary>
-        public Dictionary<string, object> ExtensionData { get; }
-
-        /// <summary>
         /// Creates new endpoint data object.
         /// </summary>
         /// <param name="name">Name of the endpoint instance.</param>
         public EndpointInstanceData(EndpointInstanceName name)
         {
             Name = name;
-            ExtensionData = new Dictionary<string, object>();
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/EndpointInstanceData.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstanceData.cs
@@ -1,0 +1,30 @@
+namespace NServiceBus.Routing
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Contains information about the endpoint instance.
+    /// </summary>
+    public class EndpointInstanceData
+    {
+        /// <summary>
+        /// The name of the instance.
+        /// </summary>
+        public EndpointInstanceName Name { get; }
+
+        /// <summary>
+        /// The extension data.
+        /// </summary>
+        public Dictionary<string, object> ExtensionData { get; }
+
+        /// <summary>
+        /// Creates new endpoint data object.
+        /// </summary>
+        /// <param name="name">Name of the endpoint instance.</param>
+        public EndpointInstanceData(EndpointInstanceName name)
+        {
+            Name = name;
+            ExtensionData = new Dictionary<string, object>();
+        }
+    }
+}

--- a/src/NServiceBus.Core/Routing/EndpointInstances.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstances.cs
@@ -9,22 +9,30 @@ namespace NServiceBus.Routing
     /// </summary>
     public class EndpointInstances
     {
-        List<Func<EndpointName, IEnumerable<EndpointInstanceName>>> rules = new List<Func<EndpointName, IEnumerable<EndpointInstanceName>>>();
+        List<Func<EndpointName, IEnumerable<EndpointInstanceData>>> rules = new List<Func<EndpointName, IEnumerable<EndpointInstanceData>>>();
 
-        internal IEnumerable<EndpointInstanceName> FindInstances(EndpointName endpoint)
+        internal IEnumerable<EndpointInstanceData> FindInstances(EndpointName endpoint)
         {
             var distinctInstances = rules.SelectMany(r => r(endpoint)).Distinct();
             return distinctInstances.EnsureNonEmpty(() => $"The list of instances of endpoint {endpoint} has not been provided to the routing module. Plase use 'BusConfiguration.Routing().EndpointInstances' to supply this information.");
         }
 
-
+        /// <summary>
+        /// Adds a dynamic rule for determining endpoint instances.
+        /// </summary>
+        /// <param name="dynamicRule">The rule.</param>
+        public void AddDynamic(Func<EndpointName, IEnumerable<EndpointInstanceData>> dynamicRule)
+        {
+            rules.Add(dynamicRule);
+        } 
+        
         /// <summary>
         /// Adds a dynamic rule for determining endpoint instances.
         /// </summary>
         /// <param name="dynamicRule">The rule.</param>
         public void AddDynamic(Func<EndpointName, IEnumerable<EndpointInstanceName>> dynamicRule)
         {
-            rules.Add(dynamicRule);
+            rules.Add(e => dynamicRule(e).Select(i => new EndpointInstanceData(i)));
         }
 
         /// <summary>
@@ -32,9 +40,19 @@ namespace NServiceBus.Routing
         /// </summary>
         /// <param name="endpoint">Name of the endpoint.</param>
         /// <param name="instances">A static list of endpoint's instances.</param>
-        public void AddStatic(EndpointName endpoint, params EndpointInstanceName[] instances)
+        public void AddStatic(EndpointName endpoint, params EndpointInstanceData[] instances)
         {
             rules.Add(e => StaticRule(e, endpoint, instances));   
+        }
+        
+        /// <summary>
+        /// Adds static information about an endpoint.
+        /// </summary>
+        /// <param name="endpoint">Name of the endpoint.</param>
+        /// <param name="instances">A static list of endpoint's instances.</param>
+        public void AddStatic(EndpointName endpoint, params EndpointInstanceName[] instances)
+        {
+            rules.Add(e => StaticRule(e, endpoint, instances.Select(i => new EndpointInstanceData(i)).ToArray()));   
         }
 
         /// <summary>
@@ -47,13 +65,13 @@ namespace NServiceBus.Routing
             AddStatic(endpoint, transportDiscriminators.Select(d => new EndpointInstanceName(endpoint, null, d)).ToArray());
         }
 
-        private static IEnumerable<EndpointInstanceName> StaticRule(EndpointName endpointBeingQueried, EndpointName configuredEndpoint, EndpointInstanceName[] configuredInstances)
+        private static IEnumerable<EndpointInstanceData> StaticRule(EndpointName endpointBeingQueried, EndpointName configuredEndpoint, EndpointInstanceData[] configuredInstances)
         {
             if (endpointBeingQueried == configuredEndpoint)
             {
                 return configuredInstances;
             }
-            return Enumerable.Empty<EndpointInstanceName>();
+            return Enumerable.Empty<EndpointInstanceData>();
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/Itinerary.cs
+++ b/src/NServiceBus.Core/Routing/Itinerary.cs
@@ -1,0 +1,107 @@
+﻿namespace NServiceBus.Routing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Represents an itinerary.
+    /// </summary>
+    public class Itinerary
+    {
+        string ultimateDestination;
+        string[] sendVia;
+
+        /// <summary>
+        /// Creates a new itinerary with a given ultimate destination and optional route.
+        /// </summary>
+        /// <param name="ultimateDestination">The ultimate destination.</param>
+        /// <param name="sendVia">The route.</param>
+        public Itinerary(string ultimateDestination, params string[] sendVia)
+        {
+            Guard.AgainstNull(nameof(ultimateDestination), ultimateDestination);
+            Guard.AgainstNull(nameof(sendVia), sendVia);
+            this.ultimateDestination = ultimateDestination;
+            this.sendVia = sendVia;
+        }
+
+        private Itinerary()
+        {
+        }
+
+        /// <summary>
+        /// Checks if the itinerary is empty.
+        /// </summary>
+        public bool IsEmpty => ultimateDestination == null;
+
+        /// <summary>
+        /// Returns an empty itinerary.
+        /// </summary>
+        public static Itinerary Empty()
+        {
+            return new Itinerary();
+        }
+
+        /// <summary>
+        /// Extracts the itinerary from the headers dictionary in a destructive way (removing the related headers from it).
+        /// </summary>
+        /// <param name="headers">The dictionary containing headers.</param>
+        public static Itinerary ExtractFrom(IDictionary<string, string> headers)
+        {
+            string ultimateDestination;
+            if (!headers.TryGetValue(Headers.UltimateDestination, out ultimateDestination))
+            {
+                return Empty();
+            }
+            var sendViaHeaders = headers.Where(p => p.Key.StartsWith(Headers.SendVia, StringComparison.OrdinalIgnoreCase)).ToArray();
+            foreach (var header in sendViaHeaders)
+            {
+                headers.Remove(header.Key);
+            }
+            var sendVia = sendViaHeaders
+                .Select(p => new
+                {
+                    Index = int.Parse(p.Key.Replace(Headers.SendVia + ".", "")),
+                    Value = p.Value
+                })
+                .OrderBy(x => x.Index)
+                .Select(x => x.Value)
+                .ToArray();
+            return new Itinerary(ultimateDestination, sendVia);
+        }
+
+        /// <summary>
+        /// Returns an itinerary that is one-hop advanced compared to the current one.
+        /// </summary>
+        /// <param name="immediateDestination"></param>
+        /// <returns></returns>
+        public Itinerary Advance(out string immediateDestination)
+        {
+            if (sendVia != null && sendVia.Length > 0)
+            {
+                immediateDestination = sendVia[0];
+                return new Itinerary(ultimateDestination, sendVia.Skip(1).ToArray());
+            }
+            immediateDestination = ultimateDestination;
+            return Empty();
+        }
+
+        /// <summary>
+        /// Stores this itinerary in the header collection.
+        /// </summary>
+        public void Store(IDictionary<string, string> headers)
+        {
+            if (IsEmpty)
+            {
+                return;
+            }
+            headers[Headers.UltimateDestination] = ultimateDestination;
+            for (var i = 0; i < sendVia.Length; i++)
+            {
+                var hop = sendVia[i];
+                var oneBasedIndex = i + 1;
+                headers[Headers.SendVia + "." + oneBasedIndex] = hop;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/PublishersSettingsExtensions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/PublishersSettingsExtensions.cs
@@ -12,7 +12,7 @@ namespace NServiceBus
         /// </summary>
         public static Publishers Pubishers(this BusConfiguration config)
         {
-            Guard.AgainstNull("config", config);
+            Guard.AgainstNull(nameof(config), config);
             Publishers publishers;
             if (!config.Settings.TryGet(out publishers))
             {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionRouter.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionRouter.cs
@@ -7,10 +7,10 @@
 
     class SubscriptionRouter
     {
-        public SubscriptionRouter(Publishers publishers, EndpointInstances endpointInstances, TransportAddresses physicalAddresses)
+        public SubscriptionRouter(Publishers publishers, EndpointInstances knownEndpoints, TransportAddresses physicalAddresses)
         {
             this.publishers = publishers;
-            this.endpointInstances = endpointInstances;
+            this.knownEndpoints = knownEndpoints;
             this.physicalAddresses = physicalAddresses;
         }
 
@@ -18,13 +18,13 @@
         {
             var publisherAddresses = publishers
                 .GetPublisherFor(messageType).SelectMany(p => p
-                    .Resolve(e => endpointInstances.FindInstances(e), i => physicalAddresses.GetPhysicalAddress(i)));
+                    .Resolve(e => knownEndpoints.FindInstances(e).Select(i => i.Name), i => physicalAddresses.GetPhysicalAddress(i)));
 
             return publisherAddresses;
         }
 
         Publishers publishers;
-        EndpointInstances endpointInstances;
+        EndpointInstances knownEndpoints;
         TransportAddresses physicalAddresses;
     }
 }

--- a/src/NServiceBus.Core/Routing/Routers/MulticastPublishRouterConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/MulticastPublishRouterConnector.cs
@@ -1,0 +1,19 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus.Pipeline.Contexts;
+    using OutgoingPipeline;
+    using Pipeline;
+    using Routing;
+    using TransportDispatch;
+
+    class MulticastPublishRouterConnector : StageConnector<OutgoingPublishContext, OutgoingLogicalMessageContext>
+    {
+        public override Task Invoke(OutgoingPublishContext context, Func<OutgoingLogicalMessageContext, Task> next)
+        {
+            context.SetHeader(Headers.MessageIntent, MessageIntentEnum.Publish.ToString());
+            return next(new OutgoingLogicalMessageContext(context.Message, new [] { new MulticastRoutingStrategy(context.Message.MessageType) }, context));
+        }
+    }
+}

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -67,15 +67,15 @@
             }
 
             var outboundRoutingPolicy = transportDefinition.GetOutboundRoutingPolicy(context.Settings);
-            context.Pipeline.Register("UnicastSendRouterConnector", typeof(UnicastSendRouterConnector), "Determines how the message being sent should be routed");
-            context.Pipeline.Register("UnicastReplyRouterConnector", typeof(UnicastReplyRouterConnector), "Determines how replies should be routed");
+            context.Pipeline.Register("DirectSendRouterConnector", typeof(UnicastSendRouterConnector), "Determines how the message being sent should be routed");
+            context.Pipeline.Register("DirectReplyRouterConnector", typeof(UnicastReplyRouterConnector), "Determines how replies should be routed");
             if (outboundRoutingPolicy.Publishes == OutboundRoutingType.DirectSend)
             {
-                context.Pipeline.Register("UnicastPublishRouterConnector", typeof(UnicastPublishRouterConnector), "Determines how the published messages should be routed");
+                context.Pipeline.Register("DirectPublishRouterConnector", typeof(UnicastPublishRouterConnector), "Determines how the published messages should be routed");
             }
             else
             {
-                context.Pipeline.Register("MulticastPublishRouterBehavior", typeof(MulticastPublishRouterBehavior), "Determines how the published messages should be routed");                
+                context.Pipeline.Register("MulticastPublishRouterConnector", typeof(MulticastPublishRouterConnector), "Determines how the published messages should be routed");                
             }
 
             if (canReceive)
@@ -138,7 +138,8 @@
                 {
                     //TODO: 133
                     var subscriptions = builder.Build<ISubscriptionStorage>();
-                    settings.Get<UnicastRoutingTable>().AddDynamic((t, c) => QuerySubscriptionStore(subscriptions, t, c));
+                    var directRoutingTable = settings.Get<UnicastRoutingTable>();
+                    directRoutingTable.AddDynamic((t, c) => QuerySubscriptionStore(subscriptions, t, c));
                 }
             }
 

--- a/src/NServiceBus.Core/Routing/UnicastRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRouter.cs
@@ -32,10 +32,10 @@ namespace NServiceBus.Routing
             var destinationEndpoints = typesToRoute.SelectMany(t => unicastRoutingTable.GetDestinationsFor(t, contextBag)).Distinct().ToList();
 
             return destinationEndpoints.SelectMany(d => d.Resolve(
-                e => endpointInstances.FindInstances(e),
+                e => endpointInstances.FindInstances(e).Select(i => i.Name),
                 distributionStrategy.SelectDestination,
                 i => physicalAddresses.GetPhysicalAddress(i)
-                )).Select(a => new UnicastRoutingStrategy(a));
+                ));
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/UnicastRoutingDestination.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRoutingDestination.cs
@@ -5,9 +5,9 @@ namespace NServiceBus.Routing
     using System.Linq;
 
     /// <summary>
-    /// A destination of address routing.
+    /// A destination of unicast routing.
     /// </summary>
-    public class UnicastRoutingDestination
+    public sealed class UnicastRoutingDestination
     {
         EndpointName endpointName;
         EndpointInstanceName instanceName;
@@ -19,7 +19,7 @@ namespace NServiceBus.Routing
         /// <param name="endpointName">Destination endpoint.</param>
         public UnicastRoutingDestination(EndpointName endpointName)
         {
-            Guard.AgainstNull("endpointName", endpointName);
+            Guard.AgainstNull(nameof(endpointName), endpointName);
             this.endpointName = endpointName;
         }
 
@@ -29,7 +29,7 @@ namespace NServiceBus.Routing
         /// <param name="instanceName">Destination instance name.</param>
         public UnicastRoutingDestination(EndpointInstanceName instanceName)
         {
-            Guard.AgainstNull("instanceName",instanceName);
+            Guard.AgainstNull(nameof(instanceName),instanceName);
             this.instanceName = instanceName;
         }
 
@@ -39,7 +39,7 @@ namespace NServiceBus.Routing
         /// <param name="physicalAddress">Destination physical address.</param>
         public UnicastRoutingDestination(string physicalAddress)
         {
-            Guard.AgainstNullAndEmpty("physicalAddress",physicalAddress);
+            Guard.AgainstNullAndEmpty(nameof(physicalAddress),physicalAddress);
             this.physicalAddress = physicalAddress;
         }
 
@@ -64,6 +64,68 @@ namespace NServiceBus.Routing
                     yield return address;
                 }
             }
+        }
+
+        bool Equals(UnicastRoutingDestination other)
+        {
+            return Equals(endpointName, other.endpointName) && Equals(instanceName, other.instanceName) && string.Equals(physicalAddress, other.physicalAddress);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <returns>
+        /// true if the specified object  is equal to the current object; otherwise, false.
+        /// </returns>
+        /// <param name="obj">The object to compare with the current object. </param>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+            if (obj.GetType() != this.GetType())
+            {
+                return false;
+            }
+            return Equals((UnicastRoutingDestination) obj);
+        }
+
+        /// <summary>
+        /// Serves as a hash function for a particular type. 
+        /// </summary>
+        /// <returns>
+        /// A hash code for the current object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (endpointName != null ? endpointName.GetHashCode() : 0);
+                hashCode = (hashCode*397) ^ (instanceName != null ? instanceName.GetHashCode() : 0);
+                hashCode = (hashCode*397) ^ (physicalAddress != null ? physicalAddress.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+
+        /// <summary>
+        /// Checks for equality.
+        /// </summary>
+        public static bool operator ==(UnicastRoutingDestination left, UnicastRoutingDestination right)
+        {
+            return Equals(left, right);
+        }
+
+        /// <summary>
+        /// Checks for inequality.
+        /// </summary>
+        public static bool operator !=(UnicastRoutingDestination left, UnicastRoutingDestination right)
+        {
+            return !Equals(left, right);
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/UnicastRoutingRoute.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRoutingRoute.cs
@@ -1,0 +1,91 @@
+namespace NServiceBus.Routing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Represents a route in unicast routing.
+    /// </summary>
+    public sealed class UnicastRoutingRoute
+    {
+        UnicastRoutingDestination ultimateDestination;
+        DirectRoutingImmediateDestination immediateDestination;
+
+        /// <summary>
+        /// Creates new instance of the route.
+        /// </summary>
+        /// <param name="ultimateDestination">The ultimate destination of the message.</param>
+        /// <param name="immediateDestination">Optional immediate destination.</param>
+        public UnicastRoutingRoute(UnicastRoutingDestination ultimateDestination, DirectRoutingImmediateDestination immediateDestination = null)
+        {
+            this.ultimateDestination = ultimateDestination;
+            this.immediateDestination = immediateDestination ?? DirectRoutingImmediateDestination.None();
+            Guard.AgainstNull(nameof(ultimateDestination), ultimateDestination);
+        }
+
+        internal IEnumerable<UnicastRoutingStrategy> Resolve(Func<EndpointName, IEnumerable<EndpointInstanceName>> instanceResolver,
+            Func<IEnumerable<EndpointInstanceName>, IEnumerable<EndpointInstanceName>> instanceSelector,
+            Func<EndpointInstanceName, string> addressResolver
+            )
+        {
+            return ultimateDestination.Resolve(instanceResolver, instanceSelector, addressResolver)
+                .Select(d => new UnicastRoutingStrategy(d, immediateDestination.Resolve(addressResolver)));
+        }
+
+        bool Equals(UnicastRoutingRoute other)
+        {
+            return Equals(ultimateDestination, other.ultimateDestination) && Equals(immediateDestination, other.immediateDestination);
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <returns>
+        /// true if the specified object  is equal to the current object; otherwise, false.
+        /// </returns>
+        /// <param name="obj">The object to compare with the current object. </param>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+            return obj is UnicastRoutingRoute && Equals((UnicastRoutingRoute) obj);
+        }
+
+        /// <summary>
+        /// Serves as a hash function for a particular type. 
+        /// </summary>
+        /// <returns>
+        /// A hash code for the current object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((ultimateDestination != null ? ultimateDestination.GetHashCode() : 0)*397) ^ (immediateDestination != null ? immediateDestination.GetHashCode() : 0);
+            }
+        }
+
+        /// <summary>
+        /// Checks for equality.
+        /// </summary>
+        public static bool operator ==(UnicastRoutingRoute left, UnicastRoutingRoute right)
+        {
+            return Equals(left, right);
+        }
+
+        /// <summary>
+        /// Checks for inequality.
+        /// </summary>
+        public static bool operator !=(UnicastRoutingRoute left, UnicastRoutingRoute right)
+        {
+            return !Equals(left, right);
+        }
+    }
+}

--- a/src/NServiceBus.Core/Routing/UnicastRoutingStrategy.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRoutingStrategy.cs
@@ -1,20 +1,32 @@
 ﻿namespace NServiceBus.Routing
 {
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// A routing strategy for unicast routing.
     /// </summary>
     public class UnicastRoutingStrategy : RoutingStrategy
     {
-        string destination;
+        string ultimateDestination;
+        string[] route;
 
         /// <summary>
         /// Creates new routing strategy.
         /// </summary>
-        public UnicastRoutingStrategy(string destination)
+        public UnicastRoutingStrategy(string ultimateDestination, params string[] route)
         {
-            this.destination = destination;
+            this.ultimateDestination = ultimateDestination;
+            this.route = route;
+        }
+
+        /// <summary>
+        /// Returns a new routing strategy that first routes the message to <paramref name="next"/>.
+        /// </summary>
+        /// <param name="next">The immediate destination.</param>
+        public UnicastRoutingStrategy SendVia(string next)
+        {
+            return new UnicastRoutingStrategy(ultimateDestination, new[] { next}.Concat(route).ToArray());
         }
 
         /// <summary>
@@ -23,7 +35,11 @@
         /// <param name="headers">Message headers.</param>
         public override AddressTag Apply(Dictionary<string, string> headers)
         {
-            return new UnicastAddressTag(destination);
+            var itinerary = new Itinerary(ultimateDestination, route);
+            string immediateDestination;
+            var newItinerary = itinerary.Advance(out immediateDestination);
+            newItinerary.Store(headers);
+            return new UnicastAddressTag(immediateDestination);
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/UnicastRoutingTable.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRoutingTable.cs
@@ -10,11 +10,21 @@ namespace NServiceBus.Routing
     /// </summary>
     public class UnicastRoutingTable
     {
-        List<Func<Type, ContextBag, IEnumerable<UnicastRoutingDestination>>> rules = new List<Func<Type, ContextBag, IEnumerable<UnicastRoutingDestination>>>();
+        List<Func<Type, ContextBag, IEnumerable<UnicastRoutingRoute>>> rules = new List<Func<Type, ContextBag, IEnumerable<UnicastRoutingRoute>>>();
 
-        internal IEnumerable<UnicastRoutingDestination> GetDestinationsFor(Type messageType, ContextBag contextBag)
+        internal IEnumerable<UnicastRoutingRoute> GetDestinationsFor(Type messageType, ContextBag contextBag)
         {
             return rules.SelectMany(r => r(messageType, contextBag)).Distinct();
+        }
+
+        /// <summary>
+        /// Adds a static unicast route.
+        /// </summary>
+        /// <param name="messageType">Message type.</param>
+        /// <param name="route">Route.</param>
+        public void AddStatic(Type messageType, UnicastRoutingRoute route)
+        {
+            rules.Add((t, c) => StaticRule(t, messageType, route));
         }
 
         /// <summary>
@@ -24,9 +34,30 @@ namespace NServiceBus.Routing
         /// <param name="destination">Destination endpoint.</param>
         public void AddStatic(Type messageType, EndpointName destination)
         {
-            rules.Add((t, c) => StaticRule(t, messageType, new UnicastRoutingDestination(destination)));
+            rules.Add((t, c) => StaticRule(t, messageType, new UnicastRoutingRoute(new UnicastRoutingDestination(destination))));
         }
 
+        /// <summary>
+        /// Adds a static unicast route.
+        /// </summary>
+        /// <param name="messageType">Message type.</param>
+        /// <param name="destination">Destination endpoint.</param>
+        /// <param name="sendVia">Immediate dispatch instance (proxy).</param>
+        public void AddStatic(Type messageType, EndpointName destination, EndpointInstanceName sendVia)
+        {
+            rules.Add((t, c) => StaticRule(t, messageType, new UnicastRoutingRoute(new UnicastRoutingDestination(destination), new DirectRoutingImmediateDestination(sendVia))));
+        }
+
+        /// <summary>
+        /// Adds a static unicast route.
+        /// </summary>
+        /// <param name="messageType">Message type.</param>
+        /// <param name="destination">Destination endpoint.</param>
+        /// <param name="sendVia">Immediate dispatch instance (proxy).</param>
+        public void AddStatic(Type messageType, EndpointName destination, string sendVia)
+        {
+            rules.Add((t, c) => StaticRule(t, messageType, new UnicastRoutingRoute(new UnicastRoutingDestination(destination), new DirectRoutingImmediateDestination(sendVia))));
+        }
 
         /// <summary>
         /// Adds a static unicast route.
@@ -35,7 +66,7 @@ namespace NServiceBus.Routing
         /// <param name="destination">Destination endpoint instance.</param>
         public void AddStatic(Type messageType, EndpointInstanceName destination)
         {
-            rules.Add((t, c) => StaticRule(t, messageType, new UnicastRoutingDestination(destination)));
+            rules.Add((t, c) => StaticRule(t, messageType, new UnicastRoutingRoute(new UnicastRoutingDestination(destination))));
         }
 
 
@@ -46,7 +77,30 @@ namespace NServiceBus.Routing
         /// <param name="destinationAddress">Destination endpoint instance address.</param>
         public void AddStatic(Type messageType, string destinationAddress)
         {
-            rules.Add((t, c) => StaticRule(t, messageType, new UnicastRoutingDestination(destinationAddress)));
+            rules.Add((t, c) => StaticRule(t, messageType, new UnicastRoutingRoute(new UnicastRoutingDestination(destinationAddress))));
+        }
+
+        /// <summary>
+        /// Adds a static unicast route.
+        /// </summary>
+        /// <param name="messageType">Message type.</param>
+        /// <param name="destinationAddress">Destination endpoint instance address.</param>
+        /// <param name="sendVia">Immediate dispatch instance (proxy).</param>
+        public void AddStatic(Type messageType, string destinationAddress, string sendVia)
+        {
+            Guard.AgainstNull(nameof(messageType), messageType);
+            Guard.AgainstNull(nameof(destinationAddress), destinationAddress);
+            Guard.AgainstNull(nameof(sendVia), sendVia);
+            rules.Add((t, c) => StaticRule(t, messageType, new UnicastRoutingRoute(new UnicastRoutingDestination(destinationAddress), new DirectRoutingImmediateDestination(sendVia))));
+        }
+
+        /// <summary>
+        /// Adds a rule for generating unicast routes.
+        /// </summary>
+        /// <param name="dynamicRule">The rule.</param>
+        public void AddDynamic(Func<Type, ContextBag, IEnumerable<UnicastRoutingRoute>> dynamicRule)
+        {
+            rules.Add(dynamicRule);
         }
 
         /// <summary>
@@ -55,14 +109,14 @@ namespace NServiceBus.Routing
         /// <param name="dynamicRule">The rule.</param>
         public void AddDynamic(Func<Type, ContextBag, IEnumerable<UnicastRoutingDestination>> dynamicRule)
         {
-            rules.Add(dynamicRule);
+            rules.Add((t, c) => dynamicRule(t, c).Select(d => new UnicastRoutingRoute(d)));
         }
 
-        private static IEnumerable<UnicastRoutingDestination> StaticRule(Type messageBeingRouted, Type configuredMessage, UnicastRoutingDestination configuredDestination)
+        private static IEnumerable<UnicastRoutingRoute> StaticRule(Type messageBeingRouted, Type configuredMessage, UnicastRoutingRoute configuredRoute)
         {
             if (messageBeingRouted == configuredMessage)
             {
-                yield return configuredDestination;
+                yield return configuredRoute;
             }
         }
     }

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqMessageSender.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqMessageSender.cs
@@ -46,15 +46,13 @@ namespace NServiceBus.Transports.Msmq
             var dispatchOptions = transportOperation.DispatchOptions;
             var message = transportOperation.Message;
 
-                var routingStrategy = dispatchOptions.AddressTag as UnicastAddressTag;
+            var addressLabel = dispatchOptions.AddressTag as UnicastAddressTag;
+            if (addressLabel == null)
+            {
+                throw new Exception("The MSMQ transport only supports the `UnicastRouter`, strategy required " + dispatchOptions.AddressTag.GetType().Name);
+            }
 
-                if (routingStrategy == null)
-                {
-                    throw new Exception("The MSMQ transport only supports the `DirectRoutingStrategy`, strategy required " + dispatchOptions.AddressTag.GetType().Name);
-                }
-
-            var destination = routingStrategy.Destination;
-
+            var destination = addressLabel.Destination;
             var destinationAddress = MsmqAddress.Parse(destination);
             try
             {

--- a/src/NServiceBus.Core/Unicast/ContextualBus.cs
+++ b/src/NServiceBus.Core/Unicast/ContextualBus.cs
@@ -112,7 +112,6 @@ namespace NServiceBus.Unicast
             }
 
             var pipeline = new PipelineBase<RoutingContext>(builder, settings, settings.Get<PipelineConfiguration>().MainPipeline);
-
             var outgoingMessage = new OutgoingMessage(MessageBeingProcessed.MessageId, MessageBeingProcessed.Headers, MessageBeingProcessed.Body);
             var context = new RoutingContext(outgoingMessage, new UnicastRoutingStrategy(sendLocalAddress), incomingContext);
 
@@ -129,7 +128,6 @@ namespace NServiceBus.Unicast
         public async Task ForwardCurrentMessageToAsync(string destination)
         {
             var pipeline = new PipelineBase<RoutingContext>(builder, settings, settings.Get<PipelineConfiguration>().MainPipeline);
-
             var outgoingMessage = new OutgoingMessage(MessageBeingProcessed.MessageId, MessageBeingProcessed.Headers, MessageBeingProcessed.Body);
             var context = new RoutingContext(outgoingMessage, new UnicastRoutingStrategy(destination), incomingContext);
 


### PR DESCRIPTION
Related to: https://github.com/Particular/PlatformDevelopment/issues/133

### Send via

Messages can be dispatched to different endpoint than they are being send to. Unicast routing table allows to specify the immediate dispatch address where the message is going to be send immediately. If this is specified, the actual send address calculated by routing module is added as `NServiceBus.UltimateDestination` header, e.g. with routing configured like this:

```
var receiverEndpoint = new EndpointName("SendingACommandViaAProxy.Receiver");
var proxyEndpoint = new EndpointName("SendingACommandViaAProxy.Proxy");
var proxyInstance = new EndpointInstanceName(proxyEndpoint, null, null);
c.Routing().UnicastRoutingTable.AddStatic(typeof(Request), receiverEndpoint, proxyInstance);
c.Routing().EndpointInstances.AddStatic(receiverEndpoint, new EndpointInstanceName(receiverEndpoint, null, null));
```

sending a `Request` message would result in (assuming MSMQ) sending message to queue `SendingACommandViaAProxy.Proxy`. The message will contain `NServiceBus.UltimateDestination` header with value `SendingACommandViaAProxy.Receiver@myMachine`

### Timeout manager

Timeout manager is refactored to make use of this feature. Messages that are deferred are dispatched directly to the timeout manager satellite and their ultimate destination is moved to the header. Should a deferred message be configured with *send via*, it actually get two additional headers, `NServiceBus.SendVia.1` and `NServiceBus.UltimateDestination`

with the routing configured as in the previous example, deferring a `Request` message would result in adding that message to local timeout manager queue (e.g. `SendingACommandViaAProxy.Sender.TimeoutManager`). The message will contain `NServiceBus.UltimateDestination` header with value `SendingACommandViaAProxy.Receiver@myMachine` and `NServiceBus.SendVia.1` header with value `SendingACommandViaAProxy.Proxy@myMachine`. The timeout manager dispatcher will rotate the routing headers, removing the proxy address and leaving only the ultimate address when dispatching the transport message to the proxy.