### PR TITLE
[WIP] Making the factory method for serializer public

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Basic/When_registering_additional_deserializers.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_registering_additional_deserializers.cs
@@ -82,7 +82,7 @@
 
         class MyCustomSerializer : SerializationDefinition
         {
-            protected override Func<IMessageMapper, IMessageSerializer> Configure(ReadOnlySettings settings)
+            public override Func<IMessageMapper, IMessageSerializer> Configure(ReadOnlySettings settings)
             {
                 return mapper => new MyCustomMessageSerializer();
             }

--- a/src/NServiceBus.AcceptanceTests/Basic/When_registering_custom_serializer.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_registering_custom_serializer.cs
@@ -68,7 +68,7 @@
 
         class MySuperSerializer : SerializationDefinition
         {
-            protected override Func<IMessageMapper, IMessageSerializer> Configure(ReadOnlySettings settings)
+            public override Func<IMessageMapper, IMessageSerializer> Configure(ReadOnlySettings settings)
             {
                 return mapper => new MyCustomSerializer();
             }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -644,7 +644,7 @@ namespace NServiceBus
     public class JsonSerializer : NServiceBus.Serialization.SerializationDefinition
     {
         public JsonSerializer() { }
-        protected internal override System.Func<NServiceBus.MessageInterfaces.IMessageMapper, NServiceBus.Serialization.IMessageSerializer> Configure(NServiceBus.Settings.ReadOnlySettings settings) { }
+        public override System.Func<NServiceBus.MessageInterfaces.IMessageMapper, NServiceBus.Serialization.IMessageSerializer> Configure(NServiceBus.Settings.ReadOnlySettings settings) { }
     }
     public class static JsonSerializerConfigurationExtensions
     {
@@ -1048,7 +1048,7 @@ namespace NServiceBus
     public class XmlSerializer : NServiceBus.Serialization.SerializationDefinition
     {
         public XmlSerializer() { }
-        protected internal override System.Func<NServiceBus.MessageInterfaces.IMessageMapper, NServiceBus.Serialization.IMessageSerializer> Configure(NServiceBus.Settings.ReadOnlySettings settings) { }
+        public override System.Func<NServiceBus.MessageInterfaces.IMessageMapper, NServiceBus.Serialization.IMessageSerializer> Configure(NServiceBus.Settings.ReadOnlySettings settings) { }
     }
 }
 namespace NServiceBus.AutomaticSubscriptions.Config
@@ -2432,7 +2432,7 @@ namespace NServiceBus.Serialization
     public abstract class SerializationDefinition
     {
         protected SerializationDefinition() { }
-        protected internal abstract System.Func<NServiceBus.MessageInterfaces.IMessageMapper, NServiceBus.Serialization.IMessageSerializer> Configure(NServiceBus.Settings.ReadOnlySettings settings);
+        public abstract System.Func<NServiceBus.MessageInterfaces.IMessageMapper, NServiceBus.Serialization.IMessageSerializer> Configure(NServiceBus.Settings.ReadOnlySettings settings);
     }
     public class SerializationExtentions<T> : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
         where T : NServiceBus.Serialization.SerializationDefinition

--- a/src/NServiceBus.Core/Serialization/SerializationDefinition.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationDefinition.cs
@@ -12,6 +12,6 @@
         /// <summary>
         /// Provides a factory method for building a message serializer.
         /// </summary>
-        protected internal abstract Func<IMessageMapper, IMessageSerializer> Configure(ReadOnlySettings settings);
+        public abstract Func<IMessageMapper, IMessageSerializer> Configure(ReadOnlySettings settings);
     }
 }

--- a/src/NServiceBus.Core/Serializers/Json/JsonSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/Json/JsonSerializer.cs
@@ -14,7 +14,7 @@ namespace NServiceBus
         /// <summary>
         /// Provides a factory method for building a message serializer.
         /// </summary>
-        protected internal override Func<IMessageMapper, IMessageSerializer> Configure(ReadOnlySettings settings)
+        public override Func<IMessageMapper, IMessageSerializer> Configure(ReadOnlySettings settings)
         {
             var encoding = settings.GetOrDefault<Encoding>("Serialization.Json.Encoding") ?? Encoding.UTF8;
             return mapper => new JsonMessageSerializer(mapper, encoding);

--- a/src/NServiceBus.Core/Serializers/XML/XmlSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlSerializer.cs
@@ -14,7 +14,7 @@
         /// <summary>
         /// Provides a factory method for building a message serializer.
         /// </summary>
-        protected internal override Func<IMessageMapper, IMessageSerializer> Configure(ReadOnlySettings settings)
+        public override Func<IMessageMapper, IMessageSerializer> Configure(ReadOnlySettings settings)
         {
             return mapper =>
             {


### PR DESCRIPTION
After a call with @SimonCropp @indualagarsamy and @timbussmann we decided to make this trade off. It adds no new public types since the mapper and `IMessageSerializer` is already public. 

This will:

* allow our serializer sample to work
* provides a way to give users a chance to migrate away from using our serializers (upgrade guide)
* allows users on the ASQ transport that has selected XML in the past to be wire compatible without copy pasting the custom XmlSerializer


NOTE:

The ASQ transport/heartbeats/etc should still go ahead as planned and not reuse any core serializers since we want to get rid of that dependency. This is only for user consumption in v6. We'll discuss the removal of this api in v7.


### Todo

- [ ] Doco pull once we agree on this (upgrade guide)
- [ ] WIP pulls for external serializers if needed
