### PR TITLE
Removed the Transactions.SuppressDistributedTransactions settings key

### DIFF
--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -55,10 +55,6 @@
             {
                 config.Transactions().Disable();
             }
-            if (settings.ContainsKey("Transactions.SuppressDistributedTransactions"))
-            {
-                config.Transactions().DisableDistributedTransactions();
-            }
         }
 
         public static async Task DefinePersistence(this BusConfiguration config, IDictionary<string, string> settings)

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -3036,6 +3036,9 @@ namespace NServiceBus.Unicast.Transport
         public bool DoNotWrapHandlersExecutionInATransactionScope { get; set; }
         public System.Transactions.IsolationLevel IsolationLevel { get; set; }
         public bool IsTransactional { get; set; }
+        [System.ObsoleteAttribute("SuppressDistributedTransactions is no longer used here. Please use `context.Setti" +
+            "ngs.GetRequiredTransactionSupportForReceives() != TransactionSupport.Distributed" +
+            "` instead. Will be removed in version 7.0.0.", true)]
         public bool SuppressDistributedTransactions { get; set; }
         public System.TimeSpan TransactionTimeout { get; set; }
     }

--- a/src/NServiceBus.Core/BusConfiguration.cs
+++ b/src/NServiceBus.Core/BusConfiguration.cs
@@ -41,7 +41,6 @@ namespace NServiceBus
             Settings.SetDefault("Transactions.Enabled", true);
             Settings.SetDefault("Transactions.IsolationLevel", IsolationLevel.ReadCommitted);
             Settings.SetDefault("Transactions.DefaultTimeout", TransactionManager.DefaultTimeout);
-            Settings.SetDefault("Transactions.SuppressDistributedTransactions", false);
             Settings.SetDefault("Transactions.DoNotWrapHandlersExecutionInATransactionScope", false);
             Settings.SetDefault("DefaultSerializer", new XmlSerializer());
 

--- a/src/NServiceBus.Core/Settings/TransactionSettings.cs
+++ b/src/NServiceBus.Core/Settings/TransactionSettings.cs
@@ -23,8 +23,7 @@ namespace NServiceBus.Settings
         {
             config.Settings.Set("Transactions.Enabled", false);
             config.Settings.SetDefault("Transactions.DoNotWrapHandlersExecutionInATransactionScope", true);
-            config.Settings.SetDefault("Transactions.SuppressDistributedTransactions", true);
-
+          
             config.Settings.Set<ConsistencyGuarantee>(ConsistencyGuarantee.AtMostOnce);
      
             return this;
@@ -37,8 +36,7 @@ namespace NServiceBus.Settings
         {
             config.Settings.Set("Transactions.Enabled", true);
             config.Settings.SetDefault("Transactions.DoNotWrapHandlersExecutionInATransactionScope", false);
-            config.Settings.SetDefault("Transactions.SuppressDistributedTransactions", false);
-
+          
             return this;
         }
               
@@ -61,7 +59,6 @@ namespace NServiceBus.Settings
         /// </summary>
         public TransactionSettings DisableDistributedTransactions()
         {
-            config.Settings.Set("Transactions.SuppressDistributedTransactions", true);
             config.Settings.SetDefault("Transactions.DoNotWrapHandlersExecutionInATransactionScope", true);
             config.Settings.Set<ConsistencyGuarantee>(ConsistencyGuarantee.AtLeastOnce);
             return this;
@@ -72,7 +69,6 @@ namespace NServiceBus.Settings
         /// </summary>
         public TransactionSettings EnableDistributedTransactions()
         {
-            config.Settings.Set("Transactions.SuppressDistributedTransactions", false);
             config.Settings.Set<ConsistencyGuarantee>(ConsistencyGuarantee.ExactlyOnce);
             return this;
         }

--- a/src/NServiceBus.Core/Unicast/Transport/TransactionSettings.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/TransactionSettings.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Transactions;
-    using Settings;
+    using NServiceBus.Settings;
 
     /// <summary>
     /// Settings related to transactions.
@@ -14,7 +14,6 @@
             IsTransactional = settings.Get<bool>("Transactions.Enabled");
             TransactionTimeout = settings.Get<TimeSpan>("Transactions.DefaultTimeout");
             IsolationLevel = settings.Get<IsolationLevel>("Transactions.IsolationLevel");
-            SuppressDistributedTransactions = settings.Get<bool>("Transactions.SuppressDistributedTransactions");
         }
 
         /// <summary>
@@ -24,19 +23,14 @@
 
         /// <summary>
         /// Property for getting/setting the period of time when the transaction times out.
-        /// Only relevant when <see cref="IsTransactional"/> is set to true.
+        /// Only relevant when <see cref="IsTransactional" /> is set to true.
         /// </summary>
         public TimeSpan TransactionTimeout { get; set; }
 
         /// <summary>
         /// Property for getting/setting the isolation level of the transaction scope.
-        /// Only relevant when <see cref="IsTransactional"/> is set to true.
+        /// Only relevant when <see cref="IsTransactional" /> is set to true.
         /// </summary>
         public IsolationLevel IsolationLevel { get; set; }
-
-        /// <summary>
-        /// If true the transport won't enlist in distributed transactions.
-        /// </summary>
-        public bool SuppressDistributedTransactions { get; set; }
     }
 }

--- a/src/NServiceBus.Core/obsoletes.cs
+++ b/src/NServiceBus.Core/obsoletes.cs
@@ -966,6 +966,12 @@ namespace NServiceBus.Unicast.Transport
             RemoveInVersion = "7.0",
             TreatAsErrorFromVersion = "6.0")]
         public bool DoNotWrapHandlersExecutionInATransactionScope { get; set; }
+
+        [ObsoleteEx(
+         Message = "SuppressDistributedTransactions is no longer used here. Please use `context.Settings.GetRequiredTransactionSupportForReceives() != TransactionSupport.Distributed` instead.",
+         RemoveInVersion = "7.0",
+         TreatAsErrorFromVersion = "6.0")]
+        public bool SuppressDistributedTransactions { get; set; }
     }
 
     [ObsoleteEx(


### PR DESCRIPTION
Since it's been replaced with `context.Settings.GetRequiredTransactionSupportForReceives() != TransactionSupport.Distributed`