### PR TITLE
Make MessageMapper threadsafe

### DIFF
--- a/src/NServiceBus.Core.Tests/MessageMapper/MessageMapperTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageMapper/MessageMapperTests.cs
@@ -1,0 +1,94 @@
+﻿namespace MessageMapperTests
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MessageMapperTests
+    {
+        [Test]
+        public void Initialize_ShouldBeThreadsafe()
+        {
+            var mapper = new MessageMapper();
+
+            Parallel.For(0, 10, i =>
+            {
+                mapper.Initialize(new[]
+                {
+                    typeof(SampleMessageClass),
+                    typeof(ISampleMessageInterface),
+                    typeof(ClassImplementingIEnumerable<>)
+                });
+            });
+        }
+
+        [Test]
+        public void CreateInstance_WhenMessageInitialized_ShouldBeThreadsafe()
+        {
+            var mapper = new MessageMapper();
+
+            mapper.Initialize(new[]
+                {
+                    typeof(SampleMessageClass),
+                    typeof(ISampleMessageInterface),
+                    typeof(ClassImplementingIEnumerable<>)
+                });
+
+            Parallel.For(0, 10, i =>
+            {
+                mapper.CreateInstance<SampleMessageClass>();
+                mapper.CreateInstance<ISampleMessageInterface>();
+                mapper.CreateInstance<ClassImplementingIEnumerable<string>>();
+            });
+        }
+
+        [Test]
+        public void CreateInstance_WhenMessageNotInitialized_ShouldBeThreadsafe()
+        {
+            var mapper = new MessageMapper();
+
+            Parallel.For(0, 10, i =>
+            {
+                mapper.CreateInstance<SampleMessageClass>();
+                mapper.CreateInstance<ISampleMessageInterface>();
+                mapper.CreateInstance<ClassImplementingIEnumerable<string>>();
+            });
+        }
+
+        [Test]
+        public void ShouldAllowMutlipleMapperInstancesPerAppDomain()
+        {
+            Parallel.For(0, 10, i =>
+            {
+                var mapper = new MessageMapper();
+                mapper.CreateInstance<SampleMessageClass>();
+                mapper.CreateInstance<ISampleMessageInterface>();
+                mapper.CreateInstance<ClassImplementingIEnumerable<string>>();
+            });
+        }
+
+        public class SampleMessageClass
+        {
+        }
+
+        public interface ISampleMessageInterface 
+        {
+        }
+
+        public class ClassImplementingIEnumerable<TItem> : IEnumerable<TItem>
+        {
+            public IEnumerator<TItem> GetEnumerator()
+            {
+                return new List<TItem>.Enumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -125,6 +125,7 @@
     <Compile Include="DelayedDelivery\TimeoutManager\RecordingFakeDispatcher.cs" />
     <Compile Include="DelayedDelivery\TimeoutManager\TimeoutRecoverabilityBehaviourTest.cs" />
     <Compile Include="DeliveryConstraintContextExtensions\DeliveryConstraintContextExtensionsTests.cs" />
+    <Compile Include="MessageMapper\MessageMapperTests.cs" />
     <Compile Include="Msmq\TimeToBeReceivedOverrideCheckerTest.cs" />
     <Compile Include="Msmq\MsmqExtensionsTests.cs" />
     <Compile Include="Msmq\MsmqHelpers.cs" />

--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
@@ -14,7 +14,7 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
     public class MessageMapper : IMessageMapper
     {
         /// <summary>
-        /// Initializes a new instance of <see cref="MessageMapper"/>.
+        /// Initializes a new instance of <see cref="MessageMapper" />.
         /// </summary>
         public MessageMapper()
         {
@@ -38,6 +38,104 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
         }
 
         /// <summary>
+        /// If the given type is concrete, returns the interface it was generated to support.
+        /// If the given type is an interface, returns the concrete class generated to implement it.
+        /// </summary>
+        public Type GetMappedTypeFor(Type t)
+        {
+            Guard.AgainstNull(nameof(t), t);
+            RuntimeTypeHandle typeHandle;
+            if (t.IsClass)
+            {
+                if (t.IsGenericTypeDefinition)
+                {
+                    return null;
+                }
+
+                if (concreteToInterfaceTypeMapping.TryGetValue(t.TypeHandle, out typeHandle))
+                {
+                    return Type.GetTypeFromHandle(typeHandle);
+                }
+
+                return t;
+            }
+
+            if (interfaceToConcreteTypeMapping.TryGetValue(t.TypeHandle, out typeHandle))
+            {
+                return Type.GetTypeFromHandle(typeHandle);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns the type mapped to the given name.
+        /// </summary>
+        public Type GetMappedTypeFor(string typeName)
+        {
+            Guard.AgainstNullAndEmpty(nameof(typeName), typeName);
+            var name = typeName;
+            if (typeName.EndsWith(ConcreteProxyCreator.SUFFIX, StringComparison.Ordinal))
+            {
+                name = typeName.Substring(0, typeName.Length - ConcreteProxyCreator.SUFFIX.Length);
+            }
+
+            RuntimeTypeHandle typeHandle;
+            if (nameToType.TryGetValue(name, out typeHandle))
+            {
+                return Type.GetTypeFromHandle(typeHandle);
+            }
+
+            return Type.GetType(name);
+        }
+
+        /// <summary>
+        /// Calls the generic CreateInstance and performs the given action on the result.
+        /// </summary>
+        public T CreateInstance<T>(Action<T> action)
+        {
+            var result = CreateInstance<T>();
+
+            action?.Invoke(result);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Calls the <see cref="CreateInstance(Type)" /> and returns its result cast to <typeparamref name="T" />.
+        /// </summary>
+        public T CreateInstance<T>()
+        {
+            return (T) CreateInstance(typeof(T));
+        }
+
+        /// <summary>
+        /// If the given type is an interface, finds its generated concrete implementation, instantiates it, and returns the
+        /// result.
+        /// </summary>
+        public object CreateInstance(Type t)
+        {
+            var mapped = t;
+            if (t.IsInterface || t.IsAbstract)
+            {
+                mapped = GetMappedTypeFor(t);
+                if (mapped == null)
+                {
+                    InitType(t);
+                    mapped = GetMappedTypeFor(t);
+                }
+            }
+
+            RuntimeMethodHandle constructor;
+            if (typeToConstructor.TryGetValue(mapped.TypeHandle, out constructor))
+            {
+                return ((ConstructorInfo) MethodBase.GetMethodFromHandle(constructor, mapped.TypeHandle)).Invoke(null);
+            }
+
+            return FormatterServices.GetUninitializedObject(mapped);
+        }
+
+        /// <summary>
         /// Generates a concrete implementation of the given type if it is an interface.
         /// </summary>
         void InitType(Type t)
@@ -58,13 +156,15 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
 
                 foreach (var interfaceType in t.GetInterfaces())
                 {
-					foreach (var g in interfaceType.GetGenericArguments())
-					{
-						if(g == t)
-							continue;
+                    foreach (var g in interfaceType.GetGenericArguments())
+                    {
+                        if (g == t)
+                        {
+                            continue;
+                        }
 
-						InitType(g);
-					}
+                        InitType(g);
+                    }
                 }
 
                 return;
@@ -143,109 +243,12 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
             return t.FullName;
         }
 
-        /// <summary>
-        /// If the given type is concrete, returns the interface it was generated to support.
-        /// If the given type is an interface, returns the concrete class generated to implement it.
-        /// </summary>
-        public Type GetMappedTypeFor(Type t)
-        {
-            Guard.AgainstNull(nameof(t), t);
-            RuntimeTypeHandle typeHandle;
-            if (t.IsClass)
-            {
-                if (t.IsGenericTypeDefinition)
-                {
-                    return null;
-                }
-
-                if (concreteToInterfaceTypeMapping.TryGetValue(t.TypeHandle, out typeHandle))
-                {
-                    return Type.GetTypeFromHandle(typeHandle);
-                }
-
-                return t;
-            }
-
-            if (interfaceToConcreteTypeMapping.TryGetValue(t.TypeHandle, out typeHandle))
-            {
-                return Type.GetTypeFromHandle(typeHandle);
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Returns the type mapped to the given name.
-        /// </summary>
-        public Type GetMappedTypeFor(string typeName)
-        {
-            Guard.AgainstNullAndEmpty(nameof(typeName), typeName);
-            var name = typeName;
-            if (typeName.EndsWith(ConcreteProxyCreator.SUFFIX, StringComparison.Ordinal))
-            {
-                name = typeName.Substring(0, typeName.Length - ConcreteProxyCreator.SUFFIX.Length);
-            }
-
-            RuntimeTypeHandle typeHandle;
-            if (nameToType.TryGetValue(name, out typeHandle))
-            {
-                return Type.GetTypeFromHandle(typeHandle);
-            }
-
-            return Type.GetType(name);
-        }
-
-        /// <summary>
-        /// Calls the generic CreateInstance and performs the given action on the result.
-        /// </summary>
-        public T CreateInstance<T>(Action<T> action)
-        {
-            var result = CreateInstance<T>();
-
-            action?.Invoke(result);
-
-            return result;
-        }
-
-        /// <summary>
-        /// Calls the <see cref="CreateInstance(Type)"/> and returns its result cast to <typeparamref name="T"/>.
-        /// </summary>
-        public T CreateInstance<T>()
-        {
-            return (T)CreateInstance(typeof(T));
-        }
-
-        /// <summary>
-        /// If the given type is an interface, finds its generated concrete implementation, instantiates it, and returns the result.
-        /// </summary>
-        public object CreateInstance(Type t)
-        {
-            var mapped = t;
-            if (t.IsInterface || t.IsAbstract)
-            {
-                mapped = GetMappedTypeFor(t);
-                if (mapped == null)
-                {
-                    InitType(t);
-                    mapped = GetMappedTypeFor(t);
-                }
-            }
-
-            RuntimeMethodHandle constructor;
-            if (typeToConstructor.TryGetValue(mapped.TypeHandle, out constructor))
-            {
-                return ((ConstructorInfo)MethodBase.GetMethodFromHandle(constructor, mapped.TypeHandle)).Invoke(null);
-            }
-            
-            return FormatterServices.GetUninitializedObject(mapped);
-        }
-
         ConcreteProxyCreator concreteProxyCreator;
-        ConcurrentDictionary<RuntimeTypeHandle, RuntimeTypeHandle> interfaceToConcreteTypeMapping = new ConcurrentDictionary<RuntimeTypeHandle, RuntimeTypeHandle>();
         ConcurrentDictionary<RuntimeTypeHandle, RuntimeTypeHandle> concreteToInterfaceTypeMapping = new ConcurrentDictionary<RuntimeTypeHandle, RuntimeTypeHandle>();
+        ConcurrentDictionary<RuntimeTypeHandle, RuntimeTypeHandle> interfaceToConcreteTypeMapping = new ConcurrentDictionary<RuntimeTypeHandle, RuntimeTypeHandle>();
         ConcurrentDictionary<string, RuntimeTypeHandle> nameToType = new ConcurrentDictionary<string, RuntimeTypeHandle>();
         ConcurrentDictionary<RuntimeTypeHandle, RuntimeMethodHandle> typeToConstructor = new ConcurrentDictionary<RuntimeTypeHandle, RuntimeMethodHandle>();
 
-        private static readonly object messageInitializationLock = new object();
+        readonly object messageInitializationLock = new object();
     }
 }


### PR DESCRIPTION
When Concurrently Initializing the MessageMapper or using `CreateInstance` concurrently for the same type without initializing the mapper will cause an exception because the `ConcreteProxyCreator` implementation is not threadsafe (`System.ArgumentException : Duplicate type name within an assembly.`).

While this scenario usually can't occur in production since we use a single message mapper and initialize it once at startup, this can easily happen when testing. In testing users usually don't initialize the mapper but rely on it's "auto-initialize" logic which will initialize a type "on-demand" which can easily happen concurrently when sending messages in parallel from a handler or somewhere else. In those cases a race condition will try to create the proxy type twice which will cause the described exception.