### PR TITLE
Split When_multi_subscribing_to_a_polymorphic_event test into two focused tests

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -139,6 +139,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Routing\SubscriptionBehaviorExtensions.cs" />
+    <Compile Include="Routing\When_multi_subscribing_to_a_polymorphic_event_on_multicast_transports.cs" />
     <Compile Include="Routing\When_publishing_to_scaled_out_subscribers_on_unicast_transports.cs" />
     <Compile Include="Routing\When_publishing_to_scaled_out_subscribers_on_multicast_transports.cs" />
     <Compile Include="Routing\When_broadcasting_a_command.cs" />
@@ -223,7 +224,7 @@
     <Compile Include="NServiceBusAcceptanceTest.cs" />
     <Compile Include="DataBus\When_sending_databus_properties.cs" />
     <Compile Include="Routing\SubscriptionBehavior.cs" />
-    <Compile Include="Routing\When_multi_subscribing_to_a_polymorphic_event.cs" />
+    <Compile Include="Routing\When_multi_subscribing_to_a_polymorphic_event_on_unicast_transports.cs" />
     <Compile Include="Routing\When_publishing_with_overridden_local_address.cs" />
     <Compile Include="Routing\When_publishing_with_only_local_messagehandlers.cs" />
     <Compile Include="Routing\SubscriptionEventArgs.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/When_multi_subscribing_to_a_polymorphic_event_on_multicast_transports.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_multi_subscribing_to_a_polymorphic_event_on_multicast_transports.cs
@@ -1,0 +1,98 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class When_multi_subscribing_to_a_polymorphic_event_on_multicast_transports : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Both_events_should_be_delivered()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<Publisher1>(b => b.When(c => c.EndpointsStarted, (session, c) =>
+                {
+                    c.AddTrace("Publishing MyEvent1");
+                    return session.Publish(new MyEvent1());
+                }))
+                .WithEndpoint<Publisher2>(b => b.When(c => c.EndpointsStarted, (session, c) =>
+                {
+                    c.AddTrace("Publishing MyEvent2");
+                    return session.Publish(new MyEvent2());
+                }))
+                .WithEndpoint<Subscriber>()
+                .Done(c => c.SubscriberGotIMyEvent && c.SubscriberGotMyEvent2)
+                .Repeat(r => r.For<AllTransportsWithCentralizedPubSubSupport>())
+                .Should(c =>
+                {
+                    Assert.True(c.SubscriberGotIMyEvent);
+                    Assert.True(c.SubscriberGotMyEvent2);
+                })
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool SubscriberGotIMyEvent { get; set; }
+            public bool SubscriberGotMyEvent2 { get; set; }
+        }
+
+        public class Publisher1 : EndpointConfigurationBuilder
+        {
+            public Publisher1()
+            {
+                EndpointSetup<DefaultPublisher>();
+            }
+        }
+
+        public class Publisher2 : EndpointConfigurationBuilder
+        {
+            public Publisher2()
+            {
+                EndpointSetup<DefaultPublisher>();
+            }
+        }
+
+        public class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyEventHandler : IHandleMessages<IMyEvent>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(IMyEvent messageThatIsEnlisted, IMessageHandlerContext context)
+                {
+                    Context.AddTrace($"Got event '{messageThatIsEnlisted}'");
+                    if (messageThatIsEnlisted is MyEvent2)
+                    {
+                        Context.SubscriberGotMyEvent2 = true;
+                    }
+                    else
+                    {
+                        Context.SubscriberGotIMyEvent = true;
+                    }
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MyEvent1 : IMyEvent
+        {
+        }
+
+        public class MyEvent2 : IMyEvent
+        {
+        }
+
+        public interface IMyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Routing/When_multi_subscribing_to_a_polymorphic_event_on_unicast_transports.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_multi_subscribing_to_a_polymorphic_event_on_unicast_transports.cs
@@ -1,18 +1,19 @@
 ﻿namespace NServiceBus.AcceptanceTests.Routing
 {
-    using System;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NServiceBus.Config;
     using NServiceBus.Features;
     using NUnit.Framework;
 
-    public class When_multi_subscribing_to_a_polymorphic_event : NServiceBusAcceptanceTest
+    public class When_multi_subscribing_to_a_polymorphic_event_on_unicast_transports : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Both_events_should_be_delivered()
         {
-            var context = await Scenario.Define<Context>()
+            await Scenario.Define<Context>()
                 .WithEndpoint<Publisher1>(b => b.When(c => c.Publisher1HasASubscriberForIMyEvent, (session, c) =>
                 {
                     c.AddTrace("Publishing MyEvent1");
@@ -28,18 +29,15 @@
                     c.AddTrace("Subscriber1 subscribing to both events");
                     await session.Subscribe<IMyEvent>();
                     await session.Subscribe<MyEvent2>();
-
-                    if (c.HasNativePubSubSupport)
-                    {
-                        c.Publisher1HasASubscriberForIMyEvent = true;
-                        c.Publisher2HasDetectedASubscriberForEvent2 = true;
-                    }
                 }))
                 .Done(c => c.SubscriberGotIMyEvent && c.SubscriberGotMyEvent2)
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Should(c =>
+                {
+                    Assert.True(c.SubscriberGotIMyEvent);
+                    Assert.True(c.SubscriberGotMyEvent2);
+                })
                 .Run();
-
-            Assert.True(context.SubscriberGotIMyEvent);
-            Assert.True(context.SubscriberGotMyEvent2);
         }
 
         public class Context : ScenarioContext
@@ -54,14 +52,18 @@
         {
             public Publisher1()
             {
-                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((args, context) =>
-               {
-                   context.AddTrace("Publisher1 OnEndpointSubscribed " + args.MessageType);
-                   if (args.MessageType.Contains(typeof(IMyEvent).Name))
-                   {
-                       context.Publisher1HasASubscriberForIMyEvent = true;
-                   }
-               }));
+                EndpointSetup<DefaultPublisher>(b =>
+                {
+                    b.OnEndpointSubscribed<Context>((args, context) =>
+                    {
+                        context.AddTrace("Publisher1 OnEndpointSubscribed " + args.MessageType);
+                        if (args.MessageType.Contains(typeof(IMyEvent).Name))
+                        {
+                            context.Publisher1HasASubscriberForIMyEvent = true;
+                        }
+                    });
+                    b.EnableFeature<FirstLevelRetries>();
+                }).WithConfig<TransportConfig>(c => { c.MaxRetries = 2; }); //Because subscription storages can throw on concurrecy violation and need to retry
             }
         }
 
@@ -69,15 +71,19 @@
         {
             public Publisher2()
             {
-                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((args, context) =>
+                EndpointSetup<DefaultPublisher>(b =>
                 {
-                    context.AddTrace("Publisher2 OnEndpointSubscribed " + args.MessageType);
-
-                    if (args.MessageType.Contains(typeof(MyEvent2).Name))
+                    b.OnEndpointSubscribed<Context>((args, context) =>
                     {
-                        context.Publisher2HasDetectedASubscriberForEvent2 = true;
-                    }
-                }));
+                        context.AddTrace("Publisher2 OnEndpointSubscribed " + args.MessageType);
+
+                        if (args.MessageType.Contains(typeof(MyEvent2).Name))
+                        {
+                            context.Publisher2HasDetectedASubscriberForEvent2 = true;
+                        }
+                    });
+                    b.EnableFeature<FirstLevelRetries>();
+                }).WithConfig<TransportConfig>(c => { c.MaxRetries = 2; }); //Because subscription storages can throw on concurrecy violation and need to retry
             }
         }
 
