### PR TITLE
Removed the `Transactions.Enabled` setting

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2993,6 +2993,9 @@ namespace NServiceBus.Unicast.Transport
             "onScope\') instead. Will be removed in version 7.0.0.", true)]
         public bool DoNotWrapHandlersExecutionInATransactionScope { get; set; }
         public System.Transactions.IsolationLevel IsolationLevel { get; set; }
+        [System.ObsoleteAttribute("IsTransactional is no longer used here. Please use `context.Settings.GetRequiredT" +
+            "ransactionSupportForReceives() != TransactionSupport.None` instead. Will be remo" +
+            "ved in version 7.0.0.", true)]
         public bool IsTransactional { get; set; }
         [System.ObsoleteAttribute("SuppressDistributedTransactions is no longer used here. Please use `context.Setti" +
             "ngs.GetRequiredTransactionSupportForReceives() != TransactionSupport.Distributed" +

--- a/src/NServiceBus.Core/BusConfiguration.cs
+++ b/src/NServiceBus.Core/BusConfiguration.cs
@@ -38,7 +38,6 @@ namespace NServiceBus
             Settings.Set<QueueBindings>(new QueueBindings());
 
             Settings.SetDefault("Endpoint.SendOnly", false);
-            Settings.SetDefault("Transactions.Enabled", true);
             Settings.SetDefault("Transactions.IsolationLevel", IsolationLevel.ReadCommitted);
             Settings.SetDefault("Transactions.DefaultTimeout", TransactionManager.DefaultTimeout);
             Settings.SetDefault("Transactions.DoNotWrapHandlersExecutionInATransactionScope", false);

--- a/src/NServiceBus.Core/Persistence/Msmq/SubscriptionStorage/MsmqSubscriptionPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/Msmq/SubscriptionStorage/MsmqSubscriptionPersistence.cs
@@ -2,6 +2,7 @@
 {
     using Config;
     using Logging;
+    using NServiceBus.ConsistencyGuarantees;
     using NServiceBus.Transports;
 
     /// <summary>
@@ -42,7 +43,9 @@
 
             context.Container.ConfigureComponent(b =>
             {
-                var queue = new MsmqSubscriptionStorageQueue(MsmqAddress.Parse(queueName), context.Settings.Get<bool>("Transactions.Enabled"), false);
+                var isTransactional = context.Settings.GetRequiredTransactionSupportForReceives() != TransactionSupport.None;
+
+                var queue = new MsmqSubscriptionStorageQueue(MsmqAddress.Parse(queueName), isTransactional, false);
                 return new MsmqSubscriptionStorage(queue);
             }, DependencyLifecycle.SingleInstance);
         }

--- a/src/NServiceBus.Core/Recoverability/FirstLevelRetries/FirstLevelRetries.cs
+++ b/src/NServiceBus.Core/Recoverability/FirstLevelRetries/FirstLevelRetries.cs
@@ -4,8 +4,10 @@ namespace NServiceBus.Features
     using System.Threading;
     using System.Threading.Tasks;
     using Config;
+    using NServiceBus.ConsistencyGuarantees;
     using NServiceBus.Recoverability.FirstLevelRetries;
     using NServiceBus.Settings;
+    using NServiceBus.Transports;
 
     /// <summary>
     /// Used to configure Second Level Retries.
@@ -17,7 +19,7 @@ namespace NServiceBus.Features
             EnableByDefault();
             Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"), "Send only endpoints can't use FLR since it only applies to messages being received");
 
-            Prerequisite(context => context.Settings.Get<bool>("Transactions.Enabled"), "Send only endpoints can't use FLR since it requires the transport to be able to rollback");
+            Prerequisite(context => context.Settings.GetRequiredTransactionSupportForReceives() != TransactionSupport.None, "Transactions must be enabled since FLR requires the transport to be able to rollback");
 
             Prerequisite(context => GetMaxRetries(context.Settings) > 0, "FLR was disabled in config since it's set to 0");
         }

--- a/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
@@ -5,6 +5,7 @@
     using System.ServiceProcess;
     using System.Threading.Tasks;
     using Logging;
+    using NServiceBus.ConsistencyGuarantees;
     using Persistence;
     using Transports;
 
@@ -17,7 +18,7 @@
         {
             Defaults(s => s.SetDefault(InMemoryOutboxPersistence.TimeToKeepDeduplicationEntries, TimeSpan.FromDays(5)));
 
-            Prerequisite(c => c.Settings.Get<bool>("Transactions.Enabled"), "Outbox isn't needed since the receive transactions has been turned off");
+            Prerequisite(c => c.Settings.GetRequiredTransactionSupportForReceives() != TransactionSupport.None, "Outbox isn't needed since the receive transactions has been turned off");
 
             Prerequisite(c =>
             {

--- a/src/NServiceBus.Core/Settings/TransactionSettings.cs
+++ b/src/NServiceBus.Core/Settings/TransactionSettings.cs
@@ -21,7 +21,6 @@ namespace NServiceBus.Settings
         /// </summary>
         public TransactionSettings Disable()
         {
-            config.Settings.Set("Transactions.Enabled", false);
             config.Settings.SetDefault("Transactions.DoNotWrapHandlersExecutionInATransactionScope", true);
           
             config.Settings.Set<ConsistencyGuarantee>(ConsistencyGuarantee.AtMostOnce);
@@ -34,7 +33,6 @@ namespace NServiceBus.Settings
         /// </summary>
         public TransactionSettings Enable()
         {
-            config.Settings.Set("Transactions.Enabled", true);
             config.Settings.SetDefault("Transactions.DoNotWrapHandlersExecutionInATransactionScope", false);
           
             return this;

--- a/src/NServiceBus.Core/Transports/Msmq/TimeToBeReceivedOverrideCheck.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/TimeToBeReceivedOverrideCheck.cs
@@ -2,6 +2,7 @@
 {
     using NServiceBus.Config;
     using System;
+    using NServiceBus.ConsistencyGuarantees;
     using NServiceBus.Features;
     using NServiceBus.Settings;
 
@@ -16,7 +17,7 @@
         public StartupCheckResult CheckTimeToBeReceivedOverrides()
         {
             var usingMsmq = settings.Get<TransportDefinition>() is MsmqTransport;
-            var isTransactional = settings.Get<bool>("Transactions.Enabled");
+            var isTransactional = settings.GetRequiredTransactionSupportForReceives() != TransactionSupport.None;
             var outBoxRunning = settings.IsFeatureActive(typeof(Outbox));
 
             var messageAuditingConfig = settings.GetConfigSection<AuditConfig>();

--- a/src/NServiceBus.Core/Unicast/Transport/TransactionSettings.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/TransactionSettings.cs
@@ -11,15 +11,9 @@
     {
         internal TransactionSettings(ReadOnlySettings settings)
         {
-            IsTransactional = settings.Get<bool>("Transactions.Enabled");
             TransactionTimeout = settings.Get<TimeSpan>("Transactions.DefaultTimeout");
             IsolationLevel = settings.Get<IsolationLevel>("Transactions.IsolationLevel");
         }
-
-        /// <summary>
-        /// Sets whether or not the transport is transactional.
-        /// </summary>
-        public bool IsTransactional { get; set; }
 
         /// <summary>
         /// Property for getting/setting the period of time when the transaction times out.

--- a/src/NServiceBus.Core/obsoletes.cs
+++ b/src/NServiceBus.Core/obsoletes.cs
@@ -183,7 +183,7 @@ namespace NServiceBus
         TreatAsErrorFromVersion = "6",
         RemoveInVersion = "7",
         ReplacementTypeOrMember = "BusConfiguration.ExcludeAssemblies")]
-    public class AllAssemblies 
+    public class AllAssemblies
     {
     }
 
@@ -383,7 +383,7 @@ namespace NServiceBus.Unicast
     [ObsoleteEx(
         RemoveInVersion = "7.0",
         TreatAsErrorFromVersion = "6.0")]
-    public class MessageContext 
+    public class MessageContext
     {
     }
 }
@@ -436,7 +436,7 @@ namespace NServiceBus.Unicast
         Message = "Not used anymore, use the 'NServiceBus.MessageIntent' header to detect if the message is a reply",
         RemoveInVersion = "7.0",
         TreatAsErrorFromVersion = "6.0")]
-    public class ReplyOptions 
+    public class ReplyOptions
     {
     }
 }
@@ -447,7 +447,7 @@ namespace NServiceBus.MessageMutator
         Message = "Just have your mutator implement both IMutateOutgoingMessages and IMutateIncomingMessages ",
         RemoveInVersion = "7.0",
         TreatAsErrorFromVersion = "6.0")]
-    public interface IMessageMutator 
+    public interface IMessageMutator
     {
     }
 
@@ -638,7 +638,7 @@ namespace NServiceBus.Transports.Msmq
         RemoveInVersion = "7.0",
         TreatAsErrorFromVersion = "6.0",
         Message = "The msmq transaction is now available via the pipeline context")]
