### PR TITLE
Allow transports other than MSMQ to cleanup after ATTs

### DIFF
--- a/src/NServiceBus.AcceptanceTests/ConfigureInMemoryPersistence.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureInMemoryPersistence.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using NServiceBus;
+
+
+public class ConfigureInMemoryPersistence
+{
+    public Task Configure(BusConfiguration configuration, IDictionary<string, string> settings)
+    {
+        configuration.UsePersistence<InMemoryPersistence>();
+        return Task.FromResult(0);
+    }
+
+    public Task Cleanup()
+    {
+        // Nothing required for in-memory persistence
+        return Task.FromResult(0);
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/ConfigureMsmqTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureMsmqTransport.cs
@@ -11,9 +11,10 @@ public class ConfigureMsmqTransport
 {
     BusConfiguration busConfiguration;
 
-    public Task Configure(BusConfiguration configuration)
+    public Task Configure(BusConfiguration configuration, IDictionary<string, string> settings)
     {
         busConfiguration = configuration;
+        configuration.UseTransport<MsmqTransport>().ConnectionString(settings["Transport.ConnectionString"]);
         return Task.FromResult(0);
     }
 

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Reflection;
     using System.Threading.Tasks;
+    using Microsoft.CSharp.RuntimeBinder;
     using NServiceBus.Configuration.AdvanceExtensibility;
     using ScenarioDescriptors;
 
@@ -34,18 +35,24 @@
             var configurerType = endpointBuilderType.GetNestedType(typeName) ??
                                  Type.GetType(transportTypeName, false);
 
-            if (configurerType != null)
+            if (configurerType == null)
+                throw new InvalidOperationException($"Acceptance Test project must include a non-namespaced class named 'Configure{{TransportType}}Transport whose methods will be invoked dynamically to configure and cleanup tests. See {typeof(ConfigureMsmqTransport).FullName} for an example.");
+            
+            var configurer = Activator.CreateInstance(configurerType);
+
+            dynamic dc = configurer;
+
+            try
             {
-                var configurer = Activator.CreateInstance(configurerType);
-
-                dynamic dc = configurer;
-
-                await dc.Configure(config);
-                var cleanupMethod = configurer.GetType().GetMethod("Cleanup", BindingFlags.Public | BindingFlags.Instance);
-                config.GetSettings().Set("CleanupTransport", cleanupMethod != null ? configurer : new Cleaner());
+                await dc.Configure(config, settings);
             }
-
-            config.UseTransport(transportType).ConnectionString(settings["Transport.ConnectionString"]);
+            catch (RuntimeBinderException rbe)
+            {
+                throw new InvalidOperationException($"Class {configurerType.FullName} must include a \"public Task Configure(BusConfiguration configuration, IDictionary<string, string> settings)\" method.", rbe);
+            }
+            
+            var cleanupMethod = configurer.GetType().GetMethod("Cleanup", BindingFlags.Public | BindingFlags.Instance);
+            config.GetSettings().Set("CleanupTransport", cleanupMethod != null ? configurer : new Cleaner());
         }
 
         public static void DefineTransactions(this BusConfiguration config, IDictionary<string, string> settings)
@@ -70,20 +77,24 @@
 
             var configurerType = Type.GetType(typeName, false);
 
-            if (configurerType != null)
+            if (configurerType == null)
+                throw new InvalidOperationException($"Acceptance Test project must include a non-namespaced class named 'Configure{{PersistenceType}}Persistence whose methods will be invoked dynamically to configure and cleanup tests. See {typeof(ConfigureMsmqTransport).FullName} for an example.");
+
+            var configurer = Activator.CreateInstance(configurerType);
+
+            dynamic dc = configurer;
+
+            try
             {
-                var configurer = Activator.CreateInstance(configurerType);
-
-                dynamic dc = configurer;
-
-                await dc.Configure(config);
-
-                var cleanupMethod = configurer.GetType().GetMethod("Cleanup", BindingFlags.Public | BindingFlags.Instance);
-                config.GetSettings().Set("CleanupPersistence", cleanupMethod != null ? configurer : new Cleaner());
-                return;
+                await dc.Configure(config, settings);
+            }
+            catch (RuntimeBinderException rbe)
+            {
+                throw new InvalidOperationException($"Class {configurerType.FullName} must include a \"public Task Configure(BusConfiguration configuration, IDictionary<string, string> settings)\" method.", rbe);
             }
 
-            config.UsePersistence(persistenceType);
+            var cleanupMethod = configurer.GetType().GetMethod("Cleanup", BindingFlags.Public | BindingFlags.Instance);
+            config.GetSettings().Set("CleanupPersistence", cleanupMethod != null ? configurer : new Cleaner());
         }
 
         class Cleaner

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -43,7 +43,6 @@
                 await dc.Configure(config);
                 var cleanupMethod = configurer.GetType().GetMethod("Cleanup", BindingFlags.Public | BindingFlags.Instance);
                 config.GetSettings().Set("CleanupTransport", cleanupMethod != null ? configurer : new Cleaner());
-                return;
             }
 
             config.UseTransport(transportType).ConnectionString(settings["Transport.ConnectionString"]);

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -57,6 +57,7 @@
     <Compile Include="Basic\When_extending_behavior_context.cs" />
     <Compile Include="Basic\When_registering_additional_deserializers.cs" />
     <Compile Include="Basic\When_no_content_type.cs" />
