### PR TITLE
Fix for #3091 on v3.3.x

### DIFF
--- a/src/impl/encryption/NServiceBus.Encryption.Rijndael/EncryptionService.cs
+++ b/src/impl/encryption/NServiceBus.Encryption.Rijndael/EncryptionService.cs
@@ -171,11 +171,7 @@ namespace NServiceBus.Encryption.Rijndael
 
         protected virtual void AddKeyIdentifierHeader()
         {
-            var headers = Bus.OutgoingHeaders;
-            if (!headers.ContainsKey(Headers.RijndaelKeyIdentifier))
-            {
-                headers.Add(Headers.RijndaelKeyIdentifier, EncryptionKeyIdentifier);
-            }
+            Bus.OutgoingHeaders[Headers.RijndaelKeyIdentifier] = EncryptionKeyIdentifier;
         }
 
         protected virtual bool TryGetKeyIdentifierHeader(out string keyIdentifier)


### PR DESCRIPTION
Now using indexer which overwrites the current value if already present. Not moved to constructor due to documentation OutgoingHeaders property "This value will be cleared when a thread receives a message."

Connects to #3091