### PR TITLE
Correlated saga properties must have a value

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -142,6 +142,7 @@
     <Compile Include="Routing\When_publishing_an_event_implementing_two_unrelated_interfaces.cs" />
     <Compile Include="ApiExtension\When_extending_the_publish_api.cs" />
     <Compile Include="Routing\When_overriding_public_return_address.cs" />
+    <Compile Include="Sagas\When_forgetting_to_set_a_corr_property.cs" />
     <Compile Include="Sagas\When_updating_correlation_property.cs" />
     <Compile Include="Sagas\When_a_finder_exists_and_context_information_added.cs" />
     <Compile Include="Sagas\When_a_finder_exists_and_found_saga.cs" />

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
@@ -16,7 +16,10 @@
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<SagaEndpoint>(b => b.When(bus =>
                 {
-                    var message = new MessageWithSagaId();
+                    var message = new MessageWithSagaId
+                    {
+                        DataId = Guid.NewGuid()
+                    };
                     var options = new SendOptions();
 
                     options.SetHeader(Headers.SagaId, Guid.NewGuid().ToString());

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
@@ -4,8 +4,6 @@
     using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
-    using NServiceBus.Config;
-    using NServiceBus.Features;
     using NUnit.Framework;
     using ScenarioDescriptors;
 
@@ -43,18 +41,12 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>(b => b.DisableFeature<TimeoutManager>())
-                    .WithConfig<TransportConfig>(c =>
-                    {
-                        c.MaxRetries = 0;
-                    });
+                EndpointSetup<DefaultServer>();
             }
 
             public class SagaIdChangedSaga : Saga<SagaIdChangedSaga.SagaIdChangedSagaData>,
                 IAmStartedByMessages<StartSaga>
             {
-                public Context Context { get; set; }
-
                 public Task Handle(StartSaga message)
                 {
                     Data.DataId = message.DataId;

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_handle.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_handle.cs
@@ -2,11 +2,11 @@
 {
     using System;
     using System.Threading.Tasks;
-    using EndpointTemplates;
-    using AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
     using NServiceBus.Features;
     using NUnit.Framework;
-    using ScenarioDescriptors;
 
     public class When_sending_from_a_saga_handle : NServiceBusAcceptanceTest
     {
@@ -14,7 +14,10 @@
         public async Task Should_match_different_saga()
         {
             await Scenario.Define<Context>()
-                .WithEndpoint<Endpoint>(b => b.When(bus => bus.SendLocalAsync(new StartSaga1 { DataId = Guid.NewGuid() })))
+                .WithEndpoint<Endpoint>(b => b.When(bus => bus.SendLocalAsync(new StartSaga1
+                {
+                    DataId = Guid.NewGuid()
+                })))
                 .Done(c => c.DidSaga2ReceiveMessage)
                 .Repeat(r => r.For(Transports.Default))
                 .Should(c => Assert.True(c.DidSaga2ReceiveMessage))
@@ -28,7 +31,6 @@
 
         public class Endpoint : EndpointConfigurationBuilder
         {
-
             public Endpoint()
             {
                 EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
@@ -36,21 +38,21 @@
 
             public class TwoSaga1Saga1 : Saga<TwoSaga1Saga1Data>, IAmStartedByMessages<StartSaga1>, IHandleMessages<MessageSaga1WillHandle>
             {
-                public Context Context { get; set; }
-
                 public Task Handle(StartSaga1 message)
                 {
-                    var dataId = Guid.NewGuid();
-                    Data.DataId = dataId;
+                    Data.DataId = message.DataId;
                     return Bus.SendLocalAsync(new MessageSaga1WillHandle
                     {
-                        DataId = dataId
+                        DataId = message.DataId
                     });
                 }
 
                 public async Task Handle(MessageSaga1WillHandle message)
                 {
-                    await Bus.SendLocalAsync(new StartSaga2());
+                    await Bus.SendLocalAsync(new StartSaga2
+                    {
+                        DataId = message.DataId
+                    });
                     MarkAsComplete();
                 }
 
@@ -59,7 +61,6 @@
                     mapper.ConfigureMapping<MessageSaga1WillHandle>(m => m.DataId).ToSaga(s => s.DataId);
                     mapper.ConfigureMapping<StartSaga1>(m => m.DataId).ToSaga(s => s.DataId);
                 }
-
             }
 
             public class TwoSaga1Saga1Data : ContainSagaData
@@ -74,22 +75,22 @@
 
                 public Task Handle(StartSaga2 message)
                 {
+                    Data.DataId = message.DataId;
                     Context.DidSaga2ReceiveMessage = true;
 
                     return Task.FromResult(0);
-                }
-
-                public class TwoSaga1Saga2Data : ContainSagaData
-                {
-                    public virtual Guid DataId { get; set; }
                 }
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TwoSaga1Saga2Data> mapper)
                 {
                     mapper.ConfigureMapping<StartSaga2>(m => m.DataId).ToSaga(s => s.DataId);
                 }
-            }
 
+                public class TwoSaga1Saga2Data : ContainSagaData
+                {
+                    public virtual Guid DataId { get; set; }
+                }
+            }
         }
 
         [Serializable]
@@ -98,12 +99,12 @@
             public Guid DataId { get; set; }
         }
 
-
         [Serializable]
         public class StartSaga2 : ICommand
         {
             public Guid DataId { get; set; }
         }
+
         public class MessageSaga1WillHandle : IMessage
         {
             public Guid DataId { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
@@ -28,7 +28,6 @@
 
         public class Endpoint : EndpointConfigurationBuilder
         {
-
             public Endpoint()
             {
                 EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
@@ -46,7 +45,10 @@
 
                 public async Task Timeout(Saga1Timeout state)
                 {
-                    await Bus.SendLocalAsync(new StartSaga2());
+                    await Bus.SendLocalAsync(new StartSaga2
+                    {
+                        DataId = Data.DataId
+                    });
                     MarkAsComplete();
                 }
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_timeout_hit_not_found_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_timeout_hit_not_found_saga.cs
@@ -14,7 +14,7 @@
         public async Task Should_not_fire_notfound_for_tm()
         {
             var context = await Scenario.Define<Context>()
-                .WithEndpoint<Endpoint>(b => b.When(bus => bus.SendLocalAsync(new StartSaga())))
+                .WithEndpoint<Endpoint>(b => b.When(bus => bus.SendLocalAsync(new StartSaga { DataId = Guid.NewGuid() })))
                 .Done(c => c.NotFoundHandlerCalledForRegularMessage)
                 .Run();
 
@@ -36,7 +36,7 @@
             }
 
             public class TimeoutHitsNotFoundSaga : Saga<TimeoutHitsNotFoundSaga.TimeoutHitsNotFoundSagaData>,
-                IAmStartedByMessages<StartSaga>, 
+                IAmStartedByMessages<StartSaga>,
                 IHandleSagaNotFound,
                 IHandleTimeouts<TimeoutHitsNotFoundSaga.MyTimeout>,
                 IHandleMessages<SomeOtherMessage>

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
@@ -13,7 +13,7 @@
         public async Task Timeout_should_be_received_after_expiration()
         {
             await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
-                    .WithEndpoint<RecvMsgForTimeoutEndpt>(g => g.When(bus => bus.SendLocalAsync(new StartSagaMessage())))
+                    .WithEndpoint<RecvMsgForTimeoutEndpt>(g => g.When(bus => bus.SendLocalAsync(new StartSagaMessage { SomeId = Guid.NewGuid() })))
                     .Done(c => c.TimeoutReceived)
                     .Run();
         }


### PR DESCRIPTION
We now makes sure that correlated saga properties are assigned a value to catch the common misstake to forget to assign the property to the value of the incoming message property.