### PR TITLE
Refactor acceptance test exception handling

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
+++ b/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
@@ -64,10 +64,12 @@
     <Compile Include="Support\EndpointBehaviorBuilder.cs" />
     <Compile Include="Support\EndpointConfiguration.cs" />
     <Compile Include="Support\EndpointRunner.cs" />
+    <Compile Include="Support\FailTestOnErrorMessageFeature.cs" />
     <Compile Include="Support\IBusAdapter.cs" />
     <Compile Include="Support\IEndpointSetupTemplate.cs" />
     <Compile Include="Support\IScenarioWithEndpointBehavior.cs" />
     <Compile Include="Support\IWhenDefinition.cs" />
+    <Compile Include="Support\MessagesFailedException.cs" />
     <Compile Include="Support\RunDescriptor.cs" />
     <Compile Include="Support\RunDescriptorsBuilder.cs" />
     <Compile Include="Scenario.cs" />

--- a/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
+++ b/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Support\ActiveRunner.cs" />
     <Compile Include="ScenarioContext.cs" />
     <Compile Include="ContextAppender.cs" />
+    <Compile Include="Support\AggregateExceptionTestExtensions.cs" />
     <Compile Include="Support\EndpointBehavior.cs" />
     <Compile Include="Support\BehaviourFactory.cs" />
     <Compile Include="Support\DefaultScenarioDescriptor.cs" />

--- a/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
@@ -2,6 +2,8 @@
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using NServiceBus.Faults;
 
     public abstract class ScenarioContext
     {
@@ -17,6 +19,8 @@
         }
 
         public ConcurrentQueue<Exception> Exceptions = new ConcurrentQueue<Exception>();
+
+        public ConcurrentDictionary<string, IReadOnlyCollection<FailedMessage>> FailedMessages = new ConcurrentDictionary<string, IReadOnlyCollection<FailedMessage>>();
 
         public ConcurrentQueue<LogItem> Logs = new ConcurrentQueue<LogItem>();
 

--- a/src/NServiceBus.AcceptanceTesting/Support/AggregateExceptionTestExtensions.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/AggregateExceptionTestExtensions.cs
@@ -1,0 +1,21 @@
+namespace NServiceBus.AcceptanceTesting.Support
+{
+    using System;
+
+    public static class AggregateExceptionTestExtensions
+    {
+        public static MessagesFailedException ExpectFailedMessages(this AggregateException aggregateException)
+        {
+            var messagesFailedException = aggregateException.InnerException as MessagesFailedException;
+            if (messagesFailedException != null)
+            {
+                return messagesFailedException;
+            }
+
+            throw new ArgumentException(
+                "Expected AggregateException to contain a MessagesFailedException, but it did not.",
+                nameof(aggregateException),
+                aggregateException);
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointBehavior.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointBehavior.cs
@@ -16,5 +16,7 @@
         public List<IWhenDefinition> Whens { get; set; }
 
         public List<Action<BusConfiguration>> CustomConfig { get; set; }
+
+        public bool DoNotFailOnErrorMessages { get; set; }
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointBehaviorBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointBehaviorBuilder.cs
@@ -46,6 +46,13 @@
             return this;
         }
 
+        public EndpointBehaviorBuilder<TContext> DoNotFailOnErrorMessages()
+        {
+            behavior.DoNotFailOnErrorMessages = true;
+
+            return this;
+        }
+
         public EndpointBehavior Build()
         {
             return behavior;

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -18,6 +18,8 @@
         ScenarioContext scenarioContext;
         BusConfiguration busConfiguration;
 
+        public bool FailOnErrorMessage => !behavior.DoNotFailOnErrorMessages;
+
         public async Task<Result> Initialize(RunDescriptor run, EndpointBehavior endpointBehavior,
             IDictionary<Type, string> routingTable, string endpointName)
         {

--- a/src/NServiceBus.AcceptanceTesting/Support/FailTestOnErrorMessageFeature.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/FailTestOnErrorMessageFeature.cs
@@ -1,0 +1,59 @@
+﻿namespace NServiceBus.AcceptanceTesting.Support
+{
+    using System;
+    using System.Linq;
+    using NServiceBus.Faults;
+    using NServiceBus.Features;
+
+    public class FailTestOnErrorMessageFeature : Feature
+    {
+        public FailTestOnErrorMessageFeature()
+        {
+            EnableByDefault();
+
+            DependsOn<UnicastBus>();
+        }
+
+        protected internal override void Setup(FeatureConfigurationContext context)
+        {
+            var endpointInstanceName = context.Settings.EndpointName();
+            var notifications = context.Builder.Build<BusNotifications>();
+            var testContext = context.Builder.Build<ScenarioContext>();
+
+            notifications.Errors.MessageSentToErrorQueue.Subscribe(new FaultedMessageObserver(testContext, endpointInstanceName));
+        }
+
+        class FaultedMessageObserver : IObserver<FailedMessage>
+        {
+            ScenarioContext testContext;
+            EndpointName endpointName;
+
+            public FaultedMessageObserver(ScenarioContext testContext, EndpointName endpointName)
+            {
+                this.testContext = testContext;
+                this.endpointName = endpointName;
+            }
+
+            public void OnNext(FailedMessage value)
+            {
+                testContext.FailedMessages.AddOrUpdate(
+                    endpointName.ToString(),
+                    new[] { value },
+                    (i, failed) =>
+                    {
+                        var result = failed.ToList();
+                        result.Add(value);
+                        return result;
+                    });
+            }
+
+            public void OnError(Exception error)
+            {
+            }
+
+            public void OnCompleted()
+            {
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTesting/Support/IScenarioWithEndpointBehavior.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/IScenarioWithEndpointBehavior.cs
@@ -16,10 +16,6 @@
         Task<TContext> Run(RunSettings settings);
 
         IAdvancedScenarioWithEndpointBehavior<TContext> Repeat(Action<RunDescriptorsBuilder> runtimeDescriptor);
-
-        IScenarioWithEndpointBehavior<TContext> AllowExceptions(Func<Exception,bool> filter = null);
-
-        IScenarioWithEndpointBehavior<TContext> AllowSimulatedExceptions();
     }
 
     public interface IAdvancedScenarioWithEndpointBehavior<TContext> where TContext : ScenarioContext
@@ -27,7 +23,6 @@
         IAdvancedScenarioWithEndpointBehavior<TContext> Should(Action<TContext> should);
 
         IAdvancedScenarioWithEndpointBehavior<TContext> Report(Action<RunSummary> summaries);
-
 
         IAdvancedScenarioWithEndpointBehavior<TContext> MaxTestParallelism(int maxParallelism);
 

--- a/src/NServiceBus.AcceptanceTesting/Support/MessagesFailedException.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/MessagesFailedException.cs
@@ -1,0 +1,21 @@
+namespace NServiceBus.AcceptanceTesting.Support
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+    using NServiceBus.Faults;
+
+    public class MessagesFailedException : Exception
+    {
+        public MessagesFailedException(ScenarioContext scenarioContext) : base("One or more messages have been moved to the error queue.")
+        {
+            ScenarioContext = scenarioContext;
+            FailedMessages = new ReadOnlyCollection<FailedMessage>(ScenarioContext.FailedMessages.Values.SelectMany(f => f).ToList());
+        }
+
+        public ScenarioContext ScenarioContext { get; }
+
+        public IReadOnlyCollection<FailedMessage> FailedMessages { get; }
+    }
+}

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -237,13 +237,9 @@
                 await StopEndpoints(endpoints).ConfigureAwait(false);
             }
 
-            var exceptions = runDescriptor.ScenarioContext.Exceptions
-                        .Where(ex => !allowedExceptions(ex))
-                        .ToList();
-
-            if (exceptions.Any())
+            if (runDescriptor.ScenarioContext.FailedMessages.Any(kvp => endpoints.Single(e => e.Name() == kvp.Key).FailOnErrorMessage))
             {
-                throw new AggregateException(exceptions);
+                throw new MessagesFailedException(runDescriptor.ScenarioContext);
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command.cs
@@ -25,7 +25,6 @@
                         }
                     }))
                     .Done(c => c.GotTheException)
-                    .AllowExceptions()
                     .Run();
 
             Assert.IsInstanceOf<Exception>(context.Exception);

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_event.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_event.cs
@@ -25,7 +25,6 @@
                         }
                     }))
                     .Done(c => c.GotTheException)
