### PR TITLE
Make LogicalMessage ctor public

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Mutators/When_incoming_mutator_changes_message_type.cs
+++ b/src/NServiceBus.AcceptanceTests/Mutators/When_incoming_mutator_changes_message_type.cs
@@ -1,0 +1,123 @@
+﻿namespace NServiceBus.AcceptanceTests.Mutators
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class When_incoming_mutator_changes_message_type : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_invoke_handlers_for_new_message_type()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<MutatorEndpoint>(e => e
+                    .When(s => s.SendLocal(new OriginalMessage())))
+                .Done(c => c.NewMessageHandlerCalled || c.OriginalMessageHandlerCalled)
+                .Run();
+
+            Assert.IsTrue(context.NewMessageHandlerCalled);
+            Assert.IsTrue(context.NewMessageSagaHandlerCalled);
+            Assert.IsFalse(context.OriginalMessageHandlerCalled);
+            Assert.IsFalse(context.OriginalMessageSagaHandlerCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool OriginalMessageHandlerCalled { get; set; }
+            public bool NewMessageHandlerCalled { get; set; }
+            public bool OriginalMessageSagaHandlerCalled { get; set; }
+            public bool NewMessageSagaHandlerCalled { get; set; }
+        }
+
+        public class MutatorEndpoint : EndpointConfigurationBuilder
+        {
+            public MutatorEndpoint()
+            {
+                EndpointSetup<DefaultServer>(e => e
+                    .RegisterComponents(c => c
+                        .ConfigureComponent<MessageMutator>(DependencyLifecycle.SingleInstance)));
+            }
+
+            public class MessageMutator : IMutateIncomingMessages
+            {
+                public Task MutateIncoming(MutateIncomingMessageContext context)
+                {
+                    context.Message = new NewMessage();
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class OriginalMessageHandler : IHandleMessages<OriginalMessage>
+            {
+                Context TestContext;
+
+                public OriginalMessageHandler(Context testContext)
+                {
+                    TestContext = testContext;
+                }
+
+                public Task Handle(OriginalMessage message, IMessageHandlerContext context)
+                {
+                    TestContext.OriginalMessageHandlerCalled = true;
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class NewMessaeHandler : IHandleMessages<NewMessage>
+            {
+                Context TestContext;
+
+                public NewMessaeHandler(Context testContext)
+                {
+                    TestContext = testContext;
+                }
+
+                public Task Handle(NewMessage message, IMessageHandlerContext context)
+                {
+                    TestContext.NewMessageHandlerCalled = true;
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class Saga : Saga<SagaData>, IAmStartedByMessages<OriginalMessage>, IAmStartedByMessages<NewMessage>
+            {
+                Context TestContext;
+
+                public Saga(Context testContext)
+                {
+                    TestContext = testContext;
+                }
+
+                public Task Handle(OriginalMessage message, IMessageHandlerContext context)
+                {
+                    TestContext.OriginalMessageSagaHandlerCalled = true;
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(NewMessage message, IMessageHandlerContext context)
+                {
+                    TestContext.NewMessageSagaHandlerCalled = true;
+                    return Task.FromResult(0);
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                {
+                }
+            }
+
+            public class SagaData : ContainSagaData
+            {
+            }
+        }
+
+        public class OriginalMessage : ICommand
+        {
+        }
+
+        public class NewMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="CriticalError\When_raising_critical_error.cs" />
     <Compile Include="Basic\When_deferring_to_non_local.cs" />
     <Compile Include="DelayedDelivery\TimeoutManager\When_TimeoutManager_is_disabled.cs" />
+    <Compile Include="Mutators\When_incoming_mutator_changes_message_type.cs" />
     <Compile Include="Mutators\When_mutating.cs" />
     <Compile Include="BestPractices\When_publishing_command_bestpractices_disabled_on_endpoint.cs" />
     <Compile Include="BestPractices\When_sending_events_bestpractices_disabled_on_endpoint.cs" />

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -3056,6 +3056,7 @@ namespace NServiceBus.Unicast.Messages
 {
     public class MessageMetadata
     {
+        public MessageMetadata(System.Type messageType, System.Collections.Generic.IEnumerable<System.Type> messageHierarchy = null) { }
         public System.Collections.Generic.IEnumerable<System.Type> MessageHierarchy { get; }
         public System.Type MessageType { get; }
         [System.ObsoleteAttribute("You can access Recoverable via the DeliveryConstraints collection on the outgoing" +

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2027,6 +2027,7 @@ namespace NServiceBus.Pipeline
         System.Collections.Generic.Dictionary<string, string> Headers { get; }
         NServiceBus.Pipeline.LogicalMessage Message { get; }
         bool MessageHandled { get; set; }
+        void UpdateMessageInstance(object newInstance);
     }
     public interface IIncomingPhysicalMessageContext : NServiceBus.Extensibility.IExtendable, NServiceBus.IMessageProcessingContext, NServiceBus.IPipelineContext, NServiceBus.Pipeline.IBehaviorContext, NServiceBus.Pipeline.IIncomingContext
     {
@@ -2095,9 +2096,12 @@ namespace NServiceBus.Pipeline
     }
     public class LogicalMessage
     {
+        public LogicalMessage(NServiceBus.Unicast.Messages.MessageMetadata metadata, object message) { }
         public object Instance { get; }
         public System.Type MessageType { get; }
         public NServiceBus.Unicast.Messages.MessageMetadata Metadata { get; }
+        [System.ObsoleteAttribute("Please use `IIncomingLogicalMessageContext.UpdateMessageInstance(object newInstan" +
+            "ce)` instead. Will be removed in version 7.0.0.", true)]
         public void UpdateMessageInstance(object newInstance) { }
     }
     public class LogicalMessageFactory

--- a/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_incoming_messages.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_incoming_messages.cs
@@ -9,7 +9,6 @@ namespace NServiceBus.Core.Tests.DataBus
     using NServiceBus.Pipeline;
     using Unicast.Messages;
     using NUnit.Framework;
-    using Conventions = NServiceBus.Conventions;
 
     [TestFixture]
     class When_applying_the_databus_message_mutator_to_incoming_messages
@@ -26,7 +25,7 @@ namespace NServiceBus.Core.Tests.DataBus
                                   {
                                       Key = propertyKey
                                   }
-                              }, null);
+                              });
 
             var fakeDatabus = new FakeDataBus();
             var receiveBehavior = new DataBusReceiveBehavior(fakeDatabus, new DefaultDataBusSerializer(), new Conventions());

--- a/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehaviorTests.cs
@@ -16,7 +16,7 @@
         {
             var behavior = new MutateIncomingMessageBehavior();
 
-            var logicalMessage = new LogicalMessage(new MessageMetadata(typeof(TestMessage)), new TestMessage(), null);
+            var logicalMessage = new LogicalMessage(new MessageMetadata(typeof(TestMessage)), new TestMessage());
 
             var context = new IncomingLogicalMessageContext(logicalMessage, "messageId", "replyToAddress", new Dictionary<string, string>(), null);
 

--- a/src/NServiceBus.Core.Tests/Sagas/InvokeSagaNotFoundBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/InvokeSagaNotFoundBehaviorTests.cs
@@ -14,7 +14,7 @@
         [SetUp]
         public void SetupTests()
         {
-            message = new LogicalMessage(new MessageMetadata(typeof(TestMessage)), new TestMessage(), null);
+            message = new LogicalMessage(new MessageMetadata(typeof(TestMessage)), new TestMessage());
 
             behavior = new InvokeSagaNotFoundBehavior();
 

--- a/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
@@ -1,9 +1,9 @@
 ﻿namespace NServiceBus.Unicast.Tests
 {
     using System.Collections.Generic;
-    using NServiceBus.Outbox;
-    using NServiceBus.Pipeline;
-    using NServiceBus.Transports;
+    using Outbox;
+    using Pipeline;
+    using Transports;
     using Unicast.Messages;
     using NUnit.Framework;
 
@@ -16,7 +16,7 @@
             var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(new Conventions()), new InMemorySynchronizedStorage(), new InMemoryTransactionalSynchronizedStorageAdapter());
 
             var context = new IncomingLogicalMessageContext(
-                new LogicalMessage(new MessageMetadata(typeof(string)), null, null), 
+                new LogicalMessage(new MessageMetadata(typeof(string)), null), 
                 "messageId",
                 "replyToAddress",
                 new Dictionary<string, string>(), 

--- a/src/NServiceBus.Core/Encryption/DecryptBehavior.cs
+++ b/src/NServiceBus.Core/Encryption/DecryptBehavior.cs
@@ -22,7 +22,7 @@ namespace NServiceBus
                 DecryptMember(item.Item1, item.Item2, context);
             }
 
-            context.Message.UpdateMessageInstance(current);
+            context.UpdateMessageInstance(current);
 
             await next().ConfigureAwait(false);
         }

--- a/src/NServiceBus.Core/Pipeline/Incoming/IIncomingLogicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IIncomingLogicalMessageContext.cs
@@ -21,5 +21,11 @@
         /// Tells if the message has been handled.
         /// </summary>
         bool MessageHandled { get; set; }
+
+        /// <summary>
+        /// Updates the message instance contained in <see cref="LogicalMessage"/>.
+        /// </summary>
+        /// <param name="newInstance">The new instance.</param>
+        void UpdateMessageInstance(object newInstance);
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/IncomingLogicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IncomingLogicalMessageContext.cs
@@ -23,5 +23,23 @@
         public Dictionary<string, string> Headers { get; }
 
         public bool MessageHandled { get; set; }
+
+        public void UpdateMessageInstance(object newInstance)
+        {
+            Guard.AgainstNull(nameof(newInstance), newInstance);
+            var sameInstance = ReferenceEquals(Message.Instance, newInstance);
+
+            Message.Instance = newInstance;
+
+            if (sameInstance)
+            {
+                return;
+            }
+
+            var factory = this.Builder.Build<LogicalMessageFactory>();
+            var newLogicalMessage = factory.Create(newInstance);
+
+            Message.Metadata = newLogicalMessage.Metadata;
+        }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/LogicalMessage.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/LogicalMessage.cs
@@ -8,9 +8,11 @@
     /// </summary>
     public class LogicalMessage
     {
-        internal LogicalMessage(MessageMetadata metadata, object message, LogicalMessageFactory factory)
+        /// <summary>
+        /// Create a new <see cref="LogicalMessage"/> instance containg a message object and it's corresponding <see cref="MessageMetadata"/>.
+        /// </summary>
+        public LogicalMessage(MessageMetadata metadata, object message)
         {
-            this.factory = factory;
             Instance = message;
             Metadata = metadata;
         }
@@ -24,34 +26,24 @@
         /// <summary>
         /// Message metadata.
         /// </summary>
-        public MessageMetadata Metadata { get; private set; }
+        public MessageMetadata Metadata { get; internal set; }
 
         /// <summary>
         /// The message instance.
         /// </summary>
-        public object Instance { get; private set; }
+        public object Instance { get; internal set; }
 
         /// <summary>
         /// Updates the message instance.
         /// </summary>
         /// <param name="newInstance">The new instance.</param>
+        [ObsoleteEx(
+            RemoveInVersion = "7", 
+            TreatAsErrorFromVersion = "6", 
+            ReplacementTypeOrMember = "IIncomingLogicalMessageContext.UpdateMessageInstance(object newInstance)")]
         public void UpdateMessageInstance(object newInstance)
         {
-            Guard.AgainstNull(nameof(newInstance), newInstance);
-            var sameInstance = ReferenceEquals(Instance, newInstance);
-
-            Instance = newInstance;
-
-            if (sameInstance)
-            {
-                return;
-            }
-
-            var newLogicalMessage = factory.Create(newInstance);
-
-            Metadata = newLogicalMessage.Metadata;
+            throw new NotImplementedException();
         }
-
-        LogicalMessageFactory factory;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/LogicalMessageFactory.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/LogicalMessageFactory.cs
@@ -48,7 +48,7 @@ namespace NServiceBus.Pipeline
 
             var realMessageType = messageMapper.GetMappedTypeFor(messageType);
 
-            return new LogicalMessage(messageMetadataRegistry.GetMessageMetadata(realMessageType), message, this);
+            return new LogicalMessage(messageMetadataRegistry.GetMessageMetadata(realMessageType), message);
         }
 
         IMessageMapper messageMapper;

--- a/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehavior.cs
@@ -22,7 +22,7 @@
 
             if (mutatorContext.MessageInstanceChanged)
             {
-                logicalMessage.UpdateMessageInstance(mutatorContext.Message);
+                context.UpdateMessageInstance(mutatorContext.Message);
             }
 
             await next().ConfigureAwait(false);

--- a/src/NServiceBus.Core/Serialization/SerializationFeature.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationFeature.cs
@@ -56,6 +56,7 @@
 
             context.Container.ConfigureComponent(_ => mapper, DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent(_ => messageMetadataRegistry, DependencyLifecycle.SingleInstance);
+            context.Container.ConfigureComponent(_ => logicalMessageFactory, DependencyLifecycle.SingleInstance);
 
             LogFoundMessages(messageMetadataRegistry.GetAllMessages().ToList());
         }

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadata.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadata.cs
@@ -8,7 +8,12 @@
     /// </summary>
     public partial class MessageMetadata
     {
-        internal MessageMetadata(Type messageType, IEnumerable<Type> messageHierarchy = null)
+        /// <summary>
+        /// Create a new instance of <see cref="MessageMetadata"/>.
+        /// </summary>
+        /// <param name="messageType">The type of the message this metadata belongs to.</param>
+        /// <param name="messageHierarchy">the hierarchy of all message types implemented by the message this metadata belongs to.</param>
+        public MessageMetadata(Type messageType, IEnumerable<Type> messageHierarchy = null)
         {
             MessageType = messageType;
             MessageHierarchy = (messageHierarchy == null ? new List<Type>() : new List<Type>(messageHierarchy)).AsReadOnly();


### PR DESCRIPTION
Since LogicalMessage is a public property on `IIncomingLogicalMessageContext` users must be able to create their own instances in order to setup the context properly.

The whole logic around LogicalMessage and especially it's type & type hierarchy is pretty complicated. That's why I went for the straight forward solution. I wish I could do more, but it seems improving the situation will require a non-trivial refactoring and understanding message types & message hierarchy handling. I don't want to go down that rabbit hole right now since this blocks finishing the update of NServiceBus.Testing.

Also added a mutator acceptance tests to verify certain assumptions.

Connects to Particular/NServiceBus.Testing#29