### PR TITLE
Removed `RegisterConnector` from `PipelineSettings`

### DIFF
--- a/src/NServiceBus.Core/Audit/Audit.cs
+++ b/src/NServiceBus.Core/Audit/Audit.cs
@@ -16,16 +16,15 @@
 
 
         /// <summary>
-        /// See <see cref="Feature.Setup"/>.
+        /// See <see cref="Feature.Setup" />.
         /// </summary>
         protected internal override void Setup(FeatureConfigurationContext context)
         {
             context.Container.ConfigureComponent(() => new InvokeAuditPipelineBehavior(auditConfig.Address), DependencyLifecycle.InstancePerCall);
 
-            context.Pipeline.RegisterConnector<AuditToDispatchConnector>("Dispatches the audit message to the transport");
+            context.Pipeline.Register("AuditToDispatchConnector", new AuditToDispatchConnector(auditConfig.TimeToBeReceived), "Dispatches the audit message to the transport");
             context.Pipeline.Register(WellKnownStep.AuditProcessedMessage, typeof(InvokeAuditPipelineBehavior), "Execute the audit pipeline");
 
-            context.Container.ConfigureComponent(b => new AuditToDispatchConnector(auditConfig.TimeToBeReceived), DependencyLifecycle.SingleInstance);
             context.Settings.Get<QueueBindings>().BindSending(auditConfig.Address);
         }
 

--- a/src/NServiceBus.Core/Features/FeatureConfigurationContext.cs
+++ b/src/NServiceBus.Core/Features/FeatureConfigurationContext.cs
@@ -8,7 +8,7 @@
     using NServiceBus.Transports;
 
     /// <summary>
-    ///     The context available to features when they are activated.
+    /// The context available to features when they are activated.
     /// </summary>
     public class FeatureConfigurationContext
     {
@@ -22,24 +22,24 @@
         }
 
         /// <summary>
-        ///     A read only copy of the settings.
+        /// A read only copy of the settings.
         /// </summary>
         public ReadOnlySettings Settings { get; }
 
         /// <summary>
-        ///     Access to the container to allow for registrations.
+        /// Access to the container to allow for registrations.
         /// </summary>
         public IConfigureComponents Container { get; }
 
         /// <summary>
-        ///     Access to the pipeline in order to customize it.
+        /// Access to the pipeline in order to customize it.
         /// </summary>
         public PipelineSettings Pipeline { get; }
 
-        internal List<FeatureStartupTaskController> TaskControllers { get; } 
+        internal List<FeatureStartupTaskController> TaskControllers { get; }
 
         /// <summary>
