### PR TITLE
[WIP] Send options

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Basic/When_sending_to_another_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_sending_to_another_endpoint.cs
@@ -6,6 +6,7 @@
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
+    using MessageId = NServiceBus.MessageId;
 
     public class When_sending_to_another_endpoint : NServiceBusAcceptanceTest
     {
@@ -15,12 +16,7 @@
             var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                     .WithEndpoint<Sender>(b => b.When((session, c) =>
                     {
-                        var sendOptions = new SendOptions();
-
-                        sendOptions.SetHeader("MyHeader", "MyHeaderValue");
-                        sendOptions.SetMessageId("MyMessageId");
-
-                        return session.Send(new MyMessage { Id = c.Id }, sendOptions);
+                        return session.Send(new MyMessage { Id = c.Id }, Header.Set("MyHeader", "MyHeaderValue"), MessageId.Set("MyMessageId"));
                     }))
                     .WithEndpoint<Receiver>()
                     .Done(c => c.WasCalled)

--- a/src/NServiceBus.Core.Tests/Scheduler/ScheduleTests.cs
+++ b/src/NServiceBus.Core.Tests/Scheduler/ScheduleTests.cs
@@ -55,6 +55,11 @@
                 return TaskEx.CompletedTask;
             }
 
+            public Task Send(object message, params SendOption[] options)
+            {
+                throw new NotImplementedException();
+            }
+
             public Task Send<T>(Action<T> messageConstructor, SendOptions options)
             {
                 throw new NotImplementedException();

--- a/src/NServiceBus.Core/IMessageSession.cs
+++ b/src/NServiceBus.Core/IMessageSession.cs
@@ -1,7 +1,115 @@
+// ReSharper disable NotAccessedField.Local
+#pragma warning disable 1591
 namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
+
+    public class Usage
+    {
+        public void Test(IMessageSession session)
+        {
+            var options = new SendOptions();
+            options.DelayDeliveryWith(TimeSpan.FromMinutes(15));
+            options.RouteToThisEndpoint();
+            options.SetCorrelationId("correlationId");
+            options.SetMessageId("messageId");
+            options.SetHeader("header1", "value1");
+            options.SetHeader("header2", "value2");
+            options.RouteReplyToThisInstance();
+            session.Send(new object(), options);
+
+            //messageid, headers, correlationid
+            session.Send(new object(), 
+                Defer.By(TimeSpan.FromMinutes(15)), 
+                Route.ToThisEndpoint(), 
+                CorrelationId.Set("correlationId"), 
+                MessageId.Set("messageId"),
+                Header.Set("header1", "value1"),
+                Header.Set("header2", "value2"),
+                Reply.ToThisInstance());
+        }
+    }
+
+    public class SendOption
+    {
+        // require implementations to provide a key which is used to check for "duplicates" (e.g. Defer.To & Defer.By)
+    }
+
+    public class Header : SendOption
+    {
+        public static Header Set(string key, string value)
+        {
+            return new Header();
+        }
+    }
+
+    public class MessageId : SendOption
+    {
+        public static MessageId Set(string messageId)
+        {
+            return new MessageId();
+        }
+    }
+
+    public class CorrelationId : SendOption
+    {
+        public static CorrelationId Set(string correlationId)
+        {
+            return new CorrelationId();
+        }
+    }
+
+    public class Reply : SendOption
+    {
+        public static Reply ToThisInstance()
+        {
+            return new Reply();
+        }
+    }
+
+    public class Route : SendOption
+    {
+        private Route()
+        {
+        }
+
+        public static Route ToThisEndpoint()
+        {
+            return new Route();
+        }
+
+        public static Route ToAddress(string address)
+        {
+            return new Route();
+        }
+    }
+
+    public class Defer : SendOption
+    {
+        readonly TimeSpan timespan;
+        readonly DateTimeOffset deliveryDate;
+
+        private Defer(DateTimeOffset deliveryDate)
+        {
+            this.deliveryDate = deliveryDate;
+        }
+
+        private Defer(TimeSpan timespan)
+        {
+            this.timespan = timespan;
+        }
+
+        public static Defer To(DateTimeOffset deliveryDate)
+        {
+            return new Defer(deliveryDate);
+        }
+
+        public static Defer By(TimeSpan timespan)
+        {
+            return new Defer(timespan);
+        }
+    }
 
     /// <summary>
     /// A session which provides basic message operations.
@@ -14,6 +122,8 @@ namespace NServiceBus
         /// <param name="message">The message to send.</param>
         /// <param name="options">The options for the send.</param>
         Task Send(object message, SendOptions options);
+
+        Task Send(object message, params SendOption[] options);
 
         /// <summary>
         /// Instantiates a message of type T and sends it.

--- a/src/NServiceBus.Core/MessageSession.cs
+++ b/src/NServiceBus.Core/MessageSession.cs
@@ -15,6 +15,11 @@ namespace NServiceBus
             return MessageOperations.Send(context, message, options);
         }
 
