### PR TITLE
Task optimizations

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/FailTestOnErrorMessageFeature.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/FailTestOnErrorMessageFeature.cs
@@ -35,13 +35,13 @@
             protected override Task OnStart(IBusSession session)
             {
                 notifications.Errors.MessageSentToErrorQueue += OnMessageSentToErrorQueue;
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             protected override Task OnStop(IBusSession session)
             {
                 notifications.Errors.MessageSentToErrorQueue -= OnMessageSentToErrorQueue;
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             void OnMessageSentToErrorQueue(object sender, FailedMessage failedMessage)

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_told_to_scan_app_domain.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_told_to_scan_app_domain.cs
@@ -28,7 +28,7 @@ namespace NServiceBus.Core.Tests.AssemblyScanner
         {
             public Task Handle(string message, IMessageHandlerContext context)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 

--- a/src/NServiceBus.Core.Tests/Causation/AttachCausationHeadersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Causation/AttachCausationHeadersBehaviorTests.cs
@@ -17,7 +17,7 @@
             var behavior = new AttachCausationHeadersBehavior();
             var context = InitializeContext();
 
-            await behavior.Invoke(context, ()=> Task.FromResult(0));
+            await behavior.Invoke(context, ()=> TaskEx.CompletedTask);
 
             Assert.AreNotEqual(Guid.Empty.ToString(), context.Headers[Headers.ConversationId]);
         }
@@ -33,7 +33,7 @@
             var transportMessage = new IncomingMessage("xyz", new Dictionary<string, string> { { Headers.ConversationId, incomingConversationId } }, Stream.Null);
             context.Extensions.Set(transportMessage);
 
-            await behavior.Invoke(context, () => Task.FromResult(0));
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
 
             Assert.AreEqual(incomingConversationId, context.Headers[Headers.ConversationId]);
         }
@@ -47,7 +47,7 @@
             var context = InitializeContext();
 
             
-            await behavior.Invoke(context, () => Task.FromResult(0));
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
 
             Assert.AreEqual(userConversationId, context.Headers[Headers.ConversationId]);
         }
@@ -61,7 +61,7 @@
 
             context.Extensions.Set(new IncomingMessage("the message id", new Dictionary<string, string>(), Stream.Null));
 
-            await behavior.Invoke(context, () => Task.FromResult(0));
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
 
             Assert.AreEqual("the message id", context.Headers[Headers.RelatedTo]);
         }

--- a/src/NServiceBus.Core.Tests/Config/When_no_custom_configuration_source_is_specified.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_no_custom_configuration_source_is_specified.cs
@@ -40,12 +40,12 @@ namespace NServiceBus.Core.Tests.Config
                 protected override Task OnStart(IBusSession session)
                 {
                     Assert.AreEqual(settings.GetConfigSection<TestConfigurationSection>().TestSetting, "test");
-                    return Task.FromResult(0);
+                    return TaskEx.CompletedTask;
                 }
 
                 protected override Task OnStop(IBusSession session)
                 {
-                    return TaskEx.Completed;
+                    return TaskEx.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Core.Tests/Config/When_users_override_the_configuration_source.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_users_override_the_configuration_source.cs
@@ -43,12 +43,12 @@ namespace NServiceBus.Core.Tests.Config
                 {
                     var section = settings.GetConfigSection<TestConfigurationSection>();
                     Assert.AreEqual(section.TestSetting, "TestValue");
-                    return Task.FromResult(0);
+                    return TaskEx.CompletedTask;
                 }
 
                 protected override Task OnStop(IBusSession session)
                 {
-                    return TaskEx.Completed;
+                    return TaskEx.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Core.Tests/DataBus/InMemoryDataBus.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/InMemoryDataBus.cs
@@ -47,7 +47,7 @@
         public Task Start()
         {
             //no-op
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         //used for test purposes

--- a/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_incoming_messages.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_incoming_messages.cs
@@ -52,7 +52,7 @@ namespace NServiceBus.Core.Tests.DataBus
                             {"NServiceBus.DataBus." + propertyKey, databusKey}
                         },
                         null),
-                    () => Task.FromResult(0));
+                    () => TaskEx.CompletedTask);
             }
 
             var instance = (MessageWithDataBusProperty)message.Instance;

--- a/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_null_properties.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_null_properties.cs
@@ -25,7 +25,7 @@ namespace NServiceBus.Core.Tests.DataBus
                 new BinaryFormatter().Serialize(stream, "test");
                 stream.Position = 0;
 
-                await sendBehavior.Invoke(context, () => Task.FromResult(0));            
+                await sendBehavior.Invoke(context, () => TaskEx.CompletedTask);            
             }
         }
 

--- a/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_outgoing_messages.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_outgoing_messages.cs
@@ -31,7 +31,7 @@ namespace NServiceBus.Core.Tests.DataBus
                 DataBusSerializer = new DefaultDataBusSerializer(),
             };
 
-            await sendBehavior.Invoke(context, () => Task.FromResult(0));
+            await sendBehavior.Invoke(context, () => TaskEx.CompletedTask);
 
             Assert.AreEqual(TimeSpan.MaxValue, fakeDatabus.TTBRUsed);
         }
@@ -57,7 +57,7 @@ namespace NServiceBus.Core.Tests.DataBus
                DataBusSerializer = new DefaultDataBusSerializer(),
            };
 
-           await sendBehavior.Invoke(context, () => Task.FromResult(0));
+           await sendBehavior.Invoke(context, () => TaskEx.CompletedTask);
 
            Assert.AreEqual(TimeSpan.FromMinutes(1),fakeDatabus.TTBRUsed);
         }

--- a/src/NServiceBus.Core.Tests/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehaviorTests.cs
@@ -24,7 +24,7 @@
 
             context.AddDeliveryConstraint(new DelayDeliveryWith(delay));
 
-            await behavior.Invoke(context, () => Task.FromResult(0));
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
 
             Assert.AreEqual("tm", ((UnicastAddressTag)context.RoutingStrategies.First().Apply(new Dictionary<string, string>())).Destination);
 
@@ -43,7 +43,7 @@
             var context = new RoutingContext(message, new MulticastRoutingStrategy(null), null);
             context.AddDeliveryConstraint(new DelayDeliveryWith(delay));
 
-            var ex = Assert.Throws<Exception>(async () => await behavior.Invoke(context, () => Task.FromResult(0)));
+            var ex = Assert.Throws<Exception>(async () => await behavior.Invoke(context, () => TaskEx.CompletedTask));
 
             Assert.True(ex.Message.Contains("unicast routing"));
         }
@@ -60,7 +60,7 @@
             context.AddDeliveryConstraint(new DelayDeliveryWith(delay));
             context.AddDeliveryConstraint(new DiscardIfNotReceivedBefore(TimeSpan.FromSeconds(30)));
 
-            var ex = Assert.Throws<Exception>(async () => await behavior.Invoke(context, () => Task.FromResult(0)));
+            var ex = Assert.Throws<Exception>(async () => await behavior.Invoke(context, () => TaskEx.CompletedTask));
 
             Assert.True(ex.Message.Contains("TimeToBeReceived"));
         }
@@ -75,7 +75,7 @@
             var context = new RoutingContext(message, new UnicastRoutingStrategy("target"), null);
             context.AddDeliveryConstraint(new DelayDeliveryWith(delay));
 
-            await behavior.Invoke(context, () => Task.FromResult(0));
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
 
             Assert.LessOrEqual(DateTimeExtensions.ToUtcDateTime(message.Headers[TimeoutManagerHeaders.Expire]), DateTime.UtcNow + delay);
         }
@@ -91,7 +91,7 @@
             var context = new RoutingContext(message, new UnicastRoutingStrategy("target"), null);
             context.AddDeliveryConstraint(new DoNotDeliverBefore(at));
 
-            await behavior.Invoke(context, () => Task.FromResult(0));
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
 
             Assert.AreEqual(message.Headers[TimeoutManagerHeaders.Expire], DateTimeExtensions.ToWireFormattedString(at));
         }

