### PR TITLE
Removed the Msmq `RunDescriptor`

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
@@ -16,7 +16,7 @@
             await Scenario.Define<TimeoutTestContext>()
                 .WithEndpoint<EndpointWithFlakyTimeoutPersister>()
                 .Done(c => c.EndpointsStarted)
-                .Repeat(r => r.For(Transports.Msmq))
+                .Repeat(r => r.For<AllTransportsWithoutNativeDeferral>())
                 .Should(c => Assert.IsTrue(c.EndpointsStarted))
                 .Run();
         }
@@ -45,7 +45,7 @@
                     .Done(c => c.FatalErrorOccurred || stopTime <= DateTime.Now)
                     .Run();
 
-            Assert.IsFalse(testContext.FatalErrorOccurred, "Circuit breaker was trigged too soon.");
+            Assert.IsFalse(testContext.FatalErrorOccurred, "Circuit breaker was triggered too soon.");
         }
 
         public class TimeoutTestContext : ScenarioContext


### PR DESCRIPTION
Since msmq acpt tests are now moved to a separate project. 

Also fixed a bug where transports where discarded if no connection string was available even if the transport didn't need one.

@Particular/nservicebus-maintainers 