### PR TITLE
Simplify processing by improving handling of null values

### DIFF
--- a/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/FailureInfoStorageTests.cs
+++ b/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/FailureInfoStorageTests.cs
@@ -55,7 +55,7 @@ namespace NServiceBus.Core.Tests.Timeout.TimeoutManager
             storage.ClearFailureInfoForMessage(messageId);
 
             failureInfo = storage.GetFailureInfoForMessage(messageId);
-            Assert.IsNull(failureInfo);
+            Assert.AreSame(ProcessingFailureInfo.NullFailureInfo, failureInfo);
         }
 
         [Test]
@@ -78,7 +78,7 @@ namespace NServiceBus.Core.Tests.Timeout.TimeoutManager
             }
 
             var lruFailureInfo = storage.GetFailureInfoForMessage(lruMessageId);
-            Assert.IsNull(lruFailureInfo);
+            Assert.AreSame(ProcessingFailureInfo.NullFailureInfo, lruFailureInfo);
         }
     }
 }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/FailureInfoStorage.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/FailureInfoStorage.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
+    using JetBrains.Annotations;
 
     // The data structure has fixed maximum size. When the data structure reaches its maximum size,
     // the least recently used (LRU) message processing failure is removed from the storage.
@@ -48,13 +49,17 @@ namespace NServiceBus
             }
         }
 
+        [NotNull]
         public ProcessingFailureInfo GetFailureInfoForMessage(string messageId)
         {
             lock (lockObject)
             {
                 FailureInfoNode node;
-                failureInfoPerMessage.TryGetValue(messageId, out node);
-                return node?.FailureInfo;
+                if (failureInfoPerMessage.TryGetValue(messageId, out node))
+                {
+                    return node.FailureInfo;
+                }
+                return ProcessingFailureInfo.NullFailureInfo;
             }
         }
 

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ProcessingFailureInfo.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ProcessingFailureInfo.cs
@@ -12,5 +12,7 @@
 
         public int NumberOfFailedAttempts { get; }
         public Exception Exception { get; }
+
+        public static readonly ProcessingFailureInfo NullFailureInfo = new ProcessingFailureInfo(0, null);
     }
 }


### PR DESCRIPTION
After a discussion with @tmasternak we have identified a way to slightly simplify processing in `TimeoutRecoverabilityBehaviour` by removing some null-handling statements and ensuring that no nulls are passed around.