### PR TITLE
Cleanup ATs even if they fail to avoid creating orphan DBs, etc.

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -157,8 +157,6 @@
             {
                 await endpointInstance.Stop().ConfigureAwait(false);
 
-                await Cleanup().ConfigureAwait(false);
-
                 return Result.Success();
             }
             catch (Exception ex)
@@ -166,6 +164,10 @@
                 Logger.Error("Failed to stop endpoint " + configuration.EndpointName, ex);
 
                 return Result.Failure(ex);
+            }
+            finally
+            {
+                await Cleanup().ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
The cleanup allows, for example, Raven databases (named based on guids) to be removed after the test, but if the test fails with an exception, currently it will not be cleaned up *ever*. Moving the cleanup to a finally block should take care of this in most cases.

Still can't do much if you press Stop, I think.