### PR TITLE
Change Transport/Configurer classes to require interface.

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
+++ b/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Support\EndpointConfiguration.cs" />
     <Compile Include="Support\EndpointRunner.cs" />
     <Compile Include="Support\FailTestOnErrorMessageFeature.cs" />
+    <Compile Include="Support\IConfigureTestExecution.cs" />
     <Compile Include="Support\IEndpointSetupTemplate.cs" />
     <Compile Include="Support\IScenarioWithEndpointBehavior.cs" />
     <Compile Include="Support\IWhenDefinition.cs" />

--- a/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
@@ -7,7 +7,7 @@
 
     public abstract class ScenarioContext
     {
-        public Guid UniqueTestRunId { get; } = Guid.NewGuid();
+        public Guid TestRunId { get; } = Guid.NewGuid();
 
         public bool EndpointsStarted { get; set; }
 

--- a/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
@@ -7,6 +7,8 @@
 
     public abstract class ScenarioContext
     {
+        public Guid UniqueTestRunId { get; } = Guid.NewGuid();
+
         public bool EndpointsStarted { get; set; }
 
         public bool HasNativePubSubSupport { get; set; }

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -173,13 +173,13 @@
 
         async Task Cleanup()
         {
-            dynamic transportCleaner;
+            IConfigureTestExecution transportCleaner;
             if (busConfiguration.GetSettings().TryGet("CleanupTransport", out transportCleaner))
             {
                 await transportCleaner.Cleanup();
             }
 
-            dynamic persistenceCleaner;
+            IConfigureTestExecution persistenceCleaner;
             if (busConfiguration.GetSettings().TryGet("CleanupPersistence", out persistenceCleaner))
             {
                 await persistenceCleaner.Cleanup();

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Configuration.AdvanceExtensibility;
@@ -171,19 +172,16 @@
             }
         }
 
-        async Task Cleanup()
+        Task Cleanup()
         {
-            IConfigureTestExecution transportCleaner;
-            if (busConfiguration.GetSettings().TryGet("CleanupTransport", out transportCleaner))
+            List<IConfigureTestExecution> cleaners;
+            if (busConfiguration.GetSettings().TryGet("Cleaners", out cleaners))
             {
-                await transportCleaner.Cleanup();
+                var tasks = cleaners.Select(cleaner => cleaner.Cleanup());
+                return Task.WhenAll(tasks);
             }
 
-            IConfigureTestExecution persistenceCleaner;
-            if (busConfiguration.GetSettings().TryGet("CleanupPersistence", out persistenceCleaner))
-            {
-                await persistenceCleaner.Cleanup();
-            }
+            return Task.FromResult(0);
         }
 
         public string Name()

--- a/src/NServiceBus.AcceptanceTesting/Support/IConfigureTestExecution.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/IConfigureTestExecution.cs
@@ -1,0 +1,29 @@
+﻿namespace NServiceBus.AcceptanceTesting.Support
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Provide a mechanism in acceptence tests for transports and persistences 
+    /// to configure an endpoint for a test and then clean up afterwards.
+    /// </summary>
+    public interface IConfigureTestExecution
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="configuration">The BusConfiguration instance.</param>
+        /// <param name="settings">A string dictionary of settings from the RunDescriptor specifying Transport, Persistence,
+        /// connection strings, Serializer, Builder, and other details. Transports must call configuration.UseTransport&lt;T&gt;().
+        /// Persistence must call configuration.UsePersistence&lt;T&gt;(). </param>
+        /// <returns>An async Task.</returns>
+        Task Configure(BusConfiguration configuration, IDictionary<string, string> settings);
+
+        /// <summary>
+        /// Gives the transport/persistence a chance to clean up after the test is complete. Implementors of this class may store
+        /// private variables during Configure to use during the cleanup phase.
+        /// </summary>
+        /// <returns>An async Task.</returns>
+        Task Cleanup();
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/ConfigureInMemoryPersistence.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureInMemoryPersistence.cs
@@ -1,9 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using NServiceBus;
+using NServiceBus.AcceptanceTesting.Support;
 
 
-public class ConfigureInMemoryPersistence
+public class ConfigureInMemoryPersistence : IConfigureTestExecution
 {
     public Task Configure(BusConfiguration configuration, IDictionary<string, string> settings)
     {

--- a/src/NServiceBus.AcceptanceTests/ConfigureMsmqTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureMsmqTransport.cs
@@ -4,10 +4,11 @@ using System.Linq;
 using System.Messaging;
 using System.Threading.Tasks;
 using NServiceBus;
+using NServiceBus.AcceptanceTesting.Support;
 using NServiceBus.Configuration.AdvanceExtensibility;
 using NServiceBus.Transports;
 
-public class ConfigureMsmqTransport
+public class ConfigureMsmqTransport : IConfigureTestExecution
 {
     BusConfiguration busConfiguration;
 

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -73,7 +73,15 @@
 
             await configurer.Configure(config, settings).ConfigureAwait(false);
 
-            config.GetSettings().Set("Cleanup" + dependencyTypeString, configurer);
+            var configSettings = config.GetSettings();
+
+            List<IConfigureTestExecution> cleaners;
+            if (!configSettings.TryGet("Cleaners", out cleaners))
+            {
+                cleaners = new List<IConfigureTestExecution>();
+                configSettings.Set("Cleaners", cleaners);
+            }
+            cleaners.Add(configurer);
         }
 
         class Cleaner

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -2,9 +2,8 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Reflection;
     using System.Threading.Tasks;
-    using Microsoft.CSharp.RuntimeBinder;
+    using NServiceBus.AcceptanceTesting.Support;
     using NServiceBus.Configuration.AdvanceExtensibility;
     using ScenarioDescriptors;
 
@@ -20,39 +19,14 @@
             return dictionary[key];
         }
 
-        public static async Task DefineTransport(this BusConfiguration config, IDictionary<string, string> settings, Type endpointBuilderType)
+        public static Task DefineTransport(this BusConfiguration config, IDictionary<string, string> settings, Type endpointBuilderType)
         {
             if (!settings.ContainsKey("Transport"))
             {
                 settings = Transports.Default.Settings;
             }
 
-            const string typeName = "ConfigureTransport";
-
-            var transportType = Type.GetType(settings["Transport"]);
-            var transportTypeName = "Configure" + transportType.Name;
-
-            var configurerType = endpointBuilderType.GetNestedType(typeName) ??
-                                 Type.GetType(transportTypeName, false);
-
-            if (configurerType == null)
-                throw new InvalidOperationException($"Acceptance Test project must include a non-namespaced class named 'Configure{{TransportType}}Transport whose methods will be invoked dynamically to configure and cleanup tests. See {typeof(ConfigureMsmqTransport).FullName} for an example.");
-            
-            var configurer = Activator.CreateInstance(configurerType);
-
-            dynamic dc = configurer;
-
-            try
-            {
-                await dc.Configure(config, settings);
-            }
-            catch (RuntimeBinderException rbe)
-            {
-                throw new InvalidOperationException($"Class {configurerType.FullName} must include a \"public Task Configure(BusConfiguration configuration, IDictionary<string, string> settings)\" method.", rbe);
-            }
-            
-            var cleanupMethod = configurer.GetType().GetMethod("Cleanup", BindingFlags.Public | BindingFlags.Instance);
-            config.GetSettings().Set("CleanupTransport", cleanupMethod != null ? configurer : new Cleaner());
+            return ConfigureTestExecution(TestDependencyType.Transport, config, settings);
         }
 
         public static void DefineTransactions(this BusConfiguration config, IDictionary<string, string> settings)
@@ -63,38 +37,43 @@
             }
         }
 
-        public static async Task DefinePersistence(this BusConfiguration config, IDictionary<string, string> settings)
+        public static Task DefinePersistence(this BusConfiguration config, IDictionary<string, string> settings)
         {
             if (!settings.ContainsKey("Persistence"))
             { 
                 settings = Persistence.Default.Settings;
             }
 
-            var persistenceType = Type.GetType(settings["Persistence"]);
+            return ConfigureTestExecution(TestDependencyType.Persistence, config, settings);
+        }
 
+        enum TestDependencyType
+        {
+            Transport,
+            Persistence
+        }
 
-            var typeName = "Configure" + persistenceType.Name;
+        private static async Task ConfigureTestExecution(TestDependencyType type, BusConfiguration config, IDictionary<string,string> settings)
+        {
+            var dependencyTypeString = type.ToString();
+
+            var dependencyType = Type.GetType(settings[dependencyTypeString]);
+
+            var typeName = "Configure" + dependencyType.Name;
 
             var configurerType = Type.GetType(typeName, false);
 
             if (configurerType == null)
-                throw new InvalidOperationException($"Acceptance Test project must include a non-namespaced class named 'Configure{{PersistenceType}}Persistence whose methods will be invoked dynamically to configure and cleanup tests. See {typeof(ConfigureMsmqTransport).FullName} for an example.");
+                throw new InvalidOperationException($"Acceptance Test project must include a non-namespaced class named '{typeName}' implementing {typeof(IConfigureTestExecution).Name}. See {typeof(ConfigureMsmqTransport).FullName} for an example.");
 
-            var configurer = Activator.CreateInstance(configurerType);
+            var configurer = Activator.CreateInstance(configurerType) as IConfigureTestExecution;
 
-            dynamic dc = configurer;
+            if (configurer == null)
+                throw new InvalidOperationException($"{typeName} does not implement {typeof(IConfigureTestExecution).Name}.");
 
-            try
-            {
-                await dc.Configure(config, settings);
-            }
-            catch (RuntimeBinderException rbe)
-            {
-                throw new InvalidOperationException($"Class {configurerType.FullName} must include a \"public Task Configure(BusConfiguration configuration, IDictionary<string, string> settings)\" method.", rbe);
-            }
+            await configurer.Configure(config, settings).ConfigureAwait(false);
 
-            var cleanupMethod = configurer.GetType().GetMethod("Cleanup", BindingFlags.Public | BindingFlags.Instance);
-            config.GetSettings().Set("CleanupPersistence", cleanupMethod != null ? configurer : new Cleaner());
+            config.GetSettings().Set("Cleanup" + dependencyTypeString, configurer);
         }
 
         class Cleaner


### PR DESCRIPTION
Related to #3203 

Replaced the invocation of Configure{Transport/Persistence} classes as dynamic methods and reflection with a full interface `IConfigureTestEnvironment`. Saw a lot of duplication between transport and persistence and eliminated that.

Stopped short of replacing the settings as string dictionary with a class having defined properties, since this concept touches builders and serializers in addition to transports and persistences. Also didn't apply the requirement for an interface-implementing configurer class on builders/serializers.

If settings was replaced, the list of properties would (I think) be:

* UniqueTestRunId - Guid I would add that would uniquely identify each test run. Azure tests need this kind of concept to enable ignoring messages in queue from any other test run. That behavior could potentially be generalized.
* Transport
* TransportConnectionString
* Persistence
* PersistenceConnectionString
* Builder
* Serializer

Thoughts? @SeanFeldman @danielmarbach @andreasohlund @SimonCropp @Particular/nservicebus 