### PR TITLE
When registering a singleton the properties don't need to be autowired.

### DIFF
--- a/src/NServiceBus.ContainerTests/When_building_components.cs
+++ b/src/NServiceBus.ContainerTests/When_building_components.cs
@@ -8,19 +8,6 @@ namespace NServiceBus.ContainerTests
     public class When_building_components
     {
         [Test]
-        public void Singleton_components_should_get_their_dependencies_autowired()
-        {
-            using (var builder = TestContainerBuilder.ConstructBuilder())
-            {
-                builder.RegisterSingleton(typeof(ISingletonComponentWithPropertyDependency), new SingletonComponentWithPropertyDependency());
-                builder.RegisterSingleton(typeof(SingletonComponent), new SingletonComponent());
-
-                var singleton = (SingletonComponentWithPropertyDependency)builder.Build(typeof(ISingletonComponentWithPropertyDependency));
-                Assert.IsNotNull(singleton.Dependency);
-            }
-        }
-
-        [Test]
         public void Singleton_components_should_yield_the_same_instance()
         {
             using (var builder = TestContainerBuilder.ConstructBuilder())

--- a/src/NServiceBus.ContainerTests/When_registering_components.cs
+++ b/src/NServiceBus.ContainerTests/When_registering_components.cs
@@ -122,7 +122,7 @@ namespace NServiceBus.ContainerTests
             using (var builder = TestContainerBuilder.ConstructBuilder())
             {
                 builder.Configure(typeof(SomeClass), DependencyLifecycle.InstancePerCall);
-                builder.RegisterSingleton(typeof(IWithSetterDependencies), new ClassWithSetterDependencies());
+                builder.Configure(typeof(ClassWithSetterDependencies), DependencyLifecycle.SingleInstance);
 
                 var component = (ClassWithSetterDependencies)builder.Build(typeof(IWithSetterDependencies));
                 Assert.NotNull(component.ConcreteDependency, "Concrete classed should be property injected");


### PR DESCRIPTION
For example with Windsor it is only possible to do property injection on an externally owned instance with [evil hacks](http://stackoverflow.com/questions/851940/windsor-castle-injecting-properties-of-constructed-object). To be honest I think we should not do property injection on an instance not owned by the by us. 


@Particular/container-maintainers @Particular/nservicebus-maintainers @WilliamBZA thoughts?