### PR TITLE
Subscriber should override Equals and GetHashCode

### DIFF
--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/Subscriber.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/Subscriber.cs
@@ -25,5 +25,47 @@ namespace NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions
         /// The endpoint name of the subscriber or null if unknown.
         /// </summary>
         public EndpointName Endpoint { get; }
+
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <returns>
+        /// true if the specified object is equal to the current object; otherwise, false.
+        /// </returns>
+        /// <param name="obj">The object to compare with the current object.</param>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj is Subscriber && Equals((Subscriber)obj);
+        }
+
+        bool Equals(Subscriber obj) => string.Equals(TransportAddress, obj.TransportAddress) && Equals(Endpoint, obj.Endpoint);
+
+        /// <summary>
+        /// Serves as a hash function for a particular type.
+        /// </summary>
+        /// <returns>
+        /// A hash code for the current object.
+        /// </returns>
+        public override int GetHashCode() => (TransportAddress + Endpoint).GetHashCode();
+
+        /// <summary>
+        /// Checks for equality.
+        /// </summary>
+        public static bool operator ==(Subscriber left, Subscriber right) => Equals(left, right);
+
+        /// <summary>
+        /// Checks for inequality.
+        /// </summary>
+        public static bool operator !=(Subscriber left, Subscriber right) => !Equals(left, right);
     }
 }


### PR DESCRIPTION
While helping @colin-higgins with updating the RavenDB subscription persistence to an updated v6 unstable, I ran into a problem with the Subscriber class. The subscription persistence needs to be able to be easily add and remove Subscriber instances from a `List<Subscriber>`. These instances are serialized to RavenDB and back, so reference equality isn't good enough.