### PR TITLE
Synchronized storage made explicit

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists.cs
@@ -5,6 +5,7 @@
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Extensibility;
     using NServiceBus.Features;
+    using NServiceBus.Persistence;
     using NServiceBus.Sagas;
     using NUnit.Framework;
 
@@ -37,7 +38,7 @@
             class CustomFinder : IFindSagas<TestSaga06.SagaData06>.Using<StartSagaMessage>
             {
                 public Context Context { get; set; }
-                public Task<TestSaga06.SagaData06> FindBy(StartSagaMessage message, ReadOnlyContextBag context)
+                public Task<TestSaga06.SagaData06> FindBy(StartSagaMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context)
                 {
                     Context.FinderUsed = true;
                     return Task.FromResult(default(TestSaga06.SagaData06));

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_context_information_added.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_context_information_added.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.AcceptanceTests.Sagas
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Extensibility;
     using NServiceBus.Features;
+    using NServiceBus.Persistence;
     using NServiceBus.Pipeline;
     using NServiceBus.Sagas;
     using NUnit.Framework;
@@ -45,7 +46,7 @@ namespace NServiceBus.AcceptanceTests.Sagas
             class CustomFinder : IFindSagas<TestSaga07.SagaData07>.Using<StartSagaMessage>
             {
                 public Context Context { get; set; }
-                public Task<TestSaga07.SagaData07> FindBy(StartSagaMessage message, ReadOnlyContextBag context)
+                public Task<TestSaga07.SagaData07> FindBy(StartSagaMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context)
                 {
                     Context.ContextBag = context;
                     Context.FinderUsed = true;

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_found_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_found_saga.cs
@@ -5,6 +5,7 @@
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Extensibility;
     using NServiceBus.Features;
+    using NServiceBus.Persistence;
     using NServiceBus.Sagas;
     using NUnit.Framework;
 
@@ -40,7 +41,7 @@
                 // ReSharper disable once MemberCanBePrivate.Global
                 public Context Context { get; set; }
 
-                public Task<TestSaga08.SagaData08> FindBy(SomeOtherMessage message, ReadOnlyContextBag context)
+                public Task<TestSaga08.SagaData08> FindBy(SomeOtherMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context)
                 {
                     Context.FinderUsed = true;
                     return Task.FromResult(new TestSaga08.SagaData08

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2134,7 +2134,7 @@ namespace NServiceBus.Pipeline.Contexts
     }
     public class InvokeHandlerContext : NServiceBus.Pipeline.Contexts.IncomingContext, NServiceBus.IBusContext, NServiceBus.IMessageHandlerContext, NServiceBus.IMessageProcessingContext
     {
-        public InvokeHandlerContext(NServiceBus.Unicast.Behaviors.MessageHandler handler, string messageId, string replyToAddress, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.Unicast.Messages.MessageMetadata messageMetadata, object messageBeingHandled, NServiceBus.Persistence.CompletableSynchronizedStorageSession storageSession, NServiceBus.Pipeline.BehaviorContext parentContext) { }
+        public InvokeHandlerContext(NServiceBus.Unicast.Behaviors.MessageHandler handler, string messageId, string replyToAddress, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.Unicast.Messages.MessageMetadata messageMetadata, object messageBeingHandled, NServiceBus.Persistence.SynchronizedStorageSession storageSession, NServiceBus.Pipeline.BehaviorContext parentContext) { }
         public bool HandlerInvocationAborted { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public object MessageBeingHandled { get; }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -24,6 +24,11 @@ namespace NServiceBus
     {
         public AllAssemblies() { }
     }
+    public class AmbientTransaction : NServiceBus.Transports.TransportTransaction
+    {
+        public AmbientTransaction(System.Transactions.Transaction transaction) { }
+        public System.Transactions.Transaction Transaction { get; }
+    }
     public class static AutoSubscribeSettingsExtensions
     {
         public static NServiceBus.AutomaticSubscriptions.Config.AutoSubscribeSettings AutoSubscribe(this NServiceBus.BusConfiguration config) { }
@@ -549,6 +554,7 @@ namespace NServiceBus
     }
     public interface IMessageHandlerContext : NServiceBus.IBusContext, NServiceBus.IMessageProcessingContext
     {
+        NServiceBus.Persistence.SynchronizedStorageSession SynchronizedStorageSession { get; }
         void DoNotContinueDispatchingCurrentMessageToHandlers();
         System.Threading.Tasks.Task HandleCurrentMessageLater();
     }
@@ -1928,6 +1934,19 @@ namespace NServiceBus.Performance.TimeToBeReceived
 }
 namespace NServiceBus.Persistence
 {
+    public interface CompletableSynchronizedStorageSession : NServiceBus.Persistence.SynchronizedStorageSession, System.IDisposable
+    {
+        System.Threading.Tasks.Task CompleteAsync();
+    }
+    public interface ISynchronizedStorage
+    {
+        System.Threading.Tasks.Task<NServiceBus.Persistence.CompletableSynchronizedStorageSession> OpenSession(NServiceBus.Extensibility.ContextBag contextBag);
+    }
+    public interface ISynchronizedStorageAdapter
+    {
+        bool TryAdapt(NServiceBus.Outbox.OutboxTransaction transaction, out NServiceBus.Persistence.CompletableSynchronizedStorageSession session);
+        bool TryAdapt(NServiceBus.Transports.TransportTransaction transportTransaction, out NServiceBus.Persistence.CompletableSynchronizedStorageSession session);
+    }
     public abstract class PersistenceDefinition
     {
         protected PersistenceDefinition() { }
@@ -1961,6 +1980,7 @@ namespace NServiceBus.Persistence
         public sealed class Subscriptions : NServiceBus.Persistence.StorageType { }
         public sealed class Timeouts : NServiceBus.Persistence.StorageType { }
     }
+    public interface SynchronizedStorageSession { }
 }
 namespace NServiceBus.Pipeline
 {
@@ -2114,12 +2134,13 @@ namespace NServiceBus.Pipeline.Contexts
     }
     public class InvokeHandlerContext : NServiceBus.Pipeline.Contexts.IncomingContext, NServiceBus.IBusContext, NServiceBus.IMessageHandlerContext, NServiceBus.IMessageProcessingContext
     {
-        public InvokeHandlerContext(NServiceBus.Unicast.Behaviors.MessageHandler handler, string messageId, string replyToAddress, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.Unicast.Messages.MessageMetadata messageMetadata, object messageBeingHandled, NServiceBus.Pipeline.BehaviorContext parentContext) { }
+        public InvokeHandlerContext(NServiceBus.Unicast.Behaviors.MessageHandler handler, string messageId, string replyToAddress, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.Unicast.Messages.MessageMetadata messageMetadata, object messageBeingHandled, NServiceBus.Persistence.CompletableSynchronizedStorageSession storageSession, NServiceBus.Pipeline.BehaviorContext parentContext) { }
         public bool HandlerInvocationAborted { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public object MessageBeingHandled { get; }
         public NServiceBus.Unicast.Behaviors.MessageHandler MessageHandler { get; }
         public NServiceBus.Unicast.Messages.MessageMetadata MessageMetadata { get; }
+        public NServiceBus.Persistence.SynchronizedStorageSession SynchronizedStorageSession { get; }
         public void DoNotContinueDispatchingCurrentMessageToHandlers() { }
         public System.Threading.Tasks.Task HandleCurrentMessageLater() { }
     }
@@ -2306,7 +2327,7 @@ namespace NServiceBus.Sagas
         public interface Using<T, M> : NServiceBus.Sagas.IFinder
             where T : NServiceBus.IContainSagaData
         {
-            System.Threading.Tasks.Task<T> FindBy(M message, NServiceBus.Extensibility.ReadOnlyContextBag context);
+            System.Threading.Tasks.Task<T> FindBy(M message, NServiceBus.Persistence.SynchronizedStorageSession storageSession, NServiceBus.Extensibility.ReadOnlyContextBag context);
         }
     }
     public interface IHandleSagaNotFound
@@ -2315,13 +2336,13 @@ namespace NServiceBus.Sagas
     }
     public interface ISagaPersister
     {
-        System.Threading.Tasks.Task Complete(NServiceBus.IContainSagaData saga, NServiceBus.Extensibility.ContextBag context);
-        System.Threading.Tasks.Task<TSagaData> Get<TSagaData>(System.Guid sagaId, NServiceBus.Extensibility.ContextBag context)
+        System.Threading.Tasks.Task Complete(NServiceBus.IContainSagaData saga, NServiceBus.Persistence.SynchronizedStorageSession session, NServiceBus.Extensibility.ContextBag context);
+        System.Threading.Tasks.Task<TSagaData> Get<TSagaData>(System.Guid sagaId, NServiceBus.Persistence.SynchronizedStorageSession session, NServiceBus.Extensibility.ContextBag context)
             where TSagaData : NServiceBus.IContainSagaData;
-        System.Threading.Tasks.Task<TSagaData> Get<TSagaData>(string propertyName, object propertyValue, NServiceBus.Extensibility.ContextBag context)
+        System.Threading.Tasks.Task<TSagaData> Get<TSagaData>(string propertyName, object propertyValue, NServiceBus.Persistence.SynchronizedStorageSession session, NServiceBus.Extensibility.ContextBag context)
             where TSagaData : NServiceBus.IContainSagaData;
-        System.Threading.Tasks.Task Save(NServiceBus.IContainSagaData sagaInstance, NServiceBus.Sagas.SagaCorrelationProperty correlationProperty, NServiceBus.Extensibility.ContextBag context);
-        System.Threading.Tasks.Task Update(NServiceBus.IContainSagaData saga, NServiceBus.Extensibility.ContextBag context);
+        System.Threading.Tasks.Task Save(NServiceBus.IContainSagaData sagaInstance, NServiceBus.Sagas.SagaCorrelationProperty correlationProperty, NServiceBus.Persistence.SynchronizedStorageSession session, NServiceBus.Extensibility.ContextBag context);
+        System.Threading.Tasks.Task Update(NServiceBus.IContainSagaData saga, NServiceBus.Persistence.SynchronizedStorageSession session, NServiceBus.Extensibility.ContextBag context);
     }
     public class SagaCorrelationProperty
     {
@@ -2706,11 +2727,12 @@ namespace NServiceBus.Transports
     }
     public class PushContext
     {
-        public PushContext(string messageId, System.Collections.Generic.Dictionary<string, string> headers, System.IO.Stream bodyStream, NServiceBus.Extensibility.ContextBag context) { }
+        public PushContext(string messageId, System.Collections.Generic.Dictionary<string, string> headers, System.IO.Stream bodyStream, NServiceBus.Transports.TransportTransaction transportTransaction, NServiceBus.Extensibility.ContextBag context) { }
         public System.IO.Stream BodyStream { get; }
         public NServiceBus.Extensibility.ContextBag Context { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public string MessageId { get; }
+        public NServiceBus.Transports.TransportTransaction TransportTransaction { get; }
     }
     public class PushRuntimeSettings
     {
@@ -2787,6 +2809,7 @@ namespace NServiceBus.Transports
         public NServiceBus.Settings.ReadOnlySettings GlobalSettings { get; }
         public void SetDispatcherFactory(System.Func<NServiceBus.Transports.IDispatchMessages> dispatcherFactory) { }
     }
+    public interface TransportTransaction { }
 }
 namespace NServiceBus.Transports.Msmq.Config
 {

--- a/src/NServiceBus.Core.Tests/Fakes/FakeHandlingContext.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/FakeHandlingContext.cs
@@ -6,6 +6,7 @@
     using System.Threading.Tasks;
     using NServiceBus.DelayedDelivery;
     using NServiceBus.Extensibility;
+    using NServiceBus.Persistence;
 
     public class FakeHandlingContext : IMessageHandlerContext
     {
@@ -83,6 +84,8 @@
         {
             throw new NotImplementedException();
         }
+
+        public SynchronizedStorageSession SynchronizedStorageSession => null;
 
         public int DeferWasCalled
         {

--- a/src/NServiceBus.Core.Tests/Faults/ForwardFaultsToErrorQueueTests.cs
+++ b/src/NServiceBus.Core.Tests/Faults/ForwardFaultsToErrorQueueTests.cs
@@ -131,7 +131,7 @@ namespace NServiceBus.Core.Tests
 
         TransportReceiveContext CreateContext(string messageId)
         {
-            return new TransportReceiveContext(new IncomingMessage(messageId, new Dictionary<string, string>(), new MemoryStream()), new RootContext(null));
+            return new TransportReceiveContext(new IncomingMessage(messageId, new Dictionary<string, string>(), new MemoryStream()), null, new RootContext(null));
         }
         class FakeDispatchPipeline : IPipelineBase<RoutingContext>
         {

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_completing_a_saga_with_the_InMemory_persister.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_completing_a_saga_with_the_InMemory_persister.cs
@@ -16,11 +16,16 @@
                 Id = Guid.NewGuid()
             };
             var persister = new InMemorySagaPersister();
+            var insertSession = new InMemorySynchronizedStorageSession();
+            await persister.Save(saga, SagaMetadataHelper.GetMetadata<TestSaga>(saga), insertSession, new ContextBag());
+            await insertSession.CompleteAsync();
 
-            await persister.Save(saga, SagaMetadataHelper.GetMetadata<TestSaga>(saga), new ContextBag());
-            var sagaData = await persister.Get<TestSagaData>(saga.Id, new ContextBag());
-            await persister.Complete(saga, new ContextBag());
-            var completedSaga = await persister.Get<TestSagaData>(saga.Id, new ContextBag());
+            var sagaData = await persister.Get<TestSagaData>(saga.Id, new InMemorySynchronizedStorageSession(), new ContextBag());
+
+            var deleteSession = new InMemorySynchronizedStorageSession();
+            await persister.Complete(saga, deleteSession, new ContextBag());
+            await deleteSession.CompleteAsync();
+            var completedSaga = await persister.Get<TestSagaData>(saga.Id, new InMemorySynchronizedStorageSession(), new ContextBag());
 
             Assert.NotNull(sagaData);
             Assert.Null(completedSaga);

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
@@ -24,12 +24,26 @@
 
             var persister = new InMemorySagaPersister();
 
-            await persister.Save(saga1, SagaMetadataHelper.GetMetadata<SagaWithUniqueProperty>(saga1), new ContextBag());
-            await persister.Complete(saga1, new ContextBag());
-            await persister.Save(saga2, SagaMetadataHelper.GetMetadata<SagaWithUniqueProperty>(saga2), new ContextBag());
-            await persister.Complete(saga2, new ContextBag());
-            await persister.Save(saga1, SagaMetadataHelper.GetMetadata<SagaWithUniqueProperty>(saga1), new ContextBag());
-            await persister.Complete(saga1, new ContextBag());
+            using (var session1 = new InMemorySynchronizedStorageSession())
+            {
+                await persister.Save(saga1, SagaMetadataHelper.GetMetadata<SagaWithUniqueProperty>(saga1), session1, new ContextBag());
+                await persister.Complete(saga1, session1, new ContextBag());
+                await session1.CompleteAsync();
+            }
+
+            using (var session2 = new InMemorySynchronizedStorageSession())
+            {
+                await persister.Save(saga2, SagaMetadataHelper.GetMetadata<SagaWithUniqueProperty>(saga2), session2, new ContextBag());
+                await persister.Complete(saga2, session2, new ContextBag());
+                await session2.CompleteAsync();
+            }
+
+            using (var session3 = new InMemorySynchronizedStorageSession())
+            {
+                await persister.Save(saga1, SagaMetadataHelper.GetMetadata<SagaWithUniqueProperty>(saga1), session3, new ContextBag());
+                await persister.Complete(saga1, session3, new ContextBag());
+                await session3.CompleteAsync();
+            }
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_different_sagas_with_unique_properties.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_different_sagas_with_unique_properties.cs
@@ -23,8 +23,10 @@
             };
 
             var persister = new InMemorySagaPersister();
-            await persister.Save(saga1, SagaMetadataHelper.GetMetadata<SagaWithUniqueProperty>(saga1), new ContextBag());
-            await persister.Save(saga2, SagaMetadataHelper.GetMetadata<AnotherSagaTwoUniqueProperty>(saga2), new ContextBag());
-         }
+            var transaction = new InMemorySynchronizedStorageSession();
+            await persister.Save(saga1, SagaMetadataHelper.GetMetadata<SagaWithUniqueProperty>(saga1), transaction, new ContextBag());
+            await persister.Save(saga2, SagaMetadataHelper.GetMetadata<AnotherSagaTwoUniqueProperty>(saga2), transaction, new ContextBag());
+            await transaction.CompleteAsync();
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_saga_not_found_return_default.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_saga_not_found_return_default.cs
@@ -12,7 +12,7 @@
         public async Task Should_return_default_when_using_finding_saga_with_property()
         {
             var persister = new InMemorySagaPersister();
-            var simpleSageEntity = await persister.Get<SimpleSagaEntity>("propertyNotFound", "someValue", new ContextBag());
+            var simpleSageEntity = await persister.Get<SimpleSagaEntity>("propertyNotFound", "someValue", new InMemorySynchronizedStorageSession(), new ContextBag());
             Assert.IsNull(simpleSageEntity);
         }
 
@@ -20,7 +20,7 @@
         public async Task Should_return_default_when_using_finding_saga_with_id()
         {
             var persister = new InMemorySagaPersister();
-            var simpleSageEntity = await persister.Get<SimpleSagaEntity>(Guid.Empty, new ContextBag());
+            var simpleSageEntity = await persister.Get<SimpleSagaEntity>(Guid.Empty, new InMemorySynchronizedStorageSession(), new ContextBag());
             Assert.IsNull(simpleSageEntity);
         }
 
@@ -34,9 +34,10 @@
                 OrderSource = "CA"
             };
             var persister = new InMemorySagaPersister();
-            await persister.Save(simpleSagaEntity, SagaMetadataHelper.GetMetadata<SimpleSagaEntitySaga>(simpleSagaEntity), new ContextBag());
-
-            var anotherSagaEntity = await persister.Get<AnotherSimpleSagaEntity>(id, new ContextBag());
+            var session = new InMemorySynchronizedStorageSession();
+            await persister.Save(simpleSagaEntity, SagaMetadataHelper.GetMetadata<SimpleSagaEntitySaga>(simpleSagaEntity), session, new ContextBag());
+            await session.CompleteAsync();
+            var anotherSagaEntity = await persister.Get<AnotherSimpleSagaEntity>(id, new InMemorySynchronizedStorageSession(),  new ContextBag());
             Assert.IsNull(anotherSagaEntity);
         }
 

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_updating_a_saga_with_the_same_unique_property_as_another_saga.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_updating_a_saga_with_the_same_unique_property_as_another_saga.cs
@@ -23,8 +23,10 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
             };
 
             var persister = new InMemorySagaPersister();
-            await persister.Save(saga1, SagaMetadataHelper.GetMetadata<SagaWithUniqueProperty>(saga1), new ContextBag());
-            await persister.Save(saga2, SagaMetadataHelper.GetMetadata<SagaWithUniqueProperty>(saga2), new ContextBag());
+            var session = new InMemorySynchronizedStorageSession();
+            await persister.Save(saga1, SagaMetadataHelper.GetMetadata<SagaWithUniqueProperty>(saga1), session, new ContextBag());
+            await persister.Save(saga2, SagaMetadataHelper.GetMetadata<SagaWithUniqueProperty>(saga2), session, new ContextBag());
+            await session.CompleteAsync();
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_updating_a_saga_with_the_same_unique_property_value.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_updating_a_saga_with_the_same_unique_property_value.cs
@@ -18,9 +18,15 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
             };
             var persister = new InMemorySagaPersister();
 
-            await persister.Save(saga1, SagaMetadataHelper.GetMetadata<SagaWithUniqueProperty>(saga1), new ContextBag());
-            saga1 = await persister.Get<SagaWithUniquePropertyData>(saga1.Id, new ContextBag());
-            await persister.Update(saga1, new ContextBag());
+            var insertSession = new InMemorySynchronizedStorageSession();
+            await persister.Save(saga1, SagaMetadataHelper.GetMetadata<SagaWithUniqueProperty>(saga1), insertSession, new ContextBag());
+            await insertSession.CompleteAsync();
+
+            saga1 = await persister.Get<SagaWithUniquePropertyData>(saga1.Id, new InMemorySynchronizedStorageSession(), new ContextBag());
+
+            var updateSession = new InMemorySynchronizedStorageSession();
+            await persister.Update(saga1, updateSession, new ContextBag());
+            await updateSession.CompleteAsync();
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
@@ -148,6 +148,7 @@
                 new Dictionary<string, string>(),
                 null,
                 null,
+                null,
                 new RootContext(null));
 
             return behaviorContext;

--- a/src/NServiceBus.Core.Tests/Recoverability/FirstLevelRetries/FirstLevelRetriesTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/FirstLevelRetries/FirstLevelRetriesTests.cs
@@ -174,7 +174,7 @@
 
         TransportReceiveContext CreateContext(string messageId)
         {
-            return new TransportReceiveContext(new IncomingMessage(messageId, new Dictionary<string, string>(), new MemoryStream()), new RootContext(null));
+            return new TransportReceiveContext(new IncomingMessage(messageId, new Dictionary<string, string>(), new MemoryStream()), null, new RootContext(null));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Recoverability/SecondLevelRetries/SecondLevelRetriesTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/SecondLevelRetries/SecondLevelRetriesTests.cs
@@ -140,7 +140,7 @@
             return new TransportReceiveContext(new IncomingMessage(messageId, new Dictionary<string, string>
             {
                 {Headers.Retries, currentRetryCount.ToString()}
-            }, new MemoryStream(messageBody ?? new byte[0])), new RootContext(null));
+            }, new MemoryStream(messageBody ?? new byte[0])), null, new RootContext(null));
         }
     }
 

