### PR TITLE
SubscriptionBehavior to register with InsertBeforeIfExists

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehavior.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehavior.cs
@@ -61,7 +61,7 @@
             public Registration()
                 : base("SubscriptionBehavior", typeof(SubscriptionBehavior<TContext>), "So we can get subscription events")
             {
-                InsertBefore("ProcessSubscriptionRequests");
+                InsertBeforeIfExists("ProcessSubscriptionRequests");
             }
         }
     }


### PR DESCRIPTION
For transports that have native pub/sub, `ProcessSubscriptionRequests` step (`SubscriptionReceiverBehavior`) doesn't exist, causing `SubscriptionBehavior` step to fail. By registering with `InsertBeforeIfExists` transports with native pub/sub can run ATTs.