### PR TITLE
[Spike] Reduced DI for FeatureStartupTask

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/FailTestOnErrorMessageFeature.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/FailTestOnErrorMessageFeature.cs
@@ -21,6 +21,7 @@
 
         protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
+            return FeatureStartupTask.None;
         }
 
         class FailTestOnErrorMessageFeatureStartupTask : FeatureStartupTask

--- a/src/NServiceBus.AcceptanceTesting/Support/FailTestOnErrorMessageFeature.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/FailTestOnErrorMessageFeature.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTesting.Support
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.Faults;
@@ -18,7 +19,7 @@
             RegisterStartupTask<FailTestOnErrorMessageFeatureStartupTask>();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
         }
 

--- a/src/NServiceBus.AcceptanceTests/Basic/When_sending_from_a_send_only.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_sending_from_a_send_only.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Basic
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
@@ -62,8 +63,9 @@
                     RegisterStartupTask<MyTask>();
                 }
 
-                protected override void Setup(FeatureConfigurationContext context)
+                protected override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
                 {
+                    return FeatureStartupTask.None;
                 }
 
                 public class MyTask : FeatureStartupTask

--- a/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostid.cs
+++ b/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostid.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.AcceptanceTests.Hosting
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using System.Reflection;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
@@ -54,8 +55,9 @@ namespace NServiceBus.AcceptanceTests.Hosting
                 });
             }
 
-            protected override void Setup(FeatureConfigurationContext context)
+            protected override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
             {
+                return FeatureStartupTask.None;
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostinfo.cs
+++ b/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostinfo.cs
@@ -50,8 +50,9 @@ namespace NServiceBus.AcceptanceTests.Hosting
                 });
             }
 
-            protected override void Setup(FeatureConfigurationContext context)
+            protected override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
             {
+                return FeatureStartupTask.None;
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_from_sendonly.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_from_sendonly.cs
@@ -81,9 +81,10 @@
 
         public class HardCodedPersistenceFeature : Feature
         {
-            protected override void Setup(FeatureConfigurationContext context)
+            protected override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
             {
                 context.Container.ConfigureComponent<HardcodedSubscriptionManager>(DependencyLifecycle.SingleInstance);
+                return FeatureStartupTask.None;
             }
         }
 

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1426,27 +1426,27 @@ namespace NServiceBus.Features
 {
     public class Audit : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class AutoSubscribe : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class BestPracticeEnforcement : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class CriticalTimeMonitoring : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class DataBus : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class Encryptor : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public abstract class Feature
     {
@@ -1469,7 +1469,7 @@ namespace NServiceBus.Features
         protected void Prerequisite(System.Func<NServiceBus.Features.FeatureConfigurationContext, bool> condition, string description) { }
         protected void RegisterStartupTask<T>()
             where T : NServiceBus.Features.FeatureStartupTask { }
-        protected internal abstract void Setup(NServiceBus.Features.FeatureConfigurationContext context);
+        protected internal abstract System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context);
         public override string ToString() { }
     }
     public class FeatureConfigurationContext
@@ -1498,6 +1498,7 @@ namespace NServiceBus.Features
     public abstract class FeatureStartupTask
     {
         protected FeatureStartupTask() { }
+        public static System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> None { get; }
         [System.ObsoleteAttribute("Please use `OnStart(IBusContext context)` instead. Will be removed in version 7.0" +
             ".0.", true)]
         protected virtual void OnStart() { }
@@ -1506,6 +1507,7 @@ namespace NServiceBus.Features
             "0.", true)]
         protected virtual void OnStop() { }
         protected virtual System.Threading.Tasks.Task OnStop(NServiceBus.IBusContext context) { }
+        public static System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Some(params NServiceBus.Features.FeatureStartupTask[] tasks) { }
     }
     public enum FeatureState
     {
@@ -1516,31 +1518,31 @@ namespace NServiceBus.Features
     }
     public class FirstLevelRetries : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class ForwardReceivedMessages : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class InMemoryGatewayPersistence : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class InMemoryOutboxPersistence : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class InMemorySagaPersistence : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class InMemorySubscriptionPersistence : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class InMemoryTimeoutPersistence : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class JsonSerialization : NServiceBus.Serialization.ConfigureSerialization
     {
@@ -1548,19 +1550,19 @@ namespace NServiceBus.Features
     }
     public class MessageDrivenSubscriptions : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class MsmqSubscriptionPersistence : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class MsmqTransportConfigurator : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class Outbox : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class PrerequisiteStatus
     {
@@ -1569,15 +1571,15 @@ namespace NServiceBus.Features
     }
     public class Sagas : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class Scheduler : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class SecondLevelRetries : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class static SerializationFeatureHelper { }
     public class static SettingsExtentions
