### PR TITLE
throw from notimplemented  from HasSupportFor

### DIFF
--- a/src/NServiceBus.Core/Persistence/PersistenceDefinition.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceDefinition.cs
@@ -53,7 +53,7 @@
             ReplacementTypeOrMember = "HasSupportFor<T>()")]
         public bool HasSupportFor(Storage storage)
         {
-            return storageToActionMap.ContainsKey(StorageType.FromEnum(storage));
+            throw new NotImplementedException();
         }
 
         /// <summary>


### PR DESCRIPTION
this is `TreatAsErrorFromVersion = "6.0",` from v6 then it cannot be
possibly used, since people need to recompile to target. So we may as
well throw notimplemented from inside