### PR TITLE
CodeRule for detecting missing ConfigureAwaits

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Particular.CodeRules.0.1.0\build\Particular.CodeRules.props" Condition="Exists('..\packages\Particular.CodeRules.0.1.0\build\Particular.CodeRules.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -750,7 +751,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Analyzer Include="..\packages\Particular.CodeRules.0.1.0\tools\..\analyzers\dotnet\cs\Particular.CodeRules.dll" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\Resharper.Annotations.g.cs" />
     <None Include="Resources\NServiceBus_Logo-  white.png" />
@@ -792,6 +795,7 @@
     <Error Condition="!Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.4\build\dotnet\Fody.targets'))" />
     <Error Condition="!Exists('..\packages\Janitor.Fody.1.1.4.0\build\dotnet\Janitor.Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Janitor.Fody.1.1.4.0\build\dotnet\Janitor.Fody.targets'))" />
     <Error Condition="!Exists('..\packages\Obsolete.Fody.4.0.3\build\dotnet\Obsolete.Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Obsolete.Fody.4.0.3\build\dotnet\Obsolete.Fody.targets'))" />
+    <Error Condition="!Exists('..\packages\Particular.CodeRules.0.1.0\build\Particular.CodeRules.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Particular.CodeRules.0.1.0\build\Particular.CodeRules.props'))" />
   </Target>
   <Import Project="..\packages\GitVersionTask.2.0.1\Build\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.2.0.1\Build\GitVersionTask.targets')" />
   <Import Project="..\packages\NuGetPackager.0.5.5\build\NuGetPackager.targets" Condition="Exists('..\packages\NuGetPackager.0.5.5\build\NuGetPackager.targets')" />

--- a/src/NServiceBus.Core/packages.config
+++ b/src/NServiceBus.Core/packages.config
@@ -7,5 +7,6 @@
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net452" />
   <package id="NuGetPackager" version="0.5.5" targetFramework="net451" developmentDependency="true" />
   <package id="Obsolete.Fody" version="4.0.3" targetFramework="net452" developmentDependency="true" />
+  <package id="Particular.CodeRules" version="0.1.0" targetFramework="net452" developmentDependency="true" />
   <package id="Particular.Licensing.Sources" version="0.1.54" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
As part of #3340 this PR is the following:

- Adds a reference to nuget `Particular.CodeRules` which adds project properties to run the project through our specific set of requirements, and produce errors if they are not met.