### PR TITLE
obsolete UnicastBusConfig.ForwardReceivedMessagesTo

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Forwarding/When_ForwardReceivedMessagesTo_is_set.cs
+++ b/src/NServiceBus.AcceptanceTests/Forwarding/When_ForwardReceivedMessagesTo_is_set.cs
@@ -4,7 +4,6 @@
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using NServiceBus.Config;
     using NUnit.Framework;
 
     public class When_ForwardReceivedMessagesTo_is_set : NServiceBusAcceptanceTest
@@ -50,8 +49,7 @@
         {
             public EndpointThatForwards()
             {
-                EndpointSetup<DefaultServer>()
-                    .WithConfig<UnicastBusConfig>(c => c.ForwardReceivedMessagesTo = "forward_receiver");
+                EndpointSetup<DefaultServer>(c => c.ForwardReceivedMessagesTo("forward_receiver"));
             }
 
             public class MessageToForwardHandler : IHandleMessages<MessageToForward>

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_dispatching_forwarded_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_dispatching_forwarded_messages.cs
@@ -5,7 +5,6 @@
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
-    using NServiceBus.Config;
     using NServiceBus.Configuration.AdvanceExtensibility;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
@@ -42,8 +41,8 @@
                         b.GetSettings().Set("DisableOutboxTransportCheck", true);
                         b.EnableOutbox();
                         b.Pipeline.Register("BlowUpAfterDispatchBehavior", typeof(BlowUpAfterDispatchBehavior), "For testing");
-                    })
-                     .WithConfig<UnicastBusConfig>(c => c.ForwardReceivedMessagesTo = "forward_receiver_outbox");
+                        b.ForwardReceivedMessagesTo("forward_receiver_outbox");
+                    });
             }
 
             class BlowUpAfterDispatchBehavior : Behavior<IBatchDispatchContext>

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -107,6 +107,10 @@ namespace NServiceBus
     {
         public static NServiceBus.DataBus.DataBusExtentions<NServiceBus.FileShareDataBus> BasePath(this NServiceBus.DataBus.DataBusExtentions<NServiceBus.FileShareDataBus> config, string basePath) { }
     }
+    public class static ConfigureForwarding
+    {
+        public static void ForwardReceivedMessagesTo(this NServiceBus.EndpointConfiguration config, string address) { }
+    }
     public class static ConfigureHandlerSettings
     {
         public static void InitializeHandlerProperty<THandler>(this NServiceBus.EndpointConfiguration config, string property, object value) { }
@@ -1190,6 +1194,8 @@ namespace NServiceBus.Config
         [System.Configuration.ConfigurationPropertyAttribute("DistributorDataAddress", IsRequired=false)]
         public string DistributorDataAddress { get; set; }
         [System.Configuration.ConfigurationPropertyAttribute("ForwardReceivedMessagesTo", IsRequired=false)]
+        [System.ObsoleteAttribute("Please use \'EndpointConfiguration.ForwardReceivedMessagesTo\' to configure the for" +
+            "warding address. Will be removed in version 7.0.0.", true)]
         public string ForwardReceivedMessagesTo { get; set; }
         [System.Configuration.ConfigurationPropertyAttribute("MessageEndpointMappings", IsRequired=false)]
         public NServiceBus.Config.MessageEndpointMappingCollection MessageEndpointMappings { get; set; }

--- a/src/NServiceBus.Core/DetectObsoleteConfigurationSettings.cs
+++ b/src/NServiceBus.Core/DetectObsoleteConfigurationSettings.cs
@@ -1,0 +1,25 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using NServiceBus.Config;
+    using NServiceBus.Features;
+
+    class DetectObsoleteConfigurationSettings : Feature
+    {
+        public DetectObsoleteConfigurationSettings()
+        {
+            EnableByDefault();
+        }
+
+        protected internal override void Setup(FeatureConfigurationContext context)
+        {
+            var unicastBusConfig = context.Settings.GetConfigSection<UnicastBusConfig>();
+            if (!string.IsNullOrWhiteSpace(unicastBusConfig?.ForwardReceivedMessagesTo))
+            {
+                throw new NotSupportedException($"The {nameof(UnicastBusConfig.ForwardReceivedMessagesTo)} attribute in the {nameof(UnicastBusConfig)} configuration section is no longer supported. Please switch to the code first API by using `{nameof(EndpointConfiguration)}.ForwardReceivedMessagesTo` instead.");
+            }
+        }
+    }
+
+    
+}

--- a/src/NServiceBus.Core/Forwarding/ConfigureForwarding.cs
+++ b/src/NServiceBus.Core/Forwarding/ConfigureForwarding.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus
+{
+    /// <summary>
+    /// Contains extension methods to <see cref="EndpointConfiguration"/>.
+    /// </summary>
+    public static class ConfigureForwarding
+    {
+        internal const string SettingsKey = "forwardReceivedMessagesTo";
+
+        /// <summary>
+        /// Sets the address to which received messages will be forwarded.
+        /// </summary>
+        /// <param name="config">The <see cref="EndpointConfiguration"/> instance to apply the settings to.</param>
+        /// <param name="address">The address to forward successfully processed messages to.</param>
+        public static void ForwardReceivedMessagesTo(this EndpointConfiguration config, string address)
+        {
+            Guard.AgainstNull(nameof(config), config);
+            Guard.AgainstNullAndEmpty(nameof(address), address);
+            config.Settings.Set(SettingsKey, address);
+        }
+    }
+}

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -97,8 +97,10 @@
     <Compile Include="Audit\InvokeAuditPipelineBehavior.cs" />
     <Compile Include="CircuitBreakers\ICircuitBreaker.cs" />
     <Compile Include="CriticalError\ICriticalErrorContext.cs" />
+    <Compile Include="DetectObsoleteConfigurationSettings.cs" />
     <Compile Include="EndpointHelper.cs" />
     <Compile Include="Endpoint.cs" />
+    <Compile Include="Forwarding\ConfigureForwarding.cs" />
     <Compile Include="Pipeline\ForkConnector.cs" />
     <Compile Include="Pipeline\IPipelineCache.cs" />
     <Compile Include="Pipeline\PipelineCache.cs" />

--- a/src/NServiceBus.Core/Unicast/UnicastBusConfig.cs
+++ b/src/NServiceBus.Core/Unicast/UnicastBusConfig.cs
@@ -52,6 +52,10 @@ namespace NServiceBus.Config
         /// Gets/sets the address to which messages received will be forwarded.
         /// </summary>
         [ConfigurationProperty("ForwardReceivedMessagesTo", IsRequired = false)]
+        [ObsoleteEx(
+            TreatAsErrorFromVersion = "6",
+            RemoveInVersion = "7",
+            Message = "Please use 'EndpointConfiguration.ForwardReceivedMessagesTo' to configure the forwarding address.")]
         public string ForwardReceivedMessagesTo
         {
             get


### PR DESCRIPTION
move `ForwardReceivedMessagesTo` code first API in alignment with https://github.com/Particular/NServiceBus/issues/3424 and https://github.com/Particular/NServiceBus/issues/1465

since we already have quite a few obsolete checks spread around the code and there will be more, I added a feature dedicated to detecting obsolete configs. Does that make sense or should we handle that individually for each setting?

Found no docs page or snippets regarding the `ForwardReceivedMessagesTo` to update. Didn't check samples yet.