### PR TITLE
Fix replacing behaviors

### DIFF
--- a/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_empty_id_header.cs
+++ b/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_empty_id_header.cs
@@ -6,7 +6,7 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using Pipeline;
+    using NServiceBus.Pipeline;
     using NUnit.Framework;
 
     public class When_message_has_empty_id_header : NServiceBusAcceptanceTest
@@ -15,9 +15,9 @@
         public async Task A_message_id_is_generated_by_the_transport_layer()
         {
             var context = await Scenario.Define<Context>()
-                    .WithEndpoint<Endpoint>(g => g.When(async b => await b.SendLocal(new Message())))
-                    .Done(c => c.MessageReceived)
-                    .Run();
+                .WithEndpoint<Endpoint>(g => g.When(b => b.SendLocal(new Message())))
+                .Done(c => c.MessageReceived)
+                .Run();
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(context.MessageId));
             Assert.AreEqual(context.MessageId, context.Headers[Headers.MessageId], "Should populate the NServiceBus.MessageId header with the new value");
@@ -69,5 +69,4 @@
         {
         }
     }
-
 }

--- a/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_no_id_header.cs
+++ b/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_no_id_header.cs
@@ -5,7 +5,7 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using Pipeline;
+    using NServiceBus.Pipeline;
     using NUnit.Framework;
 
     public class When_message_has_no_id_header : NServiceBusAcceptanceTest
@@ -14,9 +14,9 @@
         public async Task A_message_id_is_generated_by_the_transport_layer_on_receiving_side()
         {
             var context = await Scenario.Define<Context>()
-                     .WithEndpoint<Endpoint>(g => g.When(async b => await b.SendLocal(new Message())))
-                     .Done(c => c.MessageReceived)
-                     .Run();
+                .WithEndpoint<Endpoint>(g => g.When(b => b.SendLocal(new Message())))
+                .Done(c => c.MessageReceived)
+                .Run();
 
             Assert.IsFalse(string.IsNullOrWhiteSpace(context.MessageId));
         }
@@ -65,5 +65,4 @@
         {
         }
     }
-
 }

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="EndpointTemplates\DefaultServer.cs" />
     <Compile Include="Mutators\When_using_outgoing_tm_mutator.cs" />
     <Compile Include="Performance\When_message_is_faulted.cs" />
+    <Compile Include="Pipeline\When_replacing_behavior.cs" />
     <Compile Include="Recoverability\Retries\When_message_fails_retries.cs" />
     <Compile Include="Recoverability\Retries\When_performing_slr_and_counting.cs" />
     <Compile Include="Recoverability\Retries\When_performing_slr_with_non_min_policy.cs" />

