### PR TITLE
serialize RunningEndpointInstance.Stop calls

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -257,6 +257,7 @@
     <Compile Include="Unicast\Contexts\EventMessage.cs" />
     <Compile Include="Unicast\Contexts\InterfaceMessage.cs" />
     <Compile Include="Unicast\LoadHandlersBehaviorTests.cs" />
+    <Compile Include="Unicast\RunningEndpointInstanceTest.cs" />
     <Compile Include="Unicast\StartAndStoppablesRunnerTests.cs" />
     <Compile Include="Unicast\TransportMessageTests.cs" />
     <Compile Include="Unicast\MessageTypeTests.cs" />

--- a/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
@@ -1,0 +1,39 @@
+﻿namespace NServiceBus.Unicast.Tests
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+    using NServiceBus.Core.Tests;
+    using NServiceBus.Features;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Pipeline.Contexts;
+    using NServiceBus.Settings;
+    using NServiceBus.Transport;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class RunningEndpointInstanceTest
+    {
+        [Test]
+        public async Task ShouldAllowMultipleStops()
+        {
+            var testee = new RunningEndpointInstance(
+                new FuncBuilder(), 
+                new PipelineCollection(Enumerable.Empty<TransportReceiver>()), 
+                new StartAndStoppablesRunner(Enumerable.Empty<IWantToRunWhenBusStartsAndStops>()), 
+                new FeatureRunner(new FeatureActivator(new SettingsHolder())), 
+                new FakeContextFactory());
+
+            await testee.Stop();
+
+            Assert.DoesNotThrow(async () => await testee.Stop());
+        }
+
+        class FakeContextFactory : IBusContextFactory
+        {
+            public IBusContext CreateBusContext()
+            {
+                return new BusContext(new RootContext(null));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Just a proposal

* Current `Stop` implementation contains a race condition which allows multiple threads to stop the related components multiple times (e.g. CriticalError triggered from multiple CircuitBreakers).
* Would deadlock on reentrancy but I can't see that happening.
* Do we need a timeout for the Wait?
* No longer throw an exception when endpoint already stopped (e.g. When CriticalError stops before the user). I don't think we should throw an exception to the user when calling `Stop`.