### PR TITLE
Allow default serializer to be changed

### DIFF
--- a/src/NServiceBus.Core/Serialization/SerializationFeature.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationFeature.cs
@@ -12,19 +12,15 @@
 
     class SerializationFeature : Feature
     {
-        internal SerializationFeature()
+        public SerializationFeature()
         {
             EnableByDefault();
             Defaults(s =>
             {
                 s.SetDefault("AdditionalDeserializers", new List<SerializationDefinition>());
-                s.SetDefault<SerializationDefinition>(new XmlSerializer());
             });
         }
 
-        /// <summary>
-        /// Called when the features is activated.
-        /// </summary>
         protected internal sealed override void Setup(FeatureConfigurationContext context)
         {
             var mapper = new MessageMapper();
@@ -33,7 +29,13 @@
             var messageTypes = settings.GetAvailableTypes().Where(conventions.IsMessageType);
             mapper.Initialize(messageTypes);
 
-            var defaultSerializerDefinition = context.Settings.GetOrDefault<SerializationDefinition>();
+            SerializationDefinition defaultSerializerDefinition;
+
+            if (!context.Settings.TryGet(out defaultSerializerDefinition))
+            {
+                defaultSerializerDefinition = new XmlSerializer();
+            }
+
             var defaultSerializer = CreateMessageSerializer(defaultSerializerDefinition, mapper, context);
 
             var additionalDeserializerDefinitions = context.Settings.Get<List<SerializationDefinition>>("AdditionalDeserializers");


### PR DESCRIPTION
Technically I think you could hack it today by changing it in a feature that has `DependsOn("SerializationFeature")` but with this change ASB/ASQ can change it in `TransportDefinition.Initialize` using `settings.SetDefault<SerializerDefinition>(new JsonSerializer())` which seems more resonable.