-                    .AllowExceptions()
                     .Run();
 
             Assert.IsInstanceOf<Exception>(context.Exception);

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command.cs
@@ -25,7 +25,6 @@
                         }
                     }))
                     .Done(c => c.GotTheException)
-                    .AllowExceptions()
                     .Run();
 
             Assert.IsInstanceOf<Exception>(context.Exception);

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command.cs
@@ -25,7 +25,6 @@
                         }
                     }))
                     .Done(c => c.GotTheException)
-                    .AllowExceptions()
                     .Run();
 
             Assert.IsInstanceOf<Exception>(context.Exception);

--- a/src/NServiceBus.AcceptanceTests/CriticalError/When_registering_a_custom_criticalErrorHandler.cs
+++ b/src/NServiceBus.AcceptanceTests/CriticalError/When_registering_a_custom_criticalErrorHandler.cs
@@ -19,7 +19,6 @@
             await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithLocalCallback>(b => b.When(
                     (bus, context) => bus.SendLocalAsync(new MyRequest())))
-                .AllowExceptions()
                 .Done(c => c.ExceptionReceived)
                 .Repeat(r => r.For(Transports.Default))
                 .Should(c =>

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
@@ -45,6 +45,8 @@
 
             builder.DisableFeature<TimeoutManager>();
             builder.DisableFeature<SecondLevelRetries>();
+            builder.DisableFeature<FirstLevelRetries>();
+
             await builder.DefineTransport(settings, endpointConfiguration.BuilderType);
             builder.DefineTransactions(settings);
             builder.DefineBuilder(settings);

--- a/src/NServiceBus.AcceptanceTests/NonTx/When_sending_inside_ambient_tx.cs
+++ b/src/NServiceBus.AcceptanceTests/NonTx/When_sending_inside_ambient_tx.cs
@@ -14,7 +14,9 @@
         public async Task Should_not_roll_the_message_back_to_the_queue_in_case_of_failure()
         {
             await Scenario.Define<Context>()
-                    .WithEndpoint<NonTransactionalEndpoint>(b => b.When(bus => bus.SendLocalAsync(new MyMessage())))
+                    .WithEndpoint<NonTransactionalEndpoint>(b => b
+                        .When(bus => bus.SendLocalAsync(new MyMessage()))
+                        .DoNotFailOnErrorMessages())
                     .AllowSimulatedExceptions()
                     .Done(c => c.TestComplete)
                     .Repeat(r => r.For<AllDtcTransports>())

--- a/src/NServiceBus.AcceptanceTests/NonTx/When_sending_inside_ambient_tx.cs
+++ b/src/NServiceBus.AcceptanceTests/NonTx/When_sending_inside_ambient_tx.cs
@@ -17,7 +17,6 @@
                     .WithEndpoint<NonTransactionalEndpoint>(b => b
                         .When(bus => bus.SendLocalAsync(new MyMessage()))
                         .DoNotFailOnErrorMessages())
-                    .AllowSimulatedExceptions()
                     .Done(c => c.TestComplete)
                     .Repeat(r => r.For<AllDtcTransports>())
                     .Should(c => Assert.False(c.MessageEnlistedInTheAmbientTxReceived, "The enlisted bus.SendAsync should not commit"))

--- a/src/NServiceBus.AcceptanceTests/Performance/ProcessingOptimizations/When_limiting_concurrency_via_both_api_and_config.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/ProcessingOptimizations/When_limiting_concurrency_via_both_api_and_config.cs
@@ -15,7 +15,6 @@ namespace NServiceBus.AcceptanceTests.Config
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<ThrottledEndpoint>(b => b.CustomConfig(c => c.LimitMessageProcessingConcurrencyTo(10)))
-                .AllowExceptions()
                 .Done(c => c.EndpointsStarted)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
@@ -17,7 +17,8 @@
         public async Task Should_retain_exception_details_over_FLR_and_SLR()
         {
             await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
-                .WithEndpoint<SLREndpoint>()
+                .WithEndpoint<SLREndpoint>(b => b
+                    .DoNotFailOnErrorMessages())
                 .AllowSimulatedExceptions()
                 .Done(c => c.MessageSentToError)
                 .Repeat(r => r.For<AllTransports>())

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
@@ -52,6 +52,7 @@
                 {
                     config.EnableFeature<SecondLevelRetries>();
                     config.EnableFeature<TimeoutManager>();
+                    config.EnableFeature<FirstLevelRetries>();
                 })
                     .WithConfig<TransportConfig>(c => { c.MaxRetries = 3; })
                     .WithConfig<SecondLevelRetriesConfig>(c =>

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
@@ -19,7 +19,6 @@
             await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                 .WithEndpoint<SLREndpoint>(b => b
                     .DoNotFailOnErrorMessages())
-                .AllowSimulatedExceptions()
                 .Done(c => c.MessageSentToError)
                 .Repeat(r => r.For<AllTransports>())
                 .Should(c =>

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_default_settings.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_default_settings.cs
@@ -20,7 +20,6 @@
                         await bus.SendLocalAsync(new MessageToBeRetried { Id = context.Id, SecondMessage = true });
                     })
                     .DoNotFailOnErrorMessages())
-                .AllowSimulatedExceptions()
                 .Done(c => c.SecondMessageReceived || c.NumberOfTimesInvoked > 1)
                 .Repeat(r => r.For(Transports.Default))
                 .Should(c => Assert.AreEqual(1, c.NumberOfTimesInvoked, "No retries should be in use if transactions are off"))

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_default_settings.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_default_settings.cs
@@ -13,17 +13,18 @@
         public async Task Should_not_do_any_retries_if_transactions_are_off()
         {
             await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
-                    .WithEndpoint<RetryEndpoint>(b => b.When(async (bus, context) =>
+                .WithEndpoint<RetryEndpoint>(b => b
+                    .When(async (bus, context) =>
                     {
                         await bus.SendLocalAsync(new MessageToBeRetried { Id = context.Id });
                         await bus.SendLocalAsync(new MessageToBeRetried { Id = context.Id, SecondMessage = true });
-                    }))
-                    .AllowSimulatedExceptions()
-                    .Done(c => c.SecondMessageReceived || c.NumberOfTimesInvoked > 1)
-                    .Repeat(r => r.For(Transports.Default))
-                    .Should(c => Assert.AreEqual(1, c.NumberOfTimesInvoked, "No retries should be in use if transactions are off"))
-                    .Run();
-
+                    })
+                    .DoNotFailOnErrorMessages())
+                .AllowSimulatedExceptions()
+                .Done(c => c.SecondMessageReceived || c.NumberOfTimesInvoked > 1)
+                .Repeat(r => r.For(Transports.Default))
+                .Should(c => Assert.AreEqual(1, c.NumberOfTimesInvoked, "No retries should be in use if transactions are off"))
+                .Run();
         }
 
         public class Context : ScenarioContext