--- a/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/DispatchTimeoutBehaviorTest.cs
+++ b/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/DispatchTimeoutBehaviorTest.cs
@@ -21,7 +21,7 @@
             var timeoutData = CreateTimeout();
             await timeoutPersister.Add(timeoutData, null);
 
-            await behavior.Invoke(CreateContext(timeoutData.Id), context => TaskEx.Completed);
+            await behavior.Invoke(CreateContext(timeoutData.Id), context => TaskEx.CompletedTask);
 
             var result = await timeoutPersister.Peek(timeoutData.Id, null);
             Assert.Null(result);
@@ -34,7 +34,7 @@
             var timeoutPersister = new InMemoryTimeoutPersister();
             var behavior = new DispatchTimeoutBehavior(messageDispatcher, timeoutPersister, TransportTransactionMode.TransactionScope);
 
-            await behavior.Invoke(CreateContext(Guid.NewGuid().ToString()), context => TaskEx.Completed);
+            await behavior.Invoke(CreateContext(Guid.NewGuid().ToString()), context => TaskEx.CompletedTask);
 
             Assert.AreEqual(0, messageDispatcher.OutgoingTransportOperations.UnicastTransportOperations.Count());
         }
@@ -48,7 +48,7 @@
             var timeoutData = CreateTimeout();
             await timeoutPersister.Add(timeoutData, null);
 
-            Assert.Throws<Exception>(async () => await behavior.Invoke(CreateContext(timeoutData.Id), context => TaskEx.Completed));
+            Assert.Throws<Exception>(async () => await behavior.Invoke(CreateContext(timeoutData.Id), context => TaskEx.CompletedTask));
 
             var result = await timeoutPersister.Peek(timeoutData.Id, null);
             Assert.NotNull(result);
@@ -66,7 +66,7 @@
 
             var behavior = new DispatchTimeoutBehavior(messageDispatcher, timeoutPersister, TransportTransactionMode.TransactionScope);
 
-            Assert.Throws<Exception>(async () => await behavior.Invoke(CreateContext(Guid.NewGuid().ToString()), context => TaskEx.Completed));
+            Assert.Throws<Exception>(async () => await behavior.Invoke(CreateContext(Guid.NewGuid().ToString()), context => TaskEx.CompletedTask));
         }
 
         [Test]
@@ -78,7 +78,7 @@
             var timeoutData = CreateTimeout();
             await timeoutPersister.Add(timeoutData, null);
 
-            await behavior.Invoke(CreateContext(timeoutData.Id), context => TaskEx.Completed);
+            await behavior.Invoke(CreateContext(timeoutData.Id), context => TaskEx.CompletedTask);
 
             var transportOperation = messageDispatcher.OutgoingTransportOperations.UnicastTransportOperations.Single();
             Assert.AreEqual(DispatchConsistency.Default, transportOperation.RequiredDispatchConsistency);
@@ -95,7 +95,7 @@
             var timeoutData = CreateTimeout();
             await timeoutPersister.Add(timeoutData, null);
 
-            await behavior.Invoke(CreateContext(timeoutData.Id), context => TaskEx.Completed);
+            await behavior.Invoke(CreateContext(timeoutData.Id), context => TaskEx.CompletedTask);
 
             var transportOperation = messageDispatcher.OutgoingTransportOperations.UnicastTransportOperations.Single();
             Assert.AreEqual(DispatchConsistency.Isolated, transportOperation.RequiredDispatchConsistency);
@@ -129,7 +129,7 @@
             public Task Dispatch(TransportOperations outgoingMessages, ContextBag context)
             {
                 OutgoingTransportOperations = outgoingMessages;
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -150,7 +150,7 @@
         {
             public Task Add(TimeoutData timeout, ContextBag context)
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             public Task<bool> TryRemove(string timeoutId, ContextBag context)
@@ -165,7 +165,7 @@
 
             public Task RemoveTimeoutBy(Guid sagaId, ContextBag context)
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             public Func<string, ContextBag, bool> OnTryRemove { get; set; } = (id, bag) => true;

--- a/src/NServiceBus.Core.Tests/Fakes/FakeHandlingContext.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/FakeHandlingContext.cs
@@ -32,7 +32,7 @@
                     DeferedMessage = message;
                 }
             }
-            return Task.FromResult(0);
+            return TaskEx.CompletedTask;
         }
 
         public Task Send<T>(Action<T> messageConstructor, SendOptions options)

--- a/src/NServiceBus.Core.Tests/Faults/ForwardFaultsToErrorQueueTests.cs
+++ b/src/NServiceBus.Core.Tests/Faults/ForwardFaultsToErrorQueueTests.cs
@@ -133,13 +133,13 @@ namespace NServiceBus.Core.Tests
 
                 Destination = context.ErrorQueueAddress;
                 MessageSent = context.Message;
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
         class FakeCriticalError : CriticalError
         {
-            public FakeCriticalError() : base(_ => TaskEx.Completed)
+            public FakeCriticalError() : base(_ => TaskEx.CompletedTask)
             {
             }
 

--- a/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
@@ -67,13 +67,13 @@
                 protected override Task OnStart(IBusSession session)
                 {
                     Started = true;
-                    return Task.FromResult(0);
+                    return TaskEx.CompletedTask;
                 }
 
                 protected override Task OnStop(IBusSession session)
                 {
                     Stopped = true;
-                    return Task.FromResult(0);
+                    return TaskEx.CompletedTask;
                 }
 
                 public static bool Started { get; private set; }
@@ -97,12 +97,12 @@
             {
                 protected override Task OnStart(IBusSession session)
                 {
-                    return Task.FromResult(0);
+                    return TaskEx.CompletedTask;
                 }
 
                 protected override Task OnStop(IBusSession session)
                 {
-                    return TaskEx.Completed;
+                    return TaskEx.CompletedTask;
                 }
 
                 public void Dispose()

--- a/src/NServiceBus.Core.Tests/Pipeline/BehaviorTypeCheckerTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/BehaviorTypeCheckerTests.cs
@@ -73,7 +73,7 @@
         {
             public override Task Invoke(IRootContext context, Func<Task> next)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -81,7 +81,7 @@
         {
             public override Task Invoke(IBehaviorContext context, Func<Task> next)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -89,7 +89,7 @@
         {
             public override Task Invoke(IIncomingContext context, Func<Task> next)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -97,7 +97,7 @@
         {
             public override Task Invoke(IOutgoingContext context, Func<Task> next)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -105,7 +105,7 @@
         {
             public Task Invoke(IAuditContext context, Func<RootContext, Task> stage)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -113,7 +113,7 @@
         {
             public override Task Invoke(IAuditContext context, Func<Task> next)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -121,7 +121,7 @@
         {
             public override Task Invoke(RootContext context, Func<Task> next)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -129,7 +129,7 @@
         {
             public override Task Invoke(IRootContext context, Func<Task> next)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 

--- a/src/NServiceBus.Core.Tests/Pipeline/HandlerTransactionScopeWrapperBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/HandlerTransactionScopeWrapperBehaviorTests.cs
@@ -17,7 +17,7 @@
                 IsolationLevel = IsolationLevel.Serializable
             }, TransactionScopeAsyncFlowOption.Enabled))
             {
-                await behavior.Invoke(null, () => Task.FromResult(0));
+                await behavior.Invoke(null, () => TaskEx.CompletedTask);
             }
         }
 
@@ -29,7 +29,7 @@
             await behavior.Invoke(null, () =>
             {
                 Assert.NotNull(Transaction.Current);
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             });
         }
     }

--- a/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
@@ -24,7 +24,7 @@
             var behaviorContext = CreateBehaviorContext(messageHandler);
             AssociateSagaWithMessage(saga, behaviorContext);
 
-            await terminator.Invoke(behaviorContext, _ => TaskEx.Completed);
+            await terminator.Invoke(behaviorContext, _ => TaskEx.CompletedTask);
 
             Assert.IsTrue(handlerInvoked);
         }
@@ -41,7 +41,7 @@
             var sagaInstance = AssociateSagaWithMessage(saga, behaviorContext);
             sagaInstance.MarkAsNotFound();
 
-            await terminator.Invoke(behaviorContext, _ => TaskEx.Completed);
+            await terminator.Invoke(behaviorContext, _ => TaskEx.CompletedTask);
 
             Assert.IsFalse(handlerInvoked);
         }
@@ -57,7 +57,7 @@
             var sagaInstance = AssociateSagaWithMessage(new FakeSaga(), behaviorContext);
             sagaInstance.MarkAsNotFound();
 
-            await terminator.Invoke(behaviorContext, _ => TaskEx.Completed);
+            await terminator.Invoke(behaviorContext, _ => TaskEx.CompletedTask);
 
             Assert.IsTrue(handlerInvoked);
         }
@@ -71,7 +71,7 @@
             var messageHandler = CreateMessageHandler((i, m, ctx) => handlerInvoked = true, new FakeMessageHandler());
             var behaviorContext = CreateBehaviorContext(messageHandler);
 
-            await terminator.Invoke(behaviorContext, _ => TaskEx.Completed);
+            await terminator.Invoke(behaviorContext, _ => TaskEx.CompletedTask);
 
             Assert.IsTrue(handlerInvoked);
         }
