### PR TITLE
cause a rollback when timeout already removed

### DIFF
--- a/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
@@ -11,7 +11,6 @@ namespace NServiceBus.InMemory.TimeoutPersister
     class InMemoryTimeoutPersister : IPersistTimeouts, IQueryTimeouts, IDisposable
     {
         public void Dispose()
-
         {
         }
 


### PR DESCRIPTION
In case a timeout was concurrently removed from the storage, throw an exception to abort processing the message. This is required for DTC scenarios in order to avoid duplicate message dispatches.