### PR TITLE
Hotfix 3.3.18

### DIFF
--- a/src/impl/encryption/NServiceBus.Encryption.Rijndael/EncryptionService.cs
+++ b/src/impl/encryption/NServiceBus.Encryption.Rijndael/EncryptionService.cs
@@ -171,11 +171,7 @@ namespace NServiceBus.Encryption.Rijndael
 
         protected virtual void AddKeyIdentifierHeader()
         {
-            var headers = Bus.OutgoingHeaders;
-            if (!headers.ContainsKey(Headers.RijndaelKeyIdentifier))
-            {
-                headers.Add(Headers.RijndaelKeyIdentifier, EncryptionKeyIdentifier);
-            }
+            Bus.OutgoingHeaders[Headers.RijndaelKeyIdentifier] = EncryptionKeyIdentifier;
         }
 
         protected virtual bool TryGetKeyIdentifierHeader(out string keyIdentifier)


### PR DESCRIPTION
## Summary

We have discovered a race condition when using the encryption service which can result in an unhandled exception.

If the race condition occurs it will only happen once but if no exception handling is present the process could terminate.

The Rijndael encryption service modified the global headers resulting in all message to contain the key identifier header. This is not a critical bus and only fixed in version 5.2.11

## Issues

- #3091 [Race condition in RijndaelEncryptionService can result in unhandled exception](https://github.com/Particular/NServiceBus/issues/3091).


## Changes

In this patch release we addressed these issues.

- Setting of message header can not result in unhandled exception. (v3.3.18, v4.7.10, v5.0.9, v5.1.7, v5.2.11)


## How to know if you might be affected

You are affected by the race condition when you:

- Use the latest version of the Encryption Service that uses the key identifier header to prevent potential data corruption.
- Send messages in parallel using the same bus instance.

Connects to #3091
Connects to #3119
