### PR TITLE
Passing critical error into init

### DIFF
--- a/src/NServiceBus.AcceptanceTests/FakeTransport/FakeReceiver.cs
+++ b/src/NServiceBus.AcceptanceTests/FakeTransport/FakeReceiver.cs
@@ -10,8 +10,9 @@ namespace NServiceBus.AcceptanceTests.FakeTransport
         CriticalError criticalError;
         Exception throwCritical;
 
-        public Task Init(Func<PushContext, Task> pipe, PushSettings settings)
+        public Task Init(Func<PushContext, Task> pipe, CriticalError criticalError, PushSettings settings)
         {
+            this.criticalError = criticalError;
             return Task.FromResult(0);
         }
 
@@ -28,9 +29,8 @@ namespace NServiceBus.AcceptanceTests.FakeTransport
             return Task.FromResult(0);
         }
 
-        public FakeReceiver(CriticalError criticalError, Exception throwCritical)
+        public FakeReceiver(Exception throwCritical)
         {
-            this.criticalError = criticalError;
             this.throwCritical = throwCritical;
         }
     }

--- a/src/NServiceBus.AcceptanceTests/FakeTransport/FakeTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/FakeTransport/FakeTransport.cs
@@ -10,7 +10,7 @@
     {
         protected override TransportReceivingConfigurationResult ConfigureForReceiving(TransportReceivingConfigurationContext context)
         {
-            return new TransportReceivingConfigurationResult(c => new FakeReceiver(c, context.Settings.Get<Exception>()), () => new FakeQueueCreator(), () => Task.FromResult(StartupCheckResult.Success));
+            return new TransportReceivingConfigurationResult(() => new FakeReceiver(context.Settings.Get<Exception>()), () => new FakeQueueCreator(), () => Task.FromResult(StartupCheckResult.Success));
         }
 
         protected override TransportSendingConfigurationResult ConfigureForSending(TransportSendingConfigurationContext context)

--- a/src/NServiceBus.AcceptanceTests/Performance/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -9,6 +9,7 @@
     using NServiceBus.Settings;
     using NServiceBus.Transports;
     using NUnit.Framework;
+    using CriticalError = NServiceBus.CriticalError;
 
     public class When_using_concurrency_limit : NServiceBusAcceptanceTest
     {
@@ -37,7 +38,7 @@
 
         class FakeReceiver : IPushMessages
         {
-            public Task Init(Func<PushContext, Task> pipe, PushSettings settings)
+            public Task Init(Func<PushContext, Task> pipe, CriticalError criticalError, PushSettings settings)
             {
                 return Task.FromResult(0);
             }
@@ -73,7 +74,7 @@
         {
             protected override TransportReceivingConfigurationResult ConfigureForReceiving(TransportReceivingConfigurationContext context)
             {
-                return new TransportReceivingConfigurationResult(c => new FakeReceiver(), () => new FakeQueueCreator(), () => Task.FromResult(StartupCheckResult.Success));
+                return new TransportReceivingConfigurationResult(() => new FakeReceiver(), () => new FakeQueueCreator(), () => Task.FromResult(StartupCheckResult.Success));
             }
 
             protected override TransportSendingConfigurationResult ConfigureForSending(TransportSendingConfigurationContext context)

--- a/src/NServiceBus.AcceptanceTests/ScaleOut/When_no_discriminator_is_available.cs
+++ b/src/NServiceBus.AcceptanceTests/ScaleOut/When_no_discriminator_is_available.cs
@@ -53,7 +53,7 @@
         {
             protected override TransportReceivingConfigurationResult ConfigureForReceiving(TransportReceivingConfigurationContext context)
             {
-                return new TransportReceivingConfigurationResult(c => null, () => null, () => Task.FromResult(StartupCheckResult.Success));
+                return new TransportReceivingConfigurationResult(() => null, () => null, () => Task.FromResult(StartupCheckResult.Success));
             }
 
             protected override TransportSendingConfigurationResult ConfigureForSending(TransportSendingConfigurationContext context)

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2563,7 +2563,7 @@ namespace NServiceBus.Transports
     public interface IPublishMessages { }
     public interface IPushMessages
     {
-        System.Threading.Tasks.Task Init(System.Func<NServiceBus.Transports.PushContext, System.Threading.Tasks.Task> pipe, NServiceBus.Transports.PushSettings settings);
+        System.Threading.Tasks.Task Init(System.Func<NServiceBus.Transports.PushContext, System.Threading.Tasks.Task> pipe, NServiceBus.CriticalError criticalError, NServiceBus.Transports.PushSettings settings);
         void Start(NServiceBus.Transports.PushRuntimeSettings limitations);
         System.Threading.Tasks.Task Stop();
     }
@@ -2678,7 +2678,7 @@ namespace NServiceBus.Transports
     }
     public class TransportReceivingConfigurationResult
     {
-        public TransportReceivingConfigurationResult(System.Func<NServiceBus.CriticalError, NServiceBus.Transports.IPushMessages> messagePumpFactory, System.Func<NServiceBus.Transports.ICreateQueues> queueCreatorFactory, System.Func<System.Threading.Tasks.Task<NServiceBus.Transports.StartupCheckResult>> preStartupCheck) { }
+        public TransportReceivingConfigurationResult(System.Func<NServiceBus.Transports.IPushMessages> messagePumpFactory, System.Func<NServiceBus.Transports.ICreateQueues> queueCreatorFactory, System.Func<System.Threading.Tasks.Task<NServiceBus.Transports.StartupCheckResult>> preStartupCheck) { }
     }
     public class TransportSendingConfigurationContext
     {

--- a/src/NServiceBus.Core/Transports/IPushMessages.cs
+++ b/src/NServiceBus.Core/Transports/IPushMessages.cs
@@ -11,7 +11,7 @@
         /// <summary>
         /// Initializes the <see cref="IPushMessages"/>.
         /// </summary>
-        Task Init(Func<PushContext, Task> pipe, PushSettings settings);
+        Task Init(Func<PushContext, Task> pipe, CriticalError criticalError, PushSettings settings);
 
         /// <summary>
         /// Starts pushing message/>.

--- a/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
@@ -24,7 +24,6 @@ namespace NServiceBus.Transports.Msmq
 
         public Task Init(Func<PushContext, Task> pipe, CriticalError criticalError, PushSettings settings)
         {
-            this.criticalError = criticalError;
             pipeline = pipe;
 
             receiveStrategy = receiveStrategyFactory(settings.RequiredTransactionSupport);
@@ -223,7 +222,6 @@ namespace NServiceBus.Transports.Msmq
         CancellationToken cancellationToken;
         CancellationTokenSource cancellationTokenSource;
         SemaphoreSlim concurrencyLimiter;
-        CriticalError criticalError;
         MessageQueue errorQueue;
         MessageQueue inputQueue;
 

--- a/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
@@ -11,9 +11,9 @@ namespace NServiceBus.Transports.Msmq
 
     class MessagePump : IPushMessages, IDisposable
     {
-        public MessagePump(CriticalError criticalError, Func<TransactionSupport, ReceiveStrategy> receiveStrategyFactory)
+        public MessagePump(Func<TransactionSupport, ReceiveStrategy> receiveStrategyFactory)
         {
-            this.criticalError = criticalError;
+            
             this.receiveStrategyFactory = receiveStrategyFactory;
         }
 
@@ -22,8 +22,9 @@ namespace NServiceBus.Transports.Msmq
             // Injected
         }
 
-        public Task Init(Func<PushContext, Task> pipe, PushSettings settings)
+        public Task Init(Func<PushContext, Task> pipe, CriticalError criticalError, PushSettings settings)
         {
+            this.criticalError = criticalError;
             pipeline = pipe;
 
             receiveStrategy = receiveStrategyFactory(settings.RequiredTransactionSupport);

--- a/src/NServiceBus.Core/Transports/Msmq/Msmq.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/Msmq.cs
@@ -46,7 +46,7 @@ namespace NServiceBus
             };
 
             return new TransportReceivingConfigurationResult(
-                c => new MessagePump(c, guarantee => SelectReceiveStrategy(guarantee, transactionOptions)),
+                () => new MessagePump(guarantee => SelectReceiveStrategy(guarantee, transactionOptions)),
                 () => new QueueCreator(settings), 
                 () =>
                 {

--- a/src/NServiceBus.Core/Transports/Receiving.cs
+++ b/src/NServiceBus.Core/Transports/Receiving.cs
@@ -40,7 +40,7 @@ namespace NServiceBus.Transports
             context.Container.RegisterSingleton(inboundTransport.Definition);
 
             var receiveConfigResult = inboundTransport.Configure(context.Settings);
-            context.Container.ConfigureComponent(b => receiveConfigResult.MessagePumpFactory(b.Build<CriticalError>()), DependencyLifecycle.InstancePerCall);
+            context.Container.ConfigureComponent(b => receiveConfigResult.MessagePumpFactory(), DependencyLifecycle.InstancePerCall);
             context.Container.ConfigureComponent(b => receiveConfigResult.QueueCreatorFactory(), DependencyLifecycle.SingleInstance);
 
             context.RegisterStartupTask(new PrepareForReceiving(receiveConfigResult.PreStartupCheck));

--- a/src/NServiceBus.Core/Transports/TransportReceiver.cs
+++ b/src/NServiceBus.Core/Transports/TransportReceiver.cs
@@ -38,7 +38,7 @@ namespace NServiceBus.Transport
 
             Logger.DebugFormat("Pipeline {0} is starting receiver for queue {1}.", Id, pushSettings.InputQueue);
 
-            await receiver.Init(InvokePipeline, pushSettings).ConfigureAwait(false);
+            await receiver.Init(InvokePipeline, builder.Build<CriticalError>(), pushSettings).ConfigureAwait(false);
             pipeline.Initialize(new PipelineInfo(Id, pushSettings.InputQueue));
             await pipeline.Warmup().ConfigureAwait(false);
 

--- a/src/NServiceBus.Core/Transports/TransportReceivingConfigurationResult.cs
+++ b/src/NServiceBus.Core/Transports/TransportReceivingConfigurationResult.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Transports
         /// Creates new result.
         /// </summary>
         public TransportReceivingConfigurationResult(
-            Func<CriticalError, IPushMessages> messagePumpFactory, 
+            Func<IPushMessages> messagePumpFactory, 
             Func<ICreateQueues> queueCreatorFactory,
             Func<Task<StartupCheckResult>> preStartupCheck)
         {
@@ -25,7 +25,7 @@ namespace NServiceBus.Transports
             PreStartupCheck = preStartupCheck;
         }
 
-        internal Func<CriticalError, IPushMessages> MessagePumpFactory { get; }
+        internal Func<IPushMessages> MessagePumpFactory { get; }
         internal Func<ICreateQueues> QueueCreatorFactory { get; }
         internal Func<Task<StartupCheckResult>> PreStartupCheck { get; } 
 


### PR DESCRIPTION
so that all callbacks can be initialized in the same place when implementing a transport