### PR TITLE
`MessageIntent.Publish` for `UnicastPublishRouterConnector`, fixes #3344

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -131,6 +131,10 @@
     <Compile Include="Routing\FileRoutingTableTests.cs" />
     <Compile Include="Routing\MessageDrivenSubscribeTerminatorTests.cs" />
     <Compile Include="Routing\MessageDrivenUnsubscribeTerminatorTests.cs" />
+    <Compile Include="Routing\Routers\MulticastPublishRouterBehaviorTests.cs" />
+    <Compile Include="Routing\Routers\UnicastSendRouterConnectorTests.cs" />
+    <Compile Include="Routing\Routers\UnicastReplyRouterConnectorTests.cs" />
+    <Compile Include="Routing\Routers\UnicastPublishRouterConnectorTests.cs" />
     <Compile Include="Routing\SubscriptionRouterTests.cs" />
     <Compile Include="Sagas\When_saga_has_multiple_correlated_properties.cs" />
     <Compile Include="Sagas\When_saga_is_correlated_on_a_unsupported_property_type.cs" />

--- a/src/NServiceBus.Core.Tests/Routing/Routers/MulticastPublishRouterBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/MulticastPublishRouterBehaviorTests.cs
@@ -1,0 +1,85 @@
+﻿namespace NServiceBus.Core.Tests.Routing.Routers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using NServiceBus.ObjectBuilder;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MulticastPublishRouterBehaviorTests
+    {
+        [Test]
+        public async Task Should_set_messageintent_to_publish()
+        {
+            var router = new MulticastPublishRouterBehavior();
+            var context = new FakeContext();
+
+            await router.Invoke(context, ctx => TaskEx.CompletedTask);
+
+            Assert.AreEqual(1, context.Headers.Count);
+            Assert.AreEqual(MessageIntentEnum.Publish.ToString(), context.Headers[Headers.MessageIntent]);
+        }
+
+        class FakeContext : IOutgoingPublishContext
+        {
+            public FakeContext()
+            {
+                Headers = new Dictionary<string, string>();
+                Message = new OutgoingLogicalMessage(typeof(object), new object());
+            }
+
+            public ContextBag Extensions { get; }
+            public IBuilder Builder { get; }
+
+            public Task Send(object message, SendOptions options)
+            {
+                return null;
+            }
+
+            public Task Send<T>(Action<T> messageConstructor, SendOptions options)
+            {
+                return null;
+            }
+
+            public Task Publish(object message, PublishOptions options)
+            {
+                return null;
+            }
+
+            public Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions)
+            {
+                return null;
+            }
+
+            public Task Subscribe(Type eventType, SubscribeOptions options)
+            {
+                return null;
+            }
+
+            public Task Unsubscribe(Type eventType, UnsubscribeOptions options)
+            {
+                return null;
+            }
+
+            public string MessageId { get; }
+            public Dictionary<string, string> Headers { get; }
+            public OutgoingLogicalMessage Message { get; }
+        }
+
+        class Router : IUnicastRouter
+        {
+            public Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, DistributionStrategy distributionStrategy, ContextBag contextBag)
+            {
+                IEnumerable<UnicastRoutingStrategy> unicastRoutingStrategies = new List<UnicastRoutingStrategy>
+                {
+                    new UnicastRoutingStrategy("Fake")
+                };
+                return Task.FromResult(unicastRoutingStrategies);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastPublishRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastPublishRouterConnectorTests.cs
@@ -1,0 +1,85 @@
+﻿namespace NServiceBus.Core.Tests.Routing.Routers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using NServiceBus.ObjectBuilder;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class UnicastPublishRouterConnectorTests
+    {
+        [Test]
+        public async Task Should_set_messageintent_to_publish()
+        {
+            var router = new UnicastPublishRouterConnector(new Router(), new DistributionPolicy());
+            var context = new FakeContext();
+
+            await router.Invoke(context, ctx => TaskEx.CompletedTask);
+
+            Assert.AreEqual(1, context.Headers.Count);
+            Assert.AreEqual(MessageIntentEnum.Publish.ToString(), context.Headers[Headers.MessageIntent]);
+        }
+
+        class FakeContext : IOutgoingPublishContext
+        {
+            public FakeContext()
+            {
+                Headers = new Dictionary<string, string>();
+                Message = new OutgoingLogicalMessage(typeof(object), new object());
+            }
+
+            public ContextBag Extensions { get; }
+            public IBuilder Builder { get; }
+
+            public Task Send(object message, SendOptions options)
+            {
+                return null;
+            }
+
+            public Task Send<T>(Action<T> messageConstructor, SendOptions options)
+            {
+                return null;
+            }
+
+            public Task Publish(object message, PublishOptions options)
+            {
+                return null;
+            }
+
+            public Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions)
+            {
+                return null;
+            }
+
+            public Task Subscribe(Type eventType, SubscribeOptions options)
+            {
+                return null;
+            }
+
+            public Task Unsubscribe(Type eventType, UnsubscribeOptions options)
+            {
+                return null;
+            }
+
+            public string MessageId { get; }
+            public Dictionary<string, string> Headers { get; }
+            public OutgoingLogicalMessage Message { get; }
+        }
+
+        class Router : IUnicastRouter
+        {
+            public Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, DistributionStrategy distributionStrategy, ContextBag contextBag)
+            {
+                IEnumerable<UnicastRoutingStrategy> unicastRoutingStrategies = new List<UnicastRoutingStrategy>
+                {
+                    new UnicastRoutingStrategy("Fake")
+                };
+                return Task.FromResult(unicastRoutingStrategies);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastReplyRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastReplyRouterConnectorTests.cs
@@ -1,0 +1,74 @@
+﻿namespace NServiceBus.Core.Tests.Routing.Routers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using NServiceBus.ObjectBuilder;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class UnicastReplyRouterConnectorTests
+    {
+        [Test]
+        public async Task Should_set_messageintent_to_reply()
+        {
+            var router = new UnicastReplyRouterConnector();
+            var context = new FakeContext();
+            context.Extensions.Set(new UnicastReplyRouterConnector.State { ExplicitDestination = "Fake" });
+
+            await router.Invoke(context, ctx => TaskEx.CompletedTask);
+
+            Assert.AreEqual(1, context.Headers.Count);
+            Assert.AreEqual(MessageIntentEnum.Reply.ToString(), context.Headers[Headers.MessageIntent]);
+        }
+
+        class FakeContext : IOutgoingReplyContext
+        {
+            public FakeContext()
+            {
+                Extensions = new ContextBag();
+                Headers = new Dictionary<string, string>();
+                Message = new OutgoingLogicalMessage(typeof(object), new object());
+            }
+
+            public ContextBag Extensions { get; }
+            public IBuilder Builder { get; }
+
+            public Task Send(object message, SendOptions options)
+            {
+                return null;
+            }
+
+            public Task Send<T>(Action<T> messageConstructor, SendOptions options)
+            {
+                return null;
+            }
+
+            public Task Publish(object message, PublishOptions options)
+            {
+                return null;
+            }
+
+            public Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions)
+            {
+                return null;
+            }
+
+            public Task Subscribe(Type eventType, SubscribeOptions options)
+            {
+                return null;
+            }
+
+            public Task Unsubscribe(Type eventType, UnsubscribeOptions options)
+            {
+                return null;
+            }
+
+            public string MessageId { get; }
+            public Dictionary<string, string> Headers { get; }
+            public OutgoingLogicalMessage Message { get; }
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
@@ -1,0 +1,86 @@
+﻿namespace NServiceBus.Core.Tests.Routing.Routers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using NServiceBus.ObjectBuilder;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class UnicastSendRouterConnectorTests
+    {
+        [Test]
+        public async Task Should_set_messageintent_to_send()
+        {
+            var router = new UnicastSendRouterConnector("fake", new Router(), new DistributionPolicy());
+            var context = new FakeContext();
+
+            await router.Invoke(context, ctx => TaskEx.CompletedTask);
+
+            Assert.AreEqual(1, context.Headers.Count);
+            Assert.AreEqual(MessageIntentEnum.Send.ToString(), context.Headers[Headers.MessageIntent]);
+        }
+
+        class FakeContext : IOutgoingSendContext
+        {
+            public FakeContext()
+            {
+                Extensions = new ContextBag();
+                Headers = new Dictionary<string, string>();
+                Message = new OutgoingLogicalMessage(typeof(object), new object());
+            }
+
+            public ContextBag Extensions { get; }
+            public IBuilder Builder { get; }
+
+            public Task Send(object message, SendOptions options)
+            {
+                return null;
+            }
+
+            public Task Send<T>(Action<T> messageConstructor, SendOptions options)
+            {
+                return null;
+            }
+
+            public Task Publish(object message, PublishOptions options)
+            {
+                return null;
+            }
+
+            public Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions)
+            {
+                return null;
+            }
+
+            public Task Subscribe(Type eventType, SubscribeOptions options)
+            {
+                return null;
+            }
+
+            public Task Unsubscribe(Type eventType, UnsubscribeOptions options)
+            {
+                return null;
+            }
+
+            public string MessageId { get; }
+            public Dictionary<string, string> Headers { get; }
+            public OutgoingLogicalMessage Message { get; }
+        }
+
+        class Router : IUnicastRouter
+        {
+            public Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, DistributionStrategy distributionStrategy, ContextBag contextBag)
+            {
+                IEnumerable<UnicastRoutingStrategy> unicastRoutingStrategies = new List<UnicastRoutingStrategy>
+                {
+                    new UnicastRoutingStrategy("Fake")
+                };
+                return Task.FromResult(unicastRoutingStrategies);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Routing/Routers/UnicastPublishRouterConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/UnicastPublishRouterConnector.cs
@@ -28,7 +28,7 @@ namespace NServiceBus
                 return;
             }
 
-            context.Headers[Headers.MessageIntent] = MessageIntentEnum.Send.ToString();
+            context.Headers[Headers.MessageIntent] = MessageIntentEnum.Publish.ToString();
 
             try
             {


### PR DESCRIPTION
This PR fixes #3344 by correctly setting the `MessageIntent` to `Publish` inside the `UnicastPublishRouterConnector`. 

Also added tests to verify that all other Router connectors set the message intent correctly.

@Particular/nservicebus-maintainers please review