@@ -84,7 +84,7 @@
             var messageHandler = CreateMessageHandler((i, m, ctx) => receivedMessage = m, new FakeMessageHandler());
             var behaviorContext = CreateBehaviorContext(messageHandler);
 
-            await terminator.Invoke(behaviorContext, _ => TaskEx.Completed);
+            await terminator.Invoke(behaviorContext, _ => TaskEx.CompletedTask);
 
             Assert.AreSame(behaviorContext.MessageBeingHandled, receivedMessage);
         }
@@ -97,7 +97,7 @@
             var messageHandler = CreateMessageHandler((i, m, ctx) => { }, new FakeMessageHandler());
             var behaviorContext = CreateBehaviorContext(messageHandler);
 
-            await terminator.Invoke(behaviorContext, _ => TaskEx.Completed);
+            await terminator.Invoke(behaviorContext, _ => TaskEx.CompletedTask);
 
             Assert.IsFalse(behaviorContext.Extensions.Get<InvokeHandlerTerminator.State>().ScopeWasPresent);
         }
@@ -112,7 +112,7 @@
 
             using (var scope = new TransactionScope())
             {
-                await terminator.Invoke(behaviorContext, _ => TaskEx.Completed);
+                await terminator.Invoke(behaviorContext, _ => TaskEx.CompletedTask);
                 scope.Complete();
             }
 
@@ -131,7 +131,7 @@
             var messageHandler = new MessageHandler((instance, message, handlerContext) =>
             {
                 invocationAction(instance, message, handlerContext);
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }, handlerInstance.GetType())
             {
                 Instance = handlerInstance

--- a/src/NServiceBus.Core.Tests/Recoverability/SecondLevelRetries/SecondLevelRetriesTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/SecondLevelRetries/SecondLevelRetriesTests.cs
@@ -160,7 +160,7 @@
         public Task Invoke(IRoutingContext context)
         {
             RoutingContext = context;
-            return Task.FromResult(0);
+            return TaskEx.CompletedTask;
         }
     }
 

--- a/src/NServiceBus.Core.Tests/Reliability/Outbox/FakeOutboxStorage.cs
+++ b/src/NServiceBus.Core.Tests/Reliability/Outbox/FakeOutboxStorage.cs
@@ -24,13 +24,13 @@
         public Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag options)
         {
             StoredMessage = message;
-            return Task.FromResult(0);
+            return TaskEx.CompletedTask;
         }
 
         public Task SetAsDispatched(string messageId, ContextBag options)
         {
             WasDispatched = true;
-            return Task.FromResult(0);
+            return TaskEx.CompletedTask;
         }
 
         public Task<OutboxTransaction> BeginTransaction(ContextBag context)

--- a/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageProcessingConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageProcessingConnectorTests.cs
@@ -126,7 +126,7 @@
 
         async Task Invoke(ITransportReceiveContext context)
         {
-            await behavior.Invoke(context, c => TaskEx.Completed).ConfigureAwait(false);
+            await behavior.Invoke(context, c => TaskEx.CompletedTask).ConfigureAwait(false);
         }
 
         FakeBatchPipeline fakeBatchPipeline;
@@ -160,7 +160,7 @@
             {
                 TransportOperations = context.Operations;
 
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
         }
     }

--- a/src/NServiceBus.Core.Tests/Routing/ApplyReplyToAddressBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/ApplyReplyToAddressBehaviorTests.cs
@@ -21,7 +21,7 @@
                 new RoutingStrategy[] { },
                 new RootContext(null, null));
 
-            await behavior.Invoke(context, () => Task.FromResult(0));
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
 
             Assert.AreEqual("MyAddress", context.Headers[Headers.ReplyToAddress]);
         }

--- a/src/NServiceBus.Core.Tests/Routing/DetermineRouteForPublishBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DetermineRouteForPublishBehaviorTests.cs
@@ -20,7 +20,7 @@
             await behavior.Invoke(context, _ =>
             {
                 addressTag = (MulticastAddressTag)_.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             });
 
             Assert.AreEqual(typeof(MyEvent), addressTag.MessageType);

--- a/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
@@ -37,7 +37,7 @@
             await behavior.Invoke(context, c =>
             {
                 addressTag = (UnicastAddressTag)c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             });
 
             Assert.AreEqual("ReplyAddressOfIncomingMessage", addressTag.Destination);
@@ -59,7 +59,7 @@
                         new MemoryStream()), null, new CancellationTokenSource(),
                     new RootContext(null, null)));
 
-            var ex = Assert.Throws<Exception>(async () => await behavior.Invoke(context, _ => Task.FromResult(0)));
+            var ex = Assert.Throws<Exception>(async () => await behavior.Invoke(context, _ => TaskEx.CompletedTask));
 
             Assert.True(ex.Message.Contains(typeof(MyReply).FullName));
         }
@@ -81,7 +81,7 @@
             await behavior.Invoke(context, c =>
             {
                 addressTag = (UnicastAddressTag)c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             });
 
             Assert.AreEqual("CustomReplyToAddress", addressTag.Destination);

--- a/src/NServiceBus.Core.Tests/Routing/DetermineRouteForSendBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DetermineRouteForSendBehaviorTests.cs
@@ -28,7 +28,7 @@
             await behavior.Invoke(context, c =>
             {
                 addressTag = (UnicastAddressTag) c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             });
 
             Assert.AreEqual("destination endpoint", addressTag.Destination);
@@ -48,7 +48,7 @@
             await behavior.Invoke(context, c =>
             {
                 addressTag = (UnicastAddressTag) c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             });
             
             Assert.AreEqual("MyLocalAddress", addressTag.Destination);
@@ -70,7 +70,7 @@
             await behavior.Invoke(context, c =>
             {
                 addressTag = (UnicastAddressTag) c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             });
             
             Assert.AreEqual("MappedDestination", addressTag.Destination);
@@ -89,7 +89,7 @@
 
             var context = CreateContext(options, new MessageWithoutRouting());
 
-            var ex = Assert.Throws<Exception>(async() => await behavior.Invoke(context, _ => Task.FromResult(0)));
+            var ex = Assert.Throws<Exception>(async() => await behavior.Invoke(context, _ => TaskEx.CompletedTask));
 
             Assert.True(ex.Message.Contains("No destination specified"));
         }

--- a/src/NServiceBus.Core.Tests/Routing/FileRoutingTableTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/FileRoutingTableTests.cs
@@ -135,7 +135,7 @@
 
             public Task Stop()
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
     }

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
@@ -26,7 +26,7 @@
         [Test]
         public async Task Should_Dispatch_for_all_publishers()
         {
-            await terminator.Invoke(new SubscribeContext(new FakeContext(), typeof(object), new SubscribeOptions()), c => Task.FromResult(0));
+            await terminator.Invoke(new SubscribeContext(new FakeContext(), typeof(object), new SubscribeOptions()), c => TaskEx.CompletedTask);
 
             Assert.AreEqual(1, dispatcher.DispatchedTransportOperations.Count);
         }
