### PR TITLE
Mutator alignment

### DIFF
--- a/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_sendoptions.cs
+++ b/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_sendoptions.cs
@@ -61,7 +61,7 @@
                     Context data;
                     if (context.Extensions.TryGet(out data))
                     {
-                        context.UpdateMessageInstance(new SendMessage { Secret = data.SomeValue });
+                        context.UpdateMessage(new SendMessage { Secret = data.SomeValue });
                     }
 
                     return next();

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2000,6 +2000,7 @@ namespace NServiceBus.Pipeline
     public interface IIncomingPhysicalMessageContext : NServiceBus.Extensibility.IExtendable, NServiceBus.IMessageProcessingContext, NServiceBus.IPipelineContext, NServiceBus.Pipeline.IBehaviorContext, NServiceBus.Pipeline.IIncomingContext
     {
         NServiceBus.Transports.IncomingMessage Message { get; }
+        void UpdateMessage(byte[] body);
     }
     public interface IInvokeHandlerContext : NServiceBus.Extensibility.IExtendable, NServiceBus.IMessageHandlerContext, NServiceBus.IMessageProcessingContext, NServiceBus.IPipelineContext, NServiceBus.Pipeline.IBehaviorContext, NServiceBus.Pipeline.IIncomingContext
     {
@@ -2019,12 +2020,13 @@ namespace NServiceBus.Pipeline
     {
         NServiceBus.Pipeline.OutgoingLogicalMessage Message { get; }
         System.Collections.Generic.IReadOnlyCollection<NServiceBus.Routing.RoutingStrategy> RoutingStrategies { get; }
-        void UpdateMessageInstance(object newInstance);
+        void UpdateMessage(object newInstance);
     }
     public interface IOutgoingPhysicalMessageContext : NServiceBus.Extensibility.IExtendable, NServiceBus.IPipelineContext, NServiceBus.Pipeline.IBehaviorContext, NServiceBus.Pipeline.IOutgoingContext
     {
-        byte[] Body { get; set; }
+        byte[] Body { get; }
         System.Collections.Generic.IReadOnlyCollection<NServiceBus.Routing.RoutingStrategy> RoutingStrategies { get; }
+        void UpdateMessage(byte[] body);
     }
     public interface IOutgoingPublishContext : NServiceBus.Extensibility.IExtendable, NServiceBus.IPipelineContext, NServiceBus.Pipeline.IBehaviorContext, NServiceBus.Pipeline.IOutgoingContext
     {

--- a/src/NServiceBus.Core/Encryption/EncryptBehavior.cs
+++ b/src/NServiceBus.Core/Encryption/EncryptBehavior.cs
@@ -19,7 +19,7 @@
 
             currentMessageToSend = messageMutator.MutateOutgoing(currentMessageToSend);
 
-            context.UpdateMessageInstance(currentMessageToSend);
+            context.UpdateMessage(currentMessageToSend);
 
             return next();
         }

--- a/src/NServiceBus.Core/Pipeline/Incoming/IIncomingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IIncomingPhysicalMessageContext.cs
@@ -11,5 +11,10 @@
         /// The physical message being processed.
         /// </summary>
         IncomingMessage Message { get; }
+
+        /// <summary>
+        /// Updates the message with the given body.
+        /// </summary>
+        void UpdateMessage(byte[] body);
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/IncomingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IncomingPhysicalMessageContext.cs
@@ -12,5 +12,10 @@
         }
 
         public IncomingMessage Message { get; }
+
+        public void UpdateMessage(byte[] body)
+        {
+            Message.Body = body;
+        }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehavior.cs
@@ -18,7 +18,7 @@
                 await mutator.MutateIncoming(mutatorContext).ConfigureAwait(false);
             }
 
-            if (mutatorContext.MessageChanged)
+            if (mutatorContext.MessageInstanceChanged)
             {
                 logicalMessage.UpdateMessageInstance(mutatorContext.Message);
             }

