### PR TITLE
Null check for common user Task methods

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -134,6 +134,10 @@
     <Compile Include="Persistence\InMemory\When_persisting_a_saga_with_InMemory_and_an_escalated_DTC_transaction.cs" />
     <Compile Include="Pipeline\HeaderOptionExtensionsTests.cs" />
     <Compile Include="Pipeline\Incoming\InvokeHandlerTerminatorTest.cs" />
+    <Compile Include="Pipeline\MutateInstanceMessage\MutateIncomingMessageBehaviorTests.cs" />
+    <Compile Include="Pipeline\MutateInstanceMessage\MutateOutgoingMessageBehaviorTests.cs" />
+    <Compile Include="Pipeline\MutateTransportMessage\MutateIncomingTransportMessageBehaviorTests.cs" />
+    <Compile Include="Pipeline\MutateTransportMessage\MutateOutgoingTransportMessageBehaviorTests.cs" />
     <Compile Include="Pipeline\Outgoing\ImmediateDispatchOptionExtensionsTests.cs" />
     <Compile Include="Pipeline\Outgoing\MessageIdExtensionsTests.cs" />
     <Compile Include="Pipeline\Outgoing\OutgoingPublishContextTests.cs" />
@@ -154,6 +158,8 @@
     <Compile Include="Routing\Routers\UnicastPublishRouterConnectorTests.cs" />
     <Compile Include="Routing\RoutingOptionExtensionsTests.cs" />
     <Compile Include="Routing\SubscriptionRouterTests.cs" />
+    <Compile Include="Sagas\CustomFinderAdapterTests.cs" />
+    <Compile Include="Sagas\InvokeSagaNotFoundBehaviorTests.cs" />
     <Compile Include="Sagas\When_saga_has_multiple_correlated_properties.cs" />
     <Compile Include="Sagas\When_saga_is_correlated_on_a_unsupported_property_type.cs" />
     <Compile Include="Sagas\When_saga_has_no_start_message.cs" />