-    public class MsmqUnitOfWork 
+    public class MsmqUnitOfWork
     {
     }
 }
@@ -689,14 +689,14 @@ namespace NServiceBus.Features
         RemoveInVersion = "7.0",
         TreatAsErrorFromVersion = "6.0",
         Message = "No longer used, safe to remove")]
-    public class StorageDrivenPublishing 
+    public class StorageDrivenPublishing
     {
     }
 
     [ObsoleteEx(
-        Message = "Use the ConfigureSerialization Feature class instead", 
-        TreatAsErrorFromVersion = "6.0", 
-        RemoveInVersion = "7.0", 
+        Message = "Use the ConfigureSerialization Feature class instead",
+        TreatAsErrorFromVersion = "6.0",
+        RemoveInVersion = "7.0",
         ReplacementTypeOrMember = "ConfigureSerialization")]
     public static class SerializationFeatureHelper
     {
@@ -759,7 +759,7 @@ namespace NServiceBus.Features
         RemoveInVersion = "7.0",
         TreatAsErrorFromVersion = "6.0",
         Message = "No longer used, safe to remove")]
-    public class TimeoutManagerBasedDeferral 
+    public class TimeoutManagerBasedDeferral
     {
     }
 }
@@ -941,7 +941,7 @@ namespace NServiceBus.Transports.Msmq
         Message = "No longer available, resolve an instance of IPushMessages from the container instead",
         RemoveInVersion = "7.0",
         TreatAsErrorFromVersion = "6.0")]
