### PR TITLE
Getters for SendOption extensions

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -36,6 +36,7 @@ namespace NServiceBus
         public static void DoNotEnforceBestPractices(this NServiceBus.Pipeline.ISubscribeContext context) { }
         public static void DoNotEnforceBestPractices(this NServiceBus.Pipeline.IOutgoingPublishContext context) { }
         public static void DoNotEnforceBestPractices(this NServiceBus.Pipeline.IUnsubscribeContext context) { }
+        public static bool IgnoredBestPractices(this NServiceBus.Extensibility.ExtendableOptions options) { }
     }
     public class static Bus
     {
@@ -275,6 +276,8 @@ namespace NServiceBus
     {
         public static void DelayDeliveryWith(this NServiceBus.SendOptions options, System.TimeSpan delay) { }
         public static void DoNotDeliverBefore(this NServiceBus.SendOptions options, System.DateTimeOffset at) { }
+        public static System.Nullable<System.DateTimeOffset> GetDeliveryDate(this NServiceBus.SendOptions options) { }
+        public static System.Nullable<System.TimeSpan> GetDeliveryDelay(this NServiceBus.SendOptions options) { }
     }
     public enum DependencyLifecycle
     {
@@ -371,7 +374,8 @@ namespace NServiceBus
     }
     public class static HeaderOptionExtensions
     {
-        public static void SetHeader(this NServiceBus.Extensibility.ExtendableOptions context, string key, string value) { }
+        public static System.Collections.Generic.IReadOnlyDictionary<string, string> GetHeaders(this NServiceBus.Extensibility.ExtendableOptions options) { }
+        public static void SetHeader(this NServiceBus.Extensibility.ExtendableOptions options, string key, string value) { }
     }
     public class static Headers
     {
@@ -585,6 +589,7 @@ namespace NServiceBus
     }
     public class static ImmediateDispatchOptionExtensions
     {
+        public static bool RequiredImmediateDispatch(this NServiceBus.Extensibility.ExtendableOptions options) { }
         public static void RequireImmediateDispatch(this NServiceBus.Extensibility.ExtendableOptions options) { }
     }
     [JetBrains.Annotations.UsedImplicitlyAttribute(JetBrains.Annotations.ImplicitUseTargetFlags.Default | JetBrains.Annotations.ImplicitUseTargetFlags.Itself | JetBrains.Annotations.ImplicitUseTargetFlags.Members | JetBrains.Annotations.ImplicitUseTargetFlags.WithMembers)]
@@ -686,7 +691,8 @@ namespace NServiceBus
     }
     public class static MessageIdExtensions
     {
-        public static void SetMessageId(this NServiceBus.Extensibility.ExtendableOptions context, string messageId) { }
+        public static string GetMessageId(this NServiceBus.Extensibility.ExtendableOptions options) { }
+        public static void SetMessageId(this NServiceBus.Extensibility.ExtendableOptions options, string messageId) { }
     }
     public enum MessageIntentEnum
     {
@@ -789,6 +795,15 @@ namespace NServiceBus
     {
         public static string GetDestination(this NServiceBus.ReplyOptions options) { }
         public static string GetDestination(this NServiceBus.SendOptions options) { }
+        public static string GetReplyToRoute(this NServiceBus.ReplyOptions options) { }
+        public static string GetReplyToRoute(this NServiceBus.SendOptions options) { }
+        public static string GetRouteToSpecificInstance(this NServiceBus.SendOptions options) { }
+        public static bool IsRoutingReplyToAnyInstance(this NServiceBus.SendOptions options) { }
+        public static bool IsRoutingReplyToAnyInstance(this NServiceBus.ReplyOptions options) { }
+        public static bool IsRoutingReplyToThisInstance(this NServiceBus.SendOptions options) { }
+        public static bool IsRoutingReplyToThisInstance(this NServiceBus.ReplyOptions options) { }
+        public static bool IsRoutingToThisEndpoint(this NServiceBus.SendOptions options) { }
+        public static bool IsRoutingToThisInstance(this NServiceBus.SendOptions options) { }
         public static void RouteReplyTo(this NServiceBus.ReplyOptions options, string address) { }
         public static void RouteReplyTo(this NServiceBus.SendOptions options, string address) { }
         public static void RouteReplyToAnyInstance(this NServiceBus.SendOptions options) { }

--- a/src/NServiceBus.Core.Tests/DelayedDelivery/DelayedDeliveryOptionExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/DelayedDelivery/DelayedDeliveryOptionExtensionsTests.cs
@@ -1,0 +1,45 @@
+﻿namespace NServiceBus.Core.Tests.Timeout
+{
+    using System;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class DelayedDeliveryOptionExtensionsTests
+    {
+        [Test]
+        public void GetDeliveryDelay_Should_Return_The_Configured_Delay_TimeSpan()
+        {
+            var options = new SendOptions();
+            var delay = TimeSpan.FromMinutes(42);
+            options.DelayDeliveryWith(delay);
+
+            Assert.AreEqual(delay, options.GetDeliveryDelay());
+        }
+
+        [Test]
+        public void GetDeliveryDelay_Should_Return_Null_When_No_Delay_Configured()
+        {
+            var options = new SendOptions();
+
+            Assert.IsNull(options.GetDeliveryDelay());
+        }
+
+        [Test]
+        public void GetDeliveryDate_Should_Return_The_Configured_Delivery_Date()
+        {
+            var options = new SendOptions();
+            DateTimeOffset deliveryDate = new DateTime(2012, 12, 12, 12, 12, 12);
+            options.DoNotDeliverBefore(deliveryDate);
+
+            Assert.AreEqual(deliveryDate, options.GetDeliveryDate());
+        }
+
+        [Test]
+        public void GetDeliveryDate_Should_Return_Null_When_No_Date_Configured()
+        {
+            var options = new SendOptions();
+
+            Assert.IsNull(options.GetDeliveryDate());
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="ContextBagTests.cs" />
     <Compile Include="ContextHelpers.cs" />
     <Compile Include="Correlation\CorrelationContextExtensionsTests.cs" />
+    <Compile Include="DelayedDelivery\DelayedDeliveryOptionExtensionsTests.cs" />
     <Compile Include="DelayedDelivery\RouteDeferredMessageToTimeoutManagerBehaviorTests.cs" />
     <Compile Include="DelayedDelivery\TimeoutManager\DispatchTimeoutBehaviorTest.cs" />
     <Compile Include="DelayedDelivery\TimeoutManager\ExpiredTimeoutsPollerTests.cs" />
@@ -121,11 +122,15 @@
     <Compile Include="Msmq\MsmqAddressTests.cs" />
     <Compile Include="Msmq\MsmqSubscriptionStorageQueueTests.cs" />
     <Compile Include="Persistence\InMemory\When_persisting_a_saga_with_InMemory_and_an_escalated_DTC_transaction.cs" />
+    <Compile Include="Pipeline\HeaderOptionExtensionsTests.cs" />
     <Compile Include="Pipeline\Incoming\InvokeHandlerTerminatorTest.cs" />
+    <Compile Include="Pipeline\Outgoing\ImmediateDispatchOptionExtensionsTests.cs" />
+    <Compile Include="Pipeline\Outgoing\MessageIdExtensionsTests.cs" />
     <Compile Include="Pipeline\Outgoing\OutgoingPublishContextTests.cs" />
     <Compile Include="Pipeline\Outgoing\OutgoingReplyContextTests.cs" />
     <Compile Include="Pipeline\Outgoing\OutgoingSendContextTests.cs" />
     <Compile Include="Routing\ApplyReplyToAddressBehaviorTests.cs" />
+    <Compile Include="Routing\BestPracticesOptionExtensionsTests.cs" />
     <Compile Include="Routing\DetermineRouteForPublishBehaviorTests.cs" />
     <Compile Include="Routing\Routers\UnicastSendRouterConnectorTests.cs" />
     <Compile Include="Routing\EndpointInstanceTests.cs" />

--- a/src/NServiceBus.Core.Tests/Pipeline/HeaderOptionExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/HeaderOptionExtensionsTests.cs
@@ -1,0 +1,32 @@
+﻿namespace NServiceBus.Core.Tests.Pipeline
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class HeaderOptionExtensionsTests
+    {
+        [Test]
+        public void GetHeaders_Should_Return_Configured_Headers()
+        {
+            var options = new SendOptions();
+            options.SetHeader("custom header key 1", "custom header value 1");
+            options.SetHeader("custom header key 2", "custom header value 2");
+
+            var result = options.GetHeaders();
+
+            Assert.AreEqual(2, result.Count);
+            CollectionAssert.Contains(result.Values, "custom header value 1");
+            CollectionAssert.Contains(result.Values, "custom header value 2");
+        }
+
+        [Test]
+        public void GetHeaders_Should_Return_Empty_Collection_When_No_Headers_Configured()
+        {
+            var options = new PublishOptions();
+
+            var result = options.GetHeaders();
+
+            Assert.IsEmpty(result);
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/ImmediateDispatchOptionExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/ImmediateDispatchOptionExtensionsTests.cs
@@ -1,0 +1,25 @@
+﻿namespace NServiceBus.Core.Tests.Pipeline.Outgoing
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ImmediateDispatchOptionExtensionsTests
+    {
+        [Test]
+        public void RequiresImmediateDispatch_Should_Return_False_When_No_Immediate_Dispatch_Requested()
+        {
+            var options = new SendOptions();
+
+            Assert.IsFalse(options.RequiredImmediateDispatch());
+        }
+
+        [Test]
+        public void RequiresImmediateDispatch_Should_Return_True_When_Immediate_Dispatch_Requested()
+        {
+            var options = new SendOptions();
+            options.RequireImmediateDispatch();
+
+            Assert.IsTrue(options.RequiredImmediateDispatch());
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/MessageIdExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/MessageIdExtensionsTests.cs
@@ -1,0 +1,26 @@
+﻿namespace NServiceBus.Core.Tests.Pipeline.Outgoing
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MessageIdExtensionsTests
+    {
+        [Test]
+        public void GetMessageId_Should_Return_Generated_Id_When_No_Id_Specified()
+        {
+            var options = new SendOptions();
+
+            Assert.IsNotEmpty(options.GetMessageId());
+        }
+
+        [Test]
+        public void GetMessageId_Should_Return_Defined_Id()
+        {
+            const string expectedMessageID = "expected message id";
+            var options = new PublishOptions();
+            options.SetMessageId(expectedMessageID);
+
+            Assert.AreEqual(expectedMessageID, options.GetMessageId());
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Routing/BestPracticesOptionExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/BestPracticesOptionExtensionsTests.cs
@@ -1,0 +1,26 @@
+﻿namespace NServiceBus.Core.Tests.Routing
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class BestPracticesOptionExtensionsTests
+    {
+        [Test]
+        public void IgnoredBestPractices_Should_Return_False_When_Not_Disabled_Best_Practice_Enforcement()
+        {
+            var options = new SendOptions();
+
+            Assert.IsFalse(options.IgnoredBestPractices());
+        }
+
+        [Test]
+        public void IgnoredBestPractices_Should_Return_True_When_Disabled_Best_Practice_Enforcement()
+        {
+            var options = new PublishOptions();
+            
+            options.DoNotEnforceBestPractices();
+
+            Assert.IsTrue(options.IgnoredBestPractices());
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Routing/RoutingOptionExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingOptionExtensionsTests.cs
@@ -48,5 +48,170 @@
 
           Assert.IsNull(destination);
         }
+
+        [Test]
+        public void IsRoutingToThisEndpoint_Should_Return_False_When_Not_Routed_To_This_Endpoint()
+        {
+            var options = new SendOptions();
+
+            Assert.IsFalse(options.IsRoutingToThisEndpoint());
+        }
+
+        [Test]
+        public void IsRoutingToThisEndpoint_Should_Return_True_When_Routed_To_This_Endpoint()
+        {
+            var options = new SendOptions();
+
+            options.RouteToThisEndpoint();
+
+            Assert.IsTrue(options.IsRoutingToThisEndpoint());
+        }
+
+        [Test]
+        public void IsRoutingToThisInstance_Should_Return_False_When_Not_Routed_To_This_Instance()
+        {
+            var options = new SendOptions();
+
+            Assert.IsFalse(options.IsRoutingToThisInstance());
+        }
+
+        [Test]
+        public void IsRoutingToThisInstance_Should_Return_True_When_Routed_To_This_Instance()
+        {
+            var options = new SendOptions();
+
+            options.RouteToThisInstance();
+
+            Assert.IsTrue(options.IsRoutingToThisInstance());
+        }
+
+        [Test]
+        public void GetRouteToSpecificInstance_Should_Return_Configured_Instance()
+        {
+            const string expectedInstanceId = "custom instance id";
+            var options = new SendOptions();
+
+            options.RouteToSpecificInstance(expectedInstanceId);
+
+            Assert.AreEqual(expectedInstanceId, options.GetRouteToSpecificInstance());
+        }
+
+        [Test]
+        public void GetRouteToSpecificInstance_Should_Return_Null_When_No_Instance_Configured()
+        {
+            var options = new SendOptions();
+
+            Assert.IsNull(options.GetRouteToSpecificInstance());
+        }
+
+        [Test]
+        public void SendOptions_IsRoutingReplyToThisInstance_Should_Return_True_When_Routing_Reply_To_This_Instance()
+        {
+            var options = new SendOptions();
+
+            options.RouteReplyToThisInstance();
+
+            Assert.IsTrue(options.IsRoutingReplyToThisInstance());
+        }
+
+        [Test]
+        public void SendOptions_IsRoutingReplyToThisInstance_Should_Return_False_When_Not_Routing_Reply_To_This_Instance()
+        {
+            var options = new SendOptions();
+
+            Assert.IsFalse(options.IsRoutingReplyToThisInstance());
+        }
+
+        [Test]
+        public void ReplyOptions_IsRoutingReplyToThisInstance_Should_Return_True_When_Routing_Reply_To_This_Instance()
+        {
+            var options = new ReplyOptions();
+
+            options.RouteReplyToThisInstance();
+
+            Assert.IsTrue(options.IsRoutingReplyToThisInstance());
+        }
+
+        [Test]
+        public void ReplyOptions_IsRoutingReplyToThisInstance_Should_Return_False_When_Not_Routing_Reply_To_This_Instance()
+        {
+            var options = new ReplyOptions();
+
+            Assert.IsFalse(options.IsRoutingReplyToThisInstance());
+        }
+
+        [Test]
+        public void SendOptions_IsRoutingReplyToAnyInstance_Should_Return_True_When_Routing_Reply_To_Any_Instance()
+        {
+            var options = new SendOptions();
+
+            options.RouteReplyToAnyInstance();
+
+            Assert.IsTrue(options.IsRoutingReplyToAnyInstance());
+        }
+
+        [Test]
+        public void SendOptions_IsRoutingReplyToAnyInstance_Should_Return_False_When_Not_Routing_Reply_To_Any_Instance()
+        {
+            var options = new SendOptions();
+
+            Assert.IsFalse(options.IsRoutingReplyToAnyInstance());
+        }
+
+        [Test]
+        public void ReplyOptions_IsRoutingReplyToAnyInstance_Should_Return_True_When_Routing_Reply_To_Any_Instance()
+        {
+            var options = new ReplyOptions();
+
+            options.RouteReplyToAnyInstance();
+
+            Assert.IsTrue(options.IsRoutingReplyToAnyInstance());
+        }
+
+        [Test]
+        public void ReplyOptions_IsRoutingReplyToAnyInstance_Should_Return_False_When_Not_Routing_Reply_To_Any_Instance()
+        {
+            var options = new ReplyOptions();
+
+            Assert.IsFalse(options.IsRoutingReplyToAnyInstance());
+        }
+
+        [Test]
+        public void ReplyOptions_GetReplyToRoute_Should_Return_Configured_Reply_Route()
+        {
+            const string expectedReplyToAddress = "custom replyTo address";
+            var options = new ReplyOptions();
+
+            options.RouteReplyTo(expectedReplyToAddress);
+
+            Assert.AreEqual(expectedReplyToAddress, options.GetReplyToRoute());
+        }
+
+        [Test]
+        public void ReplyOptions_GetReplyToRoute_Should_Return_Null_When_No_Route_Configured()
+        {
+            var options = new ReplyOptions();
+
+            Assert.IsNull(options.GetReplyToRoute());
+        }
+
+        [Test]
+        public void SendOptions_GetReplyToRoute_Should_Return_Configured_Reply_Route()
+        {
+            const string expectedReplyToAddress = "custom replyTo address";
+            var options = new SendOptions();
+
+            options.RouteReplyTo(expectedReplyToAddress);
+
+            Assert.AreEqual(expectedReplyToAddress, options.GetReplyToRoute());
+        }
+
+        [Test]
+        public void SendOptions_GetReplyToRoute_Should_Return_Null_When_No_Route_Configured()
+        {
+            var options = new SendOptions();
+
+            Assert.IsNull(options.GetReplyToRoute());
+        }
     }
 }

--- a/src/NServiceBus.Core/DelayedDelivery/DelayedDeliveryOptionExtensions.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/DelayedDeliveryOptionExtensions.cs
@@ -22,6 +22,20 @@
 
             options.GetExtensions().AddDeliveryConstraint(new DelayDeliveryWith(delay));
         }
+
+        /// <summary>
+        /// Returns the configured delivery delay by using <see cref="DelayDeliveryWith"/>.
+        /// </summary>
+        /// <param name="options">The options being extended.</param>
+        /// <returns>The configured <see cref="TimeSpan"/> or <c>null</c>.</returns>
+        public static TimeSpan? GetDeliveryDelay(this SendOptions options)
+        {
+            DelayDeliveryWith delay;
+            options.GetExtensions().TryGetDeliveryConstraint(out delay);
+
+            return delay?.Delay;
+        }
+
         /// <summary>
         /// Requests that the message should not be delivered before the specified time.
         /// </summary>
@@ -32,6 +46,19 @@
             Guard.AgainstNull(nameof(options), options);
 
             options.GetExtensions().AddDeliveryConstraint(new DoNotDeliverBefore(at.UtcDateTime));
+        }
+
+        /// <summary>
+        /// Returns the delivery date configured by using <see cref="DoNotDeliverBefore"/>.
+        /// </summary>
+        /// <param name="options">The options being extended.</param>
+        /// <returns>The configured <see cref="DateTimeOffset"/> or <c>null</c>.</returns>
+        public static DateTimeOffset? GetDeliveryDate(this SendOptions options)
+        {
+            DoNotDeliverBefore deliveryDate;
+            options.GetExtensions().TryGetDeliveryConstraint(out deliveryDate);
+
+            return deliveryDate?.At;
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/HeaderOptionExtensions.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/HeaderOptionExtensions.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus
 {
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using NServiceBus.Extensibility;
 
     /// <summary>
@@ -10,15 +12,25 @@
         /// <summary>
         /// Allows headers to be set for the outgoing message.
         /// </summary>
-        /// <param name="context">Context to extend.</param>
+        /// <param name="options">The options to extend.</param>
         /// <param name="key">The header key.</param>
         /// <param name="value">The header value.</param>
-        public static void SetHeader(this ExtendableOptions context, string key, string value)
+        public static void SetHeader(this ExtendableOptions options, string key, string value)
         {
-            Guard.AgainstNull(nameof(context), context);
+            Guard.AgainstNull(nameof(options), options);
             Guard.AgainstNullAndEmpty(nameof(key), key);
 
-            context.OutgoingHeaders[key] = value;
+            options.OutgoingHeaders[key] = value;
+        }
+
+        /// <summary>
+        /// Returns all headers set by <see cref="SetHeader"/> on the outgoing message.
+        /// </summary>
+        public static IReadOnlyDictionary<string, string> GetHeaders(this ExtendableOptions options)
+        {
+            Guard.AgainstNull(nameof(options), options);
+
+            return new ReadOnlyDictionary<string, string>(options.OutgoingHeaders);
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/ImmediateDispatchOptionExtensions.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/ImmediateDispatchOptionExtensions.cs
@@ -19,5 +19,20 @@ namespace NServiceBus
 
             options.GetExtensions().Set(new RoutingToDispatchConnector.State {ImmediateDispatch = true});
         }
+
+        /// <summary>
+        /// Returns whether immediate dispatch has been request by <see cref="RequireImmediateDispatch"/> or not.
+        /// </summary>
+        /// <param name="options">The options being extended.</param>
+        /// <returns><c>True</c> if immediate dispatch was requested, <c>False</c> otherwise.</returns>
+        public static bool RequiredImmediateDispatch(this ExtendableOptions options)
+        {
+            Guard.AgainstNull(nameof(options), options);
+
+            RoutingToDispatchConnector.State state;
+            options.GetExtensions().TryGet(out state);
+
+            return state?.ImmediateDispatch ?? false;
+        }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/MessageIdExtensions.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/MessageIdExtensions.cs
@@ -10,13 +10,23 @@
         /// <summary>
         /// Allows the user to set the message id.
         /// </summary>
-        /// <param name="context">Context to extend.</param>
+        /// <param name="options">Options to extend.</param>
         /// <param name="messageId">The message id to use.</param>
-        public static void SetMessageId(this ExtendableOptions context, string messageId)
+        public static void SetMessageId(this ExtendableOptions options, string messageId)
         {
             Guard.AgainstNullAndEmpty(messageId, messageId);
 
-            context.MessageId = messageId;
+            options.MessageId = messageId;
+        }
+
+        /// <summary>
+        /// Returns the message id.
+        /// </summary>
+        /// <param name="options">Options to extend.</param>
+        /// <returns>The message id.</returns>
+        public static string GetMessageId(this ExtendableOptions options)
+        {
+            return options.MessageId;
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/BestPracticesOptionExtensions.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/BestPracticesOptionExtensions.cs
@@ -17,6 +17,17 @@
         }
 
         /// <summary>
+        /// Returns whether <see cref="DoNotEnforceBestPractices(NServiceBus.Extensibility.ExtendableOptions)"/> has ben called or not.
+        /// </summary>
+        /// <returns><c>true</c> if best practice enforcment has ben disabled, <c>false</c> otherwhise.</returns>
+        public static bool IgnoredBestPractices(this ExtendableOptions options)
+        {
+            EnforceBestPracticesOptions bestPracticesOptions;
+            options.Context.TryGet(out bestPracticesOptions);
+            return !(bestPracticesOptions?.Enabled ?? true);
+        }
+
+        /// <summary>
         /// Turns off the best practice enforcement for the given context.
         /// </summary>
         public static void DoNotEnforceBestPractices(this IOutgoingReplyContext context)

--- a/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
+++ b/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
@@ -65,7 +65,7 @@
         /// <summary>
         /// Routes this message to any instance of this endpoint.
         /// </summary>
-        /// <param name="options">Context being extended.</param>
+        /// <param name="options">Option being extended.</param>
         public static void RouteToThisEndpoint(this SendOptions options)
         {
             Guard.AgainstNull(nameof(options), options);
@@ -75,9 +75,27 @@
         }
 
         /// <summary>
+        /// Returns whether the message should be routed to this endpoint.
+        /// </summary>
+        /// <param name="options">Option being extended.</param>
+        /// <returns><c>true</c> when <see cref="RouteToThisEndpoint"/> has been called, <c>false</c> otherwhise.</returns>
+        public static bool IsRoutingToThisEndpoint(this SendOptions options)
+        {
+            Guard.AgainstNull(nameof(options), options);
+
+            UnicastSendRouterConnector.State state;
+            if (options.Context.TryGet(out state))
+            {
+                return state.Option == UnicastSendRouterConnector.RouteOption.RouteToAnyInstanceOfThisEndpoint;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Routes this message to this endpoint instance.
         /// </summary>
-        /// <param name="options">Context being extended.</param>
+        /// <param name="options">Option being extended.</param>
         public static void RouteToThisInstance(this SendOptions options)
         {
             Guard.AgainstNull(nameof(options), options);
@@ -87,9 +105,27 @@
         }
 
         /// <summary>
+        /// Returns whether the message should be routed to this endpoint instance.
+        /// </summary>
+        /// <param name="options">Option being extended.</param>
+        /// <returns><c>true</c> when <see cref="IsRoutingToThisInstance"/> has been called, <c>false</c> otherwhise.</returns>
+        public static bool IsRoutingToThisInstance(this SendOptions options)
+        {
+            Guard.AgainstNull(nameof(options), options);
+
+            UnicastSendRouterConnector.State state;
+            if (options.Context.TryGet(out state))
+            {
+                return state.Option == UnicastSendRouterConnector.RouteOption.RouteToThisInstance;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Routes this message to a specific instance of a destination endpoint.
         /// </summary>
-        /// <param name="options">Context being extended.</param>
+        /// <param name="options">Option being extended.</param>
         /// <param name="instanceId">ID of destination instance.</param>
         public static void RouteToSpecificInstance(this SendOptions options, string instanceId)
         {
@@ -102,9 +138,27 @@
         }
 
         /// <summary>
+        /// Returns the instance configured by <see cref="RouteToSpecificInstance"/> where the message should be routed to.
+        /// </summary>
+        /// <param name="options">Option being extended.</param>
+        /// <returns>The configured instance ID or <c>null</c> when no instance was configured.</returns>
+        public static string GetRouteToSpecificInstance(this SendOptions options)
+        {
+            Guard.AgainstNull(nameof(options), options);
+
+            UnicastSendRouterConnector.State state;
+            if (options.Context.TryGet(out state) && state.Option == UnicastSendRouterConnector.RouteOption.RouteToSpecificInstance)
+            {
+                return state.SpecificInstance;
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Instructs the receiver to route the reply for this message to this instance.
         /// </summary>
-        /// <param name="options">Context being extended.</param>
+        /// <param name="options">Option being extended.</param>
         public static void RouteReplyToThisInstance(this SendOptions options)
         {
             Guard.AgainstNull(nameof(options), options);
@@ -112,11 +166,28 @@
             options.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>()
                 .Option = ApplyReplyToAddressBehavior.RouteOption.RouteReplyToThisInstance;
         }
-        
+
+        /// <summary>
+        /// Indicates whether <see cref="RouteReplyToThisInstance(NServiceBus.SendOptions)"/> has been called on this options.
+        /// </summary>
+        /// <param name="options">Option being extended.</param>
+        public static bool IsRoutingReplyToThisInstance(this SendOptions options)
+        {
+            Guard.AgainstNull(nameof(options), options);
+
+            ApplyReplyToAddressBehavior.State state;
+            if (options.Context.TryGet(out state))
+            {
+                return state.Option == ApplyReplyToAddressBehavior.RouteOption.RouteReplyToThisInstance;
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// Instructs the receiver to route the reply for this message to any instance of this endpoint.
         /// </summary>
-        /// <param name="options">Context being extended.</param>
+        /// <param name="options">Option being extended.</param>
         public static void RouteReplyToAnyInstance(this SendOptions options)
         {
             Guard.AgainstNull(nameof(options), options);
@@ -126,9 +197,26 @@
         }
 
         /// <summary>
+        /// Indicates whether <see cref="RouteReplyToAnyInstance(NServiceBus.SendOptions)"/> has been called on this options.
+        /// </summary>
+        /// <param name="options">Option being extended.</param>
+        public static bool IsRoutingReplyToAnyInstance(this SendOptions options)
+        {
+            Guard.AgainstNull(nameof(options), options);
+
+            ApplyReplyToAddressBehavior.State state;
+            if (options.Context.TryGet(out state))
+            {
+                return state.Option == ApplyReplyToAddressBehavior.RouteOption.RouteReplyToAnyInstanceOfThisEndpoint;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Instructs the receiver to route the reply for this message to this instance.
         /// </summary>
-        /// <param name="options">Context being extended.</param>
+        /// <param name="options">Option being extended.</param>
         public static void RouteReplyToThisInstance(this ReplyOptions options)
         {
             Guard.AgainstNull(nameof(options), options);
@@ -136,11 +224,28 @@
             options.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>()
                 .Option = ApplyReplyToAddressBehavior.RouteOption.RouteReplyToThisInstance;
         }
-        
+
+        /// <summary>
+        /// Indicates whether <see cref="RouteReplyToThisInstance(NServiceBus.ReplyOptions)"/> has been called on this options.
+        /// </summary>
+        /// <param name="options">Option being extended.</param>
+        public static bool IsRoutingReplyToThisInstance(this ReplyOptions options)
+        {
+            Guard.AgainstNull(nameof(options), options);
+
+            ApplyReplyToAddressBehavior.State state;
+            if (options.Context.TryGet(out state))
+            {
+                return state.Option == ApplyReplyToAddressBehavior.RouteOption.RouteReplyToThisInstance;
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// Instructs the receiver to route the reply for this message to any instance of this endpoint.
         /// </summary>
-        /// <param name="options">Context being extended.</param>
+        /// <param name="options">Option being extended.</param>
         public static void RouteReplyToAnyInstance(this ReplyOptions options)
         {
             Guard.AgainstNull(nameof(options), options);
@@ -150,9 +255,26 @@
         }
 
         /// <summary>
+        /// Indicates whether <see cref="RouteReplyToAnyInstance(NServiceBus.ReplyOptions)"/> has been called on this options.
+        /// </summary>
+        /// <param name="options">Option being extended.</param>
+        public static bool IsRoutingReplyToAnyInstance(this ReplyOptions options)
+        {
+            Guard.AgainstNull(nameof(options), options);
+
+            ApplyReplyToAddressBehavior.State state;
+            if (options.Context.TryGet(out state))
+            {
+                return state.Option == ApplyReplyToAddressBehavior.RouteOption.RouteReplyToAnyInstanceOfThisEndpoint;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Instructs the receiver to route the reply to specified address.
         /// </summary>
-        /// <param name="options">Context being extended.</param>
+        /// <param name="options">Option being extended.</param>
         /// <param name="address">Reply destination.</param>
         public static void RouteReplyTo(this ReplyOptions options, string address)
         {
@@ -165,9 +287,27 @@
         }
 
         /// <summary>
+        /// Returns the configured route by <see cref="RouteReplyTo(NServiceBus.ReplyOptions,string)"/>.
+        /// </summary>
+        /// <param name="options">Option being extended.</param>
+        /// <returns>The configured reply to address or <c>null</c> when no address configured.</returns>
+        public static string GetReplyToRoute(this ReplyOptions options)
+        {
+            Guard.AgainstNull(nameof(options), options);
+
+            ApplyReplyToAddressBehavior.State state;
+            if (options.Context.TryGet(out state) && state.Option == ApplyReplyToAddressBehavior.RouteOption.ExplicitReplyDestination)
+            {
+                return state.ExplicitDestination;
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Instructs the receiver to route the reply to specified address.
         /// </summary>
-        /// <param name="options">Context being extended.</param>
+        /// <param name="options">Option being extended.</param>
         /// <param name="address">Reply destination.</param>
         public static void RouteReplyTo(this SendOptions options, string address)
         {
@@ -177,6 +317,24 @@
             var state = options.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>();
             state.Option = ApplyReplyToAddressBehavior.RouteOption.ExplicitReplyDestination;
             state.ExplicitDestination = address;
+        }
+
+        /// <summary>
+        /// Returns the configured route by <see cref="RouteReplyTo(NServiceBus.SendOptions,string)"/>.
+        /// </summary>
+        /// <param name="options">Option being extended.</param>
+        /// <returns>The configured reply to address or <c>null</c> when no address configured.</returns>
+        public static string GetReplyToRoute(this SendOptions options)
+        {
+            Guard.AgainstNull(nameof(options), options);
+
+            ApplyReplyToAddressBehavior.State state;
+            if (options.Context.TryGet(out state) && state.Option == ApplyReplyToAddressBehavior.RouteOption.ExplicitReplyDestination)
+            {
+                return state.ExplicitDestination;
+            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
Adds a "Getter" extension method to every `SendOptions` (and `ExtenableOptions`) extension to retrieve the configured value.

This is mainly required for testing purposes to let the testing framework and users verify the expected SendOptions configuration