### PR TITLE
Removed Subscribe and Unsubscribe from bus context

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -431,8 +431,6 @@ namespace NServiceBus
         System.Threading.Tasks.Task Publish<T>(System.Action<T> messageConstructor, NServiceBus.PublishOptions publishOptions);
         System.Threading.Tasks.Task Send(object message, NServiceBus.SendOptions options);
         System.Threading.Tasks.Task Send<T>(System.Action<T> messageConstructor, NServiceBus.SendOptions options);
-        System.Threading.Tasks.Task Subscribe(System.Type eventType, NServiceBus.SubscribeOptions options);
-        System.Threading.Tasks.Task Unsubscribe(System.Type eventType, NServiceBus.UnsubscribeOptions options);
     }
     public class static IBusContextExtensions
     {
@@ -445,10 +443,6 @@ namespace NServiceBus
         public static System.Threading.Tasks.Task Send<T>(this NServiceBus.IBusContext context, string destination, System.Action<T> messageConstructor) { }
         public static System.Threading.Tasks.Task SendLocal(this NServiceBus.IBusContext context, object message) { }
         public static System.Threading.Tasks.Task SendLocal<T>(this NServiceBus.IBusContext context, System.Action<T> messageConstructor) { }
-        public static System.Threading.Tasks.Task Subscribe(this NServiceBus.IBusContext context, System.Type messageType) { }
-        public static System.Threading.Tasks.Task Subscribe<T>(this NServiceBus.IBusContext context) { }
-        public static System.Threading.Tasks.Task Unsubscribe(this NServiceBus.IBusContext context, System.Type messageType) { }
-        public static System.Threading.Tasks.Task Unsubscribe<T>(this NServiceBus.IBusContext context) { }
     }
     public class static IBusExtensions
     {

--- a/src/NServiceBus.Core/IBusContext.cs
+++ b/src/NServiceBus.Core/IBusContext.cs
@@ -38,20 +38,5 @@ namespace NServiceBus
         /// <param name="messageConstructor">An action which initializes properties of the message.</param>
         /// <param name="publishOptions">Specific options for this event.</param>
         Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions);
-
-        /// <summary>
-        /// Subscribes to receive published messages of the specified type.
-        /// This method is only necessary if you turned off auto-subscribe.
-        /// </summary>
-        /// <param name="eventType">The type of event to subscribe to.</param>
-        /// <param name="options">Options for the subscribe.</param>
-        Task Subscribe(Type eventType, SubscribeOptions options);
-
-        /// <summary>
-        /// Unsubscribes to receive published messages of the specified type.
-        /// </summary>
-        /// <param name="eventType">The type of event to unsubscribe to.</param>
-        /// <param name="options">Options for the subscribe.</param>
-        Task Unsubscribe(Type eventType, UnsubscribeOptions options);
     }
 }

--- a/src/NServiceBus.Core/IBusContextExtensions.cs
+++ b/src/NServiceBus.Core/IBusContextExtensions.cs
@@ -142,57 +142,5 @@ namespace NServiceBus
         {
             return context.Publish(messageConstructor, new PublishOptions());
         }
-
-        /// <summary>
-        /// Subscribes to receive published messages of the specified type.
-        /// This method is only necessary if you turned off auto-subscribe.
-        /// </summary>
-        /// <param name="context">Object being extended.</param>
-        /// <param name="messageType">The type of message to subscribe to.</param>
-        public static Task Subscribe(this IBusContext context, Type messageType)
-        {
-            Guard.AgainstNull(nameof(context), context);
-            Guard.AgainstNull(nameof(messageType), messageType);
-
-            return context.Subscribe(messageType, new SubscribeOptions());
-        }
-
-        /// <summary>
-        /// Subscribes to receive published messages of type T.
-        /// This method is only necessary if you turned off auto-subscribe.
-        /// </summary>
-        /// <param name="context">Object being extended.</param>
-        /// <typeparam name="T">The type of message to subscribe to.</typeparam>
-        public static Task Subscribe<T>(this IBusContext context)
-        {
-            Guard.AgainstNull(nameof(context), context);
-
-            return context.Subscribe(typeof(T), new SubscribeOptions());
-        }
-
-        /// <summary>
-        /// Unsubscribes from receiving published messages of the specified type.
-        /// </summary>
-        /// <param name="context">Object being extended.</param>
-        /// <param name="messageType">The type of message to subscribe to.</param>
-        public static Task Unsubscribe(this IBusContext context, Type messageType)
-        {
-            Guard.AgainstNull(nameof(context), context);
-            Guard.AgainstNull(nameof(messageType), messageType);
-
-            return context.Unsubscribe(messageType, new UnsubscribeOptions());
-        }
-
-        /// <summary>
-        /// Unsubscribes from receiving published messages of the specified type.
-        /// </summary>
-        /// <param name="context">Object being extended.</param>
-        /// <typeparam name="T">The type of message to unsubscribe from.</typeparam>
-        public static Task Unsubscribe<T>(this IBusContext context)
-        {
-            Guard.AgainstNull(nameof(context), context);
-
-            return context.Unsubscribe(typeof(T), new UnsubscribeOptions());
-        }
     }
 }


### PR DESCRIPTION
Connects to #3398 

It is potentially dangerous depending on your transactional level of the endpoint to call subscribe or unsubscribe when handling a message. Let's consider the following example

* Handle a message with a non-dtc transport
* context.Subscribe
* Message handling fails

 Result: Endpoint is subscribed although the message rolled back

## Documentation

Will be done in one GO by @SimonCropp 