### PR TITLE
Enforce Behavior with interface for contexts

### DIFF
--- a/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
@@ -216,15 +216,17 @@ namespace NServiceBus.Core.Tests.Pipeline
             }
         }
 
-        class FakeStageConnector : StageConnector<IIncomingContext,ChildContext>
+        class FakeStageConnector : StageConnector<IIncomingContext, IChildContext>
         {
-            public override Task Invoke(IIncomingContext context, Func<ChildContext, Task> next)
+            public override Task Invoke(IIncomingContext context, Func<IChildContext, Task> next)
             {
                 throw new NotImplementedException();
             }
         }
 
-        class ChildContext : IncomingContext
+        interface IChildContext : IIncomingContext { }
+
+        class ChildContext : IncomingContext, IChildContext
         {
             public ChildContext() : base("messageId", "replyToAddress", new Dictionary<string, string>(), null)
             {

--- a/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
@@ -34,7 +34,7 @@ namespace NServiceBus.Core.Tests.Pipeline
 
             removals.Add(new RemoveStep("1"));
 
-            var model = coordinator.BuildPipelineModelFor<IIncomingContext>();
+            var model = coordinator.BuildPipelineModelFor<IRootContext>();
 
             Assert.AreEqual(2, model.Count());
         }
@@ -46,7 +46,7 @@ namespace NServiceBus.Core.Tests.Pipeline
             coordinator.Register("2", typeof(FakeBehavior), "2");
             coordinator.Register("3", typeof(FakeBehavior), "3");
 
-            var model =  coordinator.BuildPipelineModelFor<IIncomingContext>().ToList();
+            var model =  coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 
             Assert.AreEqual("1", model[0].StepId);
             Assert.AreEqual("2", model[1].StepId);
@@ -63,7 +63,7 @@ namespace NServiceBus.Core.Tests.Pipeline
             replacements.Add(new ReplaceStep("1", typeof(ReplacedBehavior), "new"));
             replacements.Add(new ReplaceStep("2", typeof(ReplacedBehavior)));
 
-            var model = coordinator.BuildPipelineModelFor<IIncomingContext>().ToList();
+            var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 
             Assert.AreEqual(typeof(ReplacedBehavior).FullName, model[0].BehaviorType.FullName);
             Assert.AreEqual("new", model[0].Description);
@@ -81,7 +81,7 @@ namespace NServiceBus.Core.Tests.Pipeline
             coordinator.Register(new MyCustomRegistration("2.5", "3", "2"));
             coordinator.Register(new MyCustomRegistration("3.5", null, "3"));
 
-            var model = coordinator.BuildPipelineModelFor<IIncomingContext>().ToList();
+            var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 
             Assert.AreEqual("1", model[0].StepId);
             Assert.AreEqual("1.5", model[1].StepId);
@@ -101,7 +101,7 @@ namespace NServiceBus.Core.Tests.Pipeline
             coordinator.Register(new MyCustomRegistration("1.5", "2,3", null));
             coordinator.Register(new MyCustomRegistration("2.5", "3", null));
 
-            var model = coordinator.BuildPipelineModelFor<IIncomingContext>().ToList();
+            var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 
             Assert.AreEqual("1", model[0].StepId);
             Assert.AreEqual("1.5", model[1].StepId);
@@ -121,7 +121,7 @@ namespace NServiceBus.Core.Tests.Pipeline
             coordinator.Register(new MyCustomRegistration("2.5", "3", "2,1"));
             coordinator.Register(new MyCustomRegistration("3.5", null, "1,2,3"));
 
-            var model = coordinator.BuildPipelineModelFor<IIncomingContext>().ToList();
+            var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 
             Assert.AreEqual("1", model[0].StepId);
             Assert.AreEqual("1.5", model[1].StepId);
@@ -142,7 +142,7 @@ namespace NServiceBus.Core.Tests.Pipeline
             coordinator.Register(new MyCustomRegistration("1.6", "2", "1.5"));
             coordinator.Register(new MyCustomRegistration("1.1", "1.5", "1"));
 
-            var model = coordinator.BuildPipelineModelFor<IIncomingContext>().ToList();
+            var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 
             Assert.AreEqual("1", model[0].StepId);
             Assert.AreEqual("1.1", model[1].StepId);
@@ -160,7 +160,7 @@ namespace NServiceBus.Core.Tests.Pipeline
             coordinator.Register(new MyCustomRegistration("x","connector",""));
 
 
-            Assert.Throws<Exception>(() => coordinator.BuildPipelineModelFor<IIncomingContext>());
+            Assert.Throws<Exception>(() => coordinator.BuildPipelineModelFor<IRootContext>());
         }
 
         [Test]
@@ -171,9 +171,8 @@ namespace NServiceBus.Core.Tests.Pipeline
             coordinator.Register(new MyCustomRegistration("x", "", "connector"));
 
 
-            Assert.Throws<Exception>(() => coordinator.BuildPipelineModelFor<IIncomingContext>());
+            Assert.Throws<Exception>(() => coordinator.BuildPipelineModelFor<IRootContext>());
         }
-
 
         class MyCustomRegistration : RegisterStep
         {
@@ -199,30 +198,33 @@ namespace NServiceBus.Core.Tests.Pipeline
                 }
             }
         }
-        class FakeBehavior: Behavior<IIncomingContext>
+
+        class FakeBehavior: Behavior<IRootContext>
         {
-            public override Task Invoke(IIncomingContext context, Func<Task> next)
+            public override Task Invoke(IRootContext context, Func<Task> next)
             {
                 throw new NotImplementedException();
             }
         }
 
 
-        class ReplacedBehavior : Behavior<IIncomingContext>
+        class ReplacedBehavior : Behavior<IRootContext>
         {
-            public override Task Invoke(IIncomingContext context, Func<Task> next)
+            public override Task Invoke(IRootContext context, Func<Task> next)
             {
                 throw new NotImplementedException();
             }
         }
 
-        class FakeStageConnector : StageConnector<IIncomingContext, IChildContext>
+        class FakeStageConnector : StageConnector<IRootContext, IChildContext>
         {
-            public override Task Invoke(IIncomingContext context, Func<IChildContext, Task> next)
+            public override Task Invoke(IRootContext context, Func<IChildContext, Task> next)
             {
                 throw new NotImplementedException();
             }
         }
+
+        interface IRootContext : IBehaviorContext { }
 
         interface IChildContext : IIncomingContext { }
 

