### PR TITLE
Change XMLSerialization behavior to conform to XML standard

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -165,6 +165,7 @@
     <Compile Include="Sagas\SagaMetadataCreationTests.cs" />
     <Compile Include="Recoverability\SecondLevelRetries\DefaultRetryPolicyTests.cs" />
     <Compile Include="Serializers\SerializeMessagesBehaviorTests.cs" />
+    <Compile Include="Serializers\XML\SerializingNullableTypesTests.cs" />
     <Compile Include="StandardsTests.cs" />
     <Compile Include="Encryption\ConfigureRijndaelEncryptionServiceTests.cs" />
     <Compile Include="Encryption\RijndaelEncryptionServiceTest.cs" />

--- a/src/NServiceBus.Core.Tests/Serializers/XML/SerializingArrayTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/SerializingArrayTests.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Serializers.XML.Test
 {
     using System;
     using System.IO;
+    using System.Linq;
     using System.Text;
     using System.Xml.Linq;
     using NUnit.Framework;
@@ -154,6 +155,71 @@ namespace NServiceBus.Serializers.XML.Test
                 var result = (MessageWithNullableArray)msgArray[0];
 
                 Assert.AreEqual(null, result.SomeInts[0]);
+            }
+        }
+
+        [Test]
+        public void CanDeserializeNullableArrayWithFirstEntryXsiNilAttributeSetToTrue()
+        {
+            var xml = @"<?xml version=""1.0"" ?>
+<MessageWithNullableArray xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns=""http://tempuri.net/NServiceBus.Serializers.XML.Test"">
+<SagaId>00000000-0000-0000-0000-000000000000</SagaId>
+<SomeInts>
+<NullableOfInt32 xsi:nil=""true""></NullableOfInt32>
+</SomeInts>
+</MessageWithNullableArray>
+";
+            var data = Encoding.UTF8.GetBytes(xml);
+
+            using (var stream = new MemoryStream(data))
+            {
+                var msgArray = SerializerFactory.Create<MessageWithNullableArray>().Deserialize(stream, new[] { typeof(MessageWithNullableArray) });
+                var result = (MessageWithNullableArray)msgArray[0];
+
+                Assert.AreEqual(null, result.SomeInts[0]);
+            }
+        }
+
+        [Test]
+        public void CanDeserializeNullableArrayWithXsiNilAttributeSetToTrue()
+        {
+            var xml = @"<?xml version=""1.0"" ?>
+<MessageWithNullableArray xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns=""http://tempuri.net/NServiceBus.Serializers.XML.Test"">
+<SagaId>00000000-0000-0000-0000-000000000000</SagaId>
+<SomeInts xsi:nil=""true"">
+</SomeInts>
+</MessageWithNullableArray>
+";
+            var data = Encoding.UTF8.GetBytes(xml);
+
+            using (var stream = new MemoryStream(data))
+            {
+                var msgArray = SerializerFactory.Create<MessageWithNullableArray>().Deserialize(stream, new[] { typeof(MessageWithNullableArray) });
+                var result = (MessageWithNullableArray)msgArray[0];
+
+                Assert.IsFalse(result.SomeInts.Any());
+            }
+        }
+
+        [Test]
+        public void CanDeserializeNullableArrayWithNoElementsToEmptyList()
+        {
+            var xml = @"<?xml version=""1.0"" ?>
+<MessageWithNullableArray xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns=""http://tempuri.net/NServiceBus.Serializers.XML.Test"">
+<SagaId>00000000-0000-0000-0000-000000000000</SagaId>
+<SomeInts>
+</SomeInts>
+</MessageWithNullableArray>
+";
+            var data = Encoding.UTF8.GetBytes(xml);
+
+            using (var stream = new MemoryStream(data))
+            {
+                var msgArray = SerializerFactory.Create<MessageWithNullableArray>().Deserialize(stream, new[] { typeof(MessageWithNullableArray) });
+                var result = (MessageWithNullableArray)msgArray[0];
+
+                Assert.NotNull(result.SomeInts);
+                Assert.AreEqual(0, result.SomeInts.Length);
             }
         }
 

