### PR TITLE
Remove statics from LicenseManager

### DIFF
--- a/src/NServiceBus.Core/Licensing/ConfigureLicenseExtensions.cs
+++ b/src/NServiceBus.Core/Licensing/ConfigureLicenseExtensions.cs
@@ -18,10 +18,10 @@ namespace NServiceBus
         /// <param name="licenseText">The license text.</param>
         public static void License(this BusConfiguration config, string licenseText)
         {
-            Guard.AgainstNullAndEmpty("licenseText", licenseText);
-            Guard.AgainstNull("config", config);
+            Guard.AgainstNullAndEmpty(nameof(licenseText), licenseText);
+            Guard.AgainstNull(nameof(config), config);
             Logger.Info(@"Using license supplied via fluent API.");
-            LicenseManager.InitializeLicenseText(licenseText);
+            config.Settings.Set(Features.LicenseReminder.LicenseTextSettingsKey, licenseText);
         }
 
 
@@ -32,8 +32,8 @@ namespace NServiceBus
         /// <param name="licenseFile">A relative or absolute path to the license file.</param>
         public static void LicensePath(this BusConfiguration config, string licenseFile)
         {
-            Guard.AgainstNull("config", config);
-            Guard.AgainstNullAndEmpty("licenseFile", licenseFile);
+            Guard.AgainstNull(nameof(config), config);
+            Guard.AgainstNullAndEmpty(nameof(licenseFile), licenseFile);
             if (!File.Exists(licenseFile))
             {
                 throw new FileNotFoundException("License file not found", licenseFile);

--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -35,17 +35,17 @@ namespace NServiceBus.Licensing
 
             if (LicenseExpirationChecker.HasLicenseExpired(foundLicense))
             {
-                Logger.Fatal(" You can renew it at http://particular.net/licensing.");
+                Logger.Fatal("Your license has expired! You can renew it at http://particular.net/licensing.");
                 return;
             }
 
             if (foundLicense.UpgradeProtectionExpiration != null)
             {
-                Logger.InfoFormat("UpgradeProtectionExpiration: {0}", foundLicense.UpgradeProtectionExpiration);
+                Logger.InfoFormat("License upgrade protection expires on: {0}", foundLicense.UpgradeProtectionExpiration);
             }
             else
             {
-                Logger.InfoFormat("Expires on {0}", foundLicense.ExpirationDate);
+                Logger.InfoFormat("License expires on {0}", foundLicense.ExpirationDate);
             }
 
             license = foundLicense;

--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -7,19 +7,89 @@ namespace NServiceBus.Licensing
     using Microsoft.Win32;
     using Particular.Licensing;
 
-    static class LicenseManager
+    class LicenseManager
     {
-        internal static bool HasLicenseExpired()
+        internal bool HasLicenseExpired()
         {
             return license == null || LicenseExpirationChecker.HasLicenseExpired(license);
         }
 
-        internal static void InitializeLicenseText(string license)
+        internal void InitializeLicense(string licenseText)
         {
-            licenseText = license;
+            //only do this if not been configured by the fluent API
+            if (licenseText == null)
+            {
+                licenseText = GetExistingLicense();
+            }
+
+            if (string.IsNullOrWhiteSpace(licenseText))
+            {
+                license = GetTrialLicense();
+                PromptUserForLicenseIfTrialHasExpired();
+                return;
+            }
+
+            LicenseVerifier.Verify(licenseText);
+
+            var foundLicense = LicenseDeserializer.Deserialize(licenseText);
+
+            if (LicenseExpirationChecker.HasLicenseExpired(foundLicense))
+            {
+                Logger.Fatal(" You can renew it at http://particular.net/licensing.");
+                return;
+            }
+
+            if (foundLicense.UpgradeProtectionExpiration != null)
+            {
+                Logger.InfoFormat("UpgradeProtectionExpiration: {0}", foundLicense.UpgradeProtectionExpiration);
+            }
+            else
+            {
+                Logger.InfoFormat("Expires on {0}", foundLicense.ExpirationDate);
+            }
+
+            license = foundLicense;
         }
 
-        internal static void PromptUserForLicenseIfTrialHasExpired()
+        static License GetTrialLicense()
+        {
+            var trialStartDate = TrialStartDateStore.GetTrialStartDate();
+            var trialLicense = License.TrialLicense(trialStartDate);
+
+            //Check trial is still valid
+            if (LicenseExpirationChecker.HasLicenseExpired(trialLicense))
+            {
+                Logger.WarnFormat("Trial for the Particular Service Platform has expired");
+            }
+            else
+            {
+                var message = $"Trial for Particular Service Platform is still active, trial expires on {trialLicense.ExpirationDate.Value.ToLocalTime().ToShortDateString()}.";
+                Logger.Info(message);
+            }
+
+            return trialLicense;
+        }
+
+        static string GetExistingLicense()
+        {
+            string existingLicense;
+
+            //look in HKCU
+            if (UserSidChecker.IsNotSystemSid() && new RegistryLicenseStore().TryReadLicense(out existingLicense))
+            {
+                return existingLicense;
+            }
+
+            //look in HKLM
+            if (new RegistryLicenseStore(Registry.LocalMachine).TryReadLicense(out existingLicense))
+            {
+                return existingLicense;
+            }
+
+            return LicenseLocationConventions.TryFindLicenseText();
+        }
+
+        void PromptUserForLicenseIfTrialHasExpired()
         {
             if (!(Debugger.IsAttached && SystemInformation.UserInteractive))
             {
@@ -48,84 +118,8 @@ namespace NServiceBus.Licensing
             }
         }
 
-        static License GetTrialLicense()
-        {
-            var trialStartDate = TrialStartDateStore.GetTrialStartDate();
-            var trialLicense = License.TrialLicense(trialStartDate);
-
-            //Check trial is still valid
-            if (LicenseExpirationChecker.HasLicenseExpired(trialLicense))
-            {
-                Logger.WarnFormat("Trial for the Particular Service Platform has expired");
-            }
-            else
-            {
-                var message = $"Trial for Particular Service Platform is still active, trial expires on {trialLicense.ExpirationDate.Value.ToLocalTime().ToShortDateString()}.";
-                Logger.Info(message);
-            }
-
-            return trialLicense;
-        }
-
-        internal static void InitializeLicense()
-        {
-            //only do this if not been configured by the fluent API
-            if (licenseText == null)
-            {
-                licenseText = GetExistingLicense();
-            }
-
-            if (string.IsNullOrWhiteSpace(licenseText))
-            {
-                license = GetTrialLicense();
-                return;
-            }
-
-            LicenseVerifier.Verify(licenseText);
-
-            var foundLicense = LicenseDeserializer.Deserialize(licenseText);
-
-            if (LicenseExpirationChecker.HasLicenseExpired(foundLicense))
-            {
-                Logger.Fatal(" You can renew it at http://particular.net/licensing.");
-                return;
-            }
-
-            if (foundLicense.UpgradeProtectionExpiration != null)
-            {
-                Logger.InfoFormat("UpgradeProtectionExpiration: {0}", foundLicense.UpgradeProtectionExpiration);
-            }
-            else
-            {
-                Logger.InfoFormat("Expires on {0}", foundLicense.ExpirationDate);
-            }
-
-            license = foundLicense;
-        }
-
-        static string GetExistingLicense()
-        {
-            string existingLicense;
-
-            //look in HKCU
-            if (UserSidChecker.IsNotSystemSid() && new RegistryLicenseStore().TryReadLicense(out existingLicense))
-            {
-                return existingLicense;
-            }
-
-            //look in HKLM
-            if (new RegistryLicenseStore(Registry.LocalMachine).TryReadLicense(out existingLicense))
-            {
-                return existingLicense;
-            }
-
-            return LicenseLocationConventions.TryFindLicenseText();
-        }
-
         static ILog Logger = LogManager.GetLogger(typeof(LicenseManager));
-        static string licenseText;
-        static License license;
 
-
+        License license;
     }
 }

--- a/src/NServiceBus.Core/Licensing/LicenseReminder.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseReminder.cs
@@ -10,16 +10,20 @@ namespace NServiceBus.Features
         public LicenseReminder()
         {
             EnableByDefault();
+
+            Defaults(s => s.SetDefault(LicenseTextSettingsKey, null));
         }
 
         protected internal override void Setup(FeatureConfigurationContext context)
         {
             try
             {
-                LicenseManager.InitializeLicense();
+                var licenseManager = new LicenseManager();
+                licenseManager.InitializeLicense(context.Settings.Get<string>(LicenseTextSettingsKey));
 
-                var licenseExpired = LicenseManager.HasLicenseExpired();
+                context.Container.RegisterSingleton(licenseManager);
 
+                var licenseExpired = licenseManager.HasLicenseExpired();
                 if (!licenseExpired)
                 {
                     return;
@@ -40,5 +44,7 @@ namespace NServiceBus.Features
         }
 
         static ILog Logger = LogManager.GetLogger<LicenseReminder>();
+
+        public const string LicenseTextSettingsKey = "LicenseText";
     }
 }

--- a/src/NServiceBus.Core/Unicast/UnicastBusInternal.cs
+++ b/src/NServiceBus.Core/Unicast/UnicastBusInternal.cs
@@ -9,7 +9,6 @@ namespace NServiceBus.Unicast
     using ConsistencyGuarantees;
     using Faults;
     using Features;
-    using Licensing;
     using Logging;
     using MessageInterfaces;
     using ObjectBuilder;
@@ -30,8 +29,6 @@ namespace NServiceBus.Unicast
 
         public async Task<IBus> StartAsync()
         {
-            LicenseManager.PromptUserForLicenseIfTrialHasExpired();
-
             if (started)
             {
                 return this;


### PR DESCRIPTION
fixes #3015 

removing static variables on LicenseManager. LicenseManager is registered in the container instead.