### PR TITLE
Hotfix 5.1.7

### DIFF
--- a/src/NServiceBus.Core.Tests/Encryption/RijndaelEncryptionServiceTest.cs
+++ b/src/NServiceBus.Core.Tests/Encryption/RijndaelEncryptionServiceTest.cs
@@ -85,17 +85,6 @@
         }
 
         [Test]
-        public void Encrypt_must_set_header()
-        {
-            var encryptionKey1 = Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6");
-            var service1 = new RijndaelEncryptionServiceWithFakeBus("encryptionKey1", encryptionKey1, new List<byte[]>());
-
-            Assert.AreEqual(false, service1.OutgoingKeyIdentifierSet);
-            service1.Encrypt("string to encrypt");
-            Assert.AreEqual(true, service1.OutgoingKeyIdentifierSet);
-        }
-
-        [Test]
         public void Decrypt_using_key_identifier()
         {
             var encryptionKey1 = Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6");
@@ -172,6 +161,24 @@
             {
                 service2.Decrypt(encryptedValue);
             }, "Unable to decrypt property using configured decryption key specified in key identifier header.");
+        }
+
+        [Test]
+        public void Should_set_header_when_created_and_has_value()
+        {
+            var encryptionKey1 = Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6");
+            var service1 = new RijndaelEncryptionServiceWithFakeBus("encryptionKey1", encryptionKey1, new List<byte[]>());
+
+            Assert.AreEqual(true, service1.OutgoingKeyIdentifierSet);
+        }
+
+        [Test]
+        public void Should_not_set_header_when_created_and_no_value()
+        {
+            var encryptionKey1 = Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6");
+            var service1 = new RijndaelEncryptionServiceWithFakeBus(null, encryptionKey1, new List<byte[]>());
+
+            Assert.AreEqual(false, service1.OutgoingKeyIdentifierSet);
         }
 
         class RijndaelEncryptionServiceWithFakeBus : RijndaelEncryptionService

--- a/src/NServiceBus.Core/Encryption/RijndaelEncryptionService.cs
+++ b/src/NServiceBus.Core/Encryption/RijndaelEncryptionService.cs
@@ -67,6 +67,9 @@ namespace NServiceBus.Encryption.Rijndael
             }
 
             VerifyExpiredKeys(decryptionKeys);
+
+            if (encryptionKeyIdentifier != null)
+                AddKeyIdentifierHeader();
         }
 
         public string Decrypt(EncryptedValue encryptedValue)
@@ -147,8 +150,6 @@ namespace NServiceBus.Encryption.Rijndael
                 throw new InvalidOperationException("It is required to set the rijndael key identifer.");
             }
 
-            AddKeyIdentifierHeader();
-
             using (var rijndael = new RijndaelManaged())
             {
                 rijndael.Key = encryptionKey;
@@ -208,12 +209,7 @@ namespace NServiceBus.Encryption.Rijndael
 
         protected virtual void AddKeyIdentifierHeader()
         {
-            var outgoingHeaders = bus.OutgoingHeaders;
-
-            if (!outgoingHeaders.ContainsKey(Headers.RijndaelKeyIdentifier))
-            {
-                outgoingHeaders.Add(Headers.RijndaelKeyIdentifier, encryptionKeyIdentifier);
-            }
+            bus.OutgoingHeaders[Headers.RijndaelKeyIdentifier] = encryptionKeyIdentifier;
         }
 
         protected virtual bool TryGetKeyIdentifierHeader(out string keyIdentifier)


### PR DESCRIPTION
## Summary

We have discovered a race condition when using the encryption service which can result in an unhandled exception.

If the race condition occurs it will only happen once but if no exception handling is present the process could terminate.

The Rijndael encryption service modified the global headers resulting in all message to contain the key identifier header. This is not a critical bus and only fixed in version 5.2.11

## Issues

- #3091 [Race condition in RijndaelEncryptionService can result in unhandled exception](https://github.com/Particular/NServiceBus/issues/3091).


## Changes

In this patch release we addressed these issues.

- Setting of message header can not result in unhandled exception. (v3.3.18, v4.7.10, v5.0.9, v5.1.7, v5.2.11)


## How to know if you might be affected

You are affected by the race condition when you:

- Use the latest version of the Encryption Service that uses the key identifier header to prevent potential data corruption.
- Send messages in parallel using the same bus instance.

Connects to #3091
Connects to #3119