--- a/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehaviorTests.cs
@@ -1,0 +1,43 @@
+﻿namespace NServiceBus.Core.Tests.Pipeline.MutateInstanceMessage
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using MessageMutator;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+    using ObjectBuilder;
+    using Unicast.Messages;
+
+    [TestFixture]
+    class MutateIncomingMessageBehaviorTests
+    {
+        [Test]
+        public void Should_throw_friendly_exception_when_IMutateIncomingMessages_MutateIncoming_returns_null()
+        {
+            var behavior = new MutateIncomingMessageBehavior();
+
+            var logicalMessage = new LogicalMessage(new MessageMetadata(typeof(TestMessage)), new TestMessage(), null);
+
+            var context = new IncomingLogicalMessageContext(logicalMessage, "messageId", "replyToAddress", new Dictionary<string, string>(), null);
+
+            var builder = new FuncBuilder();
+
+            builder.Register<IMutateIncomingMessages>(() => new MutateIncomingMessagesReturnsNull());
+
+            context.Set<IBuilder>(builder);
+
+            Assert.That(async () => await behavior.Invoke(context, () => TaskEx.CompletedTask), Throws.Exception.With.Message.EqualTo("Return a Task or mark the method as async."));
+        }
+
+        class MutateIncomingMessagesReturnsNull : IMutateIncomingMessages
+        {
+            public Task MutateIncoming(MutateIncomingMessageContext context)
+            {
+                return null;
+            }
+        }
+
+        class TestMessage : IMessage
+        { }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateOutgoingMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateOutgoingMessageBehaviorTests.cs
@@ -1,0 +1,43 @@
+﻿namespace NServiceBus.Core.Tests.Pipeline.MutateInstanceMessage
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using MessageMutator;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+    using ObjectBuilder;
+
+    [TestFixture]
+    class MutateOutgoingMessageBehaviorTests
+    {
+        [Test]
+        public void Should_throw_friendly_exception_when_IMutateOutgoingMessages_MutateOutgoing_returns_null()
+        {
+            var behavior = new MutateOutgoingMessageBehavior();
+
+            var message = new FakeMessage();
+
+            var context = new OutgoingLogicalMessageContext("messageId", new Dictionary<string, string>(), new OutgoingLogicalMessage(message.GetType(), message), new List<RoutingStrategy>(), null);
+
+            var builder = new FuncBuilder();
+
+            builder.Register<IMutateOutgoingMessages>(() => new MutateOutgoingMessagesReturnsNull());
+
+            context.Set<IBuilder>(builder);
+
+            Assert.That(async () => await behavior.Invoke(context, () => TaskEx.CompletedTask), Throws.Exception.With.Message.EqualTo("Return a Task or mark the method as async."));
+        }
+
+        class MutateOutgoingMessagesReturnsNull : IMutateOutgoingMessages
+        {
+            public Task MutateOutgoing(MutateOutgoingMessageContext context)
+            {
+                return null;
+            }
+        }
+
+        class FakeMessage : IMessage
+        { }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehaviorTests.cs
@@ -1,0 +1,40 @@
+﻿namespace NServiceBus.Core.Tests.Pipeline.MutateTransportMessage
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Threading.Tasks;
+    using MessageMutator;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+    using ObjectBuilder;
+
+    [TestFixture]
+    public class MutateIncomingTransportMessageBehaviorTests
+    {
+        [Test]
+        public void Should_throw_friendly_exception_when_IMutateIncomingTransportMessages_MutateIncoming_returns_null()
+        {
+            var behavior = new MutateIncomingTransportMessageBehavior();
+
+            var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), new MemoryStream());
+
+            var context = new IncomingPhysicalMessageContext(incomingMessage, null);
+
+            var builder = new FuncBuilder();
+
+            builder.Register<IMutateIncomingTransportMessages>(() => new MutateIncomingTransportMessagesReturnsNull());
+
+            context.Set<IBuilder>(builder);
+
+            Assert.That(async () => await behavior.Invoke(context, () => TaskEx.CompletedTask), Throws.Exception.With.Message.EqualTo("Return a Task or mark the method as async."));
+        }
+
+        class MutateIncomingTransportMessagesReturnsNull : IMutateIncomingTransportMessages
+        {
+            public Task MutateIncoming(MutateIncomingTransportMessageContext context)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageBehaviorTests.cs
@@ -1,0 +1,48 @@
+﻿namespace NServiceBus.Core.Tests.Pipeline.MutateTransportMessage
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using MessageMutator;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+    using ObjectBuilder;
+
+    [TestFixture]
+    class MutateOutgoingTransportMessageBehaviorTests
+    {
+        [Test]
+        public void Should_throw_friendly_exception_when_IMutateOutgoingTransportMessages_MutateOutgoing_returns_null()
+        {
+            var behavior = new MutateOutgoingTransportMessageBehavior();
+
+            var message = new FakeMessage();
+
+            var outgoingLogicalMessage = new OutgoingLogicalMessage(message.GetType(),message);
+
+            var logicalContext = new OutgoingLogicalMessageContext("messageId", new Dictionary<string, string>(), outgoingLogicalMessage, new List<RoutingStrategy>(), null);
+
+            var physicalContext = new OutgoingPhysicalMessageContext(new byte[0], new List<RoutingStrategy>(), logicalContext);
+
+            physicalContext.Set(outgoingLogicalMessage);
+
+            var builder = new FuncBuilder();
+
+            builder.Register<IMutateOutgoingTransportMessages>(() => new MutateOutgoingTransportMessagesReturnsNull());
+
+            physicalContext.Set<IBuilder>(builder);
+
+            Assert.That(async () => await behavior.Invoke(physicalContext, () => TaskEx.CompletedTask), Throws.Exception.With.Message.EqualTo("Return a Task or mark the method as async."));
+        }
+
+        class MutateOutgoingTransportMessagesReturnsNull : IMutateOutgoingTransportMessages
+        {
+            public Task MutateOutgoing(MutateOutgoingTransportMessageContext context)
+            {
+                return null;
+            }
+        }
+
+        class FakeMessage : IMessage { }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Sagas/CustomFinderAdapterTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/CustomFinderAdapterTests.cs
@@ -1,0 +1,75 @@
+﻿namespace NServiceBus.Core.Tests.Sagas
+{
+    using System.Threading.Tasks;
+    using Extensibility;
+    using NServiceBus.Persistence;
+    using NServiceBus.Sagas;
+    using NUnit.Framework;
+    using System;
+    using System.Collections.Generic;
+
+    [TestFixture]
+    public class CustomFinderAdapterTests
+    {
+        [Test]
+        public void Throws_friendly_exception_when_IFindSagas_FindBy_returns_null()
+        {
+            var availableTypes = new List<Type>
+            {
+                typeof(ReturnsNullFinder)
+            };
+
+            var messageType = typeof(StartSagaMessage);
+
+            var messageConventions = new Conventions
+            {
+                IsCommandTypeAction = t => t == messageType
+            };
+
+            var sagaMetadata = SagaMetadata.Create(typeof(TestSaga), availableTypes, messageConventions);
+
+            SagaFinderDefinition finderDefinition;
+
+            if (!sagaMetadata.TryGetFinder(messageType.FullName, out finderDefinition))
+            {
+                throw new Exception("Finder not found");
+            }
+
+            var builder = new FuncBuilder();
+
+            builder.Register(finderDefinition.Type, () => new ReturnsNullFinder());
+
+            var customerFinderAdapter = new CustomFinderAdapter<TestSaga.SagaData, StartSagaMessage>();
+
+            Assert.That(async () => await customerFinderAdapter.Find(builder, finderDefinition, new InMemorySynchronizedStorageSession(), new ContextBag(), new StartSagaMessage()),
+                Throws.Exception.With.Message.EqualTo("Return a Task or mark the method as async."));
+        }
+    }
+
+    class TestSaga : Saga<TestSaga.SagaData>, IAmStartedByMessages<StartSagaMessage>
+    {
+        internal class SagaData : ContainSagaData
+        {
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+        {
+        }
+
+        public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
+        {
+            return TaskEx.CompletedTask;
+        }
+    }
+
+    class StartSagaMessage
+    { }
+
+    class ReturnsNullFinder : IFindSagas<TestSaga.SagaData>.Using<StartSagaMessage>
+    {
+        public Task<TestSaga.SagaData> FindBy(StartSagaMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context)
+        {
+            return null;
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Sagas/InvokeSagaNotFoundBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/InvokeSagaNotFoundBehaviorTests.cs
@@ -1,0 +1,90 @@
+﻿namespace NServiceBus.Core.Tests.Sagas
+{
+    using NServiceBus.Pipeline;
+    using NServiceBus.Sagas;
+    using NUnit.Framework;
+    using ObjectBuilder;
+    using Unicast.Messages;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    [TestFixture]
+    public class InvokeSagaNotFoundBehaviorTests
+    {
+        [SetUp]
+        public void SetupTests()
+        {
+            message = new LogicalMessage(new MessageMetadata(typeof(TestMessage)), new TestMessage(), null);
+
+            behavior = new InvokeSagaNotFoundBehavior();
+
+            incomingContext = new IncomingLogicalMessageContext(
+                message,
+                "messageId",
+                "replyToAddress",
+                new Dictionary<string, string>(),
+                null);
+
+            builder = new FuncBuilder();
+
+            incomingContext.Set<IBuilder>(builder);
+        }
+
+        [Test]
+        public void SagaNotFound_handlers_are_not_called_when_saga_is_found()
+        {
+            var validSagaHandler = new HandleSagaNotFoundValid();
+
+            builder.Register<IHandleSagaNotFound>(() => new HandleSagaNotFoundReturnsNull1());
+            builder.Register<IHandleSagaNotFound>(() => validSagaHandler);
+
+            Assert.That(async () => await behavior.Invoke(incomingContext, () => TaskEx.CompletedTask), Throws.Nothing);
+
+            Assert.False(validSagaHandler.Handled);
+        }
+
+        [Test]
+        public void Throw_friendly_exception_when_any_IHandleSagaNotFound_Handler_returns_null()
+        {
+            builder.Register<IHandleSagaNotFound>(() => new HandleSagaNotFoundReturnsNull1());
+            builder.Register<IHandleSagaNotFound>(() => new HandleSagaNotFoundValid());
+
+            Assert.That(async () => await behavior.Invoke(incomingContext, SetSagaNotFound), Throws.Exception.With.Message.EqualTo("Return a Task or mark the method as async."));
+        }
+
+
+        static Task SetSagaNotFound(IIncomingLogicalMessageContext context)
+        {
+            context.Extensions.Get<SagaInvocationResult>().SagaNotFound();
+            return TaskEx.CompletedTask;
+        }
+
+        class TestMessage : IMessage
+        { }
+
+        class HandleSagaNotFoundReturnsNull1 : IHandleSagaNotFound
+        {
+            public Task Handle(object message, IMessageProcessingContext context)
+            {
+                return null;
+            }
+        }
+
+        class HandleSagaNotFoundValid : IHandleSagaNotFound
+        {
+            public bool Handled { get; private set; }
+
+            public Task Handle(object message, IMessageProcessingContext context)
+            {
+                Handled = true;
+
+                return TaskEx.CompletedTask;
+            }
+        }
+
+        LogicalMessage message;
+        InvokeSagaNotFoundBehavior behavior;
+        FuncBuilder builder;
+        IncomingLogicalMessageContext incomingContext;
+    }
+}

--- a/src/NServiceBus.Core.Tests/Unicast/StartAndStoppablesRunnerTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/StartAndStoppablesRunnerTests.cs
@@ -141,6 +141,17 @@
             Assert.True(startable2.Stopped);
         }
 
+        [Test]
+        public void Should_throw_friendly_exception_when_IWantToRunWhenBusStartsAndStops_Start_returns_null()
+        {
+            var startable = new StartableStartReturnsNull();
+            var thingsToBeStarted = new IWantToRunWhenBusStartsAndStops[] { startable };
+
+            var runner = new StartAndStoppablesRunner(thingsToBeStarted);
+
+            Assert.That(async () => await runner.Start(null), Throws.Exception.With.Message.EqualTo("Return a Task or mark the method as async."));
+        }
+
         class Startable1 : IWantToRunWhenBusStartsAndStops
         {
             public bool Started { get; set; }
@@ -174,6 +185,32 @@
             {
                 Stopped = true;
                 return TaskEx.CompletedTask;
+            }
+        }
+
+        class StartableStartReturnsNull : IWantToRunWhenBusStartsAndStops
+        {
+            public Task Start(IMessageSession session)
+            {
+                return null;
+            }
+
+            public Task Stop(IMessageSession session)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        class StartableStopReturnsNull : IWantToRunWhenBusStartsAndStops
+        {
+            public Task Start(IMessageSession session)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task Stop(IMessageSession session)
+            {
+                return null;
             }
         }
 

--- a/src/NServiceBus.Core/IHandleMessages.cs
+++ b/src/NServiceBus.Core/IHandleMessages.cs
@@ -19,6 +19,7 @@ namespace NServiceBus
         /// This method will be called when a message arrives on at the endpoint and should contain
         /// the custom logic to execute when the message is received.
         /// </remarks>
+        /// <exception cref="System.Exception">This exception will be thrown if <code>null</code> is returned. Return a Task or mark the method as <code>async</code>.</exception>
         Task Handle(T message, IMessageHandlerContext context);
     }
 }

--- a/src/NServiceBus.Core/IWantToRunWhenBusStartsAndStops.cs
+++ b/src/NServiceBus.Core/IWantToRunWhenBusStartsAndStops.cs
@@ -13,11 +13,13 @@
         /// <summary>
         /// Method called at startup.
         /// </summary>
+        /// <exception cref="System.Exception">This exception will be thrown if <code>null</code> is returned. Return a Task or mark the method as <code>async</code>.</exception>
         Task Start(IMessageSession session);
 
         /// <summary>
         /// Method called on shutdown.
         /// </summary>
+        /// <exception cref="System.Exception">This exception will be thrown if <code>null</code> is returned. Return a Task or mark the method as <code>async</code>.</exception>
         Task Stop(IMessageSession session);
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs
@@ -22,8 +22,10 @@
             }
 
             var messageHandler = context.MessageHandler;
+
             await messageHandler
                 .Invoke(context.MessageBeingHandled, context)
+                .ThrowIfNull()
                 .ConfigureAwait(false);
         }
 

--- a/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/IMutateIncomingMessages.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/IMutateIncomingMessages.cs
@@ -12,6 +12,7 @@ namespace NServiceBus.MessageMutator
         /// <summary>
         /// Mutates the given message right after it has been deserialized.
         /// </summary>
+        /// <exception cref="System.Exception">This exception will be thrown if <code>null</code> is returned. Return a Task or mark the method as <code>async</code>.</exception>
         Task MutateIncoming(MutateIncomingMessageContext context);
     }
 }

--- a/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/IMutateOutgoingMessages.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/IMutateOutgoingMessages.cs
@@ -12,6 +12,7 @@ namespace NServiceBus.MessageMutator
         /// <summary>
         /// Mutates the given message just before it's serialized.
         /// </summary>
+        /// <exception cref="System.Exception">This exception will be thrown if <code>null</code> is returned. Return a Task or mark the method as <code>async</code>.</exception>
         Task MutateOutgoing(MutateOutgoingMessageContext context);
     }
 }

