### PR TITLE
Enable retries for concurrency exceptions

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Sagas/when_receiving_multiple_timeouts.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/when_receiving_multiple_timeouts.cs
@@ -38,6 +38,7 @@
             {
                 EndpointSetup<DefaultServer>(c =>
                 {
+                    c.EnableFeature<FirstLevelRetries>();
                     c.EnableFeature<TimeoutManager>();
                     c.ExecuteTheseHandlersFirst(typeof(CatchAllMessageHandler));
                 });


### PR DESCRIPTION
@DavidBoike 
@Particular/nservicebus-maintainers 

Please review.

https://github.com/Particular/NServiceBus.RavenDB/commit/db43863cf536850ea573ecb5080eb459d6b0c277