### PR TITLE
aligned incoming logical and physical contexts

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Basic/When_extending_behavior_context.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_extending_behavior_context.cs
@@ -69,9 +69,9 @@
                 }
             }
 
-            class CustomContextExtensionBehavior : Behavior<LogicalMessageProcessingContext>
+            class CustomContextExtensionBehavior : Behavior<IncomingLogicalMessageContext>
             {
-                public override Task Invoke(LogicalMessageProcessingContext context, Func<Task> next)
+                public override Task Invoke(IncomingLogicalMessageContext context, Func<Task> next)
                 {
                     context.Extensions.Set("CustomExtension", ExtensionValue);
                     return next();

--- a/src/NServiceBus.AcceptanceTests/Msmq/When_publishing_with_authorizer.cs
+++ b/src/NServiceBus.AcceptanceTests/Msmq/When_publishing_with_authorizer.cs
@@ -71,7 +71,7 @@
                 });
             }
 
-            bool Authorizer(PhysicalMessageProcessingContext context)
+            bool Authorizer(IncomingPhysicalMessageContext context)
             {
                 var isFromSubscriber1 = context
                     .MessageHeaders["NServiceBus.SubscriberEndpoint"]

--- a/src/NServiceBus.AcceptanceTests/Msmq/When_unsubscribing_with_authorizer.cs
+++ b/src/NServiceBus.AcceptanceTests/Msmq/When_unsubscribing_with_authorizer.cs
@@ -58,7 +58,7 @@
                 });
             }
 
-            bool Authorizer(PhysicalMessageProcessingContext context)
+            bool Authorizer(IncomingPhysicalMessageContext context)
             {
                 var isUnsubscribe = context
                     .MessageHeaders["NServiceBus.MessageIntent"] == "Unsubscribe";

--- a/src/NServiceBus.AcceptanceTests/PipelineExt/FilteringWhatGetsAudited.cs
+++ b/src/NServiceBus.AcceptanceTests/PipelineExt/FilteringWhatGetsAudited.cs
@@ -52,9 +52,9 @@ namespace NServiceBus.AcceptanceTests.PipelineExt
                 }
             }
 
-            class AddContextStorage : Behavior<PhysicalMessageProcessingContext>
+            class AddContextStorage : Behavior<IncomingPhysicalMessageContext>
             {
-                public override Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
+                public override Task Invoke(IncomingPhysicalMessageContext context, Func<Task> next)
                 {
                     context.Extensions.Set(new AuditFilterResult());
 
@@ -71,9 +71,9 @@ namespace NServiceBus.AcceptanceTests.PipelineExt
                 }
             }
 
-            class SetFiltering : Behavior<LogicalMessageProcessingContext>
+            class SetFiltering : Behavior<IncomingLogicalMessageContext>
             {
-                public override Task Invoke(LogicalMessageProcessingContext context, Func<Task> next)
+                public override Task Invoke(IncomingLogicalMessageContext context, Func<Task> next)
                 {
                     if (context.Message.MessageType == typeof(MessageToBeAudited))
                     {

--- a/src/NServiceBus.AcceptanceTests/PipelineExt/MutingHandlerExceptions.cs
+++ b/src/NServiceBus.AcceptanceTests/PipelineExt/MutingHandlerExceptions.cs
@@ -43,9 +43,9 @@ namespace NServiceBus.AcceptanceTests.PipelineExt
                 }
             }
 
-            class MyExceptionFilteringBehavior : Behavior<PhysicalMessageProcessingContext>
+            class MyExceptionFilteringBehavior : Behavior<IncomingPhysicalMessageContext>
             {
-                public override async Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
+                public override async Task Invoke(IncomingPhysicalMessageContext context, Func<Task> next)
                 {
                     try
                     {

--- a/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehavior.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehavior.cs
@@ -21,7 +21,7 @@
         }
     }
 
-    class SubscriptionBehavior<TContext> : Behavior<PhysicalMessageProcessingContext> where TContext : ScenarioContext
+    class SubscriptionBehavior<TContext> : Behavior<IncomingPhysicalMessageContext> where TContext : ScenarioContext
     {
         Action<SubscriptionEventArgs, TContext> action;
         TContext scenarioContext;
@@ -32,7 +32,7 @@
             this.scenarioContext = scenarioContext;
         }
 
-        public override async Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingPhysicalMessageContext context, Func<Task> next)
         {
             await next().ConfigureAwait(false);
             var subscriptionMessageType = GetSubscriptionMessageTypeFrom(context.Message);

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_context_information_added.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_context_information_added.cs
@@ -72,9 +72,9 @@ namespace NServiceBus.AcceptanceTests.Sagas
                 }
             }
 
