### PR TITLE
Redesigned container tests for new core assumptions

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -286,6 +286,9 @@
       <Name>NServiceBus.AcceptanceTesting</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
+++ b/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
@@ -67,6 +67,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/NServiceBus.ContainerTests/When_building_components.cs
+++ b/src/NServiceBus.ContainerTests/When_building_components.cs
@@ -55,7 +55,7 @@ namespace NServiceBus.ContainerTests
         }
 
         [Test]
-        public void Lambda_uow_components_should_resolve_from_main_container()
+        public void Lambda_uow_components_should_yield_the_same_instance()
         {
             using (var builder = TestContainerBuilder.ConstructBuilder())
             {

--- a/src/NServiceBus.ContainerTests/When_building_components.cs
+++ b/src/NServiceBus.ContainerTests/When_building_components.cs
@@ -41,14 +41,17 @@ namespace NServiceBus.ContainerTests
         }
 
         [Test]
-        public void UoW_components_should_resolve_from_main_container()
+        public void UoW_components_should_yield_the_same_instance()
         {
             using (var builder = TestContainerBuilder.ConstructBuilder())
             {
                 InitializeBuilder(builder);
-                Assert.NotNull(builder.Build(typeof(InstancePerUoWComponent)));
+
+                var instance1 = builder.Build(typeof(InstancePerUoWComponent));
+                var instance2 = builder.Build(typeof(InstancePerUoWComponent));
+
+                Assert.AreSame(instance1, instance2);
             }
-            //Not supported by typeof(WindsorObjectBuilder));
         }
 
         [Test]
@@ -57,9 +60,12 @@ namespace NServiceBus.ContainerTests
             using (var builder = TestContainerBuilder.ConstructBuilder())
             {
                 InitializeBuilder(builder);
-                Assert.NotNull(builder.Build(typeof(LambdaComponentUoW)));
+
+                var instance1 = builder.Build(typeof(LambdaComponentUoW));
+                var instance2 = builder.Build(typeof(LambdaComponentUoW));
+
+                Assert.AreSame(instance1, instance2);
             }
-            //Not supported by typeof(WindsorObjectBuilder));
         }
 
         [Test]

--- a/src/NServiceBus.ContainerTests/When_disposing_the_builder.cs
+++ b/src/NServiceBus.ContainerTests/When_disposing_the_builder.cs
@@ -35,28 +35,6 @@ namespace NServiceBus.ContainerTests
             builder.Dispose();
         }
 
-        [Test]
-        public void Should_dispose_all_IDisposable_components_in_child_container()
-        {
-            using (var main = TestContainerBuilder.ConstructBuilder())
-            {
-                DisposableComponent.DisposeCalled = false;
-                AnotherSingletonComponent.DisposeCalled = false;
-
-                main.RegisterSingleton(typeof(AnotherSingletonComponent), new AnotherSingletonComponent());
-                main.Configure(typeof(DisposableComponent), DependencyLifecycle.InstancePerUnitOfWork);
-
-                using (var builder = main.BuildChildContainer())
-                {
-                    builder.Build(typeof(DisposableComponent));
-                }
-                Assert.False(AnotherSingletonComponent.DisposeCalled, "Dispose should not be called on AnotherSingletonComponent because it belongs to main container");
-                Assert.True(DisposableComponent.DisposeCalled, "Dispose should be called on DisposableComponent");
-            }
-
-            //Not supported by, typeof(SpringObjectBuilder));
-        }
-
         public class DisposableComponent : IDisposable
         {
             public static bool DisposeCalled;

--- a/src/NServiceBus.ContainerTests/When_releasing_components.cs
+++ b/src/NServiceBus.ContainerTests/When_releasing_components.cs
@@ -32,15 +32,16 @@ namespace NServiceBus.ContainerTests
 
         }
 
-        public class TransientClass
+        public class TransientClass : IDisposable
         {
             public static bool Destructed;
 
             public string Name { get; set; }
 
-            ~TransientClass()
+            public void Dispose()
             {
                 Destructed = true;
+                GC.SuppressFinalize(this);
             }
         }
     }

