### PR TITLE
Timeout circuit breaker bug fix v6

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -76,7 +76,7 @@
     <Compile Include="Msmq\When_TimeToBeReceivedOnForwardedMessages_set_and_transactional_Msmq.cs" />
     <Compile Include="Msmq\When_TimeToBeReceived_set_and_receivetransaction_Msmq.cs" />
     <Compile Include="Msmq\When_TimeToBeReceived_set_and_DTC_Msmq.cs" />
-    <Compile Include="CriticalError\When_using_default_critical_error_handler.cs" />
+    <Compile Include="CriticalError\When_raising_critical_error.cs" />
     <Compile Include="Msmq\When_publishing.cs" />
     <Compile Include="Msmq\When_setting_msmq_label_generator.cs" />
     <Compile Include="Basic\When_deferring_to_non_local.cs" />

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -180,6 +180,8 @@
     <Compile Include="Sagas\When_a_base_class_message_hits_a_saga.cs" />
     <Compile Include="Sagas\When_a_finder_exists.cs" />
     <Compile Include="SelfVerification\When_running_saga_tests.cs" />
+    <Compile Include="Timeout\CyclingOutageTimeoutPersister.cs" />
+    <Compile Include="Timeout\When_timeout_storage_is_unavailable_temporarily.cs" />
     <Compile Include="Tx\ImmediateDispatch\When_requesting_immediate_dispatch_using_scope_suppress.cs" />
     <Compile Include="Tx\ImmediateDispatch\When_requesting_immediate_dispatch_with_at_least_once.cs" />
     <Compile Include="Tx\ImmediateDispatch\When_requesting_immediate_dispatch_with_exactly_once.cs" />

