### PR TITLE
Aligned UnicastTransportOperations and MulticastTransportOperations with TransportOperation

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2679,7 +2679,7 @@ namespace NServiceBus.Transports
     }
     public class MulticastTransportOperation : NServiceBus.Transports.IOutgoingTransportOperation
     {
-        public MulticastTransportOperation(NServiceBus.Transports.OutgoingMessage message, System.Type messageType, System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> deliveryConstraints = null, NServiceBus.Transports.DispatchConsistency requiredDispatchConsistency = 1) { }
+        public MulticastTransportOperation(NServiceBus.Transports.OutgoingMessage message, System.Type messageType, NServiceBus.Transports.DispatchConsistency requiredDispatchConsistency = 1, System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> deliveryConstraints = null) { }
         public System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> DeliveryConstraints { get; }
         public NServiceBus.Transports.OutgoingMessage Message { get; }
         public System.Type MessageType { get; }
@@ -2776,7 +2776,7 @@ namespace NServiceBus.Transports
     }
     public class TransportOperation
     {
-        public TransportOperation(NServiceBus.Transports.OutgoingMessage message, NServiceBus.Routing.AddressTag addressTag, NServiceBus.Transports.DispatchConsistency requiredDispatchConsistency, System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> deliveryConstraints = null) { }
+        public TransportOperation(NServiceBus.Transports.OutgoingMessage message, NServiceBus.Routing.AddressTag addressTag, NServiceBus.Transports.DispatchConsistency requiredDispatchConsistency = 1, System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> deliveryConstraints = null) { }
         public NServiceBus.Routing.AddressTag AddressTag { get; }
         public System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> DeliveryConstraints { get; }
         public NServiceBus.Transports.OutgoingMessage Message { get; }
@@ -2784,7 +2784,7 @@ namespace NServiceBus.Transports
     }
     public class TransportOperations
     {
-        public TransportOperations(System.Collections.Generic.IEnumerable<NServiceBus.Transports.MulticastTransportOperation> multicastTransportOperations, System.Collections.Generic.IEnumerable<NServiceBus.Transports.UnicastTransportOperation> unicastTransportOperations) { }
+        public TransportOperations(params NServiceBus.Transports.TransportOperation[] transportOperations) { }
         public System.Collections.Generic.IEnumerable<NServiceBus.Transports.MulticastTransportOperation> MulticastTransportOperations { get; }
         public System.Collections.Generic.IEnumerable<NServiceBus.Transports.UnicastTransportOperation> UnicastTransportOperations { get; }
     }
@@ -2812,7 +2812,7 @@ namespace NServiceBus.Transports
     }
     public class UnicastTransportOperation : NServiceBus.Transports.IOutgoingTransportOperation
     {
-        public UnicastTransportOperation(NServiceBus.Transports.OutgoingMessage message, string destination, System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> deliveryConstraints = null, NServiceBus.Transports.DispatchConsistency requiredDispatchConsistency = 1) { }
+        public UnicastTransportOperation(NServiceBus.Transports.OutgoingMessage message, string destination, NServiceBus.Transports.DispatchConsistency requiredDispatchConsistency = 1, System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> deliveryConstraints = null) { }
         public System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> DeliveryConstraints { get; }
         public string Destination { get; }
         public NServiceBus.Transports.OutgoingMessage Message { get; }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ExpiredTimeoutsPoller.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ExpiredTimeoutsPoller.cs
@@ -80,7 +80,7 @@ namespace NServiceBus
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                await SpinOnce();
+                await SpinOnce().ConfigureAwait(false);
             }
         }
 
@@ -107,7 +107,7 @@ namespace NServiceBus
 
                 dispatchRequest.Headers["Timeout.Id"] = timeoutData.Id;
 
