### PR TITLE
Removed Container binding of FeaturesReport and made it internal

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1480,22 +1480,6 @@ namespace NServiceBus.Features
         public void RegisterStartupTask<TTask>(System.Func<NServiceBus.ObjectBuilder.IBuilder, TTask> startupTaskFactory)
             where TTask : NServiceBus.Features.FeatureStartupTask { }
     }
-    public class FeatureDiagnosticData
-    {
-        public FeatureDiagnosticData() { }
-        public bool Active { get; }
-        public System.Collections.Generic.IReadOnlyList<System.Collections.Generic.IReadOnlyList<string>> Dependencies { get; }
-        public bool DependenciesAreMeet { get; set; }
-        public bool EnabledByDefault { get; }
-        public string Name { get; }
-        public NServiceBus.Features.PrerequisiteStatus PrerequisiteStatus { get; }
-        public System.Collections.Generic.IReadOnlyList<string> StartupTasks { get; }
-        public string Version { get; }
-    }
-    public class FeaturesReport
-    {
-        public System.Collections.Generic.IReadOnlyList<NServiceBus.Features.FeatureDiagnosticData> Features { get; }
-    }
     public abstract class FeatureStartupTask
     {
         protected FeatureStartupTask() { }
@@ -1552,11 +1536,6 @@ namespace NServiceBus.Features
     public class Outbox : NServiceBus.Features.Feature
     {
         protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
-    }
-    public class PrerequisiteStatus
-    {
-        public bool IsSatisfied { get; }
-        public System.Collections.Generic.List<string> Reasons { get; }
     }
     public class Sagas : NServiceBus.Features.Feature
     {

--- a/src/NServiceBus.Core/Features/FeatureDiagnosticData.cs
+++ b/src/NServiceBus.Core/Features/FeatureDiagnosticData.cs
@@ -2,49 +2,22 @@ namespace NServiceBus.Features
 {
     using System.Collections.Generic;
 
-    /// <summary>
-    ///     <see cref="Feature" /> diagnostics data.
-    /// </summary>
-    public class FeatureDiagnosticData
+    class FeatureDiagnosticData
     {
-        /// <summary>
-        ///     Gets the <see cref="Feature" /> name.
-        /// </summary>
         public string Name { get; internal set; }
 
-        /// <summary>
-        ///     Gets whether <see cref="Feature" /> is set to be enabled by default.
-        /// </summary>
         public bool EnabledByDefault { get; internal set; }
 
-        /// <summary>
-        ///     Gets the status of the <see cref="Feature" />.
-        /// </summary>
         public bool Active { get; internal set; }
 
-        /// <summary>
-        ///     Gets the status of the prerequisites for this <see cref="Feature" />.
-        /// </summary>
         public PrerequisiteStatus PrerequisiteStatus { get; internal set; }
 
-        /// <summary>
-        ///     Gets the list of <see cref="Feature" />s that this <see cref="Feature" /> depends on.
-        /// </summary>
         public IReadOnlyList<IReadOnlyList<string>> Dependencies { get; internal set; }
 
-        /// <summary>
-        ///     Gets the <see cref="Feature" /> version.
-        /// </summary>
         public string Version { get; internal set; }
 
-        /// <summary>
-        ///     Gets the <see cref="Feature" /> startup tasks.
-        /// </summary>
         public IReadOnlyList<string> StartupTasks { get; internal set; }
 
-        /// <summary>
-        ///     Gets whether all dependant <see cref="Feature" />s are activated.
-        /// </summary>
         public bool DependenciesAreMeet { get; set; }
     }
 }

--- a/src/NServiceBus.Core/Features/FeaturesReport.cs
+++ b/src/NServiceBus.Core/Features/FeaturesReport.cs
@@ -2,19 +2,13 @@ namespace NServiceBus.Features
 {
     using System.Collections.Generic;
 
-    /// <summary>
-    ///     Provides diagnostics data about <see cref="Feature" />s.
-    /// </summary>
-    public class FeaturesReport
+    class FeaturesReport
     {
         internal FeaturesReport(IReadOnlyList<FeatureDiagnosticData> data)
         {
             Features = data;
         }
 
-        /// <summary>
-        ///     List of <see cref="Feature" />s diagnostic data.
-        /// </summary>
         public IReadOnlyList<FeatureDiagnosticData> Features { get; private set; }
     }
 }

--- a/src/NServiceBus.Core/Features/PrerequisiteStatus.cs
+++ b/src/NServiceBus.Core/Features/PrerequisiteStatus.cs
@@ -2,10 +2,7 @@ namespace NServiceBus.Features
 {
     using System.Collections.Generic;
 
-    /// <summary>
-    /// The prerequisite status of a feature.
-    /// </summary>
-    public class PrerequisiteStatus
+    class PrerequisiteStatus
     {
         internal PrerequisiteStatus()
         {
@@ -13,14 +10,8 @@ namespace NServiceBus.Features
             IsSatisfied = true;
         }
 
-        /// <summary>
-        /// True if all prerequisites for the feature is satisfied.
-        /// </summary>
         public bool IsSatisfied { get; private set; }
 
-        /// <summary>
-        /// The list of reason why the prerequisites are not fullfilled if applicable.
-        /// </summary>
         public List<string> Reasons { get; }
 
         internal void ReportFailure(string description)

--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -46,8 +46,6 @@ namespace NServiceBus
 
             pipelineConfiguration.RegisterBehaviorsInContainer(settings, container);
 
-            container.RegisterSingleton(featureStats);
-
             DisplayDiagnosticsForFeatures.Run(featureStats);
             WireUpInstallers(concreteTypes);
 


### PR DESCRIPTION
@andreasohlund @tmasternak @SzymonPobiega and I were discussing the usefulness of `FeaturesReport`. We came to the conclusion that since we expose the feature stats on the logger we don't actually need to expose the `FeaturesReport` as a public class and register it on the container.

### Associated doco PR

https://github.com/Particular/docs.particular.net/pull/1053