@@ -40,7 +40,7 @@
             state.RetryDelay = TimeSpan.Zero;
             dispatcher.FailDispatch(10);
 
-            await terminator.Invoke(new SubscribeContext(new FakeContext(), typeof(object), options), c => Task.FromResult(0));
+            await terminator.Invoke(new SubscribeContext(new FakeContext(), typeof(object), options), c => TaskEx.CompletedTask);
 
             Assert.AreEqual(1, dispatcher.DispatchedTransportOperations.Count);
             Assert.AreEqual(10, dispatcher.FailedNumberOfTimes);
@@ -55,7 +55,7 @@
             state.RetryDelay = TimeSpan.Zero;
             dispatcher.FailDispatch(11);
 
-            Assert.Throws<QueueNotFoundException>(async () => await terminator.Invoke(new SubscribeContext(new FakeContext(), typeof(object), options), c => Task.FromResult(0)));
+            Assert.Throws<QueueNotFoundException>(async () => await terminator.Invoke(new SubscribeContext(new FakeContext(), typeof(object), options), c => TaskEx.CompletedTask));
 
             Assert.AreEqual(0, dispatcher.DispatchedTransportOperations.Count);
             Assert.AreEqual(11, dispatcher.FailedNumberOfTimes);
@@ -80,7 +80,7 @@
                 }
 
                 DispatchedTransportOperations.Add(outgoingMessages);
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
 
             public void FailDispatch(int times)

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
@@ -30,7 +30,7 @@
         [Test]
         public async Task Should_Dispatch_for_all_publishers()
         {
-            await terminator.Invoke(new UnsubscribeContext(new FakeContext(), typeof(object), new UnsubscribeOptions()), c => Task.FromResult(0));
+            await terminator.Invoke(new UnsubscribeContext(new FakeContext(), typeof(object), new UnsubscribeOptions()), c => TaskEx.CompletedTask);
 
             Assert.AreEqual(1, dispatcher.DispatchedTransportOperations.Count);
         }
@@ -44,7 +44,7 @@
             state.RetryDelay = TimeSpan.Zero;
             dispatcher.FailDispatch(10);
 
-            await terminator.Invoke(new UnsubscribeContext(new FakeContext(), typeof(object), options), c => Task.FromResult(0));
+            await terminator.Invoke(new UnsubscribeContext(new FakeContext(), typeof(object), options), c => TaskEx.CompletedTask);
 
             Assert.AreEqual(1, dispatcher.DispatchedTransportOperations.Count);
             Assert.AreEqual(10, dispatcher.FailedNumberOfTimes);
@@ -59,7 +59,7 @@
             state.RetryDelay = TimeSpan.Zero;
             dispatcher.FailDispatch(11);
 
-            Assert.Throws<QueueNotFoundException>(async () => await terminator.Invoke(new UnsubscribeContext(new FakeContext(), typeof(object), options), c => Task.FromResult(0)));
+            Assert.Throws<QueueNotFoundException>(async () => await terminator.Invoke(new UnsubscribeContext(new FakeContext(), typeof(object), options), c => TaskEx.CompletedTask));
 
             Assert.AreEqual(0, dispatcher.DispatchedTransportOperations.Count);
             Assert.AreEqual(11, dispatcher.FailedNumberOfTimes);
@@ -87,7 +87,7 @@
                 }
 
                 DispatchedTransportOperations.Add(outgoingMessages);
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 

