### PR TITLE
change context parameter in CustomConfig strongly to TContext

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointBehaviorBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointBehaviorBuilder.cs
@@ -46,9 +46,9 @@
             return this;
         }
 
-        public EndpointBehaviorBuilder<TContext> CustomConfig(Action<BusConfiguration, ScenarioContext> action)
+        public EndpointBehaviorBuilder<TContext> CustomConfig(Action<BusConfiguration, TContext> action)
         {
-            behavior.CustomConfig.Add(action);
+            behavior.CustomConfig.Add(((configuration, context) => action(configuration, (TContext) context)));
 
             return this;
         }


### PR DESCRIPTION
related to #3202 
casts the ScenarioContext to `TContext` to align with the rest of the API.