### PR TITLE
make IBehaviorContext implementations private again

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -24,26 +24,9 @@ namespace NServiceBus
     {
         public AllAssemblies() { }
     }
-    public class AuditContext : NServiceBus.BehaviorContext, NServiceBus.Audit.IAuditContext, NServiceBus.Extensibility.IExtendable, NServiceBus.Pipeline.IBehaviorContext
-    {
-        public AuditContext(NServiceBus.Transports.OutgoingMessage message, string auditAddress, NServiceBus.Pipeline.IBehaviorContext parent) { }
-        public string AuditAddress { get; }
-        public NServiceBus.Transports.OutgoingMessage Message { get; }
-    }
     public class static AutoSubscribeSettingsExtensions
     {
         public static NServiceBus.AutomaticSubscriptions.Config.AutoSubscribeSettings AutoSubscribe(this NServiceBus.BusConfiguration config) { }
-    }
-    public class BatchDispatchContext : NServiceBus.BehaviorContext, NServiceBus.Extensibility.IExtendable, NServiceBus.IBatchDispatchContext, NServiceBus.Pipeline.IBehaviorContext
-    {
-        public BatchDispatchContext(System.Collections.Generic.IReadOnlyCollection<NServiceBus.Transports.TransportOperation> operations, NServiceBus.Pipeline.IBehaviorContext parentContext) { }
-        public System.Collections.Generic.IReadOnlyCollection<NServiceBus.Transports.TransportOperation> Operations { get; }
-    }
-    public abstract class BehaviorContext : NServiceBus.Extensibility.ContextBag, NServiceBus.Extensibility.IExtendable, NServiceBus.Pipeline.IBehaviorContext
-    {
-        protected BehaviorContext(NServiceBus.Pipeline.IBehaviorContext parentContext) { }
-        public NServiceBus.ObjectBuilder.IBuilder Builder { get; }
-        public NServiceBus.Extensibility.ContextBag Extensions { get; }
     }
     public class static BestPracticesOptionExtensions
     {
@@ -196,6 +179,25 @@ namespace NServiceBus
         [System.ObsoleteAttribute("Not available any more. Will be removed in version 7.0.0.", true)]
         public static string TransportConnectionString(this NServiceBus.Configure config) { }
     }
+    public class static ConnectorContextExtensions
+    {
+        public static NServiceBus.IBatchDispatchContext CreateBatchDispatchContext(this NServiceBus.Pipeline.StageForkConnector<NServiceBus.Pipeline.Contexts.ITransportReceiveContext, NServiceBus.IIncomingPhysicalMessageContext, NServiceBus.IBatchDispatchContext> stageForkConnector, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Transports.TransportOperation> transportOperations, NServiceBus.IIncomingPhysicalMessageContext sourceContext) { }
+        public static NServiceBus.IDispatchContext CreateDispatchContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.IBatchDispatchContext, NServiceBus.IDispatchContext> stageConnector, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Transports.TransportOperation> transportOperations, NServiceBus.IBatchDispatchContext sourceContext) { }
+        public static NServiceBus.IDispatchContext CreateDispatchContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.TransportDispatch.IRoutingContext, NServiceBus.IDispatchContext> stageConnector, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Transports.TransportOperation> transportOperations, NServiceBus.TransportDispatch.IRoutingContext sourceContext) { }
+        public static NServiceBus.Faults.IFaultContext CreateFaultContext(this NServiceBus.Pipeline.ForkConnector<NServiceBus.Pipeline.Contexts.ITransportReceiveContext, NServiceBus.Faults.IFaultContext> forkConnector, NServiceBus.Pipeline.Contexts.ITransportReceiveContext sourceContext, NServiceBus.Transports.OutgoingMessage outgoingMessage, string errorQueueAddress, System.Exception exception) { }
+        public static NServiceBus.Pipeline.Contexts.IIncomingLogicalMessageContext CreateIncomingLogicalMessageContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.IIncomingPhysicalMessageContext, NServiceBus.Pipeline.Contexts.IIncomingLogicalMessageContext> stageConnector, NServiceBus.Unicast.Messages.LogicalMessage logicalMessage, NServiceBus.IIncomingPhysicalMessageContext sourceContext) { }
+        public static NServiceBus.IIncomingPhysicalMessageContext CreateIncomingPhysicalMessageContext(this NServiceBus.Pipeline.StageForkConnector<NServiceBus.Pipeline.Contexts.ITransportReceiveContext, NServiceBus.IIncomingPhysicalMessageContext, NServiceBus.IBatchDispatchContext> stageForkConnector, NServiceBus.Transports.IncomingMessage incomingMessage, NServiceBus.Pipeline.Contexts.ITransportReceiveContext sourceContext) { }
+        public static NServiceBus.Pipeline.Contexts.IInvokeHandlerContext CreateInvokeHandlerContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.Pipeline.Contexts.IIncomingLogicalMessageContext, NServiceBus.Pipeline.Contexts.IInvokeHandlerContext> stageConnector, NServiceBus.Unicast.Behaviors.MessageHandler messageHandler, NServiceBus.Persistence.CompletableSynchronizedStorageSession storageSession, NServiceBus.Pipeline.Contexts.IIncomingLogicalMessageContext sourceContext) { }
+        public static NServiceBus.Pipeline.OutgoingPipeline.IOutgoingLogicalMessageContext CreateOutgoingLogicalMessageContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.OutgoingPipeline.IOutgoingPublishContext, NServiceBus.Pipeline.OutgoingPipeline.IOutgoingLogicalMessageContext> stageConnector, NServiceBus.OutgoingPipeline.OutgoingLogicalMessage outgoingMessage, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Routing.RoutingStrategy> routingStrategies, NServiceBus.OutgoingPipeline.IOutgoingPublishContext sourceContext) { }
+        public static NServiceBus.Pipeline.OutgoingPipeline.IOutgoingLogicalMessageContext CreateOutgoingLogicalMessageContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.OutgoingPipeline.IOutgoingReplyContext, NServiceBus.Pipeline.OutgoingPipeline.IOutgoingLogicalMessageContext> stageConnector, NServiceBus.OutgoingPipeline.OutgoingLogicalMessage outgoingMessage, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Routing.RoutingStrategy> routingStrategies, NServiceBus.OutgoingPipeline.IOutgoingReplyContext sourceContext) { }
+        public static NServiceBus.Pipeline.OutgoingPipeline.IOutgoingLogicalMessageContext CreateOutgoingLogicalMessageContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.OutgoingPipeline.IOutgoingSendContext, NServiceBus.Pipeline.OutgoingPipeline.IOutgoingLogicalMessageContext> stageConnector, NServiceBus.OutgoingPipeline.OutgoingLogicalMessage outgoingMessage, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Routing.RoutingStrategy> routingStrategies, NServiceBus.OutgoingPipeline.IOutgoingSendContext sourceContext) { }
+        public static NServiceBus.OutgoingPipeline.IOutgoingPhysicalMessageContext CreateOutgoingPhysicalMessageContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.Pipeline.OutgoingPipeline.IOutgoingLogicalMessageContext, NServiceBus.OutgoingPipeline.IOutgoingPhysicalMessageContext> stageConnector, byte[] messageBody, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Routing.RoutingStrategy> routingStrategies, NServiceBus.Pipeline.OutgoingPipeline.IOutgoingLogicalMessageContext sourceContext) { }
+        public static NServiceBus.TransportDispatch.IRoutingContext CreateRoutingContext(this NServiceBus.Pipeline.ForkConnector<NServiceBus.Pipeline.Contexts.ITransportReceiveContext, NServiceBus.TransportDispatch.IRoutingContext> forkConnector, NServiceBus.Transports.OutgoingMessage outgoingMessage, string localAddress, NServiceBus.Pipeline.Contexts.ITransportReceiveContext sourceContext) { }
+        public static NServiceBus.TransportDispatch.IRoutingContext CreateRoutingContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.IForwardingContext, NServiceBus.TransportDispatch.IRoutingContext> stageConnector, NServiceBus.Transports.OutgoingMessage outgoingMessage, NServiceBus.Routing.RoutingStrategy routingStrategy, NServiceBus.IForwardingContext sourceContext) { }
+        public static NServiceBus.TransportDispatch.IRoutingContext CreateRoutingContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.Audit.IAuditContext, NServiceBus.TransportDispatch.IRoutingContext> stageConnector, NServiceBus.Transports.OutgoingMessage outgoingMessage, NServiceBus.Routing.RoutingStrategy routingStrategy, NServiceBus.Audit.IAuditContext sourceContext) { }
+        public static NServiceBus.TransportDispatch.IRoutingContext CreateRoutingContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.Faults.IFaultContext, NServiceBus.TransportDispatch.IRoutingContext> stageConnector, NServiceBus.Transports.OutgoingMessage outgoingMessage, NServiceBus.Routing.RoutingStrategy routingStrategy, NServiceBus.Faults.IFaultContext sourceContext) { }
+        public static NServiceBus.TransportDispatch.IRoutingContext CreateRoutingContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.OutgoingPipeline.IOutgoingPhysicalMessageContext, NServiceBus.TransportDispatch.IRoutingContext> stageConnector, NServiceBus.Transports.OutgoingMessage outgoingMessage, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Routing.RoutingStrategy> routingStrategies, NServiceBus.OutgoingPipeline.IOutgoingPhysicalMessageContext sourceContext) { }
+    }
     public abstract class ContainSagaData : NServiceBus.IContainSagaData
     {
         protected ContainSagaData() { }
@@ -280,11 +282,6 @@ namespace NServiceBus
         InstancePerUnitOfWork = 1,
         InstancePerCall = 2,
     }
