### PR TITLE
Adding GetDestination extension method for sendoptions

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -788,6 +788,7 @@ namespace NServiceBus
     public class static RoutingOptionExtensions
     {
         public static string GetDestination(this NServiceBus.ReplyOptions options) { }
+        public static string GetDestination(this NServiceBus.SendOptions options) { }
         public static void RouteReplyTo(this NServiceBus.ReplyOptions options, string address) { }
         public static void RouteReplyTo(this NServiceBus.SendOptions options, string address) { }
         public static void RouteReplyToAnyInstance(this NServiceBus.SendOptions options) { }

--- a/src/NServiceBus.Core.Tests/Routing/RoutingOptionExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingOptionExtensionsTests.cs
@@ -26,5 +26,27 @@
 
             Assert.IsNull(destination);
         }
+
+        [Test]
+        public void SendOptions_GetDestination_Should_Return_Configured_Destination()
+        {
+          const string expectedDestination = "custom send destination";
+          var options = new SendOptions();
+          options.SetDestination(expectedDestination);
+
+          var destination = options.GetDestination();
+
+          Assert.AreEqual(expectedDestination, destination);
+        }
+
+        [Test]
+        public void SendOptions_GetDestination_Should_Return_Null_When_No_Destination_Configured()
+        {
+          var options = new SendOptions();
+
+          var destination = options.GetDestination();
+
+          Assert.IsNull(destination);
+        }
     }
 }

--- a/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
+++ b/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
@@ -49,6 +49,20 @@
         }
 
         /// <summary>
+        /// Returns the destination configured by <see cref="SetDestination(SendOptions, string)"/>.
+        /// </summary>
+        /// <param name="options">Option being extended.</param>
+        /// <returns>The specified destination address or <c>null</c> when no destination was specified.</returns>
+        public static string GetDestination(this SendOptions options)
+        {
+          Guard.AgainstNull(nameof(options), options);
+
+          UnicastSendRouterConnector.State state;
+          options.Context.TryGet(out state);
+          return state?.ExplicitDestination;
+        }
+
+        /// <summary>
         /// Routes this message to any instance of this endpoint.
         /// </summary>
         /// <param name="options">Context being extended.</param>


### PR DESCRIPTION
Relates to https://github.com/Particular/NServiceBus/pull/3473

Attempt 2 :)

@timbussmann is working on adding in more options getters but this is the last one required to get the testing framework migrated to v6

@Particular/nservicebus-maintainers please can you review

Thanks :)