### PR TITLE
Fix wire compatibility for v6

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Correlation/When_repling_to_received_message_without_correlationid.cs
+++ b/src/NServiceBus.AcceptanceTests/Correlation/When_repling_to_received_message_without_correlationid.cs
@@ -1,0 +1,96 @@
+﻿namespace NServiceBus.AcceptanceTests.Correlation
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class When_repling_to_received_message_without_correlationid : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_use_the_incoming_message_id_as_the_correlation_id()
+        {
+            const string mycustomid = "mycustomid";
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<CorrelationEndpoint>(b => b.When(session =>
+                {
+                    var sendOptions = new SendOptions();
+                    sendOptions.RouteToThisEndpoint();
+                    sendOptions.SetMessageId(mycustomid);
+                    return session.Send(new MyRequest(), sendOptions);
+                }))
+                .Done(c => c.GotResponse)
+                .Run();
+
+            Assert.AreEqual(mycustomid, context.CorrelationIdReceived, "Correlation id should match MessageId");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotResponse { get; set; }
+            public string CorrelationIdReceived { get; set; }
+        }
+
+        public class CorrelationEndpoint : EndpointConfigurationBuilder
+        {
+            public CorrelationEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.RegisterComponents(
+                    components => { components.ConfigureComponent<RemoveCorrelationId>(DependencyLifecycle.InstancePerCall); }));
+            }
+
+            public class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Task Handle(MyRequest message, IMessageHandlerContext context)
+                {
+                    return context.Reply(new MyResponse());
+                }
+            }
+
+            public class MyResponseHandler : IHandleMessages<MyResponse>
+            {
+                public MyResponseHandler(Context context)
+                {
+                    this.context = context;
+                }
+
+                public Task Handle(MyResponse message, IMessageHandlerContext c)
+                {
+                    context.CorrelationIdReceived = c.MessageHeaders[Headers.CorrelationId];
+                    context.GotResponse = true;
+
+                    return Task.FromResult(0);
+                }
+
+                readonly Context context;
+            }
+
+            class RemoveCorrelationId : IMutateIncomingTransportMessages
+            {
+                public Task MutateIncoming(MutateIncomingTransportMessageContext context)
+                {
+                    if (context.Headers[Headers.MessageIntent] != MessageIntentEnum.Reply.ToString())
+                    {
+                        context.Headers.Remove(Headers.CorrelationId);
+                    }
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+
+        [Serializable]
+        public class MyRequest : IMessage
+        {
+        }
+
+        [Serializable]
+        public class MyResponse : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Correlation/When_replying_to_received_message_without_correlationid.cs
+++ b/src/NServiceBus.AcceptanceTests/Correlation/When_replying_to_received_message_without_correlationid.cs
@@ -1,13 +1,12 @@
 ﻿namespace NServiceBus.AcceptanceTests.Correlation
 {
-    using System;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
     using MessageMutator;
     using NUnit.Framework;
 
-    public class When_repling_to_received_message_without_correlationid : NServiceBusAcceptanceTest
+    public class When_replying_to_received_message_without_correlationid : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_use_the_incoming_message_id_as_the_correlation_id()
@@ -82,13 +81,10 @@
             }
         }
 
-
-        [Serializable]
         public class MyRequest : IMessage
         {
         }
 
-        [Serializable]
         public class MyResponse : IMessage
         {
         }

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -60,7 +60,7 @@
     <Compile Include="Causation\When_a_message_is_faulted.cs" />
     <Compile Include="Causation\When_a_message_is_audited.cs" />
     <Compile Include="ConfigureEndpointInMemoryPersistence.cs" />
-    <Compile Include="Correlation\When_repling_to_received_message_without_correlationid.cs" />
+    <Compile Include="Correlation\When_replying_to_received_message_without_correlationid.cs" />
     <Compile Include="DelayedDelivery\When_deferring_a_message_to_the_past.cs" />
     <Compile Include="DelayedDelivery\TimeoutManager\When_timeout_dispatch_fails.cs" />
     <Compile Include="DelayedDelivery\TimeoutManager\When_timeout_dispatch_fails_on_timeout_data_removal.cs" />

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Causation\When_a_message_is_faulted.cs" />
     <Compile Include="Causation\When_a_message_is_audited.cs" />
     <Compile Include="ConfigureEndpointInMemoryPersistence.cs" />
+    <Compile Include="Correlation\When_repling_to_received_message_without_correlationid.cs" />
     <Compile Include="DelayedDelivery\When_deferring_a_message_to_the_past.cs" />
     <Compile Include="DelayedDelivery\TimeoutManager\When_timeout_dispatch_fails.cs" />
     <Compile Include="DelayedDelivery\TimeoutManager\When_timeout_dispatch_fails_on_timeout_data_removal.cs" />

--- a/src/NServiceBus.Core/Correlation/AttachCorrelationIdBehavior.cs
+++ b/src/NServiceBus.Core/Correlation/AttachCorrelationIdBehavior.cs
@@ -25,6 +25,11 @@
                     {
                         correlationId = incomingCorrelationId;
                     }
+
+                    if (string.IsNullOrEmpty(correlationId) && current.Headers.TryGetValue(Headers.MessageId, out incomingCorrelationId))
+                    {
+                        correlationId = incomingCorrelationId;
+                    }
                 }
             }
 

