### PR TITLE
add getters for SendOption extensions

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -233,6 +233,8 @@ namespace NServiceBus
     }
     public class static CorrelationContextExtensions
     {
+        public static string GetCorrelationId(this NServiceBus.SendOptions options) { }
+        public static string GetCorrelationId(this NServiceBus.ReplyOptions options) { }
         public static void SetCorrelationId(this NServiceBus.SendOptions options, string correlationId) { }
         public static void SetCorrelationId(this NServiceBus.ReplyOptions options, string correlationId) { }
     }
@@ -781,7 +783,7 @@ namespace NServiceBus
     }
     public class static RoutingOptionExtensions
     {
-        public static void OverrideReplyToAddressOfIncomingMessage(this NServiceBus.ReplyOptions option, string destination) { }
+        public static string GetDestination(this NServiceBus.ReplyOptions option) { }
         public static void RouteReplyTo(this NServiceBus.ReplyOptions option, string address) { }
         public static void RouteReplyTo(this NServiceBus.SendOptions option, string address) { }
         public static void RouteReplyToAnyInstance(this NServiceBus.SendOptions option) { }
@@ -792,6 +794,7 @@ namespace NServiceBus
         public static void RouteToThisEndpoint(this NServiceBus.SendOptions option) { }
         public static void RouteToThisInstance(this NServiceBus.SendOptions option) { }
         public static void SetDestination(this NServiceBus.SendOptions option, string destination) { }
+        public static void SetDestination(this NServiceBus.ReplyOptions option, string destination) { }
     }
     public class RoutingSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -783,18 +783,18 @@ namespace NServiceBus
     }
     public class static RoutingOptionExtensions
     {
-        public static string GetDestination(this NServiceBus.ReplyOptions option) { }
-        public static void RouteReplyTo(this NServiceBus.ReplyOptions option, string address) { }
-        public static void RouteReplyTo(this NServiceBus.SendOptions option, string address) { }
-        public static void RouteReplyToAnyInstance(this NServiceBus.SendOptions option) { }
-        public static void RouteReplyToAnyInstance(this NServiceBus.ReplyOptions option) { }
-        public static void RouteReplyToThisInstance(this NServiceBus.SendOptions option) { }
-        public static void RouteReplyToThisInstance(this NServiceBus.ReplyOptions option) { }
-        public static void RouteToSpecificInstance(this NServiceBus.SendOptions option, string instanceId) { }
-        public static void RouteToThisEndpoint(this NServiceBus.SendOptions option) { }
-        public static void RouteToThisInstance(this NServiceBus.SendOptions option) { }
-        public static void SetDestination(this NServiceBus.SendOptions option, string destination) { }
-        public static void SetDestination(this NServiceBus.ReplyOptions option, string destination) { }
+        public static string GetDestination(this NServiceBus.ReplyOptions options) { }
+        public static void RouteReplyTo(this NServiceBus.ReplyOptions options, string address) { }
+        public static void RouteReplyTo(this NServiceBus.SendOptions options, string address) { }
+        public static void RouteReplyToAnyInstance(this NServiceBus.SendOptions options) { }
+        public static void RouteReplyToAnyInstance(this NServiceBus.ReplyOptions options) { }
+        public static void RouteReplyToThisInstance(this NServiceBus.SendOptions options) { }
+        public static void RouteReplyToThisInstance(this NServiceBus.ReplyOptions options) { }
+        public static void RouteToSpecificInstance(this NServiceBus.SendOptions options, string instanceId) { }
+        public static void RouteToThisEndpoint(this NServiceBus.SendOptions options) { }
+        public static void RouteToThisInstance(this NServiceBus.SendOptions options) { }
+        public static void SetDestination(this NServiceBus.SendOptions options, string destination) { }
+        public static void SetDestination(this NServiceBus.ReplyOptions options, string destination) { }
     }
     public class RoutingSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {

--- a/src/NServiceBus.Core.Tests/Correlation/CorrelationContextExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Correlation/CorrelationContextExtensionsTests.cs
@@ -1,0 +1,52 @@
+﻿namespace NServiceBus.Core.Tests.Correlation
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class CorrelationContextExtensionsTests
+    {
+        [Test]
+        public void SendOptions_GetCorrelationId_Should_Return_Configured_CorrelationId()
+        {
+            const string expectedCorrelationId = "custom correlation id";
+            var options = new SendOptions();
+            options.SetCorrelationId(expectedCorrelationId);
+
+            var correlationId = options.GetCorrelationId();
+
+            Assert.AreEqual(expectedCorrelationId, correlationId);
+        }
+
+        [Test]
+        public void SendOptions_GetCorrelationId_Should_Return_Null_When_No_CorrelationId_Configured()
+        {
+            var options = new SendOptions();
+
+            var correlationId = options.GetCorrelationId();
+
+            Assert.IsNull(correlationId);
+        }
+
+        [Test]
+        public void ReplyOptions_GetCorrelationId_Should_Return_Configured_CorrelationId()
+        {
+            const string expectedCorrelationId = "custom correlation id";
+            var options = new ReplyOptions();
+            options.SetCorrelationId(expectedCorrelationId);
+
+            var correlationId = options.GetCorrelationId();
+
+            Assert.AreEqual(expectedCorrelationId, correlationId);
+        }
+
+        [Test]
+        public void ReplyOptions_GetCorrelationId_Should_Return_Null_When_No_CorrelationId_Configured()
+        {
+            var options = new ReplyOptions();
+
+            var correlationId = options.GetCorrelationId();
+
+            Assert.IsNull(correlationId);
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Config\When_using_initialization.cs" />
     <Compile Include="ContextBagTests.cs" />
     <Compile Include="ContextHelpers.cs" />
+    <Compile Include="Correlation\CorrelationContextExtensionsTests.cs" />
     <Compile Include="DelayedDelivery\RouteDeferredMessageToTimeoutManagerBehaviorTests.cs" />
     <Compile Include="DelayedDelivery\TimeoutManager\DispatchTimeoutBehaviorTest.cs" />
     <Compile Include="DelayedDelivery\TimeoutManager\ExpiredTimeoutsPollerTests.cs" />
@@ -136,6 +137,7 @@
     <Compile Include="Routing\Routers\MulticastPublishRouterBehaviorTests.cs" />
     <Compile Include="Routing\Routers\UnicastReplyRouterConnectorTests.cs" />
     <Compile Include="Routing\Routers\UnicastPublishRouterConnectorTests.cs" />
+    <Compile Include="Routing\RoutingOptionExtensionsTests.cs" />
     <Compile Include="Routing\SubscriptionRouterTests.cs" />
     <Compile Include="Sagas\When_saga_has_multiple_correlated_properties.cs" />
     <Compile Include="Sagas\When_saga_is_correlated_on_a_unsupported_property_type.cs" />

--- a/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
@@ -68,7 +68,7 @@
             var behavior = new UnicastReplyRouterConnector();
             var options = new ReplyOptions();
 
-            options.OverrideReplyToAddressOfIncomingMessage("CustomReplyToAddress");
+            options.SetDestination("CustomReplyToAddress");
 
             var context = new OutgoingReplyContext(
                 new OutgoingLogicalMessage(new MyReply()),

--- a/src/NServiceBus.Core.Tests/Routing/RoutingOptionExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingOptionExtensionsTests.cs
@@ -1,0 +1,30 @@
+﻿namespace NServiceBus.Core.Tests.Routing
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class RoutingOptionExtensionsTests
+    {
+        [Test]
+        public void ReplyOptions_GetDestination_Should_Return_Configured_Destination()
+        {
+            const string expectedDestination = "custom reply destination";
+            var options = new ReplyOptions();
+            options.SetDestination(expectedDestination);
+
+            var destination = options.GetDestination();
+
+            Assert.AreEqual(expectedDestination, destination);
+        }
+
+        [Test]
+        public void ReplyOptions_GetDestination_Should_Return_Null_When_No_Destination_Configured()
+        {
+            var options = new ReplyOptions();
+
+            var destination = options.GetDestination();
+
+            Assert.IsNull(destination);
+        }
+    }
+}

--- a/src/NServiceBus.Core/Correlation/CorrelationContextExtensions.cs
+++ b/src/NServiceBus.Core/Correlation/CorrelationContextExtensions.cs
@@ -32,5 +32,35 @@
             options.Context.GetOrCreate<AttachCorrelationIdBehavior.State>()
                 .CustomCorrelationId = correlationId;
         }
+
+        /// <summary>
+        /// Retrieves the correlation id specified by the user by using <see cref="SetCorrelationId(NServiceBus.SendOptions,string)"/>.
+        /// </summary>
+        /// <param name="options">Options being extended.</param>
+        /// <returns>The configured correlation id or <c>null</c> when no correlation id was configured.</returns>
+        public static string GetCorrelationId(this SendOptions options)
+        {
+            Guard.AgainstNull(nameof(options), options);
+
+            AttachCorrelationIdBehavior.State state;
+            options.Context.TryGet(out state);
+
+            return state?.CustomCorrelationId;
+        }
+
+        /// <summary>
+        /// Retrieves the correlation id specified by the user by using <see cref="SetCorrelationId(NServiceBus.ReplyOptions,string)"/>.
+        /// </summary>
+        /// <param name="options">Options being extended.</param>
+        /// <returns>The configured correlation id or <c>null</c> when no correlation id was configured.</returns>
+        public static string GetCorrelationId(this ReplyOptions options)
+        {
+            Guard.AgainstNull(nameof(options), options);
+
+            AttachCorrelationIdBehavior.State state;
+            options.Context.TryGet(out state);
+
+            return state?.CustomCorrelationId;
+        }
     }
 }

