### PR TITLE
Test specific to message based subscription transports

### DIFF
--- a/src/NServiceBus.AcceptanceTests/UnitOfWork/When_a_subscription_message_arrives.cs
+++ b/src/NServiceBus.AcceptanceTests/UnitOfWork/When_a_subscription_message_arrives.cs
@@ -4,6 +4,7 @@
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
     using NServiceBus.UnitOfWork;
     using NUnit.Framework;
 
@@ -12,12 +13,12 @@
         [Test]
         public async Task Should_invoke_uow()
         {
-            var context = await Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                     .WithEndpoint<UOWEndpoint>()
                     .Done(c => c.UowWasCalled)
+                    .Repeat(b => b.For<AllTransportsWithMessageDrivenPubSub>())
+                    .Should(c => Assert.True(c.UowWasCalled))
                     .Run();
-
-            Assert.True(context.UowWasCalled);
         }
 
         public class Context : ScenarioContext


### PR DESCRIPTION
A few issues with this test

1. It is assuming a message based subscription, therefore failing for native pub/sub transports like ASB
2. Name of this test doesn't explain how it's working. From `When_a_subscription_message_arrives.Should_invoke_uow` it's not clear that "for a transport with message based subscription unit of work will be invoked".
3. This behaviour should be tested on _all_ transports

Fix to first issue is the PR. As for the rest issues, should another test be introduced instead?