### PR TITLE
No longer nesting using in Instance_per_uow_components_should_yield_different_instances_between

### DIFF
--- a/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
+++ b/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
@@ -46,14 +46,18 @@ namespace NServiceBus.ContainerTests
             {
                 builder.Configure(typeof(InstancePerUoWComponent), DependencyLifecycle.InstancePerUnitOfWork);
 
-                using (var childContainer1 = builder.BuildChildContainer())
-                using (var childContainer2 = builder.BuildChildContainer())
+                object instance1;
+                using (var nestedContainer = builder.BuildChildContainer())
                 {
-                    var childInstance1 = childContainer1.Build(typeof(InstancePerUoWComponent));
-                    var childInstance2 = childContainer2.Build(typeof(InstancePerUoWComponent));
-
-                    Assert.AreNotSame(childInstance1, childInstance2);
+                    instance1 = nestedContainer.Build(typeof(InstancePerUoWComponent));
                 }
+
+                object instance2;
+                using (var anotherNestedContainer = builder.BuildChildContainer())
+                {
+                    instance2 = anotherNestedContainer.Build(typeof(InstancePerUoWComponent));
+                }
+                Assert.AreNotSame(instance1, instance2);
             }
         }
 


### PR DESCRIPTION
With WindsorContainer when you nest the scopes like in this test then the most outer scope always applies which causes this test to fail.

@Particular/container-maintainers @WilliamBZA please review & merge