--- a/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
+++ b/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
@@ -8,13 +8,14 @@
         /// <summary>
         /// Allows a specific physical address to be used to route this message.
         /// </summary>
-        /// <param name="option">Option being extended.</param>
+        /// <param name="options">Option being extended.</param>
         /// <param name="destination">The destination address.</param>
-        public static void SetDestination(this SendOptions option, string destination)
+        public static void SetDestination(this SendOptions options, string destination)
         {
+            Guard.AgainstNull(nameof(options), options);
             Guard.AgainstNullAndEmpty(nameof(destination), destination);
 
-            var state = option.Context.GetOrCreate<UnicastSendRouterConnector.State>();
+            var state = options.Context.GetOrCreate<UnicastSendRouterConnector.State>();
             state.Option = UnicastSendRouterConnector.RouteOption.ExplicitDestination;
             state.ExplicitDestination = destination;
         }
@@ -22,57 +23,66 @@
         /// <summary>
         /// Allows the target endpoint instance for this reply to set. If not used the reply will be sent to the `ReplyToAddress` of the incoming message.
         /// </summary>
-        /// <param name="option">Option being extended.</param>
+        /// <param name="options">Option being extended.</param>
         /// <param name="destination">The new target address.</param>
-        public static void SetDestination(this ReplyOptions option, string destination)
+        public static void SetDestination(this ReplyOptions options, string destination)
         {
+            Guard.AgainstNull(nameof(options), options);
             Guard.AgainstNullAndEmpty(nameof(destination), destination);
 
-            option.Context.GetOrCreate<UnicastReplyRouterConnector.State>()
+            options.Context.GetOrCreate<UnicastReplyRouterConnector.State>()
                 .ExplicitDestination = destination;
         }
 
         /// <summary>
         /// Returns the destination configured by <see cref="SetDestination(ReplyOptions, string)"/>.
         /// </summary>