-    public class MsmqDequeueStrategy 
+    public class MsmqDequeueStrategy
     {
     }
 }
@@ -972,6 +972,13 @@ namespace NServiceBus.Unicast.Transport
          RemoveInVersion = "7.0",
          TreatAsErrorFromVersion = "6.0")]
         public bool SuppressDistributedTransactions { get; set; }
+
+        [ObsoleteEx(
+            Message = "IsTransactional is no longer used here. Please use `context.Settings.GetRequiredTransactionSupportForReceives() != TransactionSupport.None` instead.",
+            RemoveInVersion = "7.0",
+            TreatAsErrorFromVersion = "6.0")]
+        public bool IsTransactional { get; set; }
+
     }
 
     [ObsoleteEx(
@@ -1037,7 +1044,7 @@ namespace NServiceBus
         TreatAsErrorFromVersion = "6",
         RemoveInVersion = "7",
         Message = "No longer used, please use the new callbacks api described in the v6 upgrade guide")]
-    public class BusAsyncResultEventArgs 
+    public class BusAsyncResultEventArgs
     {
     }
 }
@@ -1048,7 +1055,7 @@ namespace NServiceBus.Unicast
         TreatAsErrorFromVersion = "6",
         RemoveInVersion = "7",
         Message = "No longer used, please use the new callbacks api described in the v6 upgrade guide")]
-    public class BusAsyncResult 
+    public class BusAsyncResult
     {
     }
 }
@@ -1070,7 +1077,7 @@ namespace NServiceBus.Pipeline.Contexts
         TreatAsErrorFromVersion = "6",
         RemoveInVersion = "7",
         ReplacementTypeOrMember = "OutgoingLogicalMessage")]
-    public class OutgoingContext 
+    public class OutgoingContext
     {
     }
 }
@@ -1081,7 +1088,7 @@ namespace NServiceBus.Pipeline
         TreatAsErrorFromVersion = "6",
         RemoveInVersion = "7",
         ReplacementTypeOrMember = "Behavior<T>")]
-    public interface IBehavior<in TContext> 
+    public interface IBehavior<in TContext>
     {
     }
 }
@@ -1092,7 +1099,7 @@ namespace NServiceBus.Pipeline
         TreatAsErrorFromVersion = "6",
         RemoveInVersion = "7",
         Message = "You can no longer get access to the pipeline context via DI. Please use a behavior to get access instead")]
-    public class PipelineExecutor 
+    public class PipelineExecutor
     {
     }
 }
@@ -1144,7 +1151,7 @@ namespace NServiceBus.Unicast.Transport
         TreatAsErrorFromVersion = "6",
         RemoveInVersion = "7",
         Message = "No longer used, can safely be removed")]