--- a/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehavior.cs
@@ -15,7 +15,9 @@
             var mutatorContext = new MutateIncomingMessageContext(current, context.Headers);
             foreach (var mutator in context.Builder.BuildAll<IMutateIncomingMessages>())
             {
-                await mutator.MutateIncoming(mutatorContext).ConfigureAwait(false);
+                await mutator.MutateIncoming(mutatorContext)
+                    .ThrowIfNull()
+                    .ConfigureAwait(false);
             }
 
             if (mutatorContext.MessageInstanceChanged)

--- a/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateOutgoingMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateOutgoingMessageBehavior.cs
@@ -24,7 +24,9 @@
 
             foreach (var mutator in context.Builder.BuildAll<IMutateOutgoingMessages>())
             {
-                await mutator.MutateOutgoing(mutatorContext).ConfigureAwait(false);
+                await mutator.MutateOutgoing(mutatorContext)
+                    .ThrowIfNull()
+                    .ConfigureAwait(false);
             }
 
             if (mutatorContext.MessageInstanceChanged)

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/IMutateIncomingTransportMessages.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/IMutateIncomingTransportMessages.cs
@@ -13,6 +13,7 @@ namespace NServiceBus.MessageMutator
         /// <summary>
         /// Modifies various properties of the transport message.
         /// </summary>
