### PR TITLE
Force XML in mutator test & mutate body in test

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -283,9 +283,6 @@
       <Name>NServiceBus.AcceptanceTesting</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>


### PR DESCRIPTION
Original test only mutated the header and assumed XML serializer.
Not XML serializer is force in test and also the body of the message is modified and asserted in the test.