### PR TITLE
[WIP] Include generic Type parameter as part of Find Saga meta data

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_clearing_saga_timeouts.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_clearing_saga_timeouts.cs
@@ -70,7 +70,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<PlaceOrderSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<PlaceOrder>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<PlaceOrder, Guid>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class PlaceOrderSagaData : ContainSagaData

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_base_class_message_hits_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_base_class_message_hits_a_saga.cs
@@ -60,7 +60,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData04> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessageBase>(m => m.SomeId)
+                    mapper.ConfigureMapping<StartSagaMessageBase, Guid>(m => m.SomeId)
                         .ToSaga(s => s.SomeId);
                 }
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_existing_saga_instance_exists.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_existing_saga_instance_exists.cs
@@ -58,7 +58,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData05> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                    mapper.ConfigureMapping<StartSagaMessage, Guid>(m => m.SomeId)
                         .ToSaga(s => s.SomeId);
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_saga_message_goes_through_the_slr.cs
@@ -66,9 +66,9 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData09> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                    mapper.ConfigureMapping<StartSagaMessage, Guid>(m => m.SomeId)
                         .ToSaga(s=>s.SomeId);
-                    mapper.ConfigureMapping<SecondSagaMessage>(m => m.SomeId)
+                    mapper.ConfigureMapping<SecondSagaMessage, Guid>(m => m.SomeId)
                       .ToSaga(s => s.SomeId);
                 }
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_an_endpoint_replies_to_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_an_endpoint_replies_to_a_saga.cs
@@ -93,8 +93,8 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<CorrelationTestSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.RunId).ToSaga(s => s.RunId);
-                    mapper.ConfigureMapping<DoSomethingResponse>(m => m.RunId).ToSaga(s => s.RunId);
+                    mapper.ConfigureMapping<StartSaga, Guid>(m => m.RunId).ToSaga(s => s.RunId);
+                    mapper.ConfigureMapping<DoSomethingResponse, Guid>(m => m.RunId).ToSaga(s => s.RunId);
                 }
 
                 public class CorrelationTestSagaData : ContainSagaData

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_auto_correlated_property_is_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_auto_correlated_property_is_changed.cs
@@ -53,7 +53,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<CorrIdChangedSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<StartSaga, Guid>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class CorrIdChangedSagaData : ContainSagaData

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas.cs
@@ -48,8 +48,8 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RequestResponseRequestingSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<InitiateRequestingSaga>(m => m.Id).ToSaga(s => s.CorrIdForResponse);
-                    mapper.ConfigureMapping<ResponseFromOtherSaga>(m => m.SomeCorrelationId).ToSaga(s => s.CorrIdForResponse);
+                    mapper.ConfigureMapping<InitiateRequestingSaga, Guid>(m => m.Id).ToSaga(s => s.CorrIdForResponse);
+                    mapper.ConfigureMapping<ResponseFromOtherSaga, Guid>(m => m.SomeCorrelationId).ToSaga(s => s.CorrIdForResponse);
                 }
 
                 public class RequestResponseRequestingSagaData : ContainSagaData
@@ -85,9 +85,9 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RequestResponseRespondingSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<RequestToRespondingSaga>(m => m.SomeIdThatTheResponseSagaCanCorrelateBackToUs).ToSaga(s => s.CorrIdForRequest);
+                    mapper.ConfigureMapping<RequestToRespondingSaga, Guid>(m => m.SomeIdThatTheResponseSagaCanCorrelateBackToUs).ToSaga(s => s.CorrIdForRequest);
                     //this line is just needed so we can test the non initiating handler case
-                    mapper.ConfigureMapping<SendReplyFromNonInitiatingHandler>(m => m.SagaIdSoWeCanCorrelate).ToSaga(s => s.CorrIdForRequest);
+                    mapper.ConfigureMapping<SendReplyFromNonInitiatingHandler, Guid>(m => m.SagaIdSoWeCanCorrelate).ToSaga(s => s.CorrIdForRequest);
                 }
 
                 public class RequestResponseRespondingSagaData : ContainSagaData

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_forgetting_to_set_a_corr_property.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_forgetting_to_set_a_corr_property.cs
@@ -22,12 +22,12 @@
                 .Done(c => c.Done || c.Exceptions.Any())
                 .Run();
 
