### PR TITLE
Remove shared instance of completable synch storage session

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Persistence/When_a_persistence_does_not_provide_ISynchronizationContext.cs
+++ b/src/NServiceBus.AcceptanceTests/Persistence/When_a_persistence_does_not_provide_ISynchronizationContext.cs
@@ -12,7 +12,9 @@
 
     public class When_a_persistence_does_not_provide_ISynchronizationContext
     {
-        [Test]
+        // Run this test twice to ensure that the NoOpCompletableSynchronizedStorageSession's IDisposable method
+        // is not altered by Fody to throw an ObjectDisposedException if it was disposed
+        [Test, Repeat(2)]
         public async Task ReceiveFeature_should_work_without_ISynchronizedStorage()
         {
             await Scenario.Define<Context>()

--- a/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
@@ -2,6 +2,7 @@
 {
     using System.Threading.Tasks;
     using Extensibility;
+    using Janitor;
     using NServiceBus.Outbox;
     using Persistence;
     using Pipeline;
@@ -65,6 +66,9 @@
             internal static readonly Task<CompletableSynchronizedStorageSession> EmptyResult = Task.FromResult<CompletableSynchronizedStorageSession>(new NoOpCompletableSynchronizedStorageSession());
         }
 
+        // Do not allow Fody to weave the IDisposable for us so that other threads can still access the instance of this class
+        // even after it has been disposed.
+        [SkipWeaving]
         class NoOpCompletableSynchronizedStorageSession : CompletableSynchronizedStorageSession
         {
             public Task CompleteAsync()


### PR DESCRIPTION
## Background

A fix was previously made to cater for scenarios where a Storage was used that wasn't a `ISynchronizedStorage`.

This change used a static instance of `Task<CompletableSynchronizedStorageSession>` as a helper, but this change meant that the instance was shared within the same AppDomain.

If one of the threads disposed of the `CompletableSynchronizedStorageSession` then the other threads will receive an `ObjectDisposedException`

## Fix

The fix is simply to return a new instance of `Task<CompletableSynchronizedStorageSession>` each time it is requested instead of using a static instance.

An alternative fix is to configure the `IContainer` in `InitializableEndpoint.RegisterContainerAdapter()` to use `ReceiveFeature.NoOpSynchronizedStorage` by default. This will then be overridden by future persistence definitions if they provide `ISynchronizedStorage`s.

I'm torn between which fix is better. I think the container based one is probably more correct, but this PR uses the first proposed code change. Thoughts @Particular/nservicebus-maintainers ?