--- a/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
@@ -14,13 +14,13 @@ namespace NServiceBus.Core.Tests.Pipeline
     {
         StepRegistrationsCoordinator coordinator;
         List<RemoveStep> removals;
-        List<ReplaceBehavior> replacements;
+        List<ReplaceStep> replacements;
 
         [SetUp]
         public void Setup()
         {
             removals = new List<RemoveStep>();
-            replacements = new List<ReplaceBehavior>();
+            replacements = new List<ReplaceStep>();
 
             coordinator = new StepRegistrationsCoordinator(removals, replacements);
         }
@@ -60,8 +60,8 @@ namespace NServiceBus.Core.Tests.Pipeline
             coordinator.Register("2", typeof(FakeBehavior), "2");
             coordinator.Register("3", typeof(FakeBehavior), "3");
 
-            replacements.Add(new ReplaceBehavior("1", typeof(ReplacedBehavior), "new"));
-            replacements.Add(new ReplaceBehavior("2", typeof(ReplacedBehavior)));
+            replacements.Add(new ReplaceStep("1", typeof(ReplacedBehavior), "new"));
+            replacements.Add(new ReplaceStep("2", typeof(ReplacedBehavior)));
 
             var model = coordinator.BuildPipelineModelFor<IIncomingContext>().ToList();
 

--- a/src/NServiceBus.Core.Tests/Pipeline/BehaviorTypeCheckerTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/BehaviorTypeCheckerTests.cs
@@ -3,64 +3,112 @@
     using System;
     using System.Threading.Tasks;
     using NServiceBus.Audit;
+    using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
+    using NServiceBus.Pipeline.Contexts;
     using NServiceBus.Unicast.Transport;
     using NUnit.Framework;
 
     [TestFixture]
     public class BehaviorTypeCheckerTests
     {
+        const string Description = "foo";
+
         [Test]
         public void Should_not_throw_for_simple_behavior()
         {
-            BehaviorTypeChecker.ThrowIfInvalid(typeof(ValidBehavior), "foo");
+            BehaviorTypeChecker.ThrowIfInvalid(typeof(ValidBehavior), Description);
         }
 
         [Test]
         public void Should_not_throw_for_behavior_using_context_interfaces()
         {
-            BehaviorTypeChecker.ThrowIfInvalid(typeof(BehaviorUsingContextInterface), "foo");
+            BehaviorTypeChecker.ThrowIfInvalid(typeof(BehaviorUsingContextInterface), Description);
         }
 
         [Test]
         public void Should_not_throw_for_closed_generic_behavior()
         {
-            BehaviorTypeChecker.ThrowIfInvalid(typeof(GenericBehavior<object>), "foo");
+            BehaviorTypeChecker.ThrowIfInvalid(typeof(GenericBehavior<object>), Description);
         }
 
         [Test]
         public void Should_throw_for_non_behavior()
         {
-            Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(string), "foo"));
+            Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(string), Description));
         }
 
         [Test]
         public void Should_throw_for_open_generic_behavior()
         {
-            Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(GenericBehavior<>), "foo"));
+            Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(GenericBehavior<>), Description));
         }
 
         [Test]
         public void Should_throw_for_abstract_behavior()
         {
-            Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(AbstractBehavior), "foo"));
+            Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(AbstractBehavior), Description));
         }
 
         [Test]
         public void Should_throw_for_behavior_using_context_implementations_on_tfrom()
         {
-            Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(BehaviorUsingContextImplementationOnTFrom), "foo"));
+            Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(BehaviorUsingContextImplementationOnTFrom), Description));
         }
 
         [Test]
         public void Should_throw_for_behavior_using_context_implementations_on_tto()
         {
-            Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(BehaviorUsingContextImplementationOnTTo), "foo"));
+            Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(BehaviorUsingContextImplementationOnTTo), Description));
         }
 
-        class ValidBehavior : Behavior<IBehaviorContext>
+        [Test]
+        public void Should_throw_for_behavior_using_IIncomingContext()
+        {
+            Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(BehaviorUsingIncomingContext), Description));
+        }
+
+        [Test]
+        public void Should_throw_for_behavior_using_IOutgoingContext()
+        {
+            Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(BehaviorUsingOutgoingContext), Description));
+        }
+
+        [Test]
+        public void Should_throw_for_behavior_using_IBehaviorContext()
+        {
+            Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(BehaviorUsingBehaviorContext), Description));
+        }
+
+        interface IRootContext : IBehaviorContext { }
+
+        class ValidBehavior : Behavior<IRootContext>
+        {
+            public override Task Invoke(IRootContext context, Func<Task> next)
+            {
+                return Task.FromResult(0);
+            }
+        }
+
+        class BehaviorUsingBehaviorContext : Behavior<IBehaviorContext>
         {
             public override Task Invoke(IBehaviorContext context, Func<Task> next)
+            {
+                return Task.FromResult(0);
+            }
+        }
+
+        class BehaviorUsingIncomingContext : Behavior<IIncomingContext>
+        {
+            public override Task Invoke(IIncomingContext context, Func<Task> next)
+            {
+                return Task.FromResult(0);
+            }
+        }
+
+        class BehaviorUsingOutgoingContext : Behavior<IOutgoingContext>
+        {
+            public override Task Invoke(IOutgoingContext context, Func<Task> next)
             {
                 return Task.FromResult(0);
             }
@@ -104,15 +152,15 @@
             }
         }
 
-        class GenericBehavior<T> : Behavior<IBehaviorContext>
+        class GenericBehavior<T> : Behavior<IRootContext>
         {
-            public override Task Invoke(IBehaviorContext context, Func<Task> next)
+            public override Task Invoke(IRootContext context, Func<Task> next)
             {
                 return Task.FromResult(0);
             }
         }
 
-        abstract class AbstractBehavior : Behavior<IBehaviorContext>
+        abstract class AbstractBehavior : Behavior<IRootContext>
         {
         }
     }

--- a/src/NServiceBus.Core.Tests/Pipeline/BehaviorTypeCheckerTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/BehaviorTypeCheckerTests.cs
@@ -40,12 +40,22 @@
             Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(GenericBehavior<>), "foo"));
         }
 
+        [Test]
+        public void Should_throw_for_abstract_behavior()
+        {
+            Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(AbstractBehavior), "foo"));
+        }
+
         class GenericBehavior<T> : Behavior<RootContext>
         {
             public override Task Invoke(RootContext context, Func<Task> next)
             {
                 return Task.FromResult(0);
             }
+        }
+
+        abstract class AbstractBehavior : Behavior<RootContext>
+        {
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
@@ -9,6 +9,115 @@
     public class PipelineModelBuilderTests
     {
         [Test]
+        public void ShouldDetectConflictingStepRegistrations()
+        {
+            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            {
+                RegisterStep.Create("Root1", typeof(RootBehavior), "desc"),
+                RegisterStep.Create("Root1", typeof(NonReachableChildBehavior), "desc"),
+
+            }, new List<RemoveStep>(), new List<ReplaceStep>());
+
+
+            var ex = Assert.Throws<Exception>(() => builder.Build());
+
+            Assert.AreEqual("Step registration with id 'Root1' is already registered for 'NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+RootBehavior'.", ex.Message);
+        }
+
+        [Test]
+        public void ShouldOnlyAllowReplacementOfExistingRegistrations()
+        {
+            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            {
+                RegisterStep.Create("Root1", typeof(RootBehavior), "desc"),
+
+            }, new List<RemoveStep>(), new List<ReplaceStep>
+            {
+                new ReplaceStep("DoesNotExist", typeof(RootBehavior), "desc"),
+            });
+
+
+            var ex = Assert.Throws<Exception>(() => builder.Build());
+
+            Assert.AreEqual("You can only replace an existing step registration, 'DoesNotExist' registration does not exist.", ex.Message);
+        }
+
+        [Test]
+        public void ShouldOnlyAllowRemovalOfExistingRegistrations()
+        {
+            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            {
+                RegisterStep.Create("Root1", typeof(RootBehavior), "desc"),
+
+            }, new List<RemoveStep>
+            {
+                new RemoveStep("DoesNotExist"),
+            }, new List<ReplaceStep>());
+
+
+            var ex = Assert.Throws<Exception>(() => builder.Build());
+
+            Assert.AreEqual("You cannot remove step registration with id 'DoesNotExist', registration does not exist.", ex.Message);
+        }
+
+        [Test]
+        public void ShouldOnlyAllowRemovalWhenNoOtherDependsOnItsBeforeRegistration()
+        {
+            var someBehaviorRegistration = RegisterStep.Create("SomeBehavior", typeof(SomeBehavior), "desc");
+            var anotherBehaviorRegistration = RegisterStep.Create("AnotherBehavior", typeof(AnotherBehavior), "desc");
+
+            anotherBehaviorRegistration.InsertBefore("SomeBehavior");
+
+            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            {
+                someBehaviorRegistration,
+                anotherBehaviorRegistration,
+
+            }, new List<RemoveStep> { new RemoveStep("SomeBehavior")}, new List<ReplaceStep>());
+
+
+            var ex = Assert.Throws<Exception>(() => builder.Build());
+
+            Assert.AreEqual("You cannot remove step registration with id 'SomeBehavior', registration with id 'AnotherBehavior' depends on it.", ex.Message);
+        }
+
+        [Test]
+        public void ShouldOnlyAllowRemovalWhenNoOtherDependsOnItsAfterRegistration()
+        {
+            var someBehaviorRegistration = RegisterStep.Create("SomeBehavior", typeof(SomeBehavior), "desc");
+            var anotherBehaviorRegistration = RegisterStep.Create("AnotherBehavior", typeof(AnotherBehavior), "desc");
+
+            anotherBehaviorRegistration.InsertAfter("SomeBehavior");
+
+            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            {
+                someBehaviorRegistration,
+                anotherBehaviorRegistration,
+
+            }, new List<RemoveStep> { new RemoveStep("SomeBehavior") }, new List<ReplaceStep>());
+
+
+            var ex = Assert.Throws<Exception>(() => builder.Build());
+
+            Assert.AreEqual("You cannot remove step registration with id 'SomeBehavior', registration with id 'AnotherBehavior' depends on it.", ex.Message);
+        }
+
+        [Test]
+        public void ShouldDetectMissingBehaviorForRootContext()
+        {
+            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            {
+                RegisterStep.Create("Child", typeof(ChildBehavior), "desc"),
+
+            }, new List<RemoveStep>(), new List<ReplaceStep>());
+
+
+            var ex = Assert.Throws<Exception>(() => builder.Build());
+
+            Assert.AreEqual("Can't find any behaviors/connectors for the root context (NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+ParentContext)", ex.Message);
+        }
+
+        [Test]
         public void ShouldDetectConflictingStageConnectors()
         {
             var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
@@ -16,13 +125,13 @@
                 RegisterStep.Create("Root1", typeof(RootBehavior), "desc"),
                 RegisterStep.Create("RootToChildConnector", typeof(RootToChildConnector), "desc"),
                 RegisterStep.Create("RootToChild2Connector", typeof(RootToChild2Connector), "desc")
-        
-            }, new List<RemoveStep>(), new List<ReplaceBehavior>());
+
+            }, new List<RemoveStep>(), new List<ReplaceStep>());
 
 
             var ex = Assert.Throws<Exception>(() => builder.Build());
 