--- a/src/NServiceBus.Core.Tests/Serializers/XML/SerializingNullableTypesTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/SerializingNullableTypesTests.cs
@@ -1,0 +1,134 @@
+namespace NServiceBus.Serializers.XML.Test
+{
+    using System;
+    using System.IO;
+    using System.Text;
+    using System.Xml.Linq;
+    using NUnit.Framework;
+
+    [Serializable]
+    public class MessageWithNullable : IMessage
+    {
+        public string FirstName { get; set; }
+
+        public string LastName { get; set; }
+
+        public string EmailAddress { get; set; }
+
+        public DateTime? BirthDate { get; set; } //Nullable DateTime property
+    }
+
+    [TestFixture]
+    public class SerializingNullableTypesTests
+    {
+        [Test]
+        public void NullableTypesSerializeToXsiNilWhenNull()
+        {
+            var message = new MessageWithNullable
+            {
+                FirstName = "FirstName",
+                LastName = "LastName",
+                EmailAddress = "EmailAddress",
+                BirthDate = null
+            };
+
+            using (var stream = new MemoryStream())
+            {
+                SerializerFactory.Create<MessageWithNullable>().Serialize(message, stream);
+                stream.Position = 0;
+                var reader = new StreamReader(stream);
+                var xml = reader.ReadToEnd();
+
+                var expected = XDocument.Parse(@"<?xml version=""1.0""?>
+<MessageWithNullable xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns=""http://tempuri.net/NServiceBus.Serializers.XML.Test"">
+   <FirstName>FirstName</FirstName>
+   <LastName>LastName</LastName>
+   <EmailAddress>EmailAddress</EmailAddress>
+   <BirthDate xsi:nil=""true""></BirthDate>
+</MessageWithNullable>
+");
+                var actual = XDocument.Parse(xml);
+
+                Assert.AreEqual(expected.ToString(), actual.ToString());
+            }
+        }
+
+        [Test]
+        public void NullableTypeSerializeToValueWhenNotNull()
+        {
+            var message = new MessageWithNullable
+            {
+                FirstName = "FirstName",
+                LastName = "LastName",
+                EmailAddress = "EmailAddress",
+                BirthDate = new DateTime(1950, 04, 25)
+            };
+
+            using (var stream = new MemoryStream())
+            {
+                SerializerFactory.Create<MessageWithNullable>().Serialize(message, stream);
+                stream.Position = 0;
+                var reader = new StreamReader(stream);
+                var xml = reader.ReadToEnd();
+
+                var expected = XDocument.Parse(@"<?xml version=""1.0""?>
+<MessageWithNullable xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns=""http://tempuri.net/NServiceBus.Serializers.XML.Test"">
+   <FirstName>FirstName</FirstName>
+   <LastName>LastName</LastName>
+   <EmailAddress>EmailAddress</EmailAddress>
+   <BirthDate>1950-04-25T00:00:00</BirthDate>
+</MessageWithNullable>
+");
+                var actual = XDocument.Parse(xml);
+
+                Assert.AreEqual(expected.ToString(), actual.ToString());
+            }
+        }
+
+        [Test]
+        public void CanDeserializeNilMessage()
+        {
+            var messageXml = @"<?xml version=""1.0""?>
+<MessageWithNullable xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns=""http://tempuri.net/NServiceBus.Serializers.XML.Test"">
+   <FirstName>FirstName</FirstName>
+   <LastName>LastName</LastName>
+   <EmailAddress>EmailAddress</EmailAddress>
+   <BirthDate xsi:nil=""true""></BirthDate>
+</MessageWithNullable>
+";
+
+            var data = Encoding.UTF8.GetBytes(messageXml);
+
+            using (var stream = new MemoryStream(data))
+            {
+                var msgArray = SerializerFactory.Create<MessageWithNullable>().Deserialize(stream, new[] { typeof(MessageWithNullable) });
+                var result = (MessageWithNullable)msgArray[0];
+
+                Assert.AreEqual(null, result.BirthDate);
+            }
+        }
+
+        [Test]
+        public void CanDeserializeOriginalNullValueMessage()
+        {
+            var messageXml = @"<?xml version=""1.0""?>
+<MessageWithNullable xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns=""http://tempuri.net/NServiceBus.Serializers.XML.Test"">
+   <FirstName>FirstName</FirstName>
+   <LastName>LastName</LastName>
+   <EmailAddress>EmailAddress</EmailAddress>
+   <BirthDate>null</BirthDate>
+</MessageWithNullable>
+";
+
+            var data = Encoding.UTF8.GetBytes(messageXml);
+
+            using (var stream = new MemoryStream(data))
+            {
+                var msgArray = SerializerFactory.Create<MessageWithNullable>().Deserialize(stream, new[] { typeof(MessageWithNullable) });
+                var result = (MessageWithNullable)msgArray[0];
+
+                Assert.AreEqual(null, result.BirthDate);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Serializers/XML/XmlSerialization.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlSerialization.cs
@@ -14,6 +14,8 @@
         const string BaseType = "baseType";
 
         const string DefaultNamespace = "http://tempuri.net";
+        static XNamespace xsiNamespace = "http://www.w3.org/2001/XMLSchema-instance";
+        static XNamespace xsdNamespace = "http://www.w3.org/2001/XMLSchema";
 
         Type messageType;
         XmlWriter writer;
@@ -188,7 +190,8 @@
                     var nullableType = typeof(Nullable<>).MakeGenericType(args);
                     if (type == nullableType)
                     {
-                        WriteEntry(elem, name, typeof(string), "null");
+                        elem.Add(new XElement(name, new XAttribute(xsiNamespace + "nil", true), null));
+
                         return;
                     }
                 }
@@ -282,8 +285,8 @@
 
         void WriteElementNamespaces(XElement elem, IReadOnlyList<string> baseTypes)
         {
-            elem.Add(new XAttribute(XNamespace.Xmlns + "xsi", "http://www.w3.org/2001/XMLSchema-instance"),
-                     new XAttribute(XNamespace.Xmlns + "xsd", "http://www.w3.org/2001/XMLSchema"));
+            elem.Add(new XAttribute(XNamespace.Xmlns + "xsi", xsiNamespace),
+                     new XAttribute(XNamespace.Xmlns + "xsd", xsdNamespace));
 
             for (var i = 0; i < baseTypes.Count; i++)
             {


### PR DESCRIPTION
Serializing of null values should serialize the tags to
<Tag xsi:nil="true"></Tag> instead of <Tag>null</Tag>.

This change implements that change. All previous versions of the
deserializers are able to deserialize both formats still so no changes
are required to the deserialization code.

Connects to https://github.com/Particular/NServiceBus/issues/3122