### PR TITLE
removed Get<IncomingMessage>() usages from IncomingContext

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2110,7 +2110,7 @@ namespace NServiceBus.Pipeline.Contexts
 {
     public abstract class IncomingContext : NServiceBus.Pipeline.BehaviorContext, NServiceBus.IBusContext, NServiceBus.IMessageProcessingContext
     {
-        protected IncomingContext(NServiceBus.Pipeline.BehaviorContext parentContext) { }
+        protected IncomingContext(string messageId, string replyToAddress, System.Collections.Generic.IReadOnlyDictionary<string, string> headers, NServiceBus.Pipeline.BehaviorContext parentContext) { }
         public NServiceBus.Extensibility.ContextBag Extensions { get; }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> MessageHeaders { get; }
         public string MessageId { get; }
@@ -2127,7 +2127,7 @@ namespace NServiceBus.Pipeline.Contexts
     }
     public class InvokeHandlerContext : NServiceBus.Pipeline.Contexts.IncomingContext, NServiceBus.IBusContext, NServiceBus.IMessageHandlerContext, NServiceBus.IMessageProcessingContext
     {
-        public InvokeHandlerContext(NServiceBus.Unicast.Behaviors.MessageHandler handler, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.Unicast.Messages.MessageMetadata messageMetadata, object messageBeingHandled, NServiceBus.Pipeline.BehaviorContext parentContext) { }
+        public InvokeHandlerContext(NServiceBus.Unicast.Behaviors.MessageHandler handler, string messageId, string replyToAddress, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.Unicast.Messages.MessageMetadata messageMetadata, object messageBeingHandled, NServiceBus.Pipeline.BehaviorContext parentContext) { }
         public bool HandlerInvocationAborted { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public object MessageBeingHandled { get; }
@@ -2138,7 +2138,7 @@ namespace NServiceBus.Pipeline.Contexts
     }
     public class LogicalMessageProcessingContext : NServiceBus.Pipeline.Contexts.IncomingContext
     {
-        public LogicalMessageProcessingContext(NServiceBus.Unicast.Messages.LogicalMessage logicalMessage, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.Pipeline.BehaviorContext parentContext) { }
+        public LogicalMessageProcessingContext(NServiceBus.Unicast.Messages.LogicalMessage logicalMessage, string messageId, string replyToAddress, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.Pipeline.BehaviorContext parentContext) { }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public NServiceBus.Unicast.Messages.LogicalMessage Message { get; }
         public bool MessageHandled { get; set; }

--- a/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_incoming_messages.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_incoming_messages.cs
@@ -43,10 +43,11 @@ namespace NServiceBus.Core.Tests.DataBus
 
                 fakeDatabus.StreamsToReturn[databusKey] = stream;
 
-
                 await receiveBehavior.Invoke(
                     new LogicalMessageProcessingContext(
                         message,
+                        "messageId",
+                        "replyToAddress",
                         new Dictionary<string, string>
                         {
                             {"NServiceBus.DataBus." + propertyKey, databusKey}

--- a/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
@@ -226,11 +226,9 @@ namespace NServiceBus.Core.Tests.Pipeline
 
         class ChildContext : IncomingContext
         {
-            public ChildContext() : base(null)
+            public ChildContext() : base("messageId", "replyToAddress", new Dictionary<string, string>(), null)
             {
             }
         }
-
-     
     }
 }

--- a/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
@@ -143,6 +143,8 @@
         {
             var behaviorContext = new InvokeHandlerContext(
                 messageHandler,
+                "messageId",
+                "replyToAddress",
                 new Dictionary<string, string>(),
                 null,
                 null,

--- a/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
@@ -16,7 +16,11 @@
             var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(new Conventions()));
 
             var context = new LogicalMessageProcessingContext(
-                new LogicalMessage(new MessageMetadata(typeof(string)), null, null), new Dictionary<string, string>(), null);
+                new LogicalMessage(new MessageMetadata(typeof(string)), null, null), 
+                "messageId",
+                "replyToAddress",
+                new Dictionary<string, string>(), 
+                null);
 
             Assert.Throws<InvalidOperationException>(async () => await behavior.Invoke(context, c => Task.FromResult(0)));
         }

--- a/src/NServiceBus.Core/Pipeline/Incoming/IncomingContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IncomingContext.cs
@@ -4,7 +4,6 @@
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
-    using NServiceBus.Transports;
     using NServiceBus.Unicast;
     using PublishOptions = NServiceBus.PublishOptions;
     using ReplyOptions = NServiceBus.ReplyOptions;
@@ -18,22 +17,26 @@
         /// <summary>
         /// Initializes a new instance of <see cref="IncomingContext" />.
         /// </summary>
-        protected IncomingContext(BehaviorContext parentContext)
+        protected IncomingContext(string messageId, string replyToAddress, IReadOnlyDictionary<string, string> headers, BehaviorContext parentContext)
             : base(parentContext)
         {
+
+            this.MessageId = messageId;
+            this.ReplyToAddress = replyToAddress;
+            this.MessageHeaders = headers;
         }
 
         /// <inheritdoc />
         public ContextBag Extensions => this;
 
         /// <inheritdoc />
-        public string MessageId => Get<IncomingMessage>().MessageId;
+        public string MessageId { get; }
 
         /// <inheritdoc />
-        public string ReplyToAddress => Get<IncomingMessage>().GetReplyToAddress();
+        public string ReplyToAddress { get; }
 
         /// <inheritdoc />
-        public IReadOnlyDictionary<string, string> MessageHeaders => Get<IncomingMessage>().Headers;
+        public IReadOnlyDictionary<string, string> MessageHeaders { get; }
 
         /// <inheritdoc />
         public Task SendAsync(object message, SendOptions options)

--- a/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerContext.cs
@@ -15,15 +15,15 @@ namespace NServiceBus.Pipeline.Contexts
         /// Initializes the handling stage context. This is the constructor to use for internal usage.
         /// </summary>
         internal InvokeHandlerContext(MessageHandler handler, LogicalMessageProcessingContext parentContext)
-            : this(handler, parentContext.Headers, parentContext.Message.Metadata, parentContext.Message.Instance, parentContext)
+            : this(handler, parentContext.MessageId, parentContext.ReplyToAddress, parentContext.Headers, parentContext.Message.Metadata, parentContext.Message.Instance, parentContext)
         {
         }
 
         /// <summary>
         /// Initializes the handling stage context.
         /// </summary>
-        public InvokeHandlerContext(MessageHandler handler, Dictionary<string, string> headers, MessageMetadata messageMetadata, object messageBeingHandled, BehaviorContext parentContext)
-            : base(parentContext)
+        public InvokeHandlerContext(MessageHandler handler, string messageId, string replyToAddress, Dictionary<string, string> headers, MessageMetadata messageMetadata, object messageBeingHandled, BehaviorContext parentContext)
+            : base(messageId, replyToAddress, headers, parentContext)
         {
             MessageHandler = handler;
             Headers = headers;

--- a/src/NServiceBus.Core/Pipeline/Incoming/LogicalMessageProcessingContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/LogicalMessageProcessingContext.cs
@@ -14,7 +14,7 @@
         /// <param name="logicalMessage">The logical message.</param>
         /// <param name="parentContext">The wrapped context.</param>
         internal LogicalMessageProcessingContext(LogicalMessage logicalMessage, PhysicalMessageProcessingContext parentContext)
-            : this(logicalMessage, parentContext.Message.Headers, parentContext)
+            : this(logicalMessage, parentContext.MessageId, parentContext.ReplyToAddress, parentContext.Message.Headers, parentContext)
         {
         }
 
@@ -22,10 +22,12 @@
         /// Initializes a new instance of <see cref="LogicalMessageProcessingContext" />.
         /// </summary>
         /// <param name="logicalMessage">The logical message.</param>
+        /// <param name="messageId">The id of the incoming message.</param>
+        /// <param name="replyToAddress">The address to reply to the incoming message.</param>
         /// <param name="headers">The messages headers.</param>
         /// <param name="parentContext">The wrapped context.</param>
-        public LogicalMessageProcessingContext(LogicalMessage logicalMessage, Dictionary<string, string> headers, BehaviorContext parentContext)
-            : base(parentContext)
+        public LogicalMessageProcessingContext(LogicalMessage logicalMessage, string messageId, string replyToAddress, Dictionary<string, string> headers, BehaviorContext parentContext)
+            : base(messageId, replyToAddress, headers, parentContext)
         {
             Message = logicalMessage;
             Headers = headers;

--- a/src/NServiceBus.Core/Pipeline/Incoming/PhysicalMessageProcessingContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/PhysicalMessageProcessingContext.cs
@@ -13,7 +13,7 @@
         /// Initializes a new instance of <see cref="PhysicalMessageProcessingContext" />.
         /// </summary>
         public PhysicalMessageProcessingContext(IncomingMessage message, BehaviorContext parentContext)
-            : base(parentContext)
+            : base(message.MessageId, message.GetReplyToAddress(), message.Headers, parentContext)
         {
             Message = message;
         }

--- a/src/NServiceBus.Core/Serializers/XML/Config/XmlSerialization.cs
+++ b/src/NServiceBus.Core/Serializers/XML/Config/XmlSerialization.cs
@@ -13,7 +13,7 @@
     /// </summary>
     public class XmlSerialization : ConfigureSerialization
     {
-        internal XmlSerialization() 
+        internal XmlSerialization()
         {
             RegisterStartupTask<MessageTypesInitializer>();
         }

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadata.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadata.cs
@@ -8,8 +8,7 @@
     /// </summary>
     public partial class MessageMetadata
     {
-        
-        internal MessageMetadata(Type messageType = null, IEnumerable<Type> messageHierarchy = null)
+        internal MessageMetadata(Type messageType, IEnumerable<Type> messageHierarchy = null)
         {
             MessageType = messageType;
             MessageHierarchy = (messageHierarchy == null ? new List<Type>() : new List<Type>(messageHierarchy)).AsReadOnly();


### PR DESCRIPTION
force all properties on a context to be provided via constructor to avoid magic setups in the ContextBag hierarchy within the same Pipeline.

Connects to Particular/PlatformDevelopment#187