-            Assert.AreEqual(context.SomeId, id.ToString());
+            Assert.AreEqual(context.SomeId, id);
         }
 
         public class Context : ScenarioContext
         {
-            public string SomeId { get; set; }
+            public Guid SomeId { get; set; }
             public bool Done { get; set; }
         }
 
@@ -61,14 +61,14 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<NullCorrPropertySagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                    mapper.ConfigureMapping<StartSagaMessage, Guid>(m => m.SomeId)
                         .ToSaga(s => s.SomeId);
                 }
             }
 
             public class NullCorrPropertySagaData : IContainSagaData
             {
-                public virtual string SomeId { get; set; }
+                public virtual Guid SomeId { get; set; }
                 public virtual Guid Id { get; set; }
                 public virtual string Originator { get; set; }
                 public virtual string OriginalMessageId { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
@@ -79,7 +79,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MessageWithSagaIdSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<MessageWithSagaId>(m => m.DataId)
+                    mapper.ConfigureMapping<MessageWithSagaId, Guid>(m => m.DataId)
                         .ToSaga(s => s.DataId);
                 }
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_completes_the_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_completes_the_saga.cs
@@ -122,11 +122,11 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData10> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                    mapper.ConfigureMapping<StartSagaMessage, Guid>(m => m.SomeId)
                         .ToSaga(s => s.SomeId);
-                    mapper.ConfigureMapping<CompleteSagaMessage>(m => m.SomeId)
+                    mapper.ConfigureMapping<CompleteSagaMessage, Guid>(m => m.SomeId)
                         .ToSaga(s => s.SomeId);
-                    mapper.ConfigureMapping<AnotherMessage>(m => m.SomeId)
+                    mapper.ConfigureMapping<AnotherMessage, Guid>(m => m.SomeId)
                         .ToSaga(s => s.SomeId);
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_should_start_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_that_should_start_a_saga.cs
@@ -36,7 +36,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData03> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                    mapper.ConfigureMapping<StartSagaMessage, string>(m => m.SomeId)
                         .ToSaga(s => s.SomeId);
                 }
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_replies_to_message_published_by_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_replies_to_message_published_by_a_saga.cs
@@ -97,7 +97,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ReplyToPubMsgSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<StartSaga, Guid>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class ReplyToPubMsgSagaData : ContainSagaData

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_has_a_non_empty_constructor.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_has_a_non_empty_constructor.cs
@@ -53,9 +53,9 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData11> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                    mapper.ConfigureMapping<StartSagaMessage, Guid>(m => m.SomeId)
                         .ToSaga(s => s.SomeId);
-                    mapper.ConfigureMapping<OtherMessage>(m => m.SomeId)
+                    mapper.ConfigureMapping<OtherMessage, Guid>(m => m.SomeId)
                         .ToSaga(s => s.SomeId);
                 }
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
@@ -58,7 +58,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaIdChangedSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<StartSaga, Guid>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class SagaIdChangedSagaData : ContainSagaData

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
@@ -49,10 +49,10 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData02> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(m => m.Key)
+                    mapper.ConfigureMapping<StartSagaMessage, string>(m => m.Key)
                         .ToSaga(s => s.KeyValue);
 
-                    mapper.ConfigureMapping<OtherMessage>(m => m.Part1 + "_" + m.Part2)
+                    mapper.ConfigureMapping<OtherMessage, string>(m => m.Part1 + "_" + m.Part2)
                         .ToSaga(s => s.KeyValue);
                 }
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
@@ -91,8 +91,8 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<CantBeFoundSaga1Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.Id).ToSaga(s => s.MessageId);
-                    mapper.ConfigureMapping<MessageToSaga>(m => m.Id).ToSaga(s => s.MessageId);
+                    mapper.ConfigureMapping<StartSaga, Guid>(m => m.Id).ToSaga(s => s.MessageId);
+                    mapper.ConfigureMapping<MessageToSaga, Guid>(m => m.Id).ToSaga(s => s.MessageId);
                 }
             }
 
