### PR TITLE
SettingsHolder now implements IDisposable

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2493,11 +2493,12 @@ namespace NServiceBus.Settings
             ".0.", true)]
         public void UseUniqueBrokerQueuePerMachine() { }
     }
-    public class SettingsHolder : NServiceBus.Settings.ReadOnlySettings
+    public class SettingsHolder : NServiceBus.Settings.ReadOnlySettings, System.IDisposable
     {
         public SettingsHolder() { }
         public void ApplyTo<T>(NServiceBus.ObjectBuilder.IComponentConfig config) { }
         public void ApplyTo(System.Type componentType, NServiceBus.ObjectBuilder.IComponentConfig config) { }
+        public void Dispose() { }
         public T Get<T>(string key) { }
         public T Get<T>() { }
         public object Get(string key) { }

--- a/src/NServiceBus.Core/Settings/SettingsHolder.cs
+++ b/src/NServiceBus.Core/Settings/SettingsHolder.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.Settings
     /// <summary>
     /// Setting container.
     /// </summary>
-    public class SettingsHolder : ReadOnlySettings
+    public class SettingsHolder : ReadOnlySettings, IDisposable
     {
         /// <summary>
         /// Gets the given setting by key.
@@ -301,6 +301,27 @@ namespace NServiceBus.Settings
                 {
                     config.ConfigureProperty(property.Name, Get(settingsKey));
                 }
+            }
+        }
+
+        /// <summary>
+        /// Disposes all IDisposable values stored in SettingsHolder
+        /// </summary>
+        public void Dispose()
+        {
+            //Injected at compile time
+        }
+
+        void DisposeManaged()
+        {
+            foreach (var item in Defaults.Values)
+            {
+                (item as IDisposable)?.Dispose();
+            }
+
+            foreach (var item in Overrides.Values)
+            {
+                (item as IDisposable)?.Dispose();
             }
         }
 


### PR DESCRIPTION
Per the discussion in #3392, I updated `SettingsHolder` so that it now implements `IDisposable`.

Because the `SettingsHolder` instance is registered in the container, `Dispose()` is already being called without needing to make any changes to `RunningEndpointInstance`. Is this ok to rely on, or should I make the call explicit by passing `SettingsHolder`into `RunningEndpointInstance`?

@Particular/nservicebus-maintainers thoughts?

connects to #3392 