### PR TITLE
Obsoleting ConfigureTransport

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1415,6 +1415,12 @@ namespace NServiceBus.Features
     {
         protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
+    [System.ObsoleteAttribute("Use extensions provided by the TransportDefinition class instead. Will be removed" +
+        " in version 7.0.0.", true)]
+    public class ConfigureTransport
+    {
+        public ConfigureTransport() { }
+    }
     public class CriticalTimeMonitoring : NServiceBus.Features.Feature
     {
         protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }

--- a/src/NServiceBus.Core/obsoletes.cs
+++ b/src/NServiceBus.Core/obsoletes.cs
@@ -739,6 +739,14 @@ namespace NServiceBus.Features
             throw new NotImplementedException();
         }
     }
+
+    [ObsoleteEx(
+        Message = "Use extensions provided by the TransportDefinition class instead",
+        TreatAsErrorFromVersion = "6.0",
+        RemoveInVersion = "7.0")]
+    public class ConfigureTransport
+    {
+    }
 }
 
 namespace NServiceBus.Transports


### PR DESCRIPTION
This complements PR #3025, where this type was removed completely. This PR adds `ConfigureTransport` back and obsoletes it.