### PR TITLE
Allow creating IDispatchContext from a ForkConnector.

### DIFF
--- a/src/NServiceBus.Core/Pipeline/PipelineCache.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineCache.cs
@@ -12,6 +12,7 @@ namespace NServiceBus
         public PipelineCache(IBuilder builder, ReadOnlySettings settings)
         {
             FromMainPipeline<IAuditContext>(builder, settings);
+            FromMainPipeline<IDispatchContext>(builder, settings);
             FromMainPipeline<IOutgoingPublishContext>(builder, settings);
             FromMainPipeline<ISubscribeContext>(builder, settings);
             FromMainPipeline<IUnsubscribeContext>(builder, settings);


### PR DESCRIPTION
The current state of `ConnectorContextExtensions` does not provide extension methods for creating contexts in the forks. This PR addresses this issue for the dispatch pipeline but I believe there needs to be some other extensions e.g. for the routing pipeline.