### PR TITLE
Configure msmq only when needed

### DIFF
--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportConfigurator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportConfigurator.cs
@@ -17,6 +17,7 @@
     {
         internal MsmqTransportConfigurator()
         {
+            EnableByDefault();
             DependsOn<UnicastBus>();
             DependsOn<Receiving>();
             RegisterStartupTask<CheckQueuePermissions>();
@@ -34,6 +35,9 @@
 
             protected override Task OnStart(IBusContext context)
             {
+                var usingMsmq = settings.Get<TransportDefinition>() is MsmqTransport;
+                if (!usingMsmq) { return TaskEx.Completed; }
+
                 var queueBindings = settings.Get<QueueBindings>();
                 var boundQueueAddresses = queueBindings.ReceivingAddresses.Concat(queueBindings.SendingAddresses);
 
@@ -41,7 +45,6 @@
                 {
                     CheckQueue(address);
                 }
-
                 return TaskEx.Completed;
             }
 

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportConfigurator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportConfigurator.cs
@@ -17,7 +17,6 @@
     {
         internal MsmqTransportConfigurator()
         {
-            EnableByDefault();
             DependsOn<UnicastBus>();
             DependsOn<Receiving>();
             RegisterStartupTask<CheckQueuePermissions>();

--- a/src/NServiceBus.Core/Unicast/Transport/Config/UseTransportExtensions.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/Config/UseTransportExtensions.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using NServiceBus.Features;
     using Transports;
 
     /// <summary>
@@ -48,6 +49,7 @@ namespace NServiceBus
             if (!busConfiguration.Settings.HasExplicitValue<TransportDefinition>())
             {
                 busConfiguration.UseTransport<MsmqTransport>();
+                busConfiguration.Settings.EnableFeature(typeof(MsmqTransportConfigurator));
             }
         }
     }

--- a/src/NServiceBus.Core/Unicast/Transport/Config/UseTransportExtensions.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/Config/UseTransportExtensions.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus
 {
     using System;
-    using NServiceBus.Features;
     using Transports;
 
     /// <summary>
@@ -49,7 +48,6 @@ namespace NServiceBus
             if (!busConfiguration.Settings.HasExplicitValue<TransportDefinition>())
             {
                 busConfiguration.UseTransport<MsmqTransport>();
-                busConfiguration.Settings.EnableFeature(typeof(MsmqTransportConfigurator));
             }
         }
     }


### PR DESCRIPTION
Msmq configurator should only run when msmq is the actual transport