-            public class BehaviorWhichAddsThingsToTheContext : Behavior<PhysicalMessageProcessingContext>
+            public class BehaviorWhichAddsThingsToTheContext : Behavior<IncomingPhysicalMessageContext>
             {
-                public override Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
+                public override Task Invoke(IncomingPhysicalMessageContext context, Func<Task> next)
                 {
                     context.Extensions.Set(new State
                     {

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -556,6 +556,10 @@ namespace NServiceBus
     {
         public static void RequireImmediateDispatch(this NServiceBus.Extensibility.ExtendableOptions options) { }
     }
+    public interface IncomingPhysicalMessageContext : NServiceBus.Extensibility.IExtendable, NServiceBus.IBusContext, NServiceBus.IMessageProcessingContext, NServiceBus.Pipeline.BehaviorContext, NServiceBus.Pipeline.Contexts.IncomingContext
+    {
+        NServiceBus.Transports.IncomingMessage Message { get; }
+    }
     public interface INeedInitialization
     {
         void Customize(NServiceBus.BusConfiguration configuration);
@@ -709,10 +713,6 @@ namespace NServiceBus
     {
         public PersistenceExtentions(NServiceBus.Settings.SettingsHolder settings) { }
     }
-    public interface PhysicalMessageProcessingContext : NServiceBus.Extensibility.IExtendable, NServiceBus.IBusContext, NServiceBus.IMessageProcessingContext, NServiceBus.Pipeline.BehaviorContext, NServiceBus.Pipeline.Contexts.IncomingContext
-    {
-        NServiceBus.Transports.IncomingMessage Message { get; }
-    }
     [System.ObsoleteAttribute("For performance reasons it is no longer possible to instrument the pipeline execu" +
         "tion. Will be removed in version 7.0.0.", true)]
     public class PipelineNotifications
@@ -803,7 +803,7 @@ namespace NServiceBus
     {
         public NServiceBus.ToSagaExpression<TSagaData, TMessage> ConfigureMapping<TMessage>(System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty) { }
     }
-    public abstract class SatelliteBehavior : NServiceBus.Pipeline.PipelineTerminator<NServiceBus.PhysicalMessageProcessingContext>
+    public abstract class SatelliteBehavior : NServiceBus.Pipeline.PipelineTerminator<NServiceBus.IncomingPhysicalMessageContext>
     {
         protected SatelliteBehavior() { }
     }
@@ -872,7 +872,7 @@ namespace NServiceBus
     {
         public SubscribeOptions() { }
     }
-    public delegate bool SubscriptionAuthorizer(NServiceBus.PhysicalMessageProcessingContext context);
+    public delegate bool SubscriptionAuthorizer(NServiceBus.IncomingPhysicalMessageContext context);
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface | System.AttributeTargets.All)]
     public sealed class TimeToBeReceivedAttribute : System.Attribute
     {
@@ -2037,6 +2037,12 @@ namespace NServiceBus.Pipeline
 namespace NServiceBus.Pipeline.Contexts
 {
     public interface IncomingContext : NServiceBus.Extensibility.IExtendable, NServiceBus.IBusContext, NServiceBus.IMessageProcessingContext, NServiceBus.Pipeline.BehaviorContext { }
+    public interface IncomingLogicalMessageContext : NServiceBus.Extensibility.IExtendable, NServiceBus.IBusContext, NServiceBus.IMessageProcessingContext, NServiceBus.Pipeline.BehaviorContext, NServiceBus.Pipeline.Contexts.IncomingContext
+    {
+        System.Collections.Generic.Dictionary<string, string> Headers { get; }
+        NServiceBus.Unicast.Messages.LogicalMessage Message { get; }
+        bool MessageHandled { get; set; }
+    }
     public interface InvokeHandlerContext : NServiceBus.Extensibility.IExtendable, NServiceBus.IBusContext, NServiceBus.IMessageHandlerContext, NServiceBus.IMessageProcessingContext, NServiceBus.Pipeline.BehaviorContext, NServiceBus.Pipeline.Contexts.IncomingContext
     {
         bool HandleCurrentMessageLaterWasCalled { get; }
@@ -2045,12 +2051,6 @@ namespace NServiceBus.Pipeline.Contexts
         object MessageBeingHandled { get; }
         NServiceBus.Unicast.Behaviors.MessageHandler MessageHandler { get; }
         NServiceBus.Unicast.Messages.MessageMetadata MessageMetadata { get; }
-    }
-    public interface LogicalMessageProcessingContext : NServiceBus.Extensibility.IExtendable, NServiceBus.IBusContext, NServiceBus.IMessageProcessingContext, NServiceBus.Pipeline.BehaviorContext, NServiceBus.Pipeline.Contexts.IncomingContext
-    {
-        System.Collections.Generic.Dictionary<string, string> Headers { get; }
-        NServiceBus.Unicast.Messages.LogicalMessage Message { get; }
-        bool MessageHandled { get; set; }
     }
     [System.ObsoleteAttribute("Please use `OutgoingLogicalMessage` instead. Will be removed in version 7.0.0.", true)]
     public class OutgoingContext

--- a/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_incoming_messages.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_incoming_messages.cs
@@ -44,7 +44,7 @@ namespace NServiceBus.Core.Tests.DataBus
                 fakeDatabus.StreamsToReturn[databusKey] = stream;
 
                 await receiveBehavior.Invoke(
-                    new LogicalMessageProcessingContextImpl(
+                    new IncomingLogicalMessageContextImpl(
                         message,
                         "messageId",
                         "replyToAddress",

--- a/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/DispatchTimeoutBehaviorTest.cs
+++ b/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/DispatchTimeoutBehaviorTest.cs
@@ -111,7 +111,7 @@
             };
         }
 
-        static PhysicalMessageProcessingContext CreateContext(string timeoutId)
+        static IncomingPhysicalMessageContext CreateContext(string timeoutId)
         {
             var messageId = Guid.NewGuid().ToString("D");
             var headers = new Dictionary<string, string>
@@ -119,7 +119,7 @@
                 {"Timeout.Id", timeoutId}
             };
 
-            return new PhysicalMessageProcessingContextImpl(
+            return new IncomingPhysicalMessageContextImpl(
                 new IncomingMessage(messageId, headers, new MemoryStream()), null);
         }
 

--- a/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
@@ -18,7 +18,7 @@
         {
             var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(new Conventions()), new InMemorySynchronizedStorage(), new InMemoryTransactionalSynchronizedStorageAdapter());
 
-            var context = new LogicalMessageProcessingContextImpl(
+            var context = new IncomingLogicalMessageContextImpl(
                 new LogicalMessage(new MessageMetadata(typeof(string)), null, null), 
                 "messageId",
                 "replyToAddress",

--- a/src/NServiceBus.Core.Tests/UnitOfWork/UnitOfWorkBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/UnitOfWork/UnitOfWorkBehaviorTests.cs
@@ -147,7 +147,7 @@
 
             var receiveContext = new TransportReceiveContextImpl(new IncomingMessage("fakeId", new Dictionary<string, string>(), new MemoryStream()), null, new RootContext(builder));
 
-            var context = new PhysicalMessageProcessingContextImpl(receiveContext.Message, receiveContext);
+            var context = new IncomingPhysicalMessageContextImpl(receiveContext.Message, receiveContext);
 
             return runner.Invoke(context, () =>
             {

--- a/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
@@ -6,7 +6,7 @@
     using Pipeline;
     using Transports;
 
-    class InvokeAuditPipelineBehavior : Behavior<PhysicalMessageProcessingContext>
+    class InvokeAuditPipelineBehavior : Behavior<IncomingPhysicalMessageContext>
     {
         public InvokeAuditPipelineBehavior(PipelineBase<AuditContext> auditPipeline, string auditAddress)
         {
@@ -14,7 +14,7 @@
             this.auditAddress = auditAddress;
         }
 
-        public override async Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingPhysicalMessageContext context, Func<Task> next)
         {
             await next().ConfigureAwait(false);
 

--- a/src/NServiceBus.Core/ConsistencyGuarantees/TransactionScopes/HandlerTransactionScopeWrapperBehavior.cs
+++ b/src/NServiceBus.Core/ConsistencyGuarantees/TransactionScopes/HandlerTransactionScopeWrapperBehavior.cs
@@ -5,14 +5,14 @@ namespace NServiceBus
     using System.Transactions;
     using Pipeline;
 
-    class HandlerTransactionScopeWrapperBehavior : Behavior<PhysicalMessageProcessingContext>
+    class HandlerTransactionScopeWrapperBehavior : Behavior<IncomingPhysicalMessageContext>
     {
         public HandlerTransactionScopeWrapperBehavior(TransactionOptions transactionOptions)
         {
             this.transactionOptions = transactionOptions;
         }
 
-        public override async Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingPhysicalMessageContext context, Func<Task> next)
         {
             if (Transaction.Current != null)
             {

--- a/src/NServiceBus.Core/ConsistencyGuarantees/TransactionScopes/SuppressAmbientTransactionBehavior.cs
+++ b/src/NServiceBus.Core/ConsistencyGuarantees/TransactionScopes/SuppressAmbientTransactionBehavior.cs
@@ -5,9 +5,9 @@ namespace NServiceBus
     using System.Transactions;
     using Pipeline;
 
-    class SuppressAmbientTransactionBehavior : Behavior<PhysicalMessageProcessingContext>
+    class SuppressAmbientTransactionBehavior : Behavior<IncomingPhysicalMessageContext>
     {
-        public override async Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingPhysicalMessageContext context, Func<Task> next)
         {
             if (Transaction.Current == null)
             {

--- a/src/NServiceBus.Core/DataBus/DataBusReceiveBehavior.cs
+++ b/src/NServiceBus.Core/DataBus/DataBusReceiveBehavior.cs
@@ -7,7 +7,7 @@
     using Pipeline;
     using Pipeline.Contexts;
 
-    class DataBusReceiveBehavior : Behavior<LogicalMessageProcessingContext>
+    class DataBusReceiveBehavior : Behavior<IncomingLogicalMessageContext>
     {
         public IDataBus DataBus { get; set; }
 
@@ -15,7 +15,7 @@
 
         public Conventions Conventions { get; set; }
 
-        public override async Task Invoke(LogicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingLogicalMessageContext context, Func<Task> next)
         {
             var message = context.Message.Instance;
 

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/DispatchTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/DispatchTimeoutBehavior.cs
@@ -15,7 +15,7 @@ namespace NServiceBus
             dispatchConsistency = GetDispatchConsistency(transactionSupport);
         }
 
-        protected override async Task Terminate(PhysicalMessageProcessingContext context)
+        protected override async Task Terminate(IncomingPhysicalMessageContext context)
         {
             var message = context.Message;
             var timeoutId = message.Headers["Timeout.Id"];

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
@@ -18,7 +18,7 @@ namespace NServiceBus
             this.owningTimeoutManager = owningTimeoutManager;
         }
 
-        protected override async Task Terminate(PhysicalMessageProcessingContext context)
+        protected override async Task Terminate(IncomingPhysicalMessageContext context)
         {
             var message = context.Message;
             var sagaId = Guid.Empty;

--- a/src/NServiceBus.Core/Encryption/DecryptBehavior.cs
+++ b/src/NServiceBus.Core/Encryption/DecryptBehavior.cs
@@ -7,7 +7,7 @@ namespace NServiceBus
     using Pipeline.Contexts;
     using Unicast.Transport;
 
-    class DecryptBehavior : Behavior<LogicalMessageProcessingContext>
+    class DecryptBehavior : Behavior<IncomingLogicalMessageContext>
     {
         EncryptionMutator messageMutator;
 
@@ -15,7 +15,7 @@ namespace NServiceBus
         {
             this.messageMutator = messageMutator;
         }
-        public override async Task Invoke(LogicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingLogicalMessageContext context, Func<Task> next)
         {
             if (TransportMessageExtensions.IsControlMessage(context.Headers))
             {

--- a/src/NServiceBus.Core/Forwarding/InvokeForwardingPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Forwarding/InvokeForwardingPipelineBehavior.cs
@@ -6,7 +6,7 @@
     using Pipeline;
     using Transports;
 
-    class InvokeForwardingPipelineBehavior : Behavior<PhysicalMessageProcessingContext>
+    class InvokeForwardingPipelineBehavior : Behavior<IncomingPhysicalMessageContext>
     {
         public InvokeForwardingPipelineBehavior(IPipelineBase<ForwardingContext> forwardingPipeline, string forwardingAddress)
         {
@@ -14,7 +14,7 @@
             this.forwardingAddress = forwardingAddress;
         }
 
-        public override async Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingPhysicalMessageContext context, Func<Task> next)
         {
             await next().ConfigureAwait(false);
 

--- a/src/NServiceBus.Core/Licensing/LogErrorOnInvalidLicenseBehavior.cs
+++ b/src/NServiceBus.Core/Licensing/LogErrorOnInvalidLicenseBehavior.cs
@@ -5,9 +5,9 @@ namespace NServiceBus
     using Logging;
     using Pipeline;
 
-    class LogErrorOnInvalidLicenseBehavior : Behavior<PhysicalMessageProcessingContext>
+    class LogErrorOnInvalidLicenseBehavior : Behavior<IncomingPhysicalMessageContext>
     {
-        public override async Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingPhysicalMessageContext context, Func<Task> next)
         {
             Log.Error("Your license has expired");
 

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -124,8 +124,8 @@
     <Compile Include="Pipeline\BehaviorContextImpl.cs" />
     <Compile Include="Pipeline\Incoming\IncomingContextImpl.cs" />
     <Compile Include="Pipeline\Incoming\InvokeHandlerContextImpl.cs" />
-    <Compile Include="Pipeline\Incoming\LogicalMessageProcessingContextImpl.cs" />
-    <Compile Include="Pipeline\Incoming\PhysicalMessageProcessingContextImpl.cs" />
+    <Compile Include="Pipeline\Incoming\IncomingLogicalMessageContextImpl.cs" />
+    <Compile Include="Pipeline\Incoming\IncomingPhysicalMessageContextImpl.cs" />
     <Compile Include="Pipeline\Incoming\TransportReceiveContextImpl.cs" />
     <Compile Include="Pipeline\Outgoing\BatchDispatchContextImpl.cs" />
     <Compile Include="Pipeline\Outgoing\DispatchContextImpl.cs" />
@@ -169,9 +169,9 @@
     <Compile Include="Persistence\InMemory\Outbox\InMemoryOutboxTransaction.cs" />
     <Compile Include="Persistence\ISynchronizedStorage.cs" />
     <Compile Include="Pipeline\Incoming\InvokeHandlerContext.cs" />
-    <Compile Include="Pipeline\Incoming\LogicalMessageProcessingContext.cs" />
+    <Compile Include="Pipeline\Incoming\IncomingLogicalMessageContext.cs" />
     <Compile Include="Pipeline\Incoming\PendingTransportOperations.cs" />
-    <Compile Include="Pipeline\Incoming\PhysicalMessageProcessingContext.cs" />
+    <Compile Include="Pipeline\Incoming\IncomingPhysicalMessageContext.cs" />
     <Compile Include="Pipeline\Outgoing\BatchDispatchContext.cs" />
     <Compile Include="Pipeline\Outgoing\BatchToDispatchConnector.cs" />
     <Compile Include="Pipeline\Incoming\ReceiveFeature.cs" />

--- a/src/NServiceBus.Core/Performance/Statistics/CriticalTime/CriticalTimeBehavior.cs
+++ b/src/NServiceBus.Core/Performance/Statistics/CriticalTime/CriticalTimeBehavior.cs
@@ -5,7 +5,7 @@
     using Pipeline;
 
 
-    class CriticalTimeBehavior : Behavior<PhysicalMessageProcessingContext>
+    class CriticalTimeBehavior : Behavior<IncomingPhysicalMessageContext>
     {
         CriticalTimeCalculator criticalTimeCounter;
 
@@ -14,7 +14,7 @@
             this.criticalTimeCounter = criticalTimeCounter;
         }
 
-        public override async Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingPhysicalMessageContext context, Func<Task> next)
         {
             await next().ConfigureAwait(false);
 

--- a/src/NServiceBus.Core/Performance/Statistics/ProcessingStatisticsBehavior.cs
+++ b/src/NServiceBus.Core/Performance/Statistics/ProcessingStatisticsBehavior.cs
@@ -4,9 +4,9 @@
     using System.Threading.Tasks;
     using Pipeline;
 
-    class ProcessingStatisticsBehavior : Behavior<PhysicalMessageProcessingContext>
+    class ProcessingStatisticsBehavior : Behavior<IncomingPhysicalMessageContext>
     {
-        public override async Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingPhysicalMessageContext context, Func<Task> next)
         {
             var state = new State();
 

--- a/src/NServiceBus.Core/Performance/Statistics/ReceivePerformanceDiagnosticsBehavior.cs
+++ b/src/NServiceBus.Core/Performance/Statistics/ReceivePerformanceDiagnosticsBehavior.cs
@@ -7,7 +7,7 @@ namespace NServiceBus
     using Pipeline;
 
     [SkipWeaving]
-    class ReceivePerformanceDiagnosticsBehavior : Behavior<PhysicalMessageProcessingContext>
+    class ReceivePerformanceDiagnosticsBehavior : Behavior<IncomingPhysicalMessageContext>
     {
    
         public override Task Warmup()
@@ -19,7 +19,7 @@ namespace NServiceBus
             return base.Warmup();
         }
 
-        public override async Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingPhysicalMessageContext context, Func<Task> next)
         {
             messagesPulledFromQueueCounter.Increment();
 

--- a/src/NServiceBus.Core/Performance/Statistics/SLA/SLABehavior.cs
+++ b/src/NServiceBus.Core/Performance/Statistics/SLA/SLABehavior.cs
@@ -4,7 +4,7 @@
     using System.Threading.Tasks;
     using Pipeline;
 
-    class SLABehavior : Behavior<PhysicalMessageProcessingContext>
+    class SLABehavior : Behavior<IncomingPhysicalMessageContext>
     {
         EstimatedTimeToSLABreachCalculator breachCalculator;
 
@@ -13,7 +13,7 @@
             this.breachCalculator = breachCalculator;
         }
 
-        public override async Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingPhysicalMessageContext context, Func<Task> next)
         {
             await next().ConfigureAwait(false);
 

--- a/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
@@ -13,7 +13,7 @@
     using NServiceBus.Transports;
     using NServiceBus.Unicast.Messages;
 
-    class DeserializeLogicalMessagesConnector : StageConnector<PhysicalMessageProcessingContext, LogicalMessageProcessingContext>
+    class DeserializeLogicalMessagesConnector : StageConnector<IncomingPhysicalMessageContext, IncomingLogicalMessageContext>
     {
         public DeserializeLogicalMessagesConnector(MessageDeserializerResolver deserializerResolver, LogicalMessageFactory logicalMessageFactory, MessageMetadataRegistry messageMetadataRegistry)
         {
@@ -22,7 +22,7 @@
             this.messageMetadataRegistry = messageMetadataRegistry;
         }
 
-        public override async Task Invoke(PhysicalMessageProcessingContext context, Func<LogicalMessageProcessingContext, Task> next)
+        public override async Task Invoke(IncomingPhysicalMessageContext context, Func<IncomingLogicalMessageContext, Task> next)
         {
             var incomingMessage = context.Message;
 
@@ -30,7 +30,7 @@
 
             foreach (var message in messages)
             {
-                await next(new LogicalMessageProcessingContextImpl(message, context)).ConfigureAwait(false);
+                await next(new IncomingLogicalMessageContextImpl(message, context)).ConfigureAwait(false);
             }
         }
 

--- a/src/NServiceBus.Core/Pipeline/Incoming/IncomingLogicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IncomingLogicalMessageContext.cs
@@ -6,7 +6,7 @@
     /// <summary>
     /// A context of behavior execution in logical message processing stage.
     /// </summary>
-    public interface LogicalMessageProcessingContext : IncomingContext
+    public interface IncomingLogicalMessageContext : IncomingContext
     {
         /// <summary>
         /// Message being handled.

--- a/src/NServiceBus.Core/Pipeline/Incoming/IncomingLogicalMessageContextImpl.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IncomingLogicalMessageContextImpl.cs
@@ -3,14 +3,14 @@
     using System.Collections.Generic;
     using NServiceBus.Unicast.Messages;
 
-    class LogicalMessageProcessingContextImpl : IncomingContextImpl, LogicalMessageProcessingContext
+    class IncomingLogicalMessageContextImpl : IncomingContextImpl, IncomingLogicalMessageContext
     {
-        internal LogicalMessageProcessingContextImpl(LogicalMessage logicalMessage, PhysicalMessageProcessingContext parentContext)
+        internal IncomingLogicalMessageContextImpl(LogicalMessage logicalMessage, IncomingPhysicalMessageContext parentContext)
             : this(logicalMessage, parentContext.MessageId, parentContext.ReplyToAddress, parentContext.Message.Headers, parentContext)
         {
         }
 
-        public LogicalMessageProcessingContextImpl(LogicalMessage logicalMessage, string messageId, string replyToAddress, Dictionary<string, string> headers, BehaviorContext parentContext)
+        public IncomingLogicalMessageContextImpl(LogicalMessage logicalMessage, string messageId, string replyToAddress, Dictionary<string, string> headers, BehaviorContext parentContext)
             : base(messageId, replyToAddress, headers, parentContext)
         {
             Message = logicalMessage;

--- a/src/NServiceBus.Core/Pipeline/Incoming/IncomingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IncomingPhysicalMessageContext.cs
@@ -6,7 +6,7 @@
     /// <summary>
     /// A context of behavior execution in physical message processing stage.
     /// </summary>
-    public interface PhysicalMessageProcessingContext : IncomingContext
+    public interface IncomingPhysicalMessageContext : IncomingContext
     {
         /// <summary>
         /// The physical message being processed.

--- a/src/NServiceBus.Core/Pipeline/Incoming/IncomingPhysicalMessageContextImpl.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IncomingPhysicalMessageContextImpl.cs
@@ -7,9 +7,9 @@
     /// <summary>
     /// A context of behavior execution in physical message processing stage.
     /// </summary>
-    class PhysicalMessageProcessingContextImpl : IncomingContextImpl, PhysicalMessageProcessingContext
+    class IncomingPhysicalMessageContextImpl : IncomingContextImpl, IncomingPhysicalMessageContext
     {
-        public PhysicalMessageProcessingContextImpl(IncomingMessage message, BehaviorContext parentContext)
+        public IncomingPhysicalMessageContextImpl(IncomingMessage message, BehaviorContext parentContext)
             : base(message.MessageId, message.GetReplyToAddress(), message.Headers, parentContext)
         {
             Message = message;

--- a/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerContextImpl.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerContextImpl.cs
@@ -9,7 +9,7 @@ namespace NServiceBus.Pipeline.Contexts
 
     class InvokeHandlerContextImpl : IncomingContextImpl, InvokeHandlerContext
     {
-        internal InvokeHandlerContextImpl(MessageHandler handler, SynchronizedStorageSession storageSession, LogicalMessageProcessingContext parentContext)
+        internal InvokeHandlerContextImpl(MessageHandler handler, SynchronizedStorageSession storageSession, IncomingLogicalMessageContext parentContext)
             : this(handler, parentContext.MessageId, parentContext.ReplyToAddress, parentContext.Headers, parentContext.Message.Metadata, parentContext.Message.Instance, storageSession, parentContext)
         {
         }

--- a/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
@@ -11,7 +11,7 @@
     using NServiceBus.Transports;
     using NServiceBus.Unicast;
 
-    class LoadHandlersConnector : StageConnector<LogicalMessageProcessingContext, InvokeHandlerContext>
+    class LoadHandlersConnector : StageConnector<IncomingLogicalMessageContext, InvokeHandlerContext>
     {
         public LoadHandlersConnector(MessageHandlerRegistry messageHandlerRegistry, ISynchronizedStorage synchronizedStorage, ISynchronizedStorageAdapter adapter)
         {
@@ -20,7 +20,7 @@
             this.adapter = adapter;
         }
 
-        public override async Task Invoke(LogicalMessageProcessingContext context, Func<InvokeHandlerContext, Task> next)
+        public override async Task Invoke(IncomingLogicalMessageContext context, Func<InvokeHandlerContext, Task> next)
         {
             var outboxTransaction = context.Extensions.Get<OutboxTransaction>();
             var transportTransaction = context.Extensions.Get<TransportTransaction>();

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageProcessingConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageProcessingConnector.cs
@@ -14,7 +14,7 @@ namespace NServiceBus
     using Transports;
     using TransportOperation = Transports.TransportOperation;
 
-    class TransportReceiveToPhysicalMessageProcessingConnector : StageConnector<TransportReceiveContext, PhysicalMessageProcessingContext>
+    class TransportReceiveToPhysicalMessageProcessingConnector : StageConnector<TransportReceiveContext, IncomingPhysicalMessageContext>
     {
         public TransportReceiveToPhysicalMessageProcessingConnector(IPipelineBase<BatchDispatchContext> batchDispatchPipeline, IOutboxStorage outboxStorage)
         {
@@ -22,10 +22,10 @@ namespace NServiceBus
             this.outboxStorage = outboxStorage;
         }
 
-        public override async Task Invoke(TransportReceiveContext context, Func<PhysicalMessageProcessingContext, Task> next)
+        public override async Task Invoke(TransportReceiveContext context, Func<IncomingPhysicalMessageContext, Task> next)
         {
             var messageId = context.Message.MessageId;
-            var physicalMessageContext = new PhysicalMessageProcessingContextImpl(context.Message, context);
+            var physicalMessageContext = new IncomingPhysicalMessageContextImpl(context.Message, context);
 
             var deduplicationEntry = await outboxStorage.Get(messageId, context.Extensions).ConfigureAwait(false);
             var pendingTransportOperations = new PendingTransportOperations();

--- a/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehavior.cs
@@ -6,9 +6,9 @@
     using Pipeline;
     using Pipeline.Contexts;
 
-    class MutateIncomingMessageBehavior : Behavior<LogicalMessageProcessingContext>
+    class MutateIncomingMessageBehavior : Behavior<IncomingLogicalMessageContext>
     {
-        public override async Task Invoke(LogicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingLogicalMessageContext context, Func<Task> next)
         {
             var logicalMessage = context.Message;
             var current = logicalMessage.Instance;

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
@@ -5,9 +5,9 @@
     using MessageMutator;
     using Pipeline;
 
-    class MutateIncomingTransportMessageBehavior : Behavior<PhysicalMessageProcessingContext>
+    class MutateIncomingTransportMessageBehavior : Behavior<IncomingPhysicalMessageContext>
     {
-        public override async Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingPhysicalMessageContext context, Func<Task> next)
         {
             var mutators = context.Builder.BuildAll<IMutateIncomingTransportMessages>();
             var transportMessage = context.Message;

--- a/src/NServiceBus.Core/Routing/Legacy/ProcessedMessageCounterBehavior.cs
+++ b/src/NServiceBus.Core/Routing/Legacy/ProcessedMessageCounterBehavior.cs
@@ -5,7 +5,7 @@
     using NServiceBus.Pipeline;
     using NServiceBus.Routing.Legacy;
 
-    class ProcessedMessageCounterBehavior : Behavior<PhysicalMessageProcessingContext>
+    class ProcessedMessageCounterBehavior : Behavior<IncomingPhysicalMessageContext>
     {
         ReadyMessageSender readyMessageSender;
 
@@ -14,7 +14,7 @@
             this.readyMessageSender = readyMessageSender;
         }
 
-        public override async Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingPhysicalMessageContext context, Func<Task> next)
         {
             await next();
             readyMessageSender.MessageProcessed(context.Message.Headers);

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionAuthorizer.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionAuthorizer.cs
@@ -3,7 +3,7 @@ namespace NServiceBus
     /// <summary>
     /// The signature of a subscription authorizer used by <see cref="MessageDrivenSubscriptionsConfigExtensions.SubscriptionAuthorizer"/>.
     /// </summary>
-    /// <param name="context">The current <see cref="PhysicalMessageProcessingContext"/> of the subscription control message.</param>
+    /// <param name="context">The current <see cref="IncomingPhysicalMessageContext"/> of the subscription control message.</param>
     /// <returns><code>true</code> to allow the subscription to be stored; <code>false</code> to decline the subscription.</returns>
-    public delegate bool SubscriptionAuthorizer(PhysicalMessageProcessingContext context);
+    public delegate bool SubscriptionAuthorizer(IncomingPhysicalMessageContext context);
 }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionReceiverBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionReceiverBehavior.cs
@@ -9,7 +9,7 @@
     using NServiceBus.Unicast.Subscriptions;
     using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
 
-    class SubscriptionReceiverBehavior : Behavior<PhysicalMessageProcessingContext>
+    class SubscriptionReceiverBehavior : Behavior<IncomingPhysicalMessageContext>
     {
         public SubscriptionReceiverBehavior(ISubscriptionStorage subscriptionStorage, SubscriptionAuthorizer authorizer)
         {
@@ -17,7 +17,7 @@
             this.authorizer = authorizer;
         }
 
-        public override async Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingPhysicalMessageContext context, Func<Task> next)
         {
             var incomingMessage = context.Message;
             var messageTypeString = GetSubscriptionMessageTypeFrom(incomingMessage);

--- a/src/NServiceBus.Core/Sagas/InvokeSagaNotFoundBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/InvokeSagaNotFoundBehavior.cs
@@ -7,11 +7,11 @@ namespace NServiceBus
     using Pipeline.Contexts;
     using Sagas;
 
-    class InvokeSagaNotFoundBehavior : Behavior<LogicalMessageProcessingContext>
+    class InvokeSagaNotFoundBehavior : Behavior<IncomingLogicalMessageContext>
     {
         static ILog logger = LogManager.GetLogger<InvokeSagaNotFoundBehavior>();
 
-        public override async Task Invoke(LogicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingLogicalMessageContext context, Func<Task> next)
         {
             var invocationResult = new SagaInvocationResult();
             context.Extensions.Set(invocationResult);

--- a/src/NServiceBus.Core/Satellites/SatelliteBehavior.cs
+++ b/src/NServiceBus.Core/Satellites/SatelliteBehavior.cs
@@ -5,7 +5,7 @@ namespace NServiceBus
     /// <summary>
     /// A base class for satellite behaviors.
     /// </summary>
-    public abstract class SatelliteBehavior: PipelineTerminator<PhysicalMessageProcessingContext>
+    public abstract class SatelliteBehavior: PipelineTerminator<IncomingPhysicalMessageContext>
     {
     }
 }

--- a/src/NServiceBus.Core/UnitOfWork/UnitOfWorkBehavior.cs
+++ b/src/NServiceBus.Core/UnitOfWork/UnitOfWorkBehavior.cs
@@ -7,9 +7,9 @@
     using Pipeline;
     using UnitOfWork;
 
-    class UnitOfWorkBehavior : Behavior<PhysicalMessageProcessingContext>
+    class UnitOfWorkBehavior : Behavior<IncomingPhysicalMessageContext>
     {
-        public override async Task Invoke(PhysicalMessageProcessingContext context, Func<Task> next)
+        public override async Task Invoke(IncomingPhysicalMessageContext context, Func<Task> next)
         {
             var unitsOfWork = new Stack<IManageUnitsOfWork>();
 


### PR DESCRIPTION
renamed:
* `LogicalMessageProcessingContext` -> `IncomingLogicalMessageContext`
* `PhysicalMessageProcessingContext` -> `IncomingPhysicalMessageContext`

to better align with `OutgoingXYZMessageContext`.