### PR TITLE
Use the correct error queue

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Msmq/When_a_corrupted_message_is_received.cs
+++ b/src/NServiceBus.AcceptanceTests/Msmq/When_a_corrupted_message_is_received.cs
@@ -1,0 +1,106 @@
+﻿namespace NServiceBus.AcceptanceTests.Msmq
+{
+    using System;
+    using System.Linq;
+    using System.Messaging;
+    using System.Text;
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    public class When_a_corrupted_message_is_received : NServiceBusAcceptanceTest
+    {
+        const string errorQueue = @".\private$\errorQueueForCorruptedMessages";
+
+        [TestCase(TransactionSupport.Distributed)]
+        [TestCase(TransactionSupport.MultiQueue)]
+        [TestCase(TransactionSupport.None)]
+        public async Task Should_move_it_to_the_error_queue(TransactionSupport txMode)
+        {
+            DeleteQueue();
+            try
+            {
+                await Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>(b =>
+                    {
+                        b.CustomConfig(c =>
+                        {
+                            switch (txMode)
+                            {
+                                case TransactionSupport.Distributed:
+                                    c.Transactions().EnableDistributedTransactions();
+                                    break;
+                                case TransactionSupport.MultiQueue:
+                                    c.Transactions().DisableDistributedTransactions();
+                                    break;
+                                case TransactionSupport.None:
+                                    c.Transactions().Disable();
+                                    break;
+                            }
+                        });
+                        b.When((bus, c) =>
+                        {
+                            var endpoint = AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(Endpoint));
+
+                            var inputQueue = $@".\private$\{endpoint}";
+
+                            using (var queue = new MessageQueue(inputQueue))
+                            using (var message = new Message())
+                            {
+                                message.Extension = Encoding.UTF8.GetBytes("<badheaders");
+                                queue.Send(message, MessageQueueTransactionType.Single);
+                            }
+
+                            return Task.FromResult(0);
+                        });
+                    })
+                    .Done(c => c.Logs.Any(l => l.Level == "error"))
+                    .Run();
+                Assert.True(MessageExistsInErrorQueue(), "The message should have been moved to the error queue");
+            }
+            finally
+            {
+                DeleteQueue();
+            }
+        }
+
+        static void DeleteQueue()
+        {
+            if (MessageQueue.Exists(errorQueue))
+            {
+                MessageQueue.Delete(errorQueue);
+            }
+        }
+
+        static bool MessageExistsInErrorQueue()
+        {
+            if (!MessageQueue.Exists(errorQueue))
+            {
+                return false;
+            }
+            using (var queue = new MessageQueue(errorQueue))
+            using (var message = queue.Receive(TimeSpan.FromSeconds(5)))
+            {
+                return message != null;
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.SendFailedMessagesTo("errorQueueForCorruptedMessages");
+                });
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Basic\When_registering_additional_deserializers.cs" />
     <Compile Include="Basic\When_no_content_type.cs" />
     <Compile Include="Msmq\When_Audit_OverrideTimeToBeReceived_set_and_transactional_Msmq.cs" />
+    <Compile Include="Msmq\When_a_corrupted_message_is_received.cs" />
     <Compile Include="Msmq\When_TimeToBeReceivedOnForwardedMessages_set_and_transactional_Msmq.cs" />
     <Compile Include="Msmq\When_TimeToBeReceived_set_and_receivetransaction_Msmq.cs" />
     <Compile Include="Msmq\When_TimeToBeReceived_set_and_DTC_Msmq.cs" />

--- a/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
@@ -32,7 +32,7 @@ namespace NServiceBus.Transports.Msmq
             receiveCircuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker("MsmqReceive", TimeSpan.FromSeconds(30), ex => criticalError.Raise("Failed to receive from " + settings.InputQueue, ex));
 
             var inputAddress = MsmqAddress.Parse(settings.InputQueue);
-            var errorAddress = MsmqAddress.Parse(settings.InputQueue);
+            var errorAddress = MsmqAddress.Parse(settings.ErrorQueue);
 
             if (!string.Equals(errorAddress.Machine, Environment.MachineName, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveWithNoTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveWithNoTransaction.cs
@@ -25,7 +25,7 @@ namespace NServiceBus
                 var error = $"Message '{message.Id}' is corrupt and will be moved to '{errorQueue.QueueName}'";
                 Logger.Error(error, ex);
 
-                errorQueue.Send(message, MessageQueueTransactionType.None);
+                errorQueue.Send(message, errorQueue.Transactional ? MessageQueueTransactionType.Single : MessageQueueTransactionType.None);
 
                 return;
             }


### PR DESCRIPTION
Tests and fixes to make sure corrupted msmq messages are moved to the error queue properly