### PR TITLE
Instance resolution made async.

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2262,7 +2262,7 @@ namespace NServiceBus.Routing
     public class EndpointInstances
     {
         public EndpointInstances() { }
-        public void AddDynamic(System.Func<NServiceBus.Routing.EndpointName, System.Collections.Generic.IEnumerable<NServiceBus.Routing.EndpointInstance>> dynamicRule) { }
+        public void AddDynamic(System.Func<NServiceBus.Routing.EndpointName, System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.Routing.EndpointInstance>>> dynamicRule) { }
         public void AddStatic(NServiceBus.Routing.EndpointName endpoint, params NServiceBus.Routing.EndpointInstance[] instances) { }
     }
     public sealed class EndpointName
@@ -2278,7 +2278,7 @@ namespace NServiceBus.Routing
     }
     public interface IUnicastRoute
     {
-        System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> Resolve(System.Func<NServiceBus.Routing.EndpointName, System.Collections.Generic.IEnumerable<NServiceBus.Routing.EndpointInstance>> instanceResolver);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget>> Resolve(System.Func<NServiceBus.Routing.EndpointName, System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.Routing.EndpointInstance>>> instanceResolver);
     }
     public interface IUnsubscribeContext : NServiceBus.Extensibility.IExtendable, NServiceBus.Pipeline.IBehaviorContext
     {

--- a/src/NServiceBus.Core.Tests/Routing/EndpointInstancesTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/EndpointInstancesTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.Routing;
     using NUnit.Framework;
 
@@ -17,35 +18,36 @@
         }
 
         [Test]
-        public void Should_return_instances_configured_by_static_route()
+        public async Task Should_return_instances_configured_by_static_route()
         {
             var instances = new EndpointInstances();
             var sales = new EndpointName("Sales");
-            instances.AddStatic(sales, new EndpointInstance(sales, "1", null), new EndpointInstance(sales, "2"));
+            instances.AddStatic(sales, new EndpointInstance(sales, "1"), new EndpointInstance(sales, "2"));
 
-            var salesInstances = instances.FindInstances(sales).ToList();
-            Assert.AreEqual(2, salesInstances.Count);
+            var salesInstances = await instances.FindInstances(sales);
+            Assert.AreEqual(2, salesInstances.Count());
         }
 
         [Test]
-        public void Should_filter_out_duplicate_instances()
+        public async Task Should_filter_out_duplicate_instances()
         {
             var instances = new EndpointInstances();
             var sales = new EndpointName("Sales");
-            instances.AddStatic(sales, new EndpointInstance(sales, "dup", null), new EndpointInstance(sales, "dup"));
+            instances.AddStatic(sales, new EndpointInstance(sales, "dup"), new EndpointInstance(sales, "dup"));
 
-            var salesInstances = instances.FindInstances(sales).ToList();
-            Assert.AreEqual(1, salesInstances.Count);
+            var salesInstances = await instances.FindInstances(sales);
+            Assert.AreEqual(1, salesInstances.Count());
         }
 
         [Test]
-        public void Should_default_to_single_instance_when_not_configured()
+        public async Task Should_default_to_single_instance_when_not_configured()
         {
             var instances = new EndpointInstances();
-            var salesInstances = instances.FindInstances(new EndpointName("Sales")).ToArray();
-            Assert.AreEqual(1, salesInstances.Length);
-            Assert.IsNull(salesInstances[0].Discriminator);
-            Assert.IsEmpty(salesInstances[0].Properties);
+            var salesInstancess = await instances.FindInstances(new EndpointName("Sales"));
+
+            var singleInstance = salesInstancess.Single();
+            Assert.IsNull(singleInstance.Discriminator);
+            Assert.IsEmpty(singleInstance.Properties);
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/FileRoutingTableTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/FileRoutingTableTests.cs
@@ -31,7 +31,7 @@
             var table = new FileRoutingTable("unused", TimeSpan.Zero, timer, fileAccess, 2, settings);
             await table.PerformStartup(null);
 
-            var instance = instances.FindInstances(new EndpointName("A")).Single();
+            var instance = (await instances.FindInstances(new EndpointName("A"))).Single();
             Assert.AreEqual(new EndpointInstance("A"), instance);
         }
 

--- a/src/NServiceBus.Core.Tests/Routing/UnicastRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastRouterTests.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.Extensibility;
     using NServiceBus.Routing;
     using NServiceBus.Transports;
