### PR TITLE
Minor fixes to usages of RoutingStrategy and AddressTag

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Routing\Routers\UnicastReplyRouterConnectorTests.cs" />
     <Compile Include="Routing\Routers\UnicastPublishRouterConnectorTests.cs" />
     <Compile Include="Routing\RoutingOptionExtensionsTests.cs" />
+    <Compile Include="Routing\RoutingToDispatchConnectorTests.cs" />
     <Compile Include="Routing\SubscriptionRouterTests.cs" />
     <Compile Include="Sagas\CustomFinderAdapterTests.cs" />
     <Compile Include="Sagas\InvokeSagaNotFoundBehaviorTests.cs" />

--- a/src/NServiceBus.Core.Tests/Routing/RoutingToDispatchConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingToDispatchConnectorTests.cs
@@ -1,0 +1,47 @@
+﻿namespace NServiceBus.Core.Tests.Routing
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Routing;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+    using ObjectBuilder;
+
+    [TestFixture]
+    public class RoutingToDispatchConnectorTests
+    {
+        [Test]
+        public async Task It_preserves_headers_generated_by_custom_routing_strategy()
+        {
+            var behavior = new RoutingToDispatchConnector();
+            var message = new OutgoingMessage("ID", new Dictionary<string, string>(), new byte[0]);
+            Dictionary<string, string> headers = null;
+            await behavior.Invoke(new RoutingContext(message,
+                new CustomRoutingStrategy(), new FakeContext()), context =>
+                {
+                    headers = context.Operations.First().Message.Headers;
+                    return TaskEx.CompletedTask;
+                });
+
+            Assert.IsTrue(headers.ContainsKey("CustomHeader"));
+        }
+
+        class FakeContext : ContextBag, IBehaviorContext
+        {
+            public ContextBag Extensions => this;
+            public IBuilder Builder => null;
+        }
+
+        class CustomRoutingStrategy : RoutingStrategy
+        {
+            public override AddressTag Apply(Dictionary<string, string> headers)
+            {
+                headers["CustomHeader"] = "CustomValue";
+                return new UnicastAddressTag("destination");
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehavior.cs
@@ -40,7 +40,7 @@ namespace NServiceBus
                 }
 
                 //Hack 133
-                var ultimateDestination = ((UnicastAddressTag) context.RoutingStrategies.Single().Apply(new Dictionary<string, string>(context.Message.Headers))).Destination;
+                var ultimateDestination = ((UnicastAddressTag) context.RoutingStrategies.Single().Apply(context.Message.Headers)).Destination;
                 context.Message.Headers[TimeoutManagerHeaders.RouteExpiredTimeoutTo] = ultimateDestination;
                 context.RoutingStrategies = new[]
                 {

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutRecoverabilityBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutRecoverabilityBehavior.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using JetBrains.Annotations;
     using Logging;
@@ -63,8 +62,7 @@ namespace NServiceBus
                 message.SetExceptionHeaders(failureInfo.Exception, localAddress);
 
                 var outgoingMessage = new OutgoingMessage(message.MessageId, message.Headers, message.Body);
-                var routingStrategy = new UnicastRoutingStrategy(errorQueueAddress);
-                var addressTag = routingStrategy.Apply(new Dictionary<string, string>());
+                var addressTag = new UnicastAddressTag(errorQueueAddress);
 
                 var transportOperations = new TransportOperations(new TransportOperation(outgoingMessage, addressTag));
 

--- a/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
@@ -21,8 +20,7 @@
             var operations = context.RoutingStrategies
                 .Select(rs =>
                 {
-                    var headers = new Dictionary<string, string>(context.Message.Headers);
-                    var addressLabel = rs.Apply(headers);
+                    var addressLabel = rs.Apply(context.Message.Headers);
                     var message = new OutgoingMessage(context.Message.MessageId, context.Message.Headers, context.Message.Body);
                     return new TransportOperation(message, addressLabel, dispatchConsistency, context.Extensions.GetDeliveryConstraints());
                 }).ToList();


### PR DESCRIPTION
Allow fo custom routing strategies that modify the headers (the built-in ones don't do it).