### PR TITLE
Hotfix 5.2.11

### DIFF
--- a/src/NServiceBus.Core.Tests/Encryption/ConfigureRijndaelEncryptionServiceTests.cs
+++ b/src/NServiceBus.Core.Tests/Encryption/ConfigureRijndaelEncryptionServiceTests.cs
@@ -119,7 +119,7 @@
         public void Should_throw_for_no_key_in_config()
         {
             var config = new RijndaelEncryptionServiceConfig();
-            var exception = Assert.Throws<Exception>(() => ConfigureRijndaelEncryptionService.ConvertConfigToRijndaelService(null, config));
+            var exception = Assert.Throws<Exception>(() => ConfigureRijndaelEncryptionService.ConvertConfigToRijndaelService(config));
             Assert.AreEqual("The RijndaelEncryptionServiceConfig has an empty 'Key' property.", exception.Message);
         }
 
@@ -130,7 +130,7 @@
             {
                 Key = " "
             };
-            var exception = Assert.Throws<Exception>(() => ConfigureRijndaelEncryptionService.ConvertConfigToRijndaelService(null, config));
+            var exception = Assert.Throws<Exception>(() => ConfigureRijndaelEncryptionService.ConvertConfigToRijndaelService(config));
             Assert.AreEqual("The RijndaelEncryptionServiceConfig has an empty 'Key' property.", exception.Message);
         }
 

--- a/src/NServiceBus.Core.Tests/Encryption/ConventionBasedEncryptedStringSpecs.cs
+++ b/src/NServiceBus.Core.Tests/Encryption/ConventionBasedEncryptedStringSpecs.cs
@@ -5,16 +5,16 @@
     using Conventions = NServiceBus.Conventions;
 
     [TestFixture]
-    public class When_sending_a_message_with_user_defined_convention:UserDefinedConventionContext
+    public class When_sending_a_message_with_user_defined_convention : UserDefinedConventionContext
     {
         [Test]
         public void Should_encrypt_the_value()
-        {    
+        {
             var message = new ConventionBasedSecureMessage
-                          {
-                                  EncryptedSecret = "A secret"
-                              };
-            mutator.MutateOutgoing(message);
+            {
+                EncryptedSecret = "A secret"
+            };
+            mutator.MutateOutgoing(message, null);
 
             Assert.AreEqual(string.Format("{0}@{1}", "encrypted value", "init_vector"), message.EncryptedSecret);
         }
@@ -27,22 +27,22 @@
         public void Should_encrypt_the_value()
         {
             var message = new ConventionBasedSecureMessage
-                          {
-                              EncryptedSecret = "encrypted value@init_vector"
-                          };
-            mutator.MutateIncoming(message);
+            {
+                EncryptedSecret = "encrypted value@init_vector"
+            };
+            mutator.MutateIncoming(message, null);
 
             Assert.AreEqual("A secret", message.EncryptedSecret);
         }
     }
 
     [TestFixture]
-    public class When_encrypting_a_property_that_is_not_a_string:UserDefinedConventionContext
+    public class When_encrypting_a_property_that_is_not_a_string : UserDefinedConventionContext
     {
         [Test]
         public void Should_throw_an_exception()
         {
-            var exception = Assert.Throws<Exception>(() => mutator.MutateOutgoing(new MessageWithNonStringSecureProperty()));
+            var exception = Assert.Throws<Exception>(() => mutator.MutateOutgoing(new MessageWithNonStringSecureProperty(), null));
             Assert.AreEqual("Only string properties is supported for convention based encryption, please check your convention", exception.Message);
         }
     }
@@ -53,7 +53,7 @@
         [Test]
         public void Should_throw_an_exception()
         {
-            var exception = Assert.Throws<Exception>(() => mutator.MutateIncoming(new MessageWithNonStringSecureProperty()));
+            var exception = Assert.Throws<Exception>(() => mutator.MutateIncoming(new MessageWithNonStringSecureProperty(), null));
             Assert.AreEqual("Only string properties is supported for convention based encryption, please check your convention", exception.Message);
         }
     }
@@ -64,7 +64,7 @@
         {
             return new Conventions
             {
-                IsEncryptedPropertyAction= p => p.Name.StartsWith("Encrypted")
+                IsEncryptedPropertyAction = p => p.Name.StartsWith("Encrypted")
             };
         }
     }
@@ -74,7 +74,7 @@
         public int EncryptedInt { get; set; }
     }
 
