### PR TITLE
move to single message type subscription

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_from_sendonly.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_from_sendonly.cs
@@ -97,17 +97,17 @@
                 }.AsEnumerable());
             }
 
-            public Task Subscribe(Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, IReadOnlyCollection<MessageType> messageTypes, ContextBag context)
+            public Task Subscribe(Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, MessageType messageType, ContextBag context)
             {
                 return Task.FromResult(0);
             }
 
-            public Task Unsubscribe(Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, IReadOnlyCollection<MessageType> messageTypes, ContextBag context)
+            public Task Unsubscribe(Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, MessageType messageType, ContextBag context)
             {
                 return Task.FromResult(0);
             }
 
-            public Task<IEnumerable<Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber>> GetSubscriberAddressesForMessage(IReadOnlyCollection<MessageType> messageTypes, ContextBag context)
+            public Task<IEnumerable<Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context)
             {
                 return addressTask;
             }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -3064,9 +3064,9 @@ namespace NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions
     }
     public interface ISubscriptionStorage
     {
-        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber>> GetSubscriberAddressesForMessage(System.Collections.Generic.IReadOnlyCollection<NServiceBus.Unicast.Subscriptions.MessageType> messageTypes, NServiceBus.Extensibility.ContextBag context);
-        System.Threading.Tasks.Task Subscribe(NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Unicast.Subscriptions.MessageType> messageTypes, NServiceBus.Extensibility.ContextBag context);
-        System.Threading.Tasks.Task Unsubscribe(NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Unicast.Subscriptions.MessageType> messageTypes, NServiceBus.Extensibility.ContextBag context);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber>> GetSubscriberAddressesForMessage(System.Collections.Generic.IEnumerable<NServiceBus.Unicast.Subscriptions.MessageType> messageTypes, NServiceBus.Extensibility.ContextBag context);
+        System.Threading.Tasks.Task Subscribe(NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, NServiceBus.Unicast.Subscriptions.MessageType messageType, NServiceBus.Extensibility.ContextBag context);
+        System.Threading.Tasks.Task Unsubscribe(NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, NServiceBus.Unicast.Subscriptions.MessageType messageType, NServiceBus.Extensibility.ContextBag context);
     }
     public class Subscriber
     {

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqSubscriptionStorageQueueTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqSubscriptionStorageQueueTests.cs
@@ -19,15 +19,16 @@
             var queue = new FakeStorageQueue();
             var storage = CreateAndInit(queue);
 
-            var messageTypes = new[] {new MessageType(typeof(SomeMessage))};
-            await storage.Subscribe(new Subscriber("sub1", null), messageTypes, new ContextBag());
+            var messageType = new MessageType(typeof(SomeMessage));
+            var messageTypes = new[] {messageType};
+            await storage.Subscribe(new Subscriber("sub1", null), messageType, new ContextBag());
 
             storage = CreateAndInit(queue);
 
             var subscribers = await storage.GetSubscriberAddressesForMessage(messageTypes, new ContextBag());
             Assert.AreEqual(1, subscribers.Count());
 
-            await storage.Unsubscribe(new Subscriber("sub1", null), messageTypes, new ContextBag());
+            await storage.Unsubscribe(new Subscriber("sub1", null), messageType, new ContextBag());
 
             storage = CreateAndInit(queue);
             subscribers = await storage.GetSubscriberAddressesForMessage(messageTypes, new ContextBag());
@@ -47,9 +48,10 @@
             var queue = new FakeStorageQueue();
             var storage = CreateAndInit(queue);
 
-            var messageTypes = new[] { new MessageType(typeof(SomeMessage)) };
-            await storage.Subscribe(new Subscriber("sub1", null), messageTypes, new ContextBag());
-            await storage.Subscribe(new Subscriber("SUB1", null), messageTypes, new ContextBag());
+            var messageType = new MessageType(typeof(SomeMessage));
+            var messageTypes = new[] { messageType };
+            await storage.Subscribe(new Subscriber("sub1", null), messageType, new ContextBag());
+            await storage.Subscribe(new Subscriber("SUB1", null), messageType, new ContextBag());
 
             var subscribers = await storage.GetSubscriberAddressesForMessage(messageTypes, new ContextBag());
             Assert.AreEqual(1, subscribers.Count());
@@ -61,9 +63,10 @@
             var queue = new FakeStorageQueue();
             var storage = CreateAndInit(queue);
 
-            var messageTypes = new[] { new MessageType(typeof(SomeMessage)) };
-            await storage.Subscribe(new Subscriber("sub1", null), messageTypes, new ContextBag());
-            await storage.Subscribe(new Subscriber("sub2", null), messageTypes, new ContextBag());
+            var messageType = new MessageType(typeof(SomeMessage));
+            var messageTypes = new[] { messageType };
+            await storage.Subscribe(new Subscriber("sub1", null), messageType, new ContextBag());
+            await storage.Subscribe(new Subscriber("sub2", null), messageType, new ContextBag());
 
             var subscribers = await storage.GetSubscriberAddressesForMessage(messageTypes, new ContextBag());
             Assert.AreEqual(2, subscribers.Count());
@@ -75,9 +78,10 @@
             var queue = new FakeStorageQueue();
             var storage = CreateAndInit(queue);
 
-            var messageTypes = new[] { new MessageType(typeof(SomeMessage)) };
-            await storage.Subscribe(new Subscriber("legacy", null), messageTypes, new ContextBag());
-            await storage.Subscribe(new Subscriber("new", new EndpointName("endpoint")), messageTypes, new ContextBag());
+            var messageType = new MessageType(typeof(SomeMessage));
+            var messageTypes = new[] { messageType };
+            await storage.Subscribe(new Subscriber("legacy", null), messageType, new ContextBag());
+            await storage.Subscribe(new Subscriber("new", new EndpointName("endpoint")), messageType, new ContextBag());
 
             var subscribers = (await storage.GetSubscriberAddressesForMessage(messageTypes, new ContextBag())).ToArray();
 
@@ -93,13 +97,15 @@
             var queue = new FakeStorageQueue();
             var storage = CreateAndInit(queue);
 
-            await storage.Subscribe(new Subscriber("sub1", null), new[] { new MessageType(typeof(SomeMessage)) }, new ContextBag());
-            await storage.Subscribe(new Subscriber("sub1", null), new[] { new MessageType(typeof(OtherMessage)) }, new ContextBag());
+            var someMessageType = new MessageType(typeof(SomeMessage));
+            await storage.Subscribe(new Subscriber("sub1", null), someMessageType, new ContextBag());
+            var otherMessageType = new MessageType(typeof(OtherMessage));
+            await storage.Subscribe(new Subscriber("sub1", null), otherMessageType, new ContextBag());
 
-            var subscribers = await storage.GetSubscriberAddressesForMessage(new[] { new MessageType(typeof(SomeMessage)) }, new ContextBag());
+            var subscribers = await storage.GetSubscriberAddressesForMessage(new[] { someMessageType }, new ContextBag());
             Assert.AreEqual(1, subscribers.Count());
 
-            subscribers = await storage.GetSubscriberAddressesForMessage(new[] { new MessageType(typeof(OtherMessage)) }, new ContextBag());
+            subscribers = await storage.GetSubscriberAddressesForMessage(new[] { otherMessageType }, new ContextBag());
             Assert.AreEqual(1, subscribers.Count());
         }
 