--- a/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
+++ b/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
@@ -204,7 +204,7 @@ namespace NServiceBus.ContainerTests
         }
 
         [Test]
-        public void UoW_components_should_be_singletons_in_root_container()
+        public void UoW_components_built_on_root_container_should_be_singletons_even_with_child_builder_present()
         {
             using (var builder = TestContainerBuilder.ConstructBuilder())
             {
@@ -240,7 +240,7 @@ namespace NServiceBus.ContainerTests
         }
 
         [Test]
-        public void Should_dispose_all_IDisposable_components_in_child_container()
+        public void Should_dispose_all_non_percall_IDisposable_components_in_child_container()
         {
             using (var main = TestContainerBuilder.ConstructBuilder())
             {

--- a/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
+++ b/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
@@ -59,28 +59,6 @@ namespace NServiceBus.ContainerTests
         }
 
         [Test]
-        public void Instance_per_uow_components_should_not_be_shared_across_child_containers()
-        {
-            using (var builder = TestContainerBuilder.ConstructBuilder())
-            {
-                builder.Configure(typeof(InstancePerUoWComponent), DependencyLifecycle.InstancePerUnitOfWork);
-
-                object instance1;
-                using (var childContainer = builder.BuildChildContainer())
-                {
-                    instance1 = childContainer.Build(typeof(InstancePerUoWComponent));
-                }
-
-                object instance2;
-                using (var childContainer = builder.BuildChildContainer())
-                {
-                    instance2 = childContainer.Build(typeof(InstancePerUoWComponent));
-                }
-                Assert.AreNotSame(instance1, instance2);
-            }
-        }
-
-        [Test]
         public void Should_not_allow_reconfiguration_of_child_container()
         {
             using (var builder = TestContainerBuilder.ConstructBuilder())

--- a/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
+++ b/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
@@ -187,7 +187,7 @@ namespace NServiceBus.ContainerTests
         }
 
         [Test]
-        public void UoW_components_in_the_parent_container_should_be_singletons_in_the_child_container()
+        public void UoW_components_in_the_parent_container_should_be_singletons_in_the_same_child_container()
         {
             using (var builder = TestContainerBuilder.ConstructBuilder())
             {

--- a/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
+++ b/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
@@ -2,14 +2,11 @@ namespace NServiceBus.ContainerTests
 {
     using System;
     using System.Diagnostics;
-    using System.Threading.Tasks;
-    using NServiceBus;
     using NUnit.Framework;
 
     [TestFixture]
     public class When_using_nested_containers
     {
-
         [Test]
         public void Instance_per_uow__components_should_be_disposed_when_the_child_container_is_disposed()
         {
@@ -26,59 +23,39 @@ namespace NServiceBus.ContainerTests
         }
 
         [Test]
-        public void Instance_per_uow__components_should_not_be_shared_across_child_containers()
+        public void Instance_per_uow_components_should_not_be_shared_across_child_containers()
         {
             using (var builder = TestContainerBuilder.ConstructBuilder())
             {
-                builder.Configure(typeof(InstancePerUoWComponent),
-                    DependencyLifecycle.InstancePerUnitOfWork);
+                builder.Configure(typeof(InstancePerUoWComponent), DependencyLifecycle.InstancePerUnitOfWork);
 
-                var task1 = Task<object>.Factory.StartNew(() =>
+                object instance1;
+                using (var childContainer = builder.BuildChildContainer())
                 {
-                    using (var childContainer = builder.BuildChildContainer())
-                    {
-                        return childContainer.Build(typeof(InstancePerUoWComponent));
-                    }
-                });
-                var task2 = Task<object>.Factory.StartNew(() =>
-                {
-                    using (var childContainer = builder.BuildChildContainer())
-                    {
-                        return childContainer.Build(typeof(InstancePerUoWComponent));
-                    }
-                });
-                Assert.AreNotSame(task1.Result, task2.Result);
-            }
-        }
-
-
-        [Test]
-        public void Should_resolve_child_container_instance_first()
-        {
-            using (var builder = TestContainerBuilder.ConstructBuilder())
-            {
-                builder.Configure(typeof(InstanceToReplaceInNested_Parent), DependencyLifecycle.SingleInstance);
-                var instance1 = builder.Build(typeof(IInstanceToReplaceInNested));
-                object instance2;
-                using (var nestedContainer = builder.BuildChildContainer())
-                {
-                    nestedContainer.Configure(typeof(InstanceToReplaceInNested_Child), DependencyLifecycle.SingleInstance);
-                    instance2 = nestedContainer.Build(typeof(IInstanceToReplaceInNested));
+                    instance1 = childContainer.Build(typeof(InstancePerUoWComponent));
                 }
 
+                object instance2;
+                using (var childContainer = builder.BuildChildContainer())
+                {
+                    instance2 = childContainer.Build(typeof(InstancePerUoWComponent));
+                }
                 Assert.AreNotSame(instance1, instance2);
             }
         }
 
-        public interface IInstanceToReplaceInNested
+        [Test]
+        public void Should_not_allow_reconfiguration_of_child_container()
         {
-        }
-
-        public class InstanceToReplaceInNested_Parent : IInstanceToReplaceInNested
-        {
-        }
-        public class InstanceToReplaceInNested_Child : IInstanceToReplaceInNested
-        {
+            using (var builder = TestContainerBuilder.ConstructBuilder())
+            {
+                builder.Configure(typeof(InstanceToReplaceInNested_Parent), DependencyLifecycle.SingleInstance);
+                builder.Build(typeof(IInstanceToReplaceInNested));
+                using (var nestedContainer = builder.BuildChildContainer())
+                {
+                    Assert.That(() => nestedContainer.Configure(typeof(InstanceToReplaceInNested_Child), DependencyLifecycle.SingleInstance), Throws.InvalidOperationException);
+                }
+            }
         }
 
         [Test]
@@ -101,17 +78,17 @@ namespace NServiceBus.ContainerTests
                 }
                 Assert.AreNotSame(instance1, instance2);
             }
-
         }
 
-        [Test, Explicit("Time consuming")]
+        [Test]
+        [Explicit]
         public void Instance_per_call_components_should_not_cause_memory_leaks()
         {
             const int iterations = 20000;
 
             using (var builder = TestContainerBuilder.ConstructBuilder())
             {
-                builder.Configure(typeof(InstancePerCallComponent), DependencyLifecycle.InstancePerUnitOfWork);
+                builder.Configure(typeof(InstancePerCallComponent), DependencyLifecycle.InstancePerCall);
 
                 GC.Collect();
                 var before = GC.GetTotalMemory(true);
@@ -128,6 +105,7 @@ namespace NServiceBus.ContainerTests
                 sw.Stop();
                 // Collect all generations of memory.
                 GC.Collect();
+                GC.WaitForPendingFinalizers();
 
                 var after = GC.GetTotalMemory(true);
                 Console.WriteLine("{0} Time: {1} MemDelta: {2} bytes", builder.GetType().Name, sw.Elapsed, after - before);
@@ -135,8 +113,41 @@ namespace NServiceBus.ContainerTests
                 var upperLimitBytes = 200*1024;
                 Assert.That(after - before, Is.LessThan(upperLimitBytes), "Apparently {0} consumed more than {1} KB of memory", builder, upperLimitBytes/1024);
             }
+        }
 
-            //Not supported by, typeof(NinjectObjectBuilder));
+        [Test]
+        [Explicit]
+        public void Instance_per_uow_components_should_not_cause_memory_leaks()
+        {
+            const int iterations = 20000;
+
+            using (var builder = TestContainerBuilder.ConstructBuilder())
+            {
+                builder.Configure(typeof(InstancePerUoWComponent), DependencyLifecycle.InstancePerUnitOfWork);
+
+                GC.Collect();
+                var before = GC.GetTotalMemory(true);
+                var sw = Stopwatch.StartNew();
+
+                for (var i = 0; i < iterations; i++)
+                {
+                    using (var nestedContainer = builder.BuildChildContainer())
+                    {
+                        nestedContainer.Build(typeof(InstancePerUoWComponent));
+                    }
+                }
+
+                sw.Stop();
+                // Collect all generations of memory.
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+
+                var after = GC.GetTotalMemory(true);
+                Console.WriteLine("{0} Time: {1} MemDelta: {2} bytes", builder.GetType().Name, sw.Elapsed, after - before);
+
+                var upperLimitBytes = 200 * 1024;
+                Assert.That(after - before, Is.LessThan(upperLimitBytes), "Apparently {0} consumed more than {1} KB of memory", builder, upperLimitBytes / 1024);
+            }
         }
 
         [Test]
@@ -148,14 +159,16 @@ namespace NServiceBus.ContainerTests
 
                 using (var nestedContainer = builder.BuildChildContainer())
                 {
-                    Assert.AreSame(nestedContainer.Build(typeof(InstancePerUoWComponent)), nestedContainer.Build(typeof(InstancePerUoWComponent)), "UoW's should be singleton in child container");
+                    var instance1 = nestedContainer.Build(typeof(InstancePerUoWComponent));
+                    var instance2 = nestedContainer.Build(typeof(InstancePerUoWComponent));
+
+                    Assert.AreSame(instance1, instance2, "UoW's should be singleton in child container");
                 }
             }
         }
 
         [Test]
-        [Explicit]
-        public void UoW_components_should_by_instance_per_call_in_root_container()
+        public void UoW_components_should_be_singletons_in_root_container()
         {
             using (var builder = TestContainerBuilder.ConstructBuilder())
             {
@@ -166,10 +179,10 @@ namespace NServiceBus.ContainerTests
                     //no-op
                 }
 
-                Assert.AreNotSame(builder.Build(typeof(InstancePerUoWComponent)), builder.Build(typeof(InstancePerUoWComponent)), "UoW's should be instance per call in the root container");
+                var instance1 = builder.Build(typeof(InstancePerUoWComponent));
+                var instance2 = builder.Build(typeof(InstancePerUoWComponent));
+                Assert.AreSame(instance1, instance2, "UoW's should be singletons in the root container");
             }
-
-            //Not supported by typeof(AutofacObjectBuilder), typeof(WindsorObjectBuilder));
         }
 
         [Test]
