### PR TITLE
obsolete TransportConfig.MaximumMessageThroughputPerSecond

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1306,6 +1306,8 @@ namespace NServiceBus.Config
         [System.Configuration.ConfigurationPropertyAttribute("MaximumConcurrencyLevel", DefaultValue=0, IsRequired=false)]
         public int MaximumConcurrencyLevel { get; set; }
         [System.Configuration.ConfigurationPropertyAttribute("MaximumMessageThroughputPerSecond", DefaultValue=-1, IsRequired=false)]
+        [System.ObsoleteAttribute("Message throughput throttling has been removed. Please consult the documentation " +
+            "for further information. Will be removed in version 7.0.0.", true)]
         public int MaximumMessageThroughputPerSecond { get; set; }
         [System.Configuration.ConfigurationPropertyAttribute("MaxRetries", DefaultValue=5, IsRequired=false)]
         public int MaxRetries { get; set; }

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -34,6 +34,13 @@ namespace NServiceBus
 
         public async Task<IEndpointInstance> Start()
         {
+            // remove in v7:
+            var throughputConfiguration = settings.GetConfigSection<TransportConfig>()?.MaximumMessageThroughputPerSecond;
+            if (throughputConfiguration.HasValue && throughputConfiguration != -1)
+            {
+                throw new NotSupportedException($"Message throughput throttling has been removed. Please remove the '{nameof(TransportConfig.MaximumMessageThroughputPerSecond)}' attribute from the '{nameof(TransportConfig)}' configuration section and consult the documentation for further information.");
+            }
+
             var pipelineCache = new PipelineCache(builder, settings);
             var busInterface = new StartUpBusInterface(builder, pipelineCache);
             var busSession = busInterface.CreateBusSession();

--- a/src/NServiceBus.Core/Transports/TransportConfig.cs
+++ b/src/NServiceBus.Core/Transports/TransportConfig.cs
@@ -45,6 +45,10 @@
         /// The max throughput for the transport. This allows the user to throttle their endpoint if needed.
         /// </summary>
         [ConfigurationProperty("MaximumMessageThroughputPerSecond", IsRequired = false, DefaultValue = -1)]
+        [ObsoleteEx(
+            TreatAsErrorFromVersion = "6", 
+            RemoveInVersion = "7", 
+            Message = "Message throughput throttling has been removed. Please consult the documentation for further information.")]
         public int MaximumMessageThroughputPerSecond
         {
             get


### PR DESCRIPTION
related to #2859 

* Marks the property as obsolete to avoid code based configuration
* Adds a check when starting the bus to throw an `NotSupportedException` when a non-default value has been configured by a configuration file.