### PR TITLE
add common interface to Unicast- and MulticastTransportOperation

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2655,6 +2655,12 @@ namespace NServiceBus.Transports
         public static NServiceBus.MessageIntentEnum GetMesssageIntent(this NServiceBus.Transports.IncomingMessage message) { }
         public static string GetReplyToAddress(this NServiceBus.Transports.IncomingMessage message) { }
     }
+    public interface IOutgoingTransportOperation
+    {
+        System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> DeliveryConstraints { get; }
+        NServiceBus.Transports.OutgoingMessage Message { get; }
+        NServiceBus.Transports.DispatchConsistency RequiredDispatchConsistency { get; }
+    }
     [System.ObsoleteAttribute("Please use `IDispatchMessages` instead. Will be removed in version 7.0.0.", true)]
     public interface IPublishMessages { }
     public interface IPushMessages
@@ -2668,7 +2674,7 @@ namespace NServiceBus.Transports
     {
         void Send(NServiceBus.TransportMessage message, NServiceBus.Unicast.SendOptions sendOptions);
     }
-    public class MulticastTransportOperation
+    public class MulticastTransportOperation : NServiceBus.Transports.IOutgoingTransportOperation
     {
         public MulticastTransportOperation(NServiceBus.Transports.OutgoingMessage message, System.Type messageType, System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> deliveryConstraints = null, NServiceBus.Transports.DispatchConsistency requiredDispatchConsistency = 1) { }
         public System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> DeliveryConstraints { get; }
@@ -2800,7 +2806,7 @@ namespace NServiceBus.Transports
     {
         public TransportTransaction() { }
     }
-    public class UnicastTransportOperation
+    public class UnicastTransportOperation : NServiceBus.Transports.IOutgoingTransportOperation
     {
         public UnicastTransportOperation(NServiceBus.Transports.OutgoingMessage message, string destination, System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> deliveryConstraints = null, NServiceBus.Transports.DispatchConsistency requiredDispatchConsistency = 1) { }
         public System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> DeliveryConstraints { get; }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Pipeline\PipelineCache.cs" />
     <Compile Include="Pipeline\StageForkConnector.cs" />
     <Compile Include="Pipeline\ConnectorContextExtensions.cs" />
+    <Compile Include="Transports\IOutgoingTransportOperation.cs" />
     <Compile Include="Transports\MulticastTransportOperation.cs" />
     <Compile Include="Transports\TransportOperations.cs" />
     <Compile Include="Transports\UnicastTransportOperation.cs" />

--- a/src/NServiceBus.Core/Transports/IOutgoingTransportOperation.cs
+++ b/src/NServiceBus.Core/Transports/IOutgoingTransportOperation.cs
@@ -1,0 +1,26 @@
+namespace NServiceBus.Transports
+{
+    using System.Collections.Generic;
+    using NServiceBus.DeliveryConstraints;
+
+    /// <summary>
+    /// Represents a transport operation.
+    /// </summary>
+    public interface IOutgoingTransportOperation
+    {
+        /// <summary>
+        /// The message to be sent over the transport.
+        /// </summary>
+        OutgoingMessage Message { get; }
+
+        /// <summary>
+        /// The delivery constraints that must be honored by the transport.
+        /// </summary>
+        IEnumerable<DeliveryConstraint> DeliveryConstraints { get; }
+
+        /// <summary>
+        /// The dispatch consistency the must be honored by the transport.
+        /// </summary>
+        DispatchConsistency RequiredDispatchConsistency { get; }
+    }
+}

--- a/src/NServiceBus.Core/Transports/MulticastTransportOperation.cs
+++ b/src/NServiceBus.Core/Transports/MulticastTransportOperation.cs
@@ -8,7 +8,7 @@ namespace NServiceBus.Transports
     /// <summary>
     /// Represents a transport operation which should be delivered to multiple receivers.
     /// </summary>
-    public class MulticastTransportOperation
+    public class MulticastTransportOperation : IOutgoingTransportOperation
     {
         /// <summary>
         /// Creates a new <see cref="MulticastTransportOperation"/> instance.

--- a/src/NServiceBus.Core/Transports/UnicastTransportOperation.cs
+++ b/src/NServiceBus.Core/Transports/UnicastTransportOperation.cs
@@ -7,7 +7,7 @@ namespace NServiceBus.Transports
     /// <summary>
     /// Represents a transport operation which should be delivered to a single receiver.
     /// </summary>
-    public class UnicastTransportOperation
+    public class UnicastTransportOperation: IOutgoingTransportOperation
     {
         /// <summary>
         /// Creates a new <see cref="UnicastTransportOperation"/> instance.


### PR DESCRIPTION
adds a common interface `IOutgoingTransportOperation` to both `UnicastTransportOperation` and `MulticastTransportOperation` in order to allow having them in the same collection. Requested by @yvesgoeleven for Azure transport (see #3214 )