### PR TITLE
CriticalError supports async callbacks

### DIFF
--- a/src/NServiceBus.AcceptanceTests/CriticalError/When_registering_a_custom_criticalErrorHandler.cs
+++ b/src/NServiceBus.AcceptanceTests/CriticalError/When_registering_a_custom_criticalErrorHandler.cs
@@ -52,6 +52,7 @@
                         context.Exception = aggregateException.InnerExceptions.First();
                         context.Message = s;
                         context.ExceptionReceived = true;
+                        return Task.FromResult(0);
                     });
                 });
             }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -132,7 +132,7 @@ namespace NServiceBus
     }
     public class static ConfigureCriticalErrorAction
     {
-        public static void DefineCriticalErrorAction(this NServiceBus.BusConfiguration busConfiguration, System.Action<string, System.Exception> onCriticalError) { }
+        public static void DefineCriticalErrorAction(this NServiceBus.BusConfiguration busConfiguration, System.Func<string, System.Exception, System.Threading.Tasks.Task> onCriticalError) { }
     }
     public class static ConfigureError
     {
@@ -225,8 +225,8 @@ namespace NServiceBus
     }
     public class CriticalError
     {
-        public CriticalError(System.Action<string, System.Exception> onCriticalErrorAction, NServiceBus.ObjectBuilder.IBuilder builder) { }
-        public virtual void Raise(string errorMessage, System.Exception exception) { }
+        public CriticalError(System.Func<string, System.Exception, System.Threading.Tasks.Task> onCriticalErrorAction, NServiceBus.ObjectBuilder.IBuilder builder) { }
+        public virtual System.Threading.Tasks.Task Raise(string errorMessage, System.Exception exception) { }
     }
     public class static CriticalTimeMonitoringConfig
     {

--- a/src/NServiceBus.Core.Tests/Faults/ForwardFaultsToErrorQueueTests.cs
+++ b/src/NServiceBus.Core.Tests/Faults/ForwardFaultsToErrorQueueTests.cs
@@ -154,13 +154,14 @@ namespace NServiceBus.Core.Tests
         class FakeCriticalError : CriticalError
         {
             public FakeCriticalError()
-                : base((s, e) => { }, new FakeBuilder())
+                : base((s, e) => TaskEx.Completed, new FakeBuilder())
             {
             }
 
-            public override void Raise(string errorMessage, Exception exception)
+            public override Task Raise(string errorMessage, Exception exception)
             {
                 ErrorRaised = true;
+                return TaskEx.Completed;
             }
 
             public bool ErrorRaised { get; private set; }

--- a/src/NServiceBus.Core/CriticalError/ConfigureCriticalErrorAction.cs
+++ b/src/NServiceBus.Core/CriticalError/ConfigureCriticalErrorAction.cs
@@ -1,23 +1,22 @@
 namespace NServiceBus
 {
     using System;
-
+    using System.Threading.Tasks;
 
     /// <summary>
-    ///     Allow override critical error action.
+    /// Allow override critical error action.
     /// </summary>
     public static class ConfigureCriticalErrorAction
     {
-
         /// <summary>
-        ///     Sets the function to be used when critical error occurs.
+        /// Sets the function to be used when critical error occurs.
         /// </summary>
-        /// <param name="busConfiguration">The <see cref="BusConfiguration"/> to extend.</param>
+        /// <param name="busConfiguration">The <see cref="BusConfiguration" /> to extend.</param>
         /// <param name="onCriticalError">Assigns the action to perform on critical error.</param>
-        public static void DefineCriticalErrorAction(this BusConfiguration busConfiguration, Action<string, Exception> onCriticalError)
+        public static void DefineCriticalErrorAction(this BusConfiguration busConfiguration, Func<string, Exception, Task> onCriticalError)
         {
-            Guard.AgainstNull("busConfiguration", busConfiguration);
-            Guard.AgainstNull("onCriticalError", onCriticalError);
+            Guard.AgainstNull(nameof(busConfiguration), busConfiguration);
+            Guard.AgainstNull(nameof(onCriticalError), onCriticalError);
             busConfiguration.Settings.Set("onCriticalErrorAction", onCriticalError);
         }
     }

--- a/src/NServiceBus.Core/CriticalError/CriticalError.cs
+++ b/src/NServiceBus.Core/CriticalError/CriticalError.cs
@@ -1,19 +1,19 @@
 namespace NServiceBus
 {
     using System;
-    using System.Threading;
+    using System.Threading.Tasks;
     using NServiceBus.Logging;
     using NServiceBus.ObjectBuilder;
 
     /// <summary>
-    /// A holder for that exposes access to the action defined by <see cref="ConfigureCriticalErrorAction.DefineCriticalErrorAction(BusConfiguration,Action{string,Exception})"/>.
+    /// A holder for that exposes access to the action defined by <see cref="ConfigureCriticalErrorAction.DefineCriticalErrorAction(BusConfiguration,Func{string, Exception, Task})"/>.
     /// </summary>
     /// <returns>
     /// Call <see cref="Raise"/> to trigger the action.
     /// </returns>
     public class CriticalError
     {
-        Action<string, Exception> onCriticalErrorAction;
+        Func<string, Exception, Task> onCriticalErrorAction;
         IBuilder builder;
       
         /// <summary>
@@ -21,43 +21,35 @@ namespace NServiceBus
         /// </summary>
         /// <param name="onCriticalErrorAction">The action to execute when a critical error is triggered.</param>
         /// <param name="builder">The <see cref="IBuilder"/> instance.</param>
-        public CriticalError(Action<string, Exception> onCriticalErrorAction, IBuilder builder)
+        public CriticalError(Func<string, Exception, Task> onCriticalErrorAction, IBuilder builder)
         {
-            Guard.AgainstNull("builder", builder);
+            Guard.AgainstNull(nameof(builder), builder);
 
-            this.onCriticalErrorAction = onCriticalErrorAction;
+            this.onCriticalErrorAction = onCriticalErrorAction ?? DefaultCriticalErrorHandling;
             this.builder = builder;
         }
 
-        void DefaultCriticalErrorHandling()
+        Task DefaultCriticalErrorHandling(string errorMessage, Exception exception)
         {
             var components = builder.Build<IConfigureComponents>();
             if (!components.HasComponent<IEndpoint>())
             {
-                return;
+                return TaskEx.Completed;
             }
 
-            builder.Build<IEndpoint>()
-                .Stop().GetAwaiter().GetResult();
+            return builder.Build<IEndpoint>().Stop();
         }
 
         /// <summary>
-        /// Trigger the action defined by <see cref="ConfigureCriticalErrorAction.DefineCriticalErrorAction(BusConfiguration,Action{string,Exception})"/>.
+        /// Trigger the action defined by <see cref="ConfigureCriticalErrorAction.DefineCriticalErrorAction(BusConfiguration,Func{string, Exception, Task})"/>.
         /// </summary>
-        public virtual void Raise(string errorMessage, Exception exception)
+        public virtual Task Raise(string errorMessage, Exception exception)
         {
-            Guard.AgainstNullAndEmpty("errorMessage", errorMessage);
-            Guard.AgainstNull("exception", exception);
+            Guard.AgainstNullAndEmpty(nameof(errorMessage), errorMessage);
+            Guard.AgainstNull(nameof(exception), exception);
             LogManager.GetLogger("NServiceBus").Fatal(errorMessage, exception);
 
-            if (onCriticalErrorAction == null)
-            {
-                ThreadPool.QueueUserWorkItem(state => DefaultCriticalErrorHandling());
-            }
-            else
-            {
-                ThreadPool.QueueUserWorkItem(state => onCriticalErrorAction(errorMessage, exception));
-            }
+            return onCriticalErrorAction(errorMessage, exception);
         }
     }
 }

--- a/src/NServiceBus.Core/CriticalError/CriticalErrorHandling.cs
+++ b/src/NServiceBus.Core/CriticalError/CriticalErrorHandling.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Features
 {
     using System;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Controls what happens when a critical error occurs.
@@ -8,23 +9,21 @@ namespace NServiceBus.Features
     class CriticalErrorHandling : Feature
     {
         /// <summary>
-        /// Initializes a enw instance of <see cref="CriticalErrorHandling"/>.
+        /// Initializes a new instance of <see cref="CriticalErrorHandling" />.
         /// </summary>
         internal CriticalErrorHandling()
         {
             EnableByDefault();
         }
 
-
         /// <summary>
-        /// <see cref="Feature.Setup"/>.
+        /// <see cref="Feature.Setup" />.
         /// </summary>
         protected internal override void Setup(FeatureConfigurationContext context)
         {
-            Action<string, Exception> errorAction;
+            Func<string, Exception, Task> errorAction;
             context.Settings.TryGet("onCriticalErrorAction", out errorAction);
             context.Container.ConfigureComponent(builder => new CriticalError(errorAction, builder), DependencyLifecycle.SingleInstance);
         }
-
     }
 }

--- a/src/NServiceBus.Core/Recoverability/Faults/MoveFaultsToErrorQueueBehavior.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/MoveFaultsToErrorQueueBehavior.cs
@@ -60,7 +60,7 @@ namespace NServiceBus
                 }
                 catch (Exception ex)
                 {
-                    criticalError.Raise("Failed to forward message to error queue", ex);
+                    await criticalError.Raise("Failed to forward message to error queue", ex).ConfigureAwait(false);
                     throw;
                 }
             }


### PR DESCRIPTION
CriticalError now requires a `Func<string, Exception, Task>` instead of `Action<string, Exception>`. This allows callers of CriticalError to await asynchronous critical error callbacks.