@@ -190,19 +203,52 @@ namespace NServiceBus.ContainerTests
             }
         }
 
+        [Test]
+        public void Should_dispose_all_IDisposable_components_in_child_container()
+        {
+            using (var main = TestContainerBuilder.ConstructBuilder())
+            {
+                DisposableComponent.DisposeCalled = false;
+                AnotherDisposableComponent.DisposeCalled = false;
+
+                main.RegisterSingleton(typeof(AnotherDisposableComponent), new AnotherDisposableComponent());
+                main.Configure(typeof(DisposableComponent), DependencyLifecycle.InstancePerUnitOfWork);
+
+                using (var builder = main.BuildChildContainer())
+                {
+                    builder.Build(typeof(DisposableComponent));
+                }
+                Assert.False(AnotherDisposableComponent.DisposeCalled, "Dispose should not be called on AnotherSingletonComponent because it belongs to main container");
+                Assert.True(DisposableComponent.DisposeCalled, "Dispose should be called on DisposableComponent");
+            }
+
+            //Not supported by, typeof(SpringObjectBuilder));
+        }
+
+        public interface IInstanceToReplaceInNested
+        {
+        }
+
+        public class InstanceToReplaceInNested_Parent : IInstanceToReplaceInNested
+        {
+        }
+
+        public class InstanceToReplaceInNested_Child : IInstanceToReplaceInNested
+        {
+        }
+
         class SingletonComponent : ISingletonComponent, IDisposable
         {
-            public static bool DisposeCalled;
-
             public void Dispose()
             {
                 DisposeCalled = true;
             }
+
+            public static bool DisposeCalled;
         }
 
         class ComponentThatDependsOfSingleton
         {
-
         }
     }
 