+        /// <exception cref="System.Exception">This exception will be thrown if <code>null</code> is returned. Return a Task or mark the method as <code>async</code>.</exception>
         Task MutateIncoming(MutateIncomingTransportMessageContext context);
     }
 }

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/IMutateOutgoingTransportMessages.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/IMutateOutgoingTransportMessages.cs
@@ -13,6 +13,7 @@ namespace NServiceBus.MessageMutator
         /// Performs the mutation.
         /// </summary>
         /// <param name="context">Contains information about the current message and provides ways to mutate it.</param>
+        /// <exception cref="System.Exception">This exception will be thrown if <code>null</code> is returned. Return a Task or mark the method as <code>async</code>.</exception>
         Task MutateOutgoing(MutateOutgoingTransportMessageContext context);
     }
 }

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
@@ -14,7 +14,9 @@
             var mutatorContext = new MutateIncomingTransportMessageContext(transportMessage.Body, transportMessage.Headers);
             foreach (var mutator in mutators)
             {
-                await mutator.MutateIncoming(mutatorContext).ConfigureAwait(false);
+                await mutator.MutateIncoming(mutatorContext)
+                    .ThrowIfNull()
+                    .ConfigureAwait(false);
             }
 
             if (mutatorContext.MessageBodyChanged)

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageBehavior.cs
@@ -27,7 +27,9 @@
 
             foreach (var mutator in context.Builder.BuildAll<IMutateOutgoingTransportMessages>())
             {
-                await mutator.MutateOutgoing(mutatorContext).ConfigureAwait(false);
+                await mutator.MutateOutgoing(mutatorContext)
+                    .ThrowIfNull()
+                    .ConfigureAwait(false);
             }
 
             if (mutatorContext.MessageBodyChanged)

