### PR TITLE
InMemory escalated transactions throw exception via Rollback

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Msmq\MsmqHelpers.cs" />
     <Compile Include="Msmq\MsmqAddressTests.cs" />
     <Compile Include="Msmq\MsmqSubscriptionStorageQueueTests.cs" />
+    <Compile Include="Persistence\InMemory\When_persisting_a_saga_with_InMemory_and_an_escalated_DTC_transaction.cs" />
     <Compile Include="Pipeline\Incoming\InvokeHandlerTerminatorTest.cs" />
     <Compile Include="Pipeline\Outgoing\OutgoingPublishContextTests.cs" />
     <Compile Include="Pipeline\Outgoing\OutgoingReplyContextTests.cs" />

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_InMemory_and_an_escalated_DTC_transaction.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_InMemory_and_an_escalated_DTC_transaction.cs
@@ -30,7 +30,7 @@
             {
                 using (var tx = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
-                    Transaction.Current.EnlistDurable(DummyEnlistmentNotification.Id, new DummyEnlistmentNotification(), EnlistmentOptions.None);
+                    Transaction.Current.EnlistDurable(EnlistmentWhichEnforcesDtcEscalation.Id, new EnlistmentWhichEnforcesDtcEscalation(), EnlistmentOptions.None);
 
                     var transportTransaction = new TransportTransaction();
                     transportTransaction.Set(Transaction.Current);
@@ -54,7 +54,7 @@
         }
     }
 
-    public class DummyEnlistmentNotification : IEnlistmentNotification
+    public class EnlistmentWhichEnforcesDtcEscalation : IEnlistmentNotification
     {
         public static readonly Guid Id = Guid.NewGuid();
 

--- a/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransaction.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransaction.cs
@@ -20,5 +20,10 @@ namespace NServiceBus
             }
             actions.Clear();
         }
+
+        public void Rollback()
+        {
+            actions.Clear();
+        }
     }
 }

--- a/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransactionalSynchronizedStorageAdapter.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransactionalSynchronizedStorageAdapter.cs
@@ -4,7 +4,7 @@ namespace NServiceBus
     using NServiceBus.Outbox;
     using NServiceBus.Persistence;
     using NServiceBus.Transports;
-
+    using System;
     class InMemoryTransactionalSynchronizedStorageAdapter : ISynchronizedStorageAdapter
     {
         public bool TryAdapt(OutboxTransaction transaction, out CompletableSynchronizedStorageSession session)
@@ -45,8 +45,15 @@ namespace NServiceBus
 
             public void Prepare(PreparingEnlistment preparingEnlistment)
             {
-                transaction.Commit();
-                preparingEnlistment.Prepared();
+                try
+                {
+                    transaction.Commit();
+                    preparingEnlistment.Prepared();
+                }
+                catch (Exception ex)
+                {
+                    preparingEnlistment.ForceRollback(ex);
+                }
             }
 
             public void Commit(Enlistment enlistment)

--- a/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransactionalSynchronizedStorageAdapter.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransactionalSynchronizedStorageAdapter.cs
@@ -34,7 +34,7 @@ namespace NServiceBus
             return false;
         }
 
-        private class EnlistmentNotification : IEnlistmentNotification
+        class EnlistmentNotification : IEnlistmentNotification
         {
             InMemoryTransaction transaction;
 
@@ -63,6 +63,7 @@ namespace NServiceBus
 
             public void Rollback(Enlistment enlistment)
             {
+                transaction.Rollback();
                 enlistment.Done();
             }
 


### PR DESCRIPTION
InMemoryTransaction storage with concurrent access could result in valid
Exceptions being thrown, but the exception was thrown on the wrong
thread since the transaction wasn't being rolled back via DTC correctly

Connects to #3244 