### PR TITLE
Refactoring AcceptanceTesting ScenarioConfigSource more meaningful expcetion

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioConfigSource.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioConfigSource.cs
@@ -60,6 +60,11 @@
 
                     if (configuration.AuditEndpoint != null)
                     {
+                        if (!routingTable.ContainsKey(configuration.AuditEndpoint))
+                        {
+                            throw new ConfigurationErrorsException(string.Format("{0} was not found in routingTable. Make sure that you call WithEndpoint<{0}>() method in your test.", configuration.AuditEndpoint));
+                        }
+
                         return new AuditConfig { QueueName = routingTable[configuration.AuditEndpoint] } as T;
                     }
                 }


### PR DESCRIPTION
Refactoring to add meaningful exception when one in AcceptanceTest will use .AuditTo<Endpoint> without calling WithEndpoint<Endpoint>. Previously it caused key not found exception in dictionary