### PR TITLE
MessageProcessingAbortedExcepton made public

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -645,6 +645,11 @@ namespace NServiceBus
         Unsubscribe = 4,
         Reply = 5,
     }
+    public class MessageProcessingAbortedException : System.Exception
+    {
+        public MessageProcessingAbortedException() { }
+        protected MessageProcessingAbortedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
     public class static MessageProcessingOptimizationExtensions
     {
         public static void LimitMessageProcessingConcurrencyTo(this NServiceBus.BusConfiguration config, int maxConcurrency) { }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -645,11 +645,6 @@ namespace NServiceBus
         Unsubscribe = 4,
         Reply = 5,
     }
-    public class MessageProcessingAbortedException : System.Exception
-    {
-        public MessageProcessingAbortedException() { }
-        protected MessageProcessingAbortedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-    }
     public class static MessageProcessingOptimizationExtensions
     {
         public static void LimitMessageProcessingConcurrencyTo(this NServiceBus.BusConfiguration config, int maxConcurrency) { }
@@ -2576,6 +2571,11 @@ namespace NServiceBus.Transports
     public interface ISendMessages
     {
         void Send(NServiceBus.TransportMessage message, NServiceBus.Unicast.SendOptions sendOptions);
+    }
+    public class MessageProcessingAbortedException : System.Exception
+    {
+        public MessageProcessingAbortedException() { }
+        protected MessageProcessingAbortedException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
     public class OutboundRoutingPolicy
     {

--- a/src/NServiceBus.Core/Pipeline/Incoming/MessageProcessingAbortedException.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/MessageProcessingAbortedException.cs
@@ -1,14 +1,11 @@
-namespace NServiceBus
+namespace NServiceBus.Transports
 {
     using System;
     using System.Runtime.Serialization;
     using JetBrains.Annotations;
-    using NServiceBus.Features;
-    using NServiceBus.Transports;
 
     /// <summary>
-    /// This exception can be thrown by any of recoverability behaviors ie.e <see cref="FirstLevelRetries"/>, <see cref="SecondLevelRetries"/> or <see cref="StoreFaultsInErrorQueue"/>
-    /// It is meant to indicate to the <see cref="IPushMessages"/> that message should be returned to input queue and will be handeled by recoverability mechanisms on next receive.
+    /// When thrown during pipeline invocation indicates that <see cref="IPushMessages"/> should return message to the input queue causing any recive transactions to rollback.
     /// </summary>
     [Serializable]
     public class MessageProcessingAbortedException : Exception

--- a/src/NServiceBus.Core/Pipeline/Incoming/MessageProcessingAbortedException.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/MessageProcessingAbortedException.cs
@@ -1,8 +1,30 @@
 namespace NServiceBus
 {
     using System;
+    using System.Runtime.Serialization;
+    using JetBrains.Annotations;
+    using NServiceBus.Features;
+    using NServiceBus.Transports;
 
-    class MessageProcessingAbortedException : Exception
+    /// <summary>
+    /// This exception can be thrown by any of recoverability behaviors ie.e <see cref="FirstLevelRetries"/>, <see cref="SecondLevelRetries"/> or <see cref="StoreFaultsInErrorQueue"/>
+    /// It is meant to indicate to the <see cref="IPushMessages"/> that message should be returned to input queue and will be handeled by recoverability mechanisms on next receive.
+    /// </summary>
+    [Serializable]
+    public class MessageProcessingAbortedException : Exception
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="MessageProcessingAbortedException"/>.
+        /// </summary>
+        public MessageProcessingAbortedException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="MessageProcessingAbortedException"/>.
+        /// </summary>
+        protected MessageProcessingAbortedException([NotNull] SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
     }
 }

--- a/src/NServiceBus.Core/Recoverability/FirstLevelRetries/FirstLevelRetriesBehavior.cs
+++ b/src/NServiceBus.Core/Recoverability/FirstLevelRetries/FirstLevelRetriesBehavior.cs
@@ -5,6 +5,7 @@ namespace NServiceBus
     using Logging;
     using NServiceBus.Features;
     using NServiceBus.Settings;
+    using NServiceBus.Transports;
     using Pipeline;
     using Pipeline.Contexts;
 
@@ -26,6 +27,10 @@ namespace NServiceBus
             catch (MessageDeserializationException)
             {
                 throw; // no retries for poison messages
+            }
+            catch (MessageProcessingAbortedException)
+            {
+                throw; // we do not not count explicit abort as failed processing
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This exception needs to be exposed so that v6 transport seam can properly support message receive rollback due to recoverability functionality. For example #3216.
This connects to #3078 spike for using OperationAbortedException instead. In addition it connect also to #3044.