### PR TITLE
[SPIKE] Proposal CancellationTokenSource for pipeline cancellation

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Performance/When_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/When_message_is_audited.cs
@@ -65,11 +65,12 @@
                     this.testContext = testContext;
                 }
 
-                public Task Handle(MessageToBeAudited message, IMessageHandlerContext context)
+                public async Task Handle(MessageToBeAudited message, IMessageHandlerContext context)
                 {
+                    await Task.Delay(TimeSpan.FromMinutes(2), context.CancellationToken);
+
                     testContext.Headers = context.MessageHeaders;
                     testContext.IsMessageHandledByTheAuditEndpoint = true;
-                    return Task.FromResult(0);
                 }
             }
         }

--- a/src/NServiceBus.Core.Tests/Fakes/FakeHandlingContext.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/FakeHandlingContext.cs
@@ -15,6 +15,7 @@
         public string MessageId { get; }
         public string ReplyToAddress { get; }
         public IReadOnlyDictionary<string, string> MessageHeaders { get; }
+        public CancellationToken CancellationToken { get; }
         public ContextBag Extensions { get; }
 
         public Task Send(object message, SendOptions options)

--- a/src/NServiceBus.Core.Tests/Unicast/HandlerInvocationCache.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/HandlerInvocationCache.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
     using NServiceBus.Persistence;
@@ -203,7 +204,9 @@
         public string MessageId { get; }
         public string ReplyToAddress { get; }
         public IReadOnlyDictionary<string, string> MessageHeaders { get; }
+        public CancellationToken CancellationToken { get; }
         public ContextBag Extensions { get; }
+
         public Task Send(object message, SendOptions options)
         {
             throw new NotImplementedException();

--- a/src/NServiceBus.Core/IMessageHandlerContext.cs
+++ b/src/NServiceBus.Core/IMessageHandlerContext.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Persistence;
 
@@ -25,5 +26,10 @@ namespace NServiceBus
         /// via this session will be persisted before the message receive is acknowledged.
         /// </summary>
         SynchronizedStorageSession SynchronizedStorageSession { get; }
+
+        /// <summary>
+        /// Token
+        /// </summary>
+        CancellationToken CancellationToken { get; }
     }
 }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -491,7 +491,6 @@
     <Compile Include="Transports\Msmq\ReceiveWithTransactionScope.cs" />
     <Compile Include="Forwarding\ForwardReceivedMessages.cs" />
     <Compile Include="Recoverability\FirstLevelRetries\FirstLevelRetriesBehavior.cs" />
-    <Compile Include="Pipeline\Incoming\MessageProcessingAbortedException.cs" />
     <Compile Include="Unicast\Config\RegisterHandlersInOrder.cs" />
     <Compile Include="Performance\Statistics\SLA\SLABehavior.cs" />
     <Compile Include="Performance\Statistics\CriticalTime\CriticalTimeBehavior.cs" />

--- a/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerContext.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Persistence;
     using NServiceBus.Pipeline;
@@ -49,6 +50,11 @@ namespace NServiceBus
         /// via this session will be persisted before the message receive is acknowledged.
         /// </summary>
         public SynchronizedStorageSession SynchronizedStorageSession => Get<SynchronizedStorageSession>();
+
+        /// <summary>
+        /// Token
+        /// </summary>
+        public CancellationToken CancellationToken => this.Get<CancellationTokenSource>().Token;
 
         /// <summary>
         /// Message headers.

--- a/src/NServiceBus.Core/Pipeline/Incoming/MessageProcessingAbortedException.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/MessageProcessingAbortedException.cs
@@ -1,8 +1,0 @@
-namespace NServiceBus
-{
-    using System;
-
-    class MessageProcessingAbortedException : Exception
-    {
-    }
-}

--- a/src/NServiceBus.Core/Recoverability/Faults/MoveFaultsToErrorQueueBehavior.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/MoveFaultsToErrorQueueBehavior.cs
@@ -27,10 +27,6 @@ namespace NServiceBus
             {
                 await next().ConfigureAwait(false);
             }
