### PR TITLE
[WIP] Adds cancellation token support to IQueryTimeouts

### DIFF
--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails.cs
@@ -11,7 +11,7 @@
     using NServiceBus.Persistence;
     using NServiceBus.Timeout.Core;
     using NUnit.Framework;
-
+    using System.Threading;
     public class When_timeout_dispatch_fails : NServiceBusAcceptanceTest
     {
         [Test]
@@ -90,7 +90,7 @@
             {
                 public Context TestContext { get; set; }
 
-                public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice)
+                public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice, int maxChunkSize = Int32.MaxValue, CancellationToken cancellationToken = default(CancellationToken))
                 {
                     var timeout = new TimeoutsChunk.Timeout(Guid.NewGuid().ToString(), DateTime.UtcNow);
                     var timeouts = new List<TimeoutsChunk.Timeout>

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails_on_timeout_data_removal.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails_on_timeout_data_removal.cs
@@ -114,7 +114,7 @@
 
                 TimeoutData timeoutData;
 
-                public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice, CancellationToken cancellationToken = default(CancellationToken))
+                public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice, int maxChunkSize = Int32.MaxValue, CancellationToken cancellationToken = default(CancellationToken))
                 {
                     var timeouts = timeoutData != null
                         ? new List<TimeoutsChunk.Timeout>

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails_on_timeout_data_removal.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails_on_timeout_data_removal.cs
@@ -13,7 +13,7 @@
     using NServiceBus.Pipeline;
     using NServiceBus.Timeout.Core;
     using NUnit.Framework;
-
+    using System.Threading;
     public class When_timeout_dispatch_fails_on_timeout_data_removal : NServiceBusAcceptanceTest
     {
         [Test]
@@ -114,7 +114,7 @@
 
                 TimeoutData timeoutData;
 
-                public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice)
+                public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice, CancellationToken cancellationToken = default(CancellationToken))
                 {
                     var timeouts = timeoutData != null
                         ? new List<TimeoutsChunk.Timeout>

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_storage_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_storage_fails.cs
@@ -11,7 +11,7 @@
     using NServiceBus.Persistence;
     using NServiceBus.Timeout.Core;
     using NUnit.Framework;
-
+    using System.Threading;
     public class When_timeout_storage_fails : NServiceBusAcceptanceTest
     {
         [Test]
@@ -97,7 +97,7 @@
                     testContext = context;
                 }
 
-                public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice)
+                public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice, CancellationToken cancellationToken = default(CancellationToken))
                 {
                     return Task.FromResult(new TimeoutsChunk(new List<TimeoutsChunk.Timeout>(), DateTime.UtcNow + TimeSpan.FromSeconds(10)));
                 }

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_storage_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_storage_fails.cs
@@ -97,7 +97,7 @@
                     testContext = context;
                 }
 
-                public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice, CancellationToken cancellationToken = default(CancellationToken))
+                public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice, int maxChunkSize = Int32.MaxValue, CancellationToken cancellationToken = default(CancellationToken))
                 {
                     return Task.FromResult(new TimeoutsChunk(new List<TimeoutsChunk.Timeout>(), DateTime.UtcNow + TimeSpan.FromSeconds(10)));
                 }

--- a/src/NServiceBus.AcceptanceTests/Timeout/CyclingOutageTimeoutPersister.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeout/CyclingOutageTimeoutPersister.cs
@@ -95,7 +95,7 @@
             return Task.FromResult<TimeoutData>(null);
         }
 
-        public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice, int maxChunkSize = Int32.MaxValue, CancellationToken cancellationToken = default(CancellationToken))
         {
             ThrowExceptionUntilWaitTimeReached();
 

--- a/src/NServiceBus.AcceptanceTests/Timeout/CyclingOutageTimeoutPersister.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeout/CyclingOutageTimeoutPersister.cs
@@ -7,7 +7,7 @@
     using System.Threading.Tasks;
     using NServiceBus.Extensibility;
     using Timeout.Core;
-
+    using System.Threading;
     /// <summary>
     /// This class mocks outages for timeout storage. 
     /// If SecondsToWait is set to 10, it will throw exceptions for 10 seconds, then be available for 10 seconds, and repeat.
@@ -95,7 +95,7 @@
             return Task.FromResult<TimeoutData>(null);
         }
 
