### PR TITLE
Need to specify different error queue

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Volatile/When_sending_to_non_durable_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Volatile/When_sending_to_non_durable_endpoint.cs
@@ -4,6 +4,7 @@
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NServiceBus.Config;
     using NUnit.Framework;
 
     public class When_sending_to_non_durable_endpoint : NServiceBusAcceptanceTest
@@ -30,7 +31,11 @@
             public Sender()
             {
                 EndpointSetup<DefaultServer>(builder => builder.DisableDurableMessages())
-                    .AddMapping<MyMessage>(typeof(Receiver));
+                    .AddMapping<MyMessage>(typeof(Receiver))
+                    .WithConfig<MessageForwardingInCaseOfFaultConfig>(c =>
+                    {
+                        c.ErrorQueue = "NonDurableError";
+                    });
             }
         }
 
@@ -38,7 +43,11 @@
         {
             public Receiver()
             {
-                EndpointSetup<DefaultServer>(builder => builder.DisableDurableMessages());
+                EndpointSetup<DefaultServer>(builder => builder.DisableDurableMessages())
+                    .WithConfig<MessageForwardingInCaseOfFaultConfig>(c =>
+                    {
+                        c.ErrorQueue = "NonDurableError";
+                    });
             }
         }
 


### PR DESCRIPTION
The error queue needs to be different otherwise the queue could already exist from previous tests and the durability flag is true.

This was found as part of testing in Rabbit transport because we don't delete queues (it was not reliable), instead we just purge them.