@@ -1590,21 +1592,21 @@ namespace NServiceBus.Features
     }
     public class SLAMonitoring : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     [System.ObsoleteAttribute("No longer used, safe to remove. Will be removed in version 7.0.0.", true)]
     public class StorageDrivenPublishing : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class TimeoutManager : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     [System.ObsoleteAttribute("No longer used, safe to remove. Will be removed in version 7.0.0.", true)]
     public class TimeoutManagerBasedDeferral : NServiceBus.Features.Feature
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal override System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class XmlSerialization : NServiceBus.Serialization.ConfigureSerialization
     {
@@ -2447,7 +2449,7 @@ namespace NServiceBus.Serialization
         protected ConfigureSerialization() { }
         protected abstract System.Type GetSerializerType(NServiceBus.Features.FeatureConfigurationContext context);
         protected virtual void RegisterSerializer(NServiceBus.Features.FeatureConfigurationContext context, System.Type serializerType) { }
-        protected internal void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected internal System.Collections.Generic.IReadOnlyCollection<NServiceBus.Features.FeatureStartupTask> Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public interface IMessageSerializer
     {

--- a/src/NServiceBus.Core.Tests/Config/When_no_custom_configuration_source_is_specified.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_no_custom_configuration_source_is_specified.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Core.Tests.Config
 {
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using NServiceBus.Features;
     using NServiceBus.Settings;
@@ -23,13 +24,9 @@ namespace NServiceBus.Core.Tests.Config
 
         class ConfigSectionValidatorFeature : Feature
         {
-            public ConfigSectionValidatorFeature()
+            protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
             {
-                RegisterStartupTask<ValidatorTask>();
-            }
-
-            protected internal override void Setup(FeatureConfigurationContext context)
-            {
+                return FeatureStartupTask.Some(new ValidatorTask(context.Settings));
             }
 
             class ValidatorTask : FeatureStartupTask

--- a/src/NServiceBus.Core.Tests/Config/When_users_override_the_configuration_source.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_users_override_the_configuration_source.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Core.Tests.Config
 {
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using NServiceBus.Config.ConfigurationSource;
     using NServiceBus.Features;
@@ -30,8 +31,9 @@ namespace NServiceBus.Core.Tests.Config
                 RegisterStartupTask<ValidatorTask>();
             }
 
-            protected internal override void Setup(FeatureConfigurationContext context)
+            protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
             {
+                return FeatureStartupTask.None;
             }
 
             class ValidatorTask : FeatureStartupTask

--- a/src/NServiceBus.Core.Tests/Features/FeatureDefaultsTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDefaultsTests.cs
@@ -17,8 +17,9 @@
                 Defaults(s => s.EnableFeatureByDefault<FeatureThatIsEnabledByAnother>());
             }
 
-            protected internal override void Setup(FeatureConfigurationContext context)
+            protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
             {
+                return FeatureStartupTask.None;
             }
         }
 
@@ -31,8 +32,9 @@
 
             public bool DefaultCalled;
             
-            protected internal override void Setup(FeatureConfigurationContext context)
+            protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
             {
+                return FeatureStartupTask.None;
             }
         }
 

--- a/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Core.Tests.Features
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using NServiceBus.Features;
     using NUnit.Framework;
@@ -128,9 +129,10 @@
         public Action<Feature> OnActivation;
         public Action<Feature> OnDefaults;
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             OnActivation?.Invoke(this);
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Serializers/Json/When_not_overriding_stream_encoding.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/When_not_overriding_stream_encoding.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Serializers.Json.Tests
 {
+    using System.Collections.Generic;
     using System.Text;
     using System.Threading.Tasks;
     using Features;
@@ -31,8 +32,9 @@ namespace NServiceBus.Serializers.Json.Tests
                 RegisterStartupTask<ValidatorTask>();
             }
 
-            protected internal override void Setup(FeatureConfigurationContext context)
+            protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
             {
+                return FeatureStartupTask.None;
             }
 
             class ValidatorTask : FeatureStartupTask

--- a/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Serializers.Json.Tests
 {
+    using System.Collections.Generic;
     using System.Text;
     using System.Threading.Tasks;
     using Features;
@@ -30,8 +31,9 @@ namespace NServiceBus.Serializers.Json.Tests
                 RegisterStartupTask<ValidatorTask>();
             }
 
-            protected internal override void Setup(FeatureConfigurationContext context)
+            protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
             {
+                return FeatureStartupTask.None;
             }
 
             class ValidatorTask : FeatureStartupTask

--- a/src/NServiceBus.Core/Audit/Audit.cs
+++ b/src/NServiceBus.Core/Audit/Audit.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
     using NServiceBus.Audit;
     using NServiceBus.Pipeline;
     using NServiceBus.Transports;
@@ -15,11 +16,10 @@
             Prerequisite(config => AuditConfigReader.GetConfiguredAuditQueue(config.Settings, out auditConfig), "No configured audit queue was found");
         }
 
-
         /// <summary>
         /// See <see cref="Feature.Setup"/>.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Pipeline.Register(WellKnownStep.AuditProcessedMessage, typeof(InvokeAuditPipelineBehavior), "Execute the audit pipeline");
             context.Pipeline.RegisterConnector<AuditToDispatchConnector>("Dispatches the audit message to the transport");
@@ -34,6 +34,8 @@
 
             context.Container.ConfigureComponent(b => new AuditToDispatchConnector(auditConfig.TimeToBeReceived), DependencyLifecycle.SingleInstance);
             context.Settings.Get<QueueBindings>().BindSending(auditConfig.Address);
+
+            return FeatureStartupTask.None;
         }
 
         AuditConfigReader.Result auditConfig;