-        /// <param name="option">Option being extended.</param>
+        /// <param name="options">Option being extended.</param>
         /// <returns>The specified destination address or <c>null</c> when no destination was specified.</returns>
-        public static string GetDestination(this ReplyOptions option)
+        public static string GetDestination(this ReplyOptions options)
         {
+            Guard.AgainstNull(nameof(options), options);
+
             UnicastReplyRouterConnector.State state;
-            option.Context.TryGet(out state);
+            options.Context.TryGet(out state);
             return state?.ExplicitDestination;
         }
 
         /// <summary>
         /// Routes this message to any instance of this endpoint.
         /// </summary>
-        /// <param name="option">Context being extended.</param>
-        public static void RouteToThisEndpoint(this SendOptions option)
+        /// <param name="options">Context being extended.</param>
+        public static void RouteToThisEndpoint(this SendOptions options)
         {
-            option.Context.GetOrCreate<UnicastSendRouterConnector.State>()
+            Guard.AgainstNull(nameof(options), options);
+
+            options.Context.GetOrCreate<UnicastSendRouterConnector.State>()
                 .Option = UnicastSendRouterConnector.RouteOption.RouteToAnyInstanceOfThisEndpoint;
         }
 
         /// <summary>
         /// Routes this message to this endpoint instance.
         /// </summary>
