### PR TITLE
Routing - transport address changes required by SQLTransport

### DIFF
--- a/src/NServiceBus.AcceptanceTests/FakeTransport/FakeTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/FakeTransport/FakeTransport.cs
@@ -33,7 +33,7 @@
             throw new NotImplementedException();
         }
 
-        public override string GetDiscriminatorForThisEndpointInstance()
+        public override string GetDiscriminatorForThisEndpointInstance(ReadOnlySettings settings)
         {
             return null;
         }

--- a/src/NServiceBus.AcceptanceTests/Performance/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -96,7 +96,7 @@
                 throw new NotImplementedException();
             }
 
-            public override string GetDiscriminatorForThisEndpointInstance()
+            public override string GetDiscriminatorForThisEndpointInstance(ReadOnlySettings settings)
             {
                 return null;
             }

--- a/src/NServiceBus.AcceptanceTests/ScaleOut/When_no_discriminator_is_available.cs
+++ b/src/NServiceBus.AcceptanceTests/ScaleOut/When_no_discriminator_is_available.cs
@@ -74,7 +74,7 @@
                 throw new NotImplementedException();
             }
 
-            public override string GetDiscriminatorForThisEndpointInstance()
+            public override string GetDiscriminatorForThisEndpointInstance(ReadOnlySettings settings)
             {
                 return null;
             }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -711,7 +711,7 @@ namespace NServiceBus
         public override bool RequiresConnectionString { get; }
         protected internal override void ConfigureForReceiving(NServiceBus.Transports.TransportReceivingConfigurationContext context) { }
         protected internal override void ConfigureForSending(NServiceBus.Transports.TransportSendingConfigurationContext context) { }
-        public override string GetDiscriminatorForThisEndpointInstance() { }
+        public override string GetDiscriminatorForThisEndpointInstance(NServiceBus.Settings.ReadOnlySettings settings) { }
         public override NServiceBus.Transports.OutboundRoutingPolicy GetOutboundRoutingPolicy(NServiceBus.Settings.ReadOnlySettings settings) { }
         public override NServiceBus.Transports.IManageSubscriptions GetSubscriptionManager() { }
         public override System.Collections.Generic.IEnumerable<System.Type> GetSupportedDeliveryConstraints() { }
@@ -2790,7 +2790,7 @@ namespace NServiceBus.Transports
         public virtual bool RequiresConnectionString { get; }
         protected internal abstract void ConfigureForReceiving(NServiceBus.Transports.TransportReceivingConfigurationContext context);
         protected internal abstract void ConfigureForSending(NServiceBus.Transports.TransportSendingConfigurationContext context);
-        public abstract string GetDiscriminatorForThisEndpointInstance();
+        public abstract string GetDiscriminatorForThisEndpointInstance(NServiceBus.Settings.ReadOnlySettings settings);
         public abstract NServiceBus.Transports.OutboundRoutingPolicy GetOutboundRoutingPolicy(NServiceBus.Settings.ReadOnlySettings settings);
         public abstract NServiceBus.Transports.IManageSubscriptions GetSubscriptionManager();
         public abstract System.Collections.Generic.IEnumerable<System.Type> GetSupportedDeliveryConstraints();

--- a/src/NServiceBus.Core/Transports/Msmq/Msmq.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/Msmq.cs
@@ -112,7 +112,7 @@ namespace NServiceBus
         /// <summary>
         /// Returns the discriminator for this endpoint instance.
         /// </summary>
-        public override string GetDiscriminatorForThisEndpointInstance()
+        public override string GetDiscriminatorForThisEndpointInstance(ReadOnlySettings settings)
         {
             return RuntimeEnvironment.MachineName;
         }

--- a/src/NServiceBus.Core/Transports/TransportDefinition.cs
+++ b/src/NServiceBus.Core/Transports/TransportDefinition.cs
@@ -53,7 +53,7 @@ namespace NServiceBus.Transports
         /// <summary>
         /// Returns the discriminator for this endpoint instance.
         /// </summary>
-        public abstract string GetDiscriminatorForThisEndpointInstance();
+        public abstract string GetDiscriminatorForThisEndpointInstance(ReadOnlySettings settings);
 
         /// <summary>
         /// Converts a given logical address to the transport address.

--- a/src/NServiceBus.Core/Unicast/Config/UnicastBus.cs
+++ b/src/NServiceBus.Core/Unicast/Config/UnicastBus.cs
@@ -39,7 +39,7 @@ namespace NServiceBus.Features
         {
             var userDiscriminator = settings.GetOrDefault<string>("EndpointInstanceDiscriminator");
             var scaleOut = settings.GetOrDefault<bool>("IndividualizeEndpointAddress");
-            var transportDiscriminator = settings.Get<TransportDefinition>().GetDiscriminatorForThisEndpointInstance();
+            var transportDiscriminator = settings.Get<TransportDefinition>().GetDiscriminatorForThisEndpointInstance(settings);
             if (scaleOut && userDiscriminator == null && transportDiscriminator == null)
             {
                 throw new Exception("No endpoint instance discriminator found. This value is usually provided by your transport so please make sure you're on the lastest version of your specific transport or set the discriminator using 'configuration.ScaleOut().UniqueQueuePerEndpointInstance(myDiscriminator)'");


### PR DESCRIPTION
@SzymonPobiega is that what you had in mind for passing settings?

I changed the test for distributing events, because the it made assumptions about format of address for scale-out that weren't true for SqlTransport, and don't have to be true for other transports either.

GetDiscriminatorForThisEndpointInstance() => would it be more descriptive if it was called "TransportDiscriminator" or "TransportSpecificDiscriminator"? Right now the difference between this and user discriminator isn't obvious.