@@ -49,7 +50,9 @@
                 public Task Handle(MessageToBeRetried message, IMessageHandlerContext context)
                 {
                     if (message.Id != Context.Id)
+                    {
                         return Task.FromResult(0); // messages from previous test runs must be ignored
+                    }
 
                     if (message.SecondMessage)
                     {
@@ -72,6 +75,4 @@
             public bool SecondMessage { get; set; }
         }
     }
-
-
 }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_dtc_on.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_dtc_on.cs
@@ -20,7 +20,6 @@
                    .WithEndpoint<RetryEndpoint>(b => b
                         .When((bus, context) => bus.SendLocalAsync(new MessageToBeRetried { Id = context.Id }))
                         .DoNotFailOnErrorMessages())
-                   .AllowSimulatedExceptions()
                    .Done(c => c.GaveUpOnRetries)
                    .Repeat(r => r.For<AllDtcTransports>())
                    .Should(c =>

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_dtc_on.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_dtc_on.cs
@@ -7,6 +7,7 @@
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
     using NServiceBus.Config;
+    using NServiceBus.Features;
     using NUnit.Framework;
 
     public class When_doing_flr_with_dtc_on : NServiceBusAcceptanceTest
@@ -49,7 +50,8 @@
         {
             public RetryEndpoint()
             {
-                EndpointSetup<DefaultServer>()
+                EndpointSetup<DefaultServer>(b => b
+                    .EnableFeature<FirstLevelRetries>())
                     .WithConfig<TransportConfig>(c => c.MaxRetries = maxretries);
             }
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_dtc_on.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_dtc_on.cs
@@ -17,7 +17,9 @@
         public async Task Should_do_X_retries_by_default_with_dtc_on()
         {
             await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
-                   .WithEndpoint<RetryEndpoint>(b => b.When((bus, context) => bus.SendLocalAsync(new MessageToBeRetried { Id = context.Id })))
+                   .WithEndpoint<RetryEndpoint>(b => b
+                        .When((bus, context) => bus.SendLocalAsync(new MessageToBeRetried { Id = context.Id }))
+                        .DoNotFailOnErrorMessages())
                    .AllowSimulatedExceptions()
                    .Done(c => c.GaveUpOnRetries)
                    .Repeat(r => r.For<AllDtcTransports>())

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
@@ -6,6 +6,7 @@
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NServiceBus.Features;
     using NUnit.Framework;
 
     public class When_doing_flr_with_native_transactions : NServiceBusAcceptanceTest
@@ -47,8 +48,8 @@
             {
                 EndpointSetup<DefaultServer>(b =>
                 {
+                    b.EnableFeature<FirstLevelRetries>();
                     b.Transactions().DisableDistributedTransactions();
-                    b.DisableFeature<Features.SecondLevelRetries>();
                 });
             }
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
@@ -17,7 +17,6 @@
                     .WithEndpoint<RetryEndpoint>(b => b
                         .When((bus, context) => bus.SendLocalAsync(new MessageToBeRetried { Id = context.Id }))
                         .DoNotFailOnErrorMessages())
-                    .AllowSimulatedExceptions()
                     .Done(c => c.ForwardedToErrorQueue)
                     .Repeat(r => r.For(Transports.Default))
                     .Should(c =>

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
@@ -14,7 +14,9 @@
         public async Task Should_do_5_retries_by_default_with_native_transactions()
         {
             await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
-                    .WithEndpoint<RetryEndpoint>(b => b.When((bus, context) => bus.SendLocalAsync(new MessageToBeRetried { Id = context.Id })))
+                    .WithEndpoint<RetryEndpoint>(b => b
+                        .When((bus, context) => bus.SendLocalAsync(new MessageToBeRetried { Id = context.Id }))
+                        .DoNotFailOnErrorMessages())
                     .AllowSimulatedExceptions()
                     .Done(c => c.ForwardedToErrorQueue)
                     .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_flr.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_flr.cs
@@ -17,7 +17,9 @@
         public async Task Should_be_moved_to_slr()
         {
             await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
-                    .WithEndpoint<SLREndpoint>(b => b.When((bus, context) => bus.SendLocalAsync(new MessageToBeRetried { Id = context.Id })))
+                    .WithEndpoint<SLREndpoint>(b => b
+                        .When((bus, context) => bus.SendLocalAsync(new MessageToBeRetried { Id = context.Id }))
+                        .DoNotFailOnErrorMessages())
                     .AllowSimulatedExceptions()
                     .Done(c => c.NumberOfTimesInvoked >= 2)
                     .Repeat(r => r.For(Transports.Default))

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_flr.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_flr.cs
@@ -20,7 +20,6 @@
                     .WithEndpoint<SLREndpoint>(b => b
                         .When((bus, context) => bus.SendLocalAsync(new MessageToBeRetried { Id = context.Id }))
                         .DoNotFailOnErrorMessages())
-                    .AllowSimulatedExceptions()
                     .Done(c => c.NumberOfTimesInvoked >= 2)
                     .Repeat(r => r.For(Transports.Default))
                     .Should(context =>

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_with_retries_set_to_0.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_with_retries_set_to_0.cs
@@ -15,7 +15,6 @@
             var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<RetryEndpoint>(b => b
                         .DoNotFailOnErrorMessages())
-                    .AllowSimulatedExceptions()
                     .Done(c => c.GaveUp)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_with_retries_set_to_0.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_with_retries_set_to_0.cs
@@ -13,7 +13,8 @@
         public async Task Should_not_retry_the_message_using_flr()
         {
             var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
-                    .WithEndpoint<RetryEndpoint>()
+                    .WithEndpoint<RetryEndpoint>(b => b
+                        .DoNotFailOnErrorMessages())
                     .AllowSimulatedExceptions()
                     .Done(c => c.GaveUp)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Features;
     using NUnit.Framework;
@@ -11,16 +12,25 @@
     public class When_message_fails_retries : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_forward_message_to_error_queue()
+        public void Should_forward_message_to_error_queue()
         {
-            var context = await Scenario.Define<Context>()
-                    .WithEndpoint<RetryEndpoint>(b => b.When((bus, c) => bus.SendLocalAsync(new MessageWhichFailsRetries())))
-                    .AllowSimulatedExceptions()
-                    .Done(c => c.ForwardedToErrorQueue)
-                    .Run();
+            Context testContext = null;
+            var exception = Assert.Throws<AggregateException>(async () => await Scenario.Define<Context>(c => testContext = c)
+                .WithEndpoint<RetryEndpoint>(b => b
+                    .When((bus, c) => bus.SendLocalAsync(new MessageWhichFailsRetries())))
+                .Done(c => c.ForwardedToErrorQueue)
+                .Run()).InnerException as MessagesFailedException;
 
-            Assert.AreEqual(1, context.Logs.Count(l => l.Message
-                .StartsWith($"Moving message '{context.PhysicalMessageId}' to the error queue because processing failed due to an exception:")));
+            Assert.IsNotNull(exception);
+            Assert.AreEqual(1, exception.FailedMessages.Count);
+            var failedMessage = exception.FailedMessages.Single();
+
+            Assert.AreEqual(typeof(MessageWhichFailsRetries).AssemblyQualifiedName, failedMessage.Headers[Headers.EnclosedMessageTypes]);
+            Assert.AreEqual(testContext.PhysicalMessageId, failedMessage.MessageId);
+            Assert.IsAssignableFrom(typeof(SimulatedException), failedMessage.Exception);
+
+            Assert.AreEqual(1, testContext.Logs.Count(l => l.Message
+                .StartsWith($"Moving message '{testContext.PhysicalMessageId}' to the error queue because processing failed due to an exception:")));
         }
 
         public class RetryEndpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
@@ -14,17 +14,18 @@
         [Test]
         public void Should_forward_message_to_error_queue()
         {
-            Context testContext = null;
-            var exception = Assert.Throws<AggregateException>(async () => await Scenario.Define<Context>(c => testContext = c)
-                .WithEndpoint<RetryEndpoint>(b => b
-                    .When((bus, c) => bus.SendLocalAsync(new MessageWhichFailsRetries())))
-                .Done(c => c.ForwardedToErrorQueue)
-                .Run()).InnerException as MessagesFailedException;
+            var exception = Assert.Throws<AggregateException>(async () => await
+                Scenario.Define<Context>()
+                    .WithEndpoint<RetryEndpoint>(b => b
+                        .When((bus, c) => bus.SendLocalAsync(new MessageWhichFailsRetries())))
+                    .Done(c => c.ForwardedToErrorQueue)
+                    .Run())
+                .ExpectFailedMessages();
 
-            Assert.IsNotNull(exception);
             Assert.AreEqual(1, exception.FailedMessages.Count);
             var failedMessage = exception.FailedMessages.Single();
 
+            var testContext = (Context)exception.ScenarioContext;
             Assert.AreEqual(typeof(MessageWhichFailsRetries).AssemblyQualifiedName, failedMessage.Headers[Headers.EnclosedMessageTypes]);
             Assert.AreEqual(testContext.PhysicalMessageId, failedMessage.MessageId);
             Assert.IsAssignableFrom(typeof(SimulatedException), failedMessage.Exception);

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_regular_exception.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_regular_exception.cs
@@ -11,7 +11,9 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
         public async Task Should_preserve_the_original_body_for_regular_exceptions()
         {
             var context = await Scenario.Define<Context>()
-                .WithEndpoint<RetryEndpoint>(b => b.When(bus => bus.SendLocalAsync(new MessageToBeRetried())))
+                .WithEndpoint<RetryEndpoint>(b => b
+                    .When(bus => bus.SendLocalAsync(new MessageToBeRetried()))
+                    .DoNotFailOnErrorMessages())
                 .AllowSimulatedExceptions()
                 .Done(c => c.SlrChecksum != default(byte))
                 .Run();
@@ -23,7 +25,9 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
         public async Task Should_reschedule_message_three_times_by_default()
         {
             var context = await Scenario.Define<Context>()
-                .WithEndpoint<RetryEndpoint>(b => b.When(bus => bus.SendLocalAsync(new MessageToBeRetried())))
+                .WithEndpoint<RetryEndpoint>(b => b
+                    .When(bus => bus.SendLocalAsync(new MessageToBeRetried()))
+                    .DoNotFailOnErrorMessages())
                 .AllowSimulatedExceptions()
                 .Done(c => c.ForwardedToErrorQueue)
                 .Run();

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_regular_exception.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_regular_exception.cs
@@ -14,7 +14,6 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
                 .WithEndpoint<RetryEndpoint>(b => b
                     .When(bus => bus.SendLocalAsync(new MessageToBeRetried()))
                     .DoNotFailOnErrorMessages())
-                .AllowSimulatedExceptions()
                 .Done(c => c.SlrChecksum != default(byte))
                 .Run();
 
@@ -28,7 +27,6 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
                 .WithEndpoint<RetryEndpoint>(b => b
                     .When(bus => bus.SendLocalAsync(new MessageToBeRetried()))
                     .DoNotFailOnErrorMessages())
-                .AllowSimulatedExceptions()
                 .Done(c => c.ForwardedToErrorQueue)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_serialization_exception.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_serialization_exception.cs
@@ -10,7 +10,9 @@
         public async Task Should_preserve_the_original_body_for_serialization_exceptions()
         {
             var context = await Scenario.Define<Context>(c => { c.SimulateSerializationException = true; })
-                .WithEndpoint<RetryEndpoint>(b => b.When(bus => bus.SendLocalAsync(new MessageToBeRetried())))
+                .WithEndpoint<RetryEndpoint>(b => b
+                    .When(bus => bus.SendLocalAsync(new MessageToBeRetried()))
+                    .DoNotFailOnErrorMessages())
                 .AllowExceptions(e => e is MessageDeserializationException)
                 .Done(c => c.SlrChecksum != default(byte))
                 .Run();

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_serialization_exception.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_serialization_exception.cs
@@ -13,7 +13,6 @@
                 .WithEndpoint<RetryEndpoint>(b => b
                     .When(bus => bus.SendLocalAsync(new MessageToBeRetried()))
                     .DoNotFailOnErrorMessages())
-                .AllowExceptions(e => e is MessageDeserializationException)
                 .Done(c => c.SlrChecksum != default(byte))
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_error_is_overridden_in_code.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_error_is_overridden_in_code.cs
@@ -17,7 +17,6 @@
                     .When(bus => bus.SendLocalAsync(new Message()))
                     .DoNotFailOnErrorMessages())
                 .WithEndpoint<ErrorSpy>()
-                .AllowSimulatedExceptions()
                 .Done(c => c.MessageReceived)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_error_is_overridden_in_code.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_error_is_overridden_in_code.cs
@@ -13,7 +13,9 @@
         public async Task Should_error_to_target_queue()
         {
             var context = await Scenario.Define<Context>()
-                .WithEndpoint<UserEndpoint>(b => b.When(bus => bus.SendLocalAsync(new Message())))
+                .WithEndpoint<UserEndpoint>(b => b
+                    .When(bus => bus.SendLocalAsync(new Message()))
+                    .DoNotFailOnErrorMessages())
                 .WithEndpoint<ErrorSpy>()
                 .AllowSimulatedExceptions()
                 .Done(c => c.MessageReceived)

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_message_with_TimeToBeReceived_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_message_with_TimeToBeReceived_fails.cs
@@ -13,7 +13,9 @@
         public async Task Should_not_honor_TimeToBeReceived_for_error_message()
         {
             var context = await Scenario.Define<Context>()
-            .WithEndpoint<EndpointThatThrows>(b => b.When(bus => bus.SendLocalAsync(new MessageThatFails())))
+            .WithEndpoint<EndpointThatThrows>(b => b
+                .When(bus => bus.SendLocalAsync(new MessageThatFails()))
+                .DoNotFailOnErrorMessages())
             .WithEndpoint<EndpointThatHandlesErrorMessages>()
             .AllowSimulatedExceptions()
             .Done(c => c.MessageFailed && c.TTBRHasExpiredAndMessageIsStillInErrorQueue)

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_message_with_TimeToBeReceived_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_message_with_TimeToBeReceived_fails.cs
@@ -17,7 +17,6 @@
                 .When(bus => bus.SendLocalAsync(new MessageThatFails()))
                 .DoNotFailOnErrorMessages())
             .WithEndpoint<EndpointThatHandlesErrorMessages>()
-            .AllowSimulatedExceptions()
             .Done(c => c.MessageFailed && c.TTBRHasExpiredAndMessageIsStillInErrorQueue)
             .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_audited.cs
@@ -17,7 +17,6 @@
             var context = await Scenario.Define<Context>()
                     .WithEndpoint<EndpointWithAuditOn>(b => b.When(bus => bus.SendLocalAsync(new MessageToBeAudited())))
                     .WithEndpoint<AuditSpyEndpoint>()
-                    .AllowSimulatedExceptions()
                     .Done(c => c.Done)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_blowing_up_just_after_dispatch.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_blowing_up_just_after_dispatch.cs
@@ -17,7 +17,6 @@
         {
             await Scenario.Define<Context>()
                 .WithEndpoint<NonDtcReceivingEndpoint>(b => b.When(bus => bus.SendLocalAsync(new PlaceOrder())))
-                .AllowSimulatedExceptions()
                 .Done(c => c.OrderAckReceived == 1)
                 .Repeat(r=>r.For<AllOutboxCapableStorages>())
                 .Should(context => Assert.AreEqual(1, context.OrderAckReceived, "Order ack should have been received since outbox dispatch isn't part of the receive tx"))

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_clearing_saga_timeouts.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_clearing_saga_timeouts.cs
@@ -22,7 +22,6 @@
                 {
                     DataId = Guid.NewGuid()
                 })))
-                .AllowExceptions()
                 .Done(c => c.Done)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_dispatching_forwarded_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_dispatching_forwarded_messages.cs
@@ -17,7 +17,9 @@
         public async Task Should_be_dispatched_immediately()
         {
             var context = await Scenario.Define<Context>()
-                    .WithEndpoint<EndpointWithAuditOn>(b => b.When(bus => bus.SendLocalAsync(new MessageToBeForwarded())))
+                    .WithEndpoint<EndpointWithAuditOn>(b => b
+                        .When(bus => bus.SendLocalAsync(new MessageToBeForwarded()))
+                        .DoNotFailOnErrorMessages())
                     .WithEndpoint<ForwardingSpyEndpoint>()
                     .Done(c => c.Done)
                     .Run();
@@ -54,20 +56,10 @@
                         return;
                     }
 
-                    if (called)
-                    {
-                        Console.Out.WriteLine("Called once, skipping next");
-                        return;
-                    }
-
                     await next().ConfigureAwait(false);
-
-                    called = true;
 
                     throw new SimulatedException();
                 }
-
-                static bool called;
             }
 
 

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_dispatching_forwarded_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_dispatching_forwarded_messages.cs
@@ -19,7 +19,6 @@
             var context = await Scenario.Define<Context>()
                     .WithEndpoint<EndpointWithAuditOn>(b => b.When(bus => bus.SendLocalAsync(new MessageToBeForwarded())))
                     .WithEndpoint<ForwardingSpyEndpoint>()
-                    .AllowSimulatedExceptions()
                     .Done(c => c.Done)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_receiving_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_receiving_a_message.cs
@@ -16,7 +16,6 @@
         {
             await Scenario.Define<Context>()
                 .WithEndpoint<NonDtcReceivingEndpoint>(b => b.When(bus => bus.SendLocalAsync(new PlaceOrder())))
-                .AllowExceptions()
                 .Done(c => c.OrderAckReceived == 1)
                 .Repeat(r => r.For<AllOutboxCapableStorages>())
                 .Run(new RunSettings { TestExecutionTimeout = TimeSpan.FromSeconds(20) });

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_receiving_messages_already_dispatched.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_receiving_messages_already_dispatched.cs
@@ -27,7 +27,6 @@
                         await bus.SendAsync(new PlaceOrder(), options);
                         await bus.SendLocalAsync(new PlaceOrder());
                     }))
-                    .AllowExceptions()
                     .Done(c => c.OrderAckReceived >= 2)
                     .Repeat(r => r.For<AllOutboxCapableStorages>())
                     .Should(context => Assert.AreEqual(2, context.OrderAckReceived))

--- a/src/NServiceBus.AcceptanceTests/Routing/When_base_event_from_2_publishers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_base_event_from_2_publishers.cs
@@ -29,7 +29,6 @@
                        c.SubscribedToPublisher2 = true;
                    }
                }))
-               .AllowExceptions(e => e.Message.Contains("Oracle.DataAccess.Client.OracleException: ORA-00001") || e.Message.Contains("System.Data.SqlClient.SqlException: Violation of PRIMARY KEY constraint"))
                .Done(c => c.GotTheEventFromPublisher1 && c.GotTheEventFromPublisher2)
                .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Routing/When_multi_subscribing_to_a_polymorphic_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_multi_subscribing_to_a_polymorphic_event.cs
@@ -35,7 +35,6 @@
                         c.Publisher2HasDetectedASubscriberForEvent2 = true;
                     }
                 }))