-    public class ConventionBasedSecureMessage:IMessage
+    public class ConventionBasedSecureMessage : IMessage
     {
         public string EncryptedSecret { get; set; }
         public string EncryptedSecretThatIsNull { get; set; }

--- a/src/NServiceBus.Core.Tests/Encryption/Issue_701.cs
+++ b/src/NServiceBus.Core.Tests/Encryption/Issue_701.cs
@@ -13,7 +13,7 @@
                 Name = "John"
             };
 
-            var result = (TestMessageWithSets)mutator.MutateOutgoing(message);
+            var result = (TestMessageWithSets)mutator.MutateOutgoing(message, null);
 
             Assert.AreEqual("John", result.Name);
         }
@@ -26,7 +26,7 @@
                 Name = "John"
             };
 
-            var result = (TestMessageWithGets)mutator.MutateOutgoing(message);
+            var result = (TestMessageWithGets)mutator.MutateOutgoing(message, null);
 
             Assert.AreEqual("John", result.Name);
         }
@@ -37,7 +37,7 @@
 
             public string Options1
             {
-// ReSharper disable once ValueParameterNotUsed
+                // ReSharper disable once ValueParameterNotUsed
                 set
                 {
                     //do nothing
@@ -46,7 +46,7 @@
 
             public int Options2
             {
-// ReSharper disable once ValueParameterNotUsed
+                // ReSharper disable once ValueParameterNotUsed
                 set
                 {
                     //do nothing

--- a/src/NServiceBus.Core.Tests/Encryption/Issue_949.cs
+++ b/src/NServiceBus.Core.Tests/Encryption/Issue_949.cs
@@ -14,7 +14,7 @@
                 Data = new int?[] {null, 1}
             };
 
-            mutator.MutateOutgoing(message);
+            mutator.MutateOutgoing(message, null);
 
             Assert.AreEqual(new int?[] { null, 1}, message.Data);
         }
@@ -27,7 +27,7 @@
                 Data = new object[] {null, this, null}
             };
 
-            mutator.MutateOutgoing(message);
+            mutator.MutateOutgoing(message, null);
 
             Assert.AreEqual(new object[] { null, this,null }, message.Data);
             

--- a/src/NServiceBus.Core.Tests/Encryption/Mailing_list_complex_dto.cs
+++ b/src/NServiceBus.Core.Tests/Encryption/Mailing_list_complex_dto.cs
@@ -16,7 +16,7 @@
 
             message.Options[TestEnum.EnumValue1]["test"] = "aString";
 
-            var result = (TestDto)mutator.MutateOutgoing(message);
+            var result = (TestDto)mutator.MutateOutgoing(message, null);
 
             Assert.True(result.Options.ContainsKey(TestEnum.EnumValue1));
         }

--- a/src/NServiceBus.Core.Tests/Encryption/When_message_contains_props_and_fields_that_cannot_be_set.cs
+++ b/src/NServiceBus.Core.Tests/Encryption/When_message_contains_props_and_fields_that_cannot_be_set.cs
@@ -11,8 +11,8 @@
         {
             var message = new BogusEntityMessage{ Entity = new BogusEntity()};
 
-            Assert.DoesNotThrow(() => mutator.MutateIncoming(message));
-            Assert.DoesNotThrow(() => mutator.MutateOutgoing(message));
+            Assert.DoesNotThrow(() => mutator.MutateIncoming(message, null));
+            Assert.DoesNotThrow(() => mutator.MutateOutgoing(message, null));
         }
 
         public class BogusEntityMessage : IMessage

--- a/src/NServiceBus.Core.Tests/Encryption/WireEncryptedStringSpecs.cs
+++ b/src/NServiceBus.Core.Tests/Encryption/WireEncryptedStringSpecs.cs
@@ -28,7 +28,7 @@
                 };
             message.ListOfSecrets = new ArrayList(message.ListOfCreditCards);
 
-            mutator.MutateOutgoing(message);
+            mutator.MutateOutgoing(message, null);
 
             Assert.AreEqual(EncryptedBase64Value, message.Secret.EncryptedValue.EncryptedBase64Value);
             Assert.AreEqual(EncryptedBase64Value, message.SecretField.EncryptedValue.EncryptedBase64Value);
@@ -55,7 +55,7 @@
             message[0] = "boo";
             message[1] = "foo";
 
-            mutator.MutateOutgoing(message);
+            mutator.MutateOutgoing(message, null);
 
             Assert.AreEqual("boo", message[0]);
             Assert.AreEqual("foo", message[1]);
@@ -87,7 +87,7 @@
             message[0] = MySecretMessage;
             message[1] = MySecretMessage;
 
