### PR TITLE
prevent timeout message loss when not using DTC

### DIFF
--- a/src/impl/unicast/transport/NServiceBus.Unicast.Transport.Transactional.Config/AdvancedTransactionalConfig.cs
+++ b/src/impl/unicast/transport/NServiceBus.Unicast.Transport.Transactional.Config/AdvancedTransactionalConfig.cs
@@ -1,7 +1,12 @@
+using System;
+using System.Configuration;
+
 namespace NServiceBus.Unicast.Transport.Transactional.Config
 {
     public static class AdvancedTransactionalConfig
     {
+        static string SuppressOutdatedTimeoutDispatchSetting = "NServiceBus/suppress-outdated-timeout-dispatch-warning";
+
         /// <summary>
         /// Suppress the use of DTC. Can be combined with IsTransactional to turn off
         /// the DTC but still use the retries
@@ -10,8 +15,39 @@ namespace NServiceBus.Unicast.Transport.Transactional.Config
         /// <returns></returns>
         public static Configure SupressDTC(this Configure config)
         {
-            Bootstrapper.SupressDTC = true;
+            if (UserSuppressedOutdatedDispatchWarning())
+            {
+                Bootstrapper.SupressDTC = true;
+                return config;
+            }
+
+            var exceptionMessage = string.Format(
+                "You are using an outdated timeout dispatch implementation which can lead to message loss! " +
+                "Please update NServiceBus package to version 4.4.8 or higher. " +
+                "You can suppress this warning by calling 'SuppressOutdatedTimeoutDispatchWarning()' before 'SuppressDTC()' (e.g. 'configure.SuppressOutdatedTimeoutDispatchWarning().SupressDTC()')" +
+                " or by adding key '{0}' with value 'true' to the appSettings section of your application configuration file.", SuppressOutdatedTimeoutDispatchSetting);
+            throw new Exception(exceptionMessage);
+        }
+        
+        public static Configure SuppressOutdatedTimeoutDispatchWarning(this Configure config)
+        {
+            Bootstrapper.SuppressOutdatedTimeoutDispatchWarning = true;
             return config;
+        }
+
+        static bool UserSuppressedOutdatedDispatchWarning()
+        {
+            return Bootstrapper.SuppressOutdatedTimeoutDispatchWarning || UserSuppressedOutdatedDispatchWarningUsingAppConfig();
+        }
+
+        static bool UserSuppressedOutdatedDispatchWarningUsingAppConfig()
+        {
+            var appSetting = ConfigurationManager.AppSettings[SuppressOutdatedTimeoutDispatchSetting];
+            if (appSetting != null)
+            {
+                return bool.Parse(appSetting);
+            }
+            return false;
         }
     }
 }

--- a/src/impl/unicast/transport/NServiceBus.Unicast.Transport.Transactional.Config/Bootstrapper.cs
+++ b/src/impl/unicast/transport/NServiceBus.Unicast.Transport.Transactional.Config/Bootstrapper.cs
@@ -51,5 +51,6 @@ namespace NServiceBus.Unicast.Transport.Transactional.Config
         public static IsolationLevel IsolationLevel { get; set; }
         public static TimeSpan TransactionTimeout { get; set; }
         public static bool SupressDTC { get; set; }
+        public static bool SuppressOutdatedTimeoutDispatchWarning { get; set; }
     }
 }


### PR DESCRIPTION
## Who's affected

You might be affected if you disabled DTC **and** you are using timeouts.

## Symptoms

When experiencing connectivity issues with the transport there's a chance that a due timeout/deferred message is lost. Therefore the message will never arrive.

## What to do if you are affected

We highly recommend to upgrade to NServiceBus 4.4.8 or higher. For more details see issue #2885

Connects to #2885