### PR TITLE
`PendingTransportOperations` should be thread-safe

### DIFF
--- a/src/NServiceBus.Core/Pipeline/Incoming/PendingTransportOperations.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/PendingTransportOperations.cs
@@ -1,22 +1,27 @@
 namespace NServiceBus
 {
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Linq;
     using Transports;
 
     class PendingTransportOperations
     {
-        public IReadOnlyCollection<TransportOperation> Operations => operations;
+        public IReadOnlyCollection<TransportOperation> Operations => new List<TransportOperation>(operations);
+
+        public bool HasOperations => !operations.IsEmpty;
 
         public void Add(TransportOperation transportOperation)
         {
-            operations.Add(transportOperation);
+            operations.Push(transportOperation);
         }
 
         public void AddRange(IEnumerable<TransportOperation> transportOperations)
         {
-            operations.AddRange(transportOperations);
+
+            operations.PushRange(transportOperations.ToArray());
         }
 
-        List<TransportOperation> operations = new List<TransportOperation>();
+        ConcurrentStack<TransportOperation> operations = new ConcurrentStack<TransportOperation>();
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageProcessingConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageProcessingConnector.cs
@@ -43,13 +43,15 @@ namespace NServiceBus
                     context.Extensions.Remove<OutboxTransaction>();
                     await outboxTransaction.Commit().ConfigureAwait(false);
                 }
+
+                physicalMessageContext.Extensions.Remove<PendingTransportOperations>();
             }
             else
             {
                 ConvertToPendingOperations(deduplicationEntry, pendingTransportOperations);
             }
 
-            if (pendingTransportOperations.Operations.Any())
+            if (pendingTransportOperations.HasOperations)
             {
                 var batchDispatchContext = this.CreateBatchDispatchContext(pendingTransportOperations.Operations, physicalMessageContext);
 


### PR DESCRIPTION
Closes #3539

Switches from using List<TransportOperation> to ConcurrentStack<TransportOperation>, making Add / AddRange threadsafe.

Operations converts ToList which makes a copy at that point of time making reads threadsafe.