### PR TITLE
No longer register Conventions on container

### DIFF
--- a/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_incoming_messages.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_incoming_messages.cs
@@ -29,12 +29,7 @@ namespace NServiceBus.Core.Tests.DataBus
                               }, null);
 
             var fakeDatabus = new FakeDataBus();
-            var receiveBehavior = new DataBusReceiveBehavior
-            {
-                DataBus = fakeDatabus,
-                DataBusSerializer = new DefaultDataBusSerializer(),
-                Conventions = new Conventions(),
-            };
+            var receiveBehavior = new DataBusReceiveBehavior(fakeDatabus, new DefaultDataBusSerializer(), new Conventions());
 
             using (var stream = new MemoryStream())
             {

--- a/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_null_properties.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_null_properties.cs
@@ -13,12 +13,7 @@ namespace NServiceBus.Core.Tests.DataBus
         public async Task Should_not_blow_up()
         {
             var context = ContextHelpers.GetOutgoingContext(new MessageWithNullDataBusProperty());
-            var sendBehavior = new DataBusSendBehavior
-            {
-                DataBus = null,
-                Conventions = new Conventions(),
-                DataBusSerializer = new DefaultDataBusSerializer(),
-            };
+            var sendBehavior = new DataBusSendBehavior(null, new DefaultDataBusSerializer(), new Conventions());
             
             using (var stream = new MemoryStream())
             {

--- a/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_outgoing_messages.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_outgoing_messages.cs
@@ -23,13 +23,8 @@ namespace NServiceBus.Core.Tests.DataBus
             var context = ContextHelpers.GetOutgoingContext(message);
             
             var fakeDatabus = new FakeDataBus();
-           
-            var sendBehavior = new DataBusSendBehavior
-            {
-                DataBus = fakeDatabus,
-                Conventions = new Conventions(),
-                DataBusSerializer = new DefaultDataBusSerializer(),
-            };
+
+            var sendBehavior = new DataBusSendBehavior(fakeDatabus, new DefaultDataBusSerializer(), new Conventions());
 
             await sendBehavior.Invoke(context, () => TaskEx.CompletedTask);
 
@@ -49,15 +44,10 @@ namespace NServiceBus.Core.Tests.DataBus
            context.Extensions.AddDeliveryConstraint(new DiscardIfNotReceivedBefore(TimeSpan.FromMinutes(1)));
 
            var fakeDatabus = new FakeDataBus();
-           
-           var sendBehavior = new DataBusSendBehavior
-           {
-               DataBus = fakeDatabus,
-               Conventions = new Conventions(),
-               DataBusSerializer = new DefaultDataBusSerializer(),
-           };
 
-           await sendBehavior.Invoke(context, () => TaskEx.CompletedTask);
+            var sendBehavior = new DataBusSendBehavior(fakeDatabus, new DefaultDataBusSerializer(), new Conventions());
+
+            await sendBehavior.Invoke(context, () => TaskEx.CompletedTask);
 
            Assert.AreEqual(TimeSpan.FromMinutes(1),fakeDatabus.TTBRUsed);
         }

--- a/src/NServiceBus.Core/DataBus/DataBus.cs
+++ b/src/NServiceBus.Core/DataBus/DataBus.cs
@@ -39,8 +39,10 @@ namespace NServiceBus.Features
 
             context.RegisterStartupTask(b => b.Build<IDataBusInitializer>());
             context.Container.ConfigureComponent<IDataBusInitializer>(DependencyLifecycle.SingleInstance);
-            context.Pipeline.Register<DataBusReceiveBehavior.Registration>();
-            context.Pipeline.Register<DataBusSendBehavior.Registration>();
+
+            var conventions = context.Settings.Get<Conventions>();
+            context.Pipeline.Register(new DataBusReceiveBehavior.Registration(conventions));
+            context.Pipeline.Register(new DataBusSendBehavior.Registration(conventions));
         }
 
         class IDataBusInitializer : FeatureStartupTask

--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -226,7 +226,6 @@ namespace NServiceBus
             {
                 Settings.SetDefault("PublicReturnAddress", publicReturnAddress);
             }
-            container.RegisterSingleton(typeof(Conventions), conventionsBuilder.Conventions);
 
             Settings.SetDefault<Conventions>(conventionsBuilder.Conventions);
 

--- a/src/NServiceBus.Core/Hosting/HostInformationFeature.cs
+++ b/src/NServiceBus.Core/Hosting/HostInformationFeature.cs
@@ -37,7 +37,7 @@
                         context.Settings.Get<string>("NServiceBus.HostInformation.DisplayName"),
                         context.Settings.Get<Dictionary<string, string>>("NServiceBus.HostInformation.Properties"));
 
-            context.Container.RegisterSingleton(hostInformation);
+            context.Container.ConfigureComponent(() => hostInformation, DependencyLifecycle.SingleInstance);
 
             context.Pipeline.Register("AuditHostInformation", typeof(AuditHostInformationBehavior), "Adds audit host information");
             context.Pipeline.Register("FaultHostInformation", typeof(FaultHostInformationBehavior), "Adds fault host information");

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/BestPracticeEnforcement.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/BestPracticeEnforcement.cs
@@ -8,7 +8,7 @@ namespace NServiceBus.Features
     public class BestPracticeEnforcement : Feature
     {
         /// <summary>
-        /// Initializes a new instance of <see cref="BestPracticeEnforcement"/>.
+        /// Initializes a new instance of <see cref="BestPracticeEnforcement" />.
         /// </summary>
         internal BestPracticeEnforcement()
         {
@@ -21,33 +21,32 @@ namespace NServiceBus.Features
         /// <param name="context">The feature context.</param>
         protected internal override void Setup(FeatureConfigurationContext context)
         {
-            context.Container.ConfigureComponent<Validations>(DependencyLifecycle.SingleInstance);
+            var validations = new Validations(context.Settings.Get<Conventions>());
 
             context.Pipeline.Register(
                 WellKnownStep.EnforceSendBestPractices,
-                typeof(EnforceSendBestPracticesBehavior),
+                new EnforceSendBestPracticesBehavior(validations),
                 "Enforces send messaging best practices");
 
             context.Pipeline.Register(
                 WellKnownStep.EnforceReplyBestPractices,
-                typeof(EnforceReplyBestPracticesBehavior),
+                new EnforceReplyBestPracticesBehavior(validations),
                 "Enforces reply messaging best practices");
 
             context.Pipeline.Register(
                 WellKnownStep.EnforcePublishBestPractices,
-                typeof(EnforcePublishBestPracticesBehavior),
+                new EnforcePublishBestPracticesBehavior(validations),
                 "Enforces publish messaging best practices");
 
             context.Pipeline.Register(
                 WellKnownStep.EnforceSubscribeBestPractices,
-                typeof(EnforceSubscribeBestPracticesBehavior),
+                new EnforceSubscribeBestPracticesBehavior(validations),
                 "Enforces subscribe messaging best practices");
 
             context.Pipeline.Register(
                 WellKnownStep.EnforceUnsubscribeBestPractices,
-                typeof(EnforceUnsubscribeBestPracticesBehavior),
+                new EnforceUnsubscribeBestPracticesBehavior(validations),
                 "Enforces unsubscribe messaging best practices");
         }
-
     }
 }


### PR DESCRIPTION
While checking for `RegisterSingleton` usages I stumbled over the conventions. It was both registered in the settings dictionary and on the container. The core only needed it on the container for the best practices behaviors and the data bus behaviors. This PR removes `Conventions` from the container

@Particular/nservicebus-maintainers please review