### PR TITLE
Reading ATT related environment variables from 2 scopes

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -186,6 +186,7 @@
     <Compile Include="Sagas\When_saga_id_changed.cs" />
     <Compile Include="Sagas\When_a_base_class_message_hits_a_saga.cs" />
     <Compile Include="Sagas\When_a_finder_exists.cs" />
+    <Compile Include="ScenarioDescriptors\EnvironmentHelper.cs" />
     <Compile Include="SelfVerification\When_running_saga_tests.cs" />
     <Compile Include="Timeout\CyclingOutageTimeoutPersister.cs" />
     <Compile Include="Timeout\When_timeout_storage_is_unavailable_temporarily.cs" />

--- a/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/EnvironmentHelper.cs
+++ b/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/EnvironmentHelper.cs
@@ -1,0 +1,17 @@
+﻿namespace NServiceBus.AcceptanceTests.ScenarioDescriptors
+{
+    using System;
+
+    class EnvironmentHelper
+    {
+        public static string GetEnvironmentVariable(string variable)
+        {
+            var candidate = Environment.GetEnvironmentVariable(variable, EnvironmentVariableTarget.User);
+
+            if (string.IsNullOrWhiteSpace(candidate))
+                return Environment.GetEnvironmentVariable(variable);
+
+            return candidate;
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/Persistence.cs
+++ b/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/Persistence.cs
@@ -12,7 +12,7 @@
         {
             get
             {
-                var specificPersistence = Environment.GetEnvironmentVariable("Persistence.UseSpecific");
+                var specificPersistence = EnvironmentHelper.GetEnvironmentVariable("Persistence.UseSpecific");
 
                 if (!string.IsNullOrEmpty(specificPersistence))
                 {

--- a/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/Transports.cs
+++ b/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/Transports.cs
@@ -29,7 +29,7 @@
         {
             get
             {
-                var specificTransport = Environment.GetEnvironmentVariable("Transport.UseSpecific");
+                var specificTransport = EnvironmentHelper.GetEnvironmentVariable("Transport.UseSpecific");
 
                 if (!string.IsNullOrEmpty(specificTransport))
                     return AllAvailable.Single(r => r.Key == specificTransport);


### PR DESCRIPTION
Currently, it's always the process scope.
The change is to first try the user scope, if nothing is found, then fall back to the process scope.

Reason: when running ATTs locally ASB/ASB/Core, need constantly restart VS for environment variables refresh to be picked up. This change solve the problem.