--- a/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageProcessingConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageProcessingConnectorTests.cs
@@ -110,7 +110,7 @@
 
         static TransportReceiveContext CreateContext()
         {
-            var context = new TransportReceiveContext(new IncomingMessage("id", new Dictionary<string, string>(), new MemoryStream()), new RootContext(null));
+            var context = new TransportReceiveContext(new IncomingMessage("id", new Dictionary<string, string>(), new MemoryStream()), null, new RootContext(null));
             return context;
         }
 

--- a/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
@@ -30,7 +30,7 @@
                         {
                             {Headers.ReplyToAddress, "ReplyAddressOfIncomingMessage"}
                         },
-                        new MemoryStream()),
+                        new MemoryStream()), null,
                     new RootContext(null)));
 
             UnicastAddressTag addressTag = null;
@@ -56,7 +56,7 @@
                     new IncomingMessage(
                         "id",
                         new Dictionary<string, string>(),
-                        new MemoryStream()),
+                        new MemoryStream()), null,
                     new RootContext(null)));
 
             var ex = Assert.Throws<Exception>(async () => await behavior.Invoke(context, _ => Task.FromResult(0)));

--- a/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
+    using NServiceBus.Persistence;
     using NServiceBus.Sagas;
     using NUnit.Framework;
     using Conventions = NServiceBus.Conventions;