--- a/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
@@ -233,7 +233,7 @@
         {
             public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
 
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
@@ -264,7 +264,7 @@
         {
             public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
 
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
@@ -344,12 +344,12 @@
         {
             public Task Handle(MessageThatStartsTheSaga message, IMessageHandlerContext context)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
 
             public Task Handle(MessageThatDoesNotStartTheSaga message, IMessageHandlerContext context)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
 
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
@@ -395,7 +395,7 @@
 
             public Task Timeout(MyTimeout state, IMessageHandlerContext context)
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
@@ -445,7 +445,7 @@
 
             public Task Handle(SomeMessageWithStringProperty message, IMessageHandlerContext context)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -465,7 +465,7 @@
 
             public Task Handle(SomeMessageWithStringProperty message, IMessageHandlerContext context)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -474,7 +474,7 @@
         {
             public Task Handle(SomeMessage message, IMessageHandlerContext context)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
 
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
@@ -493,7 +493,7 @@
         {
             public Task Handle(SomeMessageWithField message, IMessageHandlerContext context)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
 
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
@@ -511,7 +511,7 @@
         {
             public Task Handle(SomeMessage message, IMessageHandlerContext context)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
 
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)

--- a/src/NServiceBus.Core.Tests/Scheduler/DefaultSchedulerTests.cs
+++ b/src/NServiceBus.Core.Tests/Scheduler/DefaultSchedulerTests.cs
@@ -33,7 +33,7 @@
             var task = new TaskDefinition
             {
                 Every = TimeSpan.FromSeconds(5),
-                Task = c => TaskEx.Completed
+                Task = c => TaskEx.CompletedTask
             };
             var taskId = task.Id;
 
@@ -56,7 +56,7 @@
                 Task = c =>
                 {
                     i++;
-                    return TaskEx.Completed;
+                    return TaskEx.CompletedTask;
                 }
             };
             var taskId = task.Id;

--- a/src/NServiceBus.Core.Tests/Scheduler/ScheduleTests.cs
+++ b/src/NServiceBus.Core.Tests/Scheduler/ScheduleTests.cs
@@ -22,7 +22,7 @@
         [Test]
         public async Task When_scheduling_an_action_with_a_name_the_task_should_get_that_name()
         {
-            await context.ScheduleEvery(TimeSpan.FromMinutes(5), ACTION_NAME, c => TaskEx.Completed);
+            await context.ScheduleEvery(TimeSpan.FromMinutes(5), ACTION_NAME, c => TaskEx.CompletedTask);
 
             Assert.That(EnsureThatNameExists(ACTION_NAME));
         }
@@ -30,7 +30,7 @@
         [Test]
         public async Task When_scheduling_an_action_without_a_name_the_task_should_get_the_DeclaringType_as_name()
         {
-            await context.ScheduleEvery(TimeSpan.FromMinutes(5), c => TaskEx.Completed);
+            await context.ScheduleEvery(TimeSpan.FromMinutes(5), c => TaskEx.CompletedTask);
 
             Assert.That(EnsureThatNameExists("ScheduleTests"));
         }
@@ -52,7 +52,7 @@
             public Task Send(object message, SendOptions options)
             {
                 defaultScheduler.Schedule(options.Context.Get<ScheduleBehavior.State>().TaskDefinition);
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
 
             public Task Send<T>(Action<T> messageConstructor, SendOptions options)

--- a/src/NServiceBus.Core.Tests/Scheduler/ScheduledTaskMessageHandlerTests.cs
+++ b/src/NServiceBus.Core.Tests/Scheduler/ScheduledTaskMessageHandlerTests.cs
@@ -21,7 +21,7 @@
             var task = new TaskDefinition
             {
                 Every = TimeSpan.FromSeconds(5),
-                Task = c => TaskEx.Completed
+                Task = c => TaskEx.CompletedTask
             };
             taskId = task.Id;
             scheduler.Schedule(task);

--- a/src/NServiceBus.Core.Tests/Serializers/Json/When_not_overriding_stream_encoding.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/When_not_overriding_stream_encoding.cs
@@ -44,12 +44,12 @@ namespace NServiceBus.Serializers.Json.Tests
                 {
                     var serializer = builder.Build<JsonMessageSerializer>();
                     Assert.AreSame(Encoding.UTF8, serializer.Encoding);
-                    return Task.FromResult(0);
+                    return TaskEx.CompletedTask;
                 }
 
                 protected override Task OnStop(IBusSession session)
                 {
-                    return TaskEx.Completed;
+                    return TaskEx.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
@@ -43,12 +43,12 @@ namespace NServiceBus.Serializers.Json.Tests
                 {
                     var serializer = builder.Build<JsonMessageSerializer>();
                     Assert.AreSame(Encoding.UTF7, serializer.Encoding);
-                    return Task.FromResult(0);
+                    return TaskEx.CompletedTask;
                 }
 
                 protected override Task OnStop(IBusSession session)
                 {
-                    return TaskEx.Completed;
+                    return TaskEx.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.Core.Tests/Serializers/SerializeMessagesBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/SerializeMessagesBehaviorTests.cs
@@ -21,7 +21,7 @@
             var context = ContextHelpers.GetOutgoingContext(new MyMessage());
             var behavior = new SerializeMessageConnector(new FakeSerializer("myContentType"), registry);
             
-            await behavior.Invoke(context, c => Task.FromResult(0));
+            await behavior.Invoke(context, c => TaskEx.CompletedTask);
 
             Assert.AreEqual("myContentType", context.Headers[Headers.ContentType]);
         }

--- a/src/NServiceBus.Core.Tests/Timeout/FakeMessageDispatcher.cs
+++ b/src/NServiceBus.Core.Tests/Timeout/FakeMessageDispatcher.cs
@@ -16,7 +16,7 @@ namespace NServiceBus.Core.Tests.Timeout
         public Task Dispatch(TransportOperations outgoingMessages, ContextBag context)
         {
             MessagesSent += outgoingMessages.MulticastTransportOperations.Count() + outgoingMessages.UnicastTransportOperations.Count();
-            return Task.FromResult(0);
+            return TaskEx.CompletedTask;
         }
 
         volatile int messagesSent;

--- a/src/NServiceBus.Core.Tests/Unicast/Config/ConfigurationSettings.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/Config/ConfigurationSettings.cs
@@ -61,7 +61,7 @@
         {
             public Task Handle(SimpleMessage message, IMessageHandlerContext context)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -69,7 +69,7 @@
         {
             public Task Handle(SimpleMessage message, IMessageHandlerContext context)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -89,7 +89,7 @@
         {
             public Task Handle(SimpleMessage message, IMessageHandlerContext context)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 

--- a/src/NServiceBus.Core.Tests/Unicast/HandlerInvocationCache.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/HandlerInvocationCache.cs
@@ -45,7 +45,7 @@
         {
             public Task Handle(StubMessage message, IMessageHandlerContext context)
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -57,7 +57,7 @@
         {
             public Task Timeout(StubTimeoutState state, IMessageHandlerContext context)
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -114,7 +114,7 @@
                 HandleCalled = true;
                 HandledMessage = message;
                 HandlerContext = context;
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             public bool HandleCalled;
@@ -175,7 +175,7 @@
                 TimeoutCalled = true;
                 HandledState = state;
                 HandlerContext = context;
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             public StubTimeoutState HandledState;

--- a/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Threading.Tasks;
     using NServiceBus.Outbox;
     using NServiceBus.Transports;
     using Unicast.Messages;

--- a/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
@@ -26,7 +26,7 @@
             context.Extensions.Set<OutboxTransaction>(new InMemoryOutboxTransaction());
             context.Extensions.Set<TransportTransaction>(new FakeTransportTransaction());
 
-            Assert.Throws<InvalidOperationException>(async () => await behavior.Invoke(context, c => Task.FromResult(0)));
+            Assert.Throws<InvalidOperationException>(async () => await behavior.Invoke(context, c => TaskEx.CompletedTask));
         }
 
         private class FakeTransportTransaction : TransportTransaction

--- a/src/NServiceBus.Core.Tests/Unicast/StartAndStoppablesRunnerTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/StartAndStoppablesRunnerTests.cs
@@ -149,13 +149,13 @@
             public Task Start(IBusSession session)
             {
                 Started = true;
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
 
             public Task Stop(IBusSession session)
             {
                 Stopped = true;
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -167,13 +167,13 @@
             public Task Start(IBusSession session)
             {
                 Started = true;
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
 
             public Task Stop(IBusSession session)
             {
                 Stopped = true;
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -189,7 +189,7 @@
             public Task Stop(IBusSession session)
             {
                 Stopped = true;
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -206,7 +206,7 @@
             public Task Stop(IBusSession session)
             {
                 Stopped = true;
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -217,7 +217,7 @@
             public Task Start(IBusSession session)
             {
                 Started = true;
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
 
             public Task Stop(IBusSession session)
@@ -233,7 +233,7 @@
             public Task Start(IBusSession session)
             {
                 Started = true;
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
 
             public async Task Stop(IBusSession session)

--- a/src/NServiceBus.Core.Tests/UnitOfWork/UnitOfWorkBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/UnitOfWork/UnitOfWorkBehaviorTests.cs
@@ -155,7 +155,7 @@
                 {
                     throw toThrow;
                 }
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             });
         }
 
@@ -168,7 +168,7 @@
             public Task Begin()
             {
                 BeginCalled = true;
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
 
             public Task End(Exception ex = null)
@@ -192,7 +192,7 @@
             public Task End(Exception ex = null)
             {
                 EndCalled = true;
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -204,14 +204,14 @@
             public Task Begin()
             {
                 BeginCalled = true;
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
 
             public Task End(Exception ex = null)
             {
                 ExceptionPassedToEnd = ex;
                 EndCalled = true;
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -249,13 +249,13 @@
             {
                 BeginCallCount++;
                 BeginCallIndex = BeginCallCount;
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
             public Task End(Exception ex = null)
             {
                 EndCallCount++;
                 EndCallIndex = EndCallCount;
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
 
@@ -281,12 +281,12 @@
         {
             public Task Begin()
             {
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
             public Task End(Exception ex = null)
             {
                 Exception = ex;
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
             public Exception Exception;
         }
@@ -305,13 +305,13 @@
             public Task Begin()
             {
                 order.Add(name);
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
 
             public Task End(Exception ex = null)
             {
                 order.Add(name);
-                return Task.FromResult(0);
+                return TaskEx.CompletedTask;
             }
         }
     }

--- a/src/NServiceBus.Core/DataBus/DataBus.cs
+++ b/src/NServiceBus.Core/DataBus/DataBus.cs
@@ -54,7 +54,7 @@ namespace NServiceBus.Features
 
             protected override Task OnStop(IBusSession session)
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
         }
     }

--- a/src/NServiceBus.Core/DataBus/FileShareDataBusImplementation.cs
+++ b/src/NServiceBus.Core/DataBus/FileShareDataBusImplementation.cs
@@ -51,7 +51,7 @@ namespace NServiceBus
 		{
 			logger.Info("File share data bus started. Location: " + basePath);
 			//TODO: Implement a clean up thread
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
 		}
 
 		string GenerateKey(TimeSpan timeToBeReceived)

--- a/src/NServiceBus.Core/DelayedDelivery/NoOpCanceling.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/NoOpCanceling.cs
@@ -9,7 +9,7 @@
         public Task CancelDeferredMessages(string messageKey, IBehaviorContext context)
         {
             //no-op
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutPollerRunner.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutPollerRunner.cs
@@ -14,7 +14,7 @@ namespace NServiceBus.Features
         protected override Task OnStart(IBusSession session)
         {
             poller.Start();
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         protected override Task OnStop(IBusSession session)

--- a/src/NServiceBus.Core/Performance/Counters/PerformanceMonitorUsersInstaller.cs
+++ b/src/NServiceBus.Core/Performance/Counters/PerformanceMonitorUsersInstaller.cs
@@ -33,7 +33,7 @@ namespace NServiceBus
                 {
                     logger.InfoFormat(@"Did not attempt to add user '{0}' to group '{1}' since process is not running with elevate privileges. Processing will continue. To manually perform this action run the following command from an admin console:
 net localgroup ""{1}"" ""{0}"" /add", identity, builtinPerformanceMonitoringUsersName);
-                    return TaskEx.Completed;
+                    return TaskEx.CompletedTask;
                 }
                 StartProcess(identity);
             }
@@ -46,7 +46,7 @@ net localgroup ""{1}"" ""{0}"" /add", identity, builtinPerformanceMonitoringUser
                 logger.Warn(message, win32Exception);
             }
 
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
 

--- a/src/NServiceBus.Core/Performance/ReceiveStatisticsFeature.cs
+++ b/src/NServiceBus.Core/Performance/ReceiveStatisticsFeature.cs
@@ -32,13 +32,13 @@
             protected override Task OnStart(IBusSession session)
             {
                 behavior.Warmup();
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             protected override Task OnStop(IBusSession session)
             {
                 behavior.Cooldown();
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
         }
     }

--- a/src/NServiceBus.Core/Persistence/InMemory/Gateway/InMemoryGatewayDeduplication.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Gateway/InMemoryGatewayDeduplication.cs
@@ -16,7 +16,7 @@
                 var item = persistence.SingleOrDefault(m => m.Id == clientId);
                 if (item != null)
                 {
-                    return Task.FromResult(false);
+                    return TaskEx.FalseTask;
                 }
 
                 return Task.FromResult(persistence.Add(new GatewayMessage

--- a/src/NServiceBus.Core/Persistence/InMemory/InMemorySynchronizedStorage.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/InMemorySynchronizedStorage.cs
@@ -8,8 +8,9 @@ namespace NServiceBus
     {
         public Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag)
         {
-            var session = (CompletableSynchronizedStorageSession)new InMemorySynchronizedStorageSession();
-            return Task.FromResult(session);
+            return InMemorySynchronizedSessionTask;
         }
+
+        static Task<CompletableSynchronizedStorageSession> InMemorySynchronizedSessionTask = Task.FromResult((CompletableSynchronizedStorageSession)new InMemorySynchronizedStorageSession());
     }
 }

--- a/src/NServiceBus.Core/Persistence/InMemory/InMemorySynchronizedStorage.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/InMemorySynchronizedStorage.cs
@@ -8,9 +8,8 @@ namespace NServiceBus
     {
         public Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag)
         {
-            return InMemorySynchronizedSessionTask;
+            var session = (CompletableSynchronizedStorageSession)new InMemorySynchronizedStorageSession();
+            return Task.FromResult(session);
         }
-
-        static Task<CompletableSynchronizedStorageSession> InMemorySynchronizedSessionTask = Task.FromResult((CompletableSynchronizedStorageSession)new InMemorySynchronizedStorageSession());
     }
 }

--- a/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransactionalStorageSession.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/InMemoryTransactionalStorageSession.cs
@@ -39,7 +39,7 @@ namespace NServiceBus
             {
                 Transaction.Commit();
             }
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxPersistence.cs
@@ -42,7 +42,7 @@
             protected override Task OnStart(IBusSession session)
             {
                 cleanupTimer = new Timer(PerformCleanup, null, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             protected override Task OnStop(IBusSession session)
@@ -54,7 +54,7 @@
                     // TODO: Use async synchronization primitive
                     waitHandle.WaitOne();
                 }
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             void PerformCleanup(object state)

--- a/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxStorage.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxStorage.cs
@@ -15,7 +15,7 @@
             StoredMessage storedMessage;
             if (!storage.TryGetValue(messageId, out storedMessage))
             {
-                return Task.FromResult(default(OutboxMessage));
+                return noOutboxMessageTask;
             }
 
             return Task.FromResult(new OutboxMessage(messageId, storedMessage.TransportOperations));
@@ -23,7 +23,7 @@
 
         public Task<OutboxTransaction> BeginTransaction(ContextBag context)
         {
-            return Task.FromResult<OutboxTransaction>(new InMemoryOutboxTransaction());
+            return inMemoryOutboxTransactionTask;
         }
 
         public Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag context)
@@ -71,6 +71,8 @@
 
 
         ConcurrentDictionary<string, StoredMessage> storage = new ConcurrentDictionary<string, StoredMessage>();
+        static Task<OutboxMessage> noOutboxMessageTask = Task.FromResult(default(OutboxMessage));
+        static Task<OutboxTransaction> inMemoryOutboxTransactionTask = Task.FromResult<OutboxTransaction>(new InMemoryOutboxTransaction());
 
         class StoredMessage
         {

--- a/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxStorage.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxStorage.cs
@@ -15,7 +15,7 @@
             StoredMessage storedMessage;
             if (!storage.TryGetValue(messageId, out storedMessage))
             {
-                return noOutboxMessageTask;
+                return NoOutboxMessageTask;
             }
 
             return Task.FromResult(new OutboxMessage(messageId, storedMessage.TransportOperations));
@@ -23,7 +23,7 @@
 
         public Task<OutboxTransaction> BeginTransaction(ContextBag context)
         {
-            return inMemoryOutboxTransactionTask;
+            return Task.FromResult<OutboxTransaction>(new InMemoryOutboxTransaction());
         }
 
         public Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag context)
@@ -71,8 +71,7 @@
 
 
         ConcurrentDictionary<string, StoredMessage> storage = new ConcurrentDictionary<string, StoredMessage>();
-        static Task<OutboxMessage> noOutboxMessageTask = Task.FromResult(default(OutboxMessage));
-        static Task<OutboxTransaction> inMemoryOutboxTransactionTask = Task.FromResult<OutboxTransaction>(new InMemoryOutboxTransaction());
+        static Task<OutboxMessage> NoOutboxMessageTask = Task.FromResult(default(OutboxMessage));
 
         class StoredMessage
         {

--- a/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxStorage.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxStorage.cs
@@ -36,7 +36,7 @@
                     throw new Exception($"Outbox message with id '{message.MessageId}' is already present in storage.");
                 }
             });
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         public Task SetAsDispatched(string messageId, ContextBag context)
@@ -45,13 +45,13 @@
 
             if (!storage.TryGetValue(messageId, out storedMessage))
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             storedMessage.TransportOperations.Clear();
             storedMessage.Dispatched = true;
 
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         public void RemoveEntriesOlderThan(DateTime dateTime)

--- a/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxTransaction.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxTransaction.cs
@@ -28,7 +28,7 @@
         public Task Commit()
         {
             Transaction.Commit();
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
@@ -20,7 +20,7 @@ namespace NServiceBus
                 VersionedSagaEntity value;
                 data.TryRemove(sagaData.Id, out value);
             });
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         public Task<TSagaData> Get<TSagaData>(string propertyName, object propertyValue, SynchronizedStorageSession session, ContextBag context) where TSagaData : IContainSagaData
@@ -87,7 +87,7 @@ namespace NServiceBus
 
                 Interlocked.Increment(ref version);
             });
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         public Task Update(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context)
@@ -112,7 +112,7 @@ namespace NServiceBus
 
                 Interlocked.Increment(ref version);
             });
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         void ValidateUniqueProperties(SagaCorrelationProperty correlationProperty, IContainSagaData saga)

--- a/src/NServiceBus.Core/Persistence/InMemory/SubscriptionStorage/InMemorySubscriptionStorage.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/SubscriptionStorage/InMemorySubscriptionStorage.cs
@@ -18,7 +18,7 @@ namespace NServiceBus
 
                 dict.AddOrUpdate(subscriber.TransportAddress, _ => subscriber, (_, __) => subscriber);
             }
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         public Task Unsubscribe(Subscriber subscriber, IReadOnlyCollection<MessageType> messageTypes, ContextBag context)
@@ -32,7 +32,7 @@ namespace NServiceBus
                     dict.TryRemove(subscriber.TransportAddress, out _);
                 }
             }
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         public Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IReadOnlyCollection<MessageType> messageTypes, ContextBag context)

--- a/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
@@ -55,11 +55,11 @@ namespace NServiceBus
                     if (data.Id == timeoutId)
                     {
                         storage.RemoveAt(index);
-                        return Task.FromResult(true);
+                        return TaskEx.TrueTask;
                     }
                 }
 
-                return Task.FromResult(false);
+                return TaskEx.FalseTask;
             }
             finally
             {

--- a/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
@@ -27,7 +27,7 @@ namespace NServiceBus
                 readerWriterLock.ExitWriteLock();
             }
 
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         public Task<TimeoutData> Peek(string timeoutId, ContextBag context)
@@ -88,7 +88,7 @@ namespace NServiceBus
                 readerWriterLock.ExitWriteLock();
             }
 
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice)

--- a/src/NServiceBus.Core/Persistence/Msmq/SubscriptionStorage/MsmqSubscriptionStorage.cs
+++ b/src/NServiceBus.Core/Persistence/Msmq/SubscriptionStorage/MsmqSubscriptionStorage.cs
@@ -85,7 +85,7 @@ namespace NServiceBus
                     }
                 }
             }
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         public Task Unsubscribe(Subscriber subscriber, IReadOnlyCollection<MessageType> messageTypes, ContextBag context)
@@ -105,7 +105,7 @@ namespace NServiceBus
                     log.Debug($"Subscriber {subscriber} removed for message {entry.MessageType}.");
                 }    
             }
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         void Add(Subscriber subscriber, MessageType messageType)