@@ -109,12 +115,15 @@
             var queue = new FakeStorageQueue();
             var storage = CreateAndInit(queue);
 
-            await storage.Subscribe(new Subscriber("sub1", null), new[] { new MessageType(typeof(SomeMessage)), new MessageType(typeof(OtherMessage)) }, new ContextBag());
+            var someMessageType = new MessageType(typeof(SomeMessage));
+            var otherMessageType = new MessageType(typeof(OtherMessage));
+            await storage.Subscribe(new Subscriber("sub1", null), someMessageType, new ContextBag());
+            await storage.Subscribe(new Subscriber("sub1", null), otherMessageType, new ContextBag());
 
-            var subscribers = await storage.GetSubscriberAddressesForMessage(new[] { new MessageType(typeof(SomeMessage)) }, new ContextBag());
+            var subscribers = await storage.GetSubscriberAddressesForMessage(new[] { someMessageType }, new ContextBag());
             Assert.AreEqual(1, subscribers.Count());
 
-            subscribers = await storage.GetSubscriberAddressesForMessage(new[] { new MessageType(typeof(OtherMessage)) }, new ContextBag());
+            subscribers = await storage.GetSubscriberAddressesForMessage(new[] { otherMessageType }, new ContextBag());
             Assert.AreEqual(1, subscribers.Count());
         }
 
@@ -124,9 +133,10 @@
             var queue = new FakeStorageQueue();
             var storage = CreateAndInit(queue);
 
-            var messageTypes = new[] { new MessageType(typeof(SomeMessage)) };
-            await storage.Subscribe(new Subscriber("sub1", null), messageTypes, new ContextBag());
-            await storage.Subscribe(new Subscriber("sub1", new EndpointName("endpoint")), messageTypes, new ContextBag());
+            var messageType = new MessageType(typeof(SomeMessage));
+            var messageTypes = new[] { messageType };
+            await storage.Subscribe(new Subscriber("sub1", null), messageType, new ContextBag());
+            await storage.Subscribe(new Subscriber("sub1", new EndpointName("endpoint")), messageType, new ContextBag());
 
             var subscribers = await storage.GetSubscriberAddressesForMessage(messageTypes, new ContextBag());
             Assert.AreEqual(1, subscribers.Count());
@@ -138,11 +148,12 @@
             var queue = new FakeStorageQueue();
             var storage = CreateAndInit(queue);
 
