### PR TITLE
ActiveSagaInstance enhancements

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2362,10 +2362,10 @@ namespace NServiceBus.Sagas
 {
     public class ActiveSagaInstance
     {
-        [System.ObsoleteAttribute("Please use `context.MessageHandler.Instance` instead. Will be removed in version " +
-            "7.0.0.", true)]
+        public System.DateTime Created { get; }
         public NServiceBus.Saga Instance { get; }
         public bool IsNew { get; }
+        public System.DateTime Modified { get; }
         public bool NotFound { get; }
         public string SagaId { get; }
         [System.ObsoleteAttribute("Please use `.Metadata.SagaType` instead. Will be removed in version 7.0.0.", true)]

--- a/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
@@ -129,7 +129,7 @@
 
         static ActiveSagaInstance AssociateSagaWithMessage(FakeSaga saga, IInvokeHandlerContext behaviorContext)
         {
-            var sagaInstance = new ActiveSagaInstance(saga, SagaMetadata.Create(typeof(FakeSaga), new List<Type>(), new Conventions()));
+            var sagaInstance = new ActiveSagaInstance(saga, SagaMetadata.Create(typeof(FakeSaga), new List<Type>(), new Conventions()), () => DateTime.UtcNow);
             behaviorContext.Extensions.Set(sagaInstance);
             return sagaInstance;
         }

--- a/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
@@ -34,7 +34,7 @@
             }
 
             var sagaMetadata = sagaMetadataCollection.Find(context.MessageHandler.Instance.GetType());
-            var sagaInstanceState = new ActiveSagaInstance(saga, sagaMetadata);
+            var sagaInstanceState = new ActiveSagaInstance(saga, sagaMetadata, () => DateTime.UtcNow);
 
             //so that other behaviors can access the saga
             context.Extensions.Set(sagaInstanceState);
@@ -91,6 +91,8 @@
                 }
 
                 logger.DebugFormat("Saga: '{0}' with Id: '{1}' has completed.", sagaInstanceState.Metadata.Name, saga.Entity.Id);
+
+                sagaInstanceState.Completed();
             }
             else
             {
@@ -112,6 +114,8 @@
                 {
                     await sagaPersister.Update(saga.Entity, context.SynchronizedStorageSession, context.Extensions).ConfigureAwait(false);
                 }
+
+                sagaInstanceState.Updated();
             }
         }
 


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/677

Moving SagaAudit to utilize strongly typed stages for it's behaviors [instead of `InsertBefore` and `InsertAfter`](https://github.com/Particular/NServiceBus/issues/3582) the handler is no longer exposed to one of the behaviors. Removing `obsolete` allows us to access the saga `Instance` in the plugin.

Likewise the `InsertBefore`/`InsertAfter` were used to try to measure the Saga lifespan as part of the auditing process. Adding the `DateTime` properties `Created` and `Modified` along with `MarkAsModified` give us those metrics without the need to specify specific ordering in the pipeline and are more accurate.