-    public class DispatchContext : NServiceBus.BehaviorContext, NServiceBus.Extensibility.IExtendable, NServiceBus.IDispatchContext, NServiceBus.Pipeline.IBehaviorContext
-    {
-        public DispatchContext(System.Collections.Generic.IReadOnlyCollection<NServiceBus.Transports.TransportOperation> operations, NServiceBus.Pipeline.IBehaviorContext parentContext) { }
-        public System.Collections.Generic.IEnumerable<NServiceBus.Transports.TransportOperation> Operations { get; }
-    }
     public class static DurableMessagesConfig
     {
         public static void DisableDurableMessages(this NServiceBus.BusConfiguration config) { }
@@ -352,12 +349,6 @@ namespace NServiceBus
     public class First<T>
     {
         public First() { }
-    }
-    public class ForwardingContext : NServiceBus.BehaviorContext, NServiceBus.Extensibility.IExtendable, NServiceBus.IForwardingContext, NServiceBus.Pipeline.IBehaviorContext
-    {
-        public ForwardingContext(NServiceBus.Transports.OutgoingMessage messageToForward, string address, NServiceBus.Pipeline.IBehaviorContext parentContext) { }
-        public string Address { get; }
-        public NServiceBus.Transports.OutgoingMessage Message { get; }
     }
     public class static HeaderOptionExtensions
     {
@@ -621,34 +612,6 @@ namespace NServiceBus
     {
         public static void RequireImmediateDispatch(this NServiceBus.Extensibility.ExtendableOptions options) { }
     }
-    public abstract class IncomingContext : NServiceBus.BehaviorContext, NServiceBus.Extensibility.IExtendable, NServiceBus.IBusContext, NServiceBus.IMessageProcessingContext, NServiceBus.Pipeline.Contexts.IIncomingContext, NServiceBus.Pipeline.IBehaviorContext
-    {
-        protected IncomingContext(string messageId, string replyToAddress, System.Collections.Generic.IReadOnlyDictionary<string, string> headers, NServiceBus.Pipeline.IBehaviorContext parentContext) { }
-        public System.Collections.Generic.IReadOnlyDictionary<string, string> MessageHeaders { get; }
-        public string MessageId { get; }
-        public string ReplyToAddress { get; }
-        public System.Threading.Tasks.Task ForwardCurrentMessageTo(string destination) { }
-        public System.Threading.Tasks.Task Publish(object message, NServiceBus.PublishOptions options) { }
-        public System.Threading.Tasks.Task Publish<T>(System.Action<T> messageConstructor, NServiceBus.PublishOptions publishOptions) { }
-        public System.Threading.Tasks.Task Reply(object message, NServiceBus.ReplyOptions options) { }
-        public System.Threading.Tasks.Task Reply<T>(System.Action<T> messageConstructor, NServiceBus.ReplyOptions options) { }
-        public System.Threading.Tasks.Task Send(object message, NServiceBus.SendOptions options) { }
-        public System.Threading.Tasks.Task Send<T>(System.Action<T> messageConstructor, NServiceBus.SendOptions options) { }
-        public System.Threading.Tasks.Task Subscribe(System.Type eventType, NServiceBus.SubscribeOptions options) { }
-        public System.Threading.Tasks.Task Unsubscribe(System.Type eventType, NServiceBus.UnsubscribeOptions options) { }
-    }
-    public class IncomingLogicalMessageContext : NServiceBus.IncomingContext, NServiceBus.Extensibility.IExtendable, NServiceBus.IBusContext, NServiceBus.IMessageProcessingContext, NServiceBus.Pipeline.Contexts.IIncomingContext, NServiceBus.Pipeline.Contexts.IIncomingLogicalMessageContext, NServiceBus.Pipeline.IBehaviorContext
-    {
-        public IncomingLogicalMessageContext(NServiceBus.Unicast.Messages.LogicalMessage logicalMessage, string messageId, string replyToAddress, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.Pipeline.IBehaviorContext parentContext) { }
-        public System.Collections.Generic.Dictionary<string, string> Headers { get; }
-        public NServiceBus.Unicast.Messages.LogicalMessage Message { get; }
-        public bool MessageHandled { get; set; }
-    }
-    public class IncomingPhysicalMessageContext : NServiceBus.IncomingContext, NServiceBus.Extensibility.IExtendable, NServiceBus.IBusContext, NServiceBus.IIncomingPhysicalMessageContext, NServiceBus.IMessageProcessingContext, NServiceBus.Pipeline.Contexts.IIncomingContext, NServiceBus.Pipeline.IBehaviorContext
-    {
-        public IncomingPhysicalMessageContext(NServiceBus.Transports.IncomingMessage message, NServiceBus.Pipeline.IBehaviorContext parentContext) { }
-        public NServiceBus.Transports.IncomingMessage Message { get; }
-    }
     public interface INeedInitialization
     {
         void Customize(NServiceBus.BusConfiguration configuration);
@@ -657,19 +620,6 @@ namespace NServiceBus
     public class static InstallConfigExtensions
     {
         public static void EnableInstallers(this NServiceBus.BusConfiguration config, string username = null) { }
-    }
-    public class InvokeHandlerContext : NServiceBus.IncomingContext, NServiceBus.Extensibility.IExtendable, NServiceBus.IBusContext, NServiceBus.IMessageHandlerContext, NServiceBus.IMessageProcessingContext, NServiceBus.Pipeline.Contexts.IIncomingContext, NServiceBus.Pipeline.Contexts.IInvokeHandlerContext, NServiceBus.Pipeline.IBehaviorContext
-    {
-        public InvokeHandlerContext(NServiceBus.Unicast.Behaviors.MessageHandler handler, string messageId, string replyToAddress, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.Unicast.Messages.MessageMetadata messageMetadata, object messageBeingHandled, NServiceBus.Persistence.SynchronizedStorageSession storageSession, NServiceBus.Pipeline.IBehaviorContext parentContext) { }
-        public bool HandleCurrentMessageLaterWasCalled { get; }
-        public bool HandlerInvocationAborted { get; }
-        public System.Collections.Generic.Dictionary<string, string> Headers { get; }
-        public object MessageBeingHandled { get; }
-        public NServiceBus.Unicast.Behaviors.MessageHandler MessageHandler { get; }
-        public NServiceBus.Unicast.Messages.MessageMetadata MessageMetadata { get; }
-        public NServiceBus.Persistence.SynchronizedStorageSession SynchronizedStorageSession { get; }
-        public void DoNotContinueDispatchingCurrentMessageToHandlers() { }
-        public async System.Threading.Tasks.Task HandleCurrentMessageLater() { }
     }
     [System.ObsoleteAttribute("Use IBusSessionFactory to create sending context. Will be removed in version 7.0." +
         "0.", true)]
@@ -786,46 +736,6 @@ namespace NServiceBus
     {
         public static NServiceBus.Outbox.OutboxSettings EnableOutbox(this NServiceBus.BusConfiguration config) { }
     }
-    public abstract class OutgoingContext : NServiceBus.BehaviorContext, NServiceBus.Extensibility.IExtendable, NServiceBus.IBusContext, NServiceBus.OutgoingPipeline.IOutgoingContext, NServiceBus.Pipeline.IBehaviorContext
-    {
-        protected OutgoingContext(string messageId, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.Pipeline.IBehaviorContext parentContext) { }
-        public System.Collections.Generic.Dictionary<string, string> Headers { get; }
-        public string MessageId { get; }
-        public System.Threading.Tasks.Task Publish(object message, NServiceBus.PublishOptions options) { }
-        public System.Threading.Tasks.Task Publish<T>(System.Action<T> messageConstructor, NServiceBus.PublishOptions publishOptions) { }
-        public System.Threading.Tasks.Task Send(object message, NServiceBus.SendOptions options) { }
-        public System.Threading.Tasks.Task Send<T>(System.Action<T> messageConstructor, NServiceBus.SendOptions options) { }
-        public System.Threading.Tasks.Task Subscribe(System.Type eventType, NServiceBus.SubscribeOptions options) { }
-        public System.Threading.Tasks.Task Unsubscribe(System.Type eventType, NServiceBus.UnsubscribeOptions options) { }
-    }
-    public class OutgoingLogicalMessageContext : NServiceBus.OutgoingContext, NServiceBus.Extensibility.IExtendable, NServiceBus.IBusContext, NServiceBus.OutgoingPipeline.IOutgoingContext, NServiceBus.Pipeline.IBehaviorContext, NServiceBus.Pipeline.OutgoingPipeline.IOutgoingLogicalMessageContext
-    {
-        public OutgoingLogicalMessageContext(string messageId, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.OutgoingPipeline.OutgoingLogicalMessage message, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Routing.RoutingStrategy> routingStrategies, NServiceBus.Pipeline.IBehaviorContext parentContext) { }
-        public NServiceBus.OutgoingPipeline.OutgoingLogicalMessage Message { get; }
-        public System.Collections.Generic.IReadOnlyCollection<NServiceBus.Routing.RoutingStrategy> RoutingStrategies { get; }
-        public void UpdateMessageInstance(object newInstance) { }
-    }
-    public class OutgoingPhysicalMessageContext : NServiceBus.OutgoingContext, NServiceBus.Extensibility.IExtendable, NServiceBus.IBusContext, NServiceBus.OutgoingPipeline.IOutgoingContext, NServiceBus.OutgoingPipeline.IOutgoingPhysicalMessageContext, NServiceBus.Pipeline.IBehaviorContext
-    {
-        public OutgoingPhysicalMessageContext(byte[] body, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Routing.RoutingStrategy> routingStrategies, NServiceBus.Pipeline.OutgoingPipeline.IOutgoingLogicalMessageContext parentContext) { }
-        public byte[] Body { get; set; }
-        public System.Collections.Generic.IReadOnlyCollection<NServiceBus.Routing.RoutingStrategy> RoutingStrategies { get; }
-    }
-    public class OutgoingPublishContext : NServiceBus.OutgoingContext, NServiceBus.Extensibility.IExtendable, NServiceBus.IBusContext, NServiceBus.OutgoingPipeline.IOutgoingContext, NServiceBus.OutgoingPipeline.IOutgoingPublishContext, NServiceBus.Pipeline.IBehaviorContext
-    {
-        public OutgoingPublishContext(NServiceBus.OutgoingPipeline.OutgoingLogicalMessage message, NServiceBus.PublishOptions options, NServiceBus.Pipeline.IBehaviorContext parentContext) { }
-        public NServiceBus.OutgoingPipeline.OutgoingLogicalMessage Message { get; }
-    }
-    public class OutgoingReplyContext : NServiceBus.OutgoingContext, NServiceBus.Extensibility.IExtendable, NServiceBus.IBusContext, NServiceBus.OutgoingPipeline.IOutgoingContext, NServiceBus.OutgoingPipeline.IOutgoingReplyContext, NServiceBus.Pipeline.IBehaviorContext
-    {
-        public OutgoingReplyContext(NServiceBus.OutgoingPipeline.OutgoingLogicalMessage message, NServiceBus.ReplyOptions options, NServiceBus.Pipeline.IBehaviorContext parentContext) { }
-        public NServiceBus.OutgoingPipeline.OutgoingLogicalMessage Message { get; }
-    }
-    public class OutgoingSendContext : NServiceBus.OutgoingContext, NServiceBus.Extensibility.IExtendable, NServiceBus.IBusContext, NServiceBus.OutgoingPipeline.IOutgoingContext, NServiceBus.OutgoingPipeline.IOutgoingSendContext, NServiceBus.Pipeline.IBehaviorContext
-    {
-        public OutgoingSendContext(NServiceBus.OutgoingPipeline.OutgoingLogicalMessage message, NServiceBus.SendOptions options, NServiceBus.Pipeline.IBehaviorContext parentContext) { }
-        public NServiceBus.OutgoingPipeline.OutgoingLogicalMessage Message { get; }
-    }
     public class static PersistenceConfig
     {
         public static NServiceBus.PersistenceExtentions<T> UsePersistence<T>(this NServiceBus.BusConfiguration config)
@@ -872,13 +782,6 @@ namespace NServiceBus
     public class ReplyOptions : NServiceBus.Extensibility.ExtendableOptions
     {
         public ReplyOptions() { }
-    }
-    public class RoutingContext : NServiceBus.OutgoingContext, NServiceBus.Extensibility.IExtendable, NServiceBus.Pipeline.IBehaviorContext, NServiceBus.TransportDispatch.IRoutingContext
-    {
-        public RoutingContext(NServiceBus.Transports.OutgoingMessage messageToDispatch, NServiceBus.Routing.RoutingStrategy routingStrategy, NServiceBus.Pipeline.IBehaviorContext parentContext) { }
-        public RoutingContext(NServiceBus.Transports.OutgoingMessage messageToDispatch, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Routing.RoutingStrategy> routingStrategies, NServiceBus.Pipeline.IBehaviorContext parentContext) { }
-        public NServiceBus.Transports.OutgoingMessage Message { get; }
-        public System.Collections.Generic.IReadOnlyCollection<NServiceBus.Routing.RoutingStrategy> RoutingStrategies { get; set; }
     }
     public class static RoutingOptionExtensions
     {
@@ -1016,11 +919,6 @@ namespace NServiceBus
     {
         public static void AddHeaderToAllOutgoingMessages(this NServiceBus.BusConfiguration config, string key, string value) { }
     }
-    public class SubscribeContext : NServiceBus.BehaviorContext, NServiceBus.Extensibility.IExtendable, NServiceBus.Pipeline.IBehaviorContext, NServiceBus.Routing.ISubscribeContext
-    {
-        public SubscribeContext(NServiceBus.Pipeline.IBehaviorContext parentContext, System.Type eventType, NServiceBus.SubscribeOptions options) { }
-        public System.Type EventType { get; }
-    }
     public class SubscribeOptions : NServiceBus.Extensibility.ExtendableOptions
     {
         public SubscribeOptions() { }
@@ -1094,11 +992,6 @@ namespace NServiceBus
         [System.ObsoleteAttribute(@"For sending purposes use `DeliveryConstraintContextExtensions.AddDeliveryConstraint(new DiscardIfNotReceivedBefore(timeToBeReceived))` to set the `TimeToBeReceived` or `DiscardIfNotReceivedBefore constraint;DeliveryConstraintContextExtensions.TryGetDeliveryConstraint(out constraint)` to read the `TimeToBeReceived`. When receiving look at the new 'NServiceBus.TimeToBeReceived' header. Will be removed in version 7.0.0.", true)]
         public System.TimeSpan TimeToBeReceived { get; set; }
     }
-    public class TransportReceiveContext : NServiceBus.BehaviorContext, NServiceBus.Extensibility.IExtendable, NServiceBus.Pipeline.Contexts.ITransportReceiveContext, NServiceBus.Pipeline.IBehaviorContext
-    {
-        public TransportReceiveContext(NServiceBus.Transports.IncomingMessage receivedMessage, NServiceBus.Transports.TransportTransaction transportTransaction, NServiceBus.Pipeline.IBehaviorContext parentContext) { }
-        public NServiceBus.Transports.IncomingMessage Message { get; }
-    }
     public enum TransportTransactionMode
     {
         None = 0,
@@ -1116,11 +1009,6 @@ namespace NServiceBus
         public static NServiceBus.UnicastRoutingTarget ToAnonymousInstance(NServiceBus.Routing.EndpointName endpoint, string transportAddress) { }
         public static NServiceBus.UnicastRoutingTarget ToEndpointInstance(NServiceBus.Routing.EndpointInstance instance) { }
         public static NServiceBus.UnicastRoutingTarget ToTransportAddress(string transportAddress) { }
-    }
-    public class UnsubscribeContext : NServiceBus.BehaviorContext, NServiceBus.Extensibility.IExtendable, NServiceBus.Pipeline.IBehaviorContext, NServiceBus.Routing.IUnsubscribeContext
-    {
-        public UnsubscribeContext(NServiceBus.Pipeline.IBehaviorContext parentContext, System.Type eventType, NServiceBus.UnsubscribeOptions options) { }
-        public System.Type EventType { get; }
     }
     public class UnsubscribeOptions : NServiceBus.Extensibility.ExtendableOptions
     {
@@ -1494,14 +1382,6 @@ namespace NServiceBus.Faults
         public System.Exception Exception { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public string MessageId { get; }
-    }
-    public class FaultContext : NServiceBus.BehaviorContext, NServiceBus.Extensibility.IExtendable, NServiceBus.Faults.IFaultContext, NServiceBus.Pipeline.IBehaviorContext
-    {
-        public FaultContext(NServiceBus.Transports.OutgoingMessage message, string errorQueueAddress, System.Exception exception, NServiceBus.Pipeline.IBehaviorContext parent) { }
-        public string ErrorQueueAddress { get; }
-        public System.Exception Exception { get; }
-        public NServiceBus.Transports.OutgoingMessage Message { get; }
-        public void AddFaultData(string key, string value) { }
     }
     public class static FaultsHeaderKeys
     {

--- a/src/NServiceBus.Core.Tests/Pipeline/BehaviorTypeCheckerTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/BehaviorTypeCheckerTests.cs
@@ -50,18 +50,6 @@
         }
 
         [Test]
-        public void Should_throw_for_behavior_using_context_implementations_on_tfrom()
-        {
-            Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(BehaviorUsingContextImplementationOnTFrom), Description));
-        }
-
-        [Test]
-        public void Should_throw_for_behavior_using_context_implementations_on_tto()
-        {
-            Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(BehaviorUsingContextImplementationOnTTo), Description));
-        }
-
-        [Test]
         public void Should_throw_for_behavior_using_IIncomingContext()
         {
             Assert.Throws<ArgumentException>(() => BehaviorTypeChecker.ThrowIfInvalid(typeof(BehaviorUsingIncomingContext), Description));

--- a/src/NServiceBus.Core/Audit/AuditContext.cs
+++ b/src/NServiceBus.Core/Audit/AuditContext.cs
@@ -4,17 +4,8 @@ namespace NServiceBus
     using NServiceBus.Pipeline;
     using NServiceBus.Transports;
 
-    /// <summary>
-    /// Provides context to behaviors on the audit pipeline.
-    /// </summary>
-    public class AuditContext : BehaviorContext, IAuditContext
+    class AuditContext : BehaviorContext, IAuditContext
     {
-        /// <summary>
-        /// Creates a new instance of the audit context.
-        /// </summary>
-        /// <param name="message">The message to be audited.</param>
-        /// <param name="auditAddress">The audit queue address.</param>
-        /// <param name="parent">The parent context.</param>
         public AuditContext(OutgoingMessage message, string auditAddress, IBehaviorContext parent)
             : base(parent)
         {
@@ -24,14 +15,8 @@ namespace NServiceBus
             AuditAddress = auditAddress;
         }
 
-        /// <summary>
-        /// The message to be audited.
-        /// </summary>
         public OutgoingMessage Message { get; }
 
-        /// <summary>
-        /// Address of the audit queue.
-        /// </summary>
         public string AuditAddress { get; }
     }
 }

--- a/src/NServiceBus.Core/Audit/AuditToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Audit/AuditToDispatchConnector.cs
@@ -5,7 +5,7 @@ namespace NServiceBus
     using System.Threading.Tasks;
     using Audit;
     using DeliveryConstraints;
-    using Routing;
+    using NServiceBus.Routing;
     using Performance.TimeToBeReceived;
     using Pipeline;
     using TransportDispatch;
@@ -41,9 +41,9 @@ namespace NServiceBus
                 deliveryConstraints.Add(new DiscardIfNotReceivedBefore(timeToBeReceived.Value));
             }
 
-            var dispatchContext = new RoutingContext(message, new UnicastRoutingStrategy(context.AuditAddress), context);
+            var dispatchContext = this.CreateRoutingContext(context.Message, new UnicastRoutingStrategy(context.AuditAddress), context);
 
-            dispatchContext.Set(deliveryConstraints);
+            dispatchContext.Extensions.Set(deliveryConstraints);
 
             return stage(dispatchContext);
         }

