### PR TITLE
Exclude Persistence tests from source package

### DIFF
--- a/packaging/nuget/nservicebus.acceptancetests.nuspec
+++ b/packaging/nuget/nservicebus.acceptancetests.nuspec
@@ -27,6 +27,6 @@
     <file
       src="..\..\src\NServiceBus.AcceptanceTests\**\*.cs"
       target="content\App_Packages\NSB.AcceptanceTests.$version$"
-      exclude="**\bin\**\*.*;**\obj\**\*.*;..\..\src\NServiceBus.AcceptanceTests\Exceptions\**\*.cs;..\..\src\NServiceBus.AcceptanceTests\FakeTransport\**\*.cs;..\..\src\NServiceBus.AcceptanceTests\UnitOfWork\**\*.cs" />
+      exclude="**\bin\**\*.*;**\obj\**\*.*;..\..\src\NServiceBus.AcceptanceTests\Exceptions\**\*.cs;..\..\src\NServiceBus.AcceptanceTests\FakeTransport\**\*.cs;..\..\src\NServiceBus.AcceptanceTests\Persistence\**\*.cs;..\..\src\NServiceBus.AcceptanceTests\UnitOfWork\**\*.cs" />
   </files>
 </package>


### PR DESCRIPTION
Per https://github.com/Particular/NServiceBus/pull/3591#issuecomment-200950452 this removes the Persistence tests from the source package.

There was [one test](https://github.com/Particular/NServiceBus/blob/excludePersistenceTests/src/NServiceBus.AcceptanceTests/Persistence/When_a_persistence_does_not_provide_ISynchronizationContext.cs) in there that wasn't added as part of #3591, but looking at it, it seemed ok to me to also not include downstream.

Thoughts?