### PR TITLE
centralized pubsub may need MEM

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_with_only_local_messagehandlers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_with_only_local_messagehandlers.cs
@@ -78,7 +78,8 @@
         {
             public CentralizedStoragePublisher()
             {
-                EndpointSetup<DefaultServer>();
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<EventHandledByLocalEndpoint>(typeof(CentralizedStoragePublisher)); //an explicit mapping may be needed, depends on the technology underneath;
             }
 
             class CatchAllHandler : IHandleMessages<IEvent> 


### PR DESCRIPTION
This test assumes that pubsub models with a centralized storage, never require a message endpoint mapping. This is not true, it really depends on the underlying infrastructure and the configuration in which it's used.