### PR TITLE
Added check to ensure that dependency graph is acyclic

### DIFF
--- a/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
@@ -175,6 +175,30 @@
             Assert.IsInstanceOf<Level3>(order[2], "Upstream dependencies should be activated first");
         }
 
+        [Test]
+        public void Should_throw_exception_when_dependency_cycle_is_found()
+        {
+            var order = new List<Feature>();
+
+
+            var level1 = new CycleLevel1
+            {
+                OnActivation = f => order.Add(f)
+            };
+            var level2 = new CycleLevel2
+            {
+                OnActivation = f => order.Add(f)
+            };
+
+            var settings = new SettingsHolder();
+            var featureSettings = new FeatureActivator(settings);
+
+            featureSettings.Add(level1);
+            featureSettings.Add(level2);
+
+            Assert.Throws<ArgumentException>(() => featureSettings.SetupFeatures(null, null));
+        }
+
         public class Level1 : TestFeature
         {
             public Level1()
@@ -198,6 +222,24 @@
             {
                 EnableByDefault();
                 DependsOn<Level2>();
+            }
+        }
+
+        public class CycleLevel1 : TestFeature
+        {
+            public CycleLevel1()
+            {
+                EnableByDefault();
+                DependsOn<CycleLevel2>();
+            }
+        }
+
+        public class CycleLevel2 : TestFeature
+        {
+            public CycleLevel2()
+            {
+                EnableByDefault();
+                DependsOn<CycleLevel1>();
             }
         }
 

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -122,7 +122,39 @@ namespace NServiceBus.Features
                 node.Visit(output);
             }
 
+            // Step 4: DFS to check if we have an directed acyclic graph
+            foreach (var node in allNodes)
+            {
+                if (DirectedCycleExistsFrom(node, new Node [] { }))
+                {
+                    throw new ArgumentException("Cycle in dependency graph detected");
+                }
+            }
+
             return output;
+        }
+
+        static bool DirectedCycleExistsFrom(Node node, IEnumerable<Node> visitedNodes)
+        {
+            if (node.previous.Any())
+            {
+                if (visitedNodes.Any(n => n == node))
+                {
+                    return true;
+                }
+
+                var newVisitedNodes = visitedNodes.Union(new[] { node });
+
+                foreach (var subNode in node.previous)
+                {
+                    if (DirectedCycleExistsFrom(subNode, newVisitedNodes))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         bool ActivateFeature(FeatureInfo featureInfo, List<FeatureInfo> featuresToActivate, IConfigureComponents container, PipelineSettings pipelineSettings)


### PR DESCRIPTION
Added DFS to check that the dependecy graph is a directed acyclic graph and
does not have any cycles.

Used a simple DFS, which will execute in linear time. If this manifests as a performance concern we can implement something a little smarter like Tarjan's algorithm.

Connects to https://github.com/Particular/NServiceBus/issues/3329