### PR TITLE
Moved obsoleted methods from BusConfig to EndpointConfig

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -56,30 +56,6 @@ namespace NServiceBus
     public class BusConfiguration
     {
         public BusConfiguration() { }
-        [System.ObsoleteAttribute("Please use `EndpointConfiguration.AddHeaderToAllOutgoingMessages(string key,strin" +
-            "g value)` instead. Will be removed in version 7.0.0.", true)]
-        public System.Collections.Generic.IDictionary<string, string> OutgoingHeaders { get; }
-        [System.ObsoleteAttribute("Please use `EndpointConfiguration.ExcludeAssemblies` instead. Will be removed in " +
-            "version 7.0.0.", true)]
-        public void AssembliesToScan(System.Collections.Generic.IEnumerable<System.Reflection.Assembly> assemblies) { }
-        [System.ObsoleteAttribute("Please use `EndpointConfiguration.ExcludeAssemblies` instead. Will be removed in " +
-            "version 7.0.0.", true)]
-        public void AssembliesToScan(params System.Reflection.Assembly[] assemblies) { }
-        [System.ObsoleteAttribute("Endpoint name is now a mandatory constructor argument on EndpointConfiguration. W" +
-            "ill be removed in version 7.0.0.", true)]
-        public void EndpointName(string name) { }
-        [System.ObsoleteAttribute("Please use `EndpointConfiguration.UseTransport<T>().AddAddressTranslationRule(Fun" +
-            "c<LogicalAddress, string> rule)` instead. Will be removed in version 7.0.0.", true)]
-        public void OverrideLocalAddress(string queue) { }
-        [System.ObsoleteAttribute("Please use `EndpointConfiguration.OverridePublicReturnAddress(string address)` in" +
-            "stead. Will be removed in version 7.0.0.", true)]
-        public void OverridePublicReturnAddress(NServiceBus.Address address) { }
-        [System.ObsoleteAttribute("Please use `EndpointConfiguration.ExcludeAssemblies` instead. Will be removed in " +
-            "version 7.0.0.", true)]
-        public void ScanAssembliesInDirectory(string probeDirectory) { }
-        [System.ObsoleteAttribute("Please use `EndpointConfiguration.ExcludeTypes` instead. Will be removed in versi" +
-            "on 7.0.0.", true)]
-        public void TypesToScan(System.Collections.Generic.IEnumerable<System.Type> typesToScan) { }
     }
     [System.ObsoleteAttribute("Please use `Notifications` instead. Will be removed in version 7.0.0.", true)]
     public class BusNotifications
@@ -304,16 +280,40 @@ namespace NServiceBus
     public class EndpointConfiguration : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
         public EndpointConfiguration(string endpointName) { }
+        [System.ObsoleteAttribute("Please use `EndpointConfiguration.AddHeaderToAllOutgoingMessages(string key,strin" +
+            "g value)` instead. Will be removed in version 7.0.0.", true)]
+        public System.Collections.Generic.IDictionary<string, string> OutgoingHeaders { get; }
         public NServiceBus.Pipeline.PipelineSettings Pipeline { get; }
+        [System.ObsoleteAttribute("Please use `EndpointConfiguration.ExcludeAssemblies` instead. Will be removed in " +
+            "version 7.0.0.", true)]
+        public void AssembliesToScan(System.Collections.Generic.IEnumerable<System.Reflection.Assembly> assemblies) { }
+        [System.ObsoleteAttribute("Please use `EndpointConfiguration.ExcludeAssemblies` instead. Will be removed in " +
+            "version 7.0.0.", true)]
+        public void AssembliesToScan(params System.Reflection.Assembly[] assemblies) { }
         public NServiceBus.ConventionsBuilder Conventions() { }
         public void CustomConfigurationSource(NServiceBus.Config.ConfigurationSource.IConfigurationSource configurationSource) { }
+        [System.ObsoleteAttribute("Endpoint name is now a mandatory constructor argument on EndpointConfiguration. W" +
+            "ill be removed in version 7.0.0.", true)]
+        public void EndpointName(string name) { }
         public void ExcludeAssemblies(params string[] assemblies) { }
         public void ExcludeTypes(params System.Type[] types) { }
+        [System.ObsoleteAttribute("Please use `EndpointConfiguration.UseTransport<T>().AddAddressTranslationRule(Fun" +
+            "c<LogicalAddress, string> rule)` instead. Will be removed in version 7.0.0.", true)]
+        public void OverrideLocalAddress(string queue) { }
         public void OverridePublicReturnAddress(string address) { }
+        [System.ObsoleteAttribute("Please use `EndpointConfiguration.OverridePublicReturnAddress(string address)` in" +
+            "stead. Will be removed in version 7.0.0.", true)]
+        public void OverridePublicReturnAddress(NServiceBus.Address address) { }
         public void RegisterComponents(System.Action<NServiceBus.ObjectBuilder.IConfigureComponents> registration) { }
         public void RunWhenEndpointStartsAndStops(NServiceBus.IWantToRunWhenBusStartsAndStops callbackObject) { }
+        [System.ObsoleteAttribute("Please use `EndpointConfiguration.ExcludeAssemblies` instead. Will be removed in " +
+            "version 7.0.0.", true)]
+        public void ScanAssembliesInDirectory(string probeDirectory) { }
         public void ScanAssembliesInNestedDirectories() { }
         public void SendOnly() { }
+        [System.ObsoleteAttribute("Please use `EndpointConfiguration.ExcludeTypes` instead. Will be removed in versi" +
+            "on 7.0.0.", true)]
+        public void TypesToScan(System.Collections.Generic.IEnumerable<System.Type> typesToScan) { }
         public void UseContainer<T>(System.Action<NServiceBus.Container.ContainerCustomizations> customizations = null)
             where T : NServiceBus.Container.ContainerDefinition, new () { }
         public void UseContainer(System.Type definitionType) { }

--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -20,7 +20,7 @@ namespace NServiceBus
     /// <summary>
     /// Configuration used to create an endpoint instance.
     /// </summary>
-    public class EndpointConfiguration : ExposeSettings
+    public partial class EndpointConfiguration : ExposeSettings
     {
         /// <summary>
         /// Initializes the endpoint configuration builder.

--- a/src/NServiceBus.Core/obsoletes.cs
+++ b/src/NServiceBus.Core/obsoletes.cs
@@ -124,6 +124,10 @@ namespace NServiceBus
         TreatAsErrorFromVersion = "6.0")]
     public class BusConfiguration
     {
+    }
+
+    public partial class EndpointConfiguration
+    {
         [ObsoleteEx(
             ReplacementTypeOrMember = "EndpointConfiguration.AddHeaderToAllOutgoingMessages(string key,string value)",
             RemoveInVersion = "7.0",
@@ -196,7 +200,6 @@ namespace NServiceBus
         {
             throw new NotImplementedException();
         }
-
     }
 
     [ObsoleteEx(


### PR DESCRIPTION
This will better guide users upgrading.

@indualagarsamy ran into a problem with vierd compiler errors related to `.EndpointName` when upgrading. This should solve that.

cc @SimonCropp