@@ -60,8 +61,8 @@
             routingTable.RouteToEndpoint(typeof(Event), shipping);
 
             endpointInstances.AddStatic(sales, new EndpointInstance(sales, "1"));
-            endpointInstances.AddDynamic(e => new[] { new EndpointInstance(sales, "2")});
-            endpointInstances.AddStatic(shipping, new EndpointInstance(shipping, "1"), new EndpointInstance(shipping, "2"));
+            endpointInstances.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(sales, "2"))));
+            endpointInstances.AddStatic(shipping, new EndpointInstance(shipping, "1", null), new EndpointInstance(shipping, "2"));
 
             transportAddresses.AddRule(i => i.ToString());
 

--- a/src/NServiceBus.Core/EnumerableEx.cs
+++ b/src/NServiceBus.Core/EnumerableEx.cs
@@ -3,10 +3,16 @@ namespace NServiceBus
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Linq;
     using Janitor;
 
     static class EnumerableEx
     {
+        public static IEnumerable<T> Single<T>(T singleElement)
+        {
+            return Enumerable.Repeat(singleElement, 1);
+        } 
+
         public static IEnumerable<T> EnsureNonEmpty<T>(this IEnumerable<T> source, Func<string> exceptionMessage)
         {
             return new NonEmptyEnumerable<T>(source, () =>

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -42,7 +42,7 @@
 
                     var messageTypesHandled = GetMessageTypesHandledByThisEndpoint(handlerRegistry, conventions, settings);
 
-                    return new ApplySubscriptions(messageTypesHandled);
+                    return new ApplySubscriptions(messageTypesHandled, type => Task.FromResult(true));
                 });
             }
             else
@@ -53,14 +53,23 @@
 
                     var messageTypesToSubscribe = GetMessageTypesHandledByThisEndpoint(handlerRegistry, conventions, settings);
 
+                    Func<Type, Task<bool>> asyncPredicate;
                     if (settings.RequireExplicitRouting)
                     {
                         var subscriptionRouter = b.Build<SubscriptionRouter>();
 
-                        messageTypesToSubscribe = messageTypesToSubscribe.Where(t => subscriptionRouter.GetAddressesForEventType(t).Any())
-                            .ToList();
+                        asyncPredicate = async type =>
+                        {
+                            var addresses = await subscriptionRouter.GetAddressesForEventType(type).ConfigureAwait(false);
+                            return addresses.Any();
+                        };
                     }
-                    return new ApplySubscriptions(messageTypesToSubscribe);
+                    else
+                    {
+                        asyncPredicate = type => Task.FromResult(true);
+                    }
+
+                    return new ApplySubscriptions(messageTypesToSubscribe, asyncPredicate);
                 });
             }
         }
@@ -79,17 +88,21 @@
 
         class ApplySubscriptions : FeatureStartupTask
         {
-            public ApplySubscriptions(IEnumerable<Type> eventsToSubscribe)
+            public ApplySubscriptions(IEnumerable<Type> messagesHandledByThisEndpoint, Func<Type, Task<bool>> asyncPredicate)
             {
-                this.eventsToSubscribe = eventsToSubscribe;
+                this.messagesHandledByThisEndpoint = messagesHandledByThisEndpoint;
+                this.asyncPredicate = asyncPredicate;
             }
 
             protected override async Task OnStart(IBusSession session)
             {
-                foreach (var eventType in eventsToSubscribe)
+                foreach (var eventType in messagesHandledByThisEndpoint)
                 {
-                    await session.Subscribe(eventType).ConfigureAwait(false);
-                    Logger.DebugFormat("Auto subscribed to event {0}", eventType);
+                    if (await asyncPredicate(eventType).ConfigureAwait(false))
+                    {
+                        await session.Subscribe(eventType).ConfigureAwait(false);
+                        Logger.DebugFormat("Auto subscribed to event {0}", eventType);
+                    }
                 }
             }
 
@@ -98,7 +111,8 @@
                 return TaskEx.Completed;
             }
 
-            IEnumerable<Type> eventsToSubscribe;
+            IEnumerable<Type> messagesHandledByThisEndpoint;
+            Func<Type, Task<bool>> asyncPredicate;
 
             static ILog Logger = LogManager.GetLogger<ApplySubscriptions>();
         }

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTable.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTable.cs
@@ -92,14 +92,14 @@ namespace NServiceBus
             }
         }
 