-        /// <param name="option">Context being extended.</param>
-        public static void RouteToThisInstance(this SendOptions option)
+        /// <param name="options">Context being extended.</param>
+        public static void RouteToThisInstance(this SendOptions options)
         {
-            option.Context.GetOrCreate<UnicastSendRouterConnector.State>()
+            Guard.AgainstNull(nameof(options), options);
+
+            options.Context.GetOrCreate<UnicastSendRouterConnector.State>()
                 .Option = UnicastSendRouterConnector.RouteOption.RouteToThisInstance;
         }
 
         /// <summary>
         /// Routes this message to a specific instance of a destination endpoint.
         /// </summary>
-        /// <param name="option">Context being extended.</param>
+        /// <param name="options">Context being extended.</param>
         /// <param name="instanceId">ID of destination instance.</param>
-        public static void RouteToSpecificInstance(this SendOptions option, string instanceId)
+        public static void RouteToSpecificInstance(this SendOptions options, string instanceId)
         {
+            Guard.AgainstNull(nameof(options), options);
             Guard.AgainstNull(nameof(instanceId), instanceId);
-            var state = option.Context.GetOrCreate<UnicastSendRouterConnector.State>();
+
+            var state = options.Context.GetOrCreate<UnicastSendRouterConnector.State>();
             state.Option = UnicastSendRouterConnector.RouteOption.RouteToSpecificInstance;
             state.SpecificInstance = instanceId;
         }
@@ -80,52 +90,62 @@
         /// <summary>
         /// Instructs the receiver to route the reply for this message to this instance.
         /// </summary>
-        /// <param name="option">Context being extended.</param>
-        public static void RouteReplyToThisInstance(this SendOptions option)
+        /// <param name="options">Context being extended.</param>
+        public static void RouteReplyToThisInstance(this SendOptions options)
         {
-            option.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>()
+            Guard.AgainstNull(nameof(options), options);
+
+            options.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>()
                 .Option = ApplyReplyToAddressBehavior.RouteOption.RouteReplyToThisInstance;
         }
         
         /// <summary>
         /// Instructs the receiver to route the reply for this message to any instance of this endpoint.
         /// </summary>
-        /// <param name="option">Context being extended.</param>
-        public static void RouteReplyToAnyInstance(this SendOptions option)
+        /// <param name="options">Context being extended.</param>
+        public static void RouteReplyToAnyInstance(this SendOptions options)
         {
-            option.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>()
+            Guard.AgainstNull(nameof(options), options);
+
+            options.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>()
                 .Option = ApplyReplyToAddressBehavior.RouteOption.RouteReplyToAnyInstanceOfThisEndpoint;
         }
 
         /// <summary>
         /// Instructs the receiver to route the reply for this message to this instance.
         /// </summary>
-        /// <param name="option">Context being extended.</param>
-        public static void RouteReplyToThisInstance(this ReplyOptions option)
+        /// <param name="options">Context being extended.</param>
+        public static void RouteReplyToThisInstance(this ReplyOptions options)
         {
-            option.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>()
+            Guard.AgainstNull(nameof(options), options);
+
+            options.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>()
                 .Option = ApplyReplyToAddressBehavior.RouteOption.RouteReplyToThisInstance;
         }
         
         /// <summary>
         /// Instructs the receiver to route the reply for this message to any instance of this endpoint.
         /// </summary>
