### PR TITLE
Increasing TTL for acceptance tests

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_expired.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_expired.cs
@@ -12,7 +12,7 @@
         public async Task Message_should_not_be_received()
         {
             var context = await Scenario.Define<Context>()
-                    .WithEndpoint<Endpoint>(b => b.When((bus, c) => bus.SendLocal(new MyMessage())))
+                    .WithEndpoint<Endpoint>()
                     .Run(TimeSpan.FromSeconds(10));
 
             Assert.IsFalse(context.WasCalled);
@@ -39,10 +39,30 @@
                     return Task.FromResult(0);
                 }
             }
+
+            class DelayReceiverFromStarting: IWantToRunWhenBusStartsAndStops
+            {
+                /// <summary>
+                /// Method called at startup.
+                /// </summary>
+                public async Task Start(IBusSession session)
+                {
+                    await session.SendLocal(new MyMessage());
+                    await Task.Delay(TimeSpan.FromSeconds(5));
+                }
+
+                /// <summary>
+                /// Method called on shutdown.
+                /// </summary>
+                public Task Stop(IBusSession session)
+                {
+                    return Task.FromResult(0);
+                }
+            }
         }
 
         [Serializable]
-        [TimeToBeReceived("00:00:00.0000001")]
+        [TimeToBeReceived("00:00:02")]
         public class MyMessage : IMessage
         {
         }

--- a/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_expired_convention.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_expired_convention.cs
@@ -12,7 +12,7 @@
         public async Task Message_should_not_be_received()
         {
             var context = await Scenario.Define<Context>()
-                    .WithEndpoint<Endpoint>(b => b.When((bus, c) => bus.SendLocal(new MyMessage())))
+                    .WithEndpoint<Endpoint>()
                     .Run(TimeSpan.FromSeconds(10));
 
             Assert.IsFalse(context.WasCalled);
@@ -31,7 +31,7 @@
                 {
                     if (messageType == typeof(MyMessage))
                     {
-                        return TimeSpan.Parse("00:00:00.0000001");
+                        return TimeSpan.Parse("00:00:02");
                     }
                     return TimeSpan.MaxValue;
                 }));
@@ -44,6 +44,26 @@
                 public Task Handle(MyMessage message, IMessageHandlerContext context)
                 {
                     Context.WasCalled = true;
+                    return Task.FromResult(0);
+                }
+            }
+
+            class DelayReceiverFromStarting : IWantToRunWhenBusStartsAndStops
+            {
+                /// <summary>
+                /// Method called at startup.
+                /// </summary>
+                public async Task Start(IBusSession session)
+                {
+                    await session.SendLocal(new MyMessage());
+                    await Task.Delay(TimeSpan.FromSeconds(5));
+                }
+
+                /// <summary>
+                /// Method called on shutdown.
+                /// </summary>
+                public Task Stop(IBusSession session)
+                {
                     return Task.FromResult(0);
                 }
             }


### PR DESCRIPTION
To support transports that do not support sub millisecond TTLs

In RabbitMQ transport  the TTL needs to be greater or equal then a millisecond.