--- a/src/NServiceBus.Core/Sagas/CustomFinderAdapter.cs
+++ b/src/NServiceBus.Core/Sagas/CustomFinderAdapter.cs
@@ -15,7 +15,10 @@ namespace NServiceBus
 
             var finder = (IFindSagas<TSagaData>.Using<TMessage>) builder.Build(customFinderType);
 
-            return await finder.FindBy((TMessage) message, storageSession, context).ConfigureAwait(false);
+            return await finder
+                .FindBy((TMessage) message, storageSession, context)
+                .ThrowIfNull()
+                .ConfigureAwait(false);
         }
     }
 }

--- a/src/NServiceBus.Core/Sagas/IFindSagas.cs
+++ b/src/NServiceBus.Core/Sagas/IFindSagas.cs
@@ -18,6 +18,7 @@ namespace NServiceBus.Sagas
             /// <summary>
             /// Finds a saga entity of the type T using a message of type M.
             /// </summary>
+            /// <exception cref="System.Exception">This exception will be thrown if <code>null</code> is returned. Return a Task&lt;T&gt; or mark the method as <code>async</code>.</exception>
             Task<T> FindBy(M message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context);
         }
     }

--- a/src/NServiceBus.Core/Sagas/IHandleSagaNotFound.cs
+++ b/src/NServiceBus.Core/Sagas/IHandleSagaNotFound.cs
@@ -13,6 +13,7 @@ namespace NServiceBus.Sagas
         /// Implementors will implement this method, likely using an injected IBus
         /// to send responses to the client who sent the message.
         /// </summary>