-        /// <param name="option">Context being extended.</param>
-        public static void RouteReplyToAnyInstance(this ReplyOptions option)
+        /// <param name="options">Context being extended.</param>
+        public static void RouteReplyToAnyInstance(this ReplyOptions options)
         {
-            option.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>()
+            Guard.AgainstNull(nameof(options), options);
+
+            options.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>()
                 .Option = ApplyReplyToAddressBehavior.RouteOption.RouteReplyToAnyInstanceOfThisEndpoint;
         }
 
         /// <summary>
         /// Instructs the receiver to route the reply to specified address.
         /// </summary>
-        /// <param name="option">Context being extended.</param>
+        /// <param name="options">Context being extended.</param>
         /// <param name="address">Reply destination.</param>
-        public static void RouteReplyTo(this ReplyOptions option, string address)
+        public static void RouteReplyTo(this ReplyOptions options, string address)
         {
+            Guard.AgainstNull(nameof(options), options);
             Guard.AgainstNull(nameof(address), address);
-            var state = option.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>();
+
+            var state = options.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>();
             state.Option = ApplyReplyToAddressBehavior.RouteOption.ExplicitReplyDestination;
             state.ExplicitDestination = address;
         }
@@ -133,12 +153,14 @@
         /// <summary>
         /// Instructs the receiver to route the reply to specified address.
         /// </summary>
-        /// <param name="option">Context being extended.</param>
+        /// <param name="options">Context being extended.</param>
         /// <param name="address">Reply destination.</param>
-        public static void RouteReplyTo(this SendOptions option, string address)
+        public static void RouteReplyTo(this SendOptions options, string address)
         {
+            Guard.AgainstNull(nameof(options), options);
             Guard.AgainstNull(nameof(address), address);
-            var state = option.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>();
+
+            var state = options.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>();
             state.Option = ApplyReplyToAddressBehavior.RouteOption.ExplicitReplyDestination;
             state.ExplicitDestination = address;
         }

--- a/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
+++ b/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
@@ -24,12 +24,24 @@
         /// </summary>
         /// <param name="option">Option being extended.</param>
         /// <param name="destination">The new target address.</param>
-        public static void OverrideReplyToAddressOfIncomingMessage(this ReplyOptions option, string destination)
+        public static void SetDestination(this ReplyOptions option, string destination)
         {
             Guard.AgainstNullAndEmpty(nameof(destination), destination);
 
             option.Context.GetOrCreate<UnicastReplyRouterConnector.State>()
                 .ExplicitDestination = destination;
+        }
+
+        /// <summary>
+        /// Returns the destination configured by <see cref="SetDestination(ReplyOptions, string)"/>.
+        /// </summary>
+        /// <param name="option">Option being extended.</param>
+        /// <returns>The specified destination address or <c>null</c> when no destination was specified.</returns>
+        public static string GetDestination(this ReplyOptions option)
+        {
+            UnicastReplyRouterConnector.State state;
+            option.Context.TryGet(out state);
+            return state?.ExplicitDestination;
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Sagas/Saga.cs
+++ b/src/NServiceBus.Core/Sagas/Saga.cs
@@ -106,7 +106,7 @@ namespace NServiceBus
 
             var options = new ReplyOptions();
 
-            options.OverrideReplyToAddressOfIncomingMessage(Entity.Originator);
+            options.SetDestination(Entity.Originator);
             options.SetCorrelationId(Entity.OriginalMessageId);
 
             //until we have metadata we just set this to null to avoid our own saga id being set on outgoing messages since


### PR DESCRIPTION
Adding setters to `SendOptions.SetCorrelationId` and `ReplyOptions.SetDestination` (renamed from `OverrideReplyToAddressOfIncomingMessage`)

We need access to the configured settings to SendOption in the testing framework. This is the approach which doesn't require us to make any internal implementation details public.

We want to try the idea with these two options to see how well it works on the testing library. If that proves to work, this would require a getter extension method for every extension to `SendOption` and `ReplyOption`.

We're very happy to hear alternative approaches to solve our unit testing problems.