### PR TITLE
Upgrade to latest Json.NET

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -54,8 +54,9 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.5.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Obsolete, Version=4.0.3.0, Culture=neutral, PublicKeyToken=1ca091877d12ca03, processorArchitecture=MSIL">
       <HintPath>..\packages\Obsolete.Fody.4.0.3\lib\dotnet\Obsolete.dll</HintPath>

--- a/src/NServiceBus.Core/Serializers/Json/MessageContractResolver.cs
+++ b/src/NServiceBus.Core/Serializers/Json/MessageContractResolver.cs
@@ -9,7 +9,6 @@ namespace NServiceBus
         IMessageMapper messageMapper;
 
         public MessageContractResolver(IMessageMapper messageMapper)
-            : base(true)
         {
             this.messageMapper = messageMapper;
         }

--- a/src/NServiceBus.Core/packages.config
+++ b/src/NServiceBus.Core/packages.config
@@ -4,7 +4,7 @@
   <package id="Fody" version="1.29.4" targetFramework="net452" developmentDependency="true" />
   <package id="GitVersionTask" version="2.0.1" targetFramework="net45" developmentDependency="true" />
   <package id="Janitor.Fody" version="1.1.4.0" targetFramework="net452" developmentDependency="true" />
-  <package id="Newtonsoft.Json" version="5.0.6" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net452" />
   <package id="NuGetPackager" version="0.5.5" targetFramework="net451" developmentDependency="true" />
   <package id="Obsolete.Fody" version="4.0.3" targetFramework="net452" developmentDependency="true" />
   <package id="Particular.Licensing.Sources" version="0.1.54" targetFramework="net45" />


### PR DESCRIPTION
I'm using the latest version of JSon.NET in the custom checks and send messages against NServiceBus unstable using 5.x version of Json.NET and it works fine. I think any breaking changes should be captured by wire-compat tests or am I wrong?

@Particular/nservicebus-maintainers please review