### PR TITLE
Removed assumption that reconfiguring child containers should throw

### DIFF
--- a/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
+++ b/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
@@ -62,20 +62,6 @@ namespace NServiceBus.ContainerTests
         }
 
         [Test]
-        public void Should_not_allow_reconfiguration_of_child_container()
-        {
-            using (var builder = TestContainerBuilder.ConstructBuilder())
-            {
-                builder.Configure(typeof(InstanceToReplaceInNested_Parent), DependencyLifecycle.SingleInstance);
-                builder.Build(typeof(IInstanceToReplaceInNested));
-                using (var nestedContainer = builder.BuildChildContainer())
-                {
-                    Assert.That(() => nestedContainer.Configure(typeof(InstanceToReplaceInNested_Child), DependencyLifecycle.SingleInstance), Throws.InvalidOperationException);
-                }
-            }
-        }
-
-        [Test]
         public void Instance_per_call_components_should_not_be_shared_across_child_containers()
         {
             using (var builder = TestContainerBuilder.ConstructBuilder())


### PR DESCRIPTION
This means that container impls don't have to write funky code to prevent
it should they support it.

This failed for structuremap which does support this. If the core wants to prevent this it needs to check and throw instead of forcing the containers to do it.

That said since the core [returns an `IBuilder`](https://github.com/Particular/NServiceBus/blob/develop/src/NServiceBus.Core/ObjectBuilder/Common/CommonObjectBuilder.cs#L22) they only way to be able to reconfigure it is knowing how to cast it.

I'm convinced that we'll catch this in a code review so calling YAGNI on this test that is just limiting the individual containers. 


@WilliamBZA can you link to the code you had to write in Ninject?