### PR TITLE
Passing headers to apply of routing strategy in RouteDeferredMessageToTimeoutManagerBehavior

### DIFF
--- a/src/NServiceBus.Core/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehavior.cs
@@ -29,7 +29,7 @@ namespace NServiceBus
                 }
                 if (context.RoutingStrategies.Count > 1)
                 {
-                    var destinations = string.Join(", ", context.RoutingStrategies.Select(s => s.Apply(new Dictionary<string, string>())).Cast<UnicastAddressTag>().Select(l => l.Destination));
+                    var destinations = string.Join(", ", context.RoutingStrategies.Select(s => s.Apply(new Dictionary<string, string>(context.Message.Headers))).Cast<UnicastAddressTag>().Select(l => l.Destination));
                     throw new Exception($"A deferred message cannot contain more than one destination: {destinations}. This is the case when publishing an event to multiple subscriber endpoints or sending a command with overriden distribution strategy.");
                 }
 
@@ -40,7 +40,7 @@ namespace NServiceBus
                 }
 
                 //Hack 133
-                var ultimateDestination = ((UnicastAddressTag) context.RoutingStrategies.First().Apply(new Dictionary<string, string>())).Destination;
+                var ultimateDestination = ((UnicastAddressTag) context.RoutingStrategies.Single().Apply(new Dictionary<string, string>(context.Message.Headers))).Destination;
                 context.Message.Headers[TimeoutManagerHeaders.RouteExpiredTimeoutTo] = ultimateDestination;
                 context.RoutingStrategies = new[]
                 {


### PR DESCRIPTION
For consistency reasons we should either pass in the headers always to the routing strategies or refactor those to not depend on headers. The simplest low hanging fruit seemed for me to pass in the headers also in the `RouteDeferredMessageToTimeoutManagerBehavior`


@Particular/nservicebus-maintainers please review


Or would it be better to get rid of the headers on the strategies (which would be a breaking change)?


// cc @SzymonPobiega @janovesk 