--- a/src/NServiceBus.Core/Pipeline/BehaviorChain.cs
+++ b/src/NServiceBus.Core/Pipeline/BehaviorChain.cs
@@ -30,7 +30,7 @@
         {
             if (currentIndex == itemDescriptors.Length)
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             var behavior = itemDescriptors[currentIndex];

--- a/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
@@ -24,7 +24,7 @@
         {
             var outboxTransaction = context.Extensions.Get<OutboxTransaction>();
             var transportTransaction = context.Extensions.Get<TransportTransaction>();
-            using (var storageSession = await AdaptOrOpenNewSynchronizedStorageSession(transportTransaction, outboxTransaction, context.Extensions))
+            using (var storageSession = await AdaptOrOpenNewSynchronizedStorageSession(transportTransaction, outboxTransaction, context.Extensions).ConfigureAwait(false))
             {
                 var handlersToInvoke = messageHandlerRegistry.GetHandlersFor(context.Message.MessageType).ToList();
 

--- a/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
@@ -61,7 +61,7 @@
         {
             public Task<OutboxMessage> Get(string messageId, ContextBag options)
             {
-                return Task.FromResult<OutboxMessage>(null);
+                return noOutboxMessageTask;
             }
 
             public Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag options)
@@ -76,8 +76,11 @@
 
             public Task<OutboxTransaction> BeginTransaction(ContextBag context)
             {
-                return Task.FromResult<OutboxTransaction>(new NoOpOutboxTransaction());
+                return noOpTransactionTask;
             }
+
+            static Task<OutboxTransaction> noOpTransactionTask = Task.FromResult<OutboxTransaction>(new NoOpOutboxTransaction());
+            static Task<OutboxMessage> noOutboxMessageTask = Task.FromResult<OutboxMessage>(null);
         }
         class NoOpOutboxTransaction : OutboxTransaction
         {

--- a/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
@@ -66,12 +66,12 @@
 
             public Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag options)
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             public Task SetAsDispatched(string messageId, ContextBag options)
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             public Task<OutboxTransaction> BeginTransaction(ContextBag context)
@@ -87,7 +87,7 @@
 
             public Task Commit()
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
         }
     }