@@ -117,8 +117,8 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<CantBeFoundSaga2Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.Id).ToSaga(s => s.MessageId);
-                    mapper.ConfigureMapping<MessageToSaga>(m => m.Id).ToSaga(s => s.MessageId);
+                    mapper.ConfigureMapping<StartSaga, Guid>(m => m.Id).ToSaga(s => s.MessageId);
+                    mapper.ConfigureMapping<MessageToSaga, Guid>(m => m.Id).ToSaga(s => s.MessageId);
                 }
             }
 
@@ -191,8 +191,8 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ReceiverWithOrderedSagasSaga1Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.Id).ToSaga(s => s.MessageId);
-                    mapper.ConfigureMapping<MessageToSaga>(m => m.Id).ToSaga(s => s.MessageId);
+                    mapper.ConfigureMapping<StartSaga, Guid>(m => m.Id).ToSaga(s => s.MessageId);
+                    mapper.ConfigureMapping<MessageToSaga, Guid>(m => m.Id).ToSaga(s => s.MessageId);
                 }
             }
 
@@ -220,8 +220,8 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ReceiverWithOrderedSagasSaga2Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.Id).ToSaga(s => s.MessageId);
-                    mapper.ConfigureMapping<MessageToSaga>(m => m.Id).ToSaga(s => s.MessageId);
+                    mapper.ConfigureMapping<StartSaga, Guid>(m => m.Id).ToSaga(s => s.MessageId);
+                    mapper.ConfigureMapping<MessageToSaga, Guid>(m => m.Id).ToSaga(s => s.MessageId);
                 }
             }
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_handle.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_handle.cs
@@ -58,8 +58,8 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TwoSaga1Saga1Data> mapper)
                 {
-                    mapper.ConfigureMapping<MessageSaga1WillHandle>(m => m.DataId).ToSaga(s => s.DataId);
-                    mapper.ConfigureMapping<StartSaga1>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<MessageSaga1WillHandle, Guid>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<StartSaga1, Guid>(m => m.DataId).ToSaga(s => s.DataId);
                 }
             }
 
@@ -83,7 +83,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TwoSaga1Saga2Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga2>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<StartSaga2, Guid>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class TwoSaga1Saga2Data : ContainSagaData

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sending_from_a_saga_timeout.cs
@@ -61,7 +61,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SendFromTimeoutSaga1Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga1>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<StartSaga1, Guid>(m => m.DataId).ToSaga(s => s.DataId);
                 }
             }
 
@@ -83,7 +83,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SendFromTimeoutSaga2Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga2>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<StartSaga2, Guid>(m => m.DataId).ToSaga(s => s.DataId);
                 }
             }
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_base_event_from_other_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_base_event_from_other_saga.cs
@@ -87,7 +87,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaStartedByBaseEventSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<StartSaga, Guid>(m => m.DataId).ToSaga(s => s.DataId);
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_event_from_another_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_event_from_another_saga.cs
@@ -93,7 +93,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<EventFromOtherSaga1Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<StartSaga, Guid>(m => m.DataId).ToSaga(s => s.DataId);
                 }
             }
         }