+        /// <exception cref="System.Exception">This exception will be thrown if <code>null</code> is returned. Return a Task or mark the method as <code>async</code>.</exception>
         Task Handle(object message, IMessageProcessingContext context);
     }
 }

--- a/src/NServiceBus.Core/Sagas/IHandleTimeouts.cs
+++ b/src/NServiceBus.Core/Sagas/IHandleTimeouts.cs
@@ -12,6 +12,7 @@ namespace NServiceBus
         /// <summary>
         /// Called when the timeout has expired.
         /// </summary>
+        /// <exception cref="System.Exception">This exception will be thrown if <code>null</code> is returned. Return a Task or mark the method as <code>async</code>.</exception>
         Task Timeout(T state, IMessageHandlerContext context);
     }
 }

--- a/src/NServiceBus.Core/Sagas/InvokeSagaNotFoundBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/InvokeSagaNotFoundBehavior.cs
@@ -25,7 +25,11 @@ namespace NServiceBus
             foreach (var handler in context.Builder.BuildAll<IHandleSagaNotFound>())
             {
                 logger.DebugFormat("Invoking SagaNotFoundHandler ('{0}')", handler.GetType().FullName);
-                await handler.Handle(context.Message.Instance, context).ConfigureAwait(false);
+
+                await handler
+                    .Handle(context.Message.Instance, context)
+                    .ThrowIfNull()
+                    .ConfigureAwait(false);
             }
         }
 