@@ -233,7 +234,7 @@
 
             public class Finder : IFindSagas<SagaData>.Using<StartSagaMessage>
             {
-                public Task<SagaData> FindBy(StartSagaMessage message, ReadOnlyContextBag context)
+                public Task<SagaData> FindBy(StartSagaMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context)
                 {
                     return Task.FromResult(default(SagaData));
                 }
@@ -266,7 +267,7 @@
 
             public class Finder : IFindSagas<SagaData>.Using<StartSagaMessage>
             {
-                public Task<SagaData> FindBy(StartSagaMessage message, ReadOnlyContextBag context)
+                public Task<SagaData> FindBy(StartSagaMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context)
                 {
                     return Task.FromResult(default(SagaData));
                 }
@@ -471,7 +472,7 @@
 
             internal class CustomFinder : IFindSagas<SagaData>.Using<SomeMessage>
             {
-                public Task<SagaData> FindBy(SomeMessage message, ReadOnlyContextBag context)
+                public Task<SagaData> FindBy(SomeMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context)
                 {
                     return Task.FromResult(default(SagaData));
                 }

--- a/src/NServiceBus.Core.Tests/Unicast/HandlerInvocationCache.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/HandlerInvocationCache.cs
@@ -6,6 +6,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
+    using NServiceBus.Persistence;
     using NServiceBus.Unicast.Behaviors;
     using NUnit.Framework;
     using PublishOptions = NServiceBus.PublishOptions;
@@ -257,5 +258,7 @@
         {
             throw new NotImplementedException();
         }
+
+        public SynchronizedStorageSession SynchronizedStorageSession => null;
     }
 }

--- a/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
@@ -3,6 +3,9 @@
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using NServiceBus.InMemory.Outbox;
+    using NServiceBus.Outbox;
+    using NServiceBus.Transports;
     using Pipeline.Contexts;
     using Unicast.Messages;
     using NUnit.Framework;
@@ -13,7 +16,7 @@
         [Test]
         public void Should_throw_when_there_are_no_registered_message_handlers()
         {
-            var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(new Conventions()));
+            var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(new Conventions()), new InMemorySynchronizedStorage(), new InMemoryTransactionalSynchronizedStorageAdapter());
 
             var context = new LogicalMessageProcessingContext(
                 new LogicalMessage(new MessageMetadata(typeof(string)), null, null), 
@@ -22,7 +25,14 @@
                 new Dictionary<string, string>(), 
                 null);
 
+            context.Set<OutboxTransaction>(new InMemoryOutboxTransaction());
+            context.Set<TransportTransaction>(new FakeTransportTransaction());
+
             Assert.Throws<InvalidOperationException>(async () => await behavior.Invoke(context, c => Task.FromResult(0)));
+        }
+
+        private class FakeTransportTransaction : TransportTransaction
+        {
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/UnitOfWork/UnitOfWorkBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/UnitOfWork/UnitOfWorkBehaviorTests.cs
@@ -145,7 +145,7 @@
         {
             var runner = new UnitOfWorkBehavior();
 
-            var receiveContext = new TransportReceiveContext(new IncomingMessage("fakeId", new Dictionary<string, string>(), new MemoryStream()), new RootContext(builder));
+            var receiveContext = new TransportReceiveContext(new IncomingMessage("fakeId", new Dictionary<string, string>(), new MemoryStream()), null, new RootContext(builder));
 
             var context = new PhysicalMessageProcessingContext(receiveContext.Message, receiveContext);
 

--- a/src/NServiceBus.Core/IMessageHandlerContext.cs
+++ b/src/NServiceBus.Core/IMessageHandlerContext.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System.Threading.Tasks;
+    using NServiceBus.Persistence;
 
     /// <summary>
     /// The context of the currently processed message for a message handler.
@@ -18,5 +19,11 @@ namespace NServiceBus
         /// handlers.
         /// </summary>
         void DoNotContinueDispatchingCurrentMessageToHandlers();
+
+        /// <summary>
+        /// Gets the synchronized storage session for processing the current message. NServiceBus makes sure the changes made 
+        /// via this session will be persisted before the message receive is acknowleged.
+        /// </summary>
+        SynchronizedStorageSession SynchronizedStorageSession { get; }
     }
 }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -117,6 +117,10 @@
     <Compile Include="IHandleMessages.cs" />
     <Compile Include="IInitializableEndpoint.cs" />
     <Compile Include="IEndpoint.cs" />