-            Assert.True(ex.Message.Contains("Multiple stage connectors found"));
+            Assert.AreEqual("Multiple stage connectors found for stage 'NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+ParentContext'. Please remove one of: NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+RootToChildConnector;NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+RootToChild2Connector", ex.Message);
         }
 
         [Test]
@@ -33,7 +142,7 @@
                 RegisterStep.Create("Root", typeof(RootBehavior), "desc"),
                 RegisterStep.Create("RootToChildConnector", typeof(RootToChild2Connector), "desc"),
                 RegisterStep.Create("Child", typeof(NonReachableChildBehavior), "desc")
-            }, new List<RemoveStep>(), new List<ReplaceBehavior>());
+            }, new List<RemoveStep>(), new List<ReplaceStep>());
 
 
             var model = builder.Build();
@@ -49,8 +158,8 @@
                 RegisterStep.Create("Root1", typeof(RootBehavior), "desc"),
                 RegisterStep.Create("RootToChildConnector", typeof(RootToChildConnector), "desc"),
                 RegisterStep.Create("Terminator", typeof(Terminator), "desc")
-        
-            }, new List<RemoveStep>(), new List<ReplaceBehavior>());
+
+            }, new List<RemoveStep>(), new List<ReplaceStep>());
 
 
             var model = builder.Build();
@@ -98,9 +207,24 @@
             }
         }
 