--- a/src/NServiceBus.Core/Causation/MessageCausation.cs
+++ b/src/NServiceBus.Core/Causation/MessageCausation.cs
@@ -1,14 +1,18 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
+
     class MessageCausation:Feature
     {
         public MessageCausation()
         {
             EnableByDefault();
         }
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Pipeline.Register("AttachCausationHeaders", typeof(AttachCausationHeadersBehavior), "Adds related to and conversation id headers to outgoing messages");
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/ConsistencyGuarantees/TransactionScopes/WrapHandlersInTransactionScope.cs
+++ b/src/NServiceBus.Core/ConsistencyGuarantees/TransactionScopes/WrapHandlersInTransactionScope.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Features
 {
     using System;
+    using System.Collections.Generic;
     using System.Transactions;
 
     class WrapHandlersInTransactionScope : Feature
@@ -10,7 +11,7 @@
             EnableByDefault();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             if (context.Settings.GetOrDefault<bool>("Transactions.DoNotWrapHandlersExecutionInATransactionScope"))
             {
@@ -28,6 +29,8 @@
 
                 context.Pipeline.Register("HandlerTransactionScopeWrapper", typeof(HandlerTransactionScopeWrapperBehavior), "Makes sure that the handlers gets wrapped in a transaction scope");
             }
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Correlation/MessageCorrelation.cs
+++ b/src/NServiceBus.Core/Correlation/MessageCorrelation.cs
@@ -1,14 +1,18 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
+
     class MessageCorrelation : Feature
     {
         public MessageCorrelation()
         {
             EnableByDefault();
         }
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Pipeline.Register("AttachCorrelationId", typeof(AttachCorrelationIdBehavior), "Makes sure that outgoing messages have a correlation id header set");
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/DataBus/CustomIDataBus.cs
+++ b/src/NServiceBus.Core/DataBus/CustomIDataBus.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Features
 {
     using System;
+    using System.Collections.Generic;
 
     class CustomIDataBus : Feature
     {
@@ -9,9 +10,11 @@
             DependsOn<DataBus>();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Container.ConfigureComponent(context.Settings.Get<Type>("CustomDataBusType"), DependencyLifecycle.SingleInstance);
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/DataBus/DataBus.cs
+++ b/src/NServiceBus.Core/DataBus/DataBus.cs
@@ -18,7 +18,7 @@ namespace NServiceBus.Features
             RegisterStartupTask<IDataBusInitializer>();
         }
 
-        /// This feature envies the FileShareDataBus feature. In this case probably the DataBus feature should be abstract the the FileShareDatabus feature should implement it
+        // This feature envies the FileShareDataBus feature. In this case probably the DataBus feature should be abstract the the FileShareDatabus feature should implement it
         static Type GetSelectedFeatureForDataBus(ReadOnlySettings settings)
         {
             DataBusDefinition dataBusDefinition;

--- a/src/NServiceBus.Core/DataBus/DataBus.cs
+++ b/src/NServiceBus.Core/DataBus/DataBus.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Features
 {
     using System;
     using System.Threading.Tasks;
+    using System.Collections.Generic;
     using NServiceBus.DataBus;
     using NServiceBus.Settings;
 
@@ -17,7 +18,8 @@ namespace NServiceBus.Features
             RegisterStartupTask<IDataBusInitializer>();
         }
 
-        static Type GetSelectedFeatureForDataBus(SettingsHolder settings)
+        /// This feature envies the FileShareDataBus feature. In this case probably the DataBus feature should be abstract the the FileShareDatabus feature should implement it
+        static Type GetSelectedFeatureForDataBus(ReadOnlySettings settings)
         {
             DataBusDefinition dataBusDefinition;
 
@@ -42,7 +44,7 @@ namespace NServiceBus.Features
         /// <summary>
         ///     Called when the features is activated.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             if (!context.Container.HasComponent<IDataBusSerializer>())
             {
@@ -51,6 +53,8 @@ namespace NServiceBus.Features
 
             context.Pipeline.Register<DataBusReceiveBehavior.Registration>();
             context.Pipeline.Register<DataBusSendBehavior.Registration>();
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/DataBus/DataBusFileBased.cs
+++ b/src/NServiceBus.Core/DataBus/DataBusFileBased.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Features
 {
     using System;
+    using System.Collections.Generic;
     using NServiceBus.DataBus;
 
     class DataBusFileBased : Feature
@@ -13,7 +14,7 @@ namespace NServiceBus.Features
         /// <summary>
         /// See <see cref="Feature.Setup"/>
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             string basePath;
             if (!context.Settings.TryGet("FileShareDataBusPath", out basePath))
@@ -23,6 +24,8 @@ namespace NServiceBus.Features
             var dataBus = new FileShareDataBusImplementation(basePath);
 
             context.Container.RegisterSingleton<IDataBus>(dataBus);
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/DelayedDelivery/DelayedDeliveryFeature.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/DelayedDeliveryFeature.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
     using NServiceBus.Config;
     using NServiceBus.DelayedDelivery;
     using NServiceBus.DeliveryConstraints;
@@ -20,7 +21,7 @@
             });
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             var transportHasNativeDelayedDelivery = context.DoesTransportSupportConstraint<DelayedDeliveryConstraint>();
             var timeoutMgrDisabled = IsTimeoutManagerDisabled(context);
@@ -57,6 +58,8 @@
             }
 
             context.Pipeline.Register("ApplyDelayedDeliveryConstraint", typeof(ApplyDelayedDeliveryConstraintBehavior), "Applied relevant delayed delivery constraints requested by the user");
+
+            return FeatureStartupTask.None;
         }
 
         static bool IsTimeoutManagerDisabled(FeatureConfigurationContext context)

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
@@ -1,6 +1,8 @@
 ﻿namespace NServiceBus.Features
 {
     using System;
+    using System.Collections.Generic;
+    using CircuitBreakers;
     using NServiceBus.DelayedDelivery;
     using NServiceBus.DelayedDelivery.TimeoutManager;
     using DeliveryConstraints;
@@ -37,7 +39,7 @@
         /// <summary>
         ///     See <see cref="Feature.Setup" />.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             string processorAddress;
 
@@ -77,9 +79,11 @@
 
                 return new ExpiredTimeoutsPoller(b.Build<IQueryTimeouts>(), b.Build<IDispatchMessages>(), dispatcherAddress, circuitBreaker);
             }, DependencyLifecycle.SingleInstance);
+
+            return FeatureStartupTask.None;
         }
 
-        bool HasAlternateTimeoutManagerBeenConfigured(ReadOnlySettings settings)
+        static bool HasAlternateTimeoutManagerBeenConfigured(ReadOnlySettings settings)
         {
             return settings.Get<TimeoutManagerAddressConfiguration>().TransportAddress != null;
         }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using CircuitBreakers;
     using NServiceBus.DelayedDelivery;
     using NServiceBus.DelayedDelivery.TimeoutManager;
     using DeliveryConstraints;

--- a/src/NServiceBus.Core/Encryption/Encryptor.cs
+++ b/src/NServiceBus.Core/Encryption/Encryptor.cs
@@ -64,13 +64,15 @@ Perhaps you forgot to define your encryption message conventions or to define me
         /// <summary>
         /// <see cref="Feature.Setup"/>.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Container.ConfigureComponent(serviceConstructor, DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent<EncryptionMutator>(DependencyLifecycle.SingleInstance);
 
             context.Pipeline.Register<EncryptBehavior.EncryptRegistration>();
             context.Pipeline.Register<DecryptBehavior.DecryptRegistration>();
+
+            return FeatureStartupTask.None;
         }
 
         static ILog log = LogManager.GetLogger<Encryptor>();

--- a/src/NServiceBus.Core/Features/Feature.cs
+++ b/src/NServiceBus.Core/Features/Feature.cs
@@ -59,7 +59,7 @@
         /// <summary>
         ///     Called when the features is activated.
         /// </summary>
-        protected internal abstract void Setup(FeatureConfigurationContext context);
+        protected internal abstract IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context);
 
         /// <summary>
         ///     Adds a setup prerequisite condition. If false this feature won't be setup.