-                .AllowExceptions(e => e.Message.Contains("Oracle.DataAccess.Client.OracleException: ORA-00001") || e.Message.Contains("System.Data.SqlClient.SqlException: Violation of PRIMARY KEY constraint"))
                 .Done(c => c.SubscriberGotIMyEvent && c.SubscriberGotMyEvent2)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
@@ -4,6 +4,8 @@
     using System.Threading.Tasks;
     using EndpointTemplates;
     using AcceptanceTesting;
+    using NServiceBus.Config;
+    using NServiceBus.Features;
     using NUnit.Framework;
     using ScenarioDescriptors;
 
@@ -14,16 +16,19 @@
         public async Task Should_invoke_the_correct_handle_methods_on_the_saga()
         {
             await Scenario.Define<Context>()
-                    .WithEndpoint<SagaMsgThruSlrEndpt>(b => b.When(bus => bus.SendLocalAsync(new StartSagaMessage { SomeId = Guid.NewGuid() })))
-                    .Done(c => c.SecondMessageProcessed)
-                    .Repeat(r => r.For(Transports.Default))
-                    .Run();
+                .WithEndpoint<SagaMsgThruSlrEndpt>(b => b
+                    .When(bus => bus.SendLocalAsync(new StartSagaMessage
+                    {
+                        SomeId = Guid.NewGuid()
+                    })))
+                .Done(c => c.SecondMessageProcessed)
+                .Repeat(r => r.For(Transports.Default))
+                .Run();
         }
 
         public class Context : ScenarioContext
         {
             public bool SecondMessageProcessed { get; set; }
-
 
             public int NumberOfTimesInvoked { get; set; }
         }