-         class RootToChild2Connector : StageConnector<ParentContext, ChildContextReachableButNotInheritingFromRootContext>
+        class RootToChild2Connector : StageConnector<ParentContext, ChildContextReachableButNotInheritingFromRootContext>
         {
             public override Task Invoke(ParentContext context, Func<ChildContextReachableButNotInheritingFromRootContext, Task> next)
+            {
+                throw new NotImplementedException();
+            }
+        }
+        class SomeBehavior : Behavior<ParentContext>
+        {
+            public override Task Invoke(ParentContext context, Func<Task> next)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        class AnotherBehavior : Behavior<ParentContext>
+        {
+            public override Task Invoke(ParentContext context, Func<Task> next)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
@@ -11,7 +11,7 @@
         [Test]
         public void ShouldDetectConflictingStepRegistrations()
         {
-            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            var builder = new PipelineModelBuilder(typeof(IParentContext), new List<RegisterStep>
             {
                 RegisterStep.Create("Root1", typeof(RootBehavior), "desc"),
                 RegisterStep.Create("Root1", typeof(ChildBehaviorOfChildContextNotInheritedFromParentContext), "desc"),
@@ -27,7 +27,7 @@
         [Test]
         public void ShouldOnlyAllowReplacementOfExistingRegistrations()
         {
-            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            var builder = new PipelineModelBuilder(typeof(IParentContext), new List<RegisterStep>
             {
                 RegisterStep.Create("Root1", typeof(RootBehavior), "desc"),
 
@@ -45,7 +45,7 @@
         [Test]
         public void ShouldOnlyAllowRemovalOfExistingRegistrations()
         {
-            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            var builder = new PipelineModelBuilder(typeof(IParentContext), new List<RegisterStep>
             {
                 RegisterStep.Create("Root1", typeof(RootBehavior), "desc"),
 
@@ -68,7 +68,7 @@
 
             anotherBehaviorRegistration.InsertBefore("SomeBehaviorOfParentContext");
 
-            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            var builder = new PipelineModelBuilder(typeof(IParentContext), new List<RegisterStep>
             {
                 someBehaviorRegistration,
                 anotherBehaviorRegistration,
@@ -89,7 +89,7 @@
 
             anotherBehaviorRegistration.InsertAfter("SomeBehaviorOfParentContext");
 
-            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            var builder = new PipelineModelBuilder(typeof(IParentContext), new List<RegisterStep>
             {
                 someBehaviorRegistration,
                 anotherBehaviorRegistration,
@@ -105,7 +105,7 @@
         [Test]
         public void ShouldDetectMissingBehaviorForRootContext()
         {
-            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            var builder = new PipelineModelBuilder(typeof(IParentContext), new List<RegisterStep>
             {
                 RegisterStep.Create("Child", typeof(ChildBehaviorOfChildContext), "desc"),
 
@@ -114,13 +114,13 @@
 
             var ex = Assert.Throws<Exception>(() => builder.Build());
 
-            Assert.AreEqual("Can't find any behaviors/connectors for the root context (NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+ParentContext)", ex.Message);
+            Assert.AreEqual("Can't find any behaviors/connectors for the root context (NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+IParentContext)", ex.Message);
         }
 
         [Test]
         public void ShouldDetectConflictingStageConnectors()
         {
-            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            var builder = new PipelineModelBuilder(typeof(IParentContext), new List<RegisterStep>
             {
                 RegisterStep.Create("Root1", typeof(RootBehavior), "desc"),
                 RegisterStep.Create("ParentContextToChildContextConnector", typeof(ParentContextToChildContextConnector), "desc"),
@@ -131,7 +131,7 @@
 
             var ex = Assert.Throws<Exception>(() => builder.Build());
 
-            Assert.AreEqual("Multiple stage connectors found for stage 'NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+ParentContext'. Please remove one of: 'NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+ParentContextToChildContextConnector', 'NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+ParentContextToChildContextNotInheritedFromParentContextConnector'", ex.Message);
+            Assert.AreEqual("Multiple stage connectors found for stage 'NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+IParentContext'. Please remove one of: 'NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+ParentContextToChildContextConnector', 'NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+ParentContextToChildContextNotInheritedFromParentContextConnector'", ex.Message);
         }
 
         [Test]
@@ -142,7 +142,7 @@
 
             anotherBehaviorRegistration.InsertAfter("DoesNotExist");
 
-            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            var builder = new PipelineModelBuilder(typeof(IParentContext), new List<RegisterStep>
             {
                 someBehaviorRegistration,
                 anotherBehaviorRegistration,
@@ -163,7 +163,7 @@
 
             anotherBehaviorRegistration.InsertBefore("DoesNotExist");
 
-            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            var builder = new PipelineModelBuilder(typeof(IParentContext), new List<RegisterStep>
             {
                 someBehaviorRegistration,
                 anotherBehaviorRegistration,
@@ -179,7 +179,7 @@
         [Test]
         public void ShouldDetectRegistrationsWithContextsReachableFromTheRootContext()
         {
-            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            var builder = new PipelineModelBuilder(typeof(IParentContext), new List<RegisterStep>
             {
                 RegisterStep.Create("Root", typeof(RootBehavior), "desc"),
                 RegisterStep.Create("ParentContextToChildContextNotInheritedFromParentContextConnector", typeof(ParentContextToChildContextNotInheritedFromParentContextConnector), "desc"),
@@ -195,7 +195,7 @@
         [Test]
         public void ShouldDetectRegistrationsWithContextsNotReachableFromTheRootContext()
         {
-            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            var builder = new PipelineModelBuilder(typeof(IParentContext), new List<RegisterStep>
             {
                 RegisterStep.Create("Root", typeof(RootBehavior), "desc"),
                 RegisterStep.Create("ParentContextToChildContextConnector", typeof(ParentContextToChildContextConnector), "desc"),
@@ -211,10 +211,11 @@
         [Test]
         public void ShouldHandleTheTerminator()
         {
-            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            var builder = new PipelineModelBuilder(typeof(IParentContext), new List<RegisterStep>
             {
                 RegisterStep.Create("Root1", typeof(RootBehavior), "desc"),
                 RegisterStep.Create("ParentContextToChildContextConnector", typeof(ParentContextToChildContextConnector), "desc"),
+                RegisterStep.Create("Child", typeof(ChildBehaviorOfChildContextNotInheritedFromParentContext), "desc"),
                 RegisterStep.Create("Terminator", typeof(Terminator), "desc")
 
             }, new List<RemoveStep>(), new List<ReplaceStep>());
@@ -225,7 +226,9 @@
             Assert.AreEqual(3, model.Count);
         }
 
-        class ParentContext : BehaviorContext
+        interface IParentContext : IBehaviorContext { }
+
+        class ParentContext : BehaviorContext, IParentContext
         {
             public ParentContext(IBehaviorContext parentContext)
                 : base(parentContext)
@@ -233,13 +236,17 @@
             }
         }
 
-        class ChildContext : ParentContext
+        interface IChildContext : IParentContext { }
+
+        class ChildContext : ParentContext, IChildContext
         {
             public ChildContext(IBehaviorContext parentContext)
                 : base(parentContext)
             {
             }
         }
+
+        interface IChildContextNotInheritedFromParentContext : IBehaviorContext { }
 
         class ChildContextNotInheritedFromParentContext : BehaviorContext
         {
@@ -249,65 +256,65 @@
             }
         }
 
-        class ParentContextToChildContextConnector : StageConnector<ParentContext, ChildContext>
+        class ParentContextToChildContextConnector : StageConnector<IParentContext, IChildContext>
         {
-            public override Task Invoke(ParentContext context, Func<ChildContext, Task> next)
+            public override Task Invoke(IParentContext context, Func<IChildContext, Task> next)
             {
                 throw new NotImplementedException();
             }
         }
 
-        class Terminator : PipelineTerminator<ChildContext>
+        class Terminator : PipelineTerminator<IChildContext>
         {
-            protected override Task Terminate(ChildContext context)
+            protected override Task Terminate(IChildContext context)
             {
                 throw new NotImplementedException();
             }
         }
 
-        class ParentContextToChildContextNotInheritedFromParentContextConnector : StageConnector<ParentContext, ChildContextNotInheritedFromParentContext>
+        class ParentContextToChildContextNotInheritedFromParentContextConnector : StageConnector<IParentContext, IChildContextNotInheritedFromParentContext>
         {
-            public override Task Invoke(ParentContext context, Func<ChildContextNotInheritedFromParentContext, Task> next)
+            public override Task Invoke(IParentContext context, Func<IChildContextNotInheritedFromParentContext, Task> next)
             {
                 throw new NotImplementedException();
             }
         }
 
-        class SomeBehaviorOfParentContext : Behavior<ParentContext>
+        class SomeBehaviorOfParentContext : Behavior<IParentContext>
         {
-            public override Task Invoke(ParentContext context, Func<Task> next)
+            public override Task Invoke(IParentContext context, Func<Task> next)
             {
                 throw new NotImplementedException();
             }
         }
 
-        class AnotherBehaviorOfParentContext : Behavior<ParentContext>
+        class AnotherBehaviorOfParentContext : Behavior<IParentContext>
         {
-            public override Task Invoke(ParentContext context, Func<Task> next)
+            public override Task Invoke(IParentContext context, Func<Task> next)
             {
                 throw new NotImplementedException();
             }
         }
 
-        class RootBehavior : Behavior<ParentContext>
+        class RootBehavior : Behavior<IParentContext>
         {
-            public override Task Invoke(ParentContext context, Func<Task> next)
+            public override Task Invoke(IParentContext context, Func<Task> next)
             {
                 throw new NotImplementedException();
             }
         }
 
-        class ChildBehaviorOfChildContext : Behavior<ChildContext>
+        class ChildBehaviorOfChildContext : Behavior<IChildContext>
         {
-            public override Task Invoke(ChildContext context, Func<Task> next)
+            public override Task Invoke(IChildContext context, Func<Task> next)
             {
                 throw new NotImplementedException();
             }
         }
 
-        class ChildBehaviorOfChildContextNotInheritedFromParentContext : Behavior<ChildContextNotInheritedFromParentContext>
+        class ChildBehaviorOfChildContextNotInheritedFromParentContext : Behavior<IChildContextNotInheritedFromParentContext>
         {
-            public override Task Invoke(ChildContextNotInheritedFromParentContext context, Func<Task> next)
+            public override Task Invoke(IChildContextNotInheritedFromParentContext context, Func<Task> next)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
@@ -14,7 +14,7 @@
             var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
             {
                 RegisterStep.Create("Root1", typeof(RootBehavior), "desc"),
-                RegisterStep.Create("Root1", typeof(NonReachableChildBehavior), "desc"),
+                RegisterStep.Create("Root1", typeof(ChildBehaviorOfChildContextNotInheritedFromParentContext), "desc"),
 
             }, new List<RemoveStep>(), new List<ReplaceStep>());
 
@@ -63,43 +63,43 @@
         [Test]
         public void ShouldOnlyAllowRemovalWhenNoOtherDependsOnItsBeforeRegistration()
         {
-            var someBehaviorRegistration = RegisterStep.Create("SomeBehavior", typeof(SomeBehavior), "desc");
-            var anotherBehaviorRegistration = RegisterStep.Create("AnotherBehavior", typeof(AnotherBehavior), "desc");
+            var someBehaviorRegistration = RegisterStep.Create("SomeBehaviorOfParentContext", typeof(SomeBehaviorOfParentContext), "desc");
+            var anotherBehaviorRegistration = RegisterStep.Create("AnotherBehaviorOfParentContext", typeof(AnotherBehaviorOfParentContext), "desc");
 
-            anotherBehaviorRegistration.InsertBefore("SomeBehavior");
+            anotherBehaviorRegistration.InsertBefore("SomeBehaviorOfParentContext");
 
             var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
             {
                 someBehaviorRegistration,
                 anotherBehaviorRegistration,
 
-            }, new List<RemoveStep> { new RemoveStep("SomeBehavior")}, new List<ReplaceStep>());
+            }, new List<RemoveStep> { new RemoveStep("SomeBehaviorOfParentContext")}, new List<ReplaceStep>());
 
 
             var ex = Assert.Throws<Exception>(() => builder.Build());
 
-            Assert.AreEqual("You cannot remove step registration with id 'SomeBehavior', registration with id 'AnotherBehavior' depends on it.", ex.Message);
+            Assert.AreEqual("You cannot remove step registration with id 'SomeBehaviorOfParentContext', registration with id 'AnotherBehaviorOfParentContext' depends on it.", ex.Message);
         }
 
         [Test]
         public void ShouldOnlyAllowRemovalWhenNoOtherDependsOnItsAfterRegistration()
         {
-            var someBehaviorRegistration = RegisterStep.Create("SomeBehavior", typeof(SomeBehavior), "desc");
-            var anotherBehaviorRegistration = RegisterStep.Create("AnotherBehavior", typeof(AnotherBehavior), "desc");
+            var someBehaviorRegistration = RegisterStep.Create("SomeBehaviorOfParentContext", typeof(SomeBehaviorOfParentContext), "desc");
+            var anotherBehaviorRegistration = RegisterStep.Create("AnotherBehaviorOfParentContext", typeof(AnotherBehaviorOfParentContext), "desc");
 
-            anotherBehaviorRegistration.InsertAfter("SomeBehavior");
+            anotherBehaviorRegistration.InsertAfter("SomeBehaviorOfParentContext");
 
             var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
             {
                 someBehaviorRegistration,
                 anotherBehaviorRegistration,
 
-            }, new List<RemoveStep> { new RemoveStep("SomeBehavior") }, new List<ReplaceStep>());
+            }, new List<RemoveStep> { new RemoveStep("SomeBehaviorOfParentContext") }, new List<ReplaceStep>());
 
 
             var ex = Assert.Throws<Exception>(() => builder.Build());
 
-            Assert.AreEqual("You cannot remove step registration with id 'SomeBehavior', registration with id 'AnotherBehavior' depends on it.", ex.Message);
+            Assert.AreEqual("You cannot remove step registration with id 'SomeBehaviorOfParentContext', registration with id 'AnotherBehaviorOfParentContext' depends on it.", ex.Message);
         }
 
         [Test]
@@ -107,7 +107,7 @@
         {
             var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
             {
-                RegisterStep.Create("Child", typeof(ChildBehavior), "desc"),
+                RegisterStep.Create("Child", typeof(ChildBehaviorOfChildContext), "desc"),
 
             }, new List<RemoveStep>(), new List<ReplaceStep>());
 
@@ -123,15 +123,57 @@
             var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
             {
                 RegisterStep.Create("Root1", typeof(RootBehavior), "desc"),
-                RegisterStep.Create("RootToChildConnector", typeof(RootToChildConnector), "desc"),
-                RegisterStep.Create("RootToChild2Connector", typeof(RootToChild2Connector), "desc")
+                RegisterStep.Create("ParentContextToChildContextConnector", typeof(ParentContextToChildContextConnector), "desc"),
+                RegisterStep.Create("ParentContextToChildContextNotInheritedFromParentContextConnector", typeof(ParentContextToChildContextNotInheritedFromParentContextConnector), "desc")
 
             }, new List<RemoveStep>(), new List<ReplaceStep>());
 
 
             var ex = Assert.Throws<Exception>(() => builder.Build());
 
-            Assert.AreEqual("Multiple stage connectors found for stage 'NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+ParentContext'. Please remove one of: NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+RootToChildConnector;NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+RootToChild2Connector", ex.Message);
+            Assert.AreEqual("Multiple stage connectors found for stage 'NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+ParentContext'. Please remove one of: 'NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+ParentContextToChildContextConnector', 'NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+ParentContextToChildContextNotInheritedFromParentContextConnector'", ex.Message);
+        }
+
+        [Test]
+        public void ShouldDetectNonExistingInsertAfterRegistrations()
+        {
+            var someBehaviorRegistration = RegisterStep.Create("SomeBehaviorOfParentContext", typeof(SomeBehaviorOfParentContext), "desc");
+            var anotherBehaviorRegistration = RegisterStep.Create("AnotherBehaviorOfParentContext", typeof(AnotherBehaviorOfParentContext), "desc");
+
+            anotherBehaviorRegistration.InsertAfter("DoesNotExist");
+
+            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            {
+                someBehaviorRegistration,
+                anotherBehaviorRegistration,
+
+            }, new List<RemoveStep>(), new List<ReplaceStep>());
+
+
+            var ex = Assert.Throws<Exception>(() => builder.Build());
+
+            Assert.AreEqual("Registration 'DoesNotExist' specified in the insertafter of the 'AnotherBehaviorOfParentContext' step does not exist. Current StepIds: 'SomeBehaviorOfParentContext', 'AnotherBehaviorOfParentContext'", ex.Message);
+        }
+
+        [Test]
+        public void ShouldDetectNonExistingInsertBeforeRegistrations()
+        {
+            var someBehaviorRegistration = RegisterStep.Create("SomeBehaviorOfParentContext", typeof(SomeBehaviorOfParentContext), "desc");
+            var anotherBehaviorRegistration = RegisterStep.Create("AnotherBehaviorOfParentContext", typeof(AnotherBehaviorOfParentContext), "desc");
+
+            anotherBehaviorRegistration.InsertBefore("DoesNotExist");
+
+            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            {
+                someBehaviorRegistration,
+                anotherBehaviorRegistration,
+
+            }, new List<RemoveStep>(), new List<ReplaceStep>());
+
+
+            var ex = Assert.Throws<Exception>(() => builder.Build());
+
+            Assert.AreEqual("Registration 'DoesNotExist' specified in the insertbefore of the 'AnotherBehaviorOfParentContext' step does not exist. Current StepIds: 'SomeBehaviorOfParentContext', 'AnotherBehaviorOfParentContext'", ex.Message);
         }
 
         [Test]
@@ -140,8 +182,8 @@
             var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
             {
                 RegisterStep.Create("Root", typeof(RootBehavior), "desc"),
-                RegisterStep.Create("RootToChildConnector", typeof(RootToChild2Connector), "desc"),
-                RegisterStep.Create("Child", typeof(NonReachableChildBehavior), "desc")
+                RegisterStep.Create("ParentContextToChildContextNotInheritedFromParentContextConnector", typeof(ParentContextToChildContextNotInheritedFromParentContextConnector), "desc"),
+                RegisterStep.Create("Child", typeof(ChildBehaviorOfChildContextNotInheritedFromParentContext), "desc")
             }, new List<RemoveStep>(), new List<ReplaceStep>());
 
 
@@ -151,12 +193,28 @@
         }
 
         [Test]
+        public void ShouldDetectRegistrationsWithContextsNotReachableFromTheRootContext()
+        {
+            var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
+            {
+                RegisterStep.Create("Root", typeof(RootBehavior), "desc"),
+                RegisterStep.Create("ParentContextToChildContextConnector", typeof(ParentContextToChildContextConnector), "desc"),
+                RegisterStep.Create("Child", typeof(ChildBehaviorOfChildContextNotInheritedFromParentContext), "desc")
+            }, new List<RemoveStep>(), new List<ReplaceStep>());
+
+
+            var model = builder.Build();
+
+            Assert.AreEqual(2, model.Count);
+        }
+
+        [Test]
         public void ShouldHandleTheTerminator()
         {
             var builder = new PipelineModelBuilder(typeof(ParentContext), new List<RegisterStep>
             {
                 RegisterStep.Create("Root1", typeof(RootBehavior), "desc"),
-                RegisterStep.Create("RootToChildConnector", typeof(RootToChildConnector), "desc"),
+                RegisterStep.Create("ParentContextToChildContextConnector", typeof(ParentContextToChildContextConnector), "desc"),
                 RegisterStep.Create("Terminator", typeof(Terminator), "desc")
 
             }, new List<RemoveStep>(), new List<ReplaceStep>());
@@ -183,15 +241,15 @@
             }
         }
 
-        class ChildContextReachableButNotInheritingFromRootContext : BehaviorContext
+        class ChildContextNotInheritedFromParentContext : BehaviorContext
         {
-            public ChildContextReachableButNotInheritingFromRootContext(IBehaviorContext parentContext)
+            public ChildContextNotInheritedFromParentContext(IBehaviorContext parentContext)
                 : base(parentContext)
             {
             }
         }
 
-        class RootToChildConnector : StageConnector<ParentContext, ChildContext>
+        class ParentContextToChildContextConnector : StageConnector<ParentContext, ChildContext>
         {
             public override Task Invoke(ParentContext context, Func<ChildContext, Task> next)
             {
@@ -207,14 +265,15 @@
             }
         }
 
-        class RootToChild2Connector : StageConnector<ParentContext, ChildContextReachableButNotInheritingFromRootContext>
+        class ParentContextToChildContextNotInheritedFromParentContextConnector : StageConnector<ParentContext, ChildContextNotInheritedFromParentContext>
         {
-            public override Task Invoke(ParentContext context, Func<ChildContextReachableButNotInheritingFromRootContext, Task> next)
+            public override Task Invoke(ParentContext context, Func<ChildContextNotInheritedFromParentContext, Task> next)
             {
                 throw new NotImplementedException();
             }
         }
-        class SomeBehavior : Behavior<ParentContext>
+
+        class SomeBehaviorOfParentContext : Behavior<ParentContext>
         {
             public override Task Invoke(ParentContext context, Func<Task> next)
             {
@@ -222,7 +281,7 @@
             }
         }
 
-        class AnotherBehavior : Behavior<ParentContext>
+        class AnotherBehaviorOfParentContext : Behavior<ParentContext>
         {
             public override Task Invoke(ParentContext context, Func<Task> next)
             {
@@ -238,7 +297,7 @@
             }
         }
 
-        class ChildBehavior : Behavior<ChildContext>
+        class ChildBehaviorOfChildContext : Behavior<ChildContext>
         {
             public override Task Invoke(ChildContext context, Func<Task> next)
             {
@@ -246,9 +305,9 @@
             }
         }
 
-        class NonReachableChildBehavior : Behavior<ChildContextReachableButNotInheritingFromRootContext>
+        class ChildBehaviorOfChildContextNotInheritedFromParentContext : Behavior<ChildContextNotInheritedFromParentContext>
         {
-            public override Task Invoke(ChildContextReachableButNotInheritingFromRootContext context, Func<Task> next)
+            public override Task Invoke(ChildContextNotInheritedFromParentContext context, Func<Task> next)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -548,7 +548,7 @@
     <Compile Include="Pipeline\PipelineSettings.cs" />
     <Compile Include="Pipeline\RegisterStep.cs" />
     <Compile Include="Pipeline\RemoveStep.cs" />
-    <Compile Include="Pipeline\ReplaceBehavior.cs" />
+    <Compile Include="Pipeline\ReplaceStep.cs" />
     <Compile Include="Pipeline\WellknownStep.cs" />
     <Compile Include="Sagas\AttachSagaDetailsToOutGoingMessageBehavior.cs" />
     <Compile Include="Sagas\ContainSagaData.cs" />

--- a/src/NServiceBus.Core/Pipeline/BehaviorTypeChecker.cs
+++ b/src/NServiceBus.Core/Pipeline/BehaviorTypeChecker.cs
@@ -9,17 +9,17 @@ namespace NServiceBus
         public static void ThrowIfInvalid(Type behavior, string paramName)
         {
             Guard.AgainstNull(nameof(behavior), behavior);
-            //if (behavior.IsAbstract)
-            //{
-            //    throw new ArgumentException(string.Format("The behavior '{0}' is invalid since it is abstract.", behavior.Name), paramName);
-            //}
+            if (behavior.IsAbstract)
+            {
+                throw new ArgumentException($"The behavior '{behavior.Name}' is invalid since it is abstract.", paramName);
+            }
             if (behavior.IsGenericTypeDefinition)
             {
                 throw new ArgumentException($"The behavior '{behavior.Name}' is invalid since it is an open generic.", paramName);
             }
             if (!IsAssignableToIBehavior(behavior))
             {
-                throw new ArgumentException($@"The behavior '{behavior.Name}' is invalid since it does not implement IBehavior<T>.", paramName);
+                throw new ArgumentException($@"The behavior '{behavior.Name}' is invalid since it does not implement IBehavior<TFrom, TTo>.", paramName);
             }
         }
 

--- a/src/NServiceBus.Core/Pipeline/BehaviorTypeChecker.cs
+++ b/src/NServiceBus.Core/Pipeline/BehaviorTypeChecker.cs
@@ -1,9 +1,20 @@
 namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
+    using NServiceBus.OutgoingPipeline;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Pipeline.Contexts;
 
     static class BehaviorTypeChecker
     {
+        static HashSet<Type> NotAllowedInterfaces = new HashSet<Type>
+        {
+            typeof(IBehaviorContext),
+            typeof(IIncomingContext),
+            typeof(IOutgoingContext),
+        };
+
         public static void ThrowIfInvalid(Type behavior, string paramName)
         {
             Guard.AgainstNull(nameof(behavior), behavior);
@@ -26,10 +37,20 @@ namespace NServiceBus
                 throw new ArgumentException($@"The behavior '{behavior.Name}' is invalid since the TFrom context of IBehavior<TFrom, TTo> is not an interface.", paramName);
             }
 
+            if (NotAllowedInterfaces.Contains(inputContextType))
+            {
+                throw new ArgumentException($@"The behavior '{behavior.Name}' is invalid since the TFrom {inputContextType} context of IBehavior<TFrom, TTo> is not intended to be used.", paramName);
+            }
+
             var outputContextType = behavior.GetOutputContext();
             if (!outputContextType.IsInterface)
             {
                 throw new ArgumentException($@"The behavior '{behavior.Name}' is invalid since the TTo context of IBehavior<TFrom, TTo> is not an interface.", paramName);
+            }
+
+            if (NotAllowedInterfaces.Contains(outputContextType))
+            {
+                throw new ArgumentException($@"The behavior '{behavior.Name}' is invalid since the TTo {outputContextType} context of IBehavior<TFrom, TTo> is not intended to be used.", paramName);
             }
         }
     }

--- a/src/NServiceBus.Core/Pipeline/BehaviorTypeChecker.cs
+++ b/src/NServiceBus.Core/Pipeline/BehaviorTypeChecker.cs
@@ -1,8 +1,6 @@
 namespace NServiceBus
 {
     using System;
-    using System.Linq;
-    using NServiceBus.Pipeline;
 
     static class BehaviorTypeChecker
     {
@@ -17,29 +15,22 @@ namespace NServiceBus
             {
                 throw new ArgumentException($"The behavior '{behavior.Name}' is invalid since it is an open generic.", paramName);
             }
-            if (!IsAssignableToIBehavior(behavior))
+            if (!behavior.IsBehavior())
             {
                 throw new ArgumentException($@"The behavior '{behavior.Name}' is invalid since it does not implement IBehavior<TFrom, TTo>.", paramName);
             }
-        }
 
-        static Type iBehaviorType = typeof(IBehavior<,>);
-
-        static bool IsAssignableToIBehavior(Type givenType)
-        {
-            var interfaceTypes = givenType.GetInterfaces();
-
-            if (interfaceTypes.Any(it => it.IsGenericType && it.GetGenericTypeDefinition() == iBehaviorType))
+            var inputContextType = behavior.GetInputContext();
+            if (!inputContextType.IsInterface)
             {
-                return true;
+                throw new ArgumentException($@"The behavior '{behavior.Name}' is invalid since the TFrom context of IBehavior<TFrom, TTo> is not an interface.", paramName);
             }
 
-            if (givenType.IsGenericType && givenType.GetGenericTypeDefinition() == iBehaviorType)
+            var outputContextType = behavior.GetOutputContext();
+            if (!outputContextType.IsInterface)
             {
-                return true;
+                throw new ArgumentException($@"The behavior '{behavior.Name}' is invalid since the TTo context of IBehavior<TFrom, TTo> is not an interface.", paramName);
             }
-
-            return false;
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/BehaviorTypeChecker.cs
+++ b/src/NServiceBus.Core/Pipeline/BehaviorTypeChecker.cs
@@ -39,13 +39,7 @@ namespace NServiceBus
                 return true;
             }
 
-            var baseType = givenType.BaseType;
-            if (baseType == null)
-            {
-                return false;
-            }
-
-            return IsAssignableToIBehavior(baseType);
+            return false;
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
@@ -93,7 +93,6 @@ namespace NServiceBus
                 return finalOrder;
             }
 
-            //todo: add test and better ex for missing start stage
             var currentStage = stages.SingleOrDefault(stage => stage.Key == rootContextType);
 
             if (currentStage == null)
@@ -110,23 +109,21 @@ namespace NServiceBus
                 //add the stage connector
                 finalOrder.AddRange(Sort(stageSteps));
 
-
-                //todo: add tests and better ex for missing stage connector
                 var stageConnectors = currentStage.Where(IsStageConnector).ToList();
 
-                if (stageConnectors.Count() > 1)
+                if (stageConnectors.Count > 1)
                 {
                     var connectors = string.Join(";", stageConnectors.Select(sc => sc.BehaviorType.FullName));
-                    throw new Exception($"Multiple stage connectors found for stage {currentStage.Key.FullName}. Please remove one of: {connectors}");
+                    throw new Exception($"Multiple stage connectors found for stage '{currentStage.Key.FullName}'. Please remove one of: {connectors}");
                 }
 
                 var stageConnector = stageConnectors.FirstOrDefault();
 
                 if (stageConnector == null)
                 {
-                    if (stageNumber < stages.Count())
+                    if (stageNumber < stages.Count)
                     {
-                        throw new Exception($"No stage connector found for stage {currentStage.Key.FullName}");    
+                        throw new Exception($"No stage connector found for stage {currentStage.Key.FullName}");
                     }
 
                     currentStage = null;
@@ -143,8 +140,8 @@ namespace NServiceBus
                     {
                         var args = stageConnector.BehaviorType.BaseType.GetGenericArguments();
                         var stageEndType = args[1];
-                        currentStage = stages.SingleOrDefault(stage => stage.Key == stageEndType);      
-                    }      
+                        currentStage = stages.SingleOrDefault(stage => stage.Key == stageEndType);
+                    }
                 }
 
                 stageNumber++;

--- a/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
@@ -188,24 +188,6 @@ namespace NServiceBus
                 node.Visit(output);
             }
 
-            // Step 4: Validate intput and output types
-            for (var i = 1; i < output.Count; i++)
-            {
-                var previousBehavior = output[i - 1].BehaviorType;
-                var thisBehavior = output[i].BehaviorType;
-
-                var incomingType = previousBehavior.GetOutputContext();
-                var inputType = thisBehavior.GetInputContext();
-
-                if (!inputType.IsAssignableFrom(incomingType))
-                {
-                    throw new Exception(string.Format("Cannot chain behavior {0} and {1} together because output type of behavior {0} ({2}) cannot be passed as input for behavior {1} ({3})",
-                        previousBehavior.FullName,
-                        thisBehavior.FullName,
-                        incomingType,
-                        inputType));
-                }
-            }
             return output;
         }
 

--- a/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
@@ -113,7 +113,7 @@ namespace NServiceBus
 
                 if (stageConnectors.Count > 1)
                 {
-                    var connectors = string.Join(";", stageConnectors.Select(sc => sc.BehaviorType.FullName));
+                    var connectors = $"'{string.Join("', '", stageConnectors.Select(sc => sc.BehaviorType.FullName))}'";
                     throw new Exception($"Multiple stage connectors found for stage '{currentStage.Key.FullName}'. Please remove one of: {connectors}");
                 }
 
@@ -224,7 +224,7 @@ namespace NServiceBus
                     continue;
                 }
                 var currentStepIds = GetCurrentIds(nameToNode);
-                var message = $"Registration '{beforeReference.DependsOnId}' specified in the insertbefore of the '{node.StepId}' step does not exist in this stage. Current StepIds: {currentStepIds}";
+                var message = $"Registration '{beforeReference.DependsOnId}' specified in the insertbefore of the '{node.StepId}' step does not exist. Current StepIds: {currentStepIds}";
 
                 if (!beforeReference.Enforce)
                 {

--- a/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
@@ -8,7 +8,7 @@ namespace NServiceBus
 
     class PipelineModelBuilder
     {
-        public PipelineModelBuilder(Type rootContextType,List<RegisterStep> additions, List<RemoveStep> removals, List<ReplaceBehavior> replacements)
+        public PipelineModelBuilder(Type rootContextType, List<RegisterStep> additions, List<RemoveStep> removals, List<ReplaceStep> replacements)
         {
             this.rootContextType = rootContextType;
             this.additions = additions;
@@ -276,7 +276,7 @@ namespace NServiceBus
         Type rootContextType;
         List<RegisterStep> additions;
         List<RemoveStep> removals;
-        List<ReplaceBehavior> replacements;
+        List<ReplaceStep> replacements;
         static ILog Logger = LogManager.GetLogger<PipelineModelBuilder>();
 
 
@@ -318,8 +318,6 @@ namespace NServiceBus
             public Type OutputContext { get; private set; }
         }
 
-
-
         class CaseInsensitiveIdComparer : IEqualityComparer<RemoveStep>
         {
             public bool Equals(RemoveStep x, RemoveStep y)
@@ -332,6 +330,5 @@ namespace NServiceBus
                 return obj.RemoveId.ToLower().GetHashCode();
             }
         }
-
     }
 }

--- a/src/NServiceBus.Core/Pipeline/PipelineModifications.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModifications.cs
@@ -7,6 +7,6 @@
     {
         public List<RegisterStep> Additions = new List<RegisterStep>();
         public List<RemoveStep> Removals = new List<RemoveStep>();
-        public List<ReplaceBehavior> Replacements = new List<ReplaceBehavior>();
+        public List<ReplaceStep> Replacements = new List<ReplaceStep>();
     }
 }

--- a/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
@@ -52,7 +52,7 @@ namespace NServiceBus.Pipeline
             Guard.AgainstNullAndEmpty(nameof(stepId), stepId);
 
             registeredBehaviors.Add(newBehavior);
-            modifications.Replacements.Add(new ReplaceBehavior(stepId, newBehavior, description));
+            modifications.Replacements.Add(new ReplaceStep(stepId, newBehavior, description));
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Pipeline/RegisterStepExtensions.cs
+++ b/src/NServiceBus.Core/Pipeline/RegisterStepExtensions.cs
@@ -6,6 +6,8 @@ namespace NServiceBus
 
     static class RegisterStepExtensions
     {
+        static Type BehaviorInterfaceType = typeof(IBehavior<,>);
+
         public static bool IsStageConnector(this RegisterStep step)
         {
             return typeof(IStageConnector).IsAssignableFrom(step.BehaviorType);
@@ -17,10 +19,16 @@ namespace NServiceBus
             return behaviorInterface.GetGenericArguments()[0];
         }
 
+        public static bool IsBehavior(this Type behaviorType)
+        {
+            return behaviorType.GetInterfaces()
+                .Any(x => x.IsGenericType && x.GetGenericTypeDefinition() == BehaviorInterfaceType);
+        }
+
         public static Type GetBehaviorInterface(this Type behaviorType)
         {
             return behaviorType.GetInterfaces()
-                .First(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IBehavior<,>));
+                .First(x => x.IsGenericType && x.GetGenericTypeDefinition() == BehaviorInterfaceType);
         }
 
         public static Type GetOutputContext(this RegisterStep step)

--- a/src/NServiceBus.Core/Pipeline/ReplaceStep.cs
+++ b/src/NServiceBus.Core/Pipeline/ReplaceStep.cs
@@ -2,9 +2,9 @@ namespace NServiceBus
 {
     using System;
 
-    class ReplaceBehavior
+    class ReplaceStep
     {
-        public ReplaceBehavior(string idToReplace, Type behavior, string description = null)
+        public ReplaceStep(string idToReplace, Type behavior, string description = null)
         {
             ReplaceId = idToReplace;
             Description = description;

--- a/src/NServiceBus.Core/Pipeline/StepRegistrationsCoordinator.cs
+++ b/src/NServiceBus.Core/Pipeline/StepRegistrationsCoordinator.cs
@@ -7,7 +7,7 @@ namespace NServiceBus
 
     class StepRegistrationsCoordinator
     {
-        public StepRegistrationsCoordinator(List<RemoveStep> removals, List<ReplaceBehavior> replacements)
+        public StepRegistrationsCoordinator(List<RemoveStep> removals, List<ReplaceStep> replacements)
         {
             this.removals = removals;
             this.replacements = replacements;
@@ -73,6 +73,6 @@ namespace NServiceBus
 
         List<RegisterStep> additions = new List<RegisterStep>();
         List<RemoveStep> removals;
-        List<ReplaceBehavior> replacements;
+        List<ReplaceStep> replacements;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/StepRegistrationsCoordinator.cs
+++ b/src/NServiceBus.Core/Pipeline/StepRegistrationsCoordinator.cs
@@ -25,35 +25,13 @@ namespace NServiceBus
 
         public IList<RegisterStep> BuildPipelineModelFor<TRootContext>() where TRootContext : IBehaviorContext
         {
-            var reachableContexts = ContextsReachableFrom<TRootContext>(additions)
-                .ToList();
-
-            var relevantAdditions = additions.Where(addition => reachableContexts.Contains(addition.BehaviorType.GetInputContext())).ToList();
+            var relevantAdditions = additions.ToList();
             var relevantRemovals = removals.Where(removal => relevantAdditions.Any(a => a.StepId == removal.RemoveId)).ToList();
             var relevantReplacements = replacements.Where(removal => relevantAdditions.Any(a => a.StepId == removal.ReplaceId)).ToList();
 
             var piplineModelBuilder = new PipelineModelBuilder(typeof(TRootContext), relevantAdditions, relevantRemovals, relevantReplacements);
 
             return piplineModelBuilder.Build();
-        }
-
-        static IEnumerable<Type> ContextsReachableFrom<TRootContext>(List<RegisterStep> registerSteps)
-        {
-            var stageConnectors = registerSteps.Where(s => s.IsStageConnector())
-                .ToList();
-
-            var currentContext = typeof(TRootContext);
-
-            while (currentContext != null)
-            {
-                yield return currentContext;
-
-                var context = currentContext;
-
-                currentContext = stageConnectors.Where(sc => sc.GetInputContext() == context)
-                    .Select(sc => sc.GetOutputContext())
-                    .FirstOrDefault();
-            }
         }
 
         List<RegisterStep> additions = new List<RegisterStep>();

--- a/src/NServiceBus.Core/Pipeline/StepRegistrationsCoordinator.cs
+++ b/src/NServiceBus.Core/Pipeline/StepRegistrationsCoordinator.cs
@@ -23,18 +23,16 @@ namespace NServiceBus
             additions.Add(rego);
         }
 
-        public IList<RegisterStep> BuildPipelineModelFor<TRootContext>() where TRootContext:IBehaviorContext
+        public IList<RegisterStep> BuildPipelineModelFor<TRootContext>() where TRootContext : IBehaviorContext
         {
             var reachableContexts = ContextsReachableFrom<TRootContext>(additions)
                 .ToList();
 
             var relevantAdditions = additions.Where(addition => reachableContexts.Contains(addition.BehaviorType.GetInputContext())).ToList();
-            var relevantRemovals = removals.Where(removal => relevantAdditions.Any(a=>a.StepId == removal.RemoveId)).ToList();
+            var relevantRemovals = removals.Where(removal => relevantAdditions.Any(a => a.StepId == removal.RemoveId)).ToList();
             var relevantReplacements = replacements.Where(removal => relevantAdditions.Any(a => a.StepId == removal.ReplaceId)).ToList();
 
-
-            var piplineModelBuilder = new PipelineModelBuilder(typeof(TRootContext),relevantAdditions, relevantRemovals, relevantReplacements);
-
+            var piplineModelBuilder = new PipelineModelBuilder(typeof(TRootContext), relevantAdditions, relevantRemovals, relevantReplacements);
 
             return piplineModelBuilder.Build();
         }
@@ -46,29 +44,16 @@ namespace NServiceBus
 
             var currentContext = typeof(TRootContext);
 
-         
             while (currentContext != null)
             {
                 yield return currentContext;
-                
+
                 var context = currentContext;
-                
-                currentContext = stageConnectors.Where(sc=>sc.GetInputContext() == context)
-                    .Select(sc=>sc.GetOutputContext())
+
+                currentContext = stageConnectors.Where(sc => sc.GetInputContext() == context)
+                    .Select(sc => sc.GetOutputContext())
                     .FirstOrDefault();
             }
-        }
-
-        static Type GetInputType(Type behaviorType)
-        {
-            var behaviorInterface = GetBehaviorInterface(behaviorType);
-            return behaviorInterface.GetGenericArguments()[0];
-        }
-
-        static Type GetBehaviorInterface(Type behaviorType)
-        {
-            var behaviorInterface = behaviorType.GetInterfaces().First(x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IBehavior<,>));
-            return behaviorInterface;
         }
 
         List<RegisterStep> additions = new List<RegisterStep>();


### PR DESCRIPTION
With making the behavior context classes public again it is now possible to declare a behavior like this:

```
class MyBehavior : Behavior<IncomingLogicalContext> { }
```

unforuntaly this behavior will never get picked up by the model builder internally. In this PR I'll add a runtime check to verify that behaviors use a interface inherited from `IBehaviorContext`.