--- a/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateIncomingMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateIncomingMessageContext.cs
@@ -7,8 +7,6 @@ namespace NServiceBus.MessageMutator
     /// </summary>
     public class MutateIncomingMessageContext
     {
-        object message;
-
         /// <summary>
         /// Initializes the context.
         /// </summary>
@@ -25,23 +23,22 @@ namespace NServiceBus.MessageMutator
         /// </summary>
         public object Message
         {
-            get
-            {
-                return message;
-            }
+            get { return message; }
             set
             {
                 Guard.AgainstNull(nameof(value), value);
-                MessageChanged = true;
+                MessageInstanceChanged = true;
                 message = value;
             }
         }
-
-        internal bool MessageChanged;
 
         /// <summary>
         /// The current incoming headers.
         /// </summary>
         public IDictionary<string, string> Headers { get; private set; }
+
+        object message;
+
+        internal bool MessageInstanceChanged;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateOutgoingMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateOutgoingMessageBehavior.cs
@@ -2,9 +2,9 @@
 {
     using System;
     using System.Threading.Tasks;
-    using MessageMutator;
+    using NServiceBus.MessageMutator;
+    using NServiceBus.Pipeline;
     using NServiceBus.Transports;
-    using Pipeline;
 
     class MutateOutgoingMessageBehavior : Behavior<IOutgoingLogicalMessageContext>
     {
@@ -17,9 +17,9 @@
             context.Extensions.TryGet(out incomingPhysicalMessage);
 
             var mutatorContext = new MutateOutgoingMessageContext(
-                context.Message.Instance, 
+                context.Message.Instance,
                 context.Headers,
-                incomingLogicalMessage?.Instance, 
+                incomingLogicalMessage?.Instance,
                 incomingPhysicalMessage?.Headers);
 
             foreach (var mutator in context.Builder.BuildAll<IMutateOutgoingMessages>())
@@ -29,7 +29,7 @@
 
             if (mutatorContext.MessageInstanceChanged)
             {
-                context.UpdateMessageInstance(mutatorContext.OutgoingMessage);
+                context.UpdateMessage(mutatorContext.OutgoingMessage);
             }
 
             await next().ConfigureAwait(false);

--- a/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateOutgoingMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateOutgoingMessageContext.cs
@@ -7,8 +7,6 @@ namespace NServiceBus.MessageMutator
     /// </summary>
     public class MutateOutgoingMessageContext
     {
-
-        object outgoingMessage;
         /// <summary>
         /// Initializes the context.
         /// </summary>
@@ -27,10 +25,7 @@ namespace NServiceBus.MessageMutator
         /// </summary>
         public object OutgoingMessage
         {
-            get
-            {
-                return outgoingMessage;
-            }
+            get { return outgoingMessage; }
             set
             {
                 Guard.AgainstNull(nameof(value), value);
@@ -38,10 +33,6 @@ namespace NServiceBus.MessageMutator
                 outgoingMessage = value;
             }
         }
-
-        internal bool MessageInstanceChanged;
-        object incomingMessage;
-        IReadOnlyDictionary<string, string> incomingHeaders;
 
         /// <summary>
         /// The current outgoing headers.
@@ -65,5 +56,12 @@ namespace NServiceBus.MessageMutator
             incomingHeaders = this.incomingHeaders;
             return incomingHeaders != null;
         }
+
+        IReadOnlyDictionary<string, string> incomingHeaders;
+        object incomingMessage;
+
+        internal bool MessageInstanceChanged;
+
+        object outgoingMessage;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
@@ -2,8 +2,8 @@
 {
     using System;
     using System.Threading.Tasks;
-    using MessageMutator;
-    using Pipeline;
+    using NServiceBus.MessageMutator;
+    using NServiceBus.Pipeline;
 
     class MutateIncomingTransportMessageBehavior : Behavior<IIncomingPhysicalMessageContext>
     {
@@ -16,7 +16,12 @@
             {
                 await mutator.MutateIncoming(mutatorContext).ConfigureAwait(false);
             }
-            transportMessage.Body = mutatorContext.Body;
+
+            if (mutatorContext.MessageBodyChanged)
+            {
+                context.UpdateMessage(mutatorContext.Body);
+            }
+
             await next().ConfigureAwait(false);
         }
     }

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageContext.cs
@@ -3,14 +3,12 @@ namespace NServiceBus.MessageMutator
     using System.Collections.Generic;
 
     /// <summary>
-    /// Context class for <see cref="IMutateIncomingTransportMessages"/>.
+    /// Context class for <see cref="IMutateIncomingTransportMessages" />.
     /// </summary>
     public class MutateIncomingTransportMessageContext
     {
-        byte[] body;
-
         /// <summary>
-        /// Initializes a new instance of <see cref="MutateOutgoingTransportMessageContext"/>.
+        /// Initializes a new instance of <see cref="MutateOutgoingTransportMessageContext" />.
         /// </summary>
         public MutateIncomingTransportMessageContext(byte[] body, IDictionary<string, string> headers)
         {
@@ -29,6 +27,7 @@ namespace NServiceBus.MessageMutator
             set
             {
                 Guard.AgainstNull(nameof(value), value);
+                MessageBodyChanged = true;
                 body = value;
             }
         }
@@ -38,5 +37,8 @@ namespace NServiceBus.MessageMutator
         /// </summary>
         public IDictionary<string, string> Headers { get; private set; }
 
+        byte[] body;
+
+        internal bool MessageBodyChanged;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageContext.cs
@@ -3,16 +3,12 @@ namespace NServiceBus.MessageMutator
     using System.Collections.Generic;
 
     /// <summary>
-    /// Context class for <see cref="IMutateOutgoingTransportMessages"/>.
+    /// Context class for <see cref="IMutateOutgoingTransportMessages" />.
     /// </summary>
     public class MutateOutgoingTransportMessageContext
     {
-        byte[] outgoingBody;
-        IReadOnlyDictionary<string, string> incomingHeaders;
-        object incomingMessage;
-
         /// <summary>
-        /// Initializes a new instance of <see cref="MutateOutgoingTransportMessageContext"/>.
+        /// Initializes a new instance of <see cref="MutateOutgoingTransportMessageContext" />.
         /// </summary>
         public MutateOutgoingTransportMessageContext(byte[] outgoingBody, object outgoingMessage, IDictionary<string, string> outgoingHeaders, object incomingMessage, IReadOnlyDictionary<string, string> incomingHeaders)
         {
@@ -39,7 +35,8 @@ namespace NServiceBus.MessageMutator
             get { return outgoingBody; }
             set
             {
-                Guard.AgainstNull(nameof(value),value);
+                Guard.AgainstNull(nameof(value), value);
+                MessageBodyChanged = true;
                 outgoingBody = value;
             }
         }
@@ -67,5 +64,10 @@ namespace NServiceBus.MessageMutator
             return incomingHeaders != null;
         }
 
+        IReadOnlyDictionary<string, string> incomingHeaders;
+        object incomingMessage;
+
+        internal bool MessageBodyChanged;
+        byte[] outgoingBody;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/IOutgoingLogicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/IOutgoingLogicalMessageContext.cs
@@ -21,6 +21,6 @@
         /// <summary>
         /// Updates the message instance.
         /// </summary>
-        void UpdateMessageInstance(object newInstance);
+        void UpdateMessage(object newInstance);
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/IOutgoingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/IOutgoingPhysicalMessageContext.cs
@@ -14,11 +14,16 @@
         /// <summary>
         /// A <see cref="byte"/> array containing the serialized contents of the outgoing message.
         /// </summary>
-        byte[] Body { get; set; }
+        byte[] Body { get; }
 
         /// <summary>
         /// The routing strategies for this message.
         /// </summary>
         IReadOnlyCollection<RoutingStrategy> RoutingStrategies { get; }
+
+        /// <summary>
+        /// Updates the message with the given body.
+        /// </summary>
+        void UpdateMessage(byte[] body);
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingLogicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingLogicalMessageContext.cs
@@ -18,7 +18,7 @@
 
         public IReadOnlyCollection<RoutingStrategy> RoutingStrategies { get; }
 
-        public void UpdateMessageInstance(object newInstance)
+        public void UpdateMessage(object newInstance)
         {
             Guard.AgainstNull(nameof(newInstance), newInstance);
 

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPhysicalMessageContext.cs
@@ -13,8 +13,13 @@
             RoutingStrategies = routingStrategies;
         }
 
-        public byte[] Body { get; set; }
+        public byte[] Body { get; private set; }
 
-        public IReadOnlyCollection<RoutingStrategy> RoutingStrategies { get; } 
+        public IReadOnlyCollection<RoutingStrategy> RoutingStrategies { get; }
+
+        public void UpdateMessage(byte[] body)
+        {
+            Body = body;
+        }
     }
 }

--- a/src/NServiceBus.Core/Transports/OutgoingMessage.cs
+++ b/src/NServiceBus.Core/Transports/OutgoingMessage.cs
@@ -27,13 +27,13 @@ namespace NServiceBus.Transports
         /// <summary>
         /// The body to be sent.
         /// </summary>
-        public byte[] Body { get; private set; }
+        public byte[] Body { get; }
 
 
         /// <summary>
         /// The id of the message.
         /// </summary>
-        public string MessageId { get; private set; }
+        public string MessageId { get; }
 
         /// <summary>
         /// The headers for the message.


### PR DESCRIPTION
While doing the API walkthrough I detected that we are inconsistently applying updates to message bodies and instances in the core. This PR attempts to streamline it by introducing `UpdateMessage` methods on the context. Currently the setter on the incoming message body is still public, thus allowing to set the body without using `UpdateMessage` on the context. This is unfortunate but I wanted to keep the amount of changes small. 

The next PR will address the inconsistent usage of IncomingMessage, OutgoingMessages vs. exposing it on the context. I will open up a separate issue for that.

## Documentation

I compiled the snippets and the mutator sample against this release and no changes had to be made to those projects. Did I miss anything?

@Particular/nservicebus-maintainers please review