-                var transportOperation = new TransportOperation(dispatchRequest, new UnicastAddressTag(dispatcherAddress), DispatchConsistency.Default);
+                var transportOperation = new TransportOperation(dispatchRequest, new UnicastAddressTag(dispatcherAddress));
                 await dispatcher.Dispatch(new TransportOperations(transportOperation), new ContextBag()).ConfigureAwait(false);
             }
 

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
@@ -64,7 +64,7 @@ namespace NServiceBus
                 if (data.Time.AddSeconds(-1) <= DateTime.UtcNow)
                 {
                     var outgoingMessage = new OutgoingMessage(message.MessageId, data.Headers, data.State);
-                    var transportOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(data.Destination), DispatchConsistency.Default);
+                    var transportOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(data.Destination));
                     await dispatcher.Dispatch(new TransportOperations(transportOperation), context.Extensions).ConfigureAwait(false);
                     return;
                 }

--- a/src/NServiceBus.Core/Routing/Legacy/ReadyMessageSender.cs
+++ b/src/NServiceBus.Core/Routing/Legacy/ReadyMessageSender.cs
@@ -45,7 +45,7 @@
                 readyMessage.Headers.Add(LegacyDistributorHeaders.WorkerStarting, bool.TrueString);
             }
 
-            var transportOperation = new TransportOperation(readyMessage, new UnicastAddressTag(distributorControlAddress), DispatchConsistency.Default);
+            var transportOperation = new TransportOperation(readyMessage, new UnicastAddressTag(distributorControlAddress));
             return dispatcher.Dispatch(new TransportOperations(transportOperation), new ContextBag());
         }
         

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -59,7 +59,7 @@
             var state = context.GetOrCreate<Settings>();
             try
             {
-                var transportOperation = new TransportOperation(subscriptionMessage, new UnicastAddressTag(destination), DispatchConsistency.Default);
+                var transportOperation = new TransportOperation(subscriptionMessage, new UnicastAddressTag(destination));
                 await dispatcher.Dispatch(new TransportOperations(transportOperation), context).ConfigureAwait(false);
             }
             catch (QueueNotFoundException ex)

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -57,7 +57,7 @@
             var state = context.GetOrCreate<Settings>();
             try
             {
-                var transportOperation = new TransportOperation(unsubscribeMessage, new UnicastAddressTag(destination), DispatchConsistency.Default);
+                var transportOperation = new TransportOperation(unsubscribeMessage, new UnicastAddressTag(destination));
                 await dispatcher.Dispatch(new TransportOperations(transportOperation), context).ConfigureAwait(false);
             }
             catch (QueueNotFoundException ex)

--- a/src/NServiceBus.Core/Transports/MulticastTransportOperation.cs
+++ b/src/NServiceBus.Core/Transports/MulticastTransportOperation.cs
@@ -13,7 +13,7 @@ namespace NServiceBus.Transports
         /// <summary>
         /// Creates a new <see cref="MulticastTransportOperation"/> instance.
         /// </summary>