--- a/src/NServiceBus.Core/Features/FeatureStartupTask.cs
+++ b/src/NServiceBus.Core/Features/FeatureStartupTask.cs
@@ -2,12 +2,30 @@
 {
     using System;
     using System.Threading.Tasks;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Linq;
 
     /// <summary>
     /// Base for feature startup tasks.
     /// </summary>
     public abstract class FeatureStartupTask
     {
+        /// <summary>
+        /// No feature startup tasks
+        /// </summary>
+        public static IReadOnlyCollection<FeatureStartupTask> None { get; } = new ReadOnlyCollection<FeatureStartupTask>(new List<FeatureStartupTask>());
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="tasks"></param>
+        /// <returns></returns>
+        public static IReadOnlyCollection<FeatureStartupTask> Some(params FeatureStartupTask[] tasks)
+        {
+            return new ReadOnlyCollection<FeatureStartupTask>(tasks.ToList());
+        } 
+
         /// <summary>
         /// Will be called when the endpoint starts up if the feature has been activated.
         /// </summary>

--- a/src/NServiceBus.Core/Features/FeatureStartupTask.cs
+++ b/src/NServiceBus.Core/Features/FeatureStartupTask.cs
@@ -12,15 +12,13 @@
     public abstract class FeatureStartupTask
     {
         /// <summary>
-        /// No feature startup tasks
+        /// No feature startup tasks.
         /// </summary>
         public static IReadOnlyCollection<FeatureStartupTask> None { get; } = new ReadOnlyCollection<FeatureStartupTask>(new List<FeatureStartupTask>());
 
         /// <summary>
-        /// 
+        /// Some feature startup tasks.
         /// </summary>
-        /// <param name="tasks"></param>
-        /// <returns></returns>
         public static IReadOnlyCollection<FeatureStartupTask> Some(params FeatureStartupTask[] tasks)
         {
             return new ReadOnlyCollection<FeatureStartupTask>(tasks.ToList());

--- a/src/NServiceBus.Core/Features/RootFeature.cs
+++ b/src/NServiceBus.Core/Features/RootFeature.cs
@@ -1,5 +1,7 @@
 namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
+
     /// <summary>
     /// A root feature that is always enabled.
     /// </summary>
@@ -10,8 +12,9 @@ namespace NServiceBus.Features
             EnableByDefault();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Forwarding/ForwardReceivedMessages.cs
+++ b/src/NServiceBus.Core/Forwarding/ForwardReceivedMessages.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
     using NServiceBus.Config;
     using NServiceBus.Forwarding;
     using NServiceBus.Pipeline;
@@ -21,7 +22,7 @@
         /// Invoked if the feature is activated.
         /// </summary>
         /// <param name="context">The feature context.</param>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             var forwardReceivedMessagesQueue = GetConfiguredForwardMessageQueue(context);
 
@@ -37,6 +38,8 @@
 
                 return new InvokeForwardingPipelineBehavior(pipeline, forwardReceivedMessagesQueue);
             }, DependencyLifecycle.InstancePerCall);
+
+            return FeatureStartupTask.None;
         }
 
         static string GetConfiguredForwardMessageQueue(FeatureConfigurationContext context)

--- a/src/NServiceBus.Core/Hosting/HostInformationFeature.cs
+++ b/src/NServiceBus.Core/Hosting/HostInformationFeature.cs
@@ -31,7 +31,7 @@
                 });
             });
         }
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             var hostInformation = new HostInformation(context.Settings.Get<Guid>(HostIdSettingsKey),
                         context.Settings.Get<string>("NServiceBus.HostInformation.DisplayName"),
@@ -44,6 +44,8 @@
 
             context.Container.ConfigureComponent(b => new AddHostInfoHeadersBehavior(hostInformation, context.Settings.EndpointName()), DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent(b => new AuditHostInformationBehavior(hostInformation, context.Settings.EndpointName()), DependencyLifecycle.SingleInstance);
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Licensing/LicenseReminder.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseReminder.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Features
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using Logging;
     using NServiceBus.Licensing;
@@ -14,7 +15,7 @@ namespace NServiceBus.Features
             Defaults(s => s.SetDefault(LicenseTextSettingsKey, null));
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             try
             {
@@ -26,7 +27,7 @@ namespace NServiceBus.Features
                 var licenseExpired = licenseManager.HasLicenseExpired();
                 if (!licenseExpired)
                 {
-                    return;
+                    return FeatureStartupTask.None;
                 }
 
                 context.Pipeline.Register("LicenseReminder", typeof(AuditInvalidLicenseBehavior), "Audits that the message was processed by an endpoint with an expired license");
@@ -41,6 +42,7 @@ namespace NServiceBus.Features
                 //we only log here to prevent licensing issue to abort startup and cause production outages
                 Logger.Fatal("Failed to initialize the license", ex);
             }
+            return FeatureStartupTask.None;
         }
 
         static ILog Logger = LogManager.GetLogger<LicenseReminder>();

--- a/src/NServiceBus.Core/Performance/MessageDurability/MessageDurabilityFeature.cs
+++ b/src/NServiceBus.Core/Performance/MessageDurability/MessageDurabilityFeature.cs
@@ -11,7 +11,7 @@
             EnableByDefault();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             var conventions = context.Settings.Get<Conventions>();
 
@@ -44,8 +44,9 @@
 
             context.Pipeline.Register("DetermineMessageDurability", typeof(DetermineMessageDurabilityBehavior), "Adds the NonDurableDelivery constraint for messages that have requested to be delivered in non durable mode");
 
-
             context.Container.ConfigureComponent(b => new DetermineMessageDurabilityBehavior(messageDurability), DependencyLifecycle.SingleInstance);
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Performance/ReceiveStatisticsFeature.cs
+++ b/src/NServiceBus.Core/Performance/ReceiveStatisticsFeature.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using NServiceBus.Audit;
     using NServiceBus.Features;
@@ -12,11 +13,13 @@
         {
             EnableByDefault();
         }
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Pipeline.Register("ReceivePerformanceDiagnosticsBehavior", typeof(ReceivePerformanceDiagnosticsBehavior), "Provides various performance counters for receive statistics");
             context.Pipeline.Register<ProcessingStatisticsBehavior.Registration>();
             context.Pipeline.Register("AuditProcessingStatistics", typeof(AuditProcessingStatisticsBehavior), "Add ProcessingStarted and ProcessingEnded headers");
+
+            return FeatureStartupTask.None;
         }
     }
 

--- a/src/NServiceBus.Core/Performance/Statistics/CriticalTime/CriticalTimeMonitoring.cs
+++ b/src/NServiceBus.Core/Performance/Statistics/CriticalTime/CriticalTimeMonitoring.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
     using NServiceBus.Performance.Counters;
 
     /// <summary>
@@ -14,12 +15,13 @@ namespace NServiceBus.Features
         /// <summary>
         /// <see cref="Feature.Setup"/>.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             var criticalTimeCounter = PerformanceCounterHelper.InstantiatePerformanceCounter("Critical Time", context.Settings.EndpointName().ToString());
             var criticalTimeCalculator = new CriticalTimeCalculator(criticalTimeCounter);
             context.Container.RegisterSingleton(criticalTimeCalculator);
             context.Pipeline.Register<CriticalTimeBehavior.Registration>();
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Performance/TimeToBeReceived/TimeToBeReceived.cs
+++ b/src/NServiceBus.Core/Performance/TimeToBeReceived/TimeToBeReceived.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Features
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using NServiceBus.DeliveryConstraints;
     using NServiceBus.Performance.TimeToBeReceived;
@@ -11,7 +12,7 @@
         {
             EnableByDefault();
         }
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             var mappings = GetMappings(context);
 