--- a/src/NServiceBus.AcceptanceTests/Timeout/CyclingOutageTimeoutPersister.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeout/CyclingOutageTimeoutPersister.cs
@@ -1,0 +1,118 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using Timeout.Core;
+
+    /// <summary>
+    /// This class mocks outages for timeout storage. 
+    /// If SecondsToWait is set to 10, it will throw exceptions for 10 seconds, then be available for 10 seconds, and repeat.
+    /// </summary>
+    class CyclingOutageTimeoutPersister : IPersistTimeouts, IQueryTimeouts
+    {
+        int secondsToWait;
+
+        public int SecondsToWait
+        {
+            get { return secondsToWait; }
+            set
+            {
+                secondsToWait = value;
+                NextChangeTime = DateTime.Now.AddSeconds(SecondsToWait);
+            }
+        }
+
+        static bool isAvailable = false;
+        Task completedTask = Task.FromResult(0);
+        DateTime NextChangeTime;
+        ConcurrentDictionary<string, TimeoutData> storage = new ConcurrentDictionary<string, TimeoutData>(); 
+
+        void ThrowExceptionUntilWaitTimeReached()
+        {
+            if (NextChangeTime <= DateTime.Now)
+            {
+                NextChangeTime = DateTime.Now.AddSeconds(SecondsToWait);
+                isAvailable = !isAvailable;
+            }
+
+            if (!isAvailable)
+            {
+                throw new Exception("Persister is temporarily unavailable");
+            }
+        }
+
+        public IEnumerable<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
+        {
+            ThrowExceptionUntilWaitTimeReached();
+            nextTimeToRunQuery = DateTime.Now.AddSeconds(2);
+            return Enumerable.Empty<Tuple<string, DateTime>>().ToList();
+        }
+
+        public Task Add(TimeoutData timeout)
+        {
+            ThrowExceptionUntilWaitTimeReached();
+            return completedTask;
+        }
+
+        public Task<bool> TryRemove(string timeoutId, ContextBag context)
+        {
+            ThrowExceptionUntilWaitTimeReached();
+
+            TimeoutData timeoutData = null;
+
+            if (storage.ContainsKey(timeoutId))
+            {
+                storage.TryRemove(timeoutId, out timeoutData);
+            }
+
+            return Task.FromResult(timeoutData != null);
+        }
+
+        public Task RemoveTimeoutBy(Guid sagaId, ContextBag context)
+        {
+            ThrowExceptionUntilWaitTimeReached();
+            return completedTask;
+        }
+
+        public Task Add(TimeoutData timeout, ContextBag context)
+        {
+            ThrowExceptionUntilWaitTimeReached();
+            storage.TryAdd(timeout.Id, timeout);
+            return completedTask;
+        }
+
+        public Task<TimeoutData> Peek(string timeoutId, ContextBag context)
+        {
+            ThrowExceptionUntilWaitTimeReached();
+            if (storage.ContainsKey(timeoutId))
+            {
+                return Task.FromResult(storage[timeoutId]);
+            }
+            return Task.FromResult<TimeoutData>(null);
+        }
+
+        public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice)
+        {
+            ThrowExceptionUntilWaitTimeReached();
+
+            var timeoutsDue = new List<TimeoutsChunk.Timeout>();
+            foreach (var key in storage.Keys)
+            {
+                var value = storage[key];
+                if (value.Time <= startSlice)
+                {
+                    var timeout = new TimeoutsChunk.Timeout(key, value.Time);
+                    timeoutsDue.Add(timeout);
+                }
+            }
+
+            var chunk = new TimeoutsChunk(timeoutsDue, DateTime.Now.AddSeconds(5));
+
+            return Task.FromResult(chunk);
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
@@ -1,0 +1,90 @@
+﻿namespace NServiceBus.AcceptanceTests.Timeouts
+{
+    using System;
+    using System.Threading.Tasks;
+    using Features;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+
+    class When_timeout_storage_is_unavailable_temporarily : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Endpoint_should_start()
+        {
+            await Scenario.Define<TimeoutTestContext>()
+                .WithEndpoint<EndpointWithFlakyTimeoutPersister>()
+                .Done(c => c.EndpointsStarted)
+                .Repeat(r => r.For(Transports.Msmq))
+                .Should(c => Assert.IsTrue(c.EndpointsStarted))
+                .Run();
+        }
+
+        [Test]
+        public async Task Endpoint_should_not_shutdown()
+        {
+            var stopTime = DateTime.Now.AddSeconds(45);
+
+            await Scenario.Define<TimeoutTestContext>(c =>
+            {
+                c.SecondsToWait = 10;
+            })
+                //.AllowExceptions(ex => ex.Message.Contains("Persister is temporarily unavailable"))
+                .WithEndpoint<EndpointWithFlakyTimeoutPersister>(b =>
+                {
+                    b.CustomConfig((busConfig, context) =>
+                    {
+                        busConfig.DefineCriticalErrorAction(criticalErrorContext =>
+                        {
+                            if (criticalErrorContext.Error.Contains("Persister is temporarily unavailable"))
+                                context.FatalErrorOccurred = true;
+                            return Task.FromResult(true);
+                        });
+                    });
+                })
+                .Done(c => c.FatalErrorOccurred || stopTime <= DateTime.Now)
+                .Repeat(r => r.For(Transports.Msmq))
+                .Should(c => Assert.IsFalse(c.FatalErrorOccurred, "Circuit breaker was trigged too soon."))
+                .Run();
+        }
+
+        public class TimeoutTestContext : ScenarioContext
+        {
+            public int SecondsToWait { get; set; }
+            public bool FatalErrorOccurred { get; set; }
+        }
+
+        [Serializable]
+        public class MyMessage : IMessage { }
+
+        public class EndpointWithFlakyTimeoutPersister : EndpointConfigurationBuilder
+        {
+            public TestContext TestContext { get; set; }
+            public EndpointWithFlakyTimeoutPersister()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.EnableFeature<TimeoutManager>();
+                    //config.SuppressOutdatedTimeoutPersistenceWarning();
+                });
+            }
+
+            class Initalizer : Feature
+            {
+                public Initalizer()
+                {
+                    EnableByDefault();
+                }
+
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                    var testContext = context.Settings.Get<TimeoutTestContext>();
+                    context.Container
+                        .ConfigureComponent<CyclingOutageTimeoutPersister>(DependencyLifecycle.SingleInstance)
+                        .ConfigureProperty(tp => tp.SecondsToWait, testContext.SecondsToWait);
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/CriticalError/CriticalError.cs
+++ b/src/NServiceBus.Core/CriticalError/CriticalError.cs
@@ -58,7 +58,7 @@ namespace NServiceBus
 
             lock (endpointCriticalLock)
             {
-                if (endpoint == null || criticalErrors.Any())
+                if (endpoint == null)
                 {
                     criticalErrors.Add(new LatentCritical()
                     {

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
@@ -13,9 +13,11 @@
     /// </summary>
     public class TimeoutManager : Feature
     {
+        TimeSpan TimeToWaitBeforeTriggeringCriticalError = TimeSpan.FromMinutes(2);
+
         internal TimeoutManager()
         {
-            Defaults(s => s.SetDefault("TimeToWaitBeforeTriggeringCriticalErrorForTimeoutPersisterReceiver", TimeSpan.FromSeconds(2)));
+            Defaults(s => s.SetDefault("TimeToWaitBeforeTriggeringCriticalErrorForTimeoutPersisterReceiver", TimeToWaitBeforeTriggeringCriticalError));
             EnableByDefault();
 
             Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"), "Send only endpoints can't use the timeoutmanager since it requires receive capabilities");

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -50,7 +50,7 @@ namespace NServiceBus
             var runningInstance = new RunningEndpointInstance(builder, pipelineCollection, runner, featureRunner, busSession);
 
             // set the started endpoint on CriticalError to pass the endpoint to the critical error action
-            builder.Build<CriticalError>().Endpoint = runningInstance;
+            builder.Build<CriticalError>().SetEndpoint(runningInstance);
 
             await StartPipelines(pipelineCollection).ConfigureAwait(false);
 


### PR DESCRIPTION
https://github.com/Particular/NServiceBus/pull/3014

https://github.com/Particular/NServiceBus/issues/2994

Porting the timeout tests and fix to v6

cc / @indualagarsamy @timbussmann 

I needed to refactor `CriticalError.cs` because features will raise critical errors before the endpoint property is actually populated. This meant that endpoint.Stop() was never called even though something deemed critical occurred. The expected error also never bubbled up.

**Scenario**: When the circuit breaker for the timeout storage breaks, it will raise a critical error indicating that the storage can not be reached. The critical error method threw an InvalidOperationException if the endpoint property was null, which never allowed the circuit breaker to stop the endpoint.