### PR TITLE
Deduplicate transport level destination

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Msmq\When_publishing_with_authorizer.cs" />
     <Compile Include="Msmq\When_unsubscribing_with_authorizer.cs" />
     <Compile Include="Routing\When_broadcasting_a_command.cs" />
+    <Compile Include="Routing\When_using_legacy_routing_configuration_combined_with_message_driven_pub_sub.cs" />
     <Compile Include="Routing\When_publishing_an_interface.cs" />
     <Compile Include="Routing\When_publishing_to_a_legacy_endpoint.cs" />
     <Compile Include="Routing\When_publishing_from_sendonly.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/When_using_legacy_routing_configuration_combined_with_message_driven_pub_sub.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_using_legacy_routing_configuration_combined_with_message_driven_pub_sub.cs
@@ -1,0 +1,93 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    public class When_using_legacy_routing_configuration_combined_with_message_driven_pub_sub : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Messages_should_not_get_duplicated()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(b =>
+                    b.When(c => c.Subscribed, async bus =>
+                    {
+                        await bus.Publish(new MyEvent());
+                        await bus.Send(new DoneCommand());
+                    })
+                    )
+                .WithEndpoint<Subscriber>(b => b.When((bus, context) => bus.Subscribe<MyEvent>()))
+                .Done(c => c.Done)
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Should(c => Assert.True(c.HandlerInvoked == 1))
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int HandlerInvoked { get; set; }
+            public bool Subscribed { get; set; }
+            public bool Done { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
+                {
+                    context.Subscribed = true;
+                }))
+                    .AddMapping<MyEvent>(typeof(Subscriber))
+                    .AddMapping<DoneCommand>(typeof(Subscriber));
+            }
+        }
+
+        public class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.DisableFeature<AutoSubscribe>();
+                    c.LimitMessageProcessingConcurrencyTo(1);
+                })
+                    .AddMapping<MyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyEvent messageThatIsEnlisted, IMessageHandlerContext context)
+                {
+                    Context.HandlerInvoked++;
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class DoneHandler : IHandleMessages<DoneCommand>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(DoneCommand message, IMessageHandlerContext context)
+                {
+                    Context.Done = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class DoneCommand : ICommand
+        {
+        }
+
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -770,6 +770,7 @@ namespace NServiceBus
         public override NServiceBus.Transports.IManageSubscriptions GetSubscriptionManager() { }
         public override System.Collections.Generic.IEnumerable<System.Type> GetSupportedDeliveryConstraints() { }
         public override NServiceBus.TransportTransactionMode GetSupportedTransactionMode() { }
+        public override string MakeCanonicalForm(string transportAddress) { }
         public override string ToTransportAddress(NServiceBus.LogicalAddress logicalAddress) { }
     }
     public class NonDurableDelivery : NServiceBus.DeliveryConstraints.DeliveryConstraint
@@ -2881,6 +2882,7 @@ namespace NServiceBus.Transports
         public abstract NServiceBus.Transports.IManageSubscriptions GetSubscriptionManager();
         public abstract System.Collections.Generic.IEnumerable<System.Type> GetSupportedDeliveryConstraints();
         public abstract NServiceBus.TransportTransactionMode GetSupportedTransactionMode();
+        public virtual string MakeCanonicalForm(string transportAddress) { }
         public abstract string ToTransportAddress(NServiceBus.LogicalAddress logicalAddress);
     }
     public class TransportOperation

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -55,7 +55,7 @@
 
                 foreach (MessageEndpointMapping m in legacyRoutingConfig)
                 {
-                    m.Configure(routeTable.RouteToAddress);
+                    m.Configure((type, s) => routeTable.RouteToAddress(type, transportDefinition.MakeCanonicalForm(s)));
                     m.Configure((type, s) =>
                     {
                         var typesEnclosed = knownMessageTypes.Where(t => t.IsAssignableFrom(type));

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransport.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransport.cs
@@ -156,6 +156,15 @@ namespace NServiceBus
         }
 
         /// <summary>
+        /// Returns the canonical for of the given transport address so various transport addresses can be effectively compared and deduplicated.
+        /// </summary>
+        /// <param name="transportAddress">A transport address.</param>
+        public override string MakeCanonicalForm(string transportAddress)
+        {
+            return MsmqAddress.Parse(transportAddress).ToString();
+        }
+
+        /// <summary>
         /// Returns the outbound routing policy selected for the transport.
         /// </summary>
         public override OutboundRoutingPolicy GetOutboundRoutingPolicy(ReadOnlySettings settings)

--- a/src/NServiceBus.Core/Transports/TransportDefinition.cs
+++ b/src/NServiceBus.Core/Transports/TransportDefinition.cs
@@ -54,6 +54,15 @@ namespace NServiceBus.Transports
         public abstract string ToTransportAddress(LogicalAddress logicalAddress);
 
         /// <summary>
+        /// Returns the canonical for of the given transport address so various transport addresses can be effectively compared and deduplicated.
+        /// </summary>
+        /// <param name="transportAddress">A transport address.</param>
+        public virtual string MakeCanonicalForm(string transportAddress)
+        {
+            return transportAddress;
+        }
+
+        /// <summary>
         /// Returns the outbound routing policy selected for the transport.
         /// </summary>
         public abstract OutboundRoutingPolicy GetOutboundRoutingPolicy(ReadOnlySettings settings);


### PR DESCRIPTION
Attempts to solve https://github.com/Particular/NServiceBus/issues/3274

The problem is that the transport addresses come in two flavours: `queue` or `queue@machine`. The former may be used in the `MessageEndpointMappings`. The latter is the correct/canonical form used e.g. when subscribing. 

The solution is to add a virtual method to `TransportDefinition` which transports can override to convert a non-canonical form of address to the canonical one (overridden for MSMQ). 