### PR TITLE
Make MessageHandler constructor public

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2108,6 +2108,7 @@ namespace NServiceBus.Pipeline
     }
     public class MessageHandler
     {
+        public MessageHandler(System.Func<object, object, NServiceBus.IMessageHandlerContext, System.Threading.Tasks.Task> invocation, System.Type handlerType) { }
         public System.Type HandlerType { get; }
         public object Instance { get; set; }
         public System.Threading.Tasks.Task Invoke(object message, NServiceBus.IMessageHandlerContext handlerContext) { }

--- a/src/NServiceBus.Core/Pipeline/Incoming/MessageHandler.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/MessageHandler.cs
@@ -13,7 +13,7 @@
         /// </summary>
         /// <param name="invocation">The invocation with context delegate.</param>
         /// <param name="handlerType">The handler type.</param>
-        internal MessageHandler(Func<object, object, IMessageHandlerContext, Task> invocation, Type handlerType)
+        public MessageHandler(Func<object, object, IMessageHandlerContext, Task> invocation, Type handlerType)
         {
             HandlerType = handlerType;
             this.invocation = invocation;


### PR DESCRIPTION
Connects to Particular/NServiceBus.Testing#29

MessageHandler constructor needs to have a public since it's a public property on `IInvokeHandlerContext` and we need to be able to provide our own instances for testing purposes.

@Particular/nservicebus-maintainers @hmemcpy please review