### PR TITLE
Do not autosubscribe unless there is routing info when using unicast transports

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -265,6 +265,7 @@
             {
                 throw new Exception("Starting endpoints took longer than 2 minutes");
             }
+            await completedTask.ConfigureAwait(false);
         }
 
         static async Task StartEndpoint(EndpointRunner endpoint, Func<Exception, bool> allowedExceptions, CancellationTokenSource cts)

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -144,6 +144,7 @@
     </Compile>
     <Compile Include="Routing\SubscriptionBehaviorExtensions.cs" />
     <Compile Include="Routing\When_multi_subscribing_to_a_polymorphic_event_on_multicast_transports.cs" />
+    <Compile Include="Routing\When_handler_exists_but_routing_information_is_missing.cs" />
     <Compile Include="Routing\When_publishing_to_scaled_out_subscribers_on_unicast_transports.cs" />
     <Compile Include="Routing\When_publishing_to_scaled_out_subscribers_on_multicast_transports.cs" />
     <Compile Include="Routing\When_broadcasting_a_command.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/When_handler_exists_but_routing_information_is_missing.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_handler_exists_but_routing_information_is_missing.cs
@@ -1,0 +1,49 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System.Threading.Tasks;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.AcceptanceTests.ScenarioDescriptors;
+    using NUnit.Framework;
+
+    public class when_using_autosubscribe_with_missing_routing_information : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_skip_events_with_missing_routes()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<Subscriber>()
+                .Done(c => c.EndpointsStarted)
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Should(c =>
+                {
+                    Assert.True(c.EndpointsStarted);
+                })
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+
+        public class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Task Handle(MyEvent @event, IMessageHandlerContext context)
+                {
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_Audit_OverrideTimeToBeReceived_set_and_native_receive_tx.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_Audit_OverrideTimeToBeReceived_set_and_native_receive_tx.cs
@@ -1,10 +1,9 @@
 ﻿namespace NServiceBus.AcceptanceTests
 {
     using System;
-    using System.Linq;
     using System.Threading.Tasks;
-    using NServiceBus.AcceptanceTesting;
-    using NServiceBus.Config;
+    using AcceptanceTesting;
+    using Config;
     using NUnit.Framework;
 
     public class When_Audit_OverrideTimeToBeReceived_set_and_native_receive_tx : NServiceBusAcceptanceTest
@@ -12,15 +11,18 @@
         [Test]
         public async Task Endpoint_should_not_start_and_show_error()
         {
-            var context = await Scenario.Define<Context>()
-                .WithEndpoint<Endpoint>()
-                .Done(c => c.EndpointsStarted)
-                .Run();
-
-            Assert.True(context.Exceptions.First().Message.Contains("Setting a custom OverrideTimeToBeReceived for audits is not supported on transactional MSMQ."));
+            Assert.That(async () =>
+            {
+                await Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>()
+                    .Done(c => c.EndpointsStarted)
+                    .Run();
+            }, Throws.InnerException.InnerException.Message.Contains("Setting a custom OverrideTimeToBeReceived for audits is not supported on transactional MSMQ."));
         }
 
-        public class Context : ScenarioContext { }
+        public class Context : ScenarioContext
+        {
+        }
 
         public class Endpoint : EndpointConfigurationBuilder
         {
@@ -29,7 +31,7 @@
                 EndpointSetup<DefaultServer>((config, context) =>
                 {
                     config.UseTransport<MsmqTransport>()
-                            .Transactions(TransportTransactionMode.ReceiveOnly);
+                        .Transactions(TransportTransactionMode.ReceiveOnly);
                 })
                     .WithConfig<AuditConfig>(c => c.OverrideTimeToBeReceived = TimeSpan.FromHours(1));
             }

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_TimeToBeReceivedOnForwardedMessages_set_and_tx_scope_receives.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_TimeToBeReceivedOnForwardedMessages_set_and_tx_scope_receives.cs
@@ -1,10 +1,9 @@
 ﻿namespace NServiceBus.AcceptanceTests
 {
     using System;
-    using System.Linq;
     using System.Threading.Tasks;
-    using NServiceBus.AcceptanceTesting;
-    using NServiceBus.Config;
+    using AcceptanceTesting;
+    using Config;
     using NUnit.Framework;
 
     public class When_TimeToBeReceivedOnForwardedMessages_set_and_tx_scope_receives : NServiceBusAcceptanceTest
@@ -12,15 +11,18 @@
         [Test]
         public async Task Endpoint_should_not_start_and_show_error()
         {
-            var context = await Scenario.Define<Context>()
-                .WithEndpoint<Endpoint>()
-                .Done(c => c.EndpointsStarted)
-                .Run();
-
-            Assert.True(context.Exceptions.First().Message.Contains("Setting a custom TimeToBeReceivedOnForwardedMessages is not supported on transactional MSMQ."));
+            Assert.That(async () =>
+            {
+                await Scenario.Define<Context>()
+                    .WithEndpoint<Endpoint>()
+                    .Done(c => c.EndpointsStarted)
+                    .Run();
+            }, Throws.InnerException.InnerException.Message.Contains("Setting a custom TimeToBeReceivedOnForwardedMessages is not supported on transactional MSMQ."));
         }
-        
-        public class Context : ScenarioContext { }
+
+        public class Context : ScenarioContext
+        {
+        }
 
         public class Endpoint : EndpointConfigurationBuilder
         {
@@ -29,7 +31,7 @@
                 EndpointSetup<DefaultServer>((config, context) =>
                 {
                     config.UseTransport<MsmqTransport>()
-                            .Transactions(TransportTransactionMode.TransactionScope);
+                        .Transactions(TransportTransactionMode.TransactionScope);
                 })
                     .WithConfig<UnicastBusConfig>(c => c.TimeToBeReceivedOnForwardedMessages = TimeSpan.FromHours(1));
             }


### PR DESCRIPTION
Fixes #3596

Also fixes the behavior of AT framework when one of the endpoints fail to start (adding a missing `await`)