@@ -23,9 +24,11 @@
             context.Pipeline.Register("ApplyTimeToBeReceived", typeof(ApplyTimeToBeReceivedBehavior), "Adds the `DiscardIfNotReceivedBefore` constraint to relevant messages");
 
             context.Container.ConfigureComponent(b=>new ApplyTimeToBeReceivedBehavior(mappings), DependencyLifecycle.SingleInstance);
+
+            return FeatureStartupTask.None;
         }
 
-        TimeToBeReceivedMappings GetMappings(FeatureConfigurationContext context)
+        static TimeToBeReceivedMappings GetMappings(FeatureConfigurationContext context)
         {   
             var knownMessages = context.Settings.GetAvailableTypes()
                 .Where(context.Settings.Get<Conventions>().IsMessageType)

--- a/src/NServiceBus.Core/Persistence/InMemory/Gateway/InMemoryGatewayPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Gateway/InMemoryGatewayPersistence.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
     using NServiceBus.Gateway.Deduplication;
 
     /// <summary>
@@ -15,9 +16,11 @@
         /// <summary>
         /// See <see cref="Feature.Setup"/>.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Container.ConfigureComponent<InMemoryGatewayDeduplication>(DependencyLifecycle.SingleInstance);
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransactionalStorageFeature.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransactionalStorageFeature.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus
 {
+    using System.Collections.Generic;
     using NServiceBus.Features;
 
     class InMemoryTransactionalStorageFeature : Feature
@@ -7,10 +8,12 @@
         /// <summary>
         ///     Called when the features is activated.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Container.ConfigureComponent<InMemorySynchronizedStorage>(DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent<InMemoryTransactionalSynchronizedStorageAdapter>(DependencyLifecycle.SingleInstance);
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersistence.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
 
     /// <summary>
     /// Used to configure in memory saga persistence.
@@ -15,9 +16,11 @@
         /// <summary>
         /// See <see cref="Feature.Setup"/>.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Container.ConfigureComponent<InMemorySagaPersister>(DependencyLifecycle.SingleInstance);
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Persistence/InMemory/SubscriptionStorage/InMemorySubscriptionPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/SubscriptionStorage/InMemorySubscriptionPersistence.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
     using NServiceBus.InMemory.SubscriptionStorage;
 
     /// <summary>
@@ -15,9 +16,11 @@
         /// <summary>
         /// See <see cref="Feature.Setup"/>.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Container.ConfigureComponent<InMemorySubscriptionStorage>(DependencyLifecycle.SingleInstance);
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersistence.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
     using NServiceBus.InMemory.TimeoutPersister;
 
     /// <summary>
@@ -15,9 +16,11 @@
         /// <summary>
         /// See <see cref="Feature.Setup"/>.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Container.ConfigureComponent<InMemoryTimeoutPersister>(DependencyLifecycle.SingleInstance);
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Persistence/Msmq/SubscriptionStorage/MsmqSubscriptionPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/Msmq/SubscriptionStorage/MsmqSubscriptionPersistence.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
     using Config;
     using Logging;
     using NServiceBus.Transports;
@@ -16,7 +17,7 @@
         /// Invoked if the feature is activated.
         /// </summary>
         /// <param name="context">The feature context.</param>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             var queueName = context.Settings.GetOrDefault<string>("MsmqSubscriptionPersistence.QueueName");
 

--- a/src/NServiceBus.Core/Persistence/Msmq/SubscriptionStorage/MsmqSubscriptionPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/Msmq/SubscriptionStorage/MsmqSubscriptionPersistence.cs
@@ -46,6 +46,8 @@
                 var queue = new MsmqSubscriptionStorageQueue(MsmqAddress.Parse(queueName), context.Settings.Get<bool>("Transactions.Enabled"), false);
                 return new MsmqSubscriptionStorage(queue);
             }, DependencyLifecycle.SingleInstance);
+
+            return FeatureStartupTask.None;
         }
 
         static ILog Logger = LogManager.GetLogger(typeof(MsmqSubscriptionPersistence));

--- a/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
     using NServiceBus.Outbox;
@@ -15,7 +16,7 @@
             EnableByDefault();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Pipeline.RegisterConnector<TransportReceiveToPhysicalMessageProcessingConnector>("Allows to abort processing the message");
             context.Pipeline.RegisterConnector<DeserializeLogicalMessagesConnector>("Deserializes the physical message body into logical messages");

--- a/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
@@ -45,6 +45,8 @@
                 var adapter = context.Container.HasComponent<ISynchronizedStorageAdapter>() ? b.Build<ISynchronizedStorageAdapter>() : new NoOpAdaper();
                 return new LoadHandlersConnector(b.Build<MessageHandlerRegistry>(), b.Build<ISynchronizedStorage>(), adapter);
             }, DependencyLifecycle.InstancePerCall);
+
+            return FeatureStartupTask.None;
         }
 
         class NoOpAdaper : ISynchronizedStorageAdapter

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPipelineFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPipelineFeature.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
     using NServiceBus.Pipeline;
 
     class OutgoingPipelineFeature : Feature
@@ -9,7 +10,7 @@
             EnableByDefault();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Pipeline.RegisterConnector<SerializeMessageConnector>("Converts a logical message into a physical message");
 
@@ -22,6 +23,8 @@
             context.Pipeline.RegisterConnector<RoutingToDispatchConnector>("Decides if the current message should be batched or immediately be dispatched to the transport");
             context.Pipeline.RegisterConnector<BatchToDispatchConnector>("Passes batched messages over to the immediate dispatch part of the pipeline");
             context.Pipeline.Register("ImmediateDispatchTerminator", typeof(ImmediateDispatchTerminator), "Hands the outgoing messages over to the transport for immediate delivery");
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Recoverability/Faults/ErrorSubscribers.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/ErrorSubscribers.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
+
     class ErrorSubscribers : Feature
     {
         public ErrorSubscribers()
@@ -7,9 +9,11 @@
             EnableByDefault();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Container.ConfigureComponent<BusNotifications>(DependencyLifecycle.SingleInstance);
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Recoverability/Faults/StoreFaultsInErrorQueue.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/StoreFaultsInErrorQueue.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
     using NServiceBus.Faults;
     using NServiceBus.Hosting;
     using NServiceBus.Pipeline;
@@ -18,7 +19,7 @@ namespace NServiceBus.Features
             }, "Send only endpoints can't be used to forward received messages to the error queue as the endpoint requires receive capabilities");
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
 
             var errorQueue = ErrorQueueSettings.GetConfiguredErrorQueue(context.Settings);
