### PR TITLE
AT for broadcast + slight API rename

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Routing\When_distributing_an_event.cs" />
     <Compile Include="Msmq\When_publishing_with_authorizer.cs" />
     <Compile Include="Msmq\When_unsubscribing_with_authorizer.cs" />
+    <Compile Include="Routing\When_broadcasting_a_command.cs" />
     <Compile Include="Routing\When_publishing_to_a_legacy_endpoint.cs" />
     <Compile Include="Routing\When_publishing_from_sendonly.cs" />
     <Compile Include="MessageId\When_message_has_empty_id_header.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/When_broadcasting_a_command.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_broadcasting_a_command.cs
@@ -46,7 +46,7 @@
                 {
                     c.Routing().UseFileBasedEndpointInstanceLists().LookForFilesIn(basePath);
                     c.Routing().UnicastRoutingTable.AddStatic(typeof(Request), new EndpointName("DistributingACommand.Receiver"));
-                    c.Routing().DistributionPolicy.Set(new AllInstancesDistributionStrategy(), t => t == typeof(Request));
+                    c.Routing().SetMessageDistributionStrategy(new AllInstancesDistributionStrategy(), t => t == typeof(Request));
                 });
             }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/When_broadcasting_a_command.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_broadcasting_a_command.cs
@@ -1,0 +1,129 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+
+    public class When_broadcasting_a_command : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_send_it_to_all_instances()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(b => b.When(c => c.EndpointsStarted, (bus, c) => bus.Send(new Request())))
+                .WithEndpoint<Receiver1>()
+                .WithEndpoint<Receiver2>()
+                .Done(c => c.Receiver1TimesCalled > 0 && c.Receiver2TimesCalled > 0)
+                .Run();
+
+            Assert.AreEqual(1, context.Receiver1TimesCalled);
+            Assert.AreEqual(1, context.Receiver2TimesCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int Receiver1TimesCalled { get; set; }
+            public int Receiver2TimesCalled { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                var basePath = AppDomain.CurrentDomain.BaseDirectory;
+
+                File.WriteAllLines(Path.Combine(basePath, "DistributingACommand.Receiver.txt"), new[]
+                {
+                    "1:",
+                    "2:"
+                });
+
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.Routing().UseFileBasedEndpointInstanceLists().LookForFilesIn(basePath);
+                    c.Routing().UnicastRoutingTable.AddStatic(typeof(Request), new EndpointName("DistributingACommand.Receiver"));
+                    c.Routing().DistributionPolicy.Set(new AllInstancesDistributionStrategy(), t => t == typeof(Request));
+                });
+            }
+
+            public class ResponseHandler : IHandleMessages<Response>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(Response message, IMessageHandlerContext context)
+                {
+                    if (context.MessageHeaders[Headers.ReplyToAddress].Contains("Receiver-1"))
+                    {
+                        Context.Receiver1TimesCalled++;
+                    }
+                    else if (context.MessageHeaders[Headers.ReplyToAddress].Contains("Receiver-2"))
+                    {
+                        Context.Receiver2TimesCalled++;
+                    }
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Receiver1 : EndpointConfigurationBuilder
+        {
+            public Receiver1()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.EndpointName("DistributingACommand.Receiver");
+                    c.ScaleOut().UniqueQueuePerEndpointInstance("1");
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<Request>
+            {
+                public Task Handle(Request message, IMessageHandlerContext context)
+                {
+                    return context.Reply(new Response
+                    {
+                        EndpointName = "Receiver1"
+                    });
+                }
+            }
+        }
+
+        public class Receiver2 : EndpointConfigurationBuilder
+        {
+            public Receiver2()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.EndpointName("DistributingACommand.Receiver");
+                    c.ScaleOut().UniqueQueuePerEndpointInstance("2");
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<Request>
+            {
+                public Task Handle(Request message, IMessageHandlerContext context)
+                {
+                    return context.Reply(new Response
+                    {
+                        EndpointName = "Receiver2"
+                    });
+                }
+            }
+        }
+
+        [Serializable]
+        public class Request : ICommand
+        {
+        }
+
+        [Serializable]
+        public class Response : IMessage
+        {
+            public string EndpointName { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -794,10 +794,10 @@ namespace NServiceBus
     }
     public class RoutingSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
-        public NServiceBus.Routing.DistributionPolicy DistributionPolicy { get; }
         public NServiceBus.Routing.EndpointInstances EndpointInstances { get; }
         public NServiceBus.Transports.TransportAddresses TransportAddresses { get; }
         public NServiceBus.Routing.UnicastRoutingTable UnicastRoutingTable { get; }
+        public void SetMessageDistributionStrategy(NServiceBus.Routing.DistributionStrategy distributionStrategy, System.Func<System.Type, bool> typeMatchingRule) { }
     }
     public class static RoutingSettingsExtensions
     {
@@ -2207,11 +2207,6 @@ namespace NServiceBus.Routing
     {
         public AllInstancesDistributionStrategy() { }
         public override System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> SelectDestination(System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> allInstances) { }
-    }
-    public class DistributionPolicy
-    {
-        public DistributionPolicy() { }
-        public void Set(NServiceBus.Routing.DistributionStrategy distributionStrategy, System.Func<System.Type, bool> typeMatchingRule) { }
     }
     public abstract class DistributionStrategy
     {

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2211,7 +2211,7 @@ namespace NServiceBus.Routing
     public class DistributionPolicy
     {
         public DistributionPolicy() { }
-        public void SetDistributionStrategy(NServiceBus.Routing.DistributionStrategy distributionStrategy, System.Func<System.Type, bool> typeMatchingRule) { }
+        public void Set(NServiceBus.Routing.DistributionStrategy distributionStrategy, System.Func<System.Type, bool> typeMatchingRule) { }
     }
     public abstract class DistributionStrategy
     {

--- a/src/NServiceBus.Core/Routing/DistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionPolicy.cs
@@ -24,7 +24,7 @@ namespace NServiceBus.Routing
         /// </summary>
         /// <param name="distributionStrategy">The instance of a distribution strategy.</param>
         /// <param name="typeMatchingRule">A predicate for determining the set of types.</param>
-        public void SetDistributionStrategy(DistributionStrategy distributionStrategy, Func<Type, bool> typeMatchingRule)
+        public void Set(DistributionStrategy distributionStrategy, Func<Type, bool> typeMatchingRule)
         {
             strategies.Insert(0, Tuple.Create(typeMatchingRule, distributionStrategy));
         }

--- a/src/NServiceBus.Core/Routing/DistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionPolicy.cs
@@ -4,10 +4,7 @@ namespace NServiceBus.Routing
     using System.Collections.Generic;
     using System.Linq;
 
-    /// <summary>
-    /// Allows to configure message distribution strategies.
-    /// </summary>
-    public class DistributionPolicy
+    class DistributionPolicy
     {
         List<Tuple<Func<Type, bool>,DistributionStrategy>> strategies = new List<Tuple<Func<Type, bool>, DistributionStrategy>>();
 
@@ -24,7 +21,7 @@ namespace NServiceBus.Routing
         /// </summary>
         /// <param name="distributionStrategy">The instance of a distribution strategy.</param>
         /// <param name="typeMatchingRule">A predicate for determining the set of types.</param>
-        public void Set(DistributionStrategy distributionStrategy, Func<Type, bool> typeMatchingRule)
+        internal void SetDistributionStrategy(DistributionStrategy distributionStrategy, Func<Type, bool> typeMatchingRule)
         {
             strategies.Insert(0, Tuple.Create(typeMatchingRule, distributionStrategy));
         }

--- a/src/NServiceBus.Core/Routing/RoutingSettings.cs
+++ b/src/NServiceBus.Core/Routing/RoutingSettings.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus
 {
+    using System;
     using NServiceBus.Configuration.AdvanceExtensibility;
     using NServiceBus.Routing;
     using NServiceBus.Settings;
@@ -26,9 +27,14 @@
         public EndpointInstances EndpointInstances => GetOrCreate<EndpointInstances>();
 
         /// <summary>
-        /// Gets the distribution policy.
+        /// Sets a distribution strategy for a given subset of message types.
         /// </summary>
-        public DistributionPolicy DistributionPolicy => GetOrCreate<DistributionPolicy>();
+        /// <param name="distributionStrategy">The instance of a distribution strategy.</param>
+        /// <param name="typeMatchingRule">A predicate for determining the set of types.</param>
+        public void SetMessageDistributionStrategy(DistributionStrategy distributionStrategy, Func<Type, bool> typeMatchingRule)
+        {
+            GetOrCreate<DistributionPolicy>().SetDistributionStrategy(distributionStrategy, typeMatchingRule);
+        }
 
         /// <summary>
         /// Gets the transport addresses.


### PR DESCRIPTION
 * Renamed `SetDistributionStrategy` to `Set` as per @SeanFeldman 's suggestion
 * Added an acceptance test to verify that overriding distribution strategies works (and that `AllInstancesDistributionStrategy` does what it is supposed to do)