@@ -142,7 +142,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<EventFromOtherSaga2Data> mapper)
                 {
-                    mapper.ConfigureMapping<SomethingHappenedEvent>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<SomethingHappenedEvent, Guid>(m => m.DataId).ToSaga(s => s.DataId);
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_timeout_hit_not_found_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_timeout_hit_not_found_saga.cs
@@ -56,8 +56,8 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TimeoutHitsNotFoundSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
-                    mapper.ConfigureMapping<SomeOtherMessage>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<StartSaga, Guid>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<SomeOtherMessage, Guid>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class TimeoutHitsNotFoundSagaData : ContainSagaData

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_two_sagas_subscribe_to_the_same_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_two_sagas_subscribe_to_the_same_event.cs
@@ -98,8 +98,8 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySaga1Data> mapper)
                 {
-                    mapper.ConfigureMapping<GroupPendingEvent>(m => m.DataId).ToSaga(s => s.DataId);
-                    mapper.ConfigureMapping<CompleteSaga1Now>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<GroupPendingEvent, Guid>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<CompleteSaga1Now, Guid>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class MySaga1Data : ContainSagaData
@@ -130,8 +130,8 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySaga2Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga2>(m => m.DataId).ToSaga(s => s.DataId);
-                    mapper.ConfigureMapping<GroupPendingEvent>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<StartSaga2, Guid>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<GroupPendingEvent, Guid>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class MySaga2Data : ContainSagaData

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
@@ -60,7 +60,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ChangeCorrPropertySagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                    mapper.ConfigureMapping<StartSagaMessage, Guid>(m => m.SomeId)
                         .ToSaga(s => s.SomeId);
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_ReplyToOriginator.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_ReplyToOriginator.cs
@@ -55,9 +55,9 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RequestingSagaData> mapper)
                 {
-                    mapper.ConfigureMapping<InitiateRequestingSaga>(m => m.SomeCorrelationId)
+                    mapper.ConfigureMapping<InitiateRequestingSaga, Guid>(m => m.SomeCorrelationId)
                         .ToSaga(s => s.CorrIdForResponse);
-                    mapper.ConfigureMapping<AnotherRequest>(m => m.SomeCorrelationId)
+                    mapper.ConfigureMapping<AnotherRequest, Guid>(m => m.SomeCorrelationId)
                         .ToSaga(s => s.CorrIdForResponse);
                 }
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
@@ -46,7 +46,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData01> mapper)
                 {
-                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                    mapper.ConfigureMapping<StartSagaMessage, Guid>(m => m.SomeId)
                         .ToSaga(s => s.SomeId);
                 }
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_contain_saga_data.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_contain_saga_data.cs
@@ -55,7 +55,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySagaData> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga>(m => m.DataId).ToSaga(s => s.DataId);
+                    mapper.ConfigureMapping<StartSaga, Guid>(m => m.DataId).ToSaga(s => s.DataId);
                 }
 
                 public class MySagaData : ContainSagaData

--- a/src/NServiceBus.AcceptanceTests/Sagas/when_receiving_multiple_timeouts.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/when_receiving_multiple_timeouts.cs
@@ -98,7 +98,7 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MultiTimeoutsSaga1Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga1>(m => m.ContextId)
+                    mapper.ConfigureMapping<StartSaga1, Guid>(m => m.ContextId)
                         .ToSaga(s => s.Id);
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/Sagas/when_reply_from_saga_not_found_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/when_reply_from_saga_not_found_handler.cs
@@ -78,9 +78,9 @@
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<NotFoundHandlerSaga1Data> mapper)
                 {
-                    mapper.ConfigureMapping<StartSaga1>(m => m.ContextId)
+                    mapper.ConfigureMapping<StartSaga1, Guid>(m => m.ContextId)
                         .ToSaga(s => s.ContextId);
-                    mapper.ConfigureMapping<MessageToSaga>(m => m.ContextId)
+                    mapper.ConfigureMapping<MessageToSaga, Guid>(m => m.ContextId)
                         .ToSaga(s => s.ContextId);
                 }
             }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -520,7 +520,7 @@ namespace NServiceBus
     public interface ICommand : NServiceBus.IMessage { }
     public interface IConfigureHowToFindSagaWithMessage
     {
-        void ConfigureMapping<TSagaEntity, TMessage>(System.Linq.Expressions.Expression<System.Func<TSagaEntity, object>> sagaEntityProperty, System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty)
+        void ConfigureMapping<TSagaEntity, TMessage, TSagaIdentifier>(System.Linq.Expressions.Expression<System.Func<TSagaEntity, TSagaIdentifier>> sagaEntityProperty, System.Linq.Expressions.Expression<System.Func<TMessage, TSagaIdentifier>> messageProperty)
             where TSagaEntity : NServiceBus.IContainSagaData
         ;
     }
