### PR TITLE
Fix .NET casing in core nuspec

### DIFF
--- a/packaging/nuget/nservicebus.core.nuspec
+++ b/packaging/nuget/nservicebus.core.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>$projectUrl$</projectUrl>
     <iconUrl>$iconUrl$</iconUrl>
     <requireLicenseAcceptance>$requireLicenseAcceptance$</requireLicenseAcceptance>
-    <description>The most popular open-source service bus for .net</description>
+    <description>The most popular open-source service bus for .NET</description>
     <releaseNotes></releaseNotes>
     <copyright>$copyright$</copyright>
     <tags>nservicebus servicebus msmq cqrs publish subscribe</tags>


### PR DESCRIPTION
To match the casing used at http://particular.net/service-platform