+    <Compile Include="Persistence\InMemory\InMemoryTransaction.cs" />
+    <Compile Include="Persistence\InMemory\InMemoryTransactionalStorageSession.cs" />
+    <Compile Include="Persistence\ISynchronizedStorageAdapter.cs" />
+    <Compile Include="Persistence\SynchronizedStorageSession.cs" />
     <Compile Include="Pipeline\Outgoing\OutgoingContext.cs" />
     <Compile Include="Pipeline\Outgoing\TransportMessageContextExtensions.cs" />
     <Compile Include="Scheduling\ScheduleBehavior.cs" />
@@ -125,7 +129,9 @@
     <Compile Include="IStartableBusExtensions_obsoletes.cs" />
     <Compile Include="IWantToRunWhenBusStartsAndStopsExtensions_obsoletes.cs" />
     <Compile Include="Licensing\LogErrorOnInvalidLicenseBehavior.cs" />
+    <Compile Include="Persistence\InMemory\InMemoryTransactionalStorageFeature.cs" />
     <Compile Include="Persistence\InMemory\Outbox\InMemoryOutboxTransaction.cs" />
+    <Compile Include="Persistence\ISynchronizedStorage.cs" />
     <Compile Include="Pipeline\Incoming\InvokeHandlerContext.cs" />
     <Compile Include="Pipeline\Incoming\LogicalMessageProcessingContext.cs" />
     <Compile Include="Pipeline\Incoming\PendingTransportOperations.cs" />
@@ -160,6 +166,9 @@
     <Compile Include="Routing\FileBasedDynamicRouting\FileRoutingTableSettings.cs" />
     <Compile Include="Routing\EndpointInstances.cs" />
     <Compile Include="Serialization\SerializationContextExtensions.cs" />
+    <Compile Include="Transports\AmbientTransaction.cs" />
+    <Compile Include="Transports\Msmq\NativeMsmqTransaction.cs" />
+    <Compile Include="Transports\TransportTransaction.cs" />
     <Compile Include="Transports\TransactionSupport.cs" />
     <Compile Include="Transports\Sending.cs" />
     <Compile Include="Transports\TransportAddresses.cs" />

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -104,6 +104,9 @@
     <Compile Include="ConfigureHandlerSettings.cs" />
     <Compile Include="ConsistencyGuarantees\ConsistencyGuaranteeSettingsExtensions.cs" />
     <Compile Include="ConsistencyGuarantees\TransactionScopes\WrapHandlersInTransactionScope.cs" />
+    <Compile Include="Persistence\CompletableSynchronizedStorageSession.cs" />
+    <Compile Include="Persistence\InMemory\InMemorySynchronizedStorage.cs" />
+    <Compile Include="Persistence\InMemory\InMemoryTransactionalSynchronizedStorageAdapter.cs" />
     <Compile Include="Routing\Legacy\ConfigureMSMQDistributor.cs" />
     <Compile Include="Routing\Legacy\DistributorHeaders.cs" />
     <Compile Include="Routing\Legacy\ProcessedMessageCounterBehavior.cs" />

--- a/src/NServiceBus.Core/Persistence/CompletableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Persistence/CompletableSynchronizedStorageSession.cs
@@ -1,0 +1,16 @@
+﻿namespace NServiceBus.Persistence
+{
+    using System;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Represents a storage session from point of view of the infrastructure.
+    /// </summary>
+    public interface CompletableSynchronizedStorageSession : SynchronizedStorageSession, IDisposable
+    {
+        /// <summary>
+        /// Completes the session by saving the changes.
+        /// </summary>
+        Task CompleteAsync();
+    }
+}

--- a/src/NServiceBus.Core/Persistence/ISynchronizedStorage.cs
+++ b/src/NServiceBus.Core/Persistence/ISynchronizedStorage.cs
@@ -1,0 +1,17 @@
+﻿namespace NServiceBus.Persistence
+{
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+
+    /// <summary>
+    /// Represents a storage to which the writes are synchronized with message receiving i.e. message receive is acknowledged only if data has been successfully saved.
+    /// </summary>
+    public interface ISynchronizedStorage
+    {
+        /// <summary>
+        /// Begins a new storage session which is an atomic unit of work.
+        /// </summary>
+        /// <param name="contextBag">The context information.</param>
+        Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag);
+    }
+}

--- a/src/NServiceBus.Core/Persistence/ISynchronizedStorageAdapter.cs
+++ b/src/NServiceBus.Core/Persistence/ISynchronizedStorageAdapter.cs
@@ -1,0 +1,27 @@
+﻿namespace NServiceBus.Persistence
+{
+    using NServiceBus.Outbox;
+    using NServiceBus.Transports;
+
+    /// <summary>
+    /// Converts the outbox transaction into a synchronized storage session if possible.
+    /// </summary>
+    public interface ISynchronizedStorageAdapter
+    {
+        /// <summary>
+        /// Returns a synchronized storage session based on the outbox transaction if possible. 
+        /// </summary>
+        /// <param name="transaction">Outbox transaction.</param>
+        /// <param name="session">Session or null, if unable to adapt.</param>
+        /// <returns></returns>
+        bool TryAdapt(OutboxTransaction transaction, out CompletableSynchronizedStorageSession session);
+
+        /// <summary>
+        /// Returns a synchronized storage session based on the outbox transaction if possible. 
+        /// </summary>
+        /// <param name="transportTransaction">Transport transaction.</param>
+        /// <param name="session">Session or null, if unable to adapt.</param>
+        /// <returns></returns>
+        bool TryAdapt(TransportTransaction transportTransaction, out CompletableSynchronizedStorageSession session);
+    }
+}

--- a/src/NServiceBus.Core/Persistence/InMemory/InMemorySynchronizedStorage.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/InMemorySynchronizedStorage.cs
@@ -1,0 +1,15 @@
+namespace NServiceBus
+{
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using NServiceBus.Persistence;
+
+    class InMemorySynchronizedStorage : ISynchronizedStorage
+    {
+        public Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag)
+        {
+            var session = (CompletableSynchronizedStorageSession)new InMemorySynchronizedStorageSession();
+            return Task.FromResult(session);
+        }
+    }
+}

--- a/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransaction.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransaction.cs
@@ -1,0 +1,24 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+
+    class InMemoryTransaction
+    {
+        List<Action> actions = new List<Action>();
+
+        public void Enlist(Action action)
+        {
+            actions.Add(action);
+        }
+        
+        public void Commit()
+        {
+            foreach (var action in actions)
+            {
+                action();
+            }
+            actions.Clear();
+        }
+    }
+}

