### PR TITLE
Add warning when not using max bits for encryption

### DIFF
--- a/src/NServiceBus.Core/Encryption/RijndaelEncryptionService.cs
+++ b/src/NServiceBus.Core/Encryption/RijndaelEncryptionService.cs
@@ -200,7 +200,7 @@ namespace NServiceBus
             {
                 var bitLength = key.Length * 8;
 
-                var maxValidKeyBitLength = rijndael.LegalKeySizes.Select(keyLength => keyLength.MaxSize).Max();
+                var maxValidKeyBitLength = rijndael.LegalKeySizes.Max(keyLength => keyLength.MaxSize);
                 if (bitLength < maxValidKeyBitLength)
                 {
                     Log.WarnFormat("Encryption key is {0} bits which is less than the maximum allowed {1} bits. Consider using a {1}-bit encryption key to obtain the maximum cipher strength", bitLength, maxValidKeyBitLength);

--- a/src/NServiceBus.Core/Encryption/RijndaelEncryptionService.cs
+++ b/src/NServiceBus.Core/Encryption/RijndaelEncryptionService.cs
@@ -30,6 +30,7 @@ namespace NServiceBus
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Security.Cryptography;
     using Logging;
     using NServiceBus.Pipeline;
@@ -198,6 +199,13 @@ namespace NServiceBus
             using (var rijndael = new RijndaelManaged())
             {
                 var bitLength = key.Length * 8;
+
+                var maxValidKeyBitLength = rijndael.LegalKeySizes.OrderByDescending(keyLength => keyLength.MaxSize).Select(keyLength => keyLength.MaxSize).First();
+                if (bitLength < maxValidKeyBitLength)
+                {
+                    Log.WarnFormat("Encryption key is is {0} bits which is less than the maximum allowed {1} bits. Increasing the key length to {1} bits would provide stronger security.", bitLength, maxValidKeyBitLength);
+                }
+
                 return rijndael.ValidKeySize(bitLength);
             }
         }

--- a/src/NServiceBus.Core/Encryption/RijndaelEncryptionService.cs
+++ b/src/NServiceBus.Core/Encryption/RijndaelEncryptionService.cs
@@ -203,7 +203,7 @@ namespace NServiceBus
                 var maxValidKeyBitLength = rijndael.LegalKeySizes.OrderByDescending(keyLength => keyLength.MaxSize).Select(keyLength => keyLength.MaxSize).First();
                 if (bitLength < maxValidKeyBitLength)
                 {
-                    Log.WarnFormat("Encryption key is is {0} bits which is less than the maximum allowed {1} bits. Increasing the key length to {1} bits would provide stronger security.", bitLength, maxValidKeyBitLength);
+                    Log.WarnFormat("Encryption key is {0} bits which is less than the maximum allowed {1} bits. Increasing the key length to {1} bits would provide stronger security.", bitLength, maxValidKeyBitLength);
                 }
 
                 return rijndael.ValidKeySize(bitLength);

--- a/src/NServiceBus.Core/Encryption/RijndaelEncryptionService.cs
+++ b/src/NServiceBus.Core/Encryption/RijndaelEncryptionService.cs
@@ -203,7 +203,7 @@ namespace NServiceBus
                 var maxValidKeyBitLength = rijndael.LegalKeySizes.OrderByDescending(keyLength => keyLength.MaxSize).Select(keyLength => keyLength.MaxSize).First();
                 if (bitLength < maxValidKeyBitLength)
                 {
-                    Log.WarnFormat("Encryption key is {0} bits which is less than the maximum allowed {1} bits. Increasing the key length to {1} bits would provide stronger security.", bitLength, maxValidKeyBitLength);
+                    Log.WarnFormat("Encryption key is {0} bits which is less than the maximum allowed {1} bits. Consider using a {1}-bit encryption key to obtain the maximum cipher strength", bitLength, maxValidKeyBitLength);
                 }
 
                 return rijndael.ValidKeySize(bitLength);

--- a/src/NServiceBus.Core/Encryption/RijndaelEncryptionService.cs
+++ b/src/NServiceBus.Core/Encryption/RijndaelEncryptionService.cs
@@ -200,7 +200,7 @@ namespace NServiceBus
             {
                 var bitLength = key.Length * 8;
 
-                var maxValidKeyBitLength = rijndael.LegalKeySizes.OrderByDescending(keyLength => keyLength.MaxSize).Select(keyLength => keyLength.MaxSize).First();
+                var maxValidKeyBitLength = rijndael.LegalKeySizes.Select(keyLength => keyLength.MaxSize).Max();
                 if (bitLength < maxValidKeyBitLength)
                 {
                     Log.WarnFormat("Encryption key is {0} bits which is less than the maximum allowed {1} bits. Consider using a {1}-bit encryption key to obtain the maximum cipher strength", bitLength, maxValidKeyBitLength);


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus/issues/3313

Checks what the maximum keylength is from the SymmetricAlgorithm class and logs a warning if the key length used is less than the maximum.

This is intended to allow the user to see that they could improve their security.

ping @Particular/nservicebus-maintainers 