-            catch (MessageProcessingAbortedException)
-            {
-                throw;
-            }
             catch (Exception exception)
             {
                 try

--- a/src/NServiceBus.Core/Recoverability/FirstLevelRetries/FirstLevelRetriesBehavior.cs
+++ b/src/NServiceBus.Core/Recoverability/FirstLevelRetries/FirstLevelRetriesBehavior.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Logging;
     using NServiceBus.Features;
@@ -49,7 +50,7 @@ namespace NServiceBus
                 //question: should we invoke this the first time around? feels like the naming is off?
                 notifications.Errors.InvokeMessageHasFailedAFirstLevelRetryAttempt(numberOfFailures, context.Message, ex);
 
-                throw new MessageProcessingAbortedException();
+                context.Extensions.Get<CancellationTokenSource>().Cancel();
             }
         }
 

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetriesBehavior.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetriesBehavior.cs
@@ -28,10 +28,6 @@ namespace NServiceBus
             {
                 await next().ConfigureAwait(false);
             }
-            catch (MessageProcessingAbortedException)
-            {
-                throw; // flr asked to abort
-            }
             catch (MessageDeserializationException)
             {
                 context.Message.Headers.Remove(Headers.Retries);

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveStrategy.cs
@@ -2,11 +2,12 @@ namespace NServiceBus
 {
     using System;
     using System.Messaging;
+    using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Transports;
 
     abstract class ReceiveStrategy
     {
-        public abstract Task ReceiveMessage(MessageQueue inputQueue, MessageQueue errorQueue, Func<PushContext, Task> onMessage);
+        public abstract Task ReceiveMessage(MessageQueue inputQueue, MessageQueue errorQueue, CancellationTokenSource tokenSource, Func<PushContext, Task> onMessage);
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveWithNativeTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveWithNativeTransaction.cs
@@ -3,6 +3,7 @@ namespace NServiceBus
     using System;
     using System.Collections.Generic;
     using System.Messaging;
+    using System.Threading;
     using System.Threading.Tasks;
     using Extensibility;
     using Logging;
@@ -10,7 +11,7 @@ namespace NServiceBus
 
     class ReceiveWithNativeTransaction : ReceiveStrategy
     {
-        public override async Task ReceiveMessage(MessageQueue inputQueue, MessageQueue errorQueue, Func<PushContext, Task> onMessage)
+        public override async Task ReceiveMessage(MessageQueue inputQueue, MessageQueue errorQueue, CancellationTokenSource tokenSource, Func<PushContext, Task> onMessage)
         {
             using (var msmqTransaction = new MessageQueueTransaction())
             {
@@ -46,7 +47,7 @@ namespace NServiceBus
                         var nativeMsmqTransaction = new TransportTransaction();
                         nativeMsmqTransaction.Set(msmqTransaction);
                         
-                        var pushContext = new PushContext(message.Id, headers, bodyStream, nativeMsmqTransaction, context);
+                        var pushContext = new PushContext(message.Id, headers, bodyStream, nativeMsmqTransaction, tokenSource, context);
 
                         await onMessage(pushContext).ConfigureAwait(false);
                     }

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveWithNoTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveWithNoTransaction.cs
@@ -3,6 +3,7 @@ namespace NServiceBus
     using System;
     using System.Collections.Generic;
     using System.Messaging;
+    using System.Threading;
     using System.Threading.Tasks;
     using Extensibility;
     using Logging;
@@ -10,7 +11,7 @@ namespace NServiceBus
 
     class ReceiveWithNoTransaction : ReceiveStrategy
     {
-        public override async Task ReceiveMessage(MessageQueue inputQueue, MessageQueue errorQueue, Func<PushContext, Task> onMessage)
+        public override async Task ReceiveMessage(MessageQueue inputQueue, MessageQueue errorQueue, CancellationTokenSource tokenSource, Func<PushContext, Task> onMessage)
         {
             var message = inputQueue.Receive(TimeSpan.FromMilliseconds(10), MessageQueueTransactionType.None);
 
@@ -32,7 +33,7 @@ namespace NServiceBus
 
             using (var bodyStream = message.BodyStream)
             {
-                var pushContext = new PushContext(message.Id, headers, bodyStream, new TransportTransaction(), new ContextBag());
+                var pushContext = new PushContext(message.Id, headers, bodyStream, new TransportTransaction(), tokenSource, new ContextBag());
 
                 await onMessage(pushContext).ConfigureAwait(false);
             }

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveWithTransactionScope.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveWithTransactionScope.cs
@@ -3,6 +3,7 @@ namespace NServiceBus
     using System;
     using System.Collections.Generic;
     using System.Messaging;
+    using System.Threading;
     using System.Threading.Tasks;
     using System.Transactions;
     using Extensibility;
@@ -16,7 +17,7 @@ namespace NServiceBus
             this.transactionOptions = transactionOptions;
         }
 
-        public override async Task ReceiveMessage(MessageQueue inputQueue, MessageQueue errorQueue, Func<PushContext, Task> onMessage)
+        public override async Task ReceiveMessage(MessageQueue inputQueue, MessageQueue errorQueue, CancellationTokenSource tokenSource, Func<PushContext, Task> onMessage)
         {
             using (var scope = new TransactionScope(TransactionScopeOption.Required, transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
             {
@@ -43,7 +44,7 @@ namespace NServiceBus
                 {
                     var ambientTransaction = new TransportTransaction();
                     ambientTransaction.Set(Transaction.Current);
-                    var pushContext = new PushContext(message.Id, headers, bodyStream, ambientTransaction, new ContextBag());
+                    var pushContext = new PushContext(message.Id, headers, bodyStream, ambientTransaction, tokenSource, new ContextBag());
 
                     await onMessage(pushContext).ConfigureAwait(false);
                 }

--- a/src/NServiceBus.Core/Transports/PushContext.cs
+++ b/src/NServiceBus.Core/Transports/PushContext.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.IO;
+    using System.Threading;
     using Extensibility;
 
     /// <summary>
@@ -16,20 +17,24 @@
         /// <param name="headers">The message headers.</param>
         /// <param name="bodyStream">The message body stream.</param>
         /// <param name="transportTransaction">Transaction (along with connection if applicable) used to receive the message.</param>
+        /// <param name="tokenSource">The cancellation token source.</param>
         /// <param name="context">Any context that the transport wants to be available on the pipeline.</param>
-        public PushContext(string messageId, Dictionary<string, string> headers, Stream bodyStream, TransportTransaction transportTransaction, ContextBag context)
+        public PushContext(string messageId, Dictionary<string, string> headers, Stream bodyStream, TransportTransaction transportTransaction, CancellationTokenSource tokenSource, ContextBag context)
         {
             Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
             Guard.AgainstNull(nameof(bodyStream), bodyStream);
             Guard.AgainstNull(nameof(headers), headers);
             Guard.AgainstNull(nameof(transportTransaction), transportTransaction);
             Guard.AgainstNull(nameof(context), context);
+            Guard.AgainstNull(nameof(tokenSource), tokenSource);
 
             Headers = headers;
             BodyStream = bodyStream;
             MessageId = messageId;
             Context = context;
             TransportTransaction = transportTransaction;
+
+            Context.Set(tokenSource);
         }
 
         /// <summary>


### PR DESCRIPTION
I hacked together a quick spike (doesn't even compile) to show I new concept I would like to discuss. I quickly showed it in the @Particular/tf-async-transport sync today.

So instead of pulling in #3220 we could extend the `PushContext` so that the transport has to pass in a `CancellationTokenSource` per push operation. This allows the core to cancel the token source for FLR purposes instead of throwing an opaque `MessageProcessingAbortedException`. This makes the seam more intention revealing.

There are many more advantages to this approach:

* We can create linked token sources which get cancelled when the transport is shutdown, therefore allowing the pipeline to cancel inflight receives where possible
* The token can be passed over the context into the user code. What is great about that is that almost all async APIs support `CancellationToken`. Therefore when a receive is cancelled we can also abort the user code (if they decide to opt in for that)
* The transport decides what it wants to do with the `CancellationTokenSource`. We could even forsee transports that define `CancelAfter(TimeSpan span)` on the cancellation token source and therefore the source auto cancels based on predefined settings (like PeekLock, TransactionSettings...)

@Particular/tf-async-transport @Particular/tf-asyncawait @Particular/nservicebus Thoughts? Should we go with that?
