### PR TITLE
Start and stop TransportInfrastructure

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2849,6 +2849,8 @@ namespace NServiceBus.Transports
         public abstract NServiceBus.Transports.TransportSendInfrastructure ConfigureSendInfrastructure();
         public abstract NServiceBus.Transports.TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure();
         public virtual string MakeCanonicalForm(string transportAddress) { }
+        public virtual System.Threading.Tasks.Task Start() { }
+        public virtual System.Threading.Tasks.Task Stop() { }
         public abstract string ToTransportAddress(NServiceBus.LogicalAddress logicalAddress);
     }
     public class TransportOperation

--- a/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
@@ -1,11 +1,15 @@
 ﻿namespace NServiceBus.Unicast.Tests
 {
+    using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.Core.Tests;
     using NServiceBus.Features;
+    using NServiceBus.Routing;
     using NServiceBus.Settings;
     using NUnit.Framework;
+    using Transports;
 
     [TestFixture]
     public class RunningEndpointInstanceTest
@@ -19,11 +23,42 @@
                 new PipelineCollection(Enumerable.Empty<TransportReceiver>()), 
                 new StartAndStoppablesRunner(Enumerable.Empty<IWantToRunWhenBusStartsAndStops>()), 
                 new FeatureRunner(new FeatureActivator(new SettingsHolder())),
-                new MessageSession(new RootContext(null, null, null)));
+                new MessageSession(new RootContext(null, null, null)), new FakeTransportInfrastructure());
 
             await testee.Stop();
 
             Assert.That(async () => await testee.Stop(), Throws.Nothing);
+        }
+
+        class FakeTransportInfrastructure : TransportInfrastructure
+        {
+            public override IEnumerable<Type> DeliveryConstraints { get; }
+            public override TransportTransactionMode TransactionMode { get; }
+            public override OutboundRoutingPolicy OutboundRoutingPolicy { get; }
+            public override TransportReceiveInfrastructure ConfigureReceiveInfrastructure()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override TransportSendInfrastructure ConfigureSendInfrastructure()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure()
+            {
+                throw new NotImplementedException();
+            }
+
+            public override EndpointInstance BindToLocalEndpoint(EndpointInstance instance)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override string ToTransportAddress(LogicalAddress logicalAddress)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -47,7 +47,8 @@ namespace NServiceBus
 
             var transportDefinition = settings.Get<TransportDefinition>();
             var connectionString = settings.Get<TransportConnectionString>().GetConnectionStringOrRaiseError(transportDefinition);
-            settings.Set<TransportInfrastructure>(transportDefinition.Initialize(settings, connectionString));
+            var transportInfrastructure = transportDefinition.Initialize(settings, connectionString);
+            settings.Set<TransportInfrastructure>(transportInfrastructure);
 
             var featureStats = featureActivator.SetupFeatures(container, pipelineSettings);
 
@@ -58,7 +59,7 @@ namespace NServiceBus
 
             container.ConfigureComponent(b => settings.Get<BusNotifications>(), DependencyLifecycle.SingleInstance);
 
-            var startableEndpoint = new StartableEndpoint(settings, builder, featureActivator, pipelineConfiguration, startables, new EventAggregator(settings.Get<NotificationSubscriptions>()));
+            var startableEndpoint = new StartableEndpoint(settings, builder, featureActivator, pipelineConfiguration, startables, new EventAggregator(settings.Get<NotificationSubscriptions>()), transportInfrastructure);
             return Task.FromResult<IStartableEndpoint>(startableEndpoint);
         }
 

--- a/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Transports
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Routing;
 
     /// <summary>
@@ -64,6 +65,22 @@ namespace NServiceBus.Transports
         public virtual string MakeCanonicalForm(string transportAddress)
         {
             return transportAddress;
+        }
+
+        /// <summary>
+        /// Performs any action required to warm up the transport infrastructure before starting the endpoint.
+        /// </summary>
+        public virtual Task Start()
+        {
+            return TaskEx.CompletedTask;
+        }
+
+        /// <summary>
+        /// Performs any action required to cool down the transport infrastructure when the endpoint is stopping.
+        /// </summary>
+        public virtual Task Stop()
+        {
+            return TaskEx.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -7,11 +7,12 @@ namespace NServiceBus
     using Logging;
     using ObjectBuilder;
     using Settings;
+    using Transports;
     using UnicastBus = Unicast.UnicastBus;
 
     class RunningEndpointInstance : IEndpointInstance
     {
-        public RunningEndpointInstance(SettingsHolder settings, IBuilder builder, PipelineCollection pipelineCollection, StartAndStoppablesRunner startAndStoppablesRunner, FeatureRunner featureRunner, IMessageSession messageSession)
+        public RunningEndpointInstance(SettingsHolder settings, IBuilder builder, PipelineCollection pipelineCollection, StartAndStoppablesRunner startAndStoppablesRunner, FeatureRunner featureRunner, IMessageSession messageSession, TransportInfrastructure transportInfrastructure)
         {
             this.settings = settings;
             this.builder = builder;
@@ -19,6 +20,7 @@ namespace NServiceBus
             this.startAndStoppablesRunner = startAndStoppablesRunner;
             this.featureRunner = featureRunner;
             this.messageSession = messageSession;
+            this.transportInfrastructure = transportInfrastructure;
         }
 
         public async Task Stop()
@@ -42,6 +44,7 @@ namespace NServiceBus
                 await pipelineCollection.Stop().ConfigureAwait(false);
                 await featureRunner.Stop(messageSession).ConfigureAwait(false);
                 await startAndStoppablesRunner.Stop(messageSession).ConfigureAwait(false);
+                await transportInfrastructure.Stop().ConfigureAwait(false);
                 settings.Clear();
                 builder.Dispose();
 
@@ -87,6 +90,7 @@ namespace NServiceBus
         IBuilder builder;
         FeatureRunner featureRunner;
         IMessageSession messageSession;
+        TransportInfrastructure transportInfrastructure;
 
         PipelineCollection pipelineCollection;
         SettingsHolder settings;


### PR DESCRIPTION
Ability to perform, as a transport, actions before starting an endpoint and after stopping it (e.g. initialize and close connection to the broker).

The scenario where I discovered this missing extension point was the EventStore transport. ES uses "intelligent" thread-safe connections. Such connection should be initialized when starting the endpoint and closed when stopping it.