@@ -854,7 +854,7 @@ namespace NServiceBus
     public class SagaPropertyMapper<TSagaData>
         where TSagaData : NServiceBus.IContainSagaData
     {
-        public NServiceBus.ToSagaExpression<TSagaData, TMessage> ConfigureMapping<TMessage>(System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty) { }
+        public NServiceBus.ToSagaExpression<TSagaData, TMessage, TSagaIdentifier> ConfigureMapping<TMessage, TSagaIdentifier>(System.Linq.Expressions.Expression<System.Func<TMessage, TSagaIdentifier>> messageProperty) { }
     }
     public abstract class SatelliteBehavior : NServiceBus.Pipeline.PipelineTerminator<NServiceBus.IIncomingPhysicalMessageContext>
     {
@@ -936,11 +936,11 @@ namespace NServiceBus
     {
         public static NServiceBus.ConventionsBuilder DefiningTimeToBeReceivedAs(this NServiceBus.ConventionsBuilder builder, System.Func<System.Type, System.TimeSpan> retrieveTimeToBeReceived) { }
     }
-    public class ToSagaExpression<TSagaData, TMessage>
+    public class ToSagaExpression<TSagaData, TMessage, TSagaIdentifier>
         where TSagaData : NServiceBus.IContainSagaData
     {
-        public ToSagaExpression(NServiceBus.IConfigureHowToFindSagaWithMessage sagaMessageFindingConfiguration, System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty) { }
-        public void ToSaga(System.Linq.Expressions.Expression<System.Func<TSagaData, object>> sagaEntityProperty) { }
+        public ToSagaExpression(NServiceBus.IConfigureHowToFindSagaWithMessage sagaMessageFindingConfiguration, System.Linq.Expressions.Expression<System.Func<TMessage, TSagaIdentifier>> messageProperty) { }
+        public void ToSaga(System.Linq.Expressions.Expression<System.Func<TSagaData, TSagaIdentifier>> sagaEntityProperty) { }
     }
     public class static TransactionSettingsExtentions
     {

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/AnotherSagaWithUniquePropertyData.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/AnotherSagaWithUniquePropertyData.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
 
         protected override void ConfigureHowToFindSaga(SagaPropertyMapper<AnotherSagaWithUniquePropertyData> mapper)
         {
-            mapper.ConfigureMapping<M1>(m => m.UniqueString).ToSaga(s => s.UniqueString);
+            mapper.ConfigureMapping<M1, string>(m => m.UniqueString).ToSaga(s => s.UniqueString);
         }
     }
 

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/SagaWithUniquePropertyData.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/SagaWithUniquePropertyData.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.SagaPersisters.InMemory.Tests
 
         protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaWithUniquePropertyData> mapper)
         {
-            mapper.ConfigureMapping<M12>(m => m.UniqueString).ToSaga(s => s.UniqueString);
+            mapper.ConfigureMapping<M12, string>(m => m.UniqueString).ToSaga(s => s.UniqueString);
         }
     }
     public class SagaWithUniquePropertyData : ContainSagaData

--- a/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
@@ -135,21 +135,6 @@
         }
 
         [Test]
-        public void ValidateThatMappingOnSagaIdHasTypeGuidForMessageProps()
-        {
-            var ex = Assert.Throws<Exception>(() => SagaMetadata.Create(typeof(SagaWithIdMappedToNonGuidMessageProperty)));
-            Assert.True(ex.Message.Contains(typeof(SomeMessage).Name));
-        }
-
-
-        [Test]
-        public void ValidateThatMappingOnSagaIdHasTypeGuidForMessageFields()
-        {
-            var ex = Assert.Throws<Exception>(() => SagaMetadata.Create(typeof(SagaWithIdMappedToNonGuidMessageField)));
-            Assert.True(ex.Message.Contains(typeof(SomeMessage).Name));
-        }
-
-        [Test]
         public void DetectAndRegisterCustomFindersUsingScanning()
         {
             var availableTypes = new List<Type>
@@ -200,7 +185,7 @@
 
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MyEntity> mapper)
             {
-                mapper.ConfigureMapping<M1>(m => m.UniqueProperty).ToSaga(s => s.UniqueProperty);
+                mapper.ConfigureMapping<M1, int>(m => m.UniqueProperty).ToSaga(s => s.UniqueProperty);
             }
 
             internal class MyEntity : ContainSagaData
@@ -256,7 +241,7 @@
 
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
             {
-                mapper.ConfigureMapping<StartSagaMessage>(m => m.Property)
+                mapper.ConfigureMapping<StartSagaMessage, string>(m => m.Property)
                     .ToSaga(s => s.Property);
             }
 
@@ -288,7 +273,7 @@
 
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
             {
-                mapper.ConfigureMapping<SomeMessage>(m => m.SomeProperty)
+                mapper.ConfigureMapping<SomeMessage, int>(m => m.SomeProperty)
                     .ToSaga(s => s.UniqueProperty);
             }
 