@@ -32,7 +37,15 @@
         {
             public SagaMsgThruSlrEndpt()
             {
-                EndpointSetup<DefaultServer>();
+                EndpointSetup<DefaultServer>(b =>
+                {
+                    b.EnableFeature<TimeoutManager>();
+                    b.EnableFeature<SecondLevelRetries>();
+                }).WithConfig<SecondLevelRetriesConfig>(slr =>
+                {
+                    slr.NumberOfRetries = 1;
+                    slr.TimeIncrease = TimeSpan.FromSeconds(1);
+                });
             }
 
             public class TestSaga09 : Saga<TestSagaData09>, 
@@ -62,9 +75,8 @@
                 public Task Handle(SecondSagaMessage message, IMessageHandlerContext context)
                 {
                     TestContext.NumberOfTimesInvoked++;
-                    var shouldFail = TestContext.NumberOfTimesInvoked < 2; //1 FLR and 1 SLR
 
-                    if(shouldFail)
+                    if(TestContext.NumberOfTimesInvoked < 2)
                         throw new SimulatedException();
 
                     TestContext.SecondMessageProcessed = true;

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
@@ -15,7 +15,6 @@
         {
             await Scenario.Define<Context>()
                     .WithEndpoint<SagaMsgThruSlrEndpt>(b => b.When(bus => bus.SendLocalAsync(new StartSagaMessage { SomeId = Guid.NewGuid() })))
-                    .AllowSimulatedExceptions()
                     .Done(c => c.SecondMessageProcessed)
                     .Repeat(r => r.For(Transports.Default))
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_auto_correlated_property_is_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_auto_correlated_property_is_changed.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
@@ -11,18 +12,23 @@
     public class When_auto_correlated_property_is_changed : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_throw()
+        public void Should_throw()
         {
-            var context = await Scenario.Define<Context>()
-                .WithEndpoint<Endpoint>(
-                    b => b.When(bus => bus.SendLocalAsync(new StartSaga
-                    {
-                        DataId = Guid.NewGuid()
-                    })))
-                .Done(c => c.Exceptions.Any())
-                .Run();
+            var exception = Assert.Throws<AggregateException>(async () =>
+                await Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(
+                        b => b.When(bus => bus.SendLocalAsync(new StartSaga
+                        {
+                            DataId = Guid.NewGuid()
+                        })))
+                    .Done(c => c.Exceptions.Any())
+                    .Run())
+                .ExpectFailedMessages();
 
-            Assert.True(context.Exceptions.Any(ex => ex.Message.Contains("Changing the value of correlated properties at runtime is currently not supported")));
+            Assert.AreEqual(1, exception.FailedMessages.Count);
+            StringAssert.Contains(
+                "Changing the value of correlated properties at runtime is currently not supported",
+                exception.FailedMessages.Single().Exception.Message);
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_auto_correlated_property_is_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_auto_correlated_property_is_changed.cs
@@ -19,7 +19,6 @@
                     {
                         DataId = Guid.NewGuid()
                     })))
-                .AllowExceptions()
                 .Done(c => c.Exceptions.Any())
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
@@ -15,7 +15,6 @@
                     .WithEndpoint<SagaEndpoint>(b => b
                         .When(bus => bus.SendLocalAsync(new StartSagaMessage { Key = "Part1_Part2" }))
                         .When(c => c.FirstMessageReceived, bus => bus.SendLocalAsync(new OtherMessage { Part1 = "Part1", Part2 = "Part2" })))
-                    .AllowExceptions()
                     .Done(c => c.SecondMessageReceived)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
@@ -4,23 +4,30 @@
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTesting.Support;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
     public class When_updating_existing_correlation_property : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_blow_up()
+        public void Should_blow_up()
         {
-            var context = await Scenario.Define<Context>()
-                .WithEndpoint<ChangePropertyEndpoint>(b => b.When(bus => bus.SendLocalAsync(new StartSagaMessage
-                {
-                    SomeId = Guid.NewGuid()
-                })))
-                .Done(c => c.Exceptions.Any())
-                .Run();
+            var exception = Assert.Throws<AggregateException>(async () =>
+                await Scenario.Define<Context>()
+                    .WithEndpoint<ChangePropertyEndpoint>(b => b.When(bus => bus.SendLocalAsync(new StartSagaMessage
+                    {
+                        SomeId = Guid.NewGuid()
+                    })))
+                    .Done(c => c.Exceptions.Any())
+                    .Run())
+                .ExpectFailedMessages();
 
-            Assert.True(context.Exceptions.Any(ex => ex.Message.Contains("Changing the value of correlated properties at runtime is currently not supported")));
+            Assert.AreEqual(1, exception.FailedMessages.Count);
+
+            StringAssert.Contains(
+                "Changing the value of correlated properties at runtime is currently not supported",
+                exception.FailedMessages.Single().Exception.Message);
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
@@ -17,7 +17,6 @@
                 {
                     SomeId = Guid.NewGuid()
                 })))