--- a/src/NServiceBus.Core/Forwarding/ForwardingContext.cs
+++ b/src/NServiceBus.Core/Forwarding/ForwardingContext.cs
@@ -3,32 +3,16 @@ namespace NServiceBus
     using NServiceBus.Pipeline;
     using NServiceBus.Transports;
 
-    /// <summary>
-    /// Provides context for the forwarding pipeline.
-    /// </summary>
-    public class ForwardingContext : BehaviorContext, IForwardingContext
+    class ForwardingContext : BehaviorContext, IForwardingContext
     {
-        /// <summary>
-        /// Creates a new instance of the forwarding context.
-        /// </summary>
-        /// <param name="messageToForward">The message to be forwarded.</param>
-        /// <param name="address">The forwarding queue address.</param>
-        /// <param name="parentContext">The parent context.</param>
         public ForwardingContext(OutgoingMessage messageToForward, string address, IBehaviorContext parentContext) : base(parentContext)
         {
             Message = messageToForward;
             Address = address;
         }
 
-        /// <summary>
-        /// The message to be fowarded.
-        /// </summary>
         public OutgoingMessage Message { get; }
 
-
-        /// <summary>
-        /// The address of the forwarding queue.
-        /// </summary>
         public string Address { get; }
     }
 }

--- a/src/NServiceBus.Core/Forwarding/ForwardingToRoutingConnector.cs
+++ b/src/NServiceBus.Core/Forwarding/ForwardingToRoutingConnector.cs
@@ -2,7 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
-    using Routing;
+    using NServiceBus.Routing;
     using Pipeline;
     using TransportDispatch;
 