@@ -311,7 +296,7 @@
 
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
             {
-                mapper.ConfigureMapping<SomeMessage>(m => m.SomeProperty)
+                mapper.ConfigureMapping<SomeMessage, int>(m => m.SomeProperty)
                     .ToSaga(s => s.UniqueProperty);
             }
 
@@ -387,9 +372,9 @@
 
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
             {
-                mapper.ConfigureMapping<StartMessage1>(m => m.SomeId)
+                mapper.ConfigureMapping<StartMessage1, string>(m => m.SomeId)
                     .ToSaga(s => s.SomeId);
-                mapper.ConfigureMapping<StartMessage2>(m => m.SomeId)
+                mapper.ConfigureMapping<StartMessage2, string>(m => m.SomeId)
                     .ToSaga(s => s.SomeId);
             }
 
@@ -413,44 +398,6 @@
             }
 
             public class MyTimeout
-            {
-            }
-        }
-
-        class SagaWithIdMappedToNonGuidMessageProperty : Saga<SagaWithIdMappedToNonGuidMessageProperty.SagaData>,
-            IAmStartedByMessages<SomeMessage>
-        {
-            public Task Handle(SomeMessage message, IMessageHandlerContext context)
-            {
-                return Task.FromResult(0);
-            }
-
-            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
-            {
-                mapper.ConfigureMapping<SomeMessage>(m => m.SomeProperty)
-                    .ToSaga(s => s.Id);
-            }
-
-            public class SagaData : ContainSagaData
-            {
-            }
-        }
-
-        class SagaWithIdMappedToNonGuidMessageField : Saga<SagaWithIdMappedToNonGuidMessageField.SagaData>,
-            IAmStartedByMessages<SomeMessageWithField>
-        {
-            public Task Handle(SomeMessageWithField message, IMessageHandlerContext context)
-            {
-                return Task.FromResult(0);
-            }
-
-            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
-            {
-                mapper.ConfigureMapping<SomeMessageWithField>(m => m.SomeProperty)
-                    .ToSaga(s => s.Id);
-            }
-
-            public class SagaData : ContainSagaData
             {
             }
         }

--- a/src/NServiceBus.Core.Tests/Sagas/SagaModelTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaModelTests.cs
@@ -89,8 +89,8 @@ namespace NServiceBus.Core.Tests.Sagas.TypeBasedSagas
 
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MyEntity> mapper)
             {
-                mapper.ConfigureMapping<Message1>(m => m.UniqueProperty).ToSaga(s => s.UniqueProperty);
-                mapper.ConfigureMapping<Message2>(m => m.UniqueProperty).ToSaga(s => s.UniqueProperty);
+                mapper.ConfigureMapping<Message1, int>(m => m.UniqueProperty).ToSaga(s => s.UniqueProperty);
+                mapper.ConfigureMapping<Message2, int>(m => m.UniqueProperty).ToSaga(s => s.UniqueProperty);
             }
 
             public class MyEntity : ContainSagaData

--- a/src/NServiceBus.Core.Tests/Sagas/When_saga_has_multiple_correlated_properties.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/When_saga_has_multiple_correlated_properties.cs
@@ -33,9 +33,9 @@ namespace NServiceBus.Core.Tests.Sagas.TypeBasedSagas
 
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MyEntity> mapper)
             {
-                mapper.ConfigureMapping<Message1>(m=>m.OrderId)
+                mapper.ConfigureMapping<Message1, string>(m=>m.OrderId)
                     .ToSaga(s=>s.OrderId);
-                mapper.ConfigureMapping<Message2>(m => m.LegacyOrderId)
+                mapper.ConfigureMapping<Message2, string>(m => m.LegacyOrderId)
                     .ToSaga(s => s.LegacyOrderId);
             }
 

--- a/src/NServiceBus.Core.Tests/Sagas/When_saga_is_correlated_on_a_unsupported_property_type.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/When_saga_is_correlated_on_a_unsupported_property_type.cs
@@ -27,7 +27,7 @@ namespace NServiceBus.Core.Tests.Sagas.TypeBasedSagas
 
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MyEntity> mapper)
             {
-                mapper.ConfigureMapping<Message1>(m => m.InvalidProp)
+                mapper.ConfigureMapping<Message1, DateTime>(m => m.InvalidProp)
                     .ToSaga(s => s.InvalidProp);
             }
 