-        public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice)
+        public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice, CancellationToken cancellationToken = default(CancellationToken))
         {
             ThrowExceptionUntilWaitTimeReached();
 

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2580,7 +2580,7 @@ namespace NServiceBus.Timeout.Core
     }
     public interface IQueryTimeouts
     {
-        System.Threading.Tasks.Task<NServiceBus.Timeout.Core.TimeoutsChunk> GetNextChunk(System.DateTime startSlice);
+        System.Threading.Tasks.Task<NServiceBus.Timeout.Core.TimeoutsChunk> GetNextChunk(System.DateTime startSlice, System.Threading.CancellationToken cancellationToken = null);
     }
     public class TimeoutData
     {

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2580,7 +2580,7 @@ namespace NServiceBus.Timeout.Core
     }
     public interface IQueryTimeouts
     {
-        System.Threading.Tasks.Task<NServiceBus.Timeout.Core.TimeoutsChunk> GetNextChunk(System.DateTime startSlice, System.Threading.CancellationToken cancellationToken = null);
+        System.Threading.Tasks.Task<NServiceBus.Timeout.Core.TimeoutsChunk> GetNextChunk(System.DateTime startSlice, int maxChunkSize = 2147483647, System.Threading.CancellationToken cancellationToken = null);
     }
     public class TimeoutData
     {

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Persistence/IQueryTimeouts.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Persistence/IQueryTimeouts.cs
@@ -13,10 +13,11 @@ namespace NServiceBus.Timeout.Core
         /// Retrieves the next range of timeouts that are due.
         /// </summary>
         /// <param name="startSlice">The time where to start retrieving the next slice, the slice should exclude this date.</param>
+        /// <param name="maxChunkSize">The maximum chunk size that the caller specifies to limit the number of results.</param>
         /// <param name="cancellationToken">The cancellation token used by the caller to notify that the pending work should be cancelled.</param>
         /// <returns>
         /// Returns the next range of timeouts that are due.
         /// </returns>
-        Task<TimeoutsChunk> GetNextChunk(DateTime startSlice, CancellationToken cancellationToken = default(CancellationToken));
+        Task<TimeoutsChunk> GetNextChunk(DateTime startSlice, int maxChunkSize = Int32.MaxValue, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Persistence/IQueryTimeouts.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Persistence/IQueryTimeouts.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Timeout.Core
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -12,7 +13,10 @@ namespace NServiceBus.Timeout.Core
         /// Retrieves the next range of timeouts that are due.
         /// </summary>
         /// <param name="startSlice">The time where to start retrieving the next slice, the slice should exclude this date.</param>
-        /// <returns>Returns the next range of timeouts that are due.</returns>
-        Task<TimeoutsChunk> GetNextChunk(DateTime startSlice);
+        /// <param name="cancellationToken">The cancellation token used by the caller to notify that the pending work should be cancelled.</param>
+        /// <returns>
+        /// Returns the next range of timeouts that are due.
+        /// </returns>
+        Task<TimeoutsChunk> GetNextChunk(DateTime startSlice, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
@@ -91,7 +91,7 @@ namespace NServiceBus
             return TaskEx.CompletedTask;
         }
 
-        public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice, CancellationToken cancellationToken = default(CancellationToken))
+        public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice, int maxChunkSize = Int32.MaxValue, CancellationToken cancellationToken = default(CancellationToken))
         {
             var now = DateTime.UtcNow;
             var nextTimeToRunQuery = DateTime.MaxValue;

--- a/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
@@ -91,7 +91,7 @@ namespace NServiceBus
             return TaskEx.CompletedTask;
         }
 
-        public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice)
+        public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice, CancellationToken cancellationToken = default(CancellationToken))
         {
             var now = DateTime.UtcNow;
             var nextTimeToRunQuery = DateTime.MaxValue;


### PR DESCRIPTION
This PR is intended to fix #3472, as discussed with @danielmarbach and previously with @colin-higgins the `IQueryTimeouts` RavenDB implementation needs to be cancelled in order to guarantee a clean shutdown.

@Particular/nservicebus-maintainers please review.

Connects to #3472 

Responsible Maintaners: @timbussmann @andreasohlund