### PR TITLE
Minor tweaks to storage adapter API

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1863,8 +1863,8 @@ namespace NServiceBus.Persistence
     }
     public interface ISynchronizedStorageAdapter
     {
-        bool TryAdapt(NServiceBus.Outbox.OutboxTransaction transaction, out NServiceBus.Persistence.CompletableSynchronizedStorageSession session);
-        bool TryAdapt(NServiceBus.Transports.TransportTransaction transportTransaction, out NServiceBus.Persistence.CompletableSynchronizedStorageSession session);
+        System.Threading.Tasks.Task<NServiceBus.Persistence.CompletableSynchronizedStorageSession> TryAdapt(NServiceBus.Outbox.OutboxTransaction transaction, NServiceBus.Extensibility.ContextBag context);
+        System.Threading.Tasks.Task<NServiceBus.Persistence.CompletableSynchronizedStorageSession> TryAdapt(NServiceBus.Transports.TransportTransaction transportTransaction, NServiceBus.Extensibility.ContextBag context);
     }
     public abstract class PersistenceDefinition
     {

--- a/src/NServiceBus.Core/Persistence/ISynchronizedStorageAdapter.cs
+++ b/src/NServiceBus.Core/Persistence/ISynchronizedStorageAdapter.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.Persistence
 {
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
     using NServiceBus.Outbox;
     using NServiceBus.Transports;
 
@@ -12,16 +14,16 @@
         /// Returns a synchronized storage session based on the outbox transaction if possible. 
         /// </summary>
         /// <param name="transaction">Outbox transaction.</param>
-        /// <param name="session">Session or null, if unable to adapt.</param>
-        /// <returns></returns>
-        bool TryAdapt(OutboxTransaction transaction, out CompletableSynchronizedStorageSession session);
+        /// <param name="context">Context.</param>
+        /// <returns>Session or null, if unable to adapt.</returns>
+        Task<CompletableSynchronizedStorageSession> TryAdapt(OutboxTransaction transaction, ContextBag context);
 
         /// <summary>
         /// Returns a synchronized storage session based on the outbox transaction if possible. 
         /// </summary>
         /// <param name="transportTransaction">Transport transaction.</param>
-        /// <param name="session">Session or null, if unable to adapt.</param>
-        /// <returns></returns>
-        bool TryAdapt(TransportTransaction transportTransaction, out CompletableSynchronizedStorageSession session);
+        /// <param name="context">Context.</param>
+        /// <returns>Session or null, if unable to adapt.</returns>
+        Task<CompletableSynchronizedStorageSession> TryAdapt(TransportTransaction transportTransaction, ContextBag context);
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
@@ -51,12 +51,11 @@
             }
         }
 
-        Task<CompletableSynchronizedStorageSession> AdaptOrOpenNewSynchronizedStorageSession(TransportTransaction transportTransaction, OutboxTransaction outboxTransaction, ContextBag contextBag)
+        async Task<CompletableSynchronizedStorageSession> AdaptOrOpenNewSynchronizedStorageSession(TransportTransaction transportTransaction, OutboxTransaction outboxTransaction, ContextBag contextBag)
         {
-            CompletableSynchronizedStorageSession session;
-            return adapter.TryAdapt(transportTransaction, out session) || adapter.TryAdapt(outboxTransaction, out session)
-                ? Task.FromResult(session)
-                : synchronizedStorage.OpenSession(contextBag);
+            return await adapter.TryAdapt(outboxTransaction, contextBag).ConfigureAwait(false) 
+                ?? await adapter.TryAdapt(transportTransaction, contextBag).ConfigureAwait(false)
+                ?? await synchronizedStorage.OpenSession(contextBag).ConfigureAwait(false);
         }
 
 

--- a/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
@@ -44,16 +44,16 @@
 
         class NoOpAdaper : ISynchronizedStorageAdapter
         {
-            public bool TryAdapt(OutboxTransaction transaction, out CompletableSynchronizedStorageSession session)
+            static readonly Task<CompletableSynchronizedStorageSession> EmptyResult = Task.FromResult<CompletableSynchronizedStorageSession>(null);
+
+            public Task<CompletableSynchronizedStorageSession> TryAdapt(OutboxTransaction transaction, ContextBag context)
             {
-                session = null;
-                return false;
+                return EmptyResult;
             }
 
-            public bool TryAdapt(TransportTransaction transportTransaction, out CompletableSynchronizedStorageSession session)
+            public Task<CompletableSynchronizedStorageSession> TryAdapt(TransportTransaction transportTransaction, ContextBag context)
             {
-                session = null;
-                return false;
+                return EmptyResult;
             }
         }
 


### PR DESCRIPTION
Includes small changes to the synchronized storage session API to make it more usable (adding a context bag to each call) and makes the `Adapt` methods async to allow usage of async session/transaction APIs if supported by infrastructure.

Also changes the order in which the adapters are called, giving precedence to the Outbox. This means that if the outbox is enabled, the storage session will hook up to it. Otherwise it will try to hook up to the transport.

## Downstreams

* ~~Raven pull~~ Raven persister does not use the adapter API
- [x] NHibernate pull https://github.com/Particular/NServiceBus.NHibernate/pull/153