### PR TITLE
The default installer wire up works only if a type has not been registered already

### DIFF
--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -163,13 +163,19 @@ namespace NServiceBus
 
         void WireUpInstallers(IEnumerable<Type> concreteTypes)
         {
-            foreach (var installerType in concreteTypes.Where(IsINeedToInstallSomething))
+            var installerTypes = concreteTypes.Where(IsInstaller).Where(NotAlreadyRegistered);
+            foreach (var installerType in installerTypes)
             {
                 container.ConfigureComponent(installerType, DependencyLifecycle.InstancePerCall);
             }
         }
 
-        static bool IsINeedToInstallSomething(Type t)
+        bool NotAlreadyRegistered(Type installerType)
+        {
+            return !container.HasComponent(installerType);
+        }
+
+        static bool IsInstaller(Type t)
         {
             return typeof(INeedToInstallSomething).IsAssignableFrom(t);
         }


### PR DESCRIPTION
This is meant to allow features to register installers using factory method syntax. I know that installers are evil and should go away but before we can get rid of them, let's make them at least somehow usable (in case they resist when we want to kill them).