### PR TITLE
Passing context directly instead of `IBusInterface`

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -105,7 +105,7 @@
                     await Task.Run(async () =>
                     {
                         var executedWhens = new List<Guid>();
-                        var sendContext = endpoint.CreateSendContext();
+                        var sendContext = endpoint.CreateBusContext();
 
                         while (!token.IsCancellationRequested)
                         {

--- a/src/NServiceBus.AcceptanceTests/Basic/When_sending_from_a_send_only.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_sending_from_a_send_only.cs
@@ -70,9 +70,10 @@
                 {
                     public Context Context { get; set; }
 
-                    protected override void OnStart(IBusContext context)
+                    protected override Task OnStart(IBusContext context)
                     {
                         Context.SendOnlyEndpointWasStarted = true;
+                        return Task.FromResult(0);
                     }
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/Basic/When_sending_from_a_send_only.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_sending_from_a_send_only.cs
@@ -70,7 +70,7 @@
                 {
                     public Context Context { get; set; }
 
-                    protected override void OnStart(IBusInterface sendOnlyBus)
+                    protected override void OnStart(IBusContext context)
                     {
                         Context.SendOnlyEndpointWasStarted = true;
                     }

--- a/src/NServiceBus.AcceptanceTests/Basic/When_setting_msmq_label_generator.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_setting_msmq_label_generator.cs
@@ -92,13 +92,13 @@
                 public Context Context { get; set; }
                 public ReadOnlySettings Settings { get; set; }
 
-                public Task StartAsync(IBusInterface bus)
+                public Task StartAsync(IBusContext context)
                 {
                     Context.GeneratorWasCalled = Settings.Get<bool>("GeneratorWasCalled");
                     return Task.FromResult(0);
                 }
 
-                public Task StopAsync()
+                public Task StopAsync(IBusContext context)
                 {
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/Basic/When_using_INeedInitialization.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_using_INeedInitialization.cs
@@ -51,12 +51,12 @@
 
             public class SendMessageToSender : IWantToRunWhenBusStartsAndStops
             {
-                public Task StartAsync(IBusInterface bus)
+                public Task StartAsync(IBusContext context)
                 {
-                    return bus.CreateSendContext().SendAsync(new SendMessage());
+                    return context.SendAsync(new SendMessage());
                 }
 
-                public Task StopAsync()
+                public Task StopAsync(IBusContext context)
                 {
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/Config/When_startup_is_complete.cs
+++ b/src/NServiceBus.AcceptanceTests/Config/When_startup_is_complete.cs
@@ -39,7 +39,7 @@
                 public ReadOnlySettings Settings { get; set; }
 
 
-                public Task StartAsync(IBusInterface bus)
+                public Task StartAsync(IBusContext context)
                 {
                     Context.SettingIsAvailable = Settings != null;
 
@@ -47,7 +47,7 @@
                     return Task.FromResult(0);
                 }
 
-                public Task StopAsync()
+                public Task StopAsync(IBusContext context)
                 {
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
@@ -92,7 +92,7 @@
 
             public BusNotifications Notifications { get; set; }
 
-            public Task StartAsync(IBusInterface bus)
+            public Task StartAsync(IBusContext context)
             {
                 unsubscribeStreams.Add(Notifications.Errors.MessageSentToErrorQueue.Subscribe(message =>
                 {
@@ -102,13 +102,13 @@
                 unsubscribeStreams.Add(Notifications.Errors.MessageHasFailedAFirstLevelRetryAttempt.Subscribe(message => Context.TotalNumberOfFLRTimesInvoked++));
                 unsubscribeStreams.Add(Notifications.Errors.MessageHasBeenSentToSecondLevelRetries.Subscribe(message => Context.NumberOfSLRRetriesPerformed++));
 
-                return bus.CreateSendContext().SendLocalAsync(new MessageToBeRetried
+                return context.SendLocalAsync(new MessageToBeRetried
                 {
                     Id = Context.Id
                 });
             }
 
-            public Task StopAsync()
+            public Task StopAsync(IBusContext context)
             {
                 foreach (var unsubscribeStream in unsubscribeStreams)
                 {

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_dtc_on.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_dtc_on.cs
@@ -58,7 +58,7 @@
 
                 public BusNotifications BusNotifications { get; set; }
 
-                public Task StartAsync(IBusInterface bus)
+                public Task StartAsync(IBusContext context)
                 {
                     BusNotifications.Errors.MessageSentToErrorQueue.Subscribe(e =>
                     {
@@ -67,7 +67,7 @@
                     return Task.FromResult(0);
                 }
 
-                public Task StopAsync()
+                public Task StopAsync(IBusContext context)
                 {
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
@@ -57,7 +57,7 @@
 
                 public BusNotifications BusNotifications { get; set; }
 
-                public Task StartAsync(IBusInterface bus)
+                public Task StartAsync(IBusContext context)
                 {
                     BusNotifications.Errors.MessageSentToErrorQueue.Subscribe(e =>
                     {
@@ -66,7 +66,7 @@
                     return Task.FromResult(0);
                 }
 
-                public Task StopAsync()
+                public Task StopAsync(IBusContext context)
                 {
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_with_retries_set_to_0.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_with_retries_set_to_0.cs
@@ -46,19 +46,19 @@
 
                 public BusNotifications BusNotifications { get; set; }
 
-                public Task StartAsync(IBusInterface bus)
+                public Task StartAsync(IBusContext context)
                 {
                     BusNotifications.Errors.MessageSentToErrorQueue.Subscribe(e =>
                     {
                         Context.GaveUp = true;
                     });
-                    return bus.CreateSendContext().SendLocalAsync(new MessageToBeRetried
+                    return context.SendLocalAsync(new MessageToBeRetried
                     {
                         ContextId = Context.Id
                     });
                 }
 
-                public Task StopAsync()
+                public Task StopAsync(IBusContext context)
                 {
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
@@ -46,7 +46,7 @@
 
                 public BusNotifications BusNotifications { get; set; }
 
-                public Task StartAsync(IBusInterface bus)
+                public Task StartAsync(IBusContext context)
                 {
                     BusNotifications.Errors.MessageSentToErrorQueue.Subscribe(e =>
                     {
@@ -55,7 +55,7 @@
                     return Task.FromResult(0);
                 }
 
-                public Task StopAsync()
+                public Task StopAsync(IBusContext context)
                 {
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr.cs
@@ -82,7 +82,7 @@
                 public Context Context { get; set; }
                 public BusNotifications BusNotifications { get; set; }
 
-                public Task StartAsync(IBusInterface bus)
+                public Task StartAsync(IBusContext context)
                 {
                     BusNotifications.Errors.MessageSentToErrorQueue.Subscribe(e =>
                     {
@@ -92,7 +92,7 @@
                     return Task.FromResult(0);
                 }
 
-                public Task StopAsync()
+                public Task StopAsync(IBusContext context)
                 {
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/ScaleOut/When_individualization_is_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/ScaleOut/When_individualization_is_enabled.cs
@@ -40,13 +40,13 @@
 
                 public ReadOnlySettings Settings { get; set; }
 
-                public Task StartAsync(IBusInterface bus)
+                public Task StartAsync(IBusContext context)
                 {
                     Context.Address = Settings.RootLogicalAddress().ToString();
                     return Task.FromResult(0);
                 }
 
-                public Task StopAsync()
+                public Task StopAsync(IBusContext context)
                 {
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/ScaleOut/When_individualization_is_enabled_for_msmq.cs
+++ b/src/NServiceBus.AcceptanceTests/ScaleOut/When_individualization_is_enabled_for_msmq.cs
@@ -41,14 +41,14 @@
 
                 public ReadOnlySettings ReadOnlySettings { get; set; }
 
-                public Task StartAsync(IBusInterface bus)
+                public Task StartAsync(IBusContext context)
                 {
                     Context.Address = ReadOnlySettings.Get<TransportDefinition>().ToTransportAddress(ReadOnlySettings.RootLogicalAddress());
                     Context.EndpointName = ReadOnlySettings.EndpointName().ToString();
                     return Task.FromResult(0);
                 }
 
-                public Task StopAsync()
+                public Task StopAsync(IBusContext context)
                 {
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/Scheduling/When_scheduling_a_recurring_task.cs
+++ b/src/NServiceBus.AcceptanceTests/Scheduling/When_scheduling_a_recurring_task.cs
@@ -41,18 +41,18 @@
             class SetupScheduledAction : IWantToRunWhenBusStartsAndStops
             {
                 public Context Context { get; set; }
-                public Task StartAsync(IBusInterface bus)
+                public Task StartAsync(IBusContext context)
                 {
                     Context.RequestedAt = DateTime.UtcNow;
 
-                    bus.ScheduleEvery(TimeSpan.FromSeconds(5), "MyTask", () =>
+                    context.ScheduleEvery(TimeSpan.FromSeconds(5), "MyTask", () =>
                     {
                         Context.InvokedAt = DateTime.UtcNow;
                     });
                     return Task.FromResult(0);
                 }
 
-                public Task StopAsync()
+                public Task StopAsync(IBusContext context)
                 {
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -473,7 +473,7 @@ namespace NServiceBus
     }
     public interface IBusInterface
     {
-        NServiceBus.IBusContext CreateSendContext();
+        NServiceBus.IBusContext CreateBusContext();
     }
     [System.ObsoleteAttribute("Replaced by NServiceBus.Callbacks package. Will be removed in version 7.0.0.", true)]
     public interface ICallback { }
@@ -620,8 +620,8 @@ namespace NServiceBus
     }
     public interface IWantToRunWhenBusStartsAndStops
     {
-        System.Threading.Tasks.Task StartAsync(NServiceBus.IBusInterface bus);
-        System.Threading.Tasks.Task StopAsync();
+        System.Threading.Tasks.Task StartAsync(NServiceBus.IBusContext context);
+        System.Threading.Tasks.Task StopAsync(NServiceBus.IBusContext context);
     }
     public class static IWantToRunWhenBusStartsAndStopsExtensions_obsoletes
     {
@@ -866,8 +866,8 @@ namespace NServiceBus
     }
     public class static ScheduleBusExtensions
     {
-        public static void ScheduleEvery(this NServiceBus.IBusInterface bus, System.TimeSpan timeSpan, System.Action task) { }
-        public static void ScheduleEvery(this NServiceBus.IBusInterface bus, System.TimeSpan timeSpan, string name, System.Action task) { }
+        public static void ScheduleEvery(this NServiceBus.IBusContext bus, System.TimeSpan timeSpan, System.Action task) { }
+        public static void ScheduleEvery(this NServiceBus.IBusContext bus, System.TimeSpan timeSpan, string name, System.Action task) { }
     }
     public class static SecondLevelRetriesConfigExtensions
     {
@@ -1463,7 +1463,8 @@ namespace NServiceBus.Features
     public abstract class FeatureStartupTask
     {
         protected FeatureStartupTask() { }
-        [System.ObsoleteAttribute("Please use `OnStart` instead. Will be removed in version 7.0.0.", true)]
+        [System.ObsoleteAttribute("Please use `OnStart(IBusInterface bus)` instead. Will be removed in version 7.0.0" +
+            ".", true)]
         protected virtual void OnStart() { }
         protected abstract void OnStart(NServiceBus.IBusInterface bus);
         protected virtual void OnStop() { }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1466,11 +1466,11 @@ namespace NServiceBus.Features
         [System.ObsoleteAttribute("Please use `OnStart(IBusContext context)` instead. Will be removed in version 7.0" +
             ".0.", true)]
         protected virtual void OnStart() { }
-        protected abstract void OnStart(NServiceBus.IBusContext context);
+        protected abstract System.Threading.Tasks.Task OnStart(NServiceBus.IBusContext context);
         [System.ObsoleteAttribute("Please use `OnStop(IBusContext context)` instead. Will be removed in version 7.0." +
             "0.", true)]
         protected virtual void OnStop() { }
-        protected virtual void OnStop(NServiceBus.IBusContext context) { }
+        protected virtual System.Threading.Tasks.Task OnStop(NServiceBus.IBusContext context) { }
     }
     public enum FeatureState
     {

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1463,11 +1463,14 @@ namespace NServiceBus.Features
     public abstract class FeatureStartupTask
     {
         protected FeatureStartupTask() { }
-        [System.ObsoleteAttribute("Please use `OnStart(IBusInterface bus)` instead. Will be removed in version 7.0.0" +
-            ".", true)]
+        [System.ObsoleteAttribute("Please use `OnStart(IBusContext context)` instead. Will be removed in version 7.0" +
+            ".0.", true)]
         protected virtual void OnStart() { }
-        protected abstract void OnStart(NServiceBus.IBusInterface bus);
+        protected abstract void OnStart(NServiceBus.IBusContext context);
+        [System.ObsoleteAttribute("Please use `OnStop(IBusContext context)` instead. Will be removed in version 7.0." +
+            "0.", true)]
         protected virtual void OnStop() { }
+        protected virtual void OnStop(NServiceBus.IBusContext context) { }
     }
     public enum FeatureState
     {

--- a/src/NServiceBus.Core.Tests/Config/When_no_custom_configuration_source_is_specified.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_no_custom_configuration_source_is_specified.cs
@@ -41,7 +41,7 @@ namespace NServiceBus.Core.Tests.Config
                     this.settings = settings;
                 }
 
-                protected override void OnStart(IBusInterface bus)
+                protected override void OnStart(IBusContext context)
                 {
                     Assert.AreEqual(settings.GetConfigSection<TestConfigurationSection>().TestSetting, "test");
                 }

--- a/src/NServiceBus.Core.Tests/Config/When_no_custom_configuration_source_is_specified.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_no_custom_configuration_source_is_specified.cs
@@ -41,9 +41,10 @@ namespace NServiceBus.Core.Tests.Config
                     this.settings = settings;
                 }
 
-                protected override void OnStart(IBusContext context)
+                protected override Task OnStart(IBusContext context)
                 {
                     Assert.AreEqual(settings.GetConfigSection<TestConfigurationSection>().TestSetting, "test");
+                    return Task.FromResult(0);
                 }
             }
         }

--- a/src/NServiceBus.Core.Tests/Config/When_users_override_the_configuration_source.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_users_override_the_configuration_source.cs
@@ -43,7 +43,7 @@ namespace NServiceBus.Core.Tests.Config
                     this.settings = settings;
                 }
 
-                protected override void OnStart(IBusInterface bus)
+                protected override void OnStart(IBusContext context)
                 {
                     var section = settings.GetConfigSection<TestConfigurationSection>();
                     Assert.AreEqual(section.TestSetting, "TestValue");

--- a/src/NServiceBus.Core.Tests/Config/When_users_override_the_configuration_source.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_users_override_the_configuration_source.cs
@@ -43,10 +43,11 @@ namespace NServiceBus.Core.Tests.Config
                     this.settings = settings;
                 }
 
-                protected override void OnStart(IBusContext context)
+                protected override Task OnStart(IBusContext context)
                 {
                     var section = settings.GetConfigSection<TestConfigurationSection>();
                     Assert.AreEqual(section.TestSetting, "TestValue");
+                    return Task.FromResult(0);
                 }
             }
         }

--- a/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
@@ -24,7 +24,7 @@
             featureSettings.SetupFeatures(new FeatureConfigurationContext(null, null, null));
 
             featureSettings.StartFeatures(builder, null);
-            featureSettings.StopFeatures(builder);
+            featureSettings.StopFeatures(builder, null);
 
             Assert.True(FeatureWithStartupTask.Runner.Started);
             Assert.True(FeatureWithStartupTask.Runner.Stopped);
@@ -44,7 +44,7 @@
             featureSettings.SetupFeatures(new FeatureConfigurationContext(null, null, null));
 
             featureSettings.StartFeatures(builder, null);
-            featureSettings.StopFeatures(builder);
+            featureSettings.StopFeatures(builder, null);
 
             Assert.True(FeatureWithStartupTaskWhichIsDisposable.Runner.Disposed);
         }
@@ -57,14 +57,14 @@
                 RegisterStartupTask<Runner>();
             }
 
-            public class Runner:FeatureStartupTask
+            public class Runner : FeatureStartupTask
             {
-                protected override void OnStart(IBusInterface sendOnlyBus)
+                protected override void OnStart(IBusContext context)
                 {
                     Started = true;
                 }
 
-                protected override void OnStop()
+                protected override void OnStop(IBusContext context)
                 {
                     Stopped = true;
                 }
@@ -84,7 +84,7 @@
 
             public class Runner : FeatureStartupTask, IDisposable
             {
-                protected override void OnStart(IBusInterface sendOnlyBus)
+                protected override void OnStart(IBusContext context)
                 {
                 }
 

--- a/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using NServiceBus.Features;
     using NUnit.Framework;
     using ObjectBuilder;
@@ -11,7 +12,7 @@
     public class FeatureStartupTests
     {
         [Test]
-        public void Should_start_and_stop_features()
+        public async Task Should_start_and_stop_features()
         {
             var feature = new FeatureWithStartupTask();
        
@@ -23,15 +24,15 @@
 
             featureSettings.SetupFeatures(new FeatureConfigurationContext(null, null, null));
 
-            featureSettings.StartFeatures(builder, null);
-            featureSettings.StopFeatures(builder, null);
+            await featureSettings.StartFeatures(builder, null);
+            await featureSettings.StopFeatures(builder, null);
 
             Assert.True(FeatureWithStartupTask.Runner.Started);
             Assert.True(FeatureWithStartupTask.Runner.Stopped);
         }
 
         [Test]
-        public void Should_dispose_feature_when_they_implement_IDisposable()
+        public async Task Should_dispose_feature_when_they_implement_IDisposable()
         {
             var feature = new FeatureWithStartupTaskWhichIsDisposable();
 
@@ -43,8 +44,8 @@
 
             featureSettings.SetupFeatures(new FeatureConfigurationContext(null, null, null));
 
-            featureSettings.StartFeatures(builder, null);
-            featureSettings.StopFeatures(builder, null);
+            await featureSettings.StartFeatures(builder, null);
+            await featureSettings.StopFeatures(builder, null);
 
             Assert.True(FeatureWithStartupTaskWhichIsDisposable.Runner.Disposed);
         }
@@ -59,14 +60,16 @@
 
             public class Runner : FeatureStartupTask
             {
-                protected override void OnStart(IBusContext context)
+                protected override Task OnStart(IBusContext context)
                 {
                     Started = true;
+                    return Task.FromResult(0);
                 }
 
-                protected override void OnStop(IBusContext context)
+                protected override Task OnStop(IBusContext context)
                 {
                     Stopped = true;
+                    return Task.FromResult(0);
                 }
 
                 public static bool Started { get; private set; }
@@ -84,8 +87,9 @@
 
             public class Runner : FeatureStartupTask, IDisposable
             {
-                protected override void OnStart(IBusContext context)
+                protected override Task OnStart(IBusContext context)
                 {
+                    return Task.FromResult(0);
                 }
 
                 public void Dispose()

--- a/src/NServiceBus.Core.Tests/Scheduler/ScheduleTests.cs
+++ b/src/NServiceBus.Core.Tests/Scheduler/ScheduleTests.cs
@@ -11,41 +11,41 @@
     public class ScheduleTests
     {
         const string ACTION_NAME = "my action";
-        FakeBus bus;
         DefaultScheduler scheduler;
+        IBusContext context;
 
         [SetUp]
         public void SetUp()
         {
             scheduler = new DefaultScheduler();
-            bus = new FakeBus(scheduler);
+            context = new FakeBus(scheduler).CreateBusContext();
         }
 
         [Test]
         public void When_scheduling_an_action_with_a_name_the_task_should_get_that_name()
         {
-            bus.ScheduleEvery(TimeSpan.FromMinutes(5), ACTION_NAME, () => { });
+            context.ScheduleEvery(TimeSpan.FromMinutes(5), ACTION_NAME, () => { });
             Assert.That(EnsureThatNameExists(ACTION_NAME));
         }
 
         [Test]
         public void When_scheduling_an_action_without_a_name_the_task_should_get_the_DeclaringType_as_name()
         {
-            bus.ScheduleEvery(TimeSpan.FromMinutes(5), () => { });
+            context.ScheduleEvery(TimeSpan.FromMinutes(5), () => { });
             Assert.That(EnsureThatNameExists("ScheduleTests"));
         }
 
         [Test]
         public void Ensure_retrieving_name_from_type_works_for_old_compiler()
         {
-            bus.ScheduleEvery(TimeSpan.FromMinutes(5), OldCompilerBits.ActionProvider.SimpleAction());
+            context.ScheduleEvery(TimeSpan.FromMinutes(5), OldCompilerBits.ActionProvider.SimpleAction());
             Assert.That(EnsureThatNameExists("ActionProvider"));
         }
 
         [Test]
         public void Ensure_retrieving_name_from_type_works_for_new_compiler()
         {
-            bus.ScheduleEvery(TimeSpan.FromMinutes(5), NewCompilerBits.ActionProvider.SimpleAction());
+            context.ScheduleEvery(TimeSpan.FromMinutes(5), NewCompilerBits.ActionProvider.SimpleAction());
             Assert.That(EnsureThatNameExists("ActionProvider"));
         }
 
@@ -63,7 +63,7 @@
             {
                 this.defaultScheduler = defaultScheduler;
             }
-            public IBusContext CreateSendContext()
+            public IBusContext CreateBusContext()
             {
                 return new FakeBusContext(defaultScheduler, SentMessages);
             }

--- a/src/NServiceBus.Core.Tests/Serializers/Json/When_not_overriding_stream_encoding.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/When_not_overriding_stream_encoding.cs
@@ -44,10 +44,11 @@ namespace NServiceBus.Serializers.Json.Tests
                     this.builder = builder;
                 }
 
-                protected override void OnStart(IBusContext context)
+                protected override Task OnStart(IBusContext context)
                 {
                     var serializer = builder.Build<JsonMessageSerializer>();
                     Assert.AreSame(Encoding.UTF8, serializer.Encoding);
+                    return Task.FromResult(0);
                 }
             }
         }

--- a/src/NServiceBus.Core.Tests/Serializers/Json/When_not_overriding_stream_encoding.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/When_not_overriding_stream_encoding.cs
@@ -44,7 +44,7 @@ namespace NServiceBus.Serializers.Json.Tests
                     this.builder = builder;
                 }
 
-                protected override void OnStart(IBusInterface bus)
+                protected override void OnStart(IBusContext context)
                 {
                     var serializer = builder.Build<JsonMessageSerializer>();
                     Assert.AreSame(Encoding.UTF8, serializer.Encoding);

--- a/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
@@ -43,7 +43,7 @@ namespace NServiceBus.Serializers.Json.Tests
                     this.builder = builder;
                 }
 
-                protected override void OnStart(IBusInterface bus)
+                protected override void OnStart(IBusContext context)
                 {
                     var serializer = builder.Build<JsonMessageSerializer>();
                     Assert.AreSame(Encoding.UTF7, serializer.Encoding);

--- a/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
@@ -43,10 +43,11 @@ namespace NServiceBus.Serializers.Json.Tests
                     this.builder = builder;
                 }
 
-                protected override void OnStart(IBusContext context)
+                protected override Task OnStart(IBusContext context)
                 {
                     var serializer = builder.Build<JsonMessageSerializer>();
                     Assert.AreSame(Encoding.UTF7, serializer.Encoding);
+                    return Task.FromResult(0);
                 }
             }
         }

--- a/src/NServiceBus.Core.Tests/Unicast/StartAndStoppablesRunnerTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/StartAndStoppablesRunnerTests.cs
@@ -61,7 +61,7 @@
             var runner = new StartAndStoppablesRunner(thingsToBeStarted);
             await runner.StartAsync(null);
 
-            await runner.StopAsync();
+            await runner.StopAsync(null);
 
             Assert.True(startable1.Stopped);
             Assert.True(startable2.Stopped);
@@ -86,7 +86,7 @@
                 // ignored
             }
 
-            await runner.StopAsync();
+            await runner.StopAsync(null);
 
             Assert.True(startable1.Stopped);
             Assert.True(startable2.Stopped);
@@ -112,7 +112,7 @@
                 // ignored
             }
 
-            Assert.DoesNotThrow(async() => await runner.StopAsync());
+            Assert.DoesNotThrow(async() => await runner.StopAsync(null));
             Assert.True(startable1.Stopped);
             Assert.True(startable2.Stopped);
         }
@@ -136,7 +136,7 @@
                 // ignored
             }
 
-            Assert.DoesNotThrow(async () => await runner.StopAsync());
+            Assert.DoesNotThrow(async () => await runner.StopAsync(null));
             Assert.True(startable1.Stopped);
             Assert.True(startable2.Stopped);
         }
@@ -146,13 +146,13 @@
             public bool Started { get; set; }
             public bool Stopped { get; set; }
 
-            public Task StartAsync(IBusInterface sendOnlyBus)
+            public Task StartAsync(IBusContext context)
             {
                 Started = true;
                 return Task.FromResult(0);
             }
 
-            public Task StopAsync()
+            public Task StopAsync(IBusContext context)
             {
                 Stopped = true;
                 return Task.FromResult(0);
@@ -164,13 +164,13 @@
             public bool Started { get; set; }
             public bool Stopped { get; set; }
 
-            public Task StartAsync(IBusInterface sendOnlyBus)
+            public Task StartAsync(IBusContext context)
             {
                 Started = true;
                 return Task.FromResult(0);
             }
 
-            public Task StopAsync()
+            public Task StopAsync(IBusContext context)
             {
                 Stopped = true;
                 return Task.FromResult(0);
@@ -181,12 +181,12 @@
         {
             public bool Stopped { get; set; }
 
-            public Task StartAsync(IBusInterface sendOnlyBus)
+            public Task StartAsync(IBusContext context)
             {
                 throw new InvalidOperationException("SyncThrowingStart");
             }
 
-            public Task StopAsync()
+            public Task StopAsync(IBusContext context)
             {
                 Stopped = true;
                 return Task.FromResult(0);
@@ -197,13 +197,13 @@
         {
             public bool Stopped { get; set; }
 
-            public async Task StartAsync(IBusInterface sendOnlyBus)
+            public async Task StartAsync(IBusContext context)
             {
-                await Task.Delay(20);
+                await Task.Yield();
                 throw new InvalidOperationException("AsyncThrowingStart");
             }
 
-            public Task StopAsync()
+            public Task StopAsync(IBusContext context)
             {
                 Stopped = true;
                 return Task.FromResult(0);
@@ -214,13 +214,13 @@
         {
             public bool Started { get; set; }
 
-            public Task StartAsync(IBusInterface sendOnlyBus)
+            public Task StartAsync(IBusContext context)
             {
                 Started = true;
                 return Task.FromResult(0);
             }
 
-            public Task StopAsync()
+            public Task StopAsync(IBusContext context)
             {
                 throw new InvalidOperationException("SyncThrowingStop");
             }
@@ -230,15 +230,15 @@
         {
             public bool Started { get; set; }
 
-            public Task StartAsync(IBusInterface sendOnlyBus)
+            public Task StartAsync(IBusContext context)
             {
                 Started = true;
                 return Task.FromResult(0);
             }
 
-            public async Task StopAsync()
+            public async Task StopAsync(IBusContext context)
             {
-                await Task.Delay(20);
+                await Task.Yield();
                 throw new InvalidOperationException("AsyncThrowingStop");
             }
         }

--- a/src/NServiceBus.Core/DataBus/DataBus.cs
+++ b/src/NServiceBus.Core/DataBus/DataBus.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Features
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.DataBus;
     using NServiceBus.Settings;
 
@@ -32,9 +33,9 @@ namespace NServiceBus.Features
         {
             public IDataBus DataBus { get; set; }
 
-            protected override void OnStart(IBusContext context)
+            protected override Task OnStart(IBusContext context)
             {
-                DataBus.Start();
+                return DataBus.Start();
             }
         }
 

--- a/src/NServiceBus.Core/DataBus/DataBus.cs
+++ b/src/NServiceBus.Core/DataBus/DataBus.cs
@@ -32,7 +32,7 @@ namespace NServiceBus.Features
         {
             public IDataBus DataBus { get; set; }
 
-            protected override void OnStart(IBusInterface sendOnlyBus)
+            protected override void OnStart(IBusContext context)
             {
                 DataBus.Start();
             }

--- a/src/NServiceBus.Core/DataBus/FileShareDataBusImplementation.cs
+++ b/src/NServiceBus.Core/DataBus/FileShareDataBusImplementation.cs
@@ -58,7 +58,7 @@ namespace NServiceBus.DataBus
 			using (var output = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write, FileShare.Read, 4096, FileOptions.Asynchronous))
 			{
 			    const int bufferSize = 32 * 1024;
-                await stream.CopyToAsync(output, bufferSize);
+                await stream.CopyToAsync(output, bufferSize).ConfigureAwait(false);
 			}
 
             logger.DebugFormat("Saved stream to '{0}'.", filePath);

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
@@ -85,8 +85,8 @@ namespace NServiceBus
 
         public override async Task Cooldown()
         {
-            await poller.Stop();
-            await base.Cooldown();
+            await poller.Stop().ConfigureAwait(false);
+            await base.Cooldown().ConfigureAwait(false);
         }
 
         ExpiredTimeoutsPoller poller;

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -138,7 +138,7 @@ namespace NServiceBus.Features
             }
         }
 
-        public void StartFeatures(IBuilder builder, IBusInterface sendOnlyBus)
+        public void StartFeatures(IBuilder builder, IBusContext context)
         {
             foreach (var feature in features.Where(f => f.Feature.IsActive))
             {
@@ -146,12 +146,12 @@ namespace NServiceBus.Features
                 {
                     var task = (FeatureStartupTask) builder.Build(taskType);
 
-                    task.PerformStartup(sendOnlyBus);
+                    task.PerformStartup(context);
                 }
             }
         }
 
-        public void StopFeatures(IBuilder builder)
+        public void StopFeatures(IBuilder builder, IBusContext context)
         {
             foreach (var feature in features.Where(f => f.Feature.IsActive))
             {
@@ -159,7 +159,7 @@ namespace NServiceBus.Features
                 {
                     var task = (FeatureStartupTask) builder.Build(taskType);
 
-                    task.PerformStop();
+                    task.PerformStop(context);
 
                     DisposeIfNecessary(task);
                 }

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Features
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.ObjectBuilder;
     using NServiceBus.Settings;
 
@@ -138,7 +139,7 @@ namespace NServiceBus.Features
             }
         }
 
-        public void StartFeatures(IBuilder builder, IBusContext context)
+        public async Task StartFeatures(IBuilder builder, IBusContext context)
         {
             foreach (var feature in features.Where(f => f.Feature.IsActive))
             {
@@ -146,12 +147,12 @@ namespace NServiceBus.Features
                 {
                     var task = (FeatureStartupTask) builder.Build(taskType);
 
-                    task.PerformStartup(context);
+                    await task.PerformStartup(context).ConfigureAwait(false);
                 }
             }
         }
 
-        public void StopFeatures(IBuilder builder, IBusContext context)
+        public async Task StopFeatures(IBuilder builder, IBusContext context)
         {
             foreach (var feature in features.Where(f => f.Feature.IsActive))
             {
@@ -159,7 +160,7 @@ namespace NServiceBus.Features
                 {
                     var task = (FeatureStartupTask) builder.Build(taskType);
 
-                    task.PerformStop(context);
+                    await task.PerformStop(context).ConfigureAwait(false);
 
                     DisposeIfNecessary(task);
                 }

--- a/src/NServiceBus.Core/Features/FeatureRunner.cs
+++ b/src/NServiceBus.Core/Features/FeatureRunner.cs
@@ -16,14 +16,14 @@ namespace NServiceBus.Features
             this.featureActivator = featureActivator;
         }
 
-        public void Start(IBusInterface sendOnlyBus)
+        public void Start(IBusContext busContext)
         {
-            featureActivator.StartFeatures(builder, sendOnlyBus);
+            featureActivator.StartFeatures(builder, busContext);
         }
 
-        public void Stop()
+        public void Stop(IBusContext busContext)
         {
-            featureActivator.StopFeatures(builder);
+            featureActivator.StopFeatures(builder, busContext);
         }
     }
 }

--- a/src/NServiceBus.Core/Features/FeatureRunner.cs
+++ b/src/NServiceBus.Core/Features/FeatureRunner.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Features
 {
+    using System.Threading.Tasks;
     using NServiceBus.ObjectBuilder;
 
     /// <summary>
@@ -16,14 +17,14 @@ namespace NServiceBus.Features
             this.featureActivator = featureActivator;
         }
 
-        public void Start(IBusContext busContext)
+        public Task StartAsync(IBusContext busContext)
         {
-            featureActivator.StartFeatures(builder, busContext);
+            return featureActivator.StartFeatures(builder, busContext);
         }
 
-        public void Stop(IBusContext busContext)
+        public Task StopAsync(IBusContext busContext)
         {
-            featureActivator.StopFeatures(builder, busContext);
+            return featureActivator.StopFeatures(builder, busContext);
         }
     }
 }

--- a/src/NServiceBus.Core/Features/FeatureStartupTask.cs
+++ b/src/NServiceBus.Core/Features/FeatureStartupTask.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.Features
 {
+    using System;
+
     /// <summary>
     /// Base for feature startup tasks.
     /// </summary>
@@ -8,30 +10,43 @@
         /// <summary>
         /// Will be called when the endpoint starts up if the feature has been activated.
         /// </summary>
-        [ObsoleteEx(TreatAsErrorFromVersion = "6", RemoveInVersion = "7", ReplacementTypeOrMember = "OnStart(IBusInterface bus)")]
+        [ObsoleteEx(TreatAsErrorFromVersion = "6", RemoveInVersion = "7", ReplacementTypeOrMember = "OnStart(IBusContext context)")]
         protected virtual void OnStart()
         {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        ///  Will be called after an endpoint has stopped processing messages, if the feature has been activated.
+        /// </summary>
+        [ObsoleteEx(TreatAsErrorFromVersion = "6", RemoveInVersion = "7", ReplacementTypeOrMember = "OnStop(IBusContext context)")]
+        protected virtual void OnStop()
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>
         /// Will be called after an endpoint has been started but before processing any messages, if the feature has been activated.
         /// </summary>
-        /// <param name="bus">Seond context.</param>
-        protected abstract void OnStart(IBusInterface bus);
+        /// <param name="context">Bus context.</param>
+        protected abstract void OnStart(IBusContext context);
 
         /// <summary>
-        ///  Will be called after an endpoint has stopped processing messages, if the feature has been activated.
+        /// Will be called after an endpoint has been started but before processing any messages, if the feature has been activated.
         /// </summary>
-        protected virtual void OnStop(){}
-        
-        internal void PerformStartup(IBusInterface bus)
+        /// <param name="context">Bus context.</param>
+        protected virtual void OnStop(IBusContext context)
         {
-            OnStart(bus);
+        }
+        
+        internal void PerformStartup(IBusContext context)
+        {
+            OnStart(context);
         }
 
-        internal void PerformStop()
+        internal void PerformStop(IBusContext context)
         {
-            OnStop();
+            OnStop(context);
         }
     }
 }

--- a/src/NServiceBus.Core/Features/FeatureStartupTask.cs
+++ b/src/NServiceBus.Core/Features/FeatureStartupTask.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// Will be called when the endpoint starts up if the feature has been activated.
         /// </summary>
-        [ObsoleteEx(TreatAsErrorFromVersion = "6", RemoveInVersion = "7", ReplacementTypeOrMember = "OnStart")]
+        [ObsoleteEx(TreatAsErrorFromVersion = "6", RemoveInVersion = "7", ReplacementTypeOrMember = "OnStart(IBusInterface bus)")]
         protected virtual void OnStart()
         {
         }

--- a/src/NServiceBus.Core/Features/FeatureStartupTask.cs
+++ b/src/NServiceBus.Core/Features/FeatureStartupTask.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Features
 {
     using System;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Base for feature startup tasks.
@@ -29,24 +30,25 @@
         /// Will be called after an endpoint has been started but before processing any messages, if the feature has been activated.
         /// </summary>
         /// <param name="context">Bus context.</param>
-        protected abstract void OnStart(IBusContext context);
+        protected abstract Task OnStart(IBusContext context);
 
         /// <summary>
         /// Will be called after an endpoint has been started but before processing any messages, if the feature has been activated.
         /// </summary>
         /// <param name="context">Bus context.</param>
-        protected virtual void OnStop(IBusContext context)
+        protected virtual Task OnStop(IBusContext context)
         {
+            return TaskEx.Completed;
         }
         
-        internal void PerformStartup(IBusContext context)
+        internal Task PerformStartup(IBusContext context)
         {
-            OnStart(context);
+            return OnStart(context);
         }
 
-        internal void PerformStop(IBusContext context)
+        internal Task PerformStop(IBusContext context)
         {
-            OnStop(context);
+            return OnStop(context);
         }
     }
 }

--- a/src/NServiceBus.Core/IBusInterface.cs
+++ b/src/NServiceBus.Core/IBusInterface.cs
@@ -9,6 +9,6 @@ namespace NServiceBus
         /// Creates a <see cref="IBusContext"/> which can be used to access several bus operations like send, publish, subscribe and more.
         /// </summary>
         /// <returns>a new <see cref="IBusContext"/> to which all operations performed on it are scoped.</returns>
-        IBusContext CreateSendContext();
+        IBusContext CreateBusContext();
     }
 }

--- a/src/NServiceBus.Core/IWantToRunWhenBusStartsAndStops.cs
+++ b/src/NServiceBus.Core/IWantToRunWhenBusStartsAndStops.cs
@@ -13,11 +13,11 @@
         /// <summary>
         /// Method called at startup.
         /// </summary>
-        Task StartAsync(IBusInterface bus);
+        Task StartAsync(IBusContext context);
 
         /// <summary>
         /// Method called on shutdown.
         /// </summary>
-        Task StopAsync();
+        Task StopAsync(IBusContext context);
     }
 }

--- a/src/NServiceBus.Core/Installation/InstallationSupport.cs
+++ b/src/NServiceBus.Core/Installation/InstallationSupport.cs
@@ -51,7 +51,7 @@ namespace NServiceBus.Features
                 this.readOnlySettings = readOnlySettings;
             }
 
-            protected override void OnStart(IBusInterface sendOnlyBus)
+            protected override void OnStart(IBusContext context)
             {
                 var username = GetInstallationUserName(readOnlySettings);
                 foreach (var installer in builder.BuildAll<IInstall>())

--- a/src/NServiceBus.Core/Installation/InstallationSupport.cs
+++ b/src/NServiceBus.Core/Installation/InstallationSupport.cs
@@ -5,6 +5,7 @@ namespace NServiceBus.Features
     using System.Diagnostics;
     using System.Linq;
     using System.Security.Principal;
+    using System.Threading.Tasks;
     using NServiceBus.Installation;
     using NServiceBus.ObjectBuilder;
     using NServiceBus.Settings;
@@ -51,12 +52,12 @@ namespace NServiceBus.Features
                 this.readOnlySettings = readOnlySettings;
             }
 
-            protected override void OnStart(IBusContext context)
+            protected override async Task OnStart(IBusContext context)
             {
                 var username = GetInstallationUserName(readOnlySettings);
                 foreach (var installer in builder.BuildAll<IInstall>())
                 {
-                    installer.InstallAsync(username).GetAwaiter().GetResult();
+                    await installer.InstallAsync(username).ConfigureAwait(false);
                 }
             }
 

--- a/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxPersistence.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Threading;
+    using System.Threading.Tasks;
     using NServiceBus.InMemory.Outbox;
 
     /// <summary>
@@ -33,19 +34,22 @@
 
             public TimeSpan TimeToKeepDeduplicationData { get; set; }
 
-            protected override void OnStart(IBusContext context)
+            protected override Task OnStart(IBusContext context)
             {
                 cleanupTimer = new Timer(PerformCleanup, null, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
+                return TaskEx.Completed;
             }
 
-            protected override void OnStop(IBusContext context)
+            protected override Task OnStop(IBusContext context)
             {
                 using (var waitHandle = new ManualResetEvent(false))
                 {
                     cleanupTimer.Dispose(waitHandle);
 
+                    // TODO: Use async synchronisation primitve
                     waitHandle.WaitOne();
                 }
+                return TaskEx.Completed;
             }
 
             void PerformCleanup(object state)

--- a/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxPersistence.cs
@@ -33,12 +33,12 @@
 
             public TimeSpan TimeToKeepDeduplicationData { get; set; }
 
-            protected override void OnStart(IBusInterface sendOnlyBus)
+            protected override void OnStart(IBusContext context)
             {
                 cleanupTimer = new Timer(PerformCleanup, null, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
             }
 
-            protected override void OnStop()
+            protected override void OnStop(IBusContext context)
             {
                 using (var waitHandle = new ManualResetEvent(false))
                 {

--- a/src/NServiceBus.Core/Pipeline/PipelineCollection.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineCollection.cs
@@ -23,7 +23,7 @@ namespace NServiceBus.Pipeline
                 Logger.DebugFormat("Starting {0} pipeline", pipeline.Id);
                 try
                 {
-                    await pipeline.Start();
+                    await pipeline.Start().ConfigureAwait(false);
                     Logger.DebugFormat("Started {0} pipeline", pipeline.Id);
                 }
                 catch (Exception ex)
@@ -39,7 +39,7 @@ namespace NServiceBus.Pipeline
             foreach (var pipeline in pipelines)
             {
                 Logger.DebugFormat("Stopping {0} pipeline", pipeline.Id);
-                await pipeline.Stop();
+                await pipeline.Stop().ConfigureAwait(false);
                 Logger.DebugFormat("Stopped {0} pipeline", pipeline.Id);
             }
         }

--- a/src/NServiceBus.Core/Recoverability/FirstLevelRetries/FirstLevelRetries.cs
+++ b/src/NServiceBus.Core/Recoverability/FirstLevelRetries/FirstLevelRetries.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Features
 {
     using System;
     using System.Threading;
+    using System.Threading.Tasks;
     using Config;
     using NServiceBus.Recoverability.FirstLevelRetries;
     using NServiceBus.Settings;
@@ -58,14 +59,16 @@ namespace NServiceBus.Features
                 this.statusStorage = statusStorage;
             }
 
-            protected override void OnStart(IBusContext context)
+            protected override Task OnStart(IBusContext context)
             {
                 timer = new Timer(ClearFlrStatusStorage, null, ClearingInterval, ClearingInterval);
+                return TaskEx.Completed;
             }
 
-            protected override void OnStop(IBusContext context)
+            protected override Task OnStop(IBusContext context)
             {
                 timer?.Dispose();
+                return TaskEx.Completed;
             }
 
             void ClearFlrStatusStorage(object state)

--- a/src/NServiceBus.Core/Recoverability/FirstLevelRetries/FirstLevelRetries.cs
+++ b/src/NServiceBus.Core/Recoverability/FirstLevelRetries/FirstLevelRetries.cs
@@ -58,12 +58,12 @@ namespace NServiceBus.Features
                 this.statusStorage = statusStorage;
             }
 
-            protected override void OnStart(IBusInterface sendOnlyBus)
+            protected override void OnStart(IBusContext context)
             {
                 timer = new Timer(ClearFlrStatusStorage, null, ClearingInterval, ClearingInterval);
             }
 
-            protected override void OnStop()
+            protected override void OnStop(IBusContext context)
             {
                 timer?.Dispose();
             }

--- a/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
@@ -81,7 +81,7 @@ The reason you need to do this is because we need to ensure that you have read a
 
     class DtcRunningWarning : FeatureStartupTask
     {
-        protected override void OnStart(IBusInterface sendOnlyBus)
+        protected override void OnStart(IBusContext context)
         {
             try
             {

--- a/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Configuration;
     using System.ServiceProcess;
+    using System.Threading.Tasks;
     using Logging;
     using Persistence;
     using Transports;
@@ -81,7 +82,7 @@ The reason you need to do this is because we need to ensure that you have read a
 
     class DtcRunningWarning : FeatureStartupTask
     {
-        protected override void OnStart(IBusContext context)
+        protected override Task OnStart(IBusContext context)
         {
             try
             {
@@ -103,6 +104,7 @@ Because you have configured this endpoint to run with Outbox enabled we recommen
                 // Ignore if we can't check it.
             }
 
+            return TaskEx.Completed;
         }
 
         static ILog log = LogManager.GetLogger<DtcRunningWarning>();

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -86,12 +86,11 @@
                 this.eventsToSubscribe = eventsToSubscribe;
             }
 
-            protected override void OnStart(IBusInterface sendOnlyBus)
+            protected override void OnStart(IBusContext context)
             {
-                var sendContext = sendOnlyBus.CreateBusContext();
                 foreach (var eventType in eventsToSubscribe)
                 {
-                    sendContext.SubscribeAsync(eventType).GetAwaiter().GetResult();
+                    context.SubscribeAsync(eventType).GetAwaiter().GetResult();
                     Logger.DebugFormat("Auto subscribed to event {0}", eventType);
                 }
             }

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -88,7 +88,7 @@
 
             protected override void OnStart(IBusInterface sendOnlyBus)
             {
-                var sendContext = sendOnlyBus.CreateSendContext();
+                var sendContext = sendOnlyBus.CreateBusContext();
                 foreach (var eventType in eventsToSubscribe)
                 {
                     sendContext.SubscribeAsync(eventType).GetAwaiter().GetResult();

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.Logging;
     using NServiceBus.Routing.MessageDrivenSubscriptions;
     using NServiceBus.Transports;
@@ -86,11 +87,11 @@
                 this.eventsToSubscribe = eventsToSubscribe;
             }
 
-            protected override void OnStart(IBusContext context)
+            protected override async Task OnStart(IBusContext context)
             {
                 foreach (var eventType in eventsToSubscribe)
                 {
-                    context.SubscribeAsync(eventType).GetAwaiter().GetResult();
+                    await context.SubscribeAsync(eventType).ConfigureAwait(false);
                     Logger.DebugFormat("Auto subscribed to event {0}", eventType);
                 }
             }

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
@@ -28,7 +28,7 @@ namespace NServiceBus.Features
                 this.routingTable = routingTable;
             }
 
-            protected override void OnStart(IBusInterface sendOnlyBus)
+            protected override void OnStart(IBusContext contexts)
             {
                 settings.Get<EndpointInstances>().AddDynamic(e => routingTable.GetInstances(e));
             }

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Features
 {
     using System;
+    using System.Threading.Tasks;
     using NServiceBus.Routing;
     using NServiceBus.Settings;
 
@@ -28,9 +29,10 @@ namespace NServiceBus.Features
                 this.routingTable = routingTable;
             }
 
-            protected override void OnStart(IBusContext contexts)
+            protected override Task OnStart(IBusContext contexts)
             {
                 settings.Get<EndpointInstances>().AddDynamic(e => routingTable.GetInstances(e));
+                return TaskEx.Completed;
             }
         }
     }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/StorageInitializer.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/StorageInitializer.cs
@@ -14,7 +14,7 @@
         {
             public IInitializableSubscriptionStorage SubscriptionStorage { get; set; }
 
-            protected override void OnStart(IBusInterface sendOnlyBus)
+            protected override void OnStart(IBusContext context)
             {
                 SubscriptionStorage?.Init();
             }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/StorageInitializer.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/StorageInitializer.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions
 {
+    using System.Threading.Tasks;
     using NServiceBus.Features;
 
     internal class StorageInitializer : Feature
@@ -14,9 +15,10 @@
         {
             public IInitializableSubscriptionStorage SubscriptionStorage { get; set; }
 
-            protected override void OnStart(IBusContext context)
+            protected override Task OnStart(IBusContext context)
             {
                 SubscriptionStorage?.Init();
+                return TaskEx.Completed;
             }
         }
 

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.Config;
     using NServiceBus.Extensibility;
     using NServiceBus.ObjectBuilder;
@@ -136,7 +137,7 @@
                 this.builder = builder;
             }
 
-            protected override void OnStart(IBusContext context)
+            protected override Task OnStart(IBusContext context)
             {
                 var transportDefinition = settings.Get<TransportDefinition>();
                 if (transportDefinition.GetOutboundRoutingPolicy(settings).Publishes == OutboundRoutingType.DirectSend) //Publish via send
@@ -147,6 +148,7 @@
                         settings.Get<UnicastRoutingTable>().AddDynamic((t, c) => QuerySubscriptionStore(subscriptions, t, c));
                     }
                 }
+                return TaskEx.Completed;
             }
 
             private static IEnumerable<UnicastRoutingDestination> QuerySubscriptionStore(ISubscriptionStorage subscriptions, Type messageType, ContextBag contextBag)

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -136,7 +136,7 @@
                 this.builder = builder;
             }
 
-            protected override void OnStart(IBusInterface sendOnlyBus)
+            protected override void OnStart(IBusContext context)
             {
                 var transportDefinition = settings.Get<TransportDefinition>();
                 if (transportDefinition.GetOutboundRoutingPolicy(settings).Publishes == OutboundRoutingType.DirectSend) //Publish via send

--- a/src/NServiceBus.Core/Sagas/InvokeSagaNotFoundBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/InvokeSagaNotFoundBehavior.cs
@@ -29,7 +29,7 @@ namespace NServiceBus
             foreach (var handler in context.Builder.BuildAll<IHandleSagaNotFound>())
             {
                 logger.DebugFormat("Invoking SagaNotFoundHandler ('{0}')", handler.GetType().FullName);
-                await handler.Handle(context.Message.Instance, new MessageProcessingContext(context, busOperations));
+                await handler.Handle(context.Message.Instance, new MessageProcessingContext(context, busOperations)).ConfigureAwait(false);
             }
         }
 

--- a/src/NServiceBus.Core/Scheduling/Schedule.cs
+++ b/src/NServiceBus.Core/Scheduling/Schedule.cs
@@ -17,7 +17,7 @@ namespace NServiceBus
         /// <param name="bus">Bus.</param>
         /// <param name="timeSpan">The interval to repeatedly execute the <paramref name="task"/>.</param>
         /// <param name="task">The <see cref="System.Action"/> to execute.</param>
-        public static void ScheduleEvery(this IBusInterface bus, TimeSpan timeSpan, Action task)
+        public static void ScheduleEvery(this IBusContext bus, TimeSpan timeSpan, Action task)
         {
             Guard.AgainstNull(nameof(task), task);
             Guard.AgainstNegativeAndZero(nameof(timeSpan), timeSpan);
@@ -39,7 +39,7 @@ namespace NServiceBus
         /// <param name="timeSpan">The interval to repeatedly execute the <paramref name="task"/>.</param>
         /// <param name="task">The <see cref="System.Action"/> to execute.</param>
         /// <param name="name">The name to use used for logging inside the new <see cref="Thread"/>.</param>
-        public static void ScheduleEvery(this IBusInterface bus, TimeSpan timeSpan, string name, Action task)
+        public static void ScheduleEvery(this IBusContext bus, TimeSpan timeSpan, string name, Action task)
         {
             Guard.AgainstNull(nameof(task), task);
             Guard.AgainstNullAndEmpty(nameof(name), name);
@@ -53,7 +53,7 @@ namespace NServiceBus
             Schedule(taskDefinition, bus);
         }
 
-        static void Schedule(TaskDefinition taskDefinition, IBusInterface bus)
+        static void Schedule(TaskDefinition taskDefinition, IBusContext context)
         {
             logger.DebugFormat("Task '{0}' (with id {1}) scheduled with timeSpan {2}", taskDefinition.Name, taskDefinition.Id, taskDefinition.Every);
 
@@ -62,7 +62,7 @@ namespace NServiceBus
             options.RouteToLocalEndpointInstance();
             options.Context.GetOrCreate<ScheduleBehavior.State>().TaskDefinition = taskDefinition;
 
-            bus.CreateSendContext().SendAsync(new Scheduling.Messages.ScheduledTask
+            context.SendAsync(new Scheduling.Messages.ScheduledTask
             {
                 TaskId = taskDefinition.Id,
                 Name = taskDefinition.Name,

--- a/src/NServiceBus.Core/Serializers/XML/Config/XmlSerialization.cs
+++ b/src/NServiceBus.Core/Serializers/XML/Config/XmlSerialization.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.MessageInterfaces;
     using NServiceBus.Serialization;
     using NServiceBus.Serializers.XML;
@@ -34,17 +35,19 @@
             public XmlMessageSerializer Serializer { get; set; }
             public ReadOnlySettings Settings { get; set; }
 
-            protected override void OnStart(IBusContext context)
+            protected override Task OnStart(IBusContext context)
             {
                 if (Mapper == null)
                 {
-                    return;
+                    return TaskEx.Completed;
                 }
 
                 var messageTypes = Settings.GetAvailableTypes().Where(Settings.Get<Conventions>().IsMessageType).ToList();
 
                 Mapper.Initialize(messageTypes);
                 Serializer.Initialize(messageTypes);
+
+                return TaskEx.Completed;
             }
         }
     }

--- a/src/NServiceBus.Core/Serializers/XML/Config/XmlSerialization.cs
+++ b/src/NServiceBus.Core/Serializers/XML/Config/XmlSerialization.cs
@@ -34,7 +34,7 @@
             public XmlMessageSerializer Serializer { get; set; }
             public ReadOnlySettings Settings { get; set; }
 
-            protected override void OnStart(IBusInterface sendOnlyBus)
+            protected override void OnStart(IBusContext context)
             {
                 if (Mapper == null)
                 {

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -43,7 +43,8 @@ namespace NServiceBus
 
             var allStartables = builder.BuildAll<IWantToRunWhenBusStartsAndStops>().Concat(startables).ToList();
             var runner = new StartAndStoppablesRunner(allStartables);
-            await runner.StartAsync(busInterface).ConfigureAwait(false);
+            var busContext = busInterface.CreateBusContext();
+            await runner.StartAsync(busContext).ConfigureAwait(false);
 
             AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
 
@@ -58,7 +59,7 @@ namespace NServiceBus
                 pipelineCollection = new PipelineCollection(pipelines);
                 await pipelineCollection.Start().ConfigureAwait(false);
             }
-            var runningInstance = new RunningEndpoint(builder, settings, pipelineCollection, runner, featureRunner);
+            var runningInstance = new RunningEndpoint(builder, settings, pipelineCollection, runner, featureRunner, busContext);
             return runningInstance;
         }
 
@@ -75,7 +76,7 @@ namespace NServiceBus
                 this.settings = settings;
             }
 
-            public IBusContext CreateSendContext()
+            public IBusContext CreateBusContext()
             {
                 return new BusContext(new RootContext(builder), new BusOperations(messageMapper, settings));
             }

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -40,7 +40,7 @@ namespace NServiceBus
             var busInterface = new StartUpBusInterface(builder, builder.Build<IMessageMapper>(), settings);
             var featureRunner = new FeatureRunner(builder, featureActivator);
             var busContext = busInterface.CreateBusContext();
-            featureRunner.Start(busContext);
+            await featureRunner.StartAsync(busContext).ConfigureAwait(false);
 
             var allStartables = builder.BuildAll<IWantToRunWhenBusStartsAndStops>().Concat(startables).ToList();
             var runner = new StartAndStoppablesRunner(allStartables);

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -39,11 +39,11 @@ namespace NServiceBus
         {
             var busInterface = new StartUpBusInterface(builder, builder.Build<IMessageMapper>(), settings);
             var featureRunner = new FeatureRunner(builder, featureActivator);
-            featureRunner.Start(busInterface);
+            var busContext = busInterface.CreateBusContext();
+            featureRunner.Start(busContext);
 
             var allStartables = builder.BuildAll<IWantToRunWhenBusStartsAndStops>().Concat(startables).ToList();
             var runner = new StartAndStoppablesRunner(allStartables);
-            var busContext = busInterface.CreateBusContext();
             await runner.StartAsync(busContext).ConfigureAwait(false);
 
             AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
@@ -59,7 +59,7 @@ namespace NServiceBus
                 pipelineCollection = new PipelineCollection(pipelines);
                 await pipelineCollection.Start().ConfigureAwait(false);
             }
-            var runningInstance = new RunningEndpoint(builder, settings, pipelineCollection, runner, featureRunner, busContext);
+            var runningInstance = new RunningEndpoint(builder, pipelineCollection, runner, featureRunner, busInterface);
             return runningInstance;
         }
 

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportConfigurator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportConfigurator.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using System.Messaging;
     using System.Security;
+    using System.Threading.Tasks;
     using NServiceBus.Logging;
     using NServiceBus.Settings;
     using NServiceBus.Transports;
@@ -32,7 +33,7 @@
                 this.settings = settings;
             }
 
-            protected override void OnStart(IBusContext context)
+            protected override Task OnStart(IBusContext context)
             {
                 var queueBindings = settings.Get<QueueBindings>();
                 var boundQueueAddresses = queueBindings.ReceivingAddresses.Concat(queueBindings.SendingAddresses);
@@ -41,6 +42,8 @@
                 {
                     CheckQueue(address);
                 }
+
+                return TaskEx.Completed;
             }
 
             static void CheckQueue(string address)

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportConfigurator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportConfigurator.cs
@@ -32,7 +32,7 @@
                 this.settings = settings;
             }
 
-            protected override void OnStart(IBusInterface sendOnlyBus)
+            protected override void OnStart(IBusContext context)
             {
                 var queueBindings = settings.Get<QueueBindings>();
                 var boundQueueAddresses = queueBindings.ReceivingAddresses.Concat(queueBindings.SendingAddresses);

--- a/src/NServiceBus.Core/Unicast/ContextualBusInterface.cs
+++ b/src/NServiceBus.Core/Unicast/ContextualBusInterface.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.Unicast
             this.busOperations = busOperations;
         }
         
-        public IBusContext CreateSendContext()
+        public IBusContext CreateBusContext()
         {
             return new BusContext(incomingContext, busOperations);
         }

--- a/src/NServiceBus.Core/Unicast/RunningEndpoint.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpoint.cs
@@ -12,8 +12,9 @@ namespace NServiceBus.Unicast
 
     partial class RunningEndpoint : IEndpoint
     {
-        public RunningEndpoint(IBuilder builder, ReadOnlySettings settings, PipelineCollection pipelineCollection, StartAndStoppablesRunner startAndStoppablesRunner, FeatureRunner featureRunner)
+        public RunningEndpoint(IBuilder builder, ReadOnlySettings settings, PipelineCollection pipelineCollection, StartAndStoppablesRunner startAndStoppablesRunner, FeatureRunner featureRunner, IBusContext busContext)
         {
+            this.busContext = busContext;
             this.pipelineCollection = pipelineCollection;
             this.startAndStoppablesRunner = startAndStoppablesRunner;
             this.featureRunner = featureRunner;
@@ -32,13 +33,13 @@ namespace NServiceBus.Unicast
 
             featureRunner.Stop();
             await pipelineCollection.Stop();
-            await startAndStoppablesRunner.StopAsync();
+            await startAndStoppablesRunner.StopAsync(busContext);
             builder.Dispose();
 
             stopped = true;
             Log.Info("Shutdown complete.");
         }
-        public IBusContext CreateSendContext()
+        public IBusContext CreateBusContext()
         {
             return new BusContext(new RootContext(builder), busOperations);
         }
@@ -51,5 +52,6 @@ namespace NServiceBus.Unicast
         BusOperations busOperations;
 
         static ILog Log = LogManager.GetLogger<UnicastBus>();
+        readonly IBusContext busContext;
     }
 }

--- a/src/NServiceBus.Core/Unicast/RunningEndpoint.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpoint.cs
@@ -29,7 +29,7 @@ namespace NServiceBus.Unicast
 
             await pipelineCollection.Stop().ConfigureAwait(false);
             var busContext = CreateBusContext();
-            featureRunner.Stop(busContext);
+            await featureRunner.StopAsync(busContext).ConfigureAwait(false);
             await startAndStoppablesRunner.StopAsync(busContext).ConfigureAwait(false);
             builder.Dispose();
 

--- a/src/NServiceBus.Core/Unicast/RunningEndpoint.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpoint.cs
@@ -27,10 +27,10 @@ namespace NServiceBus.Unicast
 
             Log.Info("Initiating shutdown.");
 
+            await pipelineCollection.Stop().ConfigureAwait(false);
             var busContext = CreateBusContext();
             featureRunner.Stop(busContext);
-            await pipelineCollection.Stop();
-            await startAndStoppablesRunner.StopAsync(busContext);
+            await startAndStoppablesRunner.StopAsync(busContext).ConfigureAwait(false);
             builder.Dispose();
 
             stopped = true;

--- a/src/NServiceBus.Core/Unicast/StartAndStoppablesRunner.cs
+++ b/src/NServiceBus.Core/Unicast/StartAndStoppablesRunner.cs
@@ -15,12 +15,12 @@
             wantToRunWhenBusStartsAndStopses = wantToRunWhenBusStartsAndStops;
         }
 
-        public Task StartAsync(IBusInterface sendOnlyBus)
+        public Task StartAsync(IBusContext context)
         {
             var startableTasks = new List<Task>();
             foreach (var startable in wantToRunWhenBusStartsAndStopses)
             {
-                var task = startable.StartAsync(sendOnlyBus);
+                var task = startable.StartAsync(context);
 
                 var startable1 = startable;
                 task.ContinueWith(t =>
@@ -39,7 +39,7 @@
             return Task.WhenAll(startableTasks.ToArray());
         }
 
-        public async Task StopAsync()
+        public async Task StopAsync(IBusContext context)
         {
             var stoppables = Interlocked.Exchange(ref thingsRanAtStartup, new ConcurrentBag<IWantToRunWhenBusStartsAndStops>());
             if (!stoppables.Any())
@@ -52,7 +52,7 @@
             {
                 try
                 {
-                    var task = stoppable.StopAsync();
+                    var task = stoppable.StopAsync(context);
 
                     var stoppable1 = stoppable;
                     task.ContinueWith(t =>

--- a/src/NServiceBus.PerformanceTests/Program.cs
+++ b/src/NServiceBus.PerformanceTests/Program.cs
@@ -136,13 +136,12 @@
         
         static void SeedSagaMessages(IBusContext context, int numberOfMessages, string inputQueue, int concurrency)
         {
-            var busContext = context;
             for (var i = 0; i < numberOfMessages / concurrency; i++)
             {
 
                 for (var j = 0; j < concurrency; j++)
                 {
-                    busContext.SendAsync(inputQueue, new StartSagaMessage
+                    context.SendAsync(inputQueue, new StartSagaMessage
                     {
                         Id = i
                     }).GetAwaiter().GetResult();
@@ -153,7 +152,6 @@
         static TimeSpan SeedInputQueue(IBusContext context, int numberOfMessages, string inputQueue, int numberOfThreads, bool createTransaction, bool twoPhaseCommit, bool encryption)
         {
             var sw = new Stopwatch();
-            var busContext = context;
 
             sw.Start();
             Parallel.For(
@@ -170,13 +168,13 @@
                     {
                         using (var tx = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                         {
-                            busContext.SendAsync(inputQueue, message).GetAwaiter().GetResult();
+                            context.SendAsync(inputQueue, message).GetAwaiter().GetResult();
                             tx.Complete();
                         }
                     }
                     else
                     {
-                        busContext.SendAsync(inputQueue, message).GetAwaiter().GetResult();
+                        context.SendAsync(inputQueue, message).GetAwaiter().GetResult();
                     }
                 });
             sw.Stop();

--- a/src/NServiceBus.PerformanceTests/PubSub/PubSubTestCase.cs
+++ b/src/NServiceBus.PerformanceTests/PubSub/PubSubTestCase.cs
@@ -66,9 +66,9 @@ public class PubSubTestCase : TestCase
                 break;
         }
 
-        configuration.RunWhenEndpointStartsAndStops(new StartActionRunner(b =>
+        configuration.RunWhenEndpointStartsAndStops(new StartActionRunner(context =>
         {
-            var sendContext = b.CreateSendContext();
+            var busContext = context;
             Parallel.For(
                 0,
                 NumberMessages,
@@ -76,7 +76,7 @@ public class PubSubTestCase : TestCase
                 {
                     MaxDegreeOfParallelism = NumberOfThreads
                 },
-                x => sendContext.SendLocalAsync(new PerformPublish()).GetAwaiter().GetResult());
+                x => busContext.SendLocalAsync(new PerformPublish()).GetAwaiter().GetResult());
         }));
         Statistics.StartTime = DateTime.Now;
         var endpoint = Endpoint.StartAsync(configuration).GetAwaiter().GetResult();

--- a/src/NServiceBus.PerformanceTests/PubSub/PubSubTestCase.cs
+++ b/src/NServiceBus.PerformanceTests/PubSub/PubSubTestCase.cs
@@ -68,7 +68,6 @@ public class PubSubTestCase : TestCase
 
         configuration.RunWhenEndpointStartsAndStops(new StartActionRunner(context =>
         {
-            var busContext = context;
             Parallel.For(
                 0,
                 NumberMessages,
@@ -76,7 +75,7 @@ public class PubSubTestCase : TestCase
                 {
                     MaxDegreeOfParallelism = NumberOfThreads
                 },
-                x => busContext.SendLocalAsync(new PerformPublish()).GetAwaiter().GetResult());
+                x => context.SendLocalAsync(new PerformPublish()).GetAwaiter().GetResult());
         }));
         Statistics.StartTime = DateTime.Now;
         var endpoint = Endpoint.StartAsync(configuration).GetAwaiter().GetResult();

--- a/src/NServiceBus.PerformanceTests/PubSub/PubSubTestCase.cs
+++ b/src/NServiceBus.PerformanceTests/PubSub/PubSubTestCase.cs
@@ -105,12 +105,12 @@ public class PrimeSubscriptionStorage : Feature
 
         public IInitializableSubscriptionStorage SubscriptionStorage { get; set; }
 
-        protected override void OnStart(IBusContext context)
+        protected override Task OnStart(IBusContext context)
         {
-            PrimeSubscriptionStorage(SubscriptionStorage);
+            return PrimeSubscriptionStorage(SubscriptionStorage);
         }
 
-        void PrimeSubscriptionStorage(IInitializableSubscriptionStorage subscriptionStorage)
+        async Task PrimeSubscriptionStorage(IInitializableSubscriptionStorage subscriptionStorage)
         {
             var testEventMessage = new MessageType(typeof(TestEvent));
 
@@ -129,10 +129,11 @@ public class PrimeSubscriptionStorage : Feature
 
                 using (var tx = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
-                    subscriptionStorage.Subscribe(subscriberAddress, new List<MessageType>
+                    await subscriptionStorage.Subscribe(subscriberAddress, new List<MessageType>
                     {
                         testEventMessage
-                    }, new ContextBag()).GetAwaiter().GetResult();
+                    }, new ContextBag())
+                    .ConfigureAwait(false);
 
                     tx.Complete();
                 }

--- a/src/NServiceBus.PerformanceTests/PubSub/PubSubTestCase.cs
+++ b/src/NServiceBus.PerformanceTests/PubSub/PubSubTestCase.cs
@@ -106,7 +106,7 @@ public class PrimeSubscriptionStorage : Feature
 
         public IInitializableSubscriptionStorage SubscriptionStorage { get; set; }
 
-        protected override void OnStart(IBusInterface sendOnlyBus)
+        protected override void OnStart(IBusContext context)
         {
             PrimeSubscriptionStorage(SubscriptionStorage);
         }

--- a/src/NServiceBus.PerformanceTests/StartActionRunner.cs
+++ b/src/NServiceBus.PerformanceTests/StartActionRunner.cs
@@ -6,20 +6,20 @@ namespace Runner
 
     public class StartActionRunner : IWantToRunWhenBusStartsAndStops
     {
-        Action<IBusInterface> seedAction;
+        Action<IBusContext> seedAction;
 
-        public StartActionRunner(Action<IBusInterface> seedAction)
+        public StartActionRunner(Action<IBusContext> seedAction)
         {
             this.seedAction = seedAction;
         }
 
-        public Task StartAsync(IBusInterface bus)
+        public Task StartAsync(IBusContext context)
         {
-            seedAction(bus);
+            seedAction(context);
             return Task.FromResult(0);
         }
 
-        public Task StopAsync()
+        public Task StopAsync(IBusContext context)
         {
             return Task.FromResult(0);
         }


### PR DESCRIPTION
@SzymonPobiega here is the PR. 

Talked to @timbussmann and we couldn't come up with a scenario where we would benefit from the `IBusInterface` passed into `FeatureStartupTask` and `IWantToRunWhenTheBusStartsAndStops`. We considered the hurdle to create a context everytime from the end-user perspective more cumbersome than beneficial.