@@ -10,7 +10,7 @@ namespace NServiceBus
     {
         public override Task Invoke(IForwardingContext context, Func<IRoutingContext, Task> stage)
         {
-            return stage(new RoutingContext(context.Message, new UnicastRoutingStrategy(context.Address), context));
+            return stage(this.CreateRoutingContext(context.Message, new UnicastRoutingStrategy(context.Address), context));
         }
     }
 }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Pipeline\IPipelineCache.cs" />
     <Compile Include="Pipeline\PipelineCache.cs" />
     <Compile Include="Pipeline\StageForkConnector.cs" />
+    <Compile Include="Pipeline\ConnectorContextExtensions.cs" />
     <Compile Include="Transports\MulticastTransportOperation.cs" />
     <Compile Include="Transports\TransportOperations.cs" />
     <Compile Include="Transports\UnicastTransportOperation.cs" />

--- a/src/NServiceBus.Core/Pipeline/BehaviorContext.cs
+++ b/src/NServiceBus.Core/Pipeline/BehaviorContext.cs
@@ -4,23 +4,12 @@ namespace NServiceBus
     using NServiceBus.ObjectBuilder;
     using NServiceBus.Pipeline;
 
-    /// <summary>
-    /// Provides base context for behavior context implementations.
-    /// </summary>
-    public abstract class BehaviorContext : ContextBag, IBehaviorContext
+    abstract class BehaviorContext : ContextBag, IBehaviorContext
     {
-        /// <summary>
-        /// Creates a new instance of the behavior context.
-        /// </summary>
-        /// <param name="parentContext">The parent context.</param>
-        // ReSharper disable once SuggestBaseTypeForParameter
         protected BehaviorContext(IBehaviorContext parentContext) : base(parentContext?.Extensions)
         {
         }
 
-        /// <summary>
-        /// The current <see cref="IBuilder"/>.
-        /// </summary>
         public IBuilder Builder
         {
             get
@@ -30,9 +19,6 @@ namespace NServiceBus
             }
         }
 
-        /// <summary>
-        /// Gets the extensions.
-        /// </summary>
         public ContextBag Extensions => this;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/BehaviorTypeChecker.cs
+++ b/src/NServiceBus.Core/Pipeline/BehaviorTypeChecker.cs
@@ -32,22 +32,12 @@ namespace NServiceBus
             }
 
             var inputContextType = behavior.GetInputContext();
-            if (!inputContextType.IsInterface)
-            {
-                throw new ArgumentException($@"The behavior '{behavior.Name}' is invalid since the TFrom context of IBehavior<TFrom, TTo> is not an interface.", paramName);
-            }
-
             if (NotAllowedInterfaces.Contains(inputContextType))
             {
                 throw new ArgumentException($@"The behavior '{behavior.Name}' is invalid since the TFrom {inputContextType} context of IBehavior<TFrom, TTo> is not intended to be used.", paramName);
             }
 
             var outputContextType = behavior.GetOutputContext();