--- a/src/NServiceBus.AcceptanceTests/Pipeline/When_replacing_behavior.cs
+++ b/src/NServiceBus.AcceptanceTests/Pipeline/When_replacing_behavior.cs
@@ -1,0 +1,98 @@
+﻿namespace NServiceBus.AcceptanceTests.Pipeline
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    public class When_replacing_behavior : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_invoke_replacement_in_pipeline()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithReplacement>(e => e
+                    .When(s => s.SendLocal<Message>(m => { })))
+                .Done(c => c.MessageHandled)
+                .Run();
+
+            Assert.IsFalse(context.OriginalBehaviorInvoked);
+            Assert.IsTrue(context.ReplacementBehaviorInvoked);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool OriginalBehaviorInvoked { get; set; }
+            public bool ReplacementBehaviorInvoked { get; set; }
+
+            public bool MessageHandled { get; set; }
+        }
+
+        class OriginalBehavior : Behavior<ITransportReceiveContext>
+        {
+            public OriginalBehavior(Context testContext)
+            {
+                this.testContext = testContext;
+            }
+
+            public override Task Invoke(ITransportReceiveContext context, Func<Task> next)
+            {
+                testContext.OriginalBehaviorInvoked = true;
+                return next();
+            }
+
+            Context testContext;
+        }
+
+        class ReplacementBehavior : Behavior<ITransportReceiveContext>
+        {
+            public ReplacementBehavior(Context testContext)
+            {
+                this.testContext = testContext;
+            }
+
+            public override Task Invoke(ITransportReceiveContext context, Func<Task> next)
+            {
+                testContext.ReplacementBehaviorInvoked = true;
+                return next();
+            }
+
+            Context testContext;
+        }
+
+        class EndpointWithReplacement : EndpointConfigurationBuilder
+        {
+            public EndpointWithReplacement()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    // replace before register to ensure out-of-order replacements work correctly.
+                    c.Pipeline.Replace("demoBehavior", typeof(ReplacementBehavior));
+                    c.Pipeline.Register("demoBehavior", typeof(OriginalBehavior), "test behavior replacement");
+                });
+            }
+
+            public class Handler : IHandleMessages<Message>
+            {
+                public Handler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(Message message, IMessageHandlerContext context)
+                {
+                    testContext.MessageHandled = true;
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        class Message : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_audited.cs
@@ -6,7 +6,7 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using Configuration.AdvanceExtensibility;
-    using Pipeline;
+    using NServiceBus.Pipeline;
     using NUnit.Framework;
 
     public class When_a_message_is_audited : NServiceBusAcceptanceTest

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2138,6 +2138,10 @@ namespace NServiceBus.Pipeline
         public void Remove(string stepId) { }
         public void Remove(NServiceBus.Pipeline.WellKnownStep wellKnownStep) { }
         public void Replace(string stepId, System.Type newBehavior, string description = null) { }
+        public void Replace<T>(string stepId, T newBehavior, string description = null)
+            where T : NServiceBus.Pipeline.IBehavior { }
+        public void Replace<T>(string stepId, System.Func<NServiceBus.ObjectBuilder.IBuilder, T> factoryMethod, string description = null)
+            where T : NServiceBus.Pipeline.IBehavior { }
         public void Replace(NServiceBus.Pipeline.WellKnownStep wellKnownStep, System.Type newBehavior, string description = null) { }
     }
     public abstract class PipelineTerminator<T> : NServiceBus.Pipeline.StageConnector<T, NServiceBus.Pipeline.PipelineTerminator<T>.ITerminatingContext>, NServiceBus.IPipelineTerminator

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Pipeline\Outgoing\OutgoingReplyContextTests.cs" />
     <Compile Include="Pipeline\Outgoing\OutgoingSendContextTests.cs" />
     <Compile Include="FakeBehaviorContext.cs" />
+    <Compile Include="Pipeline\RegisterStepTests.cs" />
     <Compile Include="Routing\ApplyReplyToAddressBehaviorTests.cs" />
     <Compile Include="Routing\BestPracticesOptionExtensionsTests.cs" />
     <Compile Include="Routing\DetermineRouteForPublishBehaviorTests.cs" />

--- a/src/NServiceBus.Core.Tests/Pipeline/RegisterStepTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/RegisterStepTests.cs
@@ -1,0 +1,126 @@
+﻿namespace NServiceBus.Core.Tests.Pipeline
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus.Core.Tests.Features;
+    using NServiceBus.ObjectBuilder;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    public class RegisterStepTests
+    {
+        [Test]
+        public void Replace_WhenStepIdsDoNotMatch_ShouldThrowInvalidOperationException()
+        {
+            var registerStep = RegisterStep.Create("stepId 1", typeof(BehaviorA), "description");
+            var replacement = new ReplaceStep("stepId 2", typeof(BehaviorB));
+
+            Assert.Throws<InvalidOperationException>(() => registerStep.Replace(replacement));
+        }
+
+        [Test]
+        public void Replace_ShouldReplaceBehaviorType()
+        {
+            var registerStep = RegisterStep.Create("pipelineStep", typeof(BehaviorA), "description");
+            var replacement = new ReplaceStep("pipelineStep", typeof(BehaviorB));
+
+            registerStep.Replace(replacement);
+
+            Assert.AreEqual(typeof(BehaviorB), registerStep.BehaviorType);
+        }
+
+        [Test]
+        public void Replace_WhenReplacementContainsNoDescription_ShouldKeepOriginalDescription()
+        {
+            const string originalDescription = "description";
+            var registerStep = RegisterStep.Create("pipelineStep", typeof(BehaviorA), originalDescription);
+            var replacement = new ReplaceStep("pipelineStep", typeof(BehaviorB));
+
+            registerStep.Replace(replacement);
+
+            Assert.AreEqual(originalDescription, registerStep.Description);
+        }
+
+        [Test]
+        public void Replace_WhenReplacementContainsEmptyDescription_ShouldKeepOriginalDescription()
+        {
+            const string originalDescription = "description";
+            var registerStep = RegisterStep.Create("pipelineStep", typeof(BehaviorA), originalDescription);
+            var replacement = new ReplaceStep("pipelineStep", typeof(BehaviorB), "    ");
+
+            registerStep.Replace(replacement);
+
+            Assert.AreEqual(originalDescription, registerStep.Description);
+        }
+
+        [Test]
+        public void Replace_WhenReplacementContainsDescription_ShouldReplaceDescription()
+        {
+            const string replacementDescription = "new";
+            var registerStep = RegisterStep.Create("pipelineStep", typeof(BehaviorA), "description");
+            var replacement = new ReplaceStep("pipelineStep", typeof(BehaviorB), replacementDescription);
+
+            registerStep.Replace(replacement);
+
+            Assert.AreEqual(replacementDescription, registerStep.Description);
+        }
+
+        [Test]
+        public void Replace_WhenReplacementProvidesNoFactory_ShouldBuildReplacementFromBuilder()
+        {
+            var originalBehaviorFactoryCalled = false;
+            Func<IBuilder, IBehavior> originalBehaviorFactory = b =>
+            {
+                originalBehaviorFactoryCalled = true;
+                return new BehaviorA();
+            };
+
+            var builder = new FakeBuilder(typeof(BehaviorB));
+            var registerStep = RegisterStep.Create("pipelineStep", typeof(BehaviorA), "description", originalBehaviorFactory);
+            var replacement = new ReplaceStep("pipelineStep", typeof(BehaviorB));
+
+            registerStep.Replace(replacement);
+            var behavior = registerStep.CreateBehavior(builder);
+
+            Assert.IsFalse(originalBehaviorFactoryCalled);
+            Assert.AreEqual(typeof(BehaviorB), behavior.Type);
+        }
+
+        [Test]
+        public void Replace_WhenReplacementProvidedFactory_ShouldBuildReplacementFromFactory()
+        {
+            var replacementBehaviorFactoryCalled = false;
+            Func<IBuilder, IBehavior> replacementBehaviorFactory = b =>
+            {
+                replacementBehaviorFactoryCalled = true;
+                return new BehaviorA();
+            };
+
+            var builder = new FakeBuilder(typeof(BehaviorB));
+            var registerStep = RegisterStep.Create("pipelineStep", typeof(BehaviorA), "description", b => { throw new Exception(); });
+            var replacement = new ReplaceStep("pipelineStep", typeof(BehaviorB), factoryMethod: replacementBehaviorFactory);
+
+            registerStep.Replace(replacement);
+            var behavior = registerStep.CreateBehavior(builder);
+
+            Assert.IsTrue(replacementBehaviorFactoryCalled);
+            Assert.AreEqual(typeof(BehaviorB), behavior.Type);
+        }
+
+        class BehaviorA : Behavior<IRoutingContext>
+        {
+            public override Task Invoke(IRoutingContext context, Func<Task> next)
+            {
+                return TaskEx.CompletedTask;
+            }
+        }
+
+        class BehaviorB : Behavior<IRoutingContext>
+        {
+            public override Task Invoke(IRoutingContext context, Func<Task> next)
+            {
+                return TaskEx.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
@@ -55,11 +55,7 @@ namespace NServiceBus
                 }
 
                 var registerStep = registrations[metadata.ReplaceId];
-                registerStep.BehaviorType = metadata.BehaviorType;
-                if (!string.IsNullOrEmpty(metadata.Description))
-                {
-                    registerStep.Description = metadata.Description;
-                }
+                registerStep.Replace(metadata);
             }
 
             // Step 3: validate the removals

--- a/src/NServiceBus.Core/Pipeline/ReplaceStep.cs
+++ b/src/NServiceBus.Core/Pipeline/ReplaceStep.cs
@@ -1,18 +1,22 @@
 namespace NServiceBus
 {
     using System;
+    using NServiceBus.ObjectBuilder;
+    using NServiceBus.Pipeline;
 
     class ReplaceStep
     {
-        public ReplaceStep(string idToReplace, Type behavior, string description = null)
+        public ReplaceStep(string idToReplace, Type behavior, string description = null, Func<IBuilder, IBehavior> factoryMethod = null)
         {
             ReplaceId = idToReplace;
             Description = description;
             BehaviorType = behavior;
+            FactoryMethod = factoryMethod;
         }
 
-        public string ReplaceId { get; private set; }
-        public string Description { get; private set; }
-        public Type BehaviorType { get; private set; }
+        public string ReplaceId { get; }
+        public string Description { get; }
+        public Type BehaviorType { get; }
+        public Func<IBuilder, IBehavior> FactoryMethod { get; }
     }
 }


### PR DESCRIPTION
fixes #3574 

When replacing behaviors it didn't replace the behavior factory method of the original behavior registration. When the RegisterStep should create the instance of the behavior, it would fallback to the original factory instead of resolving the new behavior.

* Replacing factory method on `RegisterStep` properly
* Allowing Replacements to define a behavior instance or a behavior factory the same way as `pipeline.Register` does
* Added an acceptance test

@Particular/nservicebus-maintainers @indualagarsamy please review