@@ -40,6 +41,8 @@ namespace NServiceBus.Features
             context.Settings.Get<QueueBindings>().BindSending(errorQueue);
 
             context.Pipeline.Register<MoveFaultsToErrorQueueBehavior.Registration>();
+
+            return FeatureStartupTask.None;
         }
 
 

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetries.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetries.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Features
 {
     using System;
+    using System.Collections.Generic;
     using NServiceBus.Config;
     using NServiceBus.Pipeline;
     using NServiceBus.Recoverability.SecondLevelRetries;
@@ -27,7 +28,7 @@ namespace NServiceBus.Features
         /// <summary>
         /// See <see cref="Feature.Setup"/>.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             var  retryPolicy = GetRetryPolicy(context.Settings);
 
@@ -42,9 +43,11 @@ namespace NServiceBus.Features
                 var dispatchPipeline = new PipelineBase<RoutingContext>(b, context.Settings, pipelinesCollection.MainPipeline);
                 return new SecondLevelRetriesBehavior(dispatchPipeline,retryPolicy,b.Build<BusNotifications>(), context.Settings.LocalAddress());
             }, DependencyLifecycle.InstancePerCall);
+
+            return FeatureStartupTask.None;
         }
 
-        bool IsEnabledInConfig(FeatureConfigurationContext context)
+        static bool IsEnabledInConfig(FeatureConfigurationContext context)
         {
             var retriesConfig = context.Settings.GetConfigSection<SecondLevelRetriesConfig>();
 

--- a/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Features
 {
     using System;
+    using System.Collections.Generic;
     using System.Configuration;
     using System.ServiceProcess;
     using System.Threading.Tasks;
@@ -28,8 +29,6 @@
 
                 return RequireOutboxConsent(c);
             }, "This transport requires outbox consent");
-
-            RegisterStartupTask<DtcRunningWarning>();
         }
 
         static bool RequireOutboxConsent(FeatureConfigurationContext context)
@@ -66,7 +65,7 @@ The reason you need to do this is because we need to ensure that you have read a
         /// <summary>
         /// See <see cref="Feature.Setup"/>.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             if (!PersistenceStartup.HasSupportFor<StorageType.Outbox>(context.Settings))
             {
@@ -75,7 +74,9 @@ The reason you need to do this is because we need to ensure that you have read a
 
             //note: in the future we should change the persister api to give us a "outbox factory" so that we can register it in DI here instead of relying on the persister to do it
 
-            context.Pipeline.Register("ForceBatchDispatchToBeIsolated", typeof(ForceBatchDispatchToBeIsolatedBehavior), "Makes sure that we dispatch straight to the transport so that we can safely set the outbox record to dispatched one the dispatch pipeline returns.");
+            context.Pipeline.Register("ForceBatchDispatchToBeIsolated", typeof(ForceBatchDispatchToBeIsolatedBehavior), "Makes sure that we dispatch straight to the transport so that we can safely set the outbox record to dispatched one the dispatch pipeline returns.");            
+
+            return FeatureStartupTask.Some(new DtcRunningWarning());
         }
 
     }

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -24,7 +24,7 @@
         /// <summary>
         /// See <see cref="Feature.Setup"/>.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             var transportDefinition = context.Settings.Get<TransportDefinition>();
             SubscribeSettings settings;
@@ -66,6 +66,8 @@
 
                 }, DependencyLifecycle.SingleInstance);
             }
+
+            return FeatureStartupTask.None;
         }
 
         static List<Type> GetMessageTypesHandledByThisEndpoint(MessageHandlerRegistry handlerRegistry, Conventions conventions,SubscribeSettings settings)

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Features
 {
     using System;
     using System.Threading.Tasks;
+    using System.Collections.Generic;
     using NServiceBus.Routing;
     using NServiceBus.Settings;
 
@@ -10,12 +11,15 @@ namespace NServiceBus.Features
         public FileRoutingTableFeature()
         {
             DependsOn<RoutingFeature>();
-            RegisterStartupTask<StartupTask>();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
-            context.Container.RegisterSingleton(new FileRoutingTable(context.Settings.Get<string>("FileBasedRouting.BasePath"), TimeSpan.FromSeconds(5)));
+            var fileRoutingTable = new FileRoutingTable(context.Settings.Get<string>("FileBasedRouting.BasePath"), TimeSpan.FromSeconds(5));
+
+            context.Container.RegisterSingleton(fileRoutingTable);
+
+            return FeatureStartupTask.Some(new StartupTask(context.Settings, fileRoutingTable));
         }
 
         class StartupTask : FeatureStartupTask

--- a/src/NServiceBus.Core/Routing/Legacy/WorkerFeature.cs
+++ b/src/NServiceBus.Core/Routing/Legacy/WorkerFeature.cs
@@ -3,6 +3,7 @@
 namespace NServiceBus.Routing.Legacy
 {
     using System;
+    using System.Collections.Generic;
     using Features;
     using Transports;
 
@@ -21,7 +22,7 @@ namespace NServiceBus.Routing.Legacy
             });
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             var masterNodeControlAddress = context.Settings.Get<string>("LegacyDistributor.ControlAddress");
             var capacity = context.Settings.Get<int>("LegacyDistributor.Capacity");
@@ -30,6 +31,8 @@ namespace NServiceBus.Routing.Legacy
             context.Container.ConfigureComponent(b => new ProcessedMessageCounterBehavior(b.Build<ReadyMessageSender>()), DependencyLifecycle.SingleInstance);
 
             context.Pipeline.Register("ProcessedMessageCounterBehavior", typeof(ProcessedMessageCounterBehavior), "Counts messages processed by the worker.");
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -27,6 +27,8 @@ namespace NServiceBus.Features
                 authorizer = _ => true;
             }
             context.Container.RegisterSingleton(authorizer);
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
     using NServiceBus.Transports;
 
     /// <summary>
@@ -17,7 +18,7 @@ namespace NServiceBus.Features
         /// <summary>
         /// See <see cref="Feature.Setup"/>.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Pipeline.Register<SubscriptionReceiverBehavior.Registration>();
             var authorizer = context.Settings.GetSubscriptionAuthorizer();

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/StorageInitializer.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/StorageInitializer.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions
 {
     using System.Threading.Tasks;
+    using System.Collections.Generic;
     using NServiceBus.Features;
 
     class StorageInitializer : Feature
@@ -22,8 +23,9 @@
             }
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/BestPracticeEnforcement.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/BestPracticeEnforcement.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
     using NServiceBus.MessagingBestPractices;
     using NServiceBus.Pipeline;
 
