### PR TITLE
Always Stop even when scenario throws

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -213,16 +213,16 @@
             var cts = new CancellationTokenSource();
             var endpoints = runners.Select(r => r.Instance).ToList();
 
-            await StartEndpoints(endpoints, allowedExceptions, cts).ConfigureAwait(false);
-            runDescriptor.ScenarioContext.EndpointsStarted = true;
-            await ExecuteWhens(endpoints, allowedExceptions, cts).ConfigureAwait(false);
-
-            var startTime = DateTime.UtcNow;
-            var maxTime = runDescriptor.TestExecutionTimeout;
-
             // ReSharper disable once LoopVariableIsNeverChangedInsideLoop
             try
             {
+                await StartEndpoints(endpoints, allowedExceptions, cts).ConfigureAwait(false);
+                runDescriptor.ScenarioContext.EndpointsStarted = true;
+                await ExecuteWhens(endpoints, allowedExceptions, cts).ConfigureAwait(false);
+
+                var startTime = DateTime.UtcNow;
+                var maxTime = runDescriptor.TestExecutionTimeout;
+
                 while (!done() && !cts.Token.IsCancellationRequested)
                 {
                     if (DateTime.UtcNow - startTime > maxTime)


### PR DESCRIPTION
Makes sure cleanup is called in the test scenario bombs

Note: In talking with @danielmarbach, we opted to go with the refactoring of the PerformScenarios method

`static async Task PerformScenarios(...` could possibly be refactored to achieve this as well