-            var messageTypes = new[] { new MessageType(typeof(SomeMessage)) };
-            await storage.Subscribe(new Subscriber("sub1", new EndpointName("e1")), messageTypes, new ContextBag());
-            await storage.Subscribe(new Subscriber("sub1", new EndpointName("e2")), messageTypes, new ContextBag());
+            var messageType = new MessageType(typeof(SomeMessage));
+            var messageTypes = new[] { messageType };
+            await storage.Subscribe(new Subscriber("sub1", new EndpointName("e1")), messageType, new ContextBag());
+            await storage.Subscribe(new Subscriber("sub1", new EndpointName("e2")), messageType, new ContextBag());
 
-            await storage.Unsubscribe(new Subscriber("sub1", new EndpointName("e3")), messageTypes, new ContextBag());
+            await storage.Unsubscribe(new Subscriber("sub1", new EndpointName("e3")), messageType, new ContextBag());
 
             var subscribers = await storage.GetSubscriberAddressesForMessage(messageTypes, new ContextBag());
             Assert.AreEqual(0, subscribers.Count());

--- a/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
@@ -26,7 +26,7 @@
                     var addressLabel = rs.Apply(headers);
                     var message = new OutgoingMessage(context.Message.MessageId, context.Message.Headers, context.Message.Body);
                     return new TransportOperation(message, addressLabel, dispatchConsistency, context.GetDeliveryConstraints());
-                });
+                }).ToList();
 
             if (log.IsDebugEnabled)
             {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/ISubscriptionStorage.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/ISubscriptionStorage.cs
@@ -12,16 +12,16 @@ namespace NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions
         /// <summary>
         /// Subscribes the given client to messages of the given types.
         /// </summary>
-        Task Subscribe(Subscriber subscriber, IReadOnlyCollection<MessageType> messageTypes, ContextBag context);
+        Task Subscribe(Subscriber subscriber, MessageType messageType, ContextBag context);
 
         /// <summary>
         /// Unsubscribes the given client from messages of the given types.
         /// </summary>
-        Task Unsubscribe(Subscriber subscriber, IReadOnlyCollection<MessageType> messageTypes, ContextBag context);
+        Task Unsubscribe(Subscriber subscriber, MessageType messageType, ContextBag context);
 
         /// <summary>
         /// Returns a list of addresses for subscribers currently subscribed to the given message type.
         /// </summary>
-        Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IReadOnlyCollection<MessageType> messageTypes, ContextBag context);
+        Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context);
     }
 }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/ISubscriptionStorage.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/ISubscriptionStorage.cs
@@ -10,12 +10,12 @@ namespace NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions
     public interface ISubscriptionStorage
     {
         /// <summary>
-        /// Subscribes the given client to messages of the given types.
+        /// Subscribes the given client to messages of a given type.
         /// </summary>
         Task Subscribe(Subscriber subscriber, MessageType messageType, ContextBag context);
 
         /// <summary>
-        /// Unsubscribes the given client from messages of the given types.
+        /// Unsubscribes the given client from messages of given type.
         /// </summary>
         Task Unsubscribe(Subscriber subscriber, MessageType messageType, ContextBag context);
 

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionReceiverBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionReceiverBehavior.cs
@@ -77,22 +77,15 @@
                 return;
             }
             Logger.Info($"{intent} from {subscriberAddress} on message type {messageTypeString}");
+            var subscriber = new Subscriber(subscriberAddress, subscriberEndpoint);
             if (incomingMessage.GetMesssageIntent() == MessageIntentEnum.Subscribe)
             {
                 var messageType = new MessageType(messageTypeString);
-
-                await subscriptionStorage.Subscribe(new Subscriber(subscriberAddress, subscriberEndpoint), new[]
-                {
-                    messageType
-                }, context.Extensions).ConfigureAwait(false);
-
+                await subscriptionStorage.Subscribe(subscriber, messageType, context.Extensions).ConfigureAwait(false);
                 return;
             }
-            
-            await subscriptionStorage.Unsubscribe(new Subscriber(subscriberAddress, subscriberEndpoint), new[]
-            {
-                new MessageType(messageTypeString)
-            }, context.Extensions).ConfigureAwait(false);
+
+            await subscriptionStorage.Unsubscribe(subscriber, new MessageType(messageTypeString), context.Extensions).ConfigureAwait(false);
         }
 
         static string GetSubscriptionMessageTypeFrom(IncomingMessage msg)

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -161,8 +161,7 @@
                     return new List<IUnicastRoute>();
                 }
 
-                var messageTypes = types.Select(t => new MessageType(t)).ToArray();
-                
+                var messageTypes = types.Select(t => new MessageType(t));
                 var subscribers = await subscriptions.GetSubscriberAddressesForMessage(messageTypes, contextBag).ConfigureAwait(false);
                 return subscribers.Select(s => new SubscriberDestination(s));
             }


### PR DESCRIPTION
`ISubscriptionStorage` had some legacy baggage to do with when we used to manage subscriptions for message hierarchies. this is no longer true. the current api expects lists but it is only ever a single item in those lists

this PR changes that api to only pass in a single instance of messagetype when subscribing or unsubscribing 