-        ///     Creates a new satellite processing pipeline.
+        /// Creates a new satellite processing pipeline.
         /// </summary>
         public PipelineSettings AddSatellitePipeline(string name, string qualifier, TransportTransactionMode requiredTransportTransactionMode, PushRuntimeSettings runtimeSettings, out string transportAddress)
         {
@@ -51,7 +51,7 @@
             Settings.Get<PipelineConfiguration>().SatellitePipelines.Add(pipelineModifications);
             var newPipeline = new PipelineSettings(pipelineModifications);
 
-            newPipeline.RegisterConnector<TransportReceiveToPhysicalMessageProcessingConnector>("Allows to abort processing the message");
+            newPipeline.Register("TransportReceiveToPhysicalMessageProcessingConnector", typeof(TransportReceiveToPhysicalMessageProcessingConnector), "Allows to abort processing the message");
             Settings.Get<QueueBindings>().BindReceiving(transportAddress);
 
             return newPipeline;

--- a/src/NServiceBus.Core/Forwarding/ForwardReceivedMessages.cs
+++ b/src/NServiceBus.Core/Forwarding/ForwardReceivedMessages.cs
@@ -10,7 +10,7 @@
         internal ForwardReceivedMessages()
         {
             EnableByDefault();
-            
+
             Prerequisite(config => config.Settings.HasSetting(ConfigureForwarding.SettingsKey), "No forwarding address was defined in the UnicastBus config");
         }
 
@@ -24,11 +24,9 @@
 
             context.Settings.Get<QueueBindings>().BindSending(forwardReceivedMessagesQueue);
 
-            context.Pipeline.Register("InvokeForwardingPipeline", typeof(InvokeForwardingPipelineBehavior), "Execute the forwarding pipeline");
+            context.Pipeline.Register("InvokeForwardingPipeline", new InvokeForwardingPipelineBehavior(forwardReceivedMessagesQueue), "Execute the forwarding pipeline");
 
-            context.Pipeline.RegisterConnector<ForwardingToRoutingConnector>("Makes sure that forwarded messages gets dispatched to the transport");
-
-            context.Container.ConfigureComponent(b => new InvokeForwardingPipelineBehavior(forwardReceivedMessagesQueue), DependencyLifecycle.InstancePerCall);
+            context.Pipeline.Register("ForwardingToRoutingConnector", new ForwardingToRoutingConnector(), "Makes sure that forwarded messages gets dispatched to the transport");
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
@@ -17,9 +17,8 @@
 
         protected internal override void Setup(FeatureConfigurationContext context)
         {
-            context.Pipeline.RegisterConnector<TransportReceiveToPhysicalMessageProcessingConnector>("Allows to abort processing the message");
-            context.Pipeline.RegisterConnector<LoadHandlersConnector>("Gets all the handlers to invoke from the MessageHandler registry based on the message type.");
-
+            context.Pipeline.Register("TransportReceiveToPhysicalMessageProcessingConnector", typeof(TransportReceiveToPhysicalMessageProcessingConnector), "Allows to abort processing the message");
+            context.Pipeline.Register("LoadHandlersConnector", typeof(LoadHandlersConnector), "Gets all the handlers to invoke from the MessageHandler registry based on the message type.");
 
             context.Pipeline
                 .Register(WellKnownStep.ExecuteUnitOfWork, typeof(UnitOfWorkBehavior), "Executes the UoW")
@@ -30,7 +29,7 @@
             context.Container.ConfigureComponent(b =>
             {
                 var storage = context.Container.HasComponent<IOutboxStorage>() ? b.Build<IOutboxStorage>() : new NoOpOutbox();
-                
+
                 return new TransportReceiveToPhysicalMessageProcessingConnector(storage);
             }, DependencyLifecycle.InstancePerCall);
 
@@ -43,8 +42,6 @@
 
         class NoOpAdaper : ISynchronizedStorageAdapter
         {
-            static readonly Task<CompletableSynchronizedStorageSession> EmptyResult = Task.FromResult<CompletableSynchronizedStorageSession>(null);
-
             public Task<CompletableSynchronizedStorageSession> TryAdapt(OutboxTransaction transaction, ContextBag context)
             {
                 return EmptyResult;
@@ -54,6 +51,8 @@
             {
                 return EmptyResult;
             }
+
+            static readonly Task<CompletableSynchronizedStorageSession> EmptyResult = Task.FromResult<CompletableSynchronizedStorageSession>(null);
         }
 
         class NoOpOutbox : IOutboxStorage
@@ -80,6 +79,7 @@
 
             static Task<OutboxMessage> NoOutboxMessageTask = Task.FromResult<OutboxMessage>(null);
         }
+
         class NoOpOutboxTransaction : OutboxTransaction
         {
             public void Dispose()

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPipelineFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPipelineFeature.cs
@@ -14,11 +14,11 @@
             context.Pipeline.Register(WellKnownStep.MutateOutgoingMessages, typeof(MutateOutgoingMessageBehavior), "Executes IMutateOutgoingMessages");
             context.Pipeline.Register(WellKnownStep.MutateOutgoingTransportMessage, typeof(MutateOutgoingTransportMessageBehavior), "Executes IMutateOutgoingTransportMessages");
 
-            context.Pipeline.Register("ForceImmediateDispatchForOperationsInSuppressedScopeBehavior", typeof(ForceImmediateDispatchForOperationsInSuppressedScopeBehavior), "Detects operations performed in a suppressed scope and request them to be immediately dispatched to the transport.");
+            context.Pipeline.Register("ForceImmediateDispatchForOperationsInSuppressedScopeBehavior", new ForceImmediateDispatchForOperationsInSuppressedScopeBehavior(), "Detects operations performed in a suppressed scope and request them to be immediately dispatched to the transport.");
 
-            context.Pipeline.RegisterConnector<OutgoingPhysicalToRoutingConnector>("Starts the message dispatch pipeline");
-            context.Pipeline.RegisterConnector<RoutingToDispatchConnector>("Decides if the current message should be batched or immediately be dispatched to the transport");
-            context.Pipeline.RegisterConnector<BatchToDispatchConnector>("Passes batched messages over to the immediate dispatch part of the pipeline");
+            context.Pipeline.Register("OutgoingPhysicalToRoutingConnector", new OutgoingPhysicalToRoutingConnector(), "Starts the message dispatch pipeline");
+            context.Pipeline.Register("RoutingToDispatchConnector", new RoutingToDispatchConnector(), "Decides if the current message should be batched or immediately be dispatched to the transport");
+            context.Pipeline.Register("BatchToDispatchConnector", new BatchToDispatchConnector(), "Passes batched messages over to the immediate dispatch part of the pipeline");
             context.Pipeline.Register("ImmediateDispatchTerminator", typeof(ImmediateDispatchTerminator), "Hands the outgoing messages over to the transport for immediate delivery");
         }
     }

--- a/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
@@ -165,11 +165,5 @@ namespace NServiceBus.Pipeline
         List<Type> registeredBehaviors = new List<Type>();
 
         PipelineModifications modifications;
-
-
-        internal void RegisterConnector<T>(string description) where T : IStageConnector
-        {
-            Register(typeof(T).Name, typeof(T), description);
-        }
     }
 }

--- a/src/NServiceBus.Core/Recoverability/Faults/StoreFaultsInErrorQueue.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/StoreFaultsInErrorQueue.cs
@@ -19,9 +19,7 @@ namespace NServiceBus.Features
             var errorQueue = ErrorQueueSettings.GetConfiguredErrorQueue(context.Settings);
             context.Settings.Get<QueueBindings>().BindSending(errorQueue);
             context.Pipeline.Register(new MoveFaultsToErrorQueueBehavior.Registration(errorQueue, context.Settings.LocalAddress()));
-            context.Pipeline.RegisterConnector<FaultToDispatchConnector>("Connector to dispatch faulted messages");
+            context.Pipeline.Register("FaultToDispatchConnector", new FaultToDispatchConnector(), "Connector to dispatch faulted messages");
         }
-
-
     }
 }


### PR DESCRIPTION
Discussed this with @SzymonPobiega 

We had `RegisterConnector` which was using `typeof(T).Name`. I think this is dangerous. Because when we rename a behavior the ID should rename stable for users to override it.

Also if we have `RegisterConnector` we should also have `RegisterStageForkConnector` and `RegisterForkConnector`. The better solution is to remove it.

## Documentation

Not affected. The implementation is internal

@Particular/nservicebus-maintainers please review and merge