### PR TITLE
[WIP] Data from IncomingMessage is accessed over the context only.

### DIFF
--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails_on_timeout_data_removal.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails_on_timeout_data_removal.cs
@@ -166,8 +166,8 @@
 
                 public override async Task Invoke(ITransportReceiveContext context, Func<Task> next)
                 {
-                    if (context.Message.Headers.ContainsKey(Headers.ControlMessageHeader) &&
-                        context.Message.Headers["Timeout.Id"] == TestContext.TestRunId.ToString())
+                    if (context.Headers.ContainsKey(Headers.ControlMessageHeader) &&
+                        context.Headers["Timeout.Id"] == TestContext.TestRunId.ToString())
                     {
                         TestContext.FailedTimeoutMovedToError = true;
                         return;

--- a/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehavior.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehavior.cs
@@ -5,13 +5,9 @@
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.Pipeline;
-    using NServiceBus.Transports;
 
     class SubscriptionBehavior<TContext> : Behavior<IIncomingPhysicalMessageContext> where TContext : ScenarioContext
     {
-        Action<SubscriptionEventArgs, TContext> action;
-        TContext scenarioContext;
-
         public SubscriptionBehavior(Action<SubscriptionEventArgs, TContext> action, TContext scenarioContext)
         {
             this.action = action;
@@ -21,13 +17,13 @@
         public override async Task Invoke(IIncomingPhysicalMessageContext context, Func<Task> next)
         {
             await next().ConfigureAwait(false);
-            var subscriptionMessageType = GetSubscriptionMessageTypeFrom(context.Message);
+            var subscriptionMessageType = GetSubscriptionMessageTypeFrom(context);
             if (subscriptionMessageType != null)
             {
                 string returnAddress;
-                if (!context.Message.Headers.TryGetValue(Headers.SubscriberTransportAddress, out returnAddress))
+                if (!context.Headers.TryGetValue(Headers.SubscriberTransportAddress, out returnAddress))
                 {
-                    context.Message.Headers.TryGetValue(Headers.ReplyToAddress, out returnAddress);
+                    context.Headers.TryGetValue(Headers.ReplyToAddress, out returnAddress);
                 }
                 action(new SubscriptionEventArgs
                 {
@@ -37,10 +33,13 @@
             }
         }
 
-        static string GetSubscriptionMessageTypeFrom(IncomingMessage msg)
+        static string GetSubscriptionMessageTypeFrom(IIncomingPhysicalMessageContext context)
         {
-            return (from header in msg.Headers where header.Key == Headers.SubscriptionMessageType select header.Value).FirstOrDefault();
+            return (from header in context.Headers where header.Key == Headers.SubscriptionMessageType select header.Value).FirstOrDefault();
         }
+
+        Action<SubscriptionEventArgs, TContext> action;
+        TContext scenarioContext;
 
         internal class Registration : RegisterStep
         {

--- a/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/DispatchTimeoutBehaviorTest.cs
+++ b/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/DispatchTimeoutBehaviorTest.cs
@@ -120,7 +120,7 @@
             };
 
             return new IncomingPhysicalMessageContext(
-                new IncomingMessage(messageId, headers, new MemoryStream()), null);
+                messageId, headers, new MemoryStream().ToArray(), null);
         }
 
         class FakeMessageDispatcher : IDispatchMessages

--- a/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/TimeoutRecoverabilityBehaviourTest.cs
+++ b/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/TimeoutRecoverabilityBehaviourTest.cs
@@ -47,7 +47,7 @@
             var headers = new Dictionary<string, string>();
 
             return new TransportReceiveContext(
-                new IncomingMessage(messageId, headers, Stream.Null), 
+                messageId, headers, Stream.Null, 
                 new TransportTransaction(), 
                 new CancellationTokenSource(), 
                 null);

--- a/src/NServiceBus.Core.Tests/Faults/ForwardFaultsToErrorQueueTests.cs
+++ b/src/NServiceBus.Core.Tests/Faults/ForwardFaultsToErrorQueueTests.cs
@@ -96,7 +96,7 @@ namespace NServiceBus.Core.Tests
 
         static ITransportReceiveContext CreateContext(string messageId, FakeFaultPipeline pipeline)
         {
-            return new TransportReceiveContext(new IncomingMessage(messageId, new Dictionary<string, string>(), new MemoryStream()), null, new CancellationTokenSource(), new RootContext(null, new FakePipelineCache(pipeline)));
+            return new TransportReceiveContext(messageId, new Dictionary<string, string>(), new MemoryStream(), null, new CancellationTokenSource(), new RootContext(null, new FakePipelineCache(pipeline)));
         }
 
         class FakePipelineCache : IPipelineCache

--- a/src/NServiceBus.Core.Tests/Recoverability/FirstLevelRetries/FirstLevelRetriesTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/FirstLevelRetries/FirstLevelRetriesTests.cs
@@ -41,7 +41,7 @@
             Assert.That(async () => await behavior.Invoke(context, () => { throw new Exception("test"); }), Throws.InstanceOf<Exception>());
 
             //should set the retries header to capture how many flr attempts where made
-            Assert.AreEqual("0", context.Message.Headers[Headers.FLRetries]);
+            Assert.AreEqual("0", context.Headers[Headers.FLRetries]);
         }
 
         [Test]
@@ -136,7 +136,7 @@
 
         ITransportReceiveContext CreateContext(string messageId, CancellationTokenSource cancellationTokenSource = null)
         {
-            return new TransportReceiveContext(new IncomingMessage(messageId, new Dictionary<string, string>(), new MemoryStream()), null, cancellationTokenSource ?? new CancellationTokenSource(), new RootContext(null, null));
+            return new TransportReceiveContext(messageId, new Dictionary<string, string>(), new MemoryStream(), null, cancellationTokenSource ?? new CancellationTokenSource(), new RootContext(null, null));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Recoverability/SecondLevelRetries/DefaultRetryPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/SecondLevelRetries/DefaultRetryPolicyTests.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using NServiceBus.Transports;
     using NUnit.Framework;
 
     [TestFixture]
@@ -17,11 +16,11 @@
             var policy = new DefaultSecondLevelRetryPolicy(2, baseDelay);
             TimeSpan delay;
 
-            Assert.True(policy.TryGetDelay(new IncomingMessage("someid", new Dictionary<string, string>(), Stream.Null), new Exception(""), 1, out delay));
+            Assert.True(policy.TryGetDelay(new TransportReceiveContext("someid", new Dictionary<string, string>(), Stream.Null, null, null, null), new Exception(""), 1, out delay));
             Assert.AreEqual(baseDelay, delay);
-            Assert.True(policy.TryGetDelay(new IncomingMessage("someid", new Dictionary<string, string>(), Stream.Null), new Exception(""), 2, out delay));
+            Assert.True(policy.TryGetDelay(new TransportReceiveContext("someid", new Dictionary<string, string>(), Stream.Null, null, null, null), new Exception(""), 2, out delay));
             Assert.AreEqual(TimeSpan.FromSeconds(20), delay);
-            Assert.False(policy.TryGetDelay(new IncomingMessage("someid", new Dictionary<string, string>(), Stream.Null), new Exception(""), 3, out delay));
+            Assert.False(policy.TryGetDelay(new TransportReceiveContext("someid", new Dictionary<string, string>(), Stream.Null, null, null, null), new Exception(""), 3, out delay));
         }
 
         [Test]
@@ -39,7 +38,7 @@
                 {SecondLevelRetriesBehavior.RetriesTimestamp, DateTimeExtensions.ToWireFormattedString(moreThanADayAgo)}
             };
 
-            Assert.False(policy.TryGetDelay(new IncomingMessage("someid", headers, Stream.Null), new Exception(""), 1, out delay));
+            Assert.False(policy.TryGetDelay(new TransportReceiveContext("someid", headers, Stream.Null, null, null, null), new Exception(""), 1, out delay));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageProcessingConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageProcessingConnectorTests.cs
@@ -110,7 +110,7 @@
 
         static ITransportReceiveContext CreateContext(FakeBatchPipeline pipeline)
         {
-            var context = new TransportReceiveContext(new IncomingMessage("id", new Dictionary<string, string>(), new MemoryStream()), null, new CancellationTokenSource(), new RootContext(null, new FakePipelineCache(pipeline)));
+            var context = new TransportReceiveContext("id", new Dictionary<string, string>(), new MemoryStream(), null, new CancellationTokenSource(), new RootContext(null, new FakePipelineCache(pipeline)));
             return context;
         }
 

--- a/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
@@ -8,7 +8,6 @@
     using System.Threading.Tasks;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
-    using NServiceBus.Transports;
     using NUnit.Framework;
 
     [TestFixture]
@@ -24,19 +23,18 @@
                 new OutgoingLogicalMessage(typeof(MyReply), new MyReply()),
                 options,
                 new TransportReceiveContext(
-                    new IncomingMessage(
-                        "id",
-                        new Dictionary<string, string>
-                        {
-                            {Headers.ReplyToAddress, "ReplyAddressOfIncomingMessage"}
-                        },
-                        new MemoryStream()), null, new CancellationTokenSource(),
+                    "id",
+                    new Dictionary<string, string>
+                    {
+                        {Headers.ReplyToAddress, "ReplyAddressOfIncomingMessage"}
+                    },
+                    new MemoryStream(), null, new CancellationTokenSource(),
                     new RootContext(null, null)));
 
             UnicastAddressTag addressTag = null;
             await behavior.Invoke(context, c =>
             {
-                addressTag = (UnicastAddressTag)c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
+                addressTag = (UnicastAddressTag) c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
                 return TaskEx.CompletedTask;
             });
 
@@ -53,10 +51,9 @@
                 new OutgoingLogicalMessage(typeof(MyReply), new MyReply()),
                 options,
                 new TransportReceiveContext(
-                    new IncomingMessage(
-                        "id",
-                        new Dictionary<string, string>(),
-                        new MemoryStream()), null, new CancellationTokenSource(),
+                    "id",
+                    new Dictionary<string, string>(),
+                    new MemoryStream(), null, new CancellationTokenSource(),
                     new RootContext(null, null)));
 
             Assert.That(async () => await behavior.Invoke(context, _ => TaskEx.CompletedTask), Throws.InstanceOf<Exception>().And.Message.Contains(typeof(MyReply).FullName));
