### PR TITLE
Throwing a meaningful exception when implementing INeedInitialization

### DIFF
--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_directory_with_nested_directories.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_directory_with_nested_directories.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Core.Tests.AssemblyScanner
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using NServiceBus.Core.Tests.Config;
     using NUnit.Framework;
 
     [TestFixture]
@@ -12,6 +13,7 @@ namespace NServiceBus.Core.Tests.AssemblyScanner
         public void Should_not_scan_nested_directories_by_default()
         {
             var busConfiguration = new BusConfiguration();
+            busConfiguration.ExcludeTypes(typeof(When_using_initialization_with_non_default_ctor.FeatureWithInitialization));
             busConfiguration.Build();
 
             var scanedTypes = busConfiguration.Settings.Get<IList<Type>>("TypesToScan");
@@ -25,6 +27,7 @@ namespace NServiceBus.Core.Tests.AssemblyScanner
         {
             var busConfiguration = new BusConfiguration();
             busConfiguration.ScanAssembliesInNestedDirectories();
+            busConfiguration.ExcludeTypes(typeof(When_using_initialization_with_non_default_ctor.FeatureWithInitialization));
             busConfiguration.Build();
 
             var scanedTypes = busConfiguration.Settings.Get<IList<Type>>("TypesToScan");

--- a/src/NServiceBus.Core.Tests/Config/When_using_initialization.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_using_initialization.cs
@@ -1,0 +1,36 @@
+﻿namespace NServiceBus.Core.Tests.Config
+{
+    using System;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_using_initialization_with_non_default_ctor
+    {
+        [Test]
+        public void Should_throw_meaningful_exception()
+        {
+            var builder = new BusConfiguration();
+
+            builder.TypesToScanInternal(new[] { typeof(FeatureWithInitialization) });
+
+            var ae = Assert.Throws<Exception>(() => builder.Build());
+            var expected = $"Unable to create the type '{nameof(FeatureWithInitialization)}'. Types implementing '{nameof(INeedInitialization)}' must have a public parameterless (default) constructor.";
+            Assert.AreEqual(expected, ae.Message);
+        }
+
+        public class FeatureWithInitialization : INeedInitialization
+        {
+            public FeatureWithInitialization(string arg)
+            {
+                // Note: this ctor will cause the builder to throw an exception.
+                // If you are using assembly scanning in your tests, make sure to exclude this type by using:
+                // busConfiguration.ExcludeTypes(typeof(When_using_initialization_with_non_default_ctor.FeatureWithInitialization));
+            }
+
+            public void Customize(BusConfiguration configuration)
+            {
+            }
+        }
+
+    }
+}

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="AssemblyScanner\When_scanning_top_level_only.cs" />
     <Compile Include="AssemblyScanner\When_told_to_scan_app_domain.cs" />
     <Compile Include="Causation\AttachCausationHeadersBehaviorTests.cs" />
+    <Compile Include="Config\When_using_initialization.cs" />
     <Compile Include="ContextBagTests.cs" />
     <Compile Include="ContextHelpers.cs" />
     <Compile Include="DelayedDelivery\RouteDeferredMessageToTimeoutManagerBehaviorTests.cs" />

--- a/src/NServiceBus.Core/BusConfiguration.cs
+++ b/src/NServiceBus.Core/BusConfiguration.cs
@@ -267,10 +267,17 @@ namespace NServiceBus
         {
             ForAllTypes<T>(types, t =>
             {
+                if (!HasDefaultConstructor(t))
+                {
+                    throw new Exception($"Unable to create the type '{t.Name}'. Types implementing '{typeof(T).Name}' must have a public parameterless (default) constructor.");
+                }
+
                 var instanceToInvoke = (T)Activator.CreateInstance(t);
                 action(instanceToInvoke);
             });
         }
+
+        static bool HasDefaultConstructor(Type type) => type.GetConstructor(Type.EmptyTypes) != null;
 
         List<Type> GetAllowedTypes(string path)
         {


### PR DESCRIPTION
If you specify a non-default ctor on a type that implements `INeedInitialization`, it would throw a nasty `System.MissingMethodException : No parameterless constructor defined for this object.` from within `Activator.CreateInstance`.

This PR checks for a presence of a default ctor prior to trying to create an instance, and would throw a meaningful exception otherwise.