--- a/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
@@ -33,7 +33,7 @@
 
         static bool IsControlMessage(IncomingMessage incomingMessage)
         {
-            return incomingMessage.Headers.ContainsKey(Headers.ControlMessageHeader) && incomingMessage.Headers[Headers.ControlMessageHeader] == true.ToString();
+            return incomingMessage.Headers.ContainsKey(Headers.ControlMessageHeader) && incomingMessage.Headers[Headers.ControlMessageHeader] == Boolean.TrueString;
         }
 
         IEnumerable<LogicalMessage> ExtractWithExceptionHandling(IncomingMessage message)

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -39,9 +39,10 @@
                 subscriptionMessage.Headers[Headers.ReplyToAddress] = subscriberAddress;
                 subscriptionMessage.Headers[Headers.SubscriberTransportAddress] = subscriberAddress;
                 subscriptionMessage.Headers[Headers.SubscriberEndpoint] = subscriberEndpoint.ToString();
-                var address = publisherAddress;
+                subscriptionMessage.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
+                subscriptionMessage.Headers[Headers.NServiceBusVersion] = GitFlowVersion.MajorMinorPatch;
 
-                subscribeTasks.Add(SendSubscribeMessageWithRetries(address, subscriptionMessage, eventType.AssemblyQualifiedName, context.Extensions));
+                subscribeTasks.Add(SendSubscribeMessageWithRetries(publisherAddress, subscriptionMessage, eventType.AssemblyQualifiedName, context.Extensions));
             }
             await Task.WhenAll(subscribeTasks.ToArray()).ConfigureAwait(false);
         }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -39,6 +39,8 @@
                 unsubscribeMessage.Headers[Headers.ReplyToAddress] = replyToAddress;
                 unsubscribeMessage.Headers[Headers.SubscriberTransportAddress] = replyToAddress;
                 unsubscribeMessage.Headers[Headers.SubscriberEndpoint] = endpoint.ToString();
+                unsubscribeMessage.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
+                unsubscribeMessage.Headers[Headers.NServiceBusVersion] = GitFlowVersion.MajorMinorPatch;
 
                 unsubscribeTasks.Add(SendUnsubscribeMessageWithRetries(publisherAddress, unsubscribeMessage, eventType.AssemblyQualifiedName, context.Extensions));
             }
@@ -62,7 +64,7 @@
                 }
                 else
                 {
-                    string message = $"Failed to unsubsribe for {messageType} at publisher queue {destination}, reason {ex.Message}";
+                    string message = $"Failed to unsubscribe for {messageType} at publisher queue {destination}, reason {ex.Message}";
                     Logger.Error(message, ex);
                     throw new QueueNotFoundException(destination, message, ex);
                 }