@@ -215,13 +261,12 @@ namespace NServiceBus.ContainerTests
 
     public class InstancePerUoWComponent : IDisposable
     {
-        public static bool DisposeCalled;
-
         public void Dispose()
         {
             DisposeCalled = true;
         }
 
+        public static bool DisposeCalled;
     }
 
     public class SingletonComponent : ISingletonComponent
@@ -234,5 +279,25 @@ namespace NServiceBus.ContainerTests
 
     public interface ISingletonComponent
     {
+    }
+
+    public class DisposableComponent : IDisposable
+    {
+        public static bool DisposeCalled;
+
+        public void Dispose()
+        {
+            DisposeCalled = true;
+        }
+    }
+
+    public class AnotherDisposableComponent : IDisposable
+    {
+        public static bool DisposeCalled;
+
+        public void Dispose()
+        {
+            DisposeCalled = true;
+        }
     }
 }

--- a/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
+++ b/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
@@ -23,6 +23,42 @@ namespace NServiceBus.ContainerTests
         }
 
         [Test]
+        public void Instance_per_uow_components_should_yield_different_instances_between_parent_and_child_containers()
+        {
+            using (var builder = TestContainerBuilder.ConstructBuilder())
+            {
+                builder.Configure(typeof(InstancePerUoWComponent), DependencyLifecycle.InstancePerUnitOfWork);
+
+                var parentInstance = builder.Build(typeof(InstancePerUoWComponent));
+
+                using (var childContainer = builder.BuildChildContainer())
+                {
+                    var childInstance = childContainer.Build(typeof(InstancePerUoWComponent));
+
+                    Assert.AreNotSame(parentInstance, childInstance);
+                }
+            }
+        }
+
+        [Test]
+        public void Instance_per_uow_components_should_yield_different_instances_between_different_instances_of_child_containers()
+        {
+            using (var builder = TestContainerBuilder.ConstructBuilder())
+            {
+                builder.Configure(typeof(InstancePerUoWComponent), DependencyLifecycle.InstancePerUnitOfWork);
+
+                using (var childContainer1 = builder.BuildChildContainer())
+                using (var childContainer2 = builder.BuildChildContainer())
+                {
+                    var childInstance1 = childContainer1.Build(typeof(InstancePerUoWComponent));
+                    var childInstance2 = childContainer2.Build(typeof(InstancePerUoWComponent));
+
+                    Assert.AreNotSame(childInstance1, childInstance2);
+                }
+            }
+        }
+
+        [Test]
         public void Instance_per_uow_components_should_not_be_shared_across_child_containers()
         {
             using (var builder = TestContainerBuilder.ConstructBuilder())

--- a/src/NServiceBus.Core.Tests.x86/NServiceBus.Core.x86.Tests.csproj
+++ b/src/NServiceBus.Core.Tests.x86/NServiceBus.Core.x86.Tests.csproj
@@ -70,5 +70,8 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -342,5 +342,8 @@
     <Content Include="TestDlls\NServiceBus.NewCompilerBits.dll" />
     <Content Include="TestDlls\NServiceBus.OldCompilerBits.dll" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
I have a hunch a few of the container test in the core were not quite right. This is an attempt to fix it.

Implemented with

* AutoFac

Smoke tested my changes with

* CastleWindsor

## Thoughts

* Unit of Work components resolved on the main conatiner should be singletons on the maint container
* Lambda Unit of Work components resolved on the main conatiner should be singletons on the maint container
* TransientClass for when_releasing_components should at least implement `IDisposable`. For example for Windsor a transient class is only tracked if it implements a decomision concern like `IDisposable`. Without that we would essentially only test the runtime and the garbage collector because `Release` is a noop.
* Removed the threads from `Instance_per_uow_components_should_not_be_shared_across_child_containers`. We explicitely want this test to fail if someone implements it with `ThreadScope`
* It should not be possible to reconfigure a child container. From the core perspectice we only get `IBuilder` after the bus is started and we create child builders. 
* `UoW_components_should_by_instance_per_call_in_root_container` was plain wrong in my opinion. The correct test is `UoW_components_should_be_singletons_in_root_container`
* `Should_dispose_all_IDisposable_components_in_child_container` belongs to child container tests


@Particular/nservicebus-maintainers thoughts?

cc @WilliamBZA 