--- a/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
@@ -61,7 +61,7 @@
         {
             public Task<OutboxMessage> Get(string messageId, ContextBag options)
             {
-                return noOutboxMessageTask;
+                return NoOutboxMessageTask;
             }
 
             public Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag options)
@@ -76,11 +76,10 @@
 
             public Task<OutboxTransaction> BeginTransaction(ContextBag context)
             {
-                return noOpTransactionTask;
+                return Task.FromResult<OutboxTransaction>(new NoOpOutboxTransaction());
             }
 
-            static Task<OutboxTransaction> noOpTransactionTask = Task.FromResult<OutboxTransaction>(new NoOpOutboxTransaction());
-            static Task<OutboxMessage> noOutboxMessageTask = Task.FromResult<OutboxMessage>(null);
+            static Task<OutboxMessage> NoOutboxMessageTask = Task.FromResult<OutboxMessage>(null);
         }
         class NoOpOutboxTransaction : OutboxTransaction
         {

--- a/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
@@ -49,7 +49,7 @@
             if (!state.ImmediateDispatch && context.Extensions.TryGet(out pendingOperations))
             {
                 pendingOperations.AddRange(operations);
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             return stage(this.CreateDispatchContext(operations.ToArray(), context));

--- a/src/NServiceBus.Core/Recoverability/FirstLevelRetries/FirstLevelRetries.cs
+++ b/src/NServiceBus.Core/Recoverability/FirstLevelRetries/FirstLevelRetries.cs
@@ -62,13 +62,13 @@ namespace NServiceBus.Features
             protected override Task OnStart(IBusSession session)
             {
                 timer = new Timer(ClearFlrStatusStorage, null, ClearingInterval, ClearingInterval);
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             protected override Task OnStop(IBusSession session)
             {
                 timer?.Dispose();
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             void ClearFlrStatusStorage(object state)

--- a/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
@@ -104,12 +104,12 @@ Because you have configured this endpoint to run with Outbox enabled we recommen
                 // Ignore if we can't check it.
             }
 
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         protected override Task OnStop(IBusSession session)
         {
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         static ILog log = LogManager.GetLogger<DtcRunningWarning>();

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -108,7 +108,7 @@
 
             protected override Task OnStop(IBusSession session)
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             IEnumerable<Type> messagesHandledByThisEndpoint;

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -88,8 +88,6 @@
 
         class ApplySubscriptions : FeatureStartupTask
         {
-            static ILog Logger = LogManager.GetLogger<ApplySubscriptions>();
-
             public ApplySubscriptions(IEnumerable<Type> messagesHandledByThisEndpoint, Func<Type, Task<bool>> asyncPredicate)
             {
                 this.messagesHandledByThisEndpoint = messagesHandledByThisEndpoint;
@@ -116,6 +114,8 @@
             Func<Type, Task<bool>> asyncPredicate;
 
             IEnumerable<Type> messagesHandledByThisEndpoint;
+
+            static ILog Logger = LogManager.GetLogger<ApplySubscriptions>();
         }
 
         internal class SubscribeSettings

--- a/src/NServiceBus.Core/Routing/EndpointInstances.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstances.cs
@@ -10,8 +10,6 @@ namespace NServiceBus.Routing
     /// </summary>
     public class EndpointInstances
     {
-        static Task<IEnumerable<EndpointInstance>> EmptyStaticRuleTask = Task.FromResult(Enumerable.Empty<EndpointInstance>());
-
         internal async Task<IEnumerable<EndpointInstance>> FindInstances(EndpointName endpoint)
         {
             var instances = new List<EndpointInstance>();
@@ -62,5 +60,6 @@ namespace NServiceBus.Routing
         }
 
         List<Func<EndpointName, Task<IEnumerable<EndpointInstance>>>> rules = new List<Func<EndpointName, Task<IEnumerable<EndpointInstance>>>>();
+        static Task<IEnumerable<EndpointInstance>> EmptyStaticRuleTask = Task.FromResult(Enumerable.Empty<EndpointInstance>());
     }
 }

--- a/src/NServiceBus.Core/Routing/EndpointInstances.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstances.cs
@@ -6,11 +6,11 @@ namespace NServiceBus.Routing
     using System.Threading.Tasks;
 
     /// <summary>
-    /// Stores the information about instances of known endpoints.
+    ///     Stores the information about instances of known endpoints.
     /// </summary>
     public class EndpointInstances
     {
-        List<Func<EndpointName, Task<IEnumerable<EndpointInstance>>>> rules = new List<Func<EndpointName, Task<IEnumerable<EndpointInstance>>>>();
+        static Task<IEnumerable<EndpointInstance>> EmptyStaticRuleTask = Task.FromResult(Enumerable.Empty<EndpointInstance>());
 
         internal async Task<IEnumerable<EndpointInstance>> FindInstances(EndpointName endpoint)
         {
@@ -25,7 +25,7 @@ namespace NServiceBus.Routing
 
 
         /// <summary>
-        /// Adds a dynamic rule for determining endpoint instances.
+        ///     Adds a dynamic rule for determining endpoint instances.
         /// </summary>
         /// <param name="dynamicRule">The rule.</param>
         public void AddDynamic(Func<EndpointName, Task<IEnumerable<EndpointInstance>>> dynamicRule)
@@ -34,7 +34,7 @@ namespace NServiceBus.Routing
         }
 
         /// <summary>
-        /// Adds static information about an endpoint.
+        ///     Adds static information about an endpoint.
         /// </summary>
         /// <param name="endpoint">Name of the endpoint.</param>
         /// <param name="instances">A static list of endpoint's instances.</param>
@@ -49,7 +49,7 @@ namespace NServiceBus.Routing
             {
                 throw new ArgumentException("At least one of the instances belongs to a different endpoint than specified in the 'endpoint' parameter.", nameof(instances));
             }
-            rules.Add(e => StaticRule(e, endpoint, instances));   
+            rules.Add(e => StaticRule(e, endpoint, instances));
         }
 
         static Task<IEnumerable<EndpointInstance>> StaticRule(EndpointName endpointBeingQueried, EndpointName configuredEndpoint, IEnumerable<EndpointInstance> configuredInstances)
@@ -58,7 +58,9 @@ namespace NServiceBus.Routing
             {
                 return Task.FromResult(configuredInstances);
             }
-            return Task.FromResult(Enumerable.Empty<EndpointInstance>());
+            return EmptyStaticRuleTask;
         }
+
+        List<Func<EndpointName, Task<IEnumerable<EndpointInstance>>>> rules = new List<Func<EndpointName, Task<IEnumerable<EndpointInstance>>>>();
     }
 }

--- a/src/NServiceBus.Core/Routing/Legacy/ReadyMessageSender.cs
+++ b/src/NServiceBus.Core/Routing/Legacy/ReadyMessageSender.cs
@@ -28,7 +28,7 @@
 
         protected override Task OnStop(IBusSession session)
         {
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         Task SendReadyMessage(int capacity, bool isStarting)

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/StorageInitializer.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/StorageInitializer.cs
@@ -25,12 +25,12 @@
             protected override Task OnStart(IBusSession session)
             {
                 SubscriptionStorage?.Init();
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             protected override Task OnStop(IBusSession session)
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
         }
     }

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -146,12 +146,12 @@
                         settings.Get<UnicastRoutingTable>().AddDynamic((t, c) => QuerySubscriptionStore(subscriptions, t, c));
                     }
                 }
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             protected override Task OnStop(IBusSession session)
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             static async Task<IEnumerable<IUnicastRoute>> QuerySubscriptionStore(ISubscriptionStorage subscriptions, List<Type> types, ContextBag contextBag)