@@ -20,7 +21,7 @@ namespace NServiceBus.Features
         /// Initializes the feature.
         /// </summary>
         /// <param name="context">The feature context.</param>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Container.ConfigureComponent<Validations>(DependencyLifecycle.SingleInstance);
 
@@ -48,6 +49,8 @@ namespace NServiceBus.Features
                 WellKnownStep.EnforceUnsubscribeBestPractices,
                 typeof(EnforceUnsubscribeBestPracticesBehavior),
                 "Enforces unsubscribe messaging best practices");
+
+            return FeatureStartupTask.None;
         }
 
     }

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -110,7 +110,7 @@
                     context.Pipeline.Register("NativeUnsubscribeTerminator", typeof(NativeUnsubscribeTerminator), "Requests the transport to unsubscribe to a given message type");
                 }
             }
-
+            return FeatureStartupTask.None;
         }
 
         static string ReplyToAddress(IBuilder builder)

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -31,7 +31,7 @@
             RegisterStartupTask<SubscriptionStoreRouteInformationProvider>();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             var canReceive = !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly");
             var transportDefinition = context.Settings.Get<TransportDefinition>();
@@ -110,6 +110,7 @@
                     context.Pipeline.Register("NativeUnsubscribeTerminator", typeof(NativeUnsubscribeTerminator), "Requests the transport to unsubscribe to a given message type");
                 }
             }
+
         }
 
         static string ReplyToAddress(IBuilder builder)

--- a/src/NServiceBus.Core/Sagas/AutoCorrelationFeature.cs
+++ b/src/NServiceBus.Core/Sagas/AutoCorrelationFeature.cs
@@ -1,15 +1,19 @@
 ﻿namespace NServiceBus.Features
 {
-    class AutoCorrelationFeature:Feature
+    using System.Collections.Generic;
+
+    class AutoCorrelationFeature : Feature
     {
         public AutoCorrelationFeature()
         {
             EnableByDefault();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Pipeline.Register("PopulateAutoCorrelationHeadersForReplies", typeof(PopulateAutoCorrelationHeadersForRepliesBehavior), "Copies existing saga headers from incoming message to outgoing message to facilitate the auto correlation in the saga, when replying to a message that was sent by a saga.");
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Sagas/Sagas.cs
+++ b/src/NServiceBus.Core/Sagas/Sagas.cs
@@ -35,7 +35,7 @@
         /// <summary>
         ///     See <see cref="Feature.Setup" />.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             // Register the Saga related behaviors for incoming messages
             context.Pipeline.Register(WellKnownStep.InvokeSaga, typeof(SagaPersistenceBehavior), "Invokes the saga logic");
@@ -56,6 +56,8 @@
                     context.Container.ConfigureComponent(t, DependencyLifecycle.InstancePerCall);
                 }
             }
+
+            return FeatureStartupTask.None;
         }
 
         static void RegisterCustomFindersInContainer(IConfigureComponents container, IEnumerable<SagaMetadata> sagaMetaModel)

--- a/src/NServiceBus.Core/Scheduling/Scheduler.cs
+++ b/src/NServiceBus.Core/Scheduling/Scheduler.cs
@@ -26,6 +26,8 @@ namespace NServiceBus.Features
             context.Container.ConfigureComponent<DefaultScheduler>(DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent<ScheduleBehavior>(DependencyLifecycle.SingleInstance);
             context.Pipeline.Register("ScheduleBehavior", typeof(ScheduleBehavior), "Registers a task definition for scheduling.");
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Scheduling/Scheduler.cs
+++ b/src/NServiceBus.Core/Scheduling/Scheduler.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
     using Scheduling;
     using ScheduledTask = Scheduling.Messages.ScheduledTask;
 
@@ -19,7 +20,7 @@ namespace NServiceBus.Features
         /// Invoked if the feature is activated.
         /// </summary>
         /// <param name="context">The feature context.</param>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Settings.Get<Conventions>().AddSystemMessagesConventions(t => typeof(ScheduledTask).IsAssignableFrom(t));
             context.Container.ConfigureComponent<DefaultScheduler>(DependencyLifecycle.SingleInstance);

--- a/src/NServiceBus.Core/Serialization/ConfigureSerialization.cs
+++ b/src/NServiceBus.Core/Serialization/ConfigureSerialization.cs
@@ -22,14 +22,14 @@
         /// <summary>
         /// Called when the features is activated.
         /// </summary>
-        protected internal sealed override void Setup(FeatureConfigurationContext context)
+        protected internal sealed override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Container.ConfigureComponent<MessageMapper>(DependencyLifecycle.SingleInstance);
 
             var serializerType = GetSerializerType(context);
             if (serializerType == null)
             {
-                return;
+                return FeatureStartupTask.None;
             }
 
             RegisterSerializer(context, serializerType);
@@ -38,6 +38,8 @@
             {
                 context.Container.ConfigureComponent(b => new MessageDeserializerResolver(b.BuildAll<IMessageSerializer>(), serializerType), DependencyLifecycle.SingleInstance);
             }
+
+            return FeatureStartupTask.None;
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/StaticHeaders/CurrentStaticHeaders.cs
+++ b/src/NServiceBus.Core/StaticHeaders/CurrentStaticHeaders.cs
@@ -12,17 +12,17 @@ namespace NServiceBus.StaticHeaders
 
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             var headers = context.Settings.Get<CurrentStaticHeaders>();
 
             context.Container.ConfigureComponent(b => new ApplyStaticHeadersBehavior(headers), DependencyLifecycle.SingleInstance);
             context.Pipeline.Register("ApplyStaticHeaders", typeof(ApplyStaticHeadersBehavior), "Applies static headers to outgoing messages");
+            return FeatureStartupTask.None;
         }
     }
 
     class CurrentStaticHeaders:Dictionary<string,string>
     {
-       
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportConfigurator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportConfigurator.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
     using System.Messaging;
@@ -9,6 +10,11 @@
     using NServiceBus.Settings;
     using NServiceBus.Transports;
     using NServiceBus.Transports.Msmq;
+    using Logging;
+    using Settings;
+    using Transports;
+    using Transports.Msmq;
+    using Utils;
 
     /// <summary>
     /// Used to configure the MSMQ transport.
@@ -20,14 +26,19 @@
             EnableByDefault();
             DependsOn<UnicastBus>();
             DependsOn<Receiving>();
-            RegisterStartupTask<CheckQueuePermissions>();
-            RegisterStartupTask<TimeToBeReceivedOverrideCheck>();
+        }
+
+        /// <summary>
+        ///     Called when the features is activated.
+        /// </summary>
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
+        {
+            return FeatureStartupTask.Some(new CheckQueuePermissions(context.Settings), new TimeToBeReceivedOverrideCheck(context.Settings));
         }
 
         class CheckQueuePermissions : FeatureStartupTask
         {
             ReadOnlySettings settings;
-
             public CheckQueuePermissions(ReadOnlySettings settings)
             {
                 this.settings = settings;
@@ -89,13 +100,7 @@
             }
 
             static ILog Logger = LogManager.GetLogger<CheckQueuePermissions>();
-        }
-        
-        /// <summary>
-        ///     Called when the features is activated.
-        /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
-        {
+            ReadOnlySettings settings;
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportConfigurator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportConfigurator.cs
@@ -10,11 +10,6 @@
     using NServiceBus.Settings;
     using NServiceBus.Transports;
     using NServiceBus.Transports.Msmq;
-    using Logging;
-    using Settings;
-    using Transports;
-    using Transports.Msmq;
-    using Utils;
 
     /// <summary>
     /// Used to configure the MSMQ transport.
@@ -33,7 +28,9 @@
         /// </summary>
         protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
-            return FeatureStartupTask.Some(new CheckQueuePermissions(context.Settings), new TimeToBeReceivedOverrideCheck(context.Settings));
+            return FeatureStartupTask.Some(
+                new CheckQueuePermissions(context.Settings), 
+                new TimeToBeReceivedOverrideCheck(context.Settings));
         }
 
         class CheckQueuePermissions : FeatureStartupTask
