### PR TITLE
Changed endpoint creation to better represent the V5 model

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -49,7 +49,7 @@
                     busConfiguration.SendOnly();
                 }
 
-                var initializable = Endpoint.Create(busConfiguration);
+                var initializable = Endpoint.Prepare(busConfiguration);
                 startable = await initializable.Initialize().ConfigureAwait(false);
 
                 if (!configuration.SendOnly)

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -290,7 +290,8 @@ namespace NServiceBus
     }
     public class static Endpoint
     {
-        public static NServiceBus.IInitializableEndpoint Create(NServiceBus.BusConfiguration configuration) { }
+        public static System.Threading.Tasks.Task<NServiceBus.IStartableEndpoint> Create(NServiceBus.BusConfiguration configuration) { }
+        public static NServiceBus.IInitializableEndpoint Prepare(NServiceBus.BusConfiguration configuration) { }
         public static async System.Threading.Tasks.Task<NServiceBus.IEndpointInstance> Start(NServiceBus.BusConfiguration configuration) { }
     }
     public sealed class EndpointInstanceName

--- a/src/NServiceBus.Core/Endpoint.cs
+++ b/src/NServiceBus.Core/Endpoint.cs
@@ -8,14 +8,25 @@ namespace NServiceBus
     public static class Endpoint
     {
         /// <summary>
-        /// Creates a new endpoint based on the provided configuration.
+        /// Creates a new initializable endpoint based on the provided configuration.
         /// </summary>
         /// <param name="configuration">Configuration.</param>
-        public static IInitializableEndpoint Create(BusConfiguration configuration)
+        public static IInitializableEndpoint Prepare(BusConfiguration configuration)
         {
             Guard.AgainstNull(nameof(configuration), configuration);
             var endpoint = configuration.Build();
             return endpoint;
+        }
+
+        /// <summary>
+        /// Creates a new startable endpoint based on the provided configuration.
+        /// </summary>
+        /// <param name="configuration">Configuration.</param>
+        public static Task<IStartableEndpoint> Create(BusConfiguration configuration)
+        {
+            Guard.AgainstNull(nameof(configuration), configuration);
+            var initializable = Prepare(configuration);
+            return initializable.Initialize();
         }
 
         /// <summary>
@@ -24,11 +35,8 @@ namespace NServiceBus
         /// <param name="configuration">Configuration.</param>
         public static async Task<IEndpointInstance> Start(BusConfiguration configuration)
         {
-            var initializable = Create(configuration);
-            var startable = await initializable.Initialize().ConfigureAwait(false);
-            return await startable.Start().ConfigureAwait(false);
+            var initializable = await Create(configuration).ConfigureAwait(false);
+            return await initializable.Start().ConfigureAwait(false);
         }
     }
-
-    
 }


### PR DESCRIPTION
Aligned the endpoint creation with the previous V5 model. The problem of the latest develop approach is that we guide users with obsoletes to use `Endpoint.Create` instead of `Bus.Create` but `Endpoint.Create` return an initializable endpoint. Therefore we bloat the code unnecessarily. With this change `Endpoint.Create` returns a startable endpoint similar to V5 `Bus.Create`

@Particular/nservicebus please review

@SzymonPobiega needs this for the doco updates.