### PR TITLE
Queue creation is async and executed in parallel.

### DIFF
--- a/src/NServiceBus.AcceptanceTests/FakeTransport/FakeQueueCreator.cs
+++ b/src/NServiceBus.AcceptanceTests/FakeTransport/FakeQueueCreator.cs
@@ -1,12 +1,13 @@
 namespace NServiceBus.AcceptanceTests.FakeTransport
 {
+    using System.Threading.Tasks;
     using NServiceBus.Transports;
 
     class FakeQueueCreator : ICreateQueues
     {
-        public void CreateQueueIfNecessary(string address, string account)
+        public Task CreateQueueIfNecessary(string address, string account)
         {
-
+            return Task.FromResult(0);
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/FakeTransport/FakeQueueCreator.cs
+++ b/src/NServiceBus.AcceptanceTests/FakeTransport/FakeQueueCreator.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.AcceptanceTests.FakeTransport
 
     class FakeQueueCreator : ICreateQueues
     {
-        public Task CreateQueueIfNecessary(string address, string account)
+        public Task CreateQueueIfNecessary(QueueBindings queueBindings, string identity)
         {
             return Task.FromResult(0);
         }

--- a/src/NServiceBus.AcceptanceTests/Performance/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -54,8 +54,9 @@
 
         class FakeQueueCreator : ICreateQueues
         {
-            public void CreateQueueIfNecessary(string address, string account)
+            public Task CreateQueueIfNecessary(string address, string account)
             {
+                return Task.FromResult(0);
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Performance/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -54,7 +54,7 @@
 
         class FakeQueueCreator : ICreateQueues
         {
-            public Task CreateQueueIfNecessary(string address, string account)
+            public Task CreateQueueIfNecessary(QueueBindings queueBindings, string identity)
             {
                 return Task.FromResult(0);
             }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2631,7 +2631,7 @@ namespace NServiceBus.Transports
     }
     public interface ICreateQueues
     {
-        void CreateQueueIfNecessary(string address, string account);
+        System.Threading.Tasks.Task CreateQueueIfNecessary(string address, string account);
     }
     [System.ObsoleteAttribute("Please use `IDispatchMessages` instead. Will be removed in version 7.0.0.", true)]
     public interface IDeferMessages

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2631,7 +2631,7 @@ namespace NServiceBus.Transports
     }
     public interface ICreateQueues
     {
-        System.Threading.Tasks.Task CreateQueueIfNecessary(string address, string account);
+        System.Threading.Tasks.Task CreateQueueIfNecessary(NServiceBus.Transports.QueueBindings queueBindings, string identity);
     }
     [System.ObsoleteAttribute("Please use `IDispatchMessages` instead. Will be removed in version 7.0.0.", true)]
     public interface IDeferMessages

--- a/src/NServiceBus.Core/Transports/ICreateQueues.cs
+++ b/src/NServiceBus.Core/Transports/ICreateQueues.cs
@@ -1,5 +1,7 @@
 namespace NServiceBus.Transports
 {
+    using System.Threading.Tasks;
+
     /// <summary>
     /// Abstraction of the capability to create queues.
     /// </summary>
@@ -8,6 +10,7 @@ namespace NServiceBus.Transports
         /// <summary>
         /// Create a messages queue where its name is the address parameter, for the given account.
         /// </summary>
-        void CreateQueueIfNecessary(string address, string account);
+        /// <remarks>This method will be executed in parallel if multiple addresses need to be created.</remarks>
+        Task CreateQueueIfNecessary(string address, string account);
     }
 }

--- a/src/NServiceBus.Core/Transports/ICreateQueues.cs
+++ b/src/NServiceBus.Core/Transports/ICreateQueues.cs
@@ -8,9 +8,8 @@ namespace NServiceBus.Transports
     public interface ICreateQueues
     {
         /// <summary>
-        /// Create a messages queue where its name is the address parameter, for the given account.
+        /// Creates message queues for the defined queue bindings and identity.
         /// </summary>
-        /// <remarks>This method will be executed in parallel if multiple addresses need to be created.</remarks>
-        Task CreateQueueIfNecessary(string address, string account);
+        Task CreateQueueIfNecessary(QueueBindings queueBindings, string identity);
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
@@ -21,16 +21,31 @@ namespace NServiceBus.Transports.Msmq
             this.settings = settings;
         }
 
+        public Task CreateQueueIfNecessary(QueueBindings queueBindings, string identity)
+        {
+            foreach (var receivingAddress in queueBindings.ReceivingAddresses)
+            {
+                CreateQueueIfNecessary(receivingAddress, identity);
+            }
+
+            foreach (var sendingAddress in queueBindings.SendingAddresses)
+            {
+                CreateQueueIfNecessary(sendingAddress, identity);
+            }
+
+            return TaskEx.Completed;
+        }
+
         ///<summary>
         /// Utility method for creating a queue if it does not exist.
         ///</summary>
         ///<param name="address">Queue path to create</param>
-        ///<param name="account">The account to be given permissions to the queue</param>
-        public Task CreateQueueIfNecessary(string address, string account)
+        ///<param name="identity">The identity to be given permissions to the queue</param>
+        private void CreateQueueIfNecessary(string address, string identity)
         {
             if (address == null)
             {
-                return TaskEx.Completed;
+                return;
             }
             var msmqAddress = MsmqAddress.Parse(address);
             var queuePath = msmqAddress.PathWithoutPrefix;
@@ -48,25 +63,25 @@ namespace NServiceBus.Transports.Msmq
                 if (MessageQueue.Exists(queuePath))
                 {
                     Logger.Debug("Queue exists, going to set permissions.");
-                    SetPermissionsForQueue(queuePath, account);
-                    return TaskEx.Completed;
+                    SetPermissionsForQueue(queuePath, identity);
+                    return;
                 }
 
                 Logger.Warn("Queue " + queuePath + " does not exist.");
                 Logger.Debug("Going to create queue: " + queuePath);
 
-                CreateQueue(queuePath, account, settings.UseTransactionalQueues);
+                CreateQueue(queuePath, identity, settings.UseTransactionalQueues);
             }
             catch (MessageQueueException ex)
             {
                 if (msmqAddress.IsRemote && (ex.MessageQueueErrorCode == MessageQueueErrorCode.IllegalQueuePathName))
                 {
-                    return TaskEx.Completed;
+                    return;
                 }
                 if (ex.MessageQueueErrorCode == MessageQueueErrorCode.QueueExists)
                 {
                     //Solve the race condition problem when multiple endpoints try to create same queue (e.g. error queue).
-                    return TaskEx.Completed;
+                    return;
                 }
                 Logger.Error($"Could not create queue {address} or check its existence. Processing will still continue.", ex);
             }
@@ -75,9 +90,9 @@ namespace NServiceBus.Transports.Msmq
                 Logger.Error($"Could not create queue {address} or check its existence. Processing will still continue.", ex);
             }
 
-            return TaskEx.Completed;
+            Logger.DebugFormat("Verified that the queue: [{0}] existed", address);
         }
-        
+
         static void CreateQueue(string queuePath, string account, bool transactional)
         {
             using (var queue = MessageQueue.Create(queuePath, transactional))
@@ -85,7 +100,7 @@ namespace NServiceBus.Transports.Msmq
                 SetPermissionsForQueue(queue, account);
             }
 
-            Logger.DebugFormat("Created queue, path: [{0}], account: [{1}], transactional: [{2}]", queuePath, account, transactional);
+            Logger.DebugFormat("Created queue, path: [{0}], identity: [{1}], transactional: [{2}]", queuePath, account, transactional);
         }
 
         static void SetPermissionsForQueue(string queuePath, string account)
@@ -111,8 +126,9 @@ namespace NServiceBus.Transports.Msmq
         }
 
         internal static string LocalAdministratorsGroupName = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null).Translate(typeof(NTAccount)).ToString();
-        internal static string LocalEveryoneGroupName = new SecurityIdentifier(WellKnownSidType.WorldSid, null).Translate(typeof(NTAccount)).ToString();
-        internal static string LocalAnonymousLogonName = new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Translate(typeof(NTAccount)).ToString();
 
+        internal static string LocalEveryoneGroupName = new SecurityIdentifier(WellKnownSidType.WorldSid, null).Translate(typeof(NTAccount)).ToString();
+
+        internal static string LocalAnonymousLogonName = new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Translate(typeof(NTAccount)).ToString();
     }
 }


### PR DESCRIPTION
Connects to #3076 

Creation of queues is async and done in parallel. I decided to go for parallel because this can speed up the installation process drastically. The downside of this would be that for example for SqlServer transport, since the connection is not thread safe, each `CreateQueueIfNecessary` would require its own connection. Thoughts?

@Particular/tf-asyncawait please review