### PR TITLE
Remove an obsolete R# annotation attribute

### DIFF
--- a/src/NServiceBus.Core/Properties/Resharper.Annotations.g.cs
+++ b/src/NServiceBus.Core/Properties/Resharper.Annotations.g.cs
@@ -868,14 +868,6 @@ namespace JetBrains.Annotations
     }
 
     /// <summary>
-    /// Indicates that the marked method unconditionally terminates control flow execution.
-    /// For example, it could unconditionally throw exception.
-    /// </summary>
-    [Obsolete("Use [ContractAnnotation('=> halt')] instead")]
-    [AttributeUsage(AttributeTargets.Method)]
-    internal sealed class TerminatesProgramAttribute : Attribute { }
-
-    /// <summary>
     /// Indicates that method is pure LINQ method, with postponed enumeration (like Enumerable.Select,
     /// .Where). This annotation allows inference of [InstantHandle] annotation for parameters
     /// of delegate type by analyzing LINQ method chains.


### PR DESCRIPTION
This removes an obsolete annotation attribute, stopping Fody from generating a warning about it.