--- a/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransactionalStorageFeature.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransactionalStorageFeature.cs
@@ -1,0 +1,92 @@
+﻿namespace NServiceBus
+{
+    using System.Threading.Tasks;
+    using System.Transactions;
+    using NServiceBus.Extensibility;
+    using NServiceBus.Features;
+    using NServiceBus.InMemory.Outbox;
+    using NServiceBus.Outbox;
+    using NServiceBus.Persistence;
+    using NServiceBus.Transports;
+
+    class InMemoryTransactionalStorageFeature : Feature
+    {
+        /// <summary>
+        ///     Called when the features is activated.
+        /// </summary>
+        protected internal override void Setup(FeatureConfigurationContext context)
+        {
+            context.Container.ConfigureComponent<InMemorySynchronizedStorage>(DependencyLifecycle.SingleInstance);
+            context.Container.ConfigureComponent<InMemoryTransactionalSynchronizedStorageAdapter>(DependencyLifecycle.SingleInstance);
+        }
+    }
+
+    class InMemorySynchronizedStorage : ISynchronizedStorage
+    {
+        public Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag)
+        {
+            var session = (CompletableSynchronizedStorageSession)new InMemorySynchronizedStorageSession();
+            return Task.FromResult(session);
+        }
+    }
+
+    class InMemoryTransactionalSynchronizedStorageAdapter : ISynchronizedStorageAdapter
+    {
+        public bool TryAdapt(OutboxTransaction transaction, out CompletableSynchronizedStorageSession session)
+        {
+            var inMemOutboxTransaction = transaction as InMemoryOutboxTransaction;
+            if (inMemOutboxTransaction != null)
+            {
+                session = new InMemorySynchronizedStorageSession(inMemOutboxTransaction.Transaction);
+                return true;
+            }
+            session = null;
+            return false;
+        }
+
+        public bool TryAdapt(TransportTransaction transportTransaction, out CompletableSynchronizedStorageSession session)
+        {
+            var ambientTransaction = transportTransaction as AmbientTransaction;
+            if (ambientTransaction != null)
+            {
+                var transaction = new InMemoryTransaction();
+                session = new InMemorySynchronizedStorageSession(transaction);
+                ambientTransaction.Transaction.EnlistVolatile(new EnlistmentNotification(transaction), EnlistmentOptions.None);
+                return true;
+            }
+            session = null;
+            return false;
+        }
+
+        private class EnlistmentNotification : IEnlistmentNotification
+        {
+            InMemoryTransaction transaction;
+
+            public EnlistmentNotification(InMemoryTransaction transaction)
+            {
+                this.transaction = transaction;
+            }
+
+            public void Prepare(PreparingEnlistment preparingEnlistment)
+            {
+                transaction.Commit();
+                preparingEnlistment.Prepared();
+            }
+
+            public void Commit(Enlistment enlistment)
+            {
+                enlistment.Done();
+            }
+
+            public void Rollback(Enlistment enlistment)
+            {
+                enlistment.Done();
+            }
+
+            public void InDoubt(Enlistment enlistment)
+            {
+                enlistment.Done();
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransactionalStorageFeature.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransactionalStorageFeature.cs
@@ -1,13 +1,6 @@
 ﻿namespace NServiceBus
 {
-    using System.Threading.Tasks;
-    using System.Transactions;
-    using NServiceBus.Extensibility;
     using NServiceBus.Features;
-    using NServiceBus.InMemory.Outbox;
-    using NServiceBus.Outbox;
-    using NServiceBus.Persistence;
-    using NServiceBus.Transports;
 
     class InMemoryTransactionalStorageFeature : Feature
     {
@@ -18,75 +11,6 @@
         {
             context.Container.ConfigureComponent<InMemorySynchronizedStorage>(DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent<InMemoryTransactionalSynchronizedStorageAdapter>(DependencyLifecycle.SingleInstance);
-        }
-    }
-
-    class InMemorySynchronizedStorage : ISynchronizedStorage
-    {
-        public Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag)
-        {
-            var session = (CompletableSynchronizedStorageSession)new InMemorySynchronizedStorageSession();
-            return Task.FromResult(session);
-        }
-    }
-
-    class InMemoryTransactionalSynchronizedStorageAdapter : ISynchronizedStorageAdapter
-    {
-        public bool TryAdapt(OutboxTransaction transaction, out CompletableSynchronizedStorageSession session)
-        {
-            var inMemOutboxTransaction = transaction as InMemoryOutboxTransaction;
-            if (inMemOutboxTransaction != null)
-            {
-                session = new InMemorySynchronizedStorageSession(inMemOutboxTransaction.Transaction);
-                return true;
-            }
-            session = null;
-            return false;
-        }
-
-        public bool TryAdapt(TransportTransaction transportTransaction, out CompletableSynchronizedStorageSession session)
-        {
-            var ambientTransaction = transportTransaction as AmbientTransaction;
-            if (ambientTransaction != null)
-            {
-                var transaction = new InMemoryTransaction();
-                session = new InMemorySynchronizedStorageSession(transaction);
-                ambientTransaction.Transaction.EnlistVolatile(new EnlistmentNotification(transaction), EnlistmentOptions.None);
-                return true;
-            }
-            session = null;
-            return false;
-        }
-
-        private class EnlistmentNotification : IEnlistmentNotification
-        {
-            InMemoryTransaction transaction;
-
-            public EnlistmentNotification(InMemoryTransaction transaction)
-            {
-                this.transaction = transaction;
-            }
-
-            public void Prepare(PreparingEnlistment preparingEnlistment)
-            {
-                transaction.Commit();
-                preparingEnlistment.Prepared();
-            }
-
-            public void Commit(Enlistment enlistment)
-            {
-                enlistment.Done();
-            }
-
-            public void Rollback(Enlistment enlistment)
-            {
-                enlistment.Done();
-            }
-
-            public void InDoubt(Enlistment enlistment)
-            {
-                enlistment.Done();
-            }
         }
     }
 }

--- a/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransactionalStorageSession.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransactionalStorageSession.cs
@@ -1,0 +1,45 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Threading.Tasks;
+    using Janitor;
+    using NServiceBus.Persistence;
+
+    [SkipWeaving]
+    class InMemorySynchronizedStorageSession : CompletableSynchronizedStorageSession
+    {
+        bool ownsTransaction;
+
+        public InMemoryTransaction Transaction { get; private set; }
+
+        public InMemorySynchronizedStorageSession(InMemoryTransaction transaction)
+        {
+            Transaction = transaction;
+        }
+
+        public InMemorySynchronizedStorageSession()
+            : this(new InMemoryTransaction())
+        {
+            ownsTransaction = true;
+        }
+
+        public void Enlist(Action action)
+        {
+            Transaction.Enlist(action);
+        }
+
+        public void Dispose()
+        {
+            Transaction = null;
+        }
+
+        public Task CompleteAsync()
+        {
+            if (ownsTransaction)
+            {
+                Transaction.Commit();
+            }
+            return TaskEx.Completed;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransactionalSynchronizedStorageAdapter.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransactionalSynchronizedStorageAdapter.cs
@@ -1,0 +1,68 @@
+namespace NServiceBus
+{
+    using System.Transactions;
+    using NServiceBus.InMemory.Outbox;
+    using NServiceBus.Outbox;
+    using NServiceBus.Persistence;
+    using NServiceBus.Transports;
+
+    class InMemoryTransactionalSynchronizedStorageAdapter : ISynchronizedStorageAdapter
+    {
+        public bool TryAdapt(OutboxTransaction transaction, out CompletableSynchronizedStorageSession session)
+        {
+            var inMemOutboxTransaction = transaction as InMemoryOutboxTransaction;
+            if (inMemOutboxTransaction != null)
+            {
+                session = new InMemorySynchronizedStorageSession(inMemOutboxTransaction.Transaction);
+                return true;
+            }
+            session = null;
+            return false;
+        }
+
+        public bool TryAdapt(TransportTransaction transportTransaction, out CompletableSynchronizedStorageSession session)
+        {
+            var ambientTransaction = transportTransaction as AmbientTransaction;
+            if (ambientTransaction != null)
+            {
+                var transaction = new InMemoryTransaction();
+                session = new InMemorySynchronizedStorageSession(transaction);
+                ambientTransaction.Transaction.EnlistVolatile(new EnlistmentNotification(transaction), EnlistmentOptions.None);
+                return true;
+            }
+            session = null;
+            return false;
+        }
+
+        private class EnlistmentNotification : IEnlistmentNotification
+        {
+            InMemoryTransaction transaction;
+
+            public EnlistmentNotification(InMemoryTransaction transaction)
+            {
+                this.transaction = transaction;
+            }
+
+            public void Prepare(PreparingEnlistment preparingEnlistment)
+            {
+                transaction.Commit();
+                preparingEnlistment.Prepared();
+            }
+
+            public void Commit(Enlistment enlistment)
+            {
+                enlistment.Done();
+            }
+
+            public void Rollback(Enlistment enlistment)
+            {
+                enlistment.Done();
+            }
+
+            public void InDoubt(Enlistment enlistment)
+            {
+                enlistment.Done();
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxPersistence.cs
@@ -16,6 +16,7 @@
         {
             DependsOn<Outbox>();
             RegisterStartupTask<OutboxCleaner>();
+            Defaults(s => s.EnableFeature(typeof(InMemoryTransactionalStorageFeature)));
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxTransaction.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxTransaction.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.InMemory.Outbox
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Janitor;
     using NServiceBus.Outbox;
@@ -9,24 +8,26 @@
     [SkipWeaving]
     class InMemoryOutboxTransaction : OutboxTransaction
     {
-        List<Action> actions = new List<Action>();
+        public InMemoryTransaction Transaction { get; private set; }
+
+        public InMemoryOutboxTransaction()
+        {
+            Transaction = new InMemoryTransaction();
+        }
          
         public void Enlist(Action action)
         {
-            actions.Add(action);
+            Transaction.Enlist(action);
         }
 
         public void Dispose()
         {
-            actions.Clear();        
+            Transaction = null;
         }
 
         public Task Commit()
         {
-            foreach (var action in actions)
-            {
-                action();
-            }
+            Transaction.Commit();
             return TaskEx.Completed;
         }
     }

--- a/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersistence.cs
@@ -9,6 +9,7 @@
         internal InMemorySagaPersistence()
         {
             DependsOn<Sagas>();
+            Defaults(s => s.EnableFeature(typeof(InMemoryTransactionalStorageFeature)));
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
@@ -6,19 +6,24 @@ namespace NServiceBus
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
+    using NServiceBus.Persistence;
     using NServiceBus.Sagas;
     using NServiceBus.Serializers.Json;
 
     class InMemorySagaPersister : ISagaPersister
     {
-        public Task Complete(IContainSagaData saga, ContextBag context)
+        public Task Complete(IContainSagaData saga, SynchronizedStorageSession session, ContextBag context)
         {
-            VersionedSagaEntity value;
-            data.TryRemove(saga.Id, out value);
+            var inMemSession = (InMemorySynchronizedStorageSession)session;
+            inMemSession.Enlist(() =>
+            {
+                VersionedSagaEntity value;
+                data.TryRemove(saga.Id, out value);
+            });
             return TaskEx.Completed;
         }
 
-        public Task<TSagaData> Get<TSagaData>(string propertyName, object propertyValue, ContextBag context) where TSagaData : IContainSagaData
+        public Task<TSagaData> Get<TSagaData>(string propertyName, object propertyValue, SynchronizedStorageSession session, ContextBag context) where TSagaData : IContainSagaData
         {
             Guard.AgainstNull(nameof(propertyValue), propertyValue);
 
@@ -43,7 +48,7 @@ namespace NServiceBus
             return Task.FromResult(default(TSagaData));
         }
 
-        public Task<TSagaData> Get<TSagaData>(Guid sagaId, ContextBag context) where TSagaData : IContainSagaData
+        public Task<TSagaData> Get<TSagaData>(Guid sagaId, SynchronizedStorageSession session, ContextBag context) where TSagaData : IContainSagaData
         {
             VersionedSagaEntity result;
             if (data.TryGetValue(sagaId, out result) && result?.SagaEntity is TSagaData)
@@ -55,50 +60,58 @@ namespace NServiceBus
             return Task.FromResult(default(TSagaData));
         }
 
-        public Task Save(IContainSagaData saga, SagaCorrelationProperty correlationProperty, ContextBag context)
+        public Task Save(IContainSagaData saga, SagaCorrelationProperty correlationProperty, SynchronizedStorageSession session, ContextBag context)
         {
-            if (correlationProperty != SagaCorrelationProperty.None)
+            var inMemSession = (InMemorySynchronizedStorageSession) session;
+            inMemSession.Enlist(() =>
             {
-                ValidateUniqueProperties(correlationProperty, saga);
-            }
+                if (correlationProperty != SagaCorrelationProperty.None)
+                {
+                    ValidateUniqueProperties(correlationProperty, saga);
+                }
 
-            VersionedSagaEntity sagaEntity;
-            if (data.TryGetValue(saga.Id, out sagaEntity))
-            {
-                sagaEntity.ConcurrencyCheck(saga, version);
-            }
+                VersionedSagaEntity sagaEntity;
+                if (data.TryGetValue(saga.Id, out sagaEntity))
+                {
+                    sagaEntity.ConcurrencyCheck(saga, version);
+                }
 
-            data.AddOrUpdate(saga.Id, id => new VersionedSagaEntity
-            {
-                SagaEntity = DeepClone(saga)
-            }, (id, original) => new VersionedSagaEntity
-            {
-                SagaEntity = DeepClone(saga),
-                VersionCache = original.VersionCache
+                data.AddOrUpdate(saga.Id, id => new VersionedSagaEntity
+                {
+                    SagaEntity = DeepClone(saga)
+                }, (id, original) => new VersionedSagaEntity
+                {
+                    SagaEntity = DeepClone(saga),
+                    VersionCache = original.VersionCache
+                });
+
+                Interlocked.Increment(ref version);
             });
-
-            Interlocked.Increment(ref version);
             return TaskEx.Completed;
         }
 
-        public Task Update(IContainSagaData saga, ContextBag context)
+        public Task Update(IContainSagaData saga, SynchronizedStorageSession session, ContextBag context)
         {
-            VersionedSagaEntity sagaEntity;
-            if (data.TryGetValue(saga.Id, out sagaEntity))
+            var inMemSession = (InMemorySynchronizedStorageSession)session;
+            inMemSession.Enlist(() =>
             {
-                sagaEntity.ConcurrencyCheck(saga, version);
-            }
+                VersionedSagaEntity sagaEntity;
+                if (data.TryGetValue(saga.Id, out sagaEntity))
+                {
+                    sagaEntity.ConcurrencyCheck(saga, version);
+                }
 
-            data.AddOrUpdate(saga.Id, id => new VersionedSagaEntity
-            {
-                SagaEntity = DeepClone(saga)
-            }, (id, original) => new VersionedSagaEntity
-            {
-                SagaEntity = DeepClone(saga),
-                VersionCache = original.VersionCache
+                data.AddOrUpdate(saga.Id, id => new VersionedSagaEntity
+                {
+                    SagaEntity = DeepClone(saga)
+                }, (id, original) => new VersionedSagaEntity
+                {
+                    SagaEntity = DeepClone(saga),
+                    VersionCache = original.VersionCache
+                });
+
+                Interlocked.Increment(ref version);
             });
-
-            Interlocked.Increment(ref version);
             return TaskEx.Completed;
         }
 

--- a/src/NServiceBus.Core/Persistence/SynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Persistence/SynchronizedStorageSession.cs
@@ -1,0 +1,24 @@
+﻿namespace NServiceBus.Persistence
+{
+    using System;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Represents a storage session.
+    /// </summary>
+    public interface SynchronizedStorageSession
+    {
+        
+    }
+
+    /// <summary>
+    /// Represents a storage session from point of view of the infrastructure.
+    /// </summary>
+    public interface CompletableSynchronizedStorageSession : SynchronizedStorageSession, IDisposable
+    {
+        /// <summary>
+        /// Completes the session by saving the changes.
+        /// </summary>
+        Task CompleteAsync();
+    }
+}

--- a/src/NServiceBus.Core/Persistence/SynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Persistence/SynchronizedStorageSession.cs
@@ -1,24 +1,10 @@
 ﻿namespace NServiceBus.Persistence
 {
-    using System;
-    using System.Threading.Tasks;
-
     /// <summary>
     /// Represents a storage session.
     /// </summary>
     public interface SynchronizedStorageSession
     {
         
-    }
-
-    /// <summary>
-    /// Represents a storage session from point of view of the infrastructure.
-    /// </summary>
-    public interface CompletableSynchronizedStorageSession : SynchronizedStorageSession, IDisposable
-    {
-        /// <summary>
-        /// Completes the session by saving the changes.
-        /// </summary>
-        Task CompleteAsync();
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerContext.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Pipeline.Contexts
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using NServiceBus.Persistence;
     using NServiceBus.Unicast;
     using NServiceBus.Unicast.Behaviors;
     using NServiceBus.Unicast.Messages;
@@ -14,27 +15,33 @@ namespace NServiceBus.Pipeline.Contexts
         /// <summary>
         /// Initializes the handling stage context. This is the constructor to use for internal usage.
         /// </summary>
-        internal InvokeHandlerContext(MessageHandler handler, LogicalMessageProcessingContext parentContext)
-            : this(handler, parentContext.MessageId, parentContext.ReplyToAddress, parentContext.Headers, parentContext.Message.Metadata, parentContext.Message.Instance, parentContext)
+        internal InvokeHandlerContext(MessageHandler handler, SynchronizedStorageSession storageSession, LogicalMessageProcessingContext parentContext)
+            : this(handler, parentContext.MessageId, parentContext.ReplyToAddress, parentContext.Headers, parentContext.Message.Metadata, parentContext.Message.Instance, storageSession, parentContext)
         {
         }
 
         /// <summary>
         /// Initializes the handling stage context.
         /// </summary>
-        public InvokeHandlerContext(MessageHandler handler, string messageId, string replyToAddress, Dictionary<string, string> headers, MessageMetadata messageMetadata, object messageBeingHandled, BehaviorContext parentContext)
+        public InvokeHandlerContext(MessageHandler handler, string messageId, string replyToAddress, Dictionary<string, string> headers, MessageMetadata messageMetadata, object messageBeingHandled, SynchronizedStorageSession storageSession, BehaviorContext parentContext)
             : base(messageId, replyToAddress, headers, parentContext)
         {
             MessageHandler = handler;
             Headers = headers;
             MessageBeingHandled = messageBeingHandled;
             MessageMetadata = messageMetadata;
+            Set(storageSession);
         }
 
         /// <summary>
         /// The current <see cref="IHandleMessages{T}" /> being executed.
         /// </summary>
         public MessageHandler MessageHandler { get; }
+
+        /// <summary>
+        /// The transactional storage session that the handler can use to persist information in sync with receiving a message.
+        /// </summary>
+        public SynchronizedStorageSession SynchronizedStorageSession => Get<SynchronizedStorageSession>();
 
         /// <summary>
         /// Message headers.

--- a/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
@@ -3,44 +3,66 @@
     using System;
     using System.Linq;
     using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using NServiceBus.Outbox;
+    using NServiceBus.Persistence;
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
+    using NServiceBus.Transports;
     using NServiceBus.Unicast;
 
     class LoadHandlersConnector : StageConnector<LogicalMessageProcessingContext, InvokeHandlerContext>
     {
-        public LoadHandlersConnector(MessageHandlerRegistry messageHandlerRegistry)
+        public LoadHandlersConnector(MessageHandlerRegistry messageHandlerRegistry, ISynchronizedStorage synchronizedStorage, ISynchronizedStorageAdapter adapter)
         {
             this.messageHandlerRegistry = messageHandlerRegistry;
+            this.synchronizedStorage = synchronizedStorage;
+            this.adapter = adapter;
         }
 
         public override async Task Invoke(LogicalMessageProcessingContext context, Func<InvokeHandlerContext, Task> next)
         {
-            var handlersToInvoke = messageHandlerRegistry.GetHandlersFor(context.Message.MessageType).ToList();
-
-            if (!context.MessageHandled && !handlersToInvoke.Any())
+            var outboxTransaction = context.Get<OutboxTransaction>();
+            var transportTransaction = context.Get<TransportTransaction>();
+            using (var storageSession = await AdaptOrOpenNewSynchronizedStorageSession(transportTransaction, outboxTransaction, context))
             {
-                var error = $"No handlers could be found for message type: {context.Message.MessageType}";
-                throw new InvalidOperationException(error);
-            }
+                var handlersToInvoke = messageHandlerRegistry.GetHandlersFor(context.Message.MessageType).ToList();
 
-            foreach (var messageHandler in handlersToInvoke)
-            {
-                messageHandler.Instance = context.Builder.Build(messageHandler.HandlerType);
-
-                var handlingContext = new InvokeHandlerContext(messageHandler, context);
-                await next(handlingContext).ConfigureAwait(false);
-
-                if (handlingContext.HandlerInvocationAborted)
+                if (!context.MessageHandled && !handlersToInvoke.Any())
                 {
-                    //if the chain was aborted skip the other handlers
-                    break;
+                    var error = $"No handlers could be found for message type: {context.Message.MessageType}";
+                    throw new InvalidOperationException(error);
                 }
-            }
 
-            context.MessageHandled = true;
+                foreach (var messageHandler in handlersToInvoke)
+                {
+                    messageHandler.Instance = context.Builder.Build(messageHandler.HandlerType);
+
+                    var handlingContext = new InvokeHandlerContext(messageHandler, storageSession, context);
+                    await next(handlingContext).ConfigureAwait(false);
+
+                    if (handlingContext.HandlerInvocationAborted)
+                    {
+                        //if the chain was aborted skip the other handlers
+                        break;
+                    }
+                }
+                context.MessageHandled = true;
+                await storageSession.CompleteAsync().ConfigureAwait(false);
+            }
         }
 
+        Task<CompletableSynchronizedStorageSession> AdaptOrOpenNewSynchronizedStorageSession(TransportTransaction transportTransaction, OutboxTransaction outboxTransaction, ContextBag contextBag)
+        {
+            CompletableSynchronizedStorageSession session;
+            return adapter.TryAdapt(transportTransaction, out session) || adapter.TryAdapt(outboxTransaction, out session)
+                ? Task.FromResult(session)
+                : synchronizedStorage.OpenSession(contextBag);
+        }
+
+
         MessageHandlerRegistry messageHandlerRegistry;
+        readonly ISynchronizedStorage synchronizedStorage;
+        readonly ISynchronizedStorageAdapter adapter;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveContext.cs
@@ -7,11 +7,12 @@
     /// </summary>
     public class TransportReceiveContext : BehaviorContext
     {
-        internal TransportReceiveContext(IncomingMessage receivedMessage, BehaviorContext parentContext)
+        internal TransportReceiveContext(IncomingMessage receivedMessage, TransportTransaction transportTransaction, BehaviorContext parentContext)
             : base(parentContext)
         {
             Message = receivedMessage;
             Set(Message);
+            Set(transportTransaction);
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageProcessingConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageProcessingConnector.cs
@@ -36,12 +36,13 @@ namespace NServiceBus
 
                 using (var outboxTransaction = await outboxStorage.BeginTransaction(context).ConfigureAwait(false))
                 {
+                    context.Set(outboxTransaction);
                     await next(physicalMessageContext).ConfigureAwait(false);
 
                     var outboxMessage = new OutboxMessage(messageId, ConvertToOutboxOperations(pendingTransportOperations.Operations).ToList());
-
                     await outboxStorage.Store(outboxMessage, outboxTransaction, context).ConfigureAwait(false);
 
+                    context.Remove<OutboxTransaction>();
                     await outboxTransaction.Commit().ConfigureAwait(false);
                 }
             }

--- a/src/NServiceBus.Core/Sagas/CustomFinderAdapter.cs
+++ b/src/NServiceBus.Core/Sagas/CustomFinderAdapter.cs
@@ -4,17 +4,18 @@ namespace NServiceBus
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
     using NServiceBus.ObjectBuilder;
+    using NServiceBus.Persistence;
     using NServiceBus.Sagas;
 
     class CustomFinderAdapter<TSagaData, TMessage> : SagaFinder where TSagaData : IContainSagaData
     {
-        public override async Task<IContainSagaData> Find(IBuilder builder, SagaFinderDefinition finderDefinition, ContextBag context, object message)
+        public override async Task<IContainSagaData> Find(IBuilder builder, SagaFinderDefinition finderDefinition, SynchronizedStorageSession storageSession, ContextBag context, object message)
         {
             var customFinderType = (Type) finderDefinition.Properties["custom-finder-clr-type"];
 
             var finder = (IFindSagas<TSagaData>.Using<TMessage>) builder.Build(customFinderType);
 
-            return await finder.FindBy((TMessage) message, context).ConfigureAwait(false);
+            return await finder.FindBy((TMessage) message, storageSession, context).ConfigureAwait(false);
         }
     }
 }

--- a/src/NServiceBus.Core/Sagas/IFindSagas.cs
+++ b/src/NServiceBus.Core/Sagas/IFindSagas.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Sagas
 {
     using System.Threading.Tasks;
     using Extensibility;
+    using NServiceBus.Persistence;
 
     /// <summary>
     /// Interface indicating that implementers can find sagas of the given type.
@@ -17,7 +18,7 @@ namespace NServiceBus.Sagas
             /// <summary>
             /// Finds a saga entity of the type T using a message of type M.
             /// </summary>
-            Task<T> FindBy(M message, ReadOnlyContextBag context);
+            Task<T> FindBy(M message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context);
         }
     }
 }

--- a/src/NServiceBus.Core/Sagas/ISagaPersister.cs
+++ b/src/NServiceBus.Core/Sagas/ISagaPersister.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Sagas
     using System;
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
+    using NServiceBus.Persistence;
 
     /// <summary>
     /// Defines the basic functionality of a persister for storing 
@@ -15,37 +16,42 @@ namespace NServiceBus.Sagas
         /// </summary>
         /// <param name="sagaInstance">The saga instance to save.</param>
         /// <param name="correlationProperty">The property to correlate. Can be null.</param>
+        /// <param name="session">Storage session.</param>
         /// <param name="context">The current pipeline context.</param>
-        Task Save(IContainSagaData sagaInstance, SagaCorrelationProperty correlationProperty, ContextBag context);
+        Task Save(IContainSagaData sagaInstance, SagaCorrelationProperty correlationProperty, SynchronizedStorageSession session, ContextBag context);
 
         /// <summary>
         /// Updates an existing saga entity in the persistence store.
         /// </summary>
         /// <param name="saga">The saga entity to updated.</param>
+        /// <param name="session">The session.</param>
         /// <param name="context">The current pipeline context.</param>
-        Task Update(IContainSagaData saga, ContextBag context);
+        Task Update(IContainSagaData saga, SynchronizedStorageSession session, ContextBag context);
 
         /// <summary>
         /// Gets a saga entity from the persistence store by its Id.
         /// </summary>
         /// <param name="sagaId">The Id of the saga entity to get.</param>
+        /// <param name="session">The session.</param>
         /// <param name="context">The current pipeline context.</param>
-        Task<TSagaData> Get<TSagaData>(Guid sagaId, ContextBag context) where TSagaData : IContainSagaData;
+        Task<TSagaData> Get<TSagaData>(Guid sagaId, SynchronizedStorageSession session, ContextBag context) where TSagaData : IContainSagaData;
 
         /// <summary>
         /// Looks up a saga entity by a given property.
         /// </summary>
         /// <param name="propertyName">From the data store, analyze this property.</param>
         /// <param name="propertyValue">From the data store, look for this value in the identified property.</param>
+        /// <param name="session">The session.</param>
         /// <param name="context">The current pipeline context.</param>
-        Task<TSagaData> Get<TSagaData>(string propertyName, object propertyValue, ContextBag context) where TSagaData : IContainSagaData;
+        Task<TSagaData> Get<TSagaData>(string propertyName, object propertyValue, SynchronizedStorageSession session, ContextBag context) where TSagaData : IContainSagaData;
 
         /// <summary>
         /// Sets a saga as completed and removes it from the active saga list
         /// in the persistence store.
         /// </summary>
         /// <param name="saga">The saga to complete.</param>
+        /// <param name="session">The session.</param>
         /// <param name="context">The current pipeline context.</param>
-        Task Complete(IContainSagaData saga, ContextBag context);
+        Task Complete(IContainSagaData saga, SynchronizedStorageSession session, ContextBag context);
     }
 }

--- a/src/NServiceBus.Core/Sagas/LoadSagaByIdWrapper.cs
+++ b/src/NServiceBus.Core/Sagas/LoadSagaByIdWrapper.cs
@@ -3,13 +3,14 @@ namespace NServiceBus.Sagas
     using System;
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
+    using NServiceBus.Persistence;
 
     //this class in only here until we can move to a better saga persister api
     class LoadSagaByIdWrapper<T> : SagaLoader where T : IContainSagaData
     {
-        public async Task<IContainSagaData> Load(ISagaPersister persister, string sagaId, ContextBag context)
+        public async Task<IContainSagaData> Load(ISagaPersister persister, string sagaId, SynchronizedStorageSession storageSession, ContextBag context)
         {
-            return await persister.Get<T>(Guid.Parse(sagaId), context).ConfigureAwait(false);
+            return await persister.Get<T>(Guid.Parse(sagaId), storageSession, context).ConfigureAwait(false);
         }
     }
 }

--- a/src/NServiceBus.Core/Sagas/SagaFinder.cs
+++ b/src/NServiceBus.Core/Sagas/SagaFinder.cs
@@ -3,10 +3,11 @@
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
     using NServiceBus.ObjectBuilder;
+    using NServiceBus.Persistence;
     using NServiceBus.Sagas;
 
     abstract class SagaFinder
     {
-        public abstract Task<IContainSagaData> Find(IBuilder builder, SagaFinderDefinition finderDefinition, ContextBag context, object message);
+        public abstract Task<IContainSagaData> Find(IBuilder builder, SagaFinderDefinition finderDefinition, SynchronizedStorageSession storageSession, ContextBag context, object message);
     }
 }

--- a/src/NServiceBus.Core/Sagas/SagaLoader.cs
+++ b/src/NServiceBus.Core/Sagas/SagaLoader.cs
@@ -2,9 +2,10 @@ namespace NServiceBus.Sagas
 {
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
+    using NServiceBus.Persistence;
 
     interface SagaLoader
     {
-        Task<IContainSagaData> Load(ISagaPersister persister, string sagaId, ContextBag context);
+        Task<IContainSagaData> Load(ISagaPersister persister, string sagaId, SynchronizedStorageSession storageSession, ContextBag context);
     }
 }

--- a/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
@@ -84,7 +84,7 @@
             {
                 if (!sagaInstanceState.IsNew)
                 {
-                    await sagaPersister.Complete(saga.Entity, context).ConfigureAwait(false);
+                    await sagaPersister.Complete(saga.Entity, context.SynchronizedStorageSession, context).ConfigureAwait(false);
                 }
 
                 if (saga.Entity.Id != Guid.Empty)
@@ -108,11 +108,11 @@
                         sagaCorrelationProperty = new SagaCorrelationProperty(correlationProperty.PropertyInfo.Name,correlationProperty.Value);
                     }
 
-                    await sagaPersister.Save(saga.Entity, sagaCorrelationProperty, context).ConfigureAwait(false);
+                    await sagaPersister.Save(saga.Entity, sagaCorrelationProperty, context.SynchronizedStorageSession, context).ConfigureAwait(false);
                 }
                 else
                 {
-                    await sagaPersister.Update(saga.Entity, context).ConfigureAwait(false);
+                    await sagaPersister.Update(saga.Entity, context.SynchronizedStorageSession, context).ConfigureAwait(false);
                 }
             }
         }
@@ -216,7 +216,7 @@
 
                 var loader = (SagaLoader) Activator.CreateInstance(loaderType);
 
-                return loader.Load(sagaPersister, sagaId, context);
+                return loader.Load(sagaPersister, sagaId, context.SynchronizedStorageSession, context);
             }
 
             SagaFinderDefinition finderDefinition = null;
@@ -238,7 +238,7 @@
             var finderType = finderDefinition.Type;
             var finder = (SagaFinder) currentContext.Builder.Build(finderType);
 
-            return finder.Find(currentContext.Builder, finderDefinition, context, context.MessageBeingHandled);
+            return finder.Find(currentContext.Builder, finderDefinition, context.SynchronizedStorageSession, context, context.MessageBeingHandled);
         }
 
         IContainSagaData CreateNewSagaEntity(SagaMetadata metadata, InvokeHandlerContext context)

--- a/src/NServiceBus.Core/Transports/AmbientTransaction.cs
+++ b/src/NServiceBus.Core/Transports/AmbientTransaction.cs
@@ -1,0 +1,24 @@
+namespace NServiceBus
+{
+    using System.Transactions;
+    using NServiceBus.Transports;
+
+    /// <summary>
+    /// Ambient transaction started by the transport receiver.
+    /// </summary>
+    public class AmbientTransaction : TransportTransaction
+    {
+        /// <summary>
+        /// Ambient transaction.
+        /// </summary>
+        public Transaction Transaction { get; }
+
+        /// <summary>
+        /// Creates new ambient transport transaction.
+        /// </summary>
+        public AmbientTransaction(Transaction transaction)
+        {
+            Transaction = transaction;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Transports/Msmq/NativeMsmqTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/NativeMsmqTransaction.cs
@@ -1,0 +1,15 @@
+namespace NServiceBus
+{
+    using System.Messaging;
+    using NServiceBus.Transports;
+
+    class NativeMsmqTransaction : TransportTransaction
+    {
+        public MessageQueueTransaction MsmqTransaction { get; }
+
+        public NativeMsmqTransaction(MessageQueueTransaction msmqTransaction)
+        {
+            MsmqTransaction = msmqTransaction;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveWithNativeTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveWithNativeTransaction.cs
@@ -43,7 +43,7 @@ namespace NServiceBus
 
                         context.Set(msmqTransaction);
 
-                        var pushContext = new PushContext(message.Id, headers, bodyStream, context);
+                        var pushContext = new PushContext(message.Id, headers, bodyStream, new NativeMsmqTransaction(msmqTransaction), context);
 
                         await onMessage(pushContext).ConfigureAwait(false);
                     }

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveWithNoTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveWithNoTransaction.cs
@@ -32,12 +32,16 @@ namespace NServiceBus
 
             using (var bodyStream = message.BodyStream)
             {
-                var pushContext = new PushContext(message.Id, headers, bodyStream, new ContextBag());
+                var pushContext = new PushContext(message.Id, headers, bodyStream, new NullTransaction(), new ContextBag());
 
                 await onMessage(pushContext).ConfigureAwait(false);
             }
         }
 
         static ILog Logger = LogManager.GetLogger<ReceiveWithNoTransaction>();
+
+        private class NullTransaction : TransportTransaction
+        {
+        }
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveWithTransactionScope.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveWithTransactionScope.cs
@@ -41,7 +41,7 @@ namespace NServiceBus
 
                 using (var bodyStream = message.BodyStream)
                 {
-                    var pushContext = new PushContext(message.Id, headers, bodyStream, new ContextBag());
+                    var pushContext = new PushContext(message.Id, headers, bodyStream, new AmbientTransaction(Transaction.Current), new ContextBag());
 
                     await onMessage(pushContext).ConfigureAwait(false);
                 }

--- a/src/NServiceBus.Core/Transports/PushContext.cs
+++ b/src/NServiceBus.Core/Transports/PushContext.cs
@@ -15,18 +15,21 @@
         /// <param name="messageId">Native message id.</param>
         /// <param name="headers">The message headers.</param>
         /// <param name="bodyStream">The message body stream.</param>
+        /// <param name="transportTransaction">Transaction (along with connection if aplicable) used to receive the message.</param>
         /// <param name="context">Any context that the transport wants to be available on the pipeline.</param>
-        public PushContext(string messageId, Dictionary<string, string> headers, Stream bodyStream, ContextBag context)
+        public PushContext(string messageId, Dictionary<string, string> headers, Stream bodyStream, TransportTransaction transportTransaction, ContextBag context)
         {
-            Guard.AgainstNullAndEmpty("messageId", messageId);
-            Guard.AgainstNull("bodyStream", bodyStream);
-            Guard.AgainstNull("headers", headers);
-            Guard.AgainstNull("context", context);
+            Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
+            Guard.AgainstNull(nameof(bodyStream), bodyStream);
+            Guard.AgainstNull(nameof(headers), headers);
+            Guard.AgainstNull(nameof(transportTransaction), transportTransaction);
+            Guard.AgainstNull(nameof(context), context);
 
             Headers = headers;
             BodyStream = bodyStream;
             MessageId = messageId;
             Context = context;
+            TransportTransaction = transportTransaction;
         }
 
         /// <summary>
@@ -48,5 +51,10 @@
         /// Context provided by the transport.
         /// </summary>
         public ContextBag Context { get; private set; }
+
+        /// <summary>
+        /// Transaction (along with connection if applicable) used to receive the message.
+        /// </summary>
+        public TransportTransaction TransportTransaction { get; private set; }
     }
 }

--- a/src/NServiceBus.Core/Transports/TransportReceiver.cs
+++ b/src/NServiceBus.Core/Transports/TransportReceiver.cs
@@ -64,7 +64,7 @@ namespace NServiceBus.Transport
         {
             using (var childBuilder = builder.CreateChildBuilder())
             {
-                var context = new TransportReceiveContext(new IncomingMessage(pushContext.MessageId, pushContext.Headers, pushContext.BodyStream), new RootContext(childBuilder));
+                var context = new TransportReceiveContext(new IncomingMessage(pushContext.MessageId, pushContext.Headers, pushContext.BodyStream), pushContext.TransportTransaction, new RootContext(childBuilder));
                 context.Merge(pushContext.Context);
                 await pipeline.Invoke(context).ConfigureAwait(false);
             }

--- a/src/NServiceBus.Core/Transports/TransportTransaction.cs
+++ b/src/NServiceBus.Core/Transports/TransportTransaction.cs
@@ -1,0 +1,9 @@
+namespace NServiceBus.Transports
+{
+    /// <summary>
+    /// Represents a transaction used to receive the message from the queueing infrastructure.
+    /// </summary>
+    public interface TransportTransaction
+    {
+    }
+}


### PR DESCRIPTION
This pull tries to bring some order to how messages are handled. The rules were there before but this is an attempt to codify them and make them explicit:

 * NServiceBus has a storage for which updates are synchronized with processing messages so that the updates to the store are guaranteed to be committed before the message is marked as processed (*at-least-once*)
 * NServiceBus message processing guarantees only applies to the message itself and the synchronized store. Side effects of all other actions need to be handled by the users. Exception: when `TransactionScope` is used, it is present on the executing thread so user's code which takes advantage of TS can tap into NSB's message processing guarantees
 * Synchronized Storage is explicit (it's session is present on APIs such as `IMessageHandlingContext` and `SagaFinder`). It is important enough to make it visible on the interface/method signature. Accessing it should be done like this:

```
context.SynchronizedStorageSession.Raven().Store(...)
```

instead of

```
context.RavenSession().Store(...)
```

where the disadvantage of the *train wreck* is in my opinion smaller than the advantage of showing the user that he does not deal with a random session but one that is synchronized message processing.

 * Synchronized store default guarantees (*at-least-once*) can be enhanced by adapting either the transport transaction or the outbox transaction (via `ISynchronizedStorageAdapter`). In such case the updates done via synchronized store are guaranteed to be executed successfully only once.
