### PR TITLE
Notifications can now be accessed from endpoint config calls

### DIFF
--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -45,6 +45,9 @@ namespace NServiceBus
             Settings.SetDefault("Transactions.IsolationLevel", IsolationLevel.ReadCommitted);
             Settings.SetDefault("Transactions.DefaultTimeout", TransactionManager.DefaultTimeout);
 
+            Settings.Set<Notifications>(new Notifications());
+            Settings.Set<NotificationSubscriptions>(new NotificationSubscriptions());
+
             conventionsBuilder = new ConventionsBuilder(Settings);
         }
 

--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -17,8 +17,6 @@ namespace NServiceBus
     {
         public InitializableEndpoint(SettingsHolder settings, IContainer container, List<Action<IConfigureComponents>> registrations, PipelineSettings pipelineSettings, PipelineConfiguration pipelineConfiguration, IReadOnlyCollection<IWantToRunWhenBusStartsAndStops> startables)
         {
-            settings.Set<Notifications>(new Notifications());
-            settings.Set<NotificationSubscriptions>(new NotificationSubscriptions());
             this.settings = settings;
             this.pipelineSettings = pipelineSettings;
             this.pipelineConfiguration = pipelineConfiguration;


### PR DESCRIPTION
This means that we can add endpoint config calls that allows users to subscribe to notifications.

Note that there is no public api yet so this just paves the way.

The reason I changed this now is that it will allow @kbaley to cleanup #3611 to not use features to hook up to the existing notifications but instead (yes sort of a backdoor) do: `config.GetSettings().Get<Notifications>.xyz`