--- a/src/NServiceBus.Core/Sagas/IConfigureHowToFindSagaWithMessage.cs
+++ b/src/NServiceBus.Core/Sagas/IConfigureHowToFindSagaWithMessage.cs
@@ -15,6 +15,6 @@ namespace NServiceBus
         /// of the given type, which message property should be matched to 
         /// which saga entity property in the persistent saga store.
         /// </summary>
-        void ConfigureMapping<TSagaEntity, TMessage>(Expression<Func<TSagaEntity, object>> sagaEntityProperty, Expression<Func<TMessage, object>> messageProperty) where TSagaEntity : IContainSagaData;
+        void ConfigureMapping<TSagaEntity, TMessage, TSagaIdentifier>(Expression<Func<TSagaEntity, TSagaIdentifier>> sagaEntityProperty, Expression<Func<TMessage, TSagaIdentifier>> messageProperty) where TSagaEntity : IContainSagaData;
     }
 }

--- a/src/NServiceBus.Core/Sagas/SagaMetadata.cs
+++ b/src/NServiceBus.Core/Sagas/SagaMetadata.cs
@@ -343,7 +343,7 @@ Sagas can only have mappings that correlate on a single saga property. Please us
 
         class SagaMapper : IConfigureHowToFindSagaWithMessage
         {
-            void IConfigureHowToFindSagaWithMessage.ConfigureMapping<TSagaEntity, TMessage>(Expression<Func<TSagaEntity, object>> sagaEntityProperty, Expression<Func<TMessage, object>> messageExpression)
+            void IConfigureHowToFindSagaWithMessage.ConfigureMapping<TSagaEntity, TMessage, TSagaIdentifier>(Expression<Func<TSagaEntity, TSagaIdentifier>> sagaEntityProperty, Expression<Func<TMessage, TSagaIdentifier>> messageExpression)
             {
                 var sagaProp = Reflect<TSagaEntity>.GetProperty(sagaEntityProperty, true);
 
@@ -362,7 +362,7 @@ Sagas can only have mappings that correlate on a single saga property. Please us
                 });
             }
 