@@ -100,7 +97,6 @@
             }
 
             static ILog Logger = LogManager.GetLogger<CheckQueuePermissions>();
-            ReadOnlySettings settings;
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/Receiving.cs
+++ b/src/NServiceBus.Core/Transports/Receiving.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Transports
 {
     using System;
+    using System.Collections.Generic;
     using Features;
 
     class Receiving : Feature
@@ -30,7 +31,7 @@ namespace NServiceBus.Transports
         /// <summary>
         /// <see cref="Feature.Setup"/>.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             var inboundTransport = context.Settings.Get<InboundTransport>();
 
@@ -41,6 +42,8 @@ namespace NServiceBus.Transports
             var receiveConfigContext = inboundTransport.Configure(context.Settings);
             context.Container.ConfigureComponent(b => receiveConfigContext.MessagePumpFactory(b.Build<CriticalError>()), DependencyLifecycle.InstancePerCall);
             context.Container.ConfigureComponent(b => receiveConfigContext.QueueCreatorFactory(), DependencyLifecycle.SingleInstance);
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/Sending.cs
+++ b/src/NServiceBus.Core/Transports/Sending.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Transports
 {
+    using System.Collections.Generic;
     using NServiceBus.Features;
 
     class Sending : Feature
@@ -10,7 +11,7 @@ namespace NServiceBus.Transports
             DependsOn<UnicastBus>();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             var transport = context.Settings.Get<OutboundTransport>();
             context.Container.ConfigureComponent(c =>
@@ -19,6 +20,8 @@ namespace NServiceBus.Transports
                 var dispatcher = sendConfigContext.DispatcherFactory();
                 return dispatcher;
             }, DependencyLifecycle.SingleInstance);
+
+            return FeatureStartupTask.None;
         }
     }
 }

--- a/src/NServiceBus.Core/Unicast/Config/RegisterHandlersInOrder.cs
+++ b/src/NServiceBus.Core/Unicast/Config/RegisterHandlersInOrder.cs
@@ -13,11 +13,11 @@ namespace NServiceBus.Features
             EnableByDefault();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             if (context.Container.HasComponent<MessageHandlerRegistry>())
             {
-                return;
+                return FeatureStartupTask.None;
             }
 
             List<Type> order;
@@ -28,6 +28,8 @@ namespace NServiceBus.Features
             }
 
             LoadMessageHandlers(context, order);
+
+            return FeatureStartupTask.None;
         }
 
         static void LoadMessageHandlers(FeatureConfigurationContext context, List<Type> orderedTypes)

--- a/src/NServiceBus.Core/Unicast/Config/UnicastBus.cs
+++ b/src/NServiceBus.Core/Unicast/Config/UnicastBus.cs
@@ -47,7 +47,7 @@ namespace NServiceBus.Features
             return new EndpointInstanceName(settings.EndpointName(), userDiscriminator, transportDiscriminator);
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             context.Container.ConfigureComponent<BusNotifications>(DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent<RunningEndpointInstance>(DependencyLifecycle.SingleInstance);
@@ -57,6 +57,8 @@ namespace NServiceBus.Features
                 .ToList();
 
             ConfigureMessageRegistry(context, knownMessages);
+
+            return FeatureStartupTask.None;
         }
 
         static void ConfigureMessageRegistry(FeatureConfigurationContext context, IEnumerable<Type> knownMessages)

--- a/src/NServiceBus.Core/obsoletes.cs
+++ b/src/NServiceBus.Core/obsoletes.cs
@@ -752,6 +752,7 @@ namespace NServiceBus.Unicast
 namespace NServiceBus.Features
 {
     using System;
+    using System.Collections.Generic;
 
     [ObsoleteEx(
         RemoveInVersion = "7.0",
@@ -763,7 +764,7 @@ namespace NServiceBus.Features
         {
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             throw new NotImplementedException();
         }
@@ -826,6 +827,7 @@ namespace NServiceBus.Transports
 namespace NServiceBus.Features
 {
     using System;
+    using System.Collections.Generic;
 
     [ObsoleteEx(
         RemoveInVersion = "7.0",
@@ -837,7 +839,7 @@ namespace NServiceBus.Features
         {
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override IReadOnlyCollection<FeatureStartupTask> Setup(FeatureConfigurationContext context)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
This is a quick spike to explore a different DI less API for `FeatureStartupTask`. As discussed with @andreasohlund and @SzymonPobiega we want to reduce the DI magic we use in the core as a long term strategy because we believe this move is going to benefit a lot for our internal design and potentially shows a few areas where we are missing explicit extension points and concepts.

One such area is the `FeatureStartupTask`. As I see it a `FeatureStartupTask` should not envie dependencies of other features. Therefore it should only have access to singleton instances created by the feature itself. If we follow that design we could actually remove the `IBuilder` access when creating `FeatureStartupTask`.

This Spike shows also that we currently have a few "weird" features that should either be merged with others or there is an explicit extension point missing. I'm going to comment more inline to proof my point.

@Particular/nservicebus Thoughts?