-            var exception = Assert.Throws<Exception>(() => mutator.MutateOutgoing(message));
+            var exception = Assert.Throws<Exception>(() => mutator.MutateOutgoing(message, null));
             Assert.AreEqual("Cannot encrypt or decrypt indexed properties that return a WireEncryptedString.", exception.Message);
         }
 
@@ -118,7 +118,7 @@
             child.Self = child;
             child.Parent = message;
 
-            mutator.MutateOutgoing(message);
+            mutator.MutateOutgoing(message, null);
 
             Assert.AreEqual(EncryptedBase64Value, message.Child.Secret.EncryptedValue.EncryptedBase64Value);
         }
@@ -138,7 +138,7 @@
             message[0] = "boo";
             message[1] = "foo";
 
-            mutator.MutateIncoming(message);
+            mutator.MutateIncoming(message, null);
 
             Assert.AreEqual("boo", message[0]);
             Assert.AreEqual("foo", message[1]);
@@ -171,7 +171,7 @@
 
                 };
 
-            mutator.MutateIncoming(message);
+            mutator.MutateIncoming(message, null);
 
             Assert.AreEqual(MySecretMessage, message.MySecret.Value);
         }
@@ -203,7 +203,7 @@
             child.Self = child;
             child.Parent = message;
 
-            mutator.MutateIncoming(message);
+            mutator.MutateIncoming(message, null);
 
             Assert.AreEqual(message.Child.Secret.Value, MySecretMessage);
 
@@ -223,7 +223,7 @@
                     Secret = new WireEncryptedString {Value = "The real value"}
                 };
 
-            var exception = Assert.Throws<Exception>(() => mutator.MutateIncoming(message));
+            var exception = Assert.Throws<Exception>(() => mutator.MutateIncoming(message, null));
             Assert.AreEqual("Encrypted property is missing encryption data", exception.Message);
         }
     }
@@ -236,7 +236,7 @@
         public void Should_decrypt_correctly()
         {
             var message = new SecureMessageWithProtectedSetter(Create());
-            mutator.MutateIncoming(message);
+            mutator.MutateIncoming(message, null);
 
             Assert.AreEqual(message.Secret.Value, MySecretMessage);
         }
@@ -252,7 +252,7 @@
                 {
                     Secret = MySecretMessage
                 };
-            mutator.MutateOutgoing(message);
+            mutator.MutateOutgoing(message, null);
 
             Assert.AreEqual(message.Secret.EncryptedValue.EncryptedBase64Value, EncryptedBase64Value);
             Assert.AreEqual(message.Secret.EncryptedBase64Value, null);
@@ -273,7 +273,7 @@
                     CreditCard = new CreditCardDetails {CreditCardNumber = Create()}
 
                 };
-            mutator.MutateIncoming(message);
+            mutator.MutateIncoming(message, null);
 
             Assert.AreEqual(MySecretMessage, message.Secret.Value);
             Assert.AreEqual(MySecretMessage, message.SecretField.Value);

--- a/src/NServiceBus.Core/Encryption/ConfigureRijndaelEncryptionService.cs
+++ b/src/NServiceBus.Core/Encryption/ConfigureRijndaelEncryptionService.cs
@@ -29,17 +29,16 @@ namespace NServiceBus
                     .Settings
                     .GetConfigSection<RijndaelEncryptionServiceConfig>();
 
-                return ConvertConfigToRijndaelService(context, section);
+                return ConvertConfigToRijndaelService(section);
             });
         }
 