--- a/src/NServiceBus.Core/TaskEx.cs
+++ b/src/NServiceBus.Core/TaskEx.cs
@@ -1,11 +1,14 @@
 namespace NServiceBus
 {
+    using System;
     using System.Threading.Tasks;
 
     static class TaskEx
     {
+        const string TaskIsNullExceptionMessage = "Return a Task or mark the method as async.";
+
         // ReSharper disable once UnusedParameter.Global
-        // Used to explicitly suppress the compiler warning about 
+        // Used to explicitly suppress the compiler warning about
         // using the returned value from async operations
         public static void Ignore(this Task task)
         {
@@ -16,5 +19,25 @@ namespace NServiceBus
 
         public static readonly Task<bool> TrueTask = Task.FromResult(true);
         public static readonly Task<bool> FalseTask = Task.FromResult(false);
+
+        public static Task<T> ThrowIfNull<T>(this Task<T> task)
+        {
+            if (task != null)
+            {
+                return task;
+            }
+
+            throw new Exception(TaskIsNullExceptionMessage);
+        }
+
+        public static Task ThrowIfNull(this Task task)
+        {
+            if (task != null)
+            {
+                return task;
+            }
+
+            throw new Exception(TaskIsNullExceptionMessage);
+        }
     }
 }

--- a/src/NServiceBus.Core/Unicast/StartAndStoppablesRunner.cs
+++ b/src/NServiceBus.Core/Unicast/StartAndStoppablesRunner.cs
@@ -20,7 +20,7 @@
             var startableTasks = new List<Task>();
             foreach (var startable in wantToRunWhenBusStartsAndStopses)
             {
-                var task = startable.Start(session);
+                var task = startable.Start(session).ThrowIfNull();
 
                 var startable1 = startable;
                 task.ContinueWith(t =>
@@ -49,7 +49,7 @@
             {
                 try
                 {
-                    var task = stoppable.Stop(session);
+                    var task = stoppable.Stop(session).ThrowIfNull();
 
                     var stoppable1 = stoppable;
                     task.ContinueWith(t =>

--- a/src/NServiceBus.Core/UnitOfWork/IManageUnitsOfWork.cs
+++ b/src/NServiceBus.Core/UnitOfWork/IManageUnitsOfWork.cs
@@ -12,11 +12,13 @@ namespace NServiceBus.UnitOfWork
         /// <summary>
         /// Called before all message handlers and modules.
         /// </summary>
+        /// <exception cref="System.Exception">This exception will be thrown if <code>null</code> is returned. Return a Task or mark the method as <code>async</code>.</exception>
         Task Begin();
 
         /// <summary>
         /// Called after all message handlers and modules, if an error has occurred the exception will be passed.
         /// </summary>
+        /// <exception cref="System.Exception">This exception will be thrown if <code>null</code> is returned. Return a Task or mark the method as <code>async</code>.</exception>
         Task End(Exception ex = null);
     }
 }

--- a/src/NServiceBus.Core/UnitOfWork/UnitOfWorkBehavior.cs
+++ b/src/NServiceBus.Core/UnitOfWork/UnitOfWorkBehavior.cs
@@ -19,6 +19,7 @@
                 {
                     unitsOfWork.Push(uow);
                     await uow.Begin()
+                        .ThrowIfNull()
                         .ConfigureAwait(false);
                 }
 
@@ -26,8 +27,10 @@
 
                 while (unitsOfWork.Count > 0)
                 {
-                    await unitsOfWork.Pop()
-                        .End().ConfigureAwait(false);
+                    var popped = unitsOfWork.Pop();
+                    await popped.End()
+                        .ThrowIfNull()
+                        .ConfigureAwait(false);
                 }
             }
             catch (MessageDeserializationException)
@@ -55,6 +58,7 @@
                 try
                 {
                     await uow.End(initialException)
+                        .ThrowIfNull()
                         .ConfigureAwait(false);
                 }
                 catch (Exception endException)


### PR DESCRIPTION
Closes #3533

Null checks for:

- IHandleMessages.Handle
- Sagas:
   - IHandleTimeouts.Timeout [Not explicitly tested]
   - IFindSagas.FindBy
   - IHandleSagaNotFound.Handle
- IWantToRunWhenBusStartsAndStops.Start
- IWantToRunWhenBusStartsAndStops.Stop [Not tested - exception is logged but swallowed]

@danielmarbach Can you review what I have done so far? Anything I missed for the first group?