### PR TITLE
Changed the instance resolution policy to default to single instance

### DIFF
--- a/src/NServiceBus.Core.Tests/Routing/EndpointInstancesTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/EndpointInstancesTests.cs
@@ -39,12 +39,13 @@
         }
 
         [Test]
-        public void Should_throw_when_trying_to_enumerate_collection_of_instances_of_unknown_endpoint()
+        public void Should_default_to_single_instance_when_not_configured()
         {
             var instances = new EndpointInstances();
-            var salesInstances = instances.FindInstances(new EndpointName("Sales"));
-            TestDelegate action = () => salesInstances.ToArray();
-            Assert.Throws<Exception>(action);
+            var salesInstances = instances.FindInstances(new EndpointName("Sales")).ToArray();
+            Assert.AreEqual(1, salesInstances.Length);
+            Assert.IsNull(salesInstances[0].UserDiscriminator);
+            Assert.IsNull(salesInstances[0].TransportDiscriminator);
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/EndpointInstances.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstances.cs
@@ -13,8 +13,8 @@ namespace NServiceBus.Routing
 
         internal IEnumerable<EndpointInstanceName> FindInstances(EndpointName endpoint)
         {
-            var distinctInstances = rules.SelectMany(r => r(endpoint)).Distinct();
-            return distinctInstances.EnsureNonEmpty(() => $"The list of instances of endpoint {endpoint} has not been provided to the routing module. Plase use 'BusConfiguration.Routing().EndpointInstances' to supply this information.");
+            var distinctInstances = rules.SelectMany(r => r(endpoint)).Distinct().ToArray();
+            return distinctInstances.EnsureNonEmpty(() => new EndpointInstanceName(endpoint, null, null));
         }
 
 


### PR DESCRIPTION
Previously following routing setup would throw because no instances are configured:

```
c.Routing().UnicastRoutingTable.AddStatic(typeof(Request), new EndpointName("Sales"));
```

In order to make it work, we required to register a default single instance:

```
c.Routing().EndpointInstances.AddStatic(new EndpointName("Sales"), new EndpointInstanceName(new EndpointName("Sales"), null, null));
```

Now it will work perfectly fine without that line.