### PR TITLE
Passing correct event type as message type when publishing interface messages

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2108,7 +2108,6 @@ namespace NServiceBus.Pipeline
     }
     public class OutgoingLogicalMessage
     {
-        public OutgoingLogicalMessage(object message) { }
         public OutgoingLogicalMessage(System.Type messageType, object message) { }
         public object Instance { get; }
         public System.Type MessageType { get; }

--- a/src/NServiceBus.Core.Tests/ContextHelpers.cs
+++ b/src/NServiceBus.Core.Tests/ContextHelpers.cs
@@ -22,9 +22,9 @@ namespace NServiceBus.Core.Tests
         {
             return new OutgoingLogicalMessageContext(
                 Guid.NewGuid().ToString(),
-                new Dictionary<string, string>(), 
-                new OutgoingLogicalMessage(message), 
-                null, 
+                new Dictionary<string, string>(),
+                new OutgoingLogicalMessage(message.GetType(), message),
+                null,
                 null);
         }
     }

--- a/src/NServiceBus.Core.Tests/Routing/ApplyReplyToAddressBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/ApplyReplyToAddressBehaviorTests.cs
@@ -30,7 +30,7 @@
             var context = new OutgoingLogicalMessageContext(
                 Guid.NewGuid().ToString(),
                 new Dictionary<string, string>(),
-                new OutgoingLogicalMessage(new MyMessage()),
+                new OutgoingLogicalMessage(typeof(MyMessage), new MyMessage()),
                 new RoutingStrategy[]
                 {
                 },
@@ -73,7 +73,7 @@
 
             options.RouteReplyToThisInstance();
 
-            var context = CreateContext(options);            
+            var context = CreateContext(options);
             await behavior.Invoke(context, () => TaskEx.CompletedTask);
 
             Assert.AreEqual("MyInstance", context.Headers[Headers.ReplyToAddress]);
@@ -87,7 +87,7 @@
 
             options.RouteReplyTo("Destination");
 
-            var context = CreateContext(options);            
+            var context = CreateContext(options);
             await behavior.Invoke(context, () => TaskEx.CompletedTask);
 
             Assert.AreEqual("Destination", context.Headers[Headers.ReplyToAddress]);
@@ -97,7 +97,7 @@
         public async Task Should_set_the_reply_to_distributor_address_when_message_comes_from_a_distributor()
         {
             var behavior = new ApplyReplyToAddressBehavior("MyEndpoint", "MyInstance", "MyPublicAddress", "MyDistributor");
-            var options = new SendOptions();            
+            var options = new SendOptions();
             var context = CreateContext(options);
 
             context.Set(new IncomingMessage("ID", new Dictionary<string, string>

--- a/src/NServiceBus.Core.Tests/Routing/DetermineRouteForPublishBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DetermineRouteForPublishBehaviorTests.cs
@@ -14,7 +14,7 @@
         {
             var behavior = new MulticastPublishRouterBehavior();
 
-            var context = new OutgoingPublishContext(new OutgoingLogicalMessage(new MyEvent()), new PublishOptions(), new RootContext(null, null));
+            var context = new OutgoingPublishContext(new OutgoingLogicalMessage(typeof(MyEvent), new MyEvent()), new PublishOptions(), new RootContext(null, null));
 
             MulticastAddressTag addressTag = null;
             await behavior.Invoke(context, _ =>

--- a/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
@@ -21,7 +21,7 @@
             var options = new ReplyOptions();
 
             var context = new OutgoingReplyContext(
-                new OutgoingLogicalMessage(new MyReply()),
+                new OutgoingLogicalMessage(typeof(MyReply), new MyReply()),
                 options,
                 new TransportReceiveContext(
                     new IncomingMessage(
@@ -50,7 +50,7 @@
             var options = new ReplyOptions();
 
             var context = new OutgoingReplyContext(
-                new OutgoingLogicalMessage(new MyReply()),
+                new OutgoingLogicalMessage(typeof(MyReply), new MyReply()),
                 options,
                 new TransportReceiveContext(
                     new IncomingMessage(
@@ -71,7 +71,7 @@
             options.SetDestination("CustomReplyToAddress");
 
             var context = new OutgoingReplyContext(
-                new OutgoingLogicalMessage(new MyReply()),
+                new OutgoingLogicalMessage(typeof(MyReply), new MyReply()),
                 options,
                 new RootContext(null, null));
 

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
@@ -41,7 +41,7 @@
             UnicastAddressTag addressTag = null;
             await behavior.Invoke(context, c =>
             {
-                addressTag = (UnicastAddressTag) c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
+                addressTag = (UnicastAddressTag)c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
                 return TaskEx.CompletedTask;
             });
 
@@ -61,7 +61,7 @@
             UnicastAddressTag addressTag = null;
             await behavior.Invoke(context, c =>
             {
-                addressTag = (UnicastAddressTag) c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
+                addressTag = (UnicastAddressTag)c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
                 return TaskEx.CompletedTask;
             });
 
@@ -81,7 +81,7 @@
             UnicastAddressTag addressTag = null;
             await behavior.Invoke(context, c =>
             {
-                addressTag = (UnicastAddressTag) c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
+                addressTag = (UnicastAddressTag)c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
                 return TaskEx.CompletedTask;
             });
 
@@ -181,7 +181,7 @@
             UnicastAddressTag addressTag = null;
             await behavior.Invoke(context, c =>
             {
-                addressTag = (UnicastAddressTag) c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
+                addressTag = (UnicastAddressTag)c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
                 return TaskEx.CompletedTask;
             });
 
@@ -213,7 +213,7 @@
                 message = new MyMessage();
             }
 
-            var context = new OutgoingSendContext(new OutgoingLogicalMessage(message), options, new RootContext(null, null));
+            var context = new OutgoingSendContext(new OutgoingLogicalMessage(message.GetType(), message), options, new RootContext(null, null));
             return context;
         }
 

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingLogicalMessage.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingLogicalMessage.cs
@@ -8,17 +8,6 @@ namespace NServiceBus.Pipeline
     public class OutgoingLogicalMessage
     {
         /// <summary>
-        /// Initializes the message with the given instance. Message type will be set to the instance type.
-        /// </summary>
-        public OutgoingLogicalMessage(object message)
-        {
-            Guard.AgainstNull(nameof(message), message);
-
-            MessageType = message.GetType();
-            Instance = message;
-        }
-
-        /// <summary>
         /// Initializes the message with a explicit message type and instance. Use this constructor if the message type is
         /// different from the instance type.
         /// </summary>

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingLogicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingLogicalMessageContext.cs
@@ -22,7 +22,7 @@
         {
             Guard.AgainstNull(nameof(newInstance), newInstance);
 
-            Message = new OutgoingLogicalMessage(newInstance);
+            Message = new OutgoingLogicalMessage(newInstance.GetType(), newInstance);
         }
     }
 }

--- a/src/NServiceBus.Core/Unicast/MessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperations.cs
@@ -10,16 +10,21 @@ namespace NServiceBus
         public static Task Publish<T>(IBehaviorContext context, Action<T> messageConstructor, PublishOptions options)
         {
             var mapper = context.Builder.Build<IMessageMapper>();
-            return Publish(context, mapper.CreateInstance(messageConstructor), options);
+            return Publish(context, typeof(T), mapper.CreateInstance(messageConstructor), options);
         }
 
         public static Task Publish(IBehaviorContext context, object message, PublishOptions options)
+        {
+            return Publish(context, message.GetType(), message, options);
+        }
+
+        static Task Publish(IBehaviorContext context, Type messageType, object message, PublishOptions options)
         {
             var cache = context.Extensions.Get<IPipelineCache>();
             var pipeline = cache.Pipeline<IOutgoingPublishContext>();
 
             var publishContext = new OutgoingPublishContext(
-                new OutgoingLogicalMessage(message),
+                new OutgoingLogicalMessage(messageType, message),
                 options,
                 context);
 
@@ -84,7 +89,7 @@ namespace NServiceBus
             var pipeline = cache.Pipeline<IOutgoingReplyContext>();
 
             var outgoingContext = new OutgoingReplyContext(
-                new OutgoingLogicalMessage(message),
+                new OutgoingLogicalMessage(message.GetType(), message),
                 options,
                 context);
 


### PR DESCRIPTION
When I was playing with the development transport I noticed that when publishing interfaces we where passing the "impl" type instead of the pure message type. Eg.

`bus.Publish<MyEvent>()` would result in `MyEvent__impl` would be passed to the dispatcher. The subscription manager would on the other hand get the "pure" types.

Are we good with making sure to not pass the impl type? 

This is the key change: https://github.com/Particular/NServiceBus/pull/3521/files#diff-59e8e774c2bd8041f702a3a0f23d4de2R13