--- a/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
@@ -231,7 +231,7 @@
             //check if we could find a finder
             if (finderDefinition == null)
             {
-                return Task.FromResult(default(IContainSagaData));
+                return defaultSagaDataCompletedTask;
             }
 
             var finderType = finderDefinition.Type;
@@ -279,6 +279,7 @@
         ISagaPersister sagaPersister;
         ICancelDeferredMessages timeoutCancellation;
 
+        static Task<IContainSagaData> defaultSagaDataCompletedTask = Task.FromResult(default(IContainSagaData));
         static ILog logger = LogManager.GetLogger<SagaPersistenceBehavior>();
     }
 }

--- a/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
@@ -231,7 +231,7 @@
             //check if we could find a finder
             if (finderDefinition == null)
             {
-                return defaultSagaDataCompletedTask;
+                return DefaultSagaDataCompletedTask;
             }
 
             var finderType = finderDefinition.Type;
@@ -279,7 +279,7 @@
         ISagaPersister sagaPersister;
         ICancelDeferredMessages timeoutCancellation;
 
-        static Task<IContainSagaData> defaultSagaDataCompletedTask = Task.FromResult(default(IContainSagaData));
+        static Task<IContainSagaData> DefaultSagaDataCompletedTask = Task.FromResult(default(IContainSagaData));
         static ILog logger = LogManager.GetLogger<SagaPersistenceBehavior>();
     }
 }

--- a/src/NServiceBus.Core/Serializers/XML/Config/XmlSerialization.cs
+++ b/src/NServiceBus.Core/Serializers/XML/Config/XmlSerialization.cs
@@ -41,12 +41,12 @@
                 var messageTypes = Settings.GetAvailableTypes()
                     .Where(conventions.IsMessageType).ToList();
                 Serializer.Initialize(messageTypes);
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             protected override Task OnStop(IBusSession session)
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
         }
     }

--- a/src/NServiceBus.Core/TaskEx.cs
+++ b/src/NServiceBus.Core/TaskEx.cs
@@ -7,6 +7,9 @@ namespace NServiceBus
         //TODO: remove when we update to 4.6 and can use Task.CompletedTask
         public static readonly Task CompletedTask = Task.FromResult(0);
 
+        public static readonly Task<bool> TrueTask = Task.FromResult(true);
+        public static readonly Task<bool> FalseTask = Task.FromResult(false);
+
         // ReSharper disable once UnusedParameter.Global
         // Used to explicitly suppress the compiler warning about 
         // using the returned value from async operations

--- a/src/NServiceBus.Core/TaskEx.cs
+++ b/src/NServiceBus.Core/TaskEx.cs
@@ -5,7 +5,7 @@ namespace NServiceBus
     static class TaskEx
     {
         //TODO: remove when we update to 4.6 and can use Task.CompletedTask
-        public static readonly Task Completed = Task.FromResult(0);
+        public static readonly Task CompletedTask = Task.FromResult(0);
 
         // ReSharper disable once UnusedParameter.Global
         // Used to explicitly suppress the compiler warning about 

--- a/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
@@ -55,7 +55,7 @@ namespace NServiceBus
                 inputQueue.Purge();
             }
 
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         public void Start(PushRuntimeSettings limitations)

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqMessageSender.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqMessageSender.cs
@@ -47,7 +47,7 @@ namespace NServiceBus.Transports.Msmq
                 ExecuteTransportOperation(context, unicastTransportOperation);
             }
 
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
 
         void ExecuteTransportOperation(ReadOnlyContextBag context, UnicastTransportOperation transportOperation)

--- a/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
@@ -31,7 +31,7 @@ namespace NServiceBus
                 CreateQueueIfNecessary(sendingAddress, identity);
             }
 
-            return TaskEx.Completed;
+            return TaskEx.CompletedTask;
         }
         
         void CreateQueueIfNecessary(string address, string identity)

--- a/src/NServiceBus.Core/Transports/Receiving.cs
+++ b/src/NServiceBus.Core/Transports/Receiving.cs
@@ -57,7 +57,7 @@ namespace NServiceBus
 
             protected override Task OnStop(IBusSession session)
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
         }
     }

--- a/src/NServiceBus.Core/Transports/Sending.cs
+++ b/src/NServiceBus.Core/Transports/Sending.cs
@@ -47,7 +47,7 @@ namespace NServiceBus
 
             protected override Task OnStop(IBusSession session)
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
         }
     }

--- a/src/NServiceBus.Core/Unicast/BusOperationsInvokeHandlerContext.cs
+++ b/src/NServiceBus.Core/Unicast/BusOperationsInvokeHandlerContext.cs
@@ -13,7 +13,7 @@ namespace NServiceBus
         {
             if (context.HandleCurrentMessageLaterWasCalled)
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
 
             var messageBeingProcessed = context.Extensions.Get<IncomingMessage>();

--- a/src/NServiceBus.Core/Unicast/Queuing/QueuesCreator.cs
+++ b/src/NServiceBus.Core/Unicast/Queuing/QueuesCreator.cs
@@ -21,11 +21,11 @@ namespace NServiceBus
         {
             if (settings.Get<bool>("Endpoint.SendOnly"))
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
             if (!settings.CreateQueues())
             {
-                return TaskEx.Completed;
+                return TaskEx.CompletedTask;
             }
             var queueCreator = builder.Build<ICreateQueues>();
             var queueBindings = settings.Get<QueueBindings>();


### PR DESCRIPTION
This PR introduces the following:

* Missing `ConfigureAwait(false)` in `LoadHandlersConnector`
* `TrueTask` and `FalseTask` as static cached completed tasks
* `CompletedTask` on `TaskEx` instead of `Completed` to better comply with the naming in :NET 4.6
* Smarter task caching in the `FileRoutingTable`

These optimizations reduce the number of `Task<TResult>` allocations.

@Particular/tf-async-core @Particular/nservicebus please review