--- a/src/NServiceBus.Core/Unicast/Transport/ControlMessageFactory.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/ControlMessageFactory.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Unicast.Transport
 {
+    using System;
     using System.Collections.Generic;
     using Transports;
 
@@ -15,7 +16,7 @@ namespace NServiceBus.Unicast.Transport
         public static OutgoingMessage Create(MessageIntentEnum intent)
         {
             var message = new OutgoingMessage(CombGuid.Generate().ToString(), new Dictionary<string, string>(), new byte[0]);
-            message.Headers[Headers.ControlMessageHeader] = true.ToString();
+            message.Headers[Headers.ControlMessageHeader] = Boolean.TrueString;
             message.Headers[Headers.MessageIntent] = intent.ToString();
 
             return message;

--- a/src/NServiceBus.Msmq.AcceptanceTests/NServiceBus.Msmq.AcceptanceTests.csproj
+++ b/src/NServiceBus.Msmq.AcceptanceTests/NServiceBus.Msmq.AcceptanceTests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="When_customizing_scope_isolation_level.cs" />
     <Compile Include="When_publishing.cs" />
     <Compile Include="When_publishing_with_authorizer.cs" />
+    <Compile Include="When_receiving_control_message_with_body.cs" />
     <Compile Include="When_receiving_with_dtc_disabled.cs" />
     <Compile Include="When_replying_to_a_message_sent_via_a_distributor.cs" />
     <Compile Include="When_setting_label_generator.cs" />

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_receiving_control_message_with_body.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_receiving_control_message_with_body.cs
@@ -53,7 +53,7 @@
                 {
                     try
                     {
-                        await next();
+                        await next().ConfigureAwait(false);
                     }
                     catch (Exception)
                     {

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_receiving_control_message_with_body.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_receiving_control_message_with_body.cs
@@ -1,0 +1,106 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using Extensibility;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+    using Pipeline;
+    using Transports;
+
+    public class When_receiving_control_message_with_body : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_treat_it_as_control_message()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<TestingEndpoint>()
+                .Done(c => c.ControlMessageProcessed || c.ControlMessageFailed)
+                .Run();
+
+            Assert.IsTrue(context.ControlMessageProcessed);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool ControlMessageProcessed { get; set; }
+            public bool ControlMessageFailed { get; set; }
+        }
+
+        public class TestingEndpoint : EndpointConfigurationBuilder
+        {
+            public TestingEndpoint()
+            {
+                EndpointSetup<DefaultServer>((config, context) =>
+                {
+                    config.UseTransport<MsmqTransport>();
+                    config.Pipeline.Register("AssertBehavior", typeof(AssertBehavior), "Asserts message was processed without any failures");
+                });
+            }
+
+            public class AssertBehavior : Behavior<IIncomingPhysicalMessageContext>
+            {
+                public AssertBehavior(Context context)
+                {
+                    this.context = context;
+                }
+
+                public override async Task Invoke(IIncomingPhysicalMessageContext c, Func<Task> next)
+                {
+                    try
+                    {
+                        await next();
+                    }
+                    catch (Exception)
+                    {
+                        context.ControlMessageFailed = true;
+                        return;
+                    }
+
+                    context.ControlMessageProcessed = true;
+                }
+
+                readonly Context context;
+            }
+
+            public class Starter : IWantToRunWhenBusStartsAndStops
+            {
+                public Starter(IDispatchMessages dispatcher)
+                {
+                    this.dispatcher = dispatcher;
+                }
+
+                public Task Start(IMessageSession session)
+                {
+                    // Simulating a v3.3 control message
+                    var body = Encoding.UTF8.GetBytes(@"<?xml version=""1.0""?>
+<Messages xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns=""http://tempuri.net/NServiceBus.Unicast.Transport"">
+    <CompletionMessage>
+        <ErrorCode>5</ErrorCode>
+    </CompletionMessage>
+</Messages>");
+                    var outgoingMessage = new OutgoingMessage("0dac4ec2-a0ed-42ee-a306-ff191322d59d\\47283703", new Dictionary<string, string>
+                    {
+                        {"NServiceBus.ControlMessage", "True"},
+                        {"NServiceBus.ReturnMessage.ErrorCode", "5"},
+                        {"NServiceBus.ContentType", "text/xml"}
+                    }, body);
+
+                    var endpoint = Conventions.EndpointNamingConvention(typeof(TestingEndpoint));
+                    return dispatcher.Dispatch(new TransportOperations(new TransportOperation(outgoingMessage, new UnicastAddressTag(endpoint))), new ContextBag());
+                }
+
+                public Task Stop(IMessageSession session)
+                {
+                    return Task.CompletedTask;
+                }
+
+                readonly IDispatchMessages dispatcher;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Theses issues were uncovered by #3573:

1. [x] Stop deserializing control messages  
Control messages are still being received from early versions of NServiceBus, eg v3.3
1. [x] Add missing Version and TimeSent headers to subscribe and unsubscribe messages
1. [x] Attempt to assign incoming message id as correlation id

fixes #3583 