### PR TITLE
added 2 convenience methods on readonly settings

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2535,6 +2535,8 @@ namespace NServiceBus.Settings
         T Get<T>();
         T Get<T>(string key);
         object Get(string key);
+        T GetConditional<T>(string key, System.Func<bool> condition);
+        T GetDefault<T>(string key);
         T GetOrDefault<T>();
         T GetOrDefault<T>(string key);
         bool HasExplicitValue(string key);
@@ -2570,6 +2572,8 @@ namespace NServiceBus.Settings
         public T Get<T>(string key) { }
         public T Get<T>() { }
         public object Get(string key) { }
+        public T GetConditional<T>(string key, System.Func<bool> condition) { }
+        public T GetDefault<T>(string key) { }
         public T GetOrDefault<T>() { }
         public T GetOrDefault<T>(string key) { }
         public bool HasExplicitValue(string key) { }

--- a/src/NServiceBus.Core.Tests/Settings/SettingsHolderTests.cs
+++ b/src/NServiceBus.Core.Tests/Settings/SettingsHolderTests.cs
@@ -34,6 +34,36 @@
             Assert.IsTrue(all.All(x => x.Disposed));
         }
 
+        [Test]
+        public void GetDefaultTest()
+        {
+            var settings = new SettingsHolder();
+            settings.Set("MySetting", "explicitValue");
+            settings.SetDefault("MySetting", "defaultValue");
+
+            Assert.AreEqual("defaultValue", settings.GetDefault<string>("MySetting"));
+        }
+
+        [Test]
+        public void GetConditional_ConditionPassedTest()
+        {
+            var settings = new SettingsHolder();
+            settings.Set("MySetting", "explicitValue");
+            settings.SetDefault("MySetting", "defaultValue");
+
+            Assert.AreEqual("explicitValue", settings.GetConditional<string>("MySetting", () => true));
+        }
+
+        [Test]
+        public void GetConditional_ConditionFailedTest()
+        {
+            var settings = new SettingsHolder();
+            settings.Set("MySetting", "explicitValue");
+            settings.SetDefault("MySetting", "defaultValue");
+
+            Assert.AreEqual("defaultValue", settings.GetConditional<string>("MySetting", () => false));
+        }
+
         class SomeDisposable : IDisposable
         {
             public bool Disposed;

--- a/src/NServiceBus.Core/Settings/ReadOnlySettings.cs
+++ b/src/NServiceBus.Core/Settings/ReadOnlySettings.cs
@@ -45,6 +45,11 @@ namespace NServiceBus.Settings
         object Get(string key);
 
         /// <summary>
+        /// Gets the setting value if the specified condition is true, otherwise the default value.
+        /// </summary>
+        T GetConditional<T>(string key, Func<bool> condition);
+
+        /// <summary>
         /// Gets the setting or default based on the typename.
         /// </summary>
         /// <typeparam name="T">The setting to get.</typeparam>
@@ -58,6 +63,14 @@ namespace NServiceBus.Settings
         /// <param name="key">The key of the setting to get.</param>
         /// <returns>The setting value.</returns>
         T GetOrDefault<T>(string key);
+
+        /// <summary>
+        /// Gets the default value for the setting or <code>default(T).</code>.
+        /// </summary>
+        /// <typeparam name="T">The value of the setting.</typeparam>
+        /// <param name="key">The key of the setting to get.</param>
+        /// <returns>The setting's default value.</returns>
+        T GetDefault<T>(string key);
 
         /// <summary>
         /// Determines whether the <see cref="ReadOnlySettings" /> contains the specified key.

--- a/src/NServiceBus.Core/Settings/SettingsHolder.cs
+++ b/src/NServiceBus.Core/Settings/SettingsHolder.cs
@@ -97,6 +97,19 @@ namespace NServiceBus.Settings
         }
 
         /// <summary>
+        /// Gets the setting value if the specified condition is true, otherwise the default value.
+        /// </summary>
+        public T GetConditional<T>(string key, Func<bool> condition)
+        {
+            if (condition())
+            {
+                return GetOrDefault<T>(key);
+            }
+
+            return GetDefault<T>(key);
+        }
+
+        /// <summary>
         /// Gets the setting or default based on the typename.
         /// </summary>
         /// <typeparam name="T">The setting to get.</typeparam>
@@ -124,6 +137,26 @@ namespace NServiceBus.Settings
             if (Defaults.TryGetValue(key, out result))
             {
                 return (T) result;
+            }
+
+            return default(T);
+        }
+
+        /// <summary>
+        /// Gets the default value for the setting or <code>default(T).</code>.
+        /// </summary>
+        /// <typeparam name="T">The value of the setting.</typeparam>
+        /// <param name="key">The key of the setting to get.</param>
+        /// <returns>The setting's default value.</returns>
+        public T GetDefault<T>(string key)
+        {
+            Guard.AgainstNullAndEmpty(nameof(key), key);
+
+            object result;
+
+            if (Defaults.TryGetValue(key, out result))
+            {
+                return (T)result;
             }
 
             return default(T);


### PR DESCRIPTION
@Particular/nservicebus-maintainers  Included in this PR are 2 convenience methods on readonlysettings that we're using in the azure servicebus transport, but I feel these could be usefull for everyone, hence this PR.

- GetDefault allows you to look up the currently configured default value (without getting the user override)

- GetConditional allows you to apply conditional logic to settings, a certain explicit setting value should only be used if the provided condition is true, otherwise the default value should be used.

Unittests are included as well.