-        internal static IEncryptionService ConvertConfigToRijndaelService(IBuilder builder, RijndaelEncryptionServiceConfig section)
+        internal static IEncryptionService ConvertConfigToRijndaelService(RijndaelEncryptionServiceConfig section)
         {
             ValidateConfigSection(section);
             var keys = ExtractKeysFromConfigSection(section);
             var decryptionKeys = ExtractDecryptionKeysFromConfigSection(section);
             return BuildRijndaelEncryptionService(
-                builder.Build<IBus>(),
                 section.KeyIdentifier,
                 keys,
                 decryptionKeys
@@ -121,7 +120,6 @@ namespace NServiceBus
             decryptionKeys.Insert(0, ParseKey(encryptionKey, KeyFormat.Ascii));
 
             RegisterEncryptionService(config, context => BuildRijndaelEncryptionService(
-                context.Build<IBus>(),
                 null,
                 new Dictionary<string, byte[]>(),
                 decryptionKeys
@@ -139,7 +137,6 @@ namespace NServiceBus
             decryptionKeys = decryptionKeys ?? new List<byte[]>();
 
             RegisterEncryptionService(config, context => BuildRijndaelEncryptionService(
-                context.Build<IBus>(),
                 encryptionKeyIdentifier,
                 new Dictionary<string, byte[]> { { encryptionKeyIdentifier, encryptionKey } },
                 decryptionKeys));
@@ -156,7 +153,6 @@ namespace NServiceBus
             decryptionKeys = decryptionKeys ?? new List<byte[]>();
 
             RegisterEncryptionService(config, context => BuildRijndaelEncryptionService(
-                context.Build<IBus>(),
                 encryptionKeyIdentifier,
                 keys,
                 decryptionKeys));
@@ -179,14 +175,12 @@ namespace NServiceBus
         }
 
         static IEncryptionService BuildRijndaelEncryptionService(
-            IBus bus,
             string encryptionKeyIdentifier,
             IDictionary<string, byte[]> keys,
             IList<byte[]> expiredKeys
             )
         {
             return new RijndaelEncryptionService(
-                bus,
                 encryptionKeyIdentifier,
                 keys,
                 expiredKeys

--- a/src/NServiceBus.Core/Encryption/DecryptBehavior.cs
+++ b/src/NServiceBus.Core/Encryption/DecryptBehavior.cs
@@ -22,7 +22,7 @@ namespace NServiceBus
                 return;
             }
             var current = context.IncomingLogicalMessage.Instance;
-            current = messageMutator.MutateIncoming(current);
+            current = messageMutator.MutateIncoming(current, context);
             context.IncomingLogicalMessage.UpdateMessageInstance(current);
             next();
         }

--- a/src/NServiceBus.Core/Encryption/EncryptBehavior.cs
+++ b/src/NServiceBus.Core/Encryption/EncryptBehavior.cs
@@ -24,7 +24,7 @@
             }
 
             var currentMessageToSend = context.OutgoingLogicalMessage.Instance;
-            currentMessageToSend = messageMutator.MutateOutgoing(currentMessageToSend);
+            currentMessageToSend = messageMutator.MutateOutgoing(currentMessageToSend, context);
             context.OutgoingLogicalMessage.UpdateMessageInstance(currentMessageToSend);
             next();
         }

--- a/src/NServiceBus.Core/Encryption/IEncryptionServiceWithContext.cs
+++ b/src/NServiceBus.Core/Encryption/IEncryptionServiceWithContext.cs
@@ -1,0 +1,17 @@
+namespace NServiceBus.Encryption
+{
+    using NServiceBus.Pipeline.Contexts;
+
+    interface IEncryptionServiceWithContext : IEncryptionService
+    {
+        /// <summary>
+        /// Encrypts the given value returning an EncryptedValue.
+        /// </summary>
+        EncryptedValue Encrypt(string value, OutgoingContext context);
+
+        /// <summary>
+        /// Decrypts the given EncryptedValue object returning the source string.
+        /// </summary>
+        string Decrypt(EncryptedValue encryptedValue, IncomingContext context);
+    }
+}

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Encryption\EncryptedValue.cs" />
     <Compile Include="Encryption\Encryptor.cs" />
     <Compile Include="Encryption\ConfigureRijndaelEncryptionService_Obsolete.cs" />
+    <Compile Include="Encryption\IEncryptionServiceWithContext.cs" />
     <Compile Include="Encryption\KeyFormat.cs" />
     <Compile Include="Encryption\RijndaelEncryptionServiceConfigValidations.cs" />
     <Compile Include="Encryption\RijndaelExpiredKey.cs" />


### PR DESCRIPTION
## Summary

We have discovered a race condition when using the encryption service which can result in an unhandled exception.

If the race condition occurs it will only happen once but if no exception handling is present the process could terminate.

The Rijndael encryption service modified the global headers resulting in all message to contain the key identifier header.

## Issues

- #3091 [Race condition in RijndaelEncryptionService can result in unhandled exception](https://github.com/Particular/NServiceBus/issues/3091).
- #3119 [RijndaelEncryptionService sets the outgoing headers globally, applying it to messages without encrypted properties as well](https://github.com/Particular/NServiceBus/issues/3119).


## Changes

In this patch release we addressed these issues.

- Setting of message header can not result in unhandled exception. (v3.3.18, v4.7.10, v5.0.9, v5.1.7, v5.2.11)
- Outgoing key identifier message header is not present on messages that do not have encrypted properties (v5.2.11)


## How to know if you might be affected

You are affected by the race condition when you:

- Use the latest version of the Encryption Service that uses the key identifier header to prevent potential data corruption.
- Send messages in parallel using the same bus instance.

Connects to #3091
Connects to #3119