+        public Task Send(object message, params SendOption[] options)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task Send<T>(Action<T> messageConstructor, SendOptions options)
         {
             return MessageOperations.Send(context, messageConstructor, options);

--- a/src/NServiceBus.Core/MessageSession.cs
+++ b/src/NServiceBus.Core/MessageSession.cs
@@ -17,7 +17,12 @@ namespace NServiceBus
 
         public Task Send(object message, params SendOption[] options)
         {
-            throw new NotImplementedException();
+            var o = new SendOptions();
+            foreach (var opt in options)
+            {
+                opt.Apply(o);
+            }
+            return MessageOperations.Send(context, message, o);
         }
 
         public Task Send<T>(Action<T> messageConstructor, SendOptions options)

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -59,6 +59,11 @@ namespace NServiceBus
             return messageSession.Send(message, options);
         }
 
+        public Task Send(object message, params SendOption[] options)
+        {
+            return messageSession.Send(message, options);
+        }
+
         public Task Send<T>(Action<T> messageConstructor, SendOptions options)
         {
             return messageSession.Send(messageConstructor, options);


### PR DESCRIPTION
Based on the [this Spike](https://github.com/Particular/NServiceBus/pull/3509) and our experiences while updating the testing framework to v6 I wasn't too happy with the current `SendOptions` API for sending messages. Current "pain points" with `SendOptions`:

* It forces us to use extension methods instead of properties (e.g. `options.SetMessageId(...)` instead of `options.MessageId = ...`) to allow downstream repositories add their own options (e.g. `SendToSite`).
* We need a way to retrieve the configured options again. The current "workaround" is to provide "getter extension methods" (e.g. `options.GetMessageId()`) which feels weird and doesn't reed nicely with many options. It also adds a lot of noise to Intellisense.
* It's nearly impossible to "stringify" the configured options with the current approach. This was noticed on the testing update, because we can't easily output configured options of an outgoing message.
* `SendOptions` can easily be reused in multiple send operations. It's quite easy to introduce bugs or undesired behavior this way.
* To share options between `SendOptions` `PublishOptions` and `ReplyOption` it's sometimes required to duplicate certain extension method (e.g. when it's only support for send and publish but not for reply).

The idea: change the signatures from `Send(object message, SendOptions options)` to `Send(object message, params ISendOption[])` (and similar with publish and reply).

Where `ISendOption` instances are provided by dedicated factories like `Defer.By(TimeSpan delay)` or `Defer.To(DateTimeOffset deliveryDate)`, `MessageId.Set(string messageId)` or `Route.ToThisEndpoint()`.

Advantages of this approach:
* It's much easier to properly "stringify" the options and to analyze options on an outgoing messaage.
* Created options are immutable.
* It's easier to scope options because you can implement the corresponding options interface (e.g. `IPublishOption`).
* This is highly subjective but I think it reads better than the extension methods.
* It allows to expose more meaningful data on the option classes usable for inspection & assertions (e.g. `Headers.Key` or `Defer.TimeSpan`).

Disadvantes:
* It's less explorable, since you can't just see all available like options on the `SendOptions` class. I'd argue this is ok since users probably need to read docs about the specific options anyway, also R# is able to show available factory methods, but it doesn't show them by default for me.
* Fluent APIs are not cool anymore. I'd argue this isn't a fluent API and more OOP than the current approach.

From the spike it seems like this shouldn't be difficult to implement since it's pretty simple to shim it using `SendOptions` internally (and the other way round). It would also be possible to release this with a v6 minor version and support both option configuration approaches in parallel. The implementation of this API is very similar to the current `SendOptions` approach but just avoids the public "options bag" class.

Sample from the Spike:

Before:

```
var options = new SendOptions();
options.DelayDeliveryWith(TimeSpan.FromMinutes(15));
options.RouteToThisEndpoint();
options.SetCorrelationId("correlationId");
options.SetMessageId("messageId");
options.SetHeader("header1", "value1");
options.SetHeader("header2", "value2");
options.RouteReplyToThisInstance();
session.Send(new object(), options);
```

After:

```
session.Send(new object(),
  Defer.By(TimeSpan.FromMinutes(15)),
  Route.ToThisEndpoint(),
  CorrelationId.Set("correlationId"),
  MessageId.Set("messageId"),
  Header.Set("header1", "value1"),
  Header.Set("header2", "value2"),
  Reply.ToThisInstance());
```

@Particular/nservicebus-maintainers please give some feedback
