### PR TITLE
Add warning when not using max bits for encryption

### DIFF
--- a/src/NServiceBus.Core/Encryption/RijndaelEncryptionService.cs
+++ b/src/NServiceBus.Core/Encryption/RijndaelEncryptionService.cs
@@ -30,6 +30,7 @@ namespace NServiceBus
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Security.Cryptography;
     using Logging;
     using NServiceBus.Pipeline;
@@ -198,6 +199,13 @@ namespace NServiceBus
             using (var rijndael = new RijndaelManaged())
             {
                 var bitLength = key.Length * 8;
+
+                var maxValidKeyBitLength = rijndael.LegalKeySizes.OrderBy(keyLength => keyLength.MaxSize).Select(keyLength => keyLength.MaxSize).First();
+                if (bitLength < maxValidKeyBitLength)
+                {
+                    Log.WarnFormat("Encryption key is is {0} bits which is less than the maximum allowed {1} bits. Increasing the key length to {1} bits would provide stronger security.", bitLength, maxValidKeyBitLength);
+                }
+
                 return rijndael.ValidKeySize(bitLength);
             }
         }


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus/issues/3313

Checks what the maximum keylength is from the SymmetricAlgorithm class and logs a warning if the key length used is less than the maximum.

This is intended to allow the user to see that they could improve their security.

@WojcikMike @ramonsmits @justabitofcode this is intended to build off of https://github.com/Particular/NServiceBus/pull/3063, so could you please review this to see if you're willing to merge it into that PR. Otherwise we can wait until that one is reviewed and merge it in separately.