### PR TITLE
Fix acceptance tests

### DIFF
--- a/src/NServiceBus.AcceptanceTests/ConventionEnforcementTests.cs
+++ b/src/NServiceBus.AcceptanceTests/ConventionEnforcementTests.cs
@@ -1,0 +1,28 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ConventionEnforcementTests : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Ensure_all_tests_derive_from_a_common_base_class()
+        {
+            var testTypes = Assembly.GetExecutingAssembly().GetTypes()
+                .Where(HasTestMethod);
+
+            var missingBaseClass = testTypes
+                .Where(t => t.BaseType == null || !typeof(NServiceBusAcceptanceTest).IsAssignableFrom(t));
+
+            CollectionAssert.IsEmpty(missingBaseClass);
+        }
+
+        static bool HasTestMethod(Type t)
+        {
+            return t.GetMethods().Any(m => m.GetCustomAttributes<TestAttribute>().Any());
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -176,7 +176,6 @@
     <Compile Include="DataBus\When_using_custom_IDataBus.cs" />
     <Compile Include="DeterministicGuid.cs" />
     <Compile Include="Hosting\When_feature_overrides_hostinfo.cs" />
-    <Compile Include="Routing\When_distributing_a_command.cs" />
     <Compile Include="Sagas\When_message_has_a_saga_id.cs" />
     <Compile Include="Recoverability\Retries\When_Subscribing_to_errors.cs" />
     <Compile Include="Sagas\When_timeout_hit_not_found_saga.cs" />

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Causation\When_a_message_is_faulted.cs" />
     <Compile Include="Causation\When_a_message_is_audited.cs" />
     <Compile Include="ConfigureEndpointInMemoryPersistence.cs" />
+    <Compile Include="ConventionEnforcementTests.cs" />
     <Compile Include="Correlation\When_replying_to_received_message_without_correlationid.cs" />
     <Compile Include="DelayedDelivery\When_deferring_a_message_to_the_past.cs" />
     <Compile Include="DelayedDelivery\TimeoutManager\When_timeout_dispatch_fails.cs" />

--- a/src/NServiceBus.AcceptanceTests/Persistence/When_a_persistence_does_not_provide_ISynchronizationContext.cs
+++ b/src/NServiceBus.AcceptanceTests/Persistence/When_a_persistence_does_not_provide_ISynchronizationContext.cs
@@ -10,7 +10,7 @@
     using Unicast.Subscriptions;
     using Unicast.Subscriptions.MessageDrivenSubscriptions;
 
-    public class When_a_persistence_does_not_provide_ISynchronizationContext
+    public class When_a_persistence_does_not_provide_ISynchronizationContext : NServiceBusAcceptanceTest
     {
         // Run this test twice to ensure that the NoOpCompletableSynchronizedStorageSession's IDisposable method
         // is not altered by Fody to throw an ObjectDisposedException if it was disposed

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists.cs
@@ -10,7 +10,7 @@
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_a_finder_exists
+    public class When_a_finder_exists : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_use_it_to_find_saga()

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_context_information_added.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_context_information_added.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.AcceptanceTests.Sagas
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_a_finder_exists_and_context_information_added
+    public class When_a_finder_exists_and_context_information_added : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_make_context_information_available()

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_found_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_found_saga.cs
@@ -10,7 +10,7 @@
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_a_finder_exists_and_found_saga
+    public class When_a_finder_exists_and_found_saga : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_find_saga_and_not_correlate()

--- a/src/NServiceBus.AcceptanceTests/SelfVerification/When_running_saga_tests.cs
+++ b/src/NServiceBus.AcceptanceTests/SelfVerification/When_running_saga_tests.cs
@@ -7,7 +7,7 @@
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_running_saga_tests
+    public class When_running_saga_tests : NServiceBusAcceptanceTest
     {
         [Test]
         public void All_saga_entities_in_acceptance_tests_should_have_virtual_properties()

--- a/src/NServiceBus.AcceptanceTests/UnitOfWork/TransactionScope/When_transactionscope_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/UnitOfWork/TransactionScope/When_transactionscope_enabled.cs
@@ -6,7 +6,7 @@
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
-    public class When_transactionscope_enabled
+    public class When_transactionscope_enabled : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_wrap_the_handlers_in_a_scope()

--- a/src/NServiceBus.AcceptanceTests/UnitOfWork/TransactionScope/When_using_timeout_greater_than_machine_max.cs
+++ b/src/NServiceBus.AcceptanceTests/UnitOfWork/TransactionScope/When_using_timeout_greater_than_machine_max.cs
@@ -5,7 +5,7 @@
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
-    public class When_using_timeout_greater_than_machine_max
+    public class When_using_timeout_greater_than_machine_max : NServiceBusAcceptanceTest
     {
         [Test]
         public void Should_blow_up()

--- a/src/NServiceBus.AcceptanceTests/UnitOfWork/When_a_subscription_message_arrives.cs
+++ b/src/NServiceBus.AcceptanceTests/UnitOfWork/When_a_subscription_message_arrives.cs
@@ -8,7 +8,7 @@
     using NServiceBus.UnitOfWork;
     using NUnit.Framework;
 
-    public class When_a_subscription_message_arrives
+    public class When_a_subscription_message_arrives : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_invoke_uow()

--- a/src/NServiceBus.Msmq.AcceptanceTests/NServiceBus.Msmq.AcceptanceTests.csproj
+++ b/src/NServiceBus.Msmq.AcceptanceTests/NServiceBus.Msmq.AcceptanceTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="When_Audit_OverrideTimeToBeReceived_set_and_native_receive_tx.cs" />
     <Compile Include="When_a_corrupted_message_is_received.cs" />
     <Compile Include="When_customizing_scope_isolation_level.cs" />
+    <Compile Include="When_distributing_a_command.cs" />
     <Compile Include="When_publishing.cs" />
     <Compile Include="When_publishing_with_authorizer.cs" />
     <Compile Include="When_receiving_control_message_with_body.cs" />


### PR DESCRIPTION
* Fixes `When_distributing_a_command` test and moves it to MSMQ project because in V6 time frame it is relevant almost exclusively to MSMQ
 * Added missing base class declarations to tests that were missing them. Without that declaration tests would not be executed if specific transport or persistence need to be enforced
 * Added a meta-test that enforces proper base class for all acceptance tests