### PR TITLE
remove obosolete OnStart and OnStop methods from FeatureStartupTask

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Basic/When_sending_from_a_send_only.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_sending_from_a_send_only.cs
@@ -81,6 +81,11 @@
                         scenarioContext.SendOnlyEndpointWasStarted = true;
                         return Task.FromResult(0);
                     }
+
+                    protected override Task OnStop(IBusContext context)
+                    {
+                        return Task.FromResult(0);
+                    }
                 }
             }
         }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1434,7 +1434,7 @@ namespace NServiceBus.Features
     {
         protected FeatureStartupTask() { }
         protected abstract System.Threading.Tasks.Task OnStart(NServiceBus.IBusContext context);
-        protected virtual System.Threading.Tasks.Task OnStop(NServiceBus.IBusContext context) { }
+        protected abstract System.Threading.Tasks.Task OnStop(NServiceBus.IBusContext context);
     }
     public enum FeatureState
     {

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1433,13 +1433,7 @@ namespace NServiceBus.Features
     public abstract class FeatureStartupTask
     {
         protected FeatureStartupTask() { }
-        [System.ObsoleteAttribute("Please use `OnStart(IBusContext context)` instead. Will be removed in version 7.0" +
-            ".0.", true)]
-        protected virtual void OnStart() { }
         protected abstract System.Threading.Tasks.Task OnStart(NServiceBus.IBusContext context);
-        [System.ObsoleteAttribute("Please use `OnStop(IBusContext context)` instead. Will be removed in version 7.0." +
-            "0.", true)]
-        protected virtual void OnStop() { }
         protected virtual System.Threading.Tasks.Task OnStop(NServiceBus.IBusContext context) { }
     }
     public enum FeatureState

--- a/src/NServiceBus.Core.Tests/Config/When_no_custom_configuration_source_is_specified.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_no_custom_configuration_source_is_specified.cs
@@ -42,6 +42,11 @@ namespace NServiceBus.Core.Tests.Config
                     Assert.AreEqual(settings.GetConfigSection<TestConfigurationSection>().TestSetting, "test");
                     return Task.FromResult(0);
                 }
+
+                protected override Task OnStop(IBusContext context)
+                {
+                    return TaskEx.Completed;
+                }
             }
         }
     }

--- a/src/NServiceBus.Core.Tests/Config/When_users_override_the_configuration_source.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_users_override_the_configuration_source.cs
@@ -45,6 +45,11 @@ namespace NServiceBus.Core.Tests.Config
                     Assert.AreEqual(section.TestSetting, "TestValue");
                     return Task.FromResult(0);
                 }
+
+                protected override Task OnStop(IBusContext context)
+                {
+                    return TaskEx.Completed;
+                }
             }
         }
     }

--- a/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
@@ -100,6 +100,11 @@
                     return Task.FromResult(0);
                 }
 
+                protected override Task OnStop(IBusContext context)
+                {
+                    return TaskEx.Completed;
+                }
+
                 public void Dispose()
                 {
                     Disposed = true;

--- a/src/NServiceBus.Core.Tests/Serializers/Json/When_not_overriding_stream_encoding.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/When_not_overriding_stream_encoding.cs
@@ -46,6 +46,11 @@ namespace NServiceBus.Serializers.Json.Tests
                     Assert.AreSame(Encoding.UTF8, serializer.Encoding);
                     return Task.FromResult(0);
                 }
+
+                protected override Task OnStop(IBusContext context)
+                {
+                    return TaskEx.Completed;
+                }
             }
         }
     }

--- a/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
@@ -45,6 +45,11 @@ namespace NServiceBus.Serializers.Json.Tests
                     Assert.AreSame(Encoding.UTF7, serializer.Encoding);
                     return Task.FromResult(0);
                 }
+
+                protected override Task OnStop(IBusContext context)
+                {
+                    return TaskEx.Completed;
+                }
             }
         }
     }

--- a/src/NServiceBus.Core/DataBus/DataBus.cs
+++ b/src/NServiceBus.Core/DataBus/DataBus.cs
@@ -51,6 +51,11 @@ namespace NServiceBus.Features
             {
                 return DataBus.Start();
             }
+
+            protected override Task OnStop(IBusContext context)
+            {
+                return TaskEx.Completed;
+            }
         }
     }
 }