@@ -78,7 +75,7 @@
             UnicastAddressTag addressTag = null;
             await behavior.Invoke(context, c =>
             {
-                addressTag = (UnicastAddressTag)c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
+                addressTag = (UnicastAddressTag) c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
                 return TaskEx.CompletedTask;
             });
 

--- a/src/NServiceBus.Core.Tests/UnitOfWork/UnitOfWorkBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/UnitOfWork/UnitOfWorkBehaviorTests.cs
@@ -139,9 +139,9 @@
         {
             var runner = new UnitOfWorkBehavior();
 
-            var receiveContext = new TransportReceiveContext(new IncomingMessage("fakeId", new Dictionary<string, string>(), new MemoryStream()), null, new CancellationTokenSource(), new RootContext(builder, null));
+            var receiveContext = new TransportReceiveContext("fakeId", new Dictionary<string, string>(), new MemoryStream(), null, new CancellationTokenSource(), new RootContext(builder, null));
 
-            var context = new IncomingPhysicalMessageContext(receiveContext.Message, receiveContext);
+            var context = new IncomingPhysicalMessageContext(receiveContext.MessageId, receiveContext.Headers, receiveContext.Body, receiveContext);
 
             return runner.Invoke(context, () =>
             {

--- a/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
@@ -16,9 +16,9 @@
         {
             await next().ConfigureAwait(false);
 
-            context.Message.RevertToOriginalBodyIfNeeded();
+            context.RevertToOriginalBodyIfNeeded();
 
-            var processedMessage = new OutgoingMessage(context.Message.MessageId, context.Message.Headers, context.Message.Body);
+            var processedMessage = new OutgoingMessage(context.MessageId, context.Headers, context.Body);
 
             var auditContext = this.CreateAuditContext(processedMessage, auditAddress, context);
             

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
@@ -19,16 +19,15 @@ namespace NServiceBus
 
         protected override async Task Terminate(IIncomingPhysicalMessageContext context)
         {
-            var message = context.Message;
             var sagaId = Guid.Empty;
 
             string sagaIdString;
-            if (message.Headers.TryGetValue(Headers.SagaId, out sagaIdString))
+            if (context.Headers.TryGetValue(Headers.SagaId, out sagaIdString))
             {
                 sagaId = Guid.Parse(sagaIdString);
             }
 
-            if (message.Headers.ContainsKey(TimeoutManagerHeaders.ClearTimeouts))
+            if (context.Headers.ContainsKey(TimeoutManagerHeaders.ClearTimeouts))
             {
                 if (sagaId == Guid.Empty)
                     throw new InvalidOperationException("Invalid saga id specified, clear timeouts is only supported for saga instances");
@@ -38,15 +37,15 @@ namespace NServiceBus
             else
             {
                 string expire;
-                if (!message.Headers.TryGetValue(TimeoutManagerHeaders.Expire, out expire))
+                if (!context.Headers.TryGetValue(TimeoutManagerHeaders.Expire, out expire))
                 {
-                    throw new InvalidOperationException("Non timeout message arrived at the timeout manager, id:" + message.MessageId);
+                    throw new InvalidOperationException("Non timeout message arrived at the timeout manager, id:" + context.MessageId);
                 }
 
-                var destination = message.GetReplyToAddress();
+                var destination = context.ReplyToAddress;
 
                 string routeExpiredTimeoutTo;
-                if (message.Headers.TryGetValue(TimeoutManagerHeaders.RouteExpiredTimeoutTo, out routeExpiredTimeoutTo))
+                if (context.Headers.TryGetValue(TimeoutManagerHeaders.RouteExpiredTimeoutTo, out routeExpiredTimeoutTo))
                 {
                     destination = routeExpiredTimeoutTo;
                 }
@@ -55,15 +54,15 @@ namespace NServiceBus
                 {
                     Destination = destination,
                     SagaId = sagaId,
-                    State = message.Body,
+                    State = context.Body,
                     Time = DateTimeExtensions.ToUtcDateTime(expire),
-                    Headers = message.Headers,
+                    Headers = context.Headers,
                     OwningTimeoutManager = owningTimeoutManager
                 };
 
                 if (data.Time.AddSeconds(-1) <= DateTime.UtcNow)
                 {
-                    var outgoingMessage = new OutgoingMessage(message.MessageId, data.Headers, data.State);
+                    var outgoingMessage = new OutgoingMessage(context.MessageId, data.Headers, data.State);
                     var transportOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(data.Destination));
                     await dispatcher.Dispatch(new TransportOperations(transportOperation), context.Extensions).ConfigureAwait(false);
                     return;

--- a/src/NServiceBus.Core/Forwarding/InvokeForwardingPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Forwarding/InvokeForwardingPipelineBehavior.cs
@@ -16,9 +16,9 @@
         {
             await next().ConfigureAwait(false);
 
-            context.Message.RevertToOriginalBodyIfNeeded();
+            context.RevertToOriginalBodyIfNeeded();
 
-            var processedMessage = new OutgoingMessage(context.Message.MessageId, context.Message.Headers, context.Message.Body);
+            var processedMessage = new OutgoingMessage(context.MessageId, context.Headers, context.Body);
 
             var forwardingContext = this.CreateForwardingContext(processedMessage, forwardingAddress, context);
 

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -264,7 +264,7 @@
     <Compile Include="Pipeline\Outgoing\IDispatchContext.cs" />
     <Compile Include="Pipeline\Outgoing\ImmediateDispatchTerminator.cs" />
     <Compile Include="Transports\DispatchConsistency.cs" />
-    <Compile Include="Transports\IncomingMessageExtensions.cs" />
+    <Compile Include="Transports\IIncomingPhysicalMessageContextExtensions.cs" />
     <Compile Include="Transports\Msmq\MsmqConnectionStringBuilder.cs" />
     <Compile Include="Container\ContainerCustomizations.cs" />
     <Compile Include="Container\ContainerDefinition.cs" />

--- a/src/NServiceBus.Core/Performance/Statistics/ProcessingStatisticsBehavior.cs
+++ b/src/NServiceBus.Core/Performance/Statistics/ProcessingStatisticsBehavior.cs
@@ -11,7 +11,7 @@
             var state = new State();
 
             string timeSentString;
-            var headers = context.Message.Headers;
+            var headers = context.Headers;
 
             if (headers.TryGetValue(Headers.TimeSent, out timeSentString))
             {

--- a/src/NServiceBus.Core/Pipeline/ConnectorContextExtensions.cs
+++ b/src/NServiceBus.Core/Pipeline/ConnectorContextExtensions.cs
@@ -55,9 +55,9 @@ namespace NServiceBus
         /// <summary>
         /// Creates a <see cref="IIncomingPhysicalMessageContext"/> based on the current context.
         /// </summary>
-        public static IIncomingPhysicalMessageContext CreateIncomingPhysicalMessageContext(this StageForkConnector<ITransportReceiveContext, IIncomingPhysicalMessageContext, IBatchDispatchContext> stageForkConnector, IncomingMessage incomingMessage, ITransportReceiveContext sourceContext)
+        public static IIncomingPhysicalMessageContext CreateIncomingPhysicalMessageContext(this StageForkConnector<ITransportReceiveContext, IIncomingPhysicalMessageContext, IBatchDispatchContext> stageForkConnector, string messageId, Dictionary<string, string> headers, byte[] body, ITransportReceiveContext sourceContext)
         {
-            return new IncomingPhysicalMessageContext(incomingMessage, sourceContext);
+            return new IncomingPhysicalMessageContext(messageId, headers, body, sourceContext);
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Pipeline/Incoming/IIncomingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IIncomingPhysicalMessageContext.cs
@@ -1,6 +1,6 @@
 ﻿namespace NServiceBus.Pipeline
 {
-    using NServiceBus.Transports;
+    using System.Collections.Generic;
 
     /// <summary>
     /// A context of behavior execution in physical message processing stage.
@@ -8,9 +8,19 @@
     public interface IIncomingPhysicalMessageContext : IIncomingContext
     {
         /// <summary>
-        /// The physical message being processed.
+        /// The body of the incoming message.
         /// </summary>
-        IncomingMessage Message { get; }
+        byte[] Body { get; }
+
+        /// <summary>
+        /// The headers of the incoming message.
+        /// </summary>
+        Dictionary<string, string> Headers { get; }
+
+        /// <summary>
+        /// Reverts to the original body if needed.
+        /// </summary>
+        void RevertToOriginalBodyIfNeeded();
 
         /// <summary>
         /// Updates the message with the given body.

--- a/src/NServiceBus.Core/Pipeline/Incoming/ITransportReceiveContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/ITransportReceiveContext.cs
@@ -1,6 +1,6 @@
 ﻿namespace NServiceBus.Pipeline
 {
-    using Transports;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Context containing a physical message.
@@ -8,12 +8,27 @@
     public interface ITransportReceiveContext : IBehaviorContext
     {
         /// <summary>
-        /// The physical message being processed.
+        /// The message id of the message being processed.
         /// </summary>
-        IncomingMessage Message { get; }
+        string MessageId { get; }
 
         /// <summary>
-        /// Allows the pipeline to flag that it has been aborted and the receive operation should be rolled back. 
+        /// The headers of the incoming message.
+        /// </summary>
+        Dictionary<string, string> Headers { get; }
+
+        /// <summary>
+        /// The body of the incoming message.
+        /// </summary>
+        byte[] Body { get; }
+
+        /// <summary>
+        /// Reverts to the original body if needed.
+        /// </summary>
+        void RevertToOriginalBodyIfNeeded();
+
+        /// <summary>
+        /// Allows the pipeline to flag that it has been aborted and the receive operation should be rolled back.
         /// </summary>
         void AbortReceiveOperation();
     }

--- a/src/NServiceBus.Core/Pipeline/Incoming/IncomingLogicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IncomingLogicalMessageContext.cs
@@ -6,7 +6,7 @@
     class IncomingLogicalMessageContext : IncomingContext, IIncomingLogicalMessageContext
     {
         internal IncomingLogicalMessageContext(LogicalMessage logicalMessage, IIncomingPhysicalMessageContext parentContext)
-            : this(logicalMessage, parentContext.MessageId, parentContext.ReplyToAddress, parentContext.Message.Headers, parentContext)
+            : this(logicalMessage, parentContext.MessageId, parentContext.ReplyToAddress, parentContext.Headers, parentContext)
         {
         }
 

--- a/src/NServiceBus.Core/Pipeline/Incoming/IncomingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IncomingPhysicalMessageContext.cs
@@ -1,21 +1,27 @@
 ﻿namespace NServiceBus
 {
+    using System.Collections.Generic;
     using NServiceBus.Pipeline;
-    using NServiceBus.Transports;
 
     class IncomingPhysicalMessageContext : IncomingContext, IIncomingPhysicalMessageContext
     {
-        public IncomingPhysicalMessageContext(IncomingMessage message, IBehaviorContext parentContext)
-            : base(message.MessageId, message.GetReplyToAddress(), message.Headers, parentContext)
+        public IncomingPhysicalMessageContext(string messageId, Dictionary<string, string> headers, byte[] body, IBehaviorContext parentContext)
+            : base(messageId, /*message.GetReplyToAddress()*/ null, headers, parentContext)
         {
-            Message = message;
+            Body = body;
+            Headers = headers;
         }
 
-        public IncomingMessage Message { get; }
+        public byte[] Body { get; }
+        public Dictionary<string, string> Headers { get; }
+
+        public void RevertToOriginalBodyIfNeeded()
+        {
+        }
 
         public void UpdateMessage(byte[] body)
         {
-            Message.Body = body;
+           // Message.Body = body;
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveContext.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus
 {
+    using System.Collections.Generic;
+    using System.IO;
     using System.Threading;
     using NServiceBus.Pipeline;
     using NServiceBus.Transports;
@@ -12,27 +14,37 @@
         /// <summary>
         /// Creates a new transport receive context.
         /// </summary>
-        /// <param name="receivedMessage">The received message.</param>
+        /// <param name="messageId">The message id.</param>
+        /// <param name="bodyStream">The message body stream.</param>
+        /// <param name="headers">The message headers.</param>
         /// <param name="transportTransaction">The transport transaction.</param>
-        /// <param name="cancellationTokenSource">Allows the pipeline to flag that it has been aborted and the receive operation should be rolled back. 
-        /// It also allows the transport to communicate to the pipeline to abort if possible.</param>
+        /// <param name="cancellationTokenSource">
+        /// Allows the pipeline to flag that it has been aborted and the receive operation should be rolled back.
+        /// It also allows the transport to communicate to the pipeline to abort if possible.
+        /// </param>
         /// <param name="parentContext">The parent context.</param>
-        public TransportReceiveContext(IncomingMessage receivedMessage, TransportTransaction transportTransaction, CancellationTokenSource cancellationTokenSource, IBehaviorContext parentContext)
+        public TransportReceiveContext(string messageId, Dictionary<string, string> headers, Stream bodyStream, TransportTransaction transportTransaction, CancellationTokenSource cancellationTokenSource, IBehaviorContext parentContext)
             : base(parentContext)
         {
+            MessageId = messageId;
+            Headers = headers;
+            Body = new byte[bodyStream.Length];
+            bodyStream.Read(Body, 0, Body.Length);
+
             this.cancellationTokenSource = cancellationTokenSource;
-            Message = receivedMessage;
-            Set(Message);
             Set(transportTransaction);
         }
 
-        /// <summary>
-        /// The physical message being processed.
-        /// </summary>
-        public IncomingMessage Message { get; }
+        public string MessageId { get; }
+        public Dictionary<string, string> Headers { get; }
+        public byte[] Body { get; internal set; } // Daniel: Intermediate hack with internal set
+
+        public void RevertToOriginalBodyIfNeeded()
+        {
+        }
 
         /// <summary>
-        /// Allows the pipeline to flag that it has been aborted and the receive operation should be rolled back. 
+        /// Allows the pipeline to flag that it has been aborted and the receive operation should be rolled back.
         /// </summary>
         public void AbortReceiveOperation()
         {

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageProcessingConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageProcessingConnector.cs
@@ -22,8 +22,8 @@ namespace NServiceBus
 
         public override async Task Invoke(ITransportReceiveContext context, Func<IIncomingPhysicalMessageContext, Task> stage, Func<IBatchDispatchContext, Task> fork)
         {
-            var messageId = context.Message.MessageId;
-            var physicalMessageContext = this.CreateIncomingPhysicalMessageContext(context.Message, context);
+            var messageId = context.MessageId;
+            var physicalMessageContext = this.CreateIncomingPhysicalMessageContext(messageId, context.Headers, context.Body, context);
 
             var deduplicationEntry = await outboxStorage.Get(messageId, context.Extensions).ConfigureAwait(false);
             var pendingTransportOperations = new PendingTransportOperations();

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
@@ -10,8 +10,7 @@
         public override async Task Invoke(IIncomingPhysicalMessageContext context, Func<Task> next)
         {
             var mutators = context.Builder.BuildAll<IMutateIncomingTransportMessages>();
-            var transportMessage = context.Message;
-            var mutatorContext = new MutateIncomingTransportMessageContext(transportMessage.Body, transportMessage.Headers);
+            var mutatorContext = new MutateIncomingTransportMessageContext(context.Body, context.Headers);
             foreach (var mutator in mutators)
             {
                 await mutator.MutateIncoming(mutatorContext).ConfigureAwait(false);

--- a/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
@@ -2,7 +2,7 @@ namespace NServiceBus.Faults
 {
     using System;
     using System.Collections.Generic;
-    using NServiceBus.Transports;
+    using NServiceBus.Pipeline;
 
     /// <summary>
     /// Errors notifications.
@@ -24,31 +24,31 @@ namespace NServiceBus.Faults
         /// </summary>
         public event EventHandler<SecondLevelRetry> MessageHasBeenSentToSecondLevelRetries;
 
-        internal void InvokeMessageHasBeenSentToErrorQueue(IncomingMessage message, Exception exception)
+        internal void InvokeMessageHasBeenSentToErrorQueue(ITransportReceiveContext context, Exception exception)
         {
             var failedMessage = new FailedMessage(
-                message.MessageId,
-                new Dictionary<string, string>(message.Headers),
-                CopyOfBody(message.Body), exception);
+                context.MessageId,
+                new Dictionary<string, string>(context.Headers),
+                CopyOfBody(context.Body), exception);
             MessageSentToErrorQueue?.Invoke(this, failedMessage);
         }
 
-        internal void InvokeMessageHasFailedAFirstLevelRetryAttempt(int firstLevelRetryAttempt, IncomingMessage message, Exception exception)
+        internal void InvokeMessageHasFailedAFirstLevelRetryAttempt(int firstLevelRetryAttempt, ITransportReceiveContext context, Exception exception)
         {
             var firstLevelRetry = new FirstLevelRetry(
-                message.MessageId,
-                new Dictionary<string, string>(message.Headers),
-                CopyOfBody(message.Body),
+                context.MessageId,
+                new Dictionary<string, string>(context.Headers),
+                CopyOfBody(context.Body),
                 exception,
                 firstLevelRetryAttempt);
             MessageHasFailedAFirstLevelRetryAttempt?.Invoke(this, firstLevelRetry);
         }
 
-        internal void InvokeMessageHasBeenSentToSecondLevelRetries(int secondLevelRetryAttempt, IncomingMessage message, Exception exception)
+        internal void InvokeMessageHasBeenSentToSecondLevelRetries(int secondLevelRetryAttempt, ITransportReceiveContext context, Exception exception)
         {
             var secondLevelRetry = new SecondLevelRetry(
-                new Dictionary<string, string>(message.Headers),
-                CopyOfBody(message.Body),
+                new Dictionary<string, string>(context.Headers),
+                CopyOfBody(context.Body),
                 exception,
                 secondLevelRetryAttempt);
 

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/CustomSecondLevelRetryPolicy.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/CustomSecondLevelRetryPolicy.cs
@@ -1,22 +1,22 @@
 namespace NServiceBus
 {
     using System;
-    using NServiceBus.Transports;
+    using NServiceBus.Pipeline;
 
     class CustomSecondLevelRetryPolicy : SecondLevelRetryPolicy
     {
-        Func<IncomingMessage, TimeSpan> customRetryPolicy;
-
-        public CustomSecondLevelRetryPolicy(Func<IncomingMessage, TimeSpan> customRetryPolicy)
+        public CustomSecondLevelRetryPolicy(Func<ITransportReceiveContext, TimeSpan> customRetryPolicy)
         {
             this.customRetryPolicy = customRetryPolicy;
         }
 
-        public override bool TryGetDelay(IncomingMessage message, Exception ex, int currentRetry, out TimeSpan delay)
+        public override bool TryGetDelay(ITransportReceiveContext context, Exception ex, int currentRetry, out TimeSpan delay)
         {
-            delay = customRetryPolicy(message);
+            delay = customRetryPolicy(context);
 
             return delay != TimeSpan.Zero;
         }
+
+        Func<ITransportReceiveContext, TimeSpan> customRetryPolicy;
     }
 }

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetries.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetries.cs
@@ -2,8 +2,8 @@ namespace NServiceBus.Features
 {
     using System;
     using NServiceBus.Config;
+    using NServiceBus.Pipeline;
     using NServiceBus.Settings;
-    using NServiceBus.Transports;
 
     /// <summary>
     /// Used to configure Second Level Retries.
@@ -22,7 +22,7 @@ namespace NServiceBus.Features
         }
 
         /// <summary>
-        /// See <see cref="Feature.Setup"/>.
+        /// See <see cref="Feature.Setup" />.
         /// </summary>
         protected internal override void Setup(FeatureConfigurationContext context)
         {
@@ -39,17 +39,21 @@ namespace NServiceBus.Features
             var retriesConfig = context.Settings.GetConfigSection<SecondLevelRetriesConfig>();
 
             if (retriesConfig == null)
+            {
                 return true;
+            }
 
             if (retriesConfig.NumberOfRetries == 0)
+            {
                 return false;
+            }
 
             return retriesConfig.Enabled;
         }
 
         static SecondLevelRetryPolicy GetRetryPolicy(ReadOnlySettings settings)
         {
-            var customRetryPolicy = settings.GetOrDefault<Func<IncomingMessage, TimeSpan>>("SecondLevelRetries.RetryPolicy");
+            var customRetryPolicy = settings.GetOrDefault<Func<ITransportReceiveContext, TimeSpan>>("SecondLevelRetries.RetryPolicy");
 
             if (customRetryPolicy != null)
             {

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetryPolicy.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetryPolicy.cs
@@ -1,10 +1,10 @@
 namespace NServiceBus
 {
     using System;
-    using NServiceBus.Transports;
+    using NServiceBus.Pipeline;
 
     abstract class SecondLevelRetryPolicy
     {
-        public abstract bool TryGetDelay(IncomingMessage message, Exception ex, int currentRetry,out TimeSpan delay);
+        public abstract bool TryGetDelay(ITransportReceiveContext context, Exception ex, int currentRetry,out TimeSpan delay);
     }
 }

--- a/src/NServiceBus.Core/Routing/Legacy/ProcessedMessageCounterBehavior.cs
+++ b/src/NServiceBus.Core/Routing/Legacy/ProcessedMessageCounterBehavior.cs
@@ -16,7 +16,7 @@
         public override async Task Invoke(IIncomingPhysicalMessageContext context, Func<Task> next)
         {
             await next().ConfigureAwait(false);
-            await readyMessageSender.MessageProcessed(context.Message.Headers).ConfigureAwait(false);
+            await readyMessageSender.MessageProcessed(context.Headers).ConfigureAwait(false);
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/IIncomingPhysicalMessageContextExtensions.cs
+++ b/src/NServiceBus.Core/Transports/IIncomingPhysicalMessageContextExtensions.cs
@@ -1,23 +1,24 @@
 namespace NServiceBus.Transports
 {
     using System;
+    using NServiceBus.Pipeline;
 
     /// <summary>
-    /// Helper methods for <see cref="IncomingMessage"/>.
+    /// Helper methods for <see cref="IIncomingPhysicalMessageContext"/>.
     /// </summary>
-    public static class IncomingMessageExtensions
+    public static class IIncomingPhysicalMessageContextExtensions
     {
         /// <summary>
         /// Gets the message intent from the headers.
         /// </summary>
-        /// <param name="message">The message.</param>
+        /// <param name="context">The context.</param>
         /// <returns>The message intent.</returns>
-        public static MessageIntentEnum GetMesssageIntent(this IncomingMessage message)
+        public static MessageIntentEnum GetMesssageIntent(this IIncomingPhysicalMessageContext context)
         {
             var messageIntent = default(MessageIntentEnum);
 
             string messageIntentString;
-            if (message.Headers.TryGetValue(Headers.MessageIntent, out messageIntentString))
+            if (context.Headers.TryGetValue(Headers.MessageIntent, out messageIntentString))
             {
                 Enum.TryParse(messageIntentString, true, out messageIntent);
             }
@@ -28,13 +29,13 @@ namespace NServiceBus.Transports
         /// <summary>
         /// Gets the reply to address.
         /// </summary>
-        /// <param name="message">The message.</param>
+        /// <param name="context">The context.</param>
         /// <returns>The reply to address.</returns>
-        public static string GetReplyToAddress(this IncomingMessage message)
+        public static string GetReplyToAddress(this IIncomingPhysicalMessageContext context)
         {
             string replyToAddress;
 
-            return message.Headers.TryGetValue(Headers.ReplyToAddress, out replyToAddress) ? replyToAddress : null;
+            return context.Headers.TryGetValue(Headers.ReplyToAddress, out replyToAddress) ? replyToAddress : null;
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/TransportReceiver.cs
+++ b/src/NServiceBus.Core/Transports/TransportReceiver.cs
@@ -61,7 +61,7 @@ namespace NServiceBus
         {
             using (var childBuilder = builder.CreateChildBuilder())
             {
-                var context = new TransportReceiveContext(new IncomingMessage(pushContext.MessageId, pushContext.Headers, pushContext.BodyStream), pushContext.TransportTransaction, pushContext.ReceiveCancellationTokenSource, new RootContext(childBuilder, pipelineCache));
+                var context = new TransportReceiveContext(pushContext.MessageId, pushContext.Headers, pushContext.BodyStream, pushContext.TransportTransaction, pushContext.ReceiveCancellationTokenSource, new RootContext(childBuilder, pipelineCache));
                 context.Extensions.Merge(pushContext.Context);
                 await pipeline.Invoke(context).ConfigureAwait(false);
             }

--- a/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionBehavior.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionBehavior.cs
@@ -5,13 +5,9 @@
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.Pipeline;
-    using NServiceBus.Transports;
 
     class SubscriptionBehavior<TContext> : Behavior<IIncomingPhysicalMessageContext> where TContext : ScenarioContext
     {
-        Action<SubscriptionEventArgs, TContext> action;
-        TContext scenarioContext;
-
         public SubscriptionBehavior(Action<SubscriptionEventArgs, TContext> action, TContext scenarioContext)
         {
             this.action = action;
@@ -21,13 +17,13 @@
         public override async Task Invoke(IIncomingPhysicalMessageContext context, Func<Task> next)
         {
             await next().ConfigureAwait(false);
-            var subscriptionMessageType = GetSubscriptionMessageTypeFrom(context.Message);
+            var subscriptionMessageType = GetSubscriptionMessageTypeFrom(context);
             if (subscriptionMessageType != null)
             {
                 string returnAddress;
-                if (!context.Message.Headers.TryGetValue(Headers.SubscriberTransportAddress, out returnAddress))
+                if (!context.Headers.TryGetValue(Headers.SubscriberTransportAddress, out returnAddress))
                 {
-                    context.Message.Headers.TryGetValue(Headers.ReplyToAddress, out returnAddress);
+                    context.Headers.TryGetValue(Headers.ReplyToAddress, out returnAddress);
                 }
                 action(new SubscriptionEventArgs
                 {
@@ -37,10 +33,13 @@
             }
         }
 
-        static string GetSubscriptionMessageTypeFrom(IncomingMessage msg)
+        static string GetSubscriptionMessageTypeFrom(IIncomingPhysicalMessageContext context)
         {
-            return (from header in msg.Headers where header.Key == Headers.SubscriptionMessageType select header.Value).FirstOrDefault();
+            return (from header in context.Headers where header.Key == Headers.SubscriptionMessageType select header.Value).FirstOrDefault();
         }
+
+        Action<SubscriptionEventArgs, TContext> action;
+        TContext scenarioContext;
 
         internal class Registration : RegisterStep
         {


### PR DESCRIPTION
We have a mess in how we expose and access data from `IncomingMessage`. Once we access it over `context.Message.Headers`, once over `context.Headers` and so forth. This PR aims to move everything to the context which makes the API more concise. As it stands right now I think the API is not releasable. There are too many unanswered questions when you as a user explore the API.

Like:

* Should I access and modify the headers over the `context.Message` instance or `context.Headers` or even both? The fact that we do some magic reference passing is not obvious by the API.

## Questions

* On the outgoing pipeline should we just expose methods to access the incoming message headers or a tuple of MessageId and Headers?
* RevertToOriginalBodyIfNeeded needs to be redundantly implemented both on transport receive and incoming physical. Is that OK?
* I still don't like that we have `MessageHeaders` and `Headers` exposed inside the pipeline only for the purpose to make the user access to headers expose `IReadonlyDictionary`. I'm contemplating to streamline it and just expose `Dictionary<string, string>` but make a copy of the headers. Thoughts?
* `CustomRetryPolicy` would expose an `ITransportReceiveContext` instead of `IncomingMessage`. Ok?
* Should we still keep around `IncomingMessage` as an internal class to wrap the body and reverting of the body? This might reduce code redundancy on the contexts described above. Thoughts?
 