### PR TITLE
Add context to EndpointBehavior.CustomConfig

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointBehavior.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointBehavior.cs
@@ -11,16 +11,30 @@
         public EndpointBehavior(Type builderType)
         {
             EndpointBuilderType = builderType;
-            CustomConfig = new List<Action<BusConfiguration>>();
         }
 
         public Type EndpointBuilderType { get; private set; }
 
-        public List<IGivenDefinition> Givens { get; set; }
-        public List<IWhenDefinition> Whens { get; set; }
-
-        public List<Action<BusConfiguration>> CustomConfig { get; set; }
+        public List<IGivenDefinition> Givens { get; } = new List<IGivenDefinition>();
+        public List<IWhenDefinition> Whens { get; } = new List<IWhenDefinition>();
+        public List<ICustomConfigDefinition> CustomConfig { get; } = new List<ICustomConfigDefinition>();
         public string AppConfig { get; set; }
+    }
+
+    [Serializable]
+    public class CustomConfigDefinition<TContext> : ICustomConfigDefinition where TContext : ScenarioContext
+    {
+        readonly Action<BusConfiguration, TContext> action;
+
+        public CustomConfigDefinition(Action<BusConfiguration, TContext> action)
+        {
+            this.action = action;
+        }
+
+        public void ExecuteAction(BusConfiguration busConfiguration, ScenarioContext context)
+        {
+            action(busConfiguration, (TContext) context);
+        }
     }
 
     [Serializable]
@@ -71,6 +85,11 @@
         readonly Action<IBus> busAction;
         readonly Action<IBus, TContext> busAndContextAction;
         Guid id;
+    }
+
+    public interface ICustomConfigDefinition
+    {
+        void ExecuteAction(BusConfiguration busConfiguration, ScenarioContext context);
     }
 
     public interface IGivenDefinition

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointBehaviorBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointBehaviorBuilder.cs
@@ -1,18 +1,13 @@
 ﻿namespace NServiceBus.AcceptanceTesting.Support
 {
     using System;
-    using System.Collections.Generic;
 
     public class EndpointBehaviorBuilder<TContext> where TContext:ScenarioContext
     {
         
         public EndpointBehaviorBuilder(Type type)
         {
-            behavior = new EndpointBehavior(type)
-                {
-                    Givens = new List<IGivenDefinition>(),
-                    Whens = new List<IWhenDefinition>()
-                };
+            behavior = new EndpointBehavior(type);
         }
 
 
@@ -52,7 +47,14 @@
 
         public EndpointBehaviorBuilder<TContext> CustomConfig(Action<BusConfiguration> action)
         {
-            behavior.CustomConfig.Add(action);
+            behavior.CustomConfig.Add(new CustomConfigDefinition<TContext>((busConfig, context) => action(busConfig)));
+
+            return this;
+        }
+
+        public EndpointBehaviorBuilder<TContext> CustomConfig(Action<BusConfiguration, TContext> action)
+        {
+            behavior.CustomConfig.Add(new CustomConfigDefinition<TContext>(action));
 
             return this;
         }

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -48,7 +48,7 @@
 
                 scenarioContext.ContextPropertyChanged += scenarioContext_ContextPropertyChanged;
 
-                endpointBehavior.CustomConfig.ForEach(customAction => customAction(busConfiguration));
+                endpointBehavior.CustomConfig.ForEach(config => config.ExecuteAction(busConfiguration, scenarioContext));
 
                 if (configuration.SendOnly)
                 {


### PR DESCRIPTION
backport changes related to #3202 to v5.

* Adds an overload to `EndpointBehavior.CustomConfig` which also provides the TestContext.

This will not be released separately (since not acceptance testing package isn't officially supported) but can be shipped with the next minor/patch release.