-    public class TransportMessageReceivedEventArgs 
+    public class TransportMessageReceivedEventArgs
     {
     }
 }
@@ -1157,7 +1164,7 @@ namespace NServiceBus.Unicast.Transport
         TreatAsErrorFromVersion = "6",
         RemoveInVersion = "7",
         Message = "No longer used, can safely be removed")]
-    public class StartedMessageProcessingEventArgs 
+    public class StartedMessageProcessingEventArgs
     {
     }
 
@@ -1176,7 +1183,7 @@ namespace NServiceBus.Unicast.Transport
         TreatAsErrorFromVersion = "6",
         RemoveInVersion = "7",
         Message = "No longer used, can safely be removed")]
-    public class TransportMessageAvailableEventArgs 
+    public class TransportMessageAvailableEventArgs
     {
     }
 }
@@ -1237,7 +1244,7 @@ namespace NServiceBus.Unicast.Transport
         TreatAsErrorFromVersion = "6",
         RemoveInVersion = "7",
         Message = "No longer used, can safely be removed")]
-    public class TransportReceiver 
+    public class TransportReceiver
     {
     }
 }
@@ -1366,7 +1373,7 @@ namespace NServiceBus
             RemoveInVersion = "7.0",
             TreatAsErrorFromVersion = "6.0",
             ReplacementTypeOrMember = "RequestTimeout<TTimeoutMessageType>(IMessageHandlerContext, DateTime)")]
-        protected void RequestTimeout<TTimeoutMessageType>(DateTime at) 
+        protected void RequestTimeout<TTimeoutMessageType>(DateTime at)
         {
             throw new NotImplementedException();
         }
@@ -1376,7 +1383,7 @@ namespace NServiceBus
             RemoveInVersion = "7.0",
             TreatAsErrorFromVersion = "6.0",
             ReplacementTypeOrMember = "RequestTimeout<TTimeoutMessageType>(IMessageHandlerContext DateTime, TTimeoutMessageType)")]
-        protected void RequestTimeout<TTimeoutMessageType>(DateTime at, Action<TTimeoutMessageType> action) 
+        protected void RequestTimeout<TTimeoutMessageType>(DateTime at, Action<TTimeoutMessageType> action)
         {
             throw new NotImplementedException();
         }
@@ -1394,7 +1401,7 @@ namespace NServiceBus
             RemoveInVersion = "7.0",
             TreatAsErrorFromVersion = "6.0",
             ReplacementTypeOrMember = "RequestTimeout<TTimeoutMessageType>(IMessageHandlerContext, TimeSpan)")]
-        protected void RequestTimeout<TTimeoutMessageType>(TimeSpan within) 
+        protected void RequestTimeout<TTimeoutMessageType>(TimeSpan within)
         {
             throw new NotImplementedException();
         }
@@ -1405,7 +1412,7 @@ namespace NServiceBus
             RemoveInVersion = "7.0",
             TreatAsErrorFromVersion = "6.0",
             ReplacementTypeOrMember = "Saga.RequestTimeout<TTimeoutMessageType>(IMessageHandlerContext, TimeSpan, TTimeoutMessageType)")]
-        protected void RequestTimeout<TTimeoutMessageType>(TimeSpan within, Action<TTimeoutMessageType> messageConstructor) 
+        protected void RequestTimeout<TTimeoutMessageType>(TimeSpan within, Action<TTimeoutMessageType> messageConstructor)
         {
             throw new NotImplementedException();
         }
@@ -1433,7 +1440,7 @@ namespace NServiceBus
             RemoveInVersion = "7.0",
             TreatAsErrorFromVersion = "6.0",
             ReplacementTypeOrMember = "ReplyToOriginator(IMessageHandlerContext, object)")]
-        protected virtual void ReplyToOriginator<TMessage>(Action<TMessage> messageConstructor) 
+        protected virtual void ReplyToOriginator<TMessage>(Action<TMessage> messageConstructor)
         {
             throw new NotImplementedException();
         }
@@ -1454,7 +1461,7 @@ namespace NServiceBus
         {
             throw new NotImplementedException();
         }
-        
+
         [ObsoleteEx(
             Message = "Please use `IMessageHandlerContext.Reply<T>(Action<T> messageConstructor)` provided to message handlers instead.",
             TreatAsErrorFromVersion = "6",


### PR DESCRIPTION
It's been replaced by
context.Settings.GetRequiredTransactionSupportForReceives() !=
TransactionSupport.None