-            if (!outputContextType.IsInterface)
-            {
-                throw new ArgumentException($@"The behavior '{behavior.Name}' is invalid since the TTo context of IBehavior<TFrom, TTo> is not an interface.", paramName);
-            }
-
             if (NotAllowedInterfaces.Contains(outputContextType))
             {
                 throw new ArgumentException($@"The behavior '{behavior.Name}' is invalid since the TTo {outputContextType} context of IBehavior<TFrom, TTo> is not intended to be used.", paramName);

--- a/src/NServiceBus.Core/Pipeline/ConnectorContextExtensions.cs
+++ b/src/NServiceBus.Core/Pipeline/ConnectorContextExtensions.cs
@@ -1,0 +1,166 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using NServiceBus.Audit;
+    using NServiceBus.Faults;
+    using NServiceBus.OutgoingPipeline;
+    using NServiceBus.Persistence;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Pipeline.Contexts;
+    using NServiceBus.Pipeline.OutgoingPipeline;
+    using NServiceBus.Routing;
+    using NServiceBus.TransportDispatch;
+    using NServiceBus.Transports;
+    using NServiceBus.Unicast.Behaviors;
+    using NServiceBus.Unicast.Messages;
+
+    /// <summary>
+    /// Contains extensions methods to map behavior contexts.
+    /// </summary>
+    public static class ConnectorContextExtensions
+    {
+        /// <summary>
+        /// Creates a <see cref="IRoutingContext"/> based on the current context.
+        /// </summary>
+        public static IRoutingContext CreateRoutingContext(this ForkConnector<ITransportReceiveContext, IRoutingContext> forkConnector, OutgoingMessage outgoingMessage, string localAddress, ITransportReceiveContext sourceContext)
+        {
+            return new RoutingContext(outgoingMessage, new UnicastRoutingStrategy(localAddress), sourceContext);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IRoutingContext"/> based on the current context.
+        /// </summary>
+        public static IRoutingContext CreateRoutingContext(this StageConnector<IForwardingContext, IRoutingContext> stageConnector, OutgoingMessage outgoingMessage, RoutingStrategy routingStrategy, IForwardingContext sourceContext)
+        {
+            return new RoutingContext(outgoingMessage, routingStrategy, sourceContext);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IRoutingContext"/> based on the current context.
+        /// </summary>
+        public static IRoutingContext CreateRoutingContext(this StageConnector<IAuditContext, IRoutingContext> stageConnector, OutgoingMessage outgoingMessage, RoutingStrategy routingStrategy, IAuditContext sourceContext)
+        {
+            return new RoutingContext(outgoingMessage, routingStrategy, sourceContext);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IRoutingContext"/> based on the current context.
+        /// </summary>
+        public static IRoutingContext CreateRoutingContext(this StageConnector<IFaultContext, IRoutingContext> stageConnector, OutgoingMessage outgoingMessage, RoutingStrategy routingStrategy, IFaultContext sourceContext)
+        {
+            return new RoutingContext(outgoingMessage, routingStrategy, sourceContext);    
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IRoutingContext"/> based on the current context.
+        /// </summary>
+        public static IRoutingContext CreateRoutingContext(this StageConnector<IOutgoingPhysicalMessageContext, IRoutingContext> stageConnector, OutgoingMessage outgoingMessage, IReadOnlyCollection<RoutingStrategy> routingStrategies, IOutgoingPhysicalMessageContext sourceContext)
+        {
+            return new RoutingContext(outgoingMessage, routingStrategies, sourceContext);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IIncomingPhysicalMessageContext"/> based on the current context.
+        /// </summary>
+        public static IIncomingPhysicalMessageContext CreateIncomingPhysicalMessageContext(this StageForkConnector<ITransportReceiveContext, IIncomingPhysicalMessageContext, IBatchDispatchContext> stageForkConnector, IncomingMessage incomingMessage, ITransportReceiveContext sourceContext)
+        {
+            return new IncomingPhysicalMessageContext(incomingMessage, sourceContext);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IIncomingLogicalMessageContext"/> based on the current context.
+        /// </summary>
+        public static IIncomingLogicalMessageContext CreateIncomingLogicalMessageContext(this StageConnector<IIncomingPhysicalMessageContext, IIncomingLogicalMessageContext> stageConnector, LogicalMessage logicalMessage, IIncomingPhysicalMessageContext sourceContext)
+        {
+            return new IncomingLogicalMessageContext(logicalMessage, sourceContext);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IInvokeHandlerContext"/> based on the current context.
+        /// </summary>
+        public static IInvokeHandlerContext CreateInvokeHandlerContext(this StageConnector<IIncomingLogicalMessageContext, IInvokeHandlerContext> stageConnector, MessageHandler messageHandler, CompletableSynchronizedStorageSession storageSession, IIncomingLogicalMessageContext sourceContext)
+        {
+            return new InvokeHandlerContext(messageHandler, storageSession, sourceContext);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IBatchDispatchContext"/> based on the current context.
+        /// </summary>
+        public static IBatchDispatchContext CreateBatchDispatchContext(this StageForkConnector<ITransportReceiveContext, IIncomingPhysicalMessageContext, IBatchDispatchContext> stageForkConnector, IReadOnlyCollection<TransportOperation> transportOperations, IIncomingPhysicalMessageContext sourceContext)
+        {
+            return new BatchDispatchContext(transportOperations, sourceContext);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IDispatchContext"/> based on the current context.
+        /// </summary>
+        public static IDispatchContext CreateDispatchContext(this StageConnector<IBatchDispatchContext, IDispatchContext> stageConnector, IReadOnlyCollection<TransportOperation> transportOperations, IBatchDispatchContext sourceContext)
+        {
+            return new DispatchContext(transportOperations, sourceContext);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IDispatchContext"/> based on the current context.
+        /// </summary>
+        public static IDispatchContext CreateDispatchContext(this StageConnector<IRoutingContext, IDispatchContext> stageConnector, IReadOnlyCollection<TransportOperation> transportOperations, IRoutingContext sourceContext)
+        {
+            return new DispatchContext(transportOperations, sourceContext);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IOutgoingLogicalMessageContext"/> based on the current context.
+        /// </summary>
+        public static IOutgoingLogicalMessageContext CreateOutgoingLogicalMessageContext(this StageConnector<IOutgoingPublishContext, IOutgoingLogicalMessageContext> stageConnector, OutgoingLogicalMessage outgoingMessage, IReadOnlyCollection<RoutingStrategy> routingStrategies, IOutgoingPublishContext sourceContext)
+        {
+            return new OutgoingLogicalMessageContext(
+                sourceContext.MessageId,
+                sourceContext.Headers,
+                outgoingMessage,
+                routingStrategies,
+                sourceContext);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IOutgoingLogicalMessageContext"/> based on the current context.
+        /// </summary>
+        public static IOutgoingLogicalMessageContext CreateOutgoingLogicalMessageContext(this StageConnector<IOutgoingReplyContext, IOutgoingLogicalMessageContext> stageConnector, OutgoingLogicalMessage outgoingMessage, IReadOnlyCollection<RoutingStrategy> routingStrategies, IOutgoingReplyContext sourceContext)
+        {
+            return new OutgoingLogicalMessageContext(
+                sourceContext.MessageId,
+                sourceContext.Headers,
+                outgoingMessage,
+                routingStrategies,
+                sourceContext);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IOutgoingLogicalMessageContext"/> based on the current context.
+        /// </summary>
+        public static IOutgoingLogicalMessageContext CreateOutgoingLogicalMessageContext(this StageConnector<IOutgoingSendContext, IOutgoingLogicalMessageContext> stageConnector, OutgoingLogicalMessage outgoingMessage, IReadOnlyCollection<RoutingStrategy> routingStrategies, IOutgoingSendContext sourceContext)
+        {
+            return new OutgoingLogicalMessageContext(
+                sourceContext.MessageId,
+                sourceContext.Headers,
+                outgoingMessage,
+                routingStrategies,
+                sourceContext);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IOutgoingPhysicalMessageContext"/> based on the current context.
+        /// </summary>
+        public static IOutgoingPhysicalMessageContext CreateOutgoingPhysicalMessageContext(this StageConnector<IOutgoingLogicalMessageContext, IOutgoingPhysicalMessageContext> stageConnector, byte[] messageBody, IReadOnlyCollection<RoutingStrategy> routingStrategies, IOutgoingLogicalMessageContext sourceContext)
+        {
+            return new OutgoingPhysicalMessageContext(messageBody, routingStrategies, sourceContext);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IFaultContext"/> based on the current context.
+        /// </summary>
+        public static IFaultContext CreateFaultContext(this ForkConnector<ITransportReceiveContext, IFaultContext> forkConnector, ITransportReceiveContext sourceContext, OutgoingMessage outgoingMessage, string errorQueueAddress, Exception exception)
+        {
+            return new FaultContext(outgoingMessage, errorQueueAddress, exception, sourceContext);
+        }
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
@@ -28,7 +28,7 @@
 
             foreach (var message in messages)
             {
-                await stage(new IncomingLogicalMessageContext(message, context)).ConfigureAwait(false);
+                await stage(this.CreateIncomingLogicalMessageContext(message, context)).ConfigureAwait(false);
             }
         }
 

--- a/src/NServiceBus.Core/Pipeline/Incoming/IncomingContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IncomingContext.cs
@@ -6,18 +6,8 @@ namespace NServiceBus
     using NServiceBus.Pipeline;
     using NServiceBus.Pipeline.Contexts;
 
-    /// <summary>
-    /// The base interface for everything after the transport receive phase.
-    /// </summary>
-    public abstract class IncomingContext : BehaviorContext, IIncomingContext
+    abstract class IncomingContext : BehaviorContext, IIncomingContext
     {
-        /// <summary>
-        /// Creates a new instance of an incoming context.
-        /// </summary>
-        /// <param name="messageId">The message id.</param>
-        /// <param name="replyToAddress">The reply to address.</param>
-        /// <param name="headers">The headers.</param>
-        /// <param name="parentContext">The parent context.</param>
         protected IncomingContext(string messageId, string replyToAddress, IReadOnlyDictionary<string, string> headers, IBehaviorContext parentContext)
             : base(parentContext)
         {
@@ -27,109 +17,52 @@ namespace NServiceBus
             MessageHeaders = headers;
         }
 
-        /// <summary>
-        /// The Id of the currently processed message.
-        /// </summary>
         public string MessageId { get; }
 
-        /// <summary>
-        /// The address of the endpoint that sent the current message being handled.
-        /// </summary>
         public string ReplyToAddress { get; }
 
-        /// <summary>
-        /// Gets the list of key/value pairs found in the header of the message.
-        /// </summary>
         public IReadOnlyDictionary<string, string> MessageHeaders { get; }
 
-        /// <summary>
-        /// Sends the provided message.
-        /// </summary>
-        /// <param name="message">The message to send.</param>
-        /// <param name="options">The options for the send.</param>
         public Task Send(object message, SendOptions options)
         {
             return BusOperations.Send(this, message, options);
         }
 
-        /// <summary>
-        /// Instantiates a message of type T and sends it.
-        /// </summary>
-        /// <typeparam name="T">The type of message, usually an interface.</typeparam>
-        /// <param name="messageConstructor">An action which initializes properties of the message.</param>
-        /// <param name="options">The options for the send.</param>
         public Task Send<T>(Action<T> messageConstructor, SendOptions options)
         {
             return BusOperations.Send(this, messageConstructor, options);
         }
 
-        /// <summary>
-        ///  Publish the message to subscribers.
-        /// </summary>
-        /// <param name="message">The message to publish.</param>
-        /// <param name="options">The options for the publish.</param>
         public Task Publish(object message, PublishOptions options)
         {
             return BusOperations.Publish(this, message, options);
         }
 
-        /// <summary>
-        /// Instantiates a message of type T and publishes it.
-        /// </summary>
-        /// <typeparam name="T">The type of message, usually an interface.</typeparam>
-        /// <param name="messageConstructor">An action which initializes properties of the message.</param>
-        /// <param name="publishOptions">Specific options for this event.</param>
         public Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions)
         {
             return BusOperations.Publish(this, messageConstructor, publishOptions);
         }
 
-        /// <summary>
-        /// Subscribes to receive published messages of the specified type.
-        /// This method is only necessary if you turned off auto-subscribe.
-        /// </summary>
-        /// <param name="eventType">The type of event to subscribe to.</param>
-        /// <param name="options">Options for the subscribe.</param>
         public Task Subscribe(Type eventType, SubscribeOptions options)
         {
             return BusOperations.Subscribe(this, eventType, options);
         }
 
-        /// <summary>
-        /// Unsubscribes to receive published messages of the specified type.
-        /// </summary>
-        /// <param name="eventType">The type of event to unsubscribe to.</param>
-        /// <param name="options">Options for the subscribe.</param>
         public Task Unsubscribe(Type eventType, UnsubscribeOptions options)
         {
             return BusOperations.Unsubscribe(this, eventType, options);
         }
 
-        /// <summary>
-        /// Sends the message to the endpoint which sent the message currently being handled.
-        /// </summary>
-        /// <param name="message">The message to send.</param>
-        /// <param name="options">Options for this reply.</param>
         public Task Reply(object message, ReplyOptions options)
         {
             return BusOperations.Reply(this, message, options);
         }
 
-        ///  <summary>
-        /// Instantiates a message of type T and performs a regular <see cref="Reply"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of message, usually an interface.</typeparam>
-        /// <param name="messageConstructor">An action which initializes properties of the message.</param>
-        /// <param name="options">Options for this reply.</param>
         public Task Reply<T>(Action<T> messageConstructor, ReplyOptions options)
         {
             return BusOperations.Reply(this, messageConstructor, options);
         }
 
-        /// <summary>
-        /// Forwards the current message being handled to the destination maintaining
-        /// all of its transport-level properties and headers.
-        /// </summary>
         public Task ForwardCurrentMessageTo(string destination)
         {
             return IncomingBusOperations.ForwardCurrentMessageTo(this, destination);

--- a/src/NServiceBus.Core/Pipeline/Incoming/IncomingLogicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IncomingLogicalMessageContext.cs
@@ -5,24 +5,13 @@
     using NServiceBus.Pipeline.Contexts;
     using NServiceBus.Unicast.Messages;
 
-    /// <summary>
-    /// A context of behavior execution in logical message processing stage.
-    /// </summary>
-    public class IncomingLogicalMessageContext : IncomingContext, IIncomingLogicalMessageContext
+    class IncomingLogicalMessageContext : IncomingContext, IIncomingLogicalMessageContext
     {
         internal IncomingLogicalMessageContext(LogicalMessage logicalMessage, IIncomingPhysicalMessageContext parentContext)
             : this(logicalMessage, parentContext.MessageId, parentContext.ReplyToAddress, parentContext.Message.Headers, parentContext)
         {
         }
 
-        /// <summary>
-        /// Creates a new instance of an incoming logical message context.
-        /// </summary>
-        /// <param name="logicalMessage">The logical message.</param>
-        /// <param name="messageId">The message id.</param>
-        /// <param name="replyToAddress">The reply to address.</param>
-        /// <param name="headers">The headers.</param>
-        /// <param name="parentContext">The parent context.</param>
         public IncomingLogicalMessageContext(LogicalMessage logicalMessage, string messageId, string replyToAddress, Dictionary<string, string> headers, IBehaviorContext parentContext)
             : base(messageId, replyToAddress, headers, parentContext)
         {
@@ -31,19 +20,10 @@
             Set(logicalMessage);
         }
 
-        /// <summary>
-        /// Message being handled.
-        /// </summary>
         public LogicalMessage Message { get; }
 
-        /// <summary>
-        /// Headers for the incoming message.
-        /// </summary>
         public Dictionary<string, string> Headers { get; }
 
-        /// <summary>
-        /// Tells if the message has been handled.
-        /// </summary>
         public bool MessageHandled { get; set; }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/IncomingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IncomingPhysicalMessageContext.cs
@@ -3,25 +3,14 @@
     using NServiceBus.Pipeline;
     using NServiceBus.Transports;
 
-    /// <summary>
-    /// A context of behavior execution in physical message processing stage.
-    /// </summary>
-    public class IncomingPhysicalMessageContext : IncomingContext, IIncomingPhysicalMessageContext
+    class IncomingPhysicalMessageContext : IncomingContext, IIncomingPhysicalMessageContext
     {
-        /// <summary>
-        /// Creates a new instance of an incoming phyiscal message context.
-        /// </summary>
-        /// <param name="message">The incoming message.</param>
-        /// <param name="parentContext">The parent context.</param>
         public IncomingPhysicalMessageContext(IncomingMessage message, IBehaviorContext parentContext)
             : base(message.MessageId, message.GetReplyToAddress(), message.Headers, parentContext)
         {
             Message = message;
         }
 
-        /// <summary>
-        /// The physical message being processed.
-        /// </summary>
         public IncomingMessage Message { get; }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerContext.cs
@@ -8,27 +8,13 @@ namespace NServiceBus
     using NServiceBus.Unicast.Behaviors;
     using NServiceBus.Unicast.Messages;
 
-    /// <summary>
-    /// A context of handling a logical message by a handler.
-    /// </summary>
-    public class InvokeHandlerContext : IncomingContext, IInvokeHandlerContext
+    class InvokeHandlerContext : IncomingContext, IInvokeHandlerContext
     {
         internal InvokeHandlerContext(MessageHandler handler, SynchronizedStorageSession storageSession, IIncomingLogicalMessageContext parentContext)
             : this(handler, parentContext.MessageId, parentContext.ReplyToAddress, parentContext.Headers, parentContext.Message.Metadata, parentContext.Message.Instance, storageSession, parentContext)
         {
         }
 
-        /// <summary>
-        /// Creates a new instance of an invoke handler context.
-        /// </summary>
-        /// <param name="handler">The message handler.</param>
-        /// <param name="messageId">The message id.</param>
-        /// <param name="replyToAddress">The reply to address.</param>
-        /// <param name="headers">The headers.</param>
-        /// <param name="messageMetadata">The message metadata.</param>
-        /// <param name="messageBeingHandled">The message being handled.</param>
-        /// <param name="storageSession">The storage session.</param>
-        /// <param name="parentContext">The parent context.</param>
         public InvokeHandlerContext(MessageHandler handler, string messageId, string replyToAddress, Dictionary<string, string> headers, MessageMetadata messageMetadata, object messageBeingHandled, SynchronizedStorageSession storageSession, IBehaviorContext parentContext)
             : base(messageId, replyToAddress, headers, parentContext)
         {
@@ -39,46 +25,20 @@ namespace NServiceBus
             Set(storageSession);
         }
 
-        /// <summary>
-        /// The current <see cref="IHandleMessages{T}" /> being executed.
-        /// </summary>
         public MessageHandler MessageHandler { get; }
 
-        /// <summary>
-        /// Gets the synchronized storage session for processing the current message. NServiceBus makes sure the changes made 
-        /// via this session will be persisted before the message receive is acknowledged.
-        /// </summary>
         public SynchronizedStorageSession SynchronizedStorageSession => Get<SynchronizedStorageSession>();
 
-        /// <summary>
-        /// Message headers.
-        /// </summary>
         public Dictionary<string, string> Headers { get; }
 
-        /// <summary>
-        /// The message instance being handled.
-        /// </summary>
         public object MessageBeingHandled { get; }
 
-        /// <summary>
-        /// <code>true</code> if <see cref="IMessageHandlerContext.DoNotContinueDispatchingCurrentMessageToHandlers" /> or <see cref="IMessageHandlerContext.HandleCurrentMessageLater"/> has been called.
-        /// </summary>
         public bool HandlerInvocationAborted { get; private set; }
 
-        /// <summary>
-        /// Metadata for the incoming message.
-        /// </summary>
         public MessageMetadata MessageMetadata { get; }
 
-        /// <summary>
-        /// Indicates whether <see cref="IMessageHandlerContext.HandleCurrentMessageLater"/> has been called.
-        /// </summary>
         public bool HandleCurrentMessageLaterWasCalled { get; private set; }
 
-        /// <summary>
-        /// Moves the message being handled to the back of the list of available 
-        /// messages so it can be handled later.
-        /// </summary>
         public async Task HandleCurrentMessageLater()
         {
             await BusOperationsInvokeHandlerContext.HandleCurrentMessageLater(this).ConfigureAwait(false);
@@ -86,10 +46,6 @@ namespace NServiceBus
             DoNotContinueDispatchingCurrentMessageToHandlers();
         }
 
-        /// <summary>
-        /// Tells the bus to stop dispatching the current message to additional
-        /// handlers.
-        /// </summary>
         public void DoNotContinueDispatchingCurrentMessageToHandlers()
         {
             HandlerInvocationAborted = true;

--- a/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
@@ -38,7 +38,7 @@
                 {
                     messageHandler.Instance = context.Builder.Build(messageHandler.HandlerType);
 
-                    var handlingContext = new InvokeHandlerContext(messageHandler, storageSession, context);
+                    var handlingContext = this.CreateInvokeHandlerContext(messageHandler, storageSession, context);
                     await stage(handlingContext).ConfigureAwait(false);
 
                     if (handlingContext.HandlerInvocationAborted)

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveContext.cs
@@ -4,17 +4,8 @@
     using NServiceBus.Pipeline.Contexts;
     using NServiceBus.Transports;
 
-    /// <summary>
-    /// Context containing a physical message.
-    /// </summary>
-    public class TransportReceiveContext : BehaviorContext, ITransportReceiveContext
+    class TransportReceiveContext : BehaviorContext, ITransportReceiveContext
     {
-        /// <summary>
-        /// Creates a new transport receive context.
-        /// </summary>
-        /// <param name="receivedMessage">The received message.</param>
-        /// <param name="transportTransaction">The transport transaction.</param>
-        /// <param name="parentContext">The parent context.</param>
         public TransportReceiveContext(IncomingMessage receivedMessage, TransportTransaction transportTransaction, IBehaviorContext parentContext)
             : base(parentContext)
         {
@@ -23,9 +14,6 @@
             Set(transportTransaction);
         }
 
-        /// <summary>
-        /// The physical message being processed.
-        /// </summary>
         public IncomingMessage Message { get; }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/BatchDispatchContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/BatchDispatchContext.cs
@@ -4,25 +4,14 @@ namespace NServiceBus
     using NServiceBus.Pipeline;
     using NServiceBus.Transports;
 
-    /// <summary>
-    /// Pipeline context for dispatching pending transport operations captured during message processing.
-    /// </summary>
-    public class BatchDispatchContext : BehaviorContext, IBatchDispatchContext
+    class BatchDispatchContext : BehaviorContext, IBatchDispatchContext
     {
-        /// <summary>
-        /// Creates a new instance of a batch dispatch context.
-        /// </summary>
-        /// <param name="operations">The captured transport operations to dispatch.</param>
-        /// <param name="parentContext">The parent context.</param>
         public BatchDispatchContext(IReadOnlyCollection<TransportOperation> operations, IBehaviorContext parentContext)
             : base(parentContext)
         {
             Operations = operations;
         }
 
-        /// <summary>
-        /// The captured transport operations to dispatch.
-        /// </summary>
         public IReadOnlyCollection<TransportOperation> Operations { get; }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/BatchToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/BatchToDispatchConnector.cs
@@ -8,7 +8,7 @@
     {
         public override Task Invoke(IBatchDispatchContext context, Func<IDispatchContext, Task> stage)
         {
-            return stage(new DispatchContext(context.Operations, context));
+            return stage(this.CreateDispatchContext(context.Operations, context));
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/DispatchContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/DispatchContext.cs
@@ -4,25 +4,14 @@ namespace NServiceBus
     using NServiceBus.Pipeline;
     using NServiceBus.Transports;
 
-    /// <summary>
-    /// Context for the immediate dispatch part of the pipeline.
-    /// </summary>
-    public class DispatchContext : BehaviorContext, IDispatchContext
+    class DispatchContext : BehaviorContext, IDispatchContext
     {
-        /// <summary>
-        /// Creates a new instance of a dispatch context.
-        /// </summary>
-        /// <param name="operations">The operations to be dispatched to the transport.</param>
-        /// <param name="parentContext">The parent context.</param>
         public DispatchContext(IReadOnlyCollection<TransportOperation> operations, IBehaviorContext parentContext)
             : base(parentContext)
         {
             Operations = operations;
         }
 
-        /// <summary>
-        /// The operations to be dispatched to the transport.
-        /// </summary>
         public IEnumerable<TransportOperation> Operations { get; private set; }
 
         //note: will be removed in a different pull

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingContext.cs
@@ -6,17 +6,8 @@ namespace NServiceBus
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
 
-    /// <summary>
-    /// The base interface for everything inside the outgoing pipeline.
-    /// </summary>
-    public abstract class OutgoingContext : BehaviorContext, IOutgoingContext
+    abstract class OutgoingContext : BehaviorContext, IOutgoingContext
     {
-        /// <summary>
-        /// Creates a new instance of an outgoing context.
-        /// </summary>
-        /// <param name="messageId">The message id.</param>
-        /// <param name="headers">The headers.</param>
-        /// <param name="parentContext">The parent context.</param>
         protected OutgoingContext(string messageId, Dictionary<string, string> headers, IBehaviorContext parentContext)
             : base(parentContext)
         {
@@ -24,74 +15,35 @@ namespace NServiceBus
             MessageId = messageId;
         }
 
-        /// <summary>
-        /// The id of the outgoing message.
-        /// </summary>
         public string MessageId { get; }
 
-        /// <summary>
-        /// The headers of the outgoing message.
-        /// </summary>
         public Dictionary<string, string> Headers { get; }
 
-        /// <summary>
-        /// Sends the provided message.
-        /// </summary>
-        /// <param name="message">The message to send.</param>
-        /// <param name="options">The options for the send.</param>
         public Task Send(object message, SendOptions options)
         {
             return BusOperations.Send(this, message, options);
         }
 
-        /// <summary>
-        /// Instantiates a message of type T and sends it.
-        /// </summary>
-        /// <typeparam name="T">The type of message, usually an interface.</typeparam>
-        /// <param name="messageConstructor">An action which initializes properties of the message.</param>
-        /// <param name="options">The options for the send.</param>
         public Task Send<T>(Action<T> messageConstructor, SendOptions options)
         {
             return BusOperations.Send(this, messageConstructor, options);
         }
 
-        /// <summary>
-        ///  Publish the message to subscribers.
-        /// </summary>
-        /// <param name="message">The message to publish.</param>
-        /// <param name="options">The options for the publish.</param>
         public Task Publish(object message, PublishOptions options)
         {
             return BusOperations.Publish(this, message, options);
         }
 
-        /// <summary>
-        /// Instantiates a message of type T and publishes it.
-        /// </summary>
-        /// <typeparam name="T">The type of message, usually an interface.</typeparam>
-        /// <param name="messageConstructor">An action which initializes properties of the message.</param>
-        /// <param name="publishOptions">Specific options for this event.</param>
         public Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions)
         {
             return BusOperations.Publish(this, messageConstructor, publishOptions);
         }
 
-        /// <summary>
-        /// Subscribes to receive published messages of the specified type.
-        /// This method is only necessary if you turned off auto-subscribe.
-        /// </summary>
-        /// <param name="eventType">The type of event to subscribe to.</param>
-        /// <param name="options">Options for the subscribe.</param>
         public Task Subscribe(Type eventType, SubscribeOptions options)
         {
             return BusOperations.Subscribe(this, eventType, options);
         }
 
-        /// <summary>
-        /// Unsubscribes to receive published messages of the specified type.
-        /// </summary>
-        /// <param name="eventType">The type of event to unsubscribe to.</param>
-        /// <param name="options">Options for the subscribe.</param>
         public Task Unsubscribe(Type eventType, UnsubscribeOptions options)
         {
             return BusOperations.Unsubscribe(this, eventType, options);

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingLogicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingLogicalMessageContext.cs
@@ -6,19 +6,8 @@
     using NServiceBus.Pipeline.OutgoingPipeline;
     using NServiceBus.Routing;
 
-    /// <summary>
-    /// Outgoing pipeline context.
-    /// </summary>
-    public class OutgoingLogicalMessageContext : OutgoingContext, IOutgoingLogicalMessageContext
+    class OutgoingLogicalMessageContext : OutgoingContext, IOutgoingLogicalMessageContext
     {
-        /// <summary>
-        /// Creates a new instance of an outgoing logical context.
-        /// </summary>
-        /// <param name="messageId">The message id.</param>
-        /// <param name="headers">The headers.</param>
-        /// <param name="message">The outgoing logical message.</param>
-        /// <param name="routingStrategies">The routing strategies.</param>
-        /// <param name="parentContext">The parent context.</param>
         public OutgoingLogicalMessageContext(string messageId, Dictionary<string, string> headers, OutgoingLogicalMessage message, IReadOnlyCollection<RoutingStrategy> routingStrategies, IBehaviorContext parentContext)
             : base(messageId, headers, parentContext)
         {
@@ -27,19 +16,10 @@
             Set(message);
         }
 
-        /// <summary>
-        /// The outgoing message.
-        /// </summary>
         public OutgoingLogicalMessage Message { get; private set; }
 
-        /// <summary>
-        /// The routing strategies for this message.
-        /// </summary>
         public IReadOnlyCollection<RoutingStrategy> RoutingStrategies { get; }
 
-        /// <summary>
-        /// Updates the message instance.
-        /// </summary>
         public void UpdateMessageInstance(object newInstance)
         {
             Guard.AgainstNull(nameof(newInstance), newInstance);

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPhysicalMessageContext.cs
@@ -5,17 +5,8 @@
     using NServiceBus.Pipeline.OutgoingPipeline;
     using NServiceBus.Routing;
 
-    /// <summary>
-    /// Represent the part of the outgoing pipeline where the message has been serialized to a byte[].
-    /// </summary>
-    public class OutgoingPhysicalMessageContext : OutgoingContext, IOutgoingPhysicalMessageContext
+    class OutgoingPhysicalMessageContext : OutgoingContext, IOutgoingPhysicalMessageContext
     {
-        /// <summary>
-        /// Creates a new instance of an outgoing physical message context.
-        /// </summary>
-        /// <param name="body">The body of the message.</param>
-        /// <param name="routingStrategies">The routing stragegies.</param>
-        /// <param name="parentContext">The parent context.</param>
         public OutgoingPhysicalMessageContext(byte[] body, IReadOnlyCollection<RoutingStrategy> routingStrategies, IOutgoingLogicalMessageContext parentContext)
             : base(parentContext.MessageId, parentContext.Headers, parentContext)
         {
@@ -23,17 +14,8 @@
             RoutingStrategies = routingStrategies;
         }
 
-        /// <summary>
-        /// The serialized body of the outgoing message.
-        /// </summary>
-        /// <summary>
-        /// A <see cref="byte"/> array containing the serialized contents of the outgoing message.
-        /// </summary>
         public byte[] Body { get; set; }
 
-        /// <summary>
-        /// The routing strategies for this message.
-        /// </summary>
         public IReadOnlyCollection<RoutingStrategy> RoutingStrategies { get; } 
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPhysicalToRoutingConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPhysicalToRoutingConnector.cs
@@ -15,7 +15,7 @@
 
             var message = new OutgoingMessage(context.MessageId, context.Headers, context.Body);
 
-            return stage(new RoutingContext(message, context.RoutingStrategies, context));
+            return stage(this.CreateRoutingContext(message, context.RoutingStrategies, context));
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPublishContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPublishContext.cs
@@ -4,17 +4,8 @@
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
 
-    /// <summary>
-    /// Pipeline context for publish operations.
-    /// </summary>
-    public class OutgoingPublishContext : OutgoingContext, IOutgoingPublishContext
+    class OutgoingPublishContext : OutgoingContext, IOutgoingPublishContext
     {
-        /// <summary>
-        /// Creates a new instance of an outgoing publish context.
-        /// </summary>
-        /// <param name="message">The message.</param>
-        /// <param name="options">The publish options.</param>
-        /// <param name="parentContext">The parent context.</param>
         public OutgoingPublishContext(OutgoingLogicalMessage message, PublishOptions options, IBehaviorContext parentContext)
             : base(options.MessageId, new Dictionary<string, string>(options.OutgoingHeaders), parentContext)
         {
@@ -26,9 +17,6 @@
             parentContext.Extensions.Merge(options.Context);
         }
 
-        /// <summary>
-        /// The message to be published.
-        /// </summary>
         public OutgoingLogicalMessage Message { get; }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingReplyContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingReplyContext.cs
@@ -4,17 +4,8 @@
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
 
-    /// <summary>
-    /// Pipeline context for reply operations.
-    /// </summary>
-    public class OutgoingReplyContext : OutgoingContext, IOutgoingReplyContext
+    class OutgoingReplyContext : OutgoingContext, IOutgoingReplyContext
     {
-        /// <summary>
-        /// Creates a new instance of an outgoing reply context.
-        /// </summary>
-        /// <param name="message">The reply message.</param>
-        /// <param name="options">The options.</param>
-        /// <param name="parentContext">The parent context.</param>
         public OutgoingReplyContext(OutgoingLogicalMessage message, ReplyOptions options, IBehaviorContext parentContext)
             : base(options.MessageId, new Dictionary<string, string>(options.OutgoingHeaders), parentContext)
         {
@@ -26,9 +17,6 @@
             parentContext.Extensions.Merge(options.Context);
         }
 
-        /// <summary>
-        /// The reply message.
-        /// </summary>
         public OutgoingLogicalMessage Message { get; }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingSendContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingSendContext.cs
@@ -4,17 +4,8 @@
     using NServiceBus.OutgoingPipeline;
     using NServiceBus.Pipeline;
 
-    /// <summary>
-    /// Pipeline context for send operations.
-    /// </summary>
-    public class OutgoingSendContext : OutgoingContext, IOutgoingSendContext
+    class OutgoingSendContext : OutgoingContext, IOutgoingSendContext
     {
-        /// <summary>
-        /// Creates a new instance of an outgoing send context.
-        /// </summary>
-        /// <param name="message">The message being sent.</param>
-        /// <param name="options">The send options.</param>
-        /// <param name="parentContext">The parent context.</param>
         public OutgoingSendContext(OutgoingLogicalMessage message, SendOptions options, IBehaviorContext parentContext)
             : base(options.MessageId, new Dictionary<string, string>(options.OutgoingHeaders), parentContext)
         {
@@ -27,9 +18,6 @@
             Merge(options.Context);
         }
 
-        /// <summary>
-        /// The message being sent.
-        /// </summary>
         public OutgoingLogicalMessage Message { get; }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/RoutingContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/RoutingContext.cs
@@ -6,28 +6,13 @@ namespace NServiceBus
     using NServiceBus.TransportDispatch;
     using NServiceBus.Transports;
 
-    /// <summary>
-    /// Context for the routing part of the pipeline.
-    /// </summary>
-    public class RoutingContext : OutgoingContext, IRoutingContext
+    class RoutingContext : OutgoingContext, IRoutingContext
     {
-        /// <summary>
-        /// Creates a new instance of a routing parentContext.
-        /// </summary>
-        /// <param name="messageToDispatch">The message to dispatch.</param>
-        /// <param name="routingStrategy">The routing strategy.</param>
-        /// <param name="parentContext">The parent context.</param>
         public RoutingContext(OutgoingMessage messageToDispatch, RoutingStrategy routingStrategy, IBehaviorContext parentContext)
             : this(messageToDispatch, new[] { routingStrategy }, parentContext)
         {
         }
 
-        /// <summary>
-        /// Creates a new instance of a routing parentContext.
-        /// </summary>
-        /// <param name="messageToDispatch">The message to dispatch.</param>
-        /// <param name="routingStrategies">The routing strategies.</param>
-        /// <param name="parentContext">The parent context.</param>
         public RoutingContext(OutgoingMessage messageToDispatch, IReadOnlyCollection<RoutingStrategy> routingStrategies, IBehaviorContext parentContext)
             : base(messageToDispatch.MessageId, messageToDispatch.Headers, parentContext)
         {
@@ -35,14 +20,8 @@ namespace NServiceBus
             RoutingStrategies = routingStrategies;
         }
 
-        /// <summary>
-        /// The message to dispatch the the transport.
-        /// </summary>
         public OutgoingMessage Message { get; }
 
-        /// <summary>
-        /// The routing strategies for the operation to be dispatched.
-        /// </summary>
         public IReadOnlyCollection<RoutingStrategy> RoutingStrategies { get; set; }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
@@ -52,7 +52,7 @@
                 return TaskEx.Completed;
             }
 
-            return stage(new DispatchContext(operations.ToArray(), context));
+            return stage(this.CreateDispatchContext(operations.ToArray(), context));
         }
 
         public class State

--- a/src/NServiceBus.Core/Recoverability/Faults/FaultContext.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/FaultContext.cs
@@ -1,21 +1,12 @@
-﻿namespace NServiceBus.Faults
+﻿namespace NServiceBus
 {
     using System;
+    using NServiceBus.Faults;
     using NServiceBus.Pipeline;
     using NServiceBus.Transports;
 
-    /// <summary>
-    /// Provides context to behaviors on the fault pipeline.
-    /// </summary>
-    public class FaultContext : BehaviorContext, IFaultContext
+    class FaultContext : BehaviorContext, IFaultContext
     {
-        /// <summary>
-        /// Creates a new instance of the fault context.
-        /// </summary>
-        /// <param name="message">The message to which fault relates to.</param>
-        /// <param name="errorQueueAddress">The fault queue address.</param>
-        /// <param name="exception">Exception that occurred while processing the message.</param>
-        /// <param name="parent">The parent context.</param>
         public FaultContext(OutgoingMessage message, string errorQueueAddress, Exception exception, IBehaviorContext parent)
             : base(parent)
         {
@@ -27,26 +18,12 @@
             Exception = exception;
         }
 
-        /// <summary>
-        /// The message to which fault relates to.
-        /// </summary>
         public OutgoingMessage Message { get; }
 
-        /// <summary>
-        /// Address of the error queue.
-        /// </summary>
         public string ErrorQueueAddress { get; }
 
-        /// <summary>
-        /// Exception that occurred while processing the message.
-        /// </summary>
         public Exception Exception { get; }
 
-        /// <summary>
-        /// Adds information about faults related to current message.
-        /// </summary>
-        /// <param name="key">The key.</param>
-        /// <param name="value">The value.</param>
         public void AddFaultData(string key, string value)
         {
             Guard.AgainstNullAndEmpty(nameof(key), key);

--- a/src/NServiceBus.Core/Recoverability/Faults/FaultToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/FaultToDispatchConnector.cs
@@ -4,7 +4,7 @@ namespace NServiceBus
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using NServiceBus.Faults;
-    using Routing;
+    using NServiceBus.Routing;
     using Pipeline;
     using TransportDispatch;
 
@@ -25,7 +25,7 @@ namespace NServiceBus
                 }
             }
 
-            var dispatchContext = new RoutingContext(message, new UnicastRoutingStrategy(context.ErrorQueueAddress), context);
+            var dispatchContext = this.CreateRoutingContext(context.Message, new UnicastRoutingStrategy(context.ErrorQueueAddress), context);
             
             return stage(dispatchContext);
         }

--- a/src/NServiceBus.Core/Recoverability/Faults/MoveFaultsToErrorQueueBehavior.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/MoveFaultsToErrorQueueBehavior.cs
@@ -43,7 +43,8 @@ namespace NServiceBus
 
                     message.Headers.Remove(Headers.Retries);
 
-                    var faultContext = new FaultContext(new OutgoingMessage(message.MessageId, message.Headers, message.Body), errorQueueAddress, exception, context);
+                    var outgoingMessage = new OutgoingMessage(message.MessageId, message.Headers, message.Body);
+                    var faultContext = this.CreateFaultContext(context, outgoingMessage, errorQueueAddress, exception);
 
                     await fork(faultContext).ConfigureAwait(false);
                     

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetriesBehavior.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetriesBehavior.cs
@@ -8,7 +8,6 @@ namespace NServiceBus
     using Logging;
     using Pipeline;
     using Pipeline.Contexts;
-    using Routing;
     using TransportDispatch;
     using Transports;
 
@@ -51,8 +50,7 @@ namespace NServiceBus
                     messageToRetry.Headers[Headers.Retries] = currentRetry.ToString();
                     messageToRetry.Headers[RetriesTimestamp] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
 
-
-                    var dispatchContext = new RoutingContext(messageToRetry, new UnicastRoutingStrategy(localAddress), context);
+                    var dispatchContext = this.CreateRoutingContext(messageToRetry, localAddress, context);
 
                     context.Extensions.Set(new List<DeliveryConstraint>
                     {

--- a/src/NServiceBus.Core/Routing/Routers/MulticastPublishRouterBehavior.cs
+++ b/src/NServiceBus.Core/Routing/Routers/MulticastPublishRouterBehavior.cs
@@ -3,9 +3,9 @@ namespace NServiceBus
     using System;
     using System.Threading.Tasks;
     using NServiceBus.Pipeline.OutgoingPipeline;
+    using NServiceBus.Routing;
     using OutgoingPipeline;
     using Pipeline;
-    using Routing;
 
     class MulticastPublishRouterBehavior : StageConnector<IOutgoingPublishContext, IOutgoingLogicalMessageContext>
     {
@@ -13,9 +13,7 @@ namespace NServiceBus
         {
             context.Headers[Headers.MessageIntent] = MessageIntentEnum.Publish.ToString();
 
-            var logicalMessageContext = new OutgoingLogicalMessageContext(
-                context.MessageId,
-                context.Headers,
+            var logicalMessageContext = this.CreateOutgoingLogicalMessageContext(
                 context.Message,
                 new[]
                 {

--- a/src/NServiceBus.Core/Routing/Routers/UnicastPublishRouterConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/UnicastPublishRouterConnector.cs
@@ -34,14 +34,7 @@ namespace NServiceBus
 
             try
             {
-                await stage(
-                    new OutgoingLogicalMessageContext(
-                        context.MessageId,
-                        context.Headers,
-                        context.Message,
-                        addressLabels,
-                        context))
-                    .ConfigureAwait(false);
+                await stage(this.CreateOutgoingLogicalMessageContext(context.Message, addressLabels, context)).ConfigureAwait(false);
             }
             catch (QueueNotFoundException ex)
             {

--- a/src/NServiceBus.Core/Routing/Routers/UnicastReplyRouterConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/UnicastReplyRouterConnector.cs
@@ -28,12 +28,7 @@ namespace NServiceBus
             context.Headers[Headers.MessageIntent] = MessageIntentEnum.Reply.ToString();
 
             var addressLabels = RouteToDestination(replyToAddress).EnsureNonEmpty(() => "No destination specified.").ToArray();
-            var logicalMessageContext = new OutgoingLogicalMessageContext(
-                    context.MessageId,
-                    context.Headers,
-                    context.Message,
-                    addressLabels,
-                    context);
+            var logicalMessageContext = this.CreateOutgoingLogicalMessageContext(context.Message, addressLabels, context);
 
             try
             {

--- a/src/NServiceBus.Core/Routing/Routers/UnicastSendRouterConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/UnicastSendRouterConnector.cs
@@ -38,12 +38,10 @@ namespace NServiceBus
 
             context.Headers[Headers.MessageIntent] = MessageIntentEnum.Send.ToString();
 
-            var logicalMessageContext = new OutgoingLogicalMessageContext(
-                    context.MessageId,
-                    context.Headers,
-                    context.Message,
-                    addressLabels.EnsureNonEmpty(() => "No destination specified for message: " + messageType).ToArray(),
-                    context);
+            var logicalMessageContext = this.CreateOutgoingLogicalMessageContext(
+                context.Message, 
+                addressLabels.EnsureNonEmpty(() => "No destination specified for message: " + messageType).ToArray(), 
+                context);
 
             try
             {

--- a/src/NServiceBus.Core/Routing/SubscribeContext.cs
+++ b/src/NServiceBus.Core/Routing/SubscribeContext.cs
@@ -4,17 +4,8 @@
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
 
-    /// <summary>
-    /// Provides context for subscription requests.
-    /// </summary>
-    public class SubscribeContext : BehaviorContext, ISubscribeContext
+    class SubscribeContext : BehaviorContext, ISubscribeContext
     {
-        /// <summary>
-        /// Creates a new instance of a subscribe context.
-        /// </summary>
-        /// <param name="parentContext">The parent context.</param>
-        /// <param name="eventType">The type of the event.</param>
-        /// <param name="options">The subscribe options.</param>
         public SubscribeContext(IBehaviorContext parentContext, Type eventType, SubscribeOptions options)
             : base(parentContext)
         {
@@ -27,9 +18,6 @@
             EventType = eventType;
         }
 
-        /// <summary>
-        /// The type of the event.
-        /// </summary>
         public Type EventType { get; }
     }
 }

--- a/src/NServiceBus.Core/Routing/UnsubscribeContext.cs
+++ b/src/NServiceBus.Core/Routing/UnsubscribeContext.cs
@@ -4,17 +4,8 @@
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
 
-    /// <summary>
-    /// Provides context for unsubscribe requests.
-    /// </summary>
-    public class UnsubscribeContext : BehaviorContext, IUnsubscribeContext
+    class UnsubscribeContext : BehaviorContext, IUnsubscribeContext
     {
-        /// <summary>
-        /// Creates a new instance of an unsubscribe context.
-        /// </summary>
-        /// <param name="parentContext">The parent context.</param>
-        /// <param name="eventType">The type of the event.</param>
-        /// <param name="options">The unsubscribe options.</param>
         public UnsubscribeContext(IBehaviorContext parentContext, Type eventType, UnsubscribeOptions options)
             : base(parentContext)
         {
@@ -27,9 +18,6 @@
             EventType = eventType;
         }
 
-        /// <summary>
-        /// The type of the event.
-        /// </summary>
         public Type EventType { get; }
     }
 }

--- a/src/NServiceBus.Core/Serialization/SerializeMessageConnector.cs
+++ b/src/NServiceBus.Core/Serialization/SerializeMessageConnector.cs
@@ -34,7 +34,7 @@
 
             if (context.ShouldSkipSerialization())
             {
-                await stage(new OutgoingPhysicalMessageContext(new byte[0], context.RoutingStrategies, context)).ConfigureAwait(false);
+                await stage(this.CreateOutgoingPhysicalMessageContext(new byte[0], context.RoutingStrategies, context)).ConfigureAwait(false);
                 return;
             }
 
@@ -42,7 +42,7 @@
             context.Headers[Headers.EnclosedMessageTypes] = SerializeEnclosedMessageTypes(context.Message.MessageType);
 
             var array = Serialize(context);
-            await stage(new OutgoingPhysicalMessageContext(array, context.RoutingStrategies, context)).ConfigureAwait(false);
+            await stage(this.CreateOutgoingPhysicalMessageContext(array, context.RoutingStrategies, context)).ConfigureAwait(false);
         }
 
         byte[] Serialize(IOutgoingLogicalMessageContext context)


### PR DESCRIPTION
Makes the implementations private again to reduce the API surface and avoid potential confusion for users whether to use the interface or the implementation.
The main reason for the implementations to be public was to keep to ability to replace not only behaviors but also stage connectors (and now fork-connectors) since they are the places where we new up concrete context implementations.
With this change:
* we can make all the implementations private again while users are still able to create new context instances in custom connectors by using the provided "factory extension methods".
* by using extension methods, we can scope the ability to instantiate contexts to an exactly defined connector. E.g. users can only create an OutgoingPhysicalMessageContext in a stage connector from logical to physical message context, nowhere else.
* Removes checks which ensure custom behaviors don't use implementations instead of the interfaces since implementations are no longer visible.

Connects to Particular/PlatformDevelopment#187