+    <Compile Include="ConfigureInMemoryPersistence.cs" />
     <Compile Include="Msmq\When_Audit_OverrideTimeToBeReceived_set_and_transactional_Msmq.cs" />
     <Compile Include="Msmq\When_TimeToBeReceivedOnForwardedMessages_set_and_transactional_Msmq.cs" />
     <Compile Include="Msmq\When_TimeToBeReceived_set_and_receivetransaction_Msmq.cs" />
@@ -114,7 +115,7 @@
     <Compile Include="Performance\TimeToBeReceived\When_TimeToBeReceived_has_not_expired.cs" />
     <Compile Include="Performance\TimeToBeReceived\When_TimeToBeReceived_has_expired.cs" />
     <Compile Include="DelayedDelivery\When_Deferring_a_message.cs" />
-    <Compile Include="Msmq\ConfigureMsmqTransport.cs" />
+    <Compile Include="ConfigureMsmqTransport.cs" />
     <Compile Include="Hosting\When_feature_overrides_hostid.cs" />
     <Compile Include="Reliability\Outbox\When_dispatching_forwarded_messages.cs" />
     <Compile Include="Reliability\Outbox\When_a_message_is_audited.cs" />

--- a/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/Persistence.cs
+++ b/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/Persistence.cs
@@ -75,6 +75,13 @@
                                 }
                 };
 
+                var connectionString = Environment.GetEnvironmentVariable(key + ".ConnectionString");
+
+                if (!string.IsNullOrEmpty(connectionString))
+                {
+                    runDescriptor.Settings.Add("Persistence.ConnectionString", connectionString);
+                }
+
                 yield return runDescriptor;
             }
         }


### PR DESCRIPTION
By convention, if `ConfigureTRANSPORTNAME` is present in ATTs project, it will be used to perform cleanup at the end of each test execution. This is working for MSMQ because it's a default transport. If a custom `ConfigureX`class for a transport is registered, execution blows up because transport and its connection string are not registered. Exception:
```
System.AggregateException : Test run failed due to one or more exception
  ----> NServiceBus.AcceptanceTesting.Support.ScenarioException : Endpoint SubscribingToAPolymorphicEvent.Publisher failed to initialize
  ----> System.InvalidCastException : Unable to cast object of type 'NServiceBus.MsmqTransport' to type 'NServiceBus.AzureServiceBusTransport'.
```

This change allows other transport register `ConfigureX` and execute properly.