@@ -111,12 +117,10 @@
             }
         }
 
-        [Serializable]
         public class MyEvent1 : IMyEvent
         {
         }
 
-        [Serializable]
         public class MyEvent2 : IMyEvent
         {
         }

--- a/src/NServiceBus.AcceptanceTests/Routing/When_multi_subscribing_to_a_polymorphic_event_on_unicast_transports.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_multi_subscribing_to_a_polymorphic_event_on_unicast_transports.cs
@@ -4,7 +4,6 @@
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.AcceptanceTests.ScenarioDescriptors;
-    using NServiceBus.Config;
     using NServiceBus.Features;
     using NUnit.Framework;
 
@@ -62,8 +61,8 @@
                             context.Publisher1HasASubscriberForIMyEvent = true;
                         }
                     });
-                    b.EnableFeature<FirstLevelRetries>();
-                }).WithConfig<TransportConfig>(c => { c.MaxRetries = 2; }); //Because subscription storages can throw on concurrecy violation and need to retry
+                    b.EnableFeature<FirstLevelRetries>(); //Because subscription storages can throw on concurrecy violation and need to retry
+                });
             }
         }
 
@@ -82,8 +81,8 @@
                             context.Publisher2HasDetectedASubscriberForEvent2 = true;
                         }
                     });
-                    b.EnableFeature<FirstLevelRetries>();
-                }).WithConfig<TransportConfig>(c => { c.MaxRetries = 2; }); //Because subscription storages can throw on concurrecy violation and need to retry
+                    b.EnableFeature<FirstLevelRetries>(); //Because subscription storages can throw on concurrecy violation and need to retry
+                });
             }
         }
 


### PR DESCRIPTION
The unicast one now enables the FLR because the subscription stores can throw concurrency exceptions and expect retries to kick in.

This was discovered during attempts to fix the NHibernate ATs.