### PR TITLE
Removed unnecessary state in EncryptionMutator to fix multi threading issues

### DIFF
--- a/src/NServiceBus.Core/Encryption/EncryptionMutator.cs
+++ b/src/NServiceBus.Core/Encryption/EncryptionMutator.cs
@@ -67,7 +67,12 @@ namespace NServiceBus.Encryption
             return false;
         }
 
-        void ForEachMember(object root, Action<object, MemberInfo> action, Func<MemberInfo, bool> appliesTo)
+        static void ForEachMember(object root, Action<object, MemberInfo> action, Func<MemberInfo, bool> appliesTo)
+        {
+            ForEachMember(root, new HashSet<object>(), action, appliesTo);
+        }
+
+        static void ForEachMember(object root, ISet<object> visitedMembers, Action<object, MemberInfo> action, Func<MemberInfo, bool> appliesTo)
         {
             if (root == null || visitedMembers.Contains(root))
             {
@@ -120,12 +125,12 @@ namespace NServiceBus.Encryption
                             break;
                         }
 
-                        ForEachMember(item, action, appliesTo);
+                        ForEachMember(item, visitedMembers, action, appliesTo);
                     }
                 }
                 else
                 {
-                    ForEachMember(child, action, appliesTo);
+                    ForEachMember(child, visitedMembers, action, appliesTo);
                 }
             }
         }
@@ -257,8 +262,6 @@ namespace NServiceBus.Encryption
 
             return members;
         }
-
-        HashSet<object> visitedMembers = new HashSet<object>();
 
         static ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<MemberInfo>> cache = new ConcurrentDictionary<RuntimeTypeHandle, IEnumerable<MemberInfo>>();
 

--- a/src/NServiceBus.Core/Encryption/Encryptor.cs
+++ b/src/NServiceBus.Core/Encryption/Encryptor.cs
@@ -12,7 +12,7 @@
     /// <summary>
     /// Used to configure encryption.
     /// </summary>
-    public class Encryptor:Feature
+    public class Encryptor : Feature
     {
         Func<IBuilder, IEncryptionService> serviceConstructor;
 
@@ -67,11 +67,12 @@ Perhaps you forgot to define your encryption message conventions or to define me
         protected internal override void Setup(FeatureConfigurationContext context)
         {
             context.Container.ConfigureComponent(serviceConstructor, DependencyLifecycle.SingleInstance);
-            context.Container.ConfigureComponent<EncryptionMutator>(DependencyLifecycle.InstancePerCall);
+            context.Container.ConfigureComponent<EncryptionMutator>(DependencyLifecycle.SingleInstance);
 
             context.Pipeline.Register<EncryptBehavior.EncryptRegistration>();
             context.Pipeline.Register<DecryptBehavior.DecryptRegistration>();
         }
+
         static ILog log = LogManager.GetLogger<Encryptor>();
     }
 }


### PR DESCRIPTION
Found by @hmemcpy and the perf test suite. Since with V6 behaviors became pipeline static the `EncryptionMutator` was reused and multiple threads tried to access the `visitedMembers` HashSet.