--- a/src/NServiceBus.Core/Features/FeatureStartupTask.cs
+++ b/src/NServiceBus.Core/Features/FeatureStartupTask.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Features
 {
-    using System;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -8,30 +7,6 @@
     /// </summary>
     public abstract class FeatureStartupTask
     {
-        /// <summary>
-        /// Will be called when the endpoint starts up if the feature has been activated.
-        /// </summary>
-        [ObsoleteEx(
-            TreatAsErrorFromVersion = "6", 
-            RemoveInVersion = "7",
-            ReplacementTypeOrMember = "OnStart(IBusContext context)")]
-        protected virtual void OnStart()
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <summary>
-        ///  Will be called after an endpoint has stopped processing messages, if the feature has been activated.
-        /// </summary>
-        [ObsoleteEx(
-            TreatAsErrorFromVersion = "6", 
-            RemoveInVersion = "7", 
-            ReplacementTypeOrMember = "OnStop(IBusContext context)")]
-        protected virtual void OnStop()
-        {
-            throw new NotImplementedException();
-        }
-
         /// <summary>
         /// Will be called after an endpoint has been started but before processing any messages, if the feature has been activated.
         /// </summary>

--- a/src/NServiceBus.Core/Features/FeatureStartupTask.cs
+++ b/src/NServiceBus.Core/Features/FeatureStartupTask.cs
@@ -17,10 +17,7 @@
         /// Will be called after an endpoint has been started but before processing any messages, if the feature has been activated.
         /// </summary>
         /// <param name="context">Bus context.</param>
-        protected virtual Task OnStop(IBusContext context)
-        {
-            return TaskEx.Completed;
-        }
+        protected abstract Task OnStop(IBusContext context);
         
         internal Task PerformStartup(IBusContext context)
         {

--- a/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
@@ -107,6 +107,11 @@ Because you have configured this endpoint to run with Outbox enabled we recommen
             return TaskEx.Completed;
         }
 
+        protected override Task OnStop(IBusContext context)
+        {
+            return TaskEx.Completed;
+        }
+
         static ILog log = LogManager.GetLogger<DtcRunningWarning>();
     }
 }

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -94,6 +94,11 @@
                 }
             }
 
+            protected override Task OnStop(IBusContext context)
+            {
+                return TaskEx.Completed;
+            }
+
             IEnumerable<Type> eventsToSubscribe;
 
             static ILog Logger = LogManager.GetLogger<ApplySubscriptions>();

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
@@ -36,6 +36,11 @@ namespace NServiceBus.Features
                 settings.Get<EndpointInstances>().AddDynamic(e => routingTable.GetInstances(e));
                 return TaskEx.Completed;
             }
+
+            protected override Task OnStop(IBusContext context)
+            {
+                return TaskEx.Completed;
+            }
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/Legacy/ReadyMessageSender.cs
+++ b/src/NServiceBus.Core/Routing/Legacy/ReadyMessageSender.cs
@@ -26,6 +26,11 @@
             Logger.DebugFormat("Ready startup message with WorkerSessionId {0} sent. ", workerSessionId);
         }
 
+        protected override Task OnStop(IBusContext context)
+        {
+            return TaskEx.Completed;
+        }
+
         Task SendReadyMessage(int capacity, bool isStarting)
         {
             //we use the actual address to make sure that the worker inside the master node will check in correctly

--- a/src/NServiceBus.Core/Routing/Legacy/ReadyMessageSender.cs
+++ b/src/NServiceBus.Core/Routing/Legacy/ReadyMessageSender.cs
@@ -26,10 +26,6 @@
             Logger.DebugFormat("Ready startup message with WorkerSessionId {0} sent. ", workerSessionId);
         }
 
-        protected override void OnStop()
-        {
-        }
-
         Task SendReadyMessage(int capacity, bool isStarting)
         {
             //we use the actual address to make sure that the worker inside the master node will check in correctly

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/StorageInitializer.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/StorageInitializer.cs
@@ -26,6 +26,11 @@
                 SubscriptionStorage?.Init();
                 return TaskEx.Completed;
             }
+
+            protected override Task OnStop(IBusContext context)
+            {
+                return TaskEx.Completed;
+            }
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -154,6 +154,11 @@
                 return TaskEx.Completed;
             }
 
+            protected override Task OnStop(IBusContext context)
+            {
+                return TaskEx.Completed;
+            }
+
             static async Task<IEnumerable<IUnicastRoute>> QuerySubscriptionStore(ISubscriptionStorage subscriptions, List<Type> types, ContextBag contextBag)
             {
                 if (!(contextBag is OutgoingPublishContext))

--- a/src/NServiceBus.Core/Serializers/XML/Config/XmlSerialization.cs
+++ b/src/NServiceBus.Core/Serializers/XML/Config/XmlSerialization.cs
@@ -43,6 +43,11 @@
                 Serializer.Initialize(messageTypes);
                 return TaskEx.Completed;
             }
+
+            protected override Task OnStop(IBusContext context)
+            {
+                return TaskEx.Completed;
+            }
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/Receiving.cs
+++ b/src/NServiceBus.Core/Transports/Receiving.cs
@@ -63,6 +63,11 @@ namespace NServiceBus.Transports
                     throw new Exception($"Pre start-up check failed: {result.ErrorMessage}");
                 }
             }
+
+            protected override Task OnStop(IBusContext context)
+            {
+                return TaskEx.Completed;
+            }
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/Sending.cs
+++ b/src/NServiceBus.Core/Transports/Sending.cs
@@ -43,6 +43,11 @@ namespace NServiceBus.Transports
                     throw new Exception("Pre start-up check failed: "+ result.ErrorMessage);
                 }
             }
+
+            protected override Task OnStop(IBusContext context)
+            {
+                return TaskEx.Completed;
+            }
         }
     }
 }


### PR DESCRIPTION
implementing the virtual methods marked as obsolete doesn't yield an error. Therefore keeping these methods there is quite dangerous since the user may never notice (in case he's not calling the base method) while the code never executes.

For `OnStart` this shouldn't be an issue anyway, since the new OnStart is abstract, therefore users have to implement the correct OnStart method, but OnStop is easily missed.

Should OnStop also be abstract?