-        IEnumerable<EndpointInstance> FindInstances(EndpointName endpoint)
+        Task<IEnumerable<EndpointInstance>> FindInstances(EndpointName endpoint)
         {
             HashSet<EndpointInstance> result;
             if (instanceMap.TryGetValue(endpoint, out result))
             {
-                return result;
+                return Task.FromResult((IEnumerable<EndpointInstance>)result);
             }
-            return Enumerable.Empty<EndpointInstance>();
+            return Task.FromResult(Enumerable.Empty<EndpointInstance>());
         }
 
         protected override Task OnStop(IBusSession context)

--- a/src/NServiceBus.Core/Routing/IUnicastRoute.cs
+++ b/src/NServiceBus.Core/Routing/IUnicastRoute.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Routing
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Represents destination of address routing.
@@ -12,6 +13,6 @@ namespace NServiceBus.Routing
         /// Resolves the destination, possibly resulting in multiple destination transport addresses.
         /// </summary>
         /// <param name="instanceResolver">A function that returns the collection of instances for a given endpoint.</param>
-        IEnumerable<UnicastRoutingTarget> Resolve(Func<EndpointName, IEnumerable<EndpointInstance>> instanceResolver);
+        Task<IEnumerable<UnicastRoutingTarget>> Resolve(Func<EndpointName, Task<IEnumerable<EndpointInstance>>> instanceResolver);
     }
 }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -22,11 +22,11 @@
             this.legacyMode = legacyMode;
         }
 
-        protected override Task Terminate(IUnsubscribeContext context)
+        protected override async Task Terminate(IUnsubscribeContext context)
         {
             var eventType = context.EventType;
 
-            var publisherAddresses = subscriptionRouter.GetAddressesForEventType(eventType)
+            var publisherAddresses = (await subscriptionRouter.GetAddressesForEventType(eventType).ConfigureAwait(false))
                 .EnsureNonEmpty(() => $"No publisher address could be found for message type {eventType}. Please ensure the configured publisher endpoint has at least one known instance.");
 
             var unsubscribeTasks = new List<Task>();
@@ -49,8 +49,7 @@
 
                 unsubscribeTasks.Add(SendUnsubscribeMessageWithRetries(publisherAddress, unsubscribeMessage, eventType.AssemblyQualifiedName, context.Extensions));
             }
-
-            return Task.WhenAll(unsubscribeTasks.ToArray());
+            await Task.WhenAll(unsubscribeTasks.ToArray()).ConfigureAwait(false);
         }
 
         async Task SendUnsubscribeMessageWithRetries(string destination, OutgoingMessage unsubscribeMessage, string messageType, ContextBag context, int retriesCount = 0)

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/PublisherAddress.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/PublisherAddress.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Routing.MessageDrivenSubscriptions
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Represents an address of a publisher.
@@ -48,7 +49,7 @@ namespace NServiceBus.Routing.MessageDrivenSubscriptions
             this.addresses = addresses;
         }
 
-        internal IEnumerable<string> Resolve(Func<EndpointName, IEnumerable<EndpointInstance>> instanceResolver, Func<EndpointInstance, string> addressResolver)
+        internal async Task<IEnumerable<string>> Resolve(Func<EndpointName, Task<IEnumerable<EndpointInstance>>> instanceResolver, Func<EndpointInstance, string> addressResolver)
         {
             if (addresses != null)
             {
@@ -58,7 +59,8 @@ namespace NServiceBus.Routing.MessageDrivenSubscriptions
             {
                 return instances.Select(addressResolver);
             }
-            return instanceResolver(endpoint).Select(addressResolver);
+            var result = await instanceResolver(endpoint).ConfigureAwait(false);
+            return result.Select(addressResolver);
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -188,9 +188,9 @@
                     }
                 }
 
-                public IEnumerable<UnicastRoutingTarget> Resolve(Func<EndpointName, IEnumerable<EndpointInstance>> instanceResolver)
+                public Task<IEnumerable<UnicastRoutingTarget>> Resolve(Func<EndpointName, Task<IEnumerable<EndpointInstance>>> instanceResolver)
                 {
-                    yield return target;
+                    return Task.FromResult(EnumerableEx.Single(target));
                 }
             }
         }


### PR DESCRIPTION
The second stage of routing is about determining the list of instances given the endpoint name. The first stage has already been `async`-ed. Because there is possibility of users implementing that second stage based on some kind of remote resource (e.g. DB or web service lookup), it makes sense to make it `async` so that they can take advantage of async APIs of their storage technology.