-                .AllowExceptions()
                 .Done(c => c.Exceptions.Any())
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/ScaleOut/When_no_discriminator_is_available.cs
+++ b/src/NServiceBus.AcceptanceTests/ScaleOut/When_no_discriminator_is_available.cs
@@ -20,7 +20,6 @@
             {
                 await Scenario.Define<Context>()
                     .WithEndpoint<IndividualizedEndpoint>().Done(c => c.EndpointsStarted)
-                    .AllowExceptions()
                     .Run();
             }
             catch (AggregateException e)

--- a/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_using_scope_suppress.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_using_scope_suppress.cs
@@ -14,7 +14,9 @@
         public async Task Should_dispatch_immediately()
         {
             var context = await Scenario.Define<Context>()
-                    .WithEndpoint<SuppressEndpoint>(b => b.When(bus => bus.SendLocalAsync(new InitiatingMessage())))
+                    .WithEndpoint<SuppressEndpoint>(b => b
+                        .When(bus => bus.SendLocalAsync(new InitiatingMessage()))
+                        .DoNotFailOnErrorMessages())
                     .Done(c => c.MessageDispatched)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_using_scope_suppress.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_using_scope_suppress.cs
@@ -15,7 +15,6 @@
         {
             var context = await Scenario.Define<Context>()
                     .WithEndpoint<SuppressEndpoint>(b => b.When(bus => bus.SendLocalAsync(new InitiatingMessage())))
-                    .AllowSimulatedExceptions()
                     .Done(c => c.MessageDispatched)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_with_at_least_once.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_with_at_least_once.cs
@@ -12,7 +12,6 @@
         {
             var context = await Scenario.Define<Context>()
                     .WithEndpoint<AtLeastOnceEndpoint>(b => b.When(bus => bus.SendLocalAsync(new InitiatingMessage())))
-                    .AllowSimulatedExceptions()
                     .Done(c => c.MessageDispatched)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_with_at_least_once.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_with_at_least_once.cs
@@ -11,9 +11,11 @@
         public async Task Should_dispatch_immediately()
         {
             var context = await Scenario.Define<Context>()
-                    .WithEndpoint<AtLeastOnceEndpoint>(b => b.When(bus => bus.SendLocalAsync(new InitiatingMessage())))
-                    .Done(c => c.MessageDispatched)
-                    .Run();
+                .WithEndpoint<AtLeastOnceEndpoint>(b => b
+                    .When(bus => bus.SendLocalAsync(new InitiatingMessage()))
+                    .DoNotFailOnErrorMessages())
+                .Done(c => c.MessageDispatched)
+                .Run();
 
             Assert.True(context.MessageDispatched, "Should dispatch the message immediately");
         }

--- a/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_with_at_most_once.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_with_at_most_once.cs
@@ -14,7 +14,6 @@
                     .WithEndpoint<NonTransactionalEndpoint>(b => b
                         .When(bus => bus.SendLocalAsync(new InitiatingMessage()))
                         .DoNotFailOnErrorMessages())
-                    .AllowSimulatedExceptions()
                     .Done(c => c.MessageDispatched)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_with_at_most_once.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_with_at_most_once.cs
@@ -11,7 +11,9 @@
         public async Task Should_dispatch_immediately()
         {
             var context = await Scenario.Define<Context>()
-                    .WithEndpoint<NonTransactionalEndpoint>(b => b.When(bus => bus.SendLocalAsync(new InitiatingMessage())))
+                    .WithEndpoint<NonTransactionalEndpoint>(b => b
+                        .When(bus => bus.SendLocalAsync(new InitiatingMessage()))
+                        .DoNotFailOnErrorMessages())
                     .AllowSimulatedExceptions()
                     .Done(c => c.MessageDispatched)
                     .Run();

--- a/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_with_exactly_once.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_with_exactly_once.cs
@@ -12,7 +12,6 @@
         {
             var context = await Scenario.Define<Context>()
                     .WithEndpoint<ExactlyOnceEndpoint>(b => b.When(bus => bus.SendLocalAsync(new InitiatingMessage())))
-                    .AllowSimulatedExceptions()
                     .Done(c => c.MessageDispatched)
                     .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_with_exactly_once.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_with_exactly_once.cs
@@ -11,9 +11,11 @@
         public async Task Should_dispatch_immediately()
         {
             var context = await Scenario.Define<Context>()
-                    .WithEndpoint<ExactlyOnceEndpoint>(b => b.When(bus => bus.SendLocalAsync(new InitiatingMessage())))
-                    .Done(c => c.MessageDispatched)
-                    .Run();
+                .WithEndpoint<ExactlyOnceEndpoint>(b => b
+                    .When(bus => bus.SendLocalAsync(new InitiatingMessage()))
+                    .DoNotFailOnErrorMessages())
+                .Done(c => c.MessageDispatched)
+                .Run();
 
             Assert.True(context.MessageDispatched, "Should dispatch the message immediately");
         }

--- a/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_native_multi_queue_transaction.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_native_multi_queue_transaction.cs
@@ -15,7 +15,6 @@
             await Scenario.Define<Context>(c => { c.FirstAttempt = true; })
                  .WithEndpoint<Endpoint>(b => b.When(bus => bus.SendLocalAsync(new MyMessage())))
                  .Done(c => c.MessageHandled)
-                 .AllowSimulatedExceptions()
                  .Repeat(r => r.For<AllNativeMultiQueueTransactionTransports>())
                  .Should(c =>
                  {

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1445,6 +1445,7 @@ namespace NServiceBus.Features
     }
     public class FeatureConfigurationContext
     {
+        public NServiceBus.ObjectBuilder.IBuilder Builder { get; }
         public NServiceBus.ObjectBuilder.IConfigureComponents Container { get; }
         public NServiceBus.Pipeline.PipelineSettings Pipeline { get; }
         public NServiceBus.Settings.ReadOnlySettings Settings { get; }

--- a/src/NServiceBus.Core/Features/FeatureConfigurationContext.cs
+++ b/src/NServiceBus.Core/Features/FeatureConfigurationContext.cs
@@ -31,6 +31,11 @@
         public PipelineSettings Pipeline => config.pipelineSettings;
 
         /// <summary>
+        ///     Access to the builder to resolve services.
+        /// </summary>
+        public IBuilder Builder => config.Builder;
+
+        /// <summary>
         ///     Creates a new satellite processing pipeline.
         /// </summary>
         public PipelineSettings AddSatellitePipeline(string name, string qualifier, TransactionSupport requiredTransactionSupport, PushRuntimeSettings runtimeSettings, out string transportAddress)


### PR DESCRIPTION
This is a spike related to #2947 which changes the way acceptance tests fail:
* Tests no longer automatically fail when an exception is logged.
* Therefore `AllowExceptions()` extension has been removed.
* Logged exceptions are still available on the `ScenarioContext`.
* Tests fail when a message is sent to the error queue.
* You can configure an endpoint(!) to not fail when an exception has been moved to the errorQ by using `DoNotFailOnErrorMessages()`.
* You can access the failed messages by retrieving the `FailedMessagesException` from the AggregateException thrown by the test.
* For easier access, use the `ExpectFailedMessages` extension method to AggregateExceptions.

@Particular/engineers please have a look at the proposed API and share your opinion.