### PR TITLE
Fix timeout poller behavior when pushing timeouts locally

### DIFF
--- a/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/DispatchTimeoutBehaviorTest.cs
+++ b/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/DispatchTimeoutBehaviorTest.cs
@@ -17,7 +17,7 @@
         public async Task Invoke_when_message_dispatched_should_remove_timeout_from_timeout_storage()
         {
             var messageDispatcher = new FakeMessageDispatcher();
-            var timeoutPersister = new InMemoryTimeoutPersister();
+            var timeoutPersister = new InMemoryTimeoutPersister(() => DateTime.UtcNow);
             var behavior = new DispatchTimeoutBehavior(messageDispatcher, timeoutPersister, TransportTransactionMode.TransactionScope);
             var timeoutData = CreateTimeout();
             await timeoutPersister.Add(timeoutData, null);
@@ -32,7 +32,7 @@
         public async Task Invoke_when_timeout_not_in_storage_should_process_successfully()
         {
             var messageDispatcher = new FakeMessageDispatcher();
-            var timeoutPersister = new InMemoryTimeoutPersister();
+            var timeoutPersister = new InMemoryTimeoutPersister(() => DateTime.UtcNow);
             var behavior = new DispatchTimeoutBehavior(messageDispatcher, timeoutPersister, TransportTransactionMode.TransactionScope);
 
             await behavior.Invoke(CreateContext(Guid.NewGuid().ToString()), context => TaskEx.CompletedTask);
@@ -44,7 +44,7 @@
         public async Task Invoke_when_dispatching_message_fails_should_keep_timeout_in_storage()
         {
             var messageDispatcher = new FailingMessageDispatcher();
-            var timeoutPersister = new InMemoryTimeoutPersister();
+            var timeoutPersister = new InMemoryTimeoutPersister(() => DateTime.UtcNow);
             var behavior = new DispatchTimeoutBehavior(messageDispatcher, timeoutPersister, TransportTransactionMode.TransactionScope);
             var timeoutData = CreateTimeout();
             await timeoutPersister.Add(timeoutData, null);
@@ -74,7 +74,7 @@
         public async Task Invoke_when_using_dtc_should_enlist_dispatch_in_transaction()
         {
             var messageDispatcher = new FakeMessageDispatcher();
-            var timeoutPersister = new InMemoryTimeoutPersister();
+            var timeoutPersister = new InMemoryTimeoutPersister(() => DateTime.UtcNow);
             var behavior = new DispatchTimeoutBehavior(messageDispatcher, timeoutPersister, TransportTransactionMode.TransactionScope);
             var timeoutData = CreateTimeout();
             await timeoutPersister.Add(timeoutData, null);
@@ -91,7 +91,7 @@
         public async Task Invoke_when_not_using_dtc_transport_should_not_enlist_dispatch_in_transaction(TransportTransactionMode nonDtcTxSettings)
         {
             var messageDispatcher = new FakeMessageDispatcher();
-            var timeoutPersister = new InMemoryTimeoutPersister();
+            var timeoutPersister = new InMemoryTimeoutPersister(() => DateTime.UtcNow);
             var behavior = new DispatchTimeoutBehavior(messageDispatcher, timeoutPersister, nonDtcTxSettings);
             var timeoutData = CreateTimeout();
             await timeoutPersister.Add(timeoutData, null);

--- a/src/NServiceBus.Core.Tests/Timeout/InMemoryTimeoutPersisterTests.cs
+++ b/src/NServiceBus.Core.Tests/Timeout/InMemoryTimeoutPersisterTests.cs
@@ -14,7 +14,7 @@ namespace NServiceBus.Core.Tests.Timeout
         public async Task When_empty_NextTimeToRunQuery_is_1_minute()
         {
             var now = DateTime.UtcNow;
-            var persister = new InMemoryTimeoutPersister();
+            var persister = new InMemoryTimeoutPersister(() => DateTime.UtcNow);
             
             var result = await persister.GetNextChunk(now);
             
@@ -25,7 +25,7 @@ namespace NServiceBus.Core.Tests.Timeout
         public async Task When_multiple_NextTimeToRunQuery_is_min_date()
         {
             var now = DateTime.UtcNow;
-            var persister = new InMemoryTimeoutPersister();
+            var persister = new InMemoryTimeoutPersister(() => DateTime.UtcNow);
             await persister.Add(new TimeoutData
                           {
                               Time = DateTime.Now.AddDays(2)
@@ -44,7 +44,7 @@ namespace NServiceBus.Core.Tests.Timeout
         [Test]
         public async Task When_multiple_future_are_returned()
         {
-            var persister = new InMemoryTimeoutPersister();
+            var persister = new InMemoryTimeoutPersister(() => DateTime.UtcNow);
             await persister.Add(new TimeoutData
                           {
                               Time = DateTime.Now.AddDays(-2)
@@ -66,7 +66,7 @@ namespace NServiceBus.Core.Tests.Timeout
         [Test]
         public async Task TryRemove_when_existing_is_removed_should_return_true()
         {
-            var persister = new InMemoryTimeoutPersister();
+            var persister = new InMemoryTimeoutPersister(() => DateTime.UtcNow);
             var inputTimeout = new TimeoutData();
             await persister.Add(inputTimeout, new ContextBag());
 
@@ -78,7 +78,7 @@ namespace NServiceBus.Core.Tests.Timeout
         [Test]
         public async Task TryRemove_when_non_existing_is_removed_should_return_false()
         {
-            var persister = new InMemoryTimeoutPersister();
+            var persister = new InMemoryTimeoutPersister(() => DateTime.UtcNow);
             var inputTimeout = new TimeoutData();
             await persister.Add(inputTimeout, new ContextBag());
 
@@ -90,7 +90,7 @@ namespace NServiceBus.Core.Tests.Timeout
         [Test]
         public async Task Peek_when_timeout_exists_should_return_timeout()
         {
-            var persister = new InMemoryTimeoutPersister();
+            var persister = new InMemoryTimeoutPersister(() => DateTime.UtcNow);
             var inputTimeout = new TimeoutData();
             await persister.Add(inputTimeout, new ContextBag());
 
@@ -102,7 +102,7 @@ namespace NServiceBus.Core.Tests.Timeout
         [Test]
         public async Task Peek_when_timeout_does_not_exist_should_return_null()
         {
-            var persister = new InMemoryTimeoutPersister();
+            var persister = new InMemoryTimeoutPersister(() => DateTime.UtcNow);
             var inputTimeout = new TimeoutData();
             await persister.Add(inputTimeout, new ContextBag());
 
@@ -114,7 +114,7 @@ namespace NServiceBus.Core.Tests.Timeout
         [Test]
         public async Task When_existing_is_removed_by_saga_id()
         {
-            var persister = new InMemoryTimeoutPersister();
+            var persister = new InMemoryTimeoutPersister(() => DateTime.UtcNow);
             var newGuid = Guid.NewGuid();
             var inputTimeout = new TimeoutData
                                {
@@ -132,7 +132,7 @@ namespace NServiceBus.Core.Tests.Timeout
         public async Task When_all_in_past_NextTimeToRunQuery_is_1_minute()
         {
             var now = DateTime.UtcNow;
-            var persister = new InMemoryTimeoutPersister();
+            var persister = new InMemoryTimeoutPersister(() => DateTime.UtcNow);
             await persister.Add(new TimeoutData
                           {
                               Time = DateTime.Now.AddDays(-1)

--- a/src/NServiceBus.Core.Tests/Timeout/InMemoryTimeoutPersisterThreadTests.cs
+++ b/src/NServiceBus.Core.Tests/Timeout/InMemoryTimeoutPersisterThreadTests.cs
@@ -18,7 +18,7 @@ namespace NServiceBus.Core.Tests.Timeout
         public void Run()
         {
             var stopwatch = Stopwatch.StartNew();
-            var inMemoryTimeoutPersister = new InMemoryTimeoutPersister();
+            var inMemoryTimeoutPersister = new InMemoryTimeoutPersister(() => DateTime.UtcNow);
 
             for (var i = 0; i < 10; i++)
             {

--- a/src/NServiceBus.Core.Tests/Timeout/When_fetching_timeouts_from_storage.cs
+++ b/src/NServiceBus.Core.Tests/Timeout/When_fetching_timeouts_from_storage.cs
@@ -15,7 +15,7 @@ namespace NServiceBus.Core.Tests.Timeout
         [SetUp]
         public void Setup()
         {
-             persister = new InMemoryTimeoutPersister();
+             persister = new InMemoryTimeoutPersister(() => DateTime.UtcNow);
         }
 
         [Test]

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ExpiredTimeoutsPoller.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ExpiredTimeoutsPoller.cs
@@ -89,8 +89,12 @@ namespace NServiceBus
 
         internal async Task SpinOnce()
         {
-            Logger.DebugFormat("Polling for timeouts at {0}.", currentTimeProvider());
+            if (NextRetrieval > currentTimeProvider())
+            {
+                return;
+            }
 
+            Logger.DebugFormat("Polling for timeouts at {0}.", currentTimeProvider());
             var timeoutChunk = await timeoutsFetcher.GetNextChunk(startSlice).ConfigureAwait(false);
 
             foreach (var timeoutData in timeoutChunk.DueTimeouts)

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ExpiredTimeoutsPoller.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ExpiredTimeoutsPoller.cs
@@ -12,19 +12,20 @@ namespace NServiceBus
 
     class ExpiredTimeoutsPoller : IDisposable
     {
-        public ExpiredTimeoutsPoller(IQueryTimeouts timeoutsFetcher, IDispatchMessages dispatcher, string dispatcherAddress, ICircuitBreaker circuitBreaker,
-            TimeSpan? sleepTillNextRetrieval = null, TimeSpan? maxNextRetrievalDelay = null)
+        public ExpiredTimeoutsPoller(IQueryTimeouts timeoutsFetcher, IDispatchMessages dispatcher, string dispatcherAddress, ICircuitBreaker circuitBreaker, Func<DateTime> currentTimeProvider)
         {
             this.timeoutsFetcher = timeoutsFetcher;
             this.dispatcher = dispatcher;
             this.dispatcherAddress = dispatcherAddress;
             this.circuitBreaker = circuitBreaker;
-            nextRetrievalPollSleep = sleepTillNextRetrieval ?? TimeSpan.FromMilliseconds(1000);
-            this.maxNextRetrievalDelay = maxNextRetrievalDelay ?? DefaultMaxNextRetrievalDelay;
-            startSlice = DateTime.UtcNow.AddYears(-10);
+            this.currentTimeProvider = currentTimeProvider;
+
+            var now = currentTimeProvider();
+            startSlice = now.AddYears(-10);
+            NextRetrieval = now;
         }
 
-        public DateTime NextRetrieval { get; set; } = DateTime.UtcNow;
+        public DateTime NextRetrieval { get; private set; }
 
         public void Dispose()
         {
@@ -37,9 +38,7 @@ namespace NServiceBus
 
             var token = tokenSource.Token;
 
-            timeoutPollerTask = Task.Factory
-                .StartNew(() => Poll(token), TaskCreationOptions.LongRunning)
-                .Unwrap();
+            timeoutPollerTask = Task.Run(() => Poll(token));
         }
 
         public Task Stop()
@@ -56,7 +55,6 @@ namespace NServiceBus
                 {
                     NextRetrieval = expiryTime;
                 }
-                timeoutPushed = true;
             }
         }
 
@@ -67,6 +65,10 @@ namespace NServiceBus
                 try
                 {
                     await InnerPoll(cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // ok, since the InnerPoll could observe the token
                 }
                 catch (Exception ex)
                 {
@@ -81,18 +83,13 @@ namespace NServiceBus
             while (!cancellationToken.IsCancellationRequested)
             {
                 await SpinOnce().ConfigureAwait(false);
+                await Task.Delay(NextRetrievalPollSleep, cancellationToken).ConfigureAwait(false);
             }
         }
 
         internal async Task SpinOnce()
         {
-            if (NextRetrieval > DateTime.UtcNow)
-            {
-                await Task.Delay(nextRetrievalPollSleep).ConfigureAwait(false);
-                return;
-            }
-
-            Logger.DebugFormat("Polling for timeouts at {0}.", DateTime.Now);
+            Logger.DebugFormat("Polling for timeouts at {0}.", currentTimeProvider());
 
             var timeoutChunk = await timeoutsFetcher.GetNextChunk(startSlice).ConfigureAwait(false);
 
@@ -113,47 +110,34 @@ namespace NServiceBus
 
             lock (lockObject)
             {
-                //Check if nextRetrieval has been modified (This means that a push come in) and if it has check if it is earlier than nextExpiredTimeout time
-                if (!timeoutPushed)
-                {
-                    NextRetrieval = timeoutChunk.NextTimeToQuery;
-                }
-                else if (timeoutChunk.NextTimeToQuery < NextRetrieval)
-                {
-                    NextRetrieval = timeoutChunk.NextTimeToQuery;
-                }
+                var nextTimeToQuery = timeoutChunk.NextTimeToQuery;
 
-                timeoutPushed = false;
+                // we cap the next retrieval to max 1 minute this will make sure that we trip the circuit breaker if we
+                // loose connectivity to our storage. This will also make sure that timeouts added (during migration) direct to storage
+                // will be picked up after at most 1 minute
+                var maxNextRetrieval = currentTimeProvider() + MaxNextRetrievalDelay;
+
+                NextRetrieval = nextTimeToQuery > maxNextRetrieval ? maxNextRetrieval : nextTimeToQuery;
+
+                Logger.DebugFormat("Polling next retrieval is at {0}.", NextRetrieval.ToLocalTime());
             }
 
-            // we cap the next retrieval to max 1 minute this will make sure that we trip the circuit breaker if we
-            // loose connectivity to our storage. This will also make sure that timeouts added (during migration) direct to storage
-            // will be picked up after at most 1 minute
-            var maxNextRetrieval = DateTime.UtcNow + maxNextRetrievalDelay;
-
-            if (NextRetrieval > maxNextRetrieval)
-            {
-                NextRetrieval = maxNextRetrieval;
-            }
-
-            Logger.DebugFormat("Polling next retrieval is at {0}.", NextRetrieval.ToLocalTime());
             circuitBreaker.Success();
         }
 
         ICircuitBreaker circuitBreaker;
+        Func<DateTime> currentTimeProvider;
         IDispatchMessages dispatcher;
         string dispatcherAddress;
         object lockObject = new object();
-        TimeSpan maxNextRetrievalDelay;
-        TimeSpan nextRetrievalPollSleep;
         DateTime startSlice;
         Task timeoutPollerTask;
-        volatile bool timeoutPushed;
 
         IQueryTimeouts timeoutsFetcher;
         CancellationTokenSource tokenSource;
 
         static ILog Logger = LogManager.GetLogger<ExpiredTimeoutsPoller>();
-        static readonly TimeSpan DefaultMaxNextRetrievalDelay = TimeSpan.FromMinutes(1);
+        static readonly TimeSpan MaxNextRetrievalDelay = TimeSpan.FromMinutes(1);
+        static readonly TimeSpan NextRetrievalPollSleep = TimeSpan.FromMilliseconds(1000);
     }
 }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
@@ -53,7 +53,7 @@
                     waitTime,
                     ex => criticalError.Raise("Repeated failures when fetching timeouts from storage, endpoint will be terminated.", ex));
 
-                return new ExpiredTimeoutsPoller(b.Build<IQueryTimeouts>(), b.Build<IDispatchMessages>(), dispatcherAddress, circuitBreaker);
+                return new ExpiredTimeoutsPoller(b.Build<IQueryTimeouts>(), b.Build<IDispatchMessages>(), dispatcherAddress, circuitBreaker, () => DateTime.UtcNow);
             }, DependencyLifecycle.SingleInstance);
 
             context.RegisterStartupTask(b => new TimeoutPollerRunner(b.Build<ExpiredTimeoutsPoller>()));

--- a/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersistence.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.Features
 {
+    using System;
+
     /// <summary>
     /// Used to configure in memory timeout persistence.
     /// </summary>
@@ -15,7 +17,7 @@
         /// </summary>
         protected internal override void Setup(FeatureConfigurationContext context)
         {
-            context.Container.ConfigureComponent<InMemoryTimeoutPersister>(DependencyLifecycle.SingleInstance);
+            context.Container.ConfigureComponent(_ => new InMemoryTimeoutPersister(() => DateTime.UtcNow),  DependencyLifecycle.SingleInstance);
         }
     }
 }

--- a/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
@@ -10,6 +10,11 @@ namespace NServiceBus
 
     class InMemoryTimeoutPersister : IPersistTimeouts, IQueryTimeouts, IDisposable
     {
+        public InMemoryTimeoutPersister(Func<DateTime> currentTimeProvider)
+        {
+            this.currentTimeProvider = currentTimeProvider;
+        }
+
         public void Dispose()
         {
         }
@@ -93,7 +98,7 @@ namespace NServiceBus
 
         public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice)
         {
-            var now = DateTime.UtcNow;
+            var now = currentTimeProvider();
             var nextTimeToRunQuery = DateTime.MaxValue;
             var dueTimeouts = new List<TimeoutsChunk.Timeout>();
 
@@ -126,6 +131,7 @@ namespace NServiceBus
             return Task.FromResult(new TimeoutsChunk(dueTimeouts, nextTimeToRunQuery));
         }
 
+        Func<DateTime> currentTimeProvider;
         ReaderWriterLockSlim readerWriterLock = new ReaderWriterLockSlim();
         List<TimeoutData> storage = new List<TimeoutData>();
         public static TimeSpan EmptyResultsNextTimeToRunQuerySpan = TimeSpan.FromMinutes(1);


### PR DESCRIPTION
The previous behavior was to run the query *immediately* after dispatching a locally-pushed timeout. The problem (apart from being inefficient) was that there were good chances the just-dispatched timeout is still in the store so we would dispatch it again. On the dispatcher side we would get a duplicate which would likely result in the need to kill one of the processing threads by throwing an exception. In non-exactly-once environments this behavior would almost always cause timeouts to be duplicated.