### PR TITLE
Invoke handlers that return a null task

### DIFF
--- a/src/NServiceBus.Core/Pipeline/Incoming/MessageHandler.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/MessageHandler.cs
@@ -38,7 +38,13 @@
         /// <param name="handlerContext">the context to pass to the handler.</param>
         public Task Invoke(object message, IMessageHandlerContext handlerContext)
         {
-            return invocation(Instance, message, handlerContext);
+            var task = invocation(Instance, message, handlerContext);
+            if (task == null)
+            {
+                // Should we warn the user somehow?
+                return Task.FromResult(0);
+            }
+            return task;
         }
     }
 }


### PR DESCRIPTION
This code allows the user to return null from a handler without crashing.

    public Task Handle(MyCommand message, IMessageHandlerContext context)
    {
        return null;
    }

cc @danielmarbach 