### PR TITLE
Making the ctor of ConventionsBuilder public

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -195,6 +195,8 @@ namespace NServiceBus
     }
     public class ConventionsBuilder : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
+        public ConventionsBuilder(NServiceBus.Settings.SettingsHolder settings) { }
+        public NServiceBus.Conventions Conventions { get; }
         public NServiceBus.ConventionsBuilder DefiningCommandsAs(System.Func<System.Type, bool> definesCommandType) { }
         public NServiceBus.ConventionsBuilder DefiningDataBusPropertiesAs(System.Func<System.Reflection.PropertyInfo, bool> definesDataBusProperty) { }
         public NServiceBus.ConventionsBuilder DefiningEncryptedPropertiesAs(System.Func<System.Reflection.PropertyInfo, bool> definesEncryptedProperty) { }

--- a/src/NServiceBus.Core/ConventionsBuilder.cs
+++ b/src/NServiceBus.Core/ConventionsBuilder.cs
@@ -6,11 +6,15 @@ namespace NServiceBus
     using Settings;
 
     /// <summary>
-    /// Conventions builder class.
+    /// Defines custom message conventions instead of using the <see cref="IMessage"/>, <see cref="IEvent"/> or <see cref="ICommand"/> interfaces, and other conventions.
     /// </summary>
     public class ConventionsBuilder : ExposeSettings
     {
-        internal ConventionsBuilder(SettingsHolder settings) : base(settings)
+        /// <summary>
+        /// Creates a new instance of ConventionsBuilder class.
+        /// </summary>
+        /// <param name="settings">An instance of the current settings.</param>
+        public ConventionsBuilder(SettingsHolder settings) : base(settings)
         {
         }
 
@@ -65,6 +69,9 @@ namespace NServiceBus
         }
 
 
-        internal Conventions Conventions = new Conventions();
+        /// <summary>
+        /// The defined <see cref="Conventions"/>.
+        /// </summary>
+        public Conventions Conventions { get; } = new Conventions();
     }
 }


### PR DESCRIPTION
Connects to https://github.com/Particular/ProductionTests/pull/57

This is needed to define custom Conventions without EndpointConfiguration. For use in SerializationTests.