### PR TITLE
register handler in InstancePerCall scope

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Basic/When_messagehandlers_share_same_class.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_messagehandlers_share_same_class.cs
@@ -1,0 +1,81 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_messagehandlers_share_same_class : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_not_share_state()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<HandlingEndpoint>(e => e.When((s, c) => s.SendLocal<SubMessage>(m => { })))
+                .Run();
+
+            Assert.AreEqual(1, context.MessageInterfaceHandlerCounter);
+            Assert.AreEqual(1, context.BaseMessageHandlerCounter);
+            Assert.AreEqual(1, context.SubMessageHandlerCounter);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int MessageInterfaceHandlerCounter { get; set; }
+            public int BaseMessageHandlerCounter { get; set; }
+            public int SubMessageHandlerCounter { get; set; }
+        }
+
+        public class HandlingEndpoint : EndpointConfigurationBuilder
+        {
+            public HandlingEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MessageHandler :
+                IHandleMessages<IBaseMessage>,
+                IHandleMessages<BaseMessage>,
+                IHandleMessages<SubMessage>
+            {
+                Context testContext;
+                int counter;
+
+                public MessageHandler(Context context)
+                {
+                    testContext = context;
+                }
+
+                public Task Handle(IBaseMessage message, IMessageHandlerContext context)
+                {
+                    testContext.MessageInterfaceHandlerCounter = ++counter;
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(BaseMessage message, IMessageHandlerContext context)
+                {
+                    testContext.BaseMessageHandlerCounter = ++counter;
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(SubMessage message, IMessageHandlerContext context)
+                {
+                    testContext.SubMessageHandlerCounter = ++counter;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public interface IBaseMessage : IMessage
+        {
+        }
+
+        public class BaseMessage : IBaseMessage
+        {
+        }
+
+        public class SubMessage : BaseMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -55,6 +55,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Basic\When_extending_behavior_context.cs" />
+    <Compile Include="Basic\When_messagehandlers_share_same_class.cs" />
     <Compile Include="Basic\When_registering_additional_deserializers.cs" />
     <Compile Include="Basic\When_no_content_type.cs" />
     <Compile Include="Causation\When_a_message_is_faulted.cs" />

--- a/src/NServiceBus.Core/Unicast/Config/RegisterHandlersInOrder.cs
+++ b/src/NServiceBus.Core/Unicast/Config/RegisterHandlersInOrder.cs
@@ -50,7 +50,7 @@ namespace NServiceBus.Features
 
             foreach (var t in types.Where(IsMessageHandler))
             {
-                context.Container.ConfigureComponent(t, DependencyLifecycle.InstancePerUnitOfWork);
+                context.Container.ConfigureComponent(t, DependencyLifecycle.InstancePerCall);
                 handlerRegistry.RegisterHandler(t);
             }
 


### PR DESCRIPTION
See #2680 
* Makes message handler stateless. This mainly affects having message handlers handling multiple messages of the same inheritance hierarchy which currently all run on the same handler instance.
* Not quite sure about the impact on Sagas (see discussion on the linked issue).