### PR TITLE
MakeCanonicalName get settings bag.

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -703,7 +703,7 @@ namespace NServiceBus
         public override NServiceBus.Transports.IManageSubscriptions GetSubscriptionManager() { }
         public override System.Collections.Generic.IEnumerable<System.Type> GetSupportedDeliveryConstraints() { }
         public override NServiceBus.TransportTransactionMode GetSupportedTransactionMode() { }
-        public override string MakeCanonicalForm(string transportAddress) { }
+        public override string MakeCanonicalForm(string transportAddress, NServiceBus.Settings.ReadOnlySettings settings) { }
         public override string ToTransportAddress(NServiceBus.LogicalAddress logicalAddress) { }
     }
     public class NonDurableDelivery : NServiceBus.DeliveryConstraints.DeliveryConstraint
@@ -2773,7 +2773,7 @@ namespace NServiceBus.Transports
         public abstract NServiceBus.Transports.IManageSubscriptions GetSubscriptionManager();
         public abstract System.Collections.Generic.IEnumerable<System.Type> GetSupportedDeliveryConstraints();
         public abstract NServiceBus.TransportTransactionMode GetSupportedTransactionMode();
-        public virtual string MakeCanonicalForm(string transportAddress) { }
+        public virtual string MakeCanonicalForm(string transportAddress, NServiceBus.Settings.ReadOnlySettings settings) { }
         public abstract string ToTransportAddress(NServiceBus.LogicalAddress logicalAddress);
     }
     public class TransportOperation

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -55,7 +55,7 @@
 
                 foreach (MessageEndpointMapping m in legacyRoutingConfig)
                 {
-                    m.Configure((type, s) => routeTable.RouteToAddress(type, transportDefinition.MakeCanonicalForm(s)));
+                    m.Configure((type, s) => routeTable.RouteToAddress(type, transportDefinition.MakeCanonicalForm(s, context.Settings)));
                     m.Configure((type, s) =>
                     {
                         var typesEnclosed = knownMessageTypes.Where(t => t.IsAssignableFrom(type));

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransport.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransport.cs
@@ -159,8 +159,7 @@ namespace NServiceBus
         /// <summary>
         /// Returns the canonical for of the given transport address so various transport addresses can be effectively compared and deduplicated.
         /// </summary>
-        /// <param name="transportAddress">A transport address.</param>
-        public override string MakeCanonicalForm(string transportAddress)
+        public override string MakeCanonicalForm(string transportAddress, ReadOnlySettings settings)
         {
             return MsmqAddress.Parse(transportAddress).ToString();
         }

--- a/src/NServiceBus.Core/Transports/TransportDefinition.cs
+++ b/src/NServiceBus.Core/Transports/TransportDefinition.cs
@@ -56,8 +56,7 @@ namespace NServiceBus.Transports
         /// <summary>
         /// Returns the canonical for of the given transport address so various transport addresses can be effectively compared and deduplicated.
         /// </summary>
-        /// <param name="transportAddress">A transport address.</param>
-        public virtual string MakeCanonicalForm(string transportAddress)
+        public virtual string MakeCanonicalForm(string transportAddress, ReadOnlySettings settings)
         {
             return transportAddress;
         }


### PR DESCRIPTION
MakeCanonicalName gets settings bag. This is required for sql transport as canonical name contains schema name which might be overridden during configuaration.