-            static void ValidateMapping<TMessage>(Expression<Func<TMessage, object>> messageExpression, PropertyInfo sagaProp)
+            static void ValidateMapping<TMessage, TSagaIdentifier>(Expression<Func<TMessage, TSagaIdentifier>> messageExpression, PropertyInfo sagaProp)
             {
                 if (sagaProp.Name.ToLower() != "id")
                 {
@@ -417,7 +417,7 @@ Sagas can only have mappings that correlate on a single saga property. Please us
             }
 
             // ReSharper disable once UnusedParameter.Local
-            void ThrowIfNotPropertyLambdaExpression<TSagaEntity>(Expression<Func<TSagaEntity, object>> expression, PropertyInfo propertyInfo)
+            void ThrowIfNotPropertyLambdaExpression<TSagaEntity, TSagaIdentifier>(Expression<Func<TSagaEntity, TSagaIdentifier>> expression, PropertyInfo propertyInfo)
             {
                 if (propertyInfo == null)
                 {

--- a/src/NServiceBus.Core/Sagas/SagaPropertyMapper.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPropertyMapper.cs
@@ -17,15 +17,16 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Specify how to map between <typeparamref name="TSagaData"/> and <typeparamref name="TMessage"/>.
+        /// Specify how to map between <typeparamref name="TSagaData"/> and <typeparamref name="TMessage"/> with identifier type <typeparamref name="TSagaIdentifier"/>.
         /// </summary>
         /// <typeparam name="TMessage">The message type to map to.</typeparam>
+        /// <typeparam name="TSagaIdentifier">The type used to identify the saga.</typeparam>
         /// <param name="messageProperty">An <see cref="Expression{TDelegate}"/> that represents the message.</param>
-        /// <returns>A <see cref="ToSagaExpression{TSagaData,TMessage}"/> that provides the fluent chained <see cref="ToSagaExpression{TSagaData,TMessage}.ToSaga"/> to link <paramref name="messageProperty"/> with <typeparamref name="TSagaData"/>.</returns>
-        public ToSagaExpression<TSagaData, TMessage> ConfigureMapping<TMessage>(Expression<Func<TMessage, object>> messageProperty)
+        /// <returns>A <see cref="ToSagaExpression{TSagaData,TMessage,TSagaIdentifier}"/> that provides the fluent chained <see cref="ToSagaExpression{TSagaData,TMessage,TSagaIdentifier}.ToSaga"/> to link <paramref name="messageProperty"/> with <typeparamref name="TSagaData"/>.</returns>
+        public ToSagaExpression<TSagaData, TMessage, TSagaIdentifier> ConfigureMapping<TMessage, TSagaIdentifier>(Expression<Func<TMessage, TSagaIdentifier>> messageProperty)
         {
             Guard.AgainstNull(nameof(messageProperty), messageProperty);
-            return new ToSagaExpression<TSagaData, TMessage>(sagaMessageFindingConfiguration, messageProperty);
+            return new ToSagaExpression<TSagaData, TMessage, TSagaIdentifier>(sagaMessageFindingConfiguration, messageProperty);
         }
     }
 }

--- a/src/NServiceBus.Core/Sagas/ToSagaExpression.cs
+++ b/src/NServiceBus.Core/Sagas/ToSagaExpression.cs
@@ -6,15 +6,15 @@ namespace NServiceBus
     /// <summary>
     /// Allows a more fluent way to map sagas.
     /// </summary>
-    public class ToSagaExpression<TSagaData, TMessage> where TSagaData : IContainSagaData
+    public class ToSagaExpression<TSagaData, TMessage, TSagaIdentifier> where TSagaData : IContainSagaData
     {
         IConfigureHowToFindSagaWithMessage sagaMessageFindingConfiguration;
-        Expression<Func<TMessage, object>> messageProperty;
+        Expression<Func<TMessage, TSagaIdentifier>> messageProperty;
 
         /// <summary>
-        /// Initializes a new instance of <see cref="ToSagaExpression{TSagaData,TMessage}"/>.
+        /// Initializes a new instance of <see cref="ToSagaExpression{TSagaData,TMessage,TSagaIdentifier}"/>.
         /// </summary>
-        public ToSagaExpression(IConfigureHowToFindSagaWithMessage sagaMessageFindingConfiguration, Expression<Func<TMessage, object>> messageProperty)
+        public ToSagaExpression(IConfigureHowToFindSagaWithMessage sagaMessageFindingConfiguration, Expression<Func<TMessage, TSagaIdentifier>> messageProperty)
         {
             Guard.AgainstNull(nameof(sagaMessageFindingConfiguration), sagaMessageFindingConfiguration);
             Guard.AgainstNull(nameof(messageProperty), messageProperty);
@@ -27,7 +27,7 @@ namespace NServiceBus
         /// Defines the property on the saga data to which the message property should be mapped.
         /// </summary>
         /// <param name="sagaEntityProperty">The property to map.</param>
-        public void ToSaga(Expression<Func<TSagaData, object>> sagaEntityProperty)
+        public void ToSaga(Expression<Func<TSagaData, TSagaIdentifier>> sagaEntityProperty)
         {
             Guard.AgainstNull(nameof(sagaEntityProperty), sagaEntityProperty);
             sagaMessageFindingConfiguration.ConfigureMapping(sagaEntityProperty, messageProperty);

--- a/src/NServiceBus.Core/Utils/Reflection/Reflect.cs
+++ b/src/NServiceBus.Core/Utils/Reflection/Reflect.cs
@@ -25,7 +25,7 @@ namespace NServiceBus
                 .ToList();
         }
 
-        public static PropertyInfo GetProperty(Expression<Func<TTarget, object>> property, bool checkForSingleDot)
+        public static PropertyInfo GetProperty<TSagaIdentifier>(Expression<Func<TTarget, TSagaIdentifier>> property, bool checkForSingleDot)
         {
             return GetMemberInfo(property, checkForSingleDot) as PropertyInfo;
         }


### PR DESCRIPTION
This change allows for compile-time checking of Saga types used to find
and load sagas. The type is passed through to the ToSagaExpression class
as well so that the type information is enforced.

Connects to https://github.com/Particular/PlatformDevelopment/issues/469
Connects to https://github.com/Particular/NServiceBus/issues/3291