### PR TITLE
Require sagas to have at least one start message

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2283,9 +2283,9 @@ namespace NServiceBus.Sagas
     }
     public class SagaMetadata
     {
-        public SagaMetadata(string name, System.Type sagaType, string entityName, System.Type sagaEntityType, System.Collections.Generic.List<NServiceBus.Sagas.CorrelationProperty> correlationProperties, System.Collections.Generic.IEnumerable<NServiceBus.Sagas.SagaMessage> messages, System.Collections.Generic.IEnumerable<NServiceBus.Sagas.SagaFinderDefinition> finders) { }
+        public SagaMetadata(string name, System.Type sagaType, string entityName, System.Type sagaEntityType, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Sagas.CorrelationProperty> correlationProperties, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Sagas.SagaMessage> messages, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Sagas.SagaFinderDefinition> finders) { }
         public System.Collections.Generic.IEnumerable<NServiceBus.Sagas.SagaMessage> AssociatedMessages { get; }
-        public System.Collections.Generic.List<NServiceBus.Sagas.CorrelationProperty> CorrelationProperties { get; }
+        public System.Collections.Generic.IReadOnlyCollection<NServiceBus.Sagas.CorrelationProperty> CorrelationProperties { get; }
         public string EntityName { get; }
         public System.Collections.Generic.IEnumerable<NServiceBus.Sagas.SagaFinderDefinition> Finders { get; }
         public string Name { get; }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2284,10 +2284,10 @@ namespace NServiceBus.Sagas
     public class SagaMetadata
     {
         public SagaMetadata(string name, System.Type sagaType, string entityName, System.Type sagaEntityType, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Sagas.CorrelationProperty> correlationProperties, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Sagas.SagaMessage> messages, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Sagas.SagaFinderDefinition> finders) { }
-        public System.Collections.Generic.IEnumerable<NServiceBus.Sagas.SagaMessage> AssociatedMessages { get; }
+        public System.Collections.Generic.IReadOnlyCollection<NServiceBus.Sagas.SagaMessage> AssociatedMessages { get; }
         public System.Collections.Generic.IReadOnlyCollection<NServiceBus.Sagas.CorrelationProperty> CorrelationProperties { get; }
         public string EntityName { get; }
-        public System.Collections.Generic.IEnumerable<NServiceBus.Sagas.SagaFinderDefinition> Finders { get; }
+        public System.Collections.Generic.IReadOnlyCollection<NServiceBus.Sagas.SagaFinderDefinition> Finders { get; }
         public string Name { get; }
         public System.Type SagaEntityType { get; }
         public System.Type SagaType { get; }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/AnotherSagaWithTwoUniquePropertiesData.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/AnotherSagaWithTwoUniquePropertiesData.cs
@@ -3,7 +3,7 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
     using System;
     using System.Threading.Tasks;
 
-    class AnotherSagaWithTwoUniqueProperties:Saga<AnotherSagaWithTwoUniquePropertiesData>, IHandleMessages<M1>
+    class AnotherSagaWithTwoUniqueProperties:Saga<AnotherSagaWithTwoUniquePropertiesData>, IAmStartedByMessages<M1>
     {
         protected override void ConfigureHowToFindSaga(SagaPropertyMapper<AnotherSagaWithTwoUniquePropertiesData> mapper)
         {

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/SagaWithTwoUniquePropertiesData.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/SagaWithTwoUniquePropertiesData.cs
@@ -1,13 +1,19 @@
 namespace NServiceBus.SagaPersisters.InMemory.Tests
 {
     using System;
+    using System.Threading.Tasks;
 
-    class SagaWithTwoUniqueProperties:Saga<SagaWithTwoUniquePropertiesData>
+    class SagaWithTwoUniqueProperties:Saga<SagaWithTwoUniquePropertiesData>,IAmStartedByMessages<StartMessage>
     {
         protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaWithTwoUniquePropertiesData> mapper)
         {
             mapper.ConfigureMapping<M11>(m => m.UniqueInt).ToSaga(s => s.UniqueInt);
             mapper.ConfigureMapping<M11>(m => m.UniqueString).ToSaga(s => s.UniqueString);
+        }
+
+        public Task Handle(StartMessage message, IMessageHandlerContext context)
+        {
+            throw new NotImplementedException();
         }
     }
 

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/SagaWithUniquePropertyData.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/SagaWithUniquePropertyData.cs
@@ -1,9 +1,15 @@
 namespace NServiceBus.SagaPersisters.InMemory.Tests
 {
     using System;
+    using System.Threading.Tasks;
 
-    class SagaWithUniqueProperty : Saga<SagaWithUniquePropertyData>
+    class SagaWithUniqueProperty : Saga<SagaWithUniquePropertyData>, IAmStartedByMessages<StartMessage>
     {
+        public Task Handle(StartMessage message, IMessageHandlerContext context)
+        {
+            throw new NotImplementedException();
+        }
+
         protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaWithUniquePropertyData> mapper)
         {
             mapper.ConfigureMapping<M12>(m => m.UniqueString).ToSaga(s => s.UniqueString);
@@ -17,12 +23,11 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
 
     public class SagaWithUniquePropertyData : IContainSagaData
     {
+        public string UniqueString { get; set; }
         public Guid Id { get; set; }
 
         public string Originator { get; set; }
 
         public string OriginalMessageId { get; set; }
-
-        public string UniqueString { get; set; }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/SimpleSagaEntity.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/SimpleSagaEntity.cs
@@ -1,12 +1,18 @@
 namespace NServiceBus.SagaPersisters.InMemory.Tests
 {
     using System;
+    using System.Threading.Tasks;
 
-    class SimpleSagaEntitySaga:Saga<SimpleSagaEntity>
+    class SimpleSagaEntitySaga:Saga<SimpleSagaEntity>,IAmStartedByMessages<StartMessage>
     {
         protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SimpleSagaEntity> mapper)
         {
             
+        }
+
+        public Task Handle(StartMessage message, IMessageHandlerContext context)
+        {
+            throw new NotImplementedException();
         }
     }
     public class SimpleSagaEntity : IContainSagaData

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/TestSagaData.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/TestSagaData.cs
@@ -2,22 +2,26 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
-    class TestSaga:Saga<TestSagaData>
+    class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartMessage>
     {
+        public Task Handle(StartMessage message, IMessageHandlerContext context)
+        {
+            throw new NotImplementedException();
+        }
+
         protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
         {
-            
         }
     }
+
+    class StartMessage
+    {
+    }
+
     public class TestSagaData : IContainSagaData
     {
-        public Guid Id { get; set; }
-
-        public string Originator { get; set; }
-
-        public string OriginalMessageId { get; set; }
-
         public RelatedClass RelatedClass { get; set; }
 
         public IList<OrderLine> OrderLines { get; set; }
@@ -29,7 +33,11 @@
         public TestComponent TestComponent { get; set; }
 
         public PolymorphicPropertyBase PolymorphicRelatedProperty { get; set; }
- 
+        public Guid Id { get; set; }
+
+        public string Originator { get; set; }
+
+        public string OriginalMessageId { get; set; }
     }
 
     public class PolymorphicProperty : PolymorphicPropertyBase
@@ -44,7 +52,8 @@
 
     public enum StatusEnum
     {
-        SomeStatus, AnotherStatus
+        SomeStatus,
+        AnotherStatus
     }
 
     public class TestComponent
@@ -58,7 +67,6 @@
         public Guid Id { get; set; }
 
         public Guid ProductId { get; set; }
-
     }
 
     public class RelatedClass

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_property_is_null.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_property_is_null.cs
@@ -29,10 +29,15 @@
             Assert.IsNull(sagaDataWithPropertyValue);
         }
 
-        class Saga : Saga<SagaData>
+        class Saga : Saga<SagaData>,IAmStartedByMessages<StartMessage>
         {
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
             {
+            }
+
+            public Task Handle(StartMessage message, IMessageHandlerContext context)
+            {
+                throw new NotImplementedException();
             }
         }
 

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_saving_a_null_unique_property.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_saving_a_null_unique_property.cs
@@ -24,7 +24,7 @@
             Assert.AreEqual("Cannot store saga with id '895e60e0-7be3-490a-afca-fe69184474ca' since the unique property 'Property' has a null value.", exception.Message);
         }
 
-        class Saga : Saga<SagaData>, IHandleMessages<M1>
+        class Saga : Saga<SagaData>, IAmStartedByMessages<M1>
         {
             public Task Handle(M1 message, IMessageHandlerContext context)
             {

--- a/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading.Tasks;
     using System.Transactions;
     using NServiceBus.ObjectBuilder;
@@ -12,6 +11,7 @@
     using NServiceBus.Unicast.Behaviors;
     using NServiceBus.Unicast.Messages;
     using NUnit.Framework;
+    using Conventions = NServiceBus.Conventions;
 
     [TestFixture]
     public class InvokeHandlerTerminatorTest
@@ -124,7 +124,7 @@
 
         static ActiveSagaInstance AssociateSagaWithMessage(FakeSaga saga, InvokeHandlerContext behaviorContext)
         {
-            var sagaInstance = new ActiveSagaInstance(saga, new SagaMetadata(string.Empty, typeof(FakeSaga), string.Empty, null, null, Enumerable.Empty<SagaMessage>(), Enumerable.Empty<SagaFinderDefinition>()));
+            var sagaInstance = new ActiveSagaInstance(saga, SagaMetadata.Create(typeof(FakeSaga), new List<Type>(), new Conventions()));
             behaviorContext.Set(sagaInstance);
             return sagaInstance;
         }
@@ -157,11 +157,28 @@
             return behaviorContext;
         }
 
-        class FakeSaga : Saga
+        class FakeSaga : Saga<FakeSaga.FakeSagaData>, IAmStartedByMessages<StartMessage>
         {
+            public Task Handle(StartMessage message, IMessageHandlerContext context)
+            {
+                throw new NotImplementedException();
+            }
+
             protected internal override void ConfigureHowToFindSaga(IConfigureHowToFindSagaWithMessage sagaMessageFindingConfiguration)
             {
             }
+
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<FakeSagaData> mapper)
+            {
+            }
+
+            public class FakeSagaData : ContainSagaData
+            {
+            }
+        }
+
+        class StartMessage
+        {
         }
 
         class FakeMessageHandler

--- a/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
@@ -47,7 +47,7 @@
             Assert.AreEqual("UniqueProperty", metadata.CorrelationProperties.Single().Name);
         }
 
-        class MySaga : Saga<MySaga.MyEntity>
+        class MySaga : Saga<MySaga.MyEntity>, IAmStartedByMessages<StartMessage>
         {
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MyEntity> mapper)
             {
@@ -58,7 +58,14 @@
             {
                 public int UniqueProperty { get; set; }
             }
+
+            public Task Handle(StartMessage message, IMessageHandlerContext context)
+            {
+                throw new NotImplementedException(); 
+            }
         }
+        
+        
 
         class M1
         {
@@ -69,20 +76,16 @@
         public void When_finder_for_non_message()
         {
             var availableTypes = new List<Type>
-                                 {
-                                     typeof(SagaWithNonMessageFinder.Finder)
-                                 };
-            var exception = Assert.Throws<Exception>(() =>
             {
-                SagaMetadata.Create(typeof(SagaWithNonMessageFinder), availableTypes, new Conventions());
-            });
+                typeof(SagaWithNonMessageFinder.Finder)
+            };
+            var exception = Assert.Throws<Exception>(() => { SagaMetadata.Create(typeof(SagaWithNonMessageFinder), availableTypes, new Conventions()); });
             Assert.AreEqual("A custom IFindSagas must target a valid message type as defined by the message conventions. Please change 'NServiceBus.Core.Tests.Sagas.TypeBasedSagas.SagaMetadataCreationTests+SagaWithNonMessageFinder+StartSagaMessage' to a valid message type or add it to the message conventions. Finder name 'NServiceBus.Core.Tests.Sagas.TypeBasedSagas.SagaMetadataCreationTests+SagaWithNonMessageFinder+Finder'.", exception.Message);
         }
 
         public class SagaWithNonMessageFinder : Saga<SagaWithNonMessageFinder.SagaData>,
             IAmStartedByMessages<SagaWithNonMessageFinder.StartSagaMessage>
         {
-
             public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
             {
                 return Task.FromResult(0);
@@ -115,20 +118,16 @@
         public void When_a_finder_and_a_mapping_exists_for_same_property()
         {
             var availableTypes = new List<Type>
-                                 {
-                                     typeof(SagaWithMappingAndFinder.Finder)
-                                 };
-            var exception = Assert.Throws<Exception>(() =>
             {
-                SagaMetadata.Create(typeof(SagaWithMappingAndFinder), availableTypes, new Conventions());
-            });
+                typeof(SagaWithMappingAndFinder.Finder)
+            };
+            var exception = Assert.Throws<Exception>(() => { SagaMetadata.Create(typeof(SagaWithMappingAndFinder), availableTypes, new Conventions()); });
             Assert.AreEqual("A custom IFindSagas and an existing mapping where found for message 'NServiceBus.Core.Tests.Sagas.TypeBasedSagas.SagaMetadataCreationTests+SagaWithMappingAndFinder+StartSagaMessage'. Please either remove the message mapping for remove the finder. Finder name 'NServiceBus.Core.Tests.Sagas.TypeBasedSagas.SagaMetadataCreationTests+SagaWithMappingAndFinder+Finder'.", exception.Message);
         }
 
         public class SagaWithMappingAndFinder : Saga<SagaWithMappingAndFinder.SagaData>,
             IAmStartedByMessages<SagaWithMappingAndFinder.StartSagaMessage>
         {
-
             public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
             {
                 return Task.FromResult(0);
@@ -166,7 +165,7 @@
             Assert.AreEqual("UniqueProperty", metadata.CorrelationProperties.Single().Name);
         }
 
-        class MySagaWithMappedAndUniqueProperty : Saga<MySagaWithMappedAndUniqueProperty.SagaData>
+        class MySagaWithMappedAndUniqueProperty : Saga<MySagaWithMappedAndUniqueProperty.SagaData>, IAmStartedByMessages<MySagaWithMappedAndUniqueProperty.StartMessage>
         {
             public class SagaData : ContainSagaData
             {
@@ -177,6 +176,16 @@
             {
                 mapper.ConfigureMapping<SomeMessage>(m => m.SomeProperty)
                     .ToSaga(s => s.UniqueProperty);
+            }
+
+
+            public Task Handle(StartMessage message, IMessageHandlerContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            public class StartMessage
+            {
             }
         }
 
@@ -187,7 +196,7 @@
             Assert.AreEqual("UniqueProperty", metadata.CorrelationProperties.Single().Name);
         }
 
-        class MySagaWithMappedProperty : Saga<MySagaWithMappedProperty.SagaData>
+        class MySagaWithMappedProperty : Saga<MySagaWithMappedProperty.SagaData>, IAmStartedByMessages<StartMessage>
         {
             public class SagaData : ContainSagaData
             {
@@ -199,6 +208,15 @@
                 mapper.ConfigureMapping<SomeMessage>(m => m.SomeProperty)
                     .ToSaga(s => s.UniqueProperty);
             }
+
+            public Task Handle(StartMessage message, IMessageHandlerContext context)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        class StartMessage
+        {
         }
 
         [Test, Ignore("Not sure we should enforce this yet")]
@@ -221,11 +239,11 @@
             IAmStartedByMessages<MySagaWithUnmappedStartProperty.MessageThatStartsTheSaga>,
             IHandleMessages<MySagaWithUnmappedStartProperty.MessageThatDoesNotStartTheSaga>
         {
-
             public class MessageThatStartsTheSaga : IMessage
             {
                 public int SomeProperty { get; set; }
             }
+
             public class MessageThatDoesNotStartTheSaga : IMessage
             {
                 public int SomeProperty { get; set; }
@@ -275,7 +293,6 @@
             IHandleMessages<SagaWith2StartersAnd1Handler.Message3>,
             IHandleTimeouts<SagaWith2StartersAnd1Handler.MyTimeout>
         {
-
             public class StartMessage1 : IMessage
             {
                 public string SomeId { get; set; }
@@ -350,7 +367,6 @@
         class SagaWithIdMappedToNonGuidMessageProperty : Saga<SagaWithIdMappedToNonGuidMessageProperty.SagaData>,
             IAmStartedByMessages<SomeMessage>
         {
-
             public class SagaData : ContainSagaData
             {
             }
@@ -398,9 +414,9 @@
         public void DetectAndRegisterCustomFindersUsingScanning()
         {
             var availableTypes = new List<Type>
-                                 {
-                                     typeof(MySagaWithScannedFinder.CustomFinder)
-                                 };
+            {
+                typeof(MySagaWithScannedFinder.CustomFinder)
+            };
             var metadata = SagaMetadata.Create(typeof(MySagaWithScannedFinder), availableTypes, new Conventions());
 
             var finder = GetFinder(metadata, typeof(SomeMessage).FullName);
@@ -441,7 +457,7 @@
             Assert.AreEqual(typeof(SagaWithInheritanceChain.SagaData), metadata.SagaEntityType);
         }
 
-        class SagaWithInheritanceChain : SagaWithInheritanceChainBase<SagaWithInheritanceChain.SagaData, SagaWithInheritanceChain.SomeOtherData>
+        class SagaWithInheritanceChain : SagaWithInheritanceChainBase<SagaWithInheritanceChain.SagaData, SagaWithInheritanceChain.SomeOtherData>,IAmStartedByMessages<StartMessage>
         {
             public class SagaData : ContainSagaData
             {
@@ -451,6 +467,11 @@
             public class SomeOtherData
             {
                 public string SomeData { get; set; }
+            }
+
+            public Task Handle(StartMessage message, IMessageHandlerContext context)
+            {
+                throw new NotImplementedException();
             }
         }
 
@@ -474,7 +495,6 @@
 
             return finder;
         }
-
     }
 
     class SomeMessageWithField : IMessage
@@ -488,5 +508,4 @@
     {
         public int SomeProperty { get; set; }
     }
-
 }

--- a/src/NServiceBus.Core.Tests/Sagas/When_saga_has_no_start_message.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/When_saga_has_no_start_message.cs
@@ -1,0 +1,41 @@
+namespace NServiceBus.Core.Tests.Sagas.TypeBasedSagas
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NServiceBus.Sagas;
+    using NUnit.Framework;
+    using Conventions = NServiceBus.Conventions;
+
+    [TestFixture]
+    public class When_saga_has_no_start_message
+    {
+        [Test]
+        public void Should_throw()
+        {
+            var ex = Assert.Throws<Exception>(() => SagaMetadata.Create(typeof(SagaWithNoStartMessage), new List<Type>(), new Conventions()));
+
+            StringAssert.Contains("Sagas must have at least one message that is allowed to start the saga", ex.Message);
+        }
+
+        class SagaWithNoStartMessage : Saga<SagaWithNoStartMessage.MyEntity>, IHandleMessages<Message1>
+        {
+            public Task Handle(Message1 message, IMessageHandlerContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MyEntity> mapper)
+            {
+            }
+
+            public class MyEntity : ContainSagaData
+            {
+            }
+        }
+
+        class Message1 : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core/Sagas/SagaMetadata.cs
+++ b/src/NServiceBus.Core/Sagas/SagaMetadata.cs
@@ -23,13 +23,20 @@ namespace NServiceBus.Sagas
         /// <param name="correlationProperties">Properties this saga is correlated on.</param>
         /// <param name="messages">The messages collection that a saga handles.</param>
         /// <param name="finders">The finder definition collection that can find this saga.</param>
-        public SagaMetadata(string name, Type sagaType, string entityName, Type sagaEntityType, List<CorrelationProperty> correlationProperties, IEnumerable<SagaMessage> messages, IEnumerable<SagaFinderDefinition> finders)
+        public SagaMetadata(string name, Type sagaType, string entityName, Type sagaEntityType, IReadOnlyCollection<CorrelationProperty> correlationProperties, IReadOnlyCollection<SagaMessage> messages, IReadOnlyCollection<SagaFinderDefinition> finders)
         {
             Name = name;
             EntityName = entityName;
             SagaEntityType = sagaEntityType;
             SagaType = sagaType;
             CorrelationProperties = correlationProperties;
+
+
+            if (!messages.Any(m => m.IsAllowedToStartSaga))
+            {
+                throw new Exception($@"
+Sagas must have at least one message that is allowed to start the saga. Please add at least one `IAmStartedByMessages` to your {name} saga.");
+            }
 
             associatedMessages = new Dictionary<string, SagaMessage>();
 
@@ -79,7 +86,7 @@ namespace NServiceBus.Sagas
         /// <summary>
         /// Properties this saga is correlated on.
         /// </summary>
-        public List<CorrelationProperty> CorrelationProperties { get; private set; }
+        public IReadOnlyCollection<CorrelationProperty> CorrelationProperties { get; private set; }
 
         internal static bool IsSagaType(Type t)
         {

--- a/src/NServiceBus.Core/Sagas/SagaMetadata.cs
+++ b/src/NServiceBus.Core/Sagas/SagaMetadata.cs
@@ -56,12 +56,12 @@ Sagas must have at least one message that is allowed to start the saga. Please a
         /// <summary>
         /// Returns the list of messages that is associated with this saga.
         /// </summary>
-        public IEnumerable<SagaMessage> AssociatedMessages => associatedMessages.Values;
+        public IReadOnlyCollection<SagaMessage> AssociatedMessages => associatedMessages.Values.ToList();
 
         /// <summary>
         /// Gets the list of finders for this saga.
         /// </summary>
-        public IEnumerable<SagaFinderDefinition> Finders => sagaFinders.Values;
+        public IReadOnlyCollection<SagaFinderDefinition> Finders => sagaFinders.Values.ToList();
 
         /// <summary>
         /// The name of the saga.


### PR DESCRIPTION
Validating that users have marked at least one of the handled messages as allowed to start the given saga.