-        public MulticastTransportOperation(OutgoingMessage message, Type messageType, IEnumerable<DeliveryConstraint> deliveryConstraints = null, DispatchConsistency requiredDispatchConsistency = DispatchConsistency.Default)
+        public MulticastTransportOperation(OutgoingMessage message, Type messageType, DispatchConsistency requiredDispatchConsistency = DispatchConsistency.Default, IEnumerable<DeliveryConstraint> deliveryConstraints = null)
         {
             Message = message;
             MessageType = messageType;

--- a/src/NServiceBus.Core/Transports/TransportOperation.cs
+++ b/src/NServiceBus.Core/Transports/TransportOperation.cs
@@ -17,7 +17,7 @@ namespace NServiceBus.Transports
         /// <param name="addressTag">The address to use when routing this message.</param>
         /// <param name="requiredDispatchConsistency">The required consistency level for the dispatch operation.</param>
         /// <param name="deliveryConstraints">The delivery constraints that must be honored by the transport.</param>
-        public TransportOperation(OutgoingMessage message, AddressTag addressTag, DispatchConsistency requiredDispatchConsistency, IEnumerable<DeliveryConstraint> deliveryConstraints = null)
+        public TransportOperation(OutgoingMessage message, AddressTag addressTag, DispatchConsistency requiredDispatchConsistency = DispatchConsistency.Default, IEnumerable<DeliveryConstraint> deliveryConstraints = null)
         {
             Message = message;
             AddressTag = addressTag;

--- a/src/NServiceBus.Core/Transports/TransportOperations.cs
+++ b/src/NServiceBus.Core/Transports/TransportOperations.cs
@@ -9,7 +9,10 @@ namespace NServiceBus.Transports
     /// </summary>
     public class TransportOperations
     {
-        internal TransportOperations(params TransportOperation[] transportOperations)
+        /// <summary>
+        /// Creates a new set of dispatchable transport operations.
+        /// </summary>
+        public TransportOperations(params TransportOperation[] transportOperations)
         {
             var multicastOperations = new List<MulticastTransportOperation>(transportOperations.Length);
             var unicastOperations = new List<UnicastTransportOperation>(transportOperations.Length);
@@ -21,16 +24,16 @@ namespace NServiceBus.Transports
                     multicastOperations.Add(new MulticastTransportOperation(
                         transportOperation.Message, 
                         ((MulticastAddressTag) transportOperation.AddressTag).MessageType, 
-                        transportOperation.DeliveryConstraints, 
-                        transportOperation.RequiredDispatchConsistency));
+                        transportOperation.RequiredDispatchConsistency, 
+                        transportOperation.DeliveryConstraints));
                 }
                 else if (transportOperation.AddressTag is UnicastAddressTag)
                 {
                     unicastOperations.Add(new UnicastTransportOperation(
                         transportOperation.Message,
                         ((UnicastAddressTag) transportOperation.AddressTag).Destination,
-                        transportOperation.DeliveryConstraints,
-                        transportOperation.RequiredDispatchConsistency));
+                        transportOperation.RequiredDispatchConsistency,
+                        transportOperation.DeliveryConstraints));
                 }
                 else
                 {
@@ -42,18 +45,6 @@ namespace NServiceBus.Transports
 
             MulticastTransportOperations = multicastOperations;
             UnicastTransportOperations = unicastOperations;
-        }
-
-        /// <summary>
-        /// Creates a new set of dispatchable transport operations.
-        /// </summary>
-        public TransportOperations(IEnumerable<MulticastTransportOperation> multicastTransportOperations, IEnumerable<UnicastTransportOperation> unicastTransportOperations)
-        {
-            Guard.AgainstNull(nameof(multicastTransportOperations), multicastTransportOperations);
-            Guard.AgainstNull(nameof(unicastTransportOperations), unicastTransportOperations);
-
-            MulticastTransportOperations = multicastTransportOperations;
-            UnicastTransportOperations = unicastTransportOperations;
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Transports/UnicastTransportOperation.cs
+++ b/src/NServiceBus.Core/Transports/UnicastTransportOperation.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Transports
         /// <summary>
         /// Creates a new <see cref="UnicastTransportOperation"/> instance.
         /// </summary>
-        public UnicastTransportOperation(OutgoingMessage message, string destination, IEnumerable<DeliveryConstraint> deliveryConstraints = null, DispatchConsistency requiredDispatchConsistency = DispatchConsistency.Default)
+        public UnicastTransportOperation(OutgoingMessage message, string destination, DispatchConsistency requiredDispatchConsistency = DispatchConsistency.Default, IEnumerable<DeliveryConstraint> deliveryConstraints = null)
         {
             Message = message;
             Destination = destination;


### PR DESCRIPTION
I was updating the CustomChecks for V6. They are using raw sending. By going over the ugprade guide I realized we have a problem between `TransportOperation` and `MulticastTransportOperation` and `UnicastTransportOperation`. Basically it boils down to have two constructors and one of them being internal. This PR makes the constructor which accepts params of `TransportOperation` public and removes the ctor accepting `MulticastTransportOperation` and `UnicastTransportOperation`. This streamlines the creation of transport operations and makes it less noisy.

## Downstream repos

* [X] No impact on NServiceBus.SqlServer
* [X] No impact on NServiceBus.AzureServiceBus
* [X] [RabbitMQ](https://github.com/Particular/NServiceBus.RabbitMQ/pull/120)
* [X] [Documentation](https://github.com/Particular/docs.particular.net/pull/1085)

@Particular/tf-async-transport please review and merge if good