### PR TITLE
Rename BusNotifications to Notifications

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/FailTestOnErrorMessageFeature.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/FailTestOnErrorMessageFeature.cs
@@ -23,7 +23,7 @@
 
         class FailTestOnErrorMessageFeatureStartupTask : FeatureStartupTask
         {
-            public FailTestOnErrorMessageFeatureStartupTask(ScenarioContext context, ReadOnlySettings settings, BusNotifications notifications)
+            public FailTestOnErrorMessageFeatureStartupTask(ScenarioContext context, ReadOnlySettings settings, Notifications notifications)
             {
                 scenarioContext = context;
                 this.notifications = notifications;
@@ -59,7 +59,7 @@
             }
 
             EndpointName endpoint;
-            BusNotifications notifications;
+            Notifications notifications;
             ScenarioContext scenarioContext;
         }
     }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
@@ -86,7 +86,7 @@
         {
             public Context Context { get; set; }
 
-            public BusNotifications Notifications { get; set; }
+            public Notifications Notifications { get; set; }
 
             public Task Start(IMessageSession session)
             {

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_dtc_on.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_dtc_on.cs
@@ -59,11 +59,11 @@
             {
                 public Context Context { get; set; }
 
-                public BusNotifications BusNotifications { get; set; }
+                public Notifications Notifications { get; set; }
 
                 public Task Start(IMessageSession session)
                 {
-                    BusNotifications.Errors.MessageSentToErrorQueue += (sender, message) => Context.GaveUpOnRetries = true;
+                    Notifications.Errors.MessageSentToErrorQueue += (sender, message) => Context.GaveUpOnRetries = true;
                     return Task.FromResult(0);
                 }
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_doing_flr_with_native_transactions.cs
@@ -58,11 +58,11 @@
             {
                 public Context Context { get; set; }
 
-                public BusNotifications BusNotifications { get; set; }
+                public Notifications Notifications { get; set; }
 
                 public Task Start(IMessageSession session)
                 {
-                    BusNotifications.Errors.MessageSentToErrorQueue += (sender, message) => Context.ForwardedToErrorQueue = true;
+                    Notifications.Errors.MessageSentToErrorQueue += (sender, message) => Context.ForwardedToErrorQueue = true;
                     return Task.FromResult(0);
                 }
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_with_retries_set_to_0.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_fails_with_retries_set_to_0.cs
@@ -44,11 +44,11 @@
             {
                 public Context Context { get; set; }
 
-                public BusNotifications BusNotifications { get; set; }
+                public Notifications Notifications { get; set; }
 
                 public Task Start(IMessageSession session)
                 {
-                    BusNotifications.Errors.MessageSentToErrorQueue += (sender, message) => Context.GaveUp = true;
+                    Notifications.Errors.MessageSentToErrorQueue += (sender, message) => Context.GaveUp = true;
                     return session.SendLocal(new MessageToBeRetried
                     {
                         ContextId = Context.Id

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
@@ -61,11 +61,11 @@
             {
                 public Context Context { get; set; }
 
-                public BusNotifications BusNotifications { get; set; }
+                public Notifications Notifications { get; set; }
 
                 public Task Start(IMessageSession session)
                 {
-                    BusNotifications.Errors.MessageSentToErrorQueue += (sender, message) => Context.ForwardedToErrorQueue = true;
+                    Notifications.Errors.MessageSentToErrorQueue += (sender, message) => Context.ForwardedToErrorQueue = true;
                     return Task.FromResult(0);
                 }
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_and_counting.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_and_counting.cs
@@ -50,15 +50,13 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
             class ErrorNotificationSpy : IWantToRunWhenBusStartsAndStops
             {
                 Context testContext;
-                BusNotifications notifications;
+                Notifications notifications;
 
-                public ErrorNotificationSpy(Context testContext, BusNotifications notifications)
+                public ErrorNotificationSpy(Context testContext, Notifications notifications)
                 {
                     this.testContext = testContext;
                     this.notifications = notifications;
                 }
-
-                public BusNotifications BusNotifications { get; set; }
 
                 public Task Start(IMessageSession session)
                 {

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_min_policy.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_min_policy.cs
@@ -52,10 +52,10 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
 
             class ErrorNotificationSpy : IWantToRunWhenBusStartsAndStops
             {
-                BusNotifications notifications;
+                Notifications notifications;
                 Context context;
 
-                public ErrorNotificationSpy(Context context, BusNotifications notifications)
+                public ErrorNotificationSpy(Context context, Notifications notifications)
                 {
                     this.notifications = notifications;
                     this.context = context;

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_non_min_policy.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_non_min_policy.cs
@@ -58,10 +58,10 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
 
             class ErrorNotificationSpy : IWantToRunWhenBusStartsAndStops
             {
-                BusNotifications notifications;
+                Notifications notifications;
                 Context context;
 
-                public ErrorNotificationSpy(Context context, BusNotifications notifications)
+                public ErrorNotificationSpy(Context context, Notifications notifications)
                 {
                     this.notifications = notifications;
                     this.context = context;

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_regular_exception.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_regular_exception.cs
@@ -87,10 +87,10 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
 
             class ErrorNotificationSpy : IWantToRunWhenBusStartsAndStops
             {
-                BusNotifications notifications;
+                Notifications notifications;
                 Context context;
 
-                public ErrorNotificationSpy(Context context, BusNotifications notifications)
+                public ErrorNotificationSpy(Context context, Notifications notifications)
                 {
                     this.notifications = notifications;
                     this.context = context;

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_serialization_exception.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_serialization_exception.cs
@@ -81,9 +81,9 @@
             class ErrorNotificationSpy : IWantToRunWhenBusStartsAndStops
             {
                 Context testContext;
-                BusNotifications notifications;
+                Notifications notifications;
 
-                public ErrorNotificationSpy(Context testContext, BusNotifications notifications)
+                public ErrorNotificationSpy(Context testContext, Notifications notifications)
                 {
                     this.testContext = testContext;
                     this.notifications = notifications;

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -81,13 +81,10 @@ namespace NServiceBus
             "on 7.0.0.", true)]
         public void TypesToScan(System.Collections.Generic.IEnumerable<System.Type> typesToScan) { }
     }
+    [System.ObsoleteAttribute("Please use `Notifications` instead. Will be removed in version 7.0.0.", true)]
     public class BusNotifications
     {
         public BusNotifications() { }
-        public NServiceBus.Faults.ErrorsNotifications Errors { get; }
-        [System.ObsoleteAttribute("For performance reasons it is no longer possible to instrument the pipeline execu" +
-            "tion. Will be removed in version 7.0.0.", true)]
-        public NServiceBus.PipelineNotifications Pipeline { get; }
     }
     [System.ObsoleteAttribute("Replaced by NServiceBus.Callbacks package. Will be removed in version 7.0.0.", true)]
     public class CompletionResult
@@ -742,6 +739,14 @@ namespace NServiceBus
     public class NonDurableDelivery : NServiceBus.DeliveryConstraints.DeliveryConstraint
     {
         public NonDurableDelivery() { }
+    }
+    public class Notifications
+    {
+        public Notifications() { }
+        public NServiceBus.Faults.ErrorsNotifications Errors { get; }
+        [System.ObsoleteAttribute("For performance reasons it is no longer possible to instrument the pipeline execu" +
+            "tion. Will be removed in version 7.0.0.", true)]
+        public NServiceBus.PipelineNotifications Pipeline { get; }
     }
     [System.ObsoleteAttribute("Please use `EndpointConfiguration.ExecuteTheseHandlersFirst` instead. Will be rem" +
         "oved in version 7.0.0.", true)]

--- a/src/NServiceBus.Core.Tests/Recoverability/FirstLevelRetries/FirstLevelRetriesTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/FirstLevelRetries/FirstLevelRetriesTests.cs
@@ -69,7 +69,7 @@
         }
 
         [Test]
-        public async Task ShouldRaiseBusNotificationsForFLR()
+        public async Task ShouldRaiseNotificationsForFLR()
         {
             var behavior = CreateFlrBehavior(new FirstLevelRetryPolicy(1));
 

--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -17,7 +17,7 @@ namespace NServiceBus
     {
         public InitializableEndpoint(SettingsHolder settings, IContainer container, List<Action<IConfigureComponents>> registrations, PipelineSettings pipelineSettings, PipelineConfiguration pipelineConfiguration, IReadOnlyCollection<IWantToRunWhenBusStartsAndStops> startables)
         {
-            settings.Set<BusNotifications>(new BusNotifications());
+            settings.Set<Notifications>(new Notifications());
             settings.Set<NotificationSubscriptions>(new NotificationSubscriptions());
             this.settings = settings;
             this.pipelineSettings = pipelineSettings;
@@ -56,7 +56,7 @@ namespace NServiceBus
             DisplayDiagnosticsForFeatures.Run(featureStats);
             WireUpInstallers(concreteTypes);
 
-            container.ConfigureComponent(b => settings.Get<BusNotifications>(), DependencyLifecycle.SingleInstance);
+            container.ConfigureComponent(b => settings.Get<Notifications>(), DependencyLifecycle.SingleInstance);
 
             var startableEndpoint = new StartableEndpoint(settings, builder, featureActivator, pipelineConfiguration, startables, new EventAggregator(settings.Get<NotificationSubscriptions>()));
             return Task.FromResult<IStartableEndpoint>(startableEndpoint);

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Audit\ConfigureAudit.cs" />
     <Compile Include="Audit\AuditToDispatchConnector.cs" />
     <Compile Include="Audit\InvokeAuditPipelineBehavior.cs" />
+    <Compile Include="Notifications.cs" />
     <Compile Include="Notifications\EventAggregator.cs" />
     <Compile Include="Encryption\WireEncryptedStringConversions.cs" />
     <Compile Include="CircuitBreakers\ICircuitBreaker.cs" />
@@ -313,7 +314,6 @@
     <Compile Include="Encryption\RijndaelExpiredKey.cs" />
     <Compile Include="Encryption\RijndaelExpiredKeyCollection.cs" />
     <Compile Include="Encryption\RijndaelEncryptionService.cs" />
-    <Compile Include="BusNotifications.cs" />
     <Compile Include="Extensibility\ExtendableOptions.cs" />
     <Compile Include="Extensibility\ExtendableOptionsExtensions.cs" />
     <Compile Include="Extensibility\ReadOnlyContextBag.cs" />

--- a/src/NServiceBus.Core/Notifications.cs
+++ b/src/NServiceBus.Core/Notifications.cs
@@ -6,12 +6,12 @@ namespace NServiceBus
     using Faults;
 
     /// <summary>
-    /// Bus notifications.
+    /// Notifications.
     /// </summary>
-    public partial class BusNotifications
+    public partial class Notifications
     {
         /// <summary>
-        /// Errors push-based notifications.
+        /// Push-based error notifications.
         /// </summary>
         public ErrorsNotifications Errors => errorNotifications;
 

--- a/src/NServiceBus.Core/Recoverability/Faults/StoreFaultsInErrorQueue.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/StoreFaultsInErrorQueue.cs
@@ -21,24 +21,24 @@ namespace NServiceBus.Features
             context.Pipeline.Register(new MoveFaultsToErrorQueueBehavior.Registration(errorQueue, context.Settings.LocalAddress()));
             context.Pipeline.Register("FaultToDispatchConnector", new FaultToDispatchConnector(), "Connector to dispatch faulted messages");
 
-            RaiseLegacyBusNotifications(context);
+            RaiseLegacyNotifications(context);
         }
 
-        //note: will soon be removed since we're deprecating BusNotifications in favor of the new notifications
-        static void RaiseLegacyBusNotifications(FeatureConfigurationContext context)
+        //note: will soon be removed since we're deprecating Notifications in favor of the new notifications
+        static void RaiseLegacyNotifications(FeatureConfigurationContext context)
         {
-            var busNotifications = context.Settings.Get<BusNotifications>();
+            var legacyNotifications = context.Settings.Get<Notifications>();
             var notifications = context.Settings.Get<NotificationSubscriptions>();
 
             notifications.Subscribe<MessageToBeRetried>(e =>
             {
                 if (e.IsImmediateRetry)
                 {
-                    busNotifications.Errors.InvokeMessageHasFailedAFirstLevelRetryAttempt(e.Attempt, e.Message, e.Exception);
+                    legacyNotifications.Errors.InvokeMessageHasFailedAFirstLevelRetryAttempt(e.Attempt, e.Message, e.Exception);
                 }
                 else
                 {
-                    busNotifications.Errors.InvokeMessageHasBeenSentToSecondLevelRetries(e.Attempt, e.Message, e.Exception);
+                    legacyNotifications.Errors.InvokeMessageHasBeenSentToSecondLevelRetries(e.Attempt, e.Message, e.Exception);
                 }
 
                 return TaskEx.CompletedTask;
@@ -46,7 +46,7 @@ namespace NServiceBus.Features
 
             notifications.Subscribe<MessageFaulted>(e =>
             {
-                busNotifications.Errors.InvokeMessageHasBeenSentToErrorQueue(e.Message, e.Exception);
+                legacyNotifications.Errors.InvokeMessageHasBeenSentToErrorQueue(e.Message, e.Exception);
                 return TaskEx.CompletedTask;
             });
         }

--- a/src/NServiceBus.Core/obsoletes.cs
+++ b/src/NServiceBus.Core/obsoletes.cs
@@ -310,7 +310,15 @@ namespace NServiceBus
         public Dictionary<string, string> Headers { get; } = new Dictionary<string, string>();
     }
 
-    public partial class BusNotifications
+    [ObsoleteEx(
+        RemoveInVersion = "7",
+        TreatAsErrorFromVersion = "6",
+        ReplacementTypeOrMember = "Notifications")]
+    public class BusNotifications
+    {
+    }
+
+    public partial class Notifications
     {
         [ObsoleteEx(Message = "For performance reasons it is no longer possible to instrument the pipeline execution", RemoveInVersion = "7.0", TreatAsErrorFromVersion = "6.0")]
         public PipelineNotifications Pipeline


### PR DESCRIPTION
fix #3425

Rename `BusNotifications` to `Notifications`

I moved over the obsolete property to `Notifications` to provide more help to migrating users. Should we do that or keep it on the obsolete class?

WIP doc PR: https://github.com/Particular/docs.particular.net/pull/1342