### PR TITLE
Testing.Fakes cleanup

### DIFF
--- a/packaging/nuget/nservicebus.testing.fakes.nuspec
+++ b/packaging/nuget/nservicebus.testing.fakes.nuspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-    <id>NServiceBus.Fakes.Sources</id>
+    <id>NServiceBus.Testing.Fakes.Sources</id>
     <title>Source only package containing fake implementations of various NServiceBus components for unit tests</title>
     <version>$version$</version>
     <authors>$authors$</authors>
@@ -20,7 +20,7 @@
   <files>
     <file
       src="..\..\src\NServiceBus.Testing.Fakes\*.cs"
-      target="content\Testing\Fakes"
+      target="content\App_Packages\NSB.Testing.Fakes.$version$"
       exclude="**\bin\**\*.*;**\obj\**\*.*;" />
   </files>
 </package>

--- a/src/NServiceBus.Testing.Fakes/FakeBuilder.cs
+++ b/src/NServiceBus.Testing.Fakes/FakeBuilder.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using NServiceBus.ObjectBuilder;
+    using ObjectBuilder;
 
     /// <summary>
     /// A fake implementation of <see cref="IBuilder" /> for testing purposes.
@@ -147,7 +147,8 @@
             factories.Add(typeof(T), factory);
         }
 
-        IDictionary<Type, object[]> instances = new Dictionary<Type, object[]>();
-        IDictionary<Type, Func<object[]>> factories = new Dictionary<Type, Func<object[]>>();
+        Dictionary<Type, Func<object[]>> factories = new Dictionary<Type, Func<object[]>>();
+
+        Dictionary<Type, object[]> instances = new Dictionary<Type, object[]>();
     }
 }

--- a/src/NServiceBus.Testing.Fakes/OutgoingMessage.cs
+++ b/src/NServiceBus.Testing.Fakes/OutgoingMessage.cs
@@ -1,6 +1,6 @@
 namespace NServiceBus.Testing
 {
-    using NServiceBus.Extensibility;
+    using Extensibility;
 
     /// <summary>
     /// Represents an outgoing message. Contains the message itself and its associated options.

--- a/src/NServiceBus.Testing.Fakes/OutgoingMessageExtensions.cs
+++ b/src/NServiceBus.Testing.Fakes/OutgoingMessageExtensions.cs
@@ -16,7 +16,7 @@ namespace NServiceBus.Testing
         {
             return repliedMessages
                 .Where(x => x.Message is TMessage)
-                .Select(x => new RepliedMessage<TMessage>((TMessage)x.Message, x.Options));
+                .Select(x => new RepliedMessage<TMessage>((TMessage) x.Message, x.Options));
         }
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace NServiceBus.Testing
         {
             return publishedMessages
                 .Where(x => x.Message is TMessage)
-                .Select(x => new PublishedMessage<TMessage>((TMessage)x.Message, x.Options));
+                .Select(x => new PublishedMessage<TMessage>((TMessage) x.Message, x.Options));
         }
 
         /// <summary>
@@ -37,14 +37,14 @@ namespace NServiceBus.Testing
         {
             return sentMessages
                 .Where(x => x.Message is TMessage)
-                .Select(x => new SentMessage<TMessage>((TMessage)x.Message, x.Options));
+                .Select(x => new SentMessage<TMessage>((TMessage) x.Message, x.Options));
         }
 
         internal static IEnumerable<TimeoutMessage<TMessage>> Containing<TMessage>(this IEnumerable<TimeoutMessage<object>> timeoutMessages)
         {
             return timeoutMessages
                 .Where(x => x.Message is TMessage)
-                .Select(x => new TimeoutMessage<TMessage>((TMessage)x.Message, x.Options, x.Within));
+                .Select(x => new TimeoutMessage<TMessage>((TMessage) x.Message, x.Options, x.Within));
         }
 
         /// <summary>

--- a/src/NServiceBus.Testing.Fakes/TestableAuditContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableAuditContext.cs
@@ -2,8 +2,8 @@
 {
     using System;
     using System.Collections.Generic;
-    using NServiceBus.Pipeline;
-    using NServiceBus.Transports;
+    using Pipeline;
+    using Transports;
 
     /// <summary>
     /// A testable implementation of <see cref="IAuditContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestableAuditContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableAuditContext.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Testing
 {
+    using System;
     using System.Collections.Generic;
     using NServiceBus.Pipeline;
     using NServiceBus.Transports;
@@ -17,12 +18,12 @@
         /// <summary>
         /// Address of the audit queue.
         /// </summary>
-        public string AuditAddress { get; set; }
+        public string AuditAddress { get; set; } = "audit queue address";
 
         /// <summary>
         /// The message to be audited.
         /// </summary>
-        public OutgoingMessage Message { get; set; }
+        public OutgoingMessage Message { get; set; } = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]);
 
         /// <summary>
         /// Adds information about the current message that should be audited.

--- a/src/NServiceBus.Testing.Fakes/TestableBatchDispatchContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableBatchDispatchContext.cs
@@ -2,8 +2,8 @@
 {
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using NServiceBus.Pipeline;
-    using NServiceBus.Transports;
+    using Pipeline;
+    using Transports;
 
     /// <summary>
     /// A testable implementation of <see cref="IBatchDispatchContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestableBehaviorContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableBehaviorContext.cs
@@ -1,8 +1,8 @@
 ﻿namespace NServiceBus.Testing
 {
-    using NServiceBus.Extensibility;
-    using NServiceBus.ObjectBuilder;
-    using NServiceBus.Pipeline;
+    using Extensibility;
+    using ObjectBuilder;
+    using Pipeline;
 
     /// <summary>
     /// A base implementation for contexts implementing <see cref="IBehaviorContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestableDispatchContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableDispatchContext.cs
@@ -1,8 +1,8 @@
 ﻿namespace NServiceBus.Testing
 {
     using System.Collections.Generic;
-    using NServiceBus.Pipeline;
-    using NServiceBus.Transports;
+    using Pipeline;
+    using Transports;
 
     /// <summary>
     /// A testable implementation of <see cref="IDispatchContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestableFaultContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableFaultContext.cs
@@ -2,8 +2,8 @@
 {
     using System;
     using System.Collections.Generic;
-    using NServiceBus.Pipeline;
-    using NServiceBus.Transports;
+    using Pipeline;
+    using Transports;
 
     /// <summary>
     /// A testable implementation of <see cref="IFaultContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestableForwardingContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableForwardingContext.cs
@@ -2,8 +2,8 @@
 {
     using System;
     using System.Collections.Generic;
-    using NServiceBus.Pipeline;
-    using NServiceBus.Transports;
+    using Pipeline;
+    using Transports;
 
     /// <summary>
     /// A testable implementation for <see cref="IForwardingContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestableIncomingContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableIncomingContext.cs
@@ -1,7 +1,7 @@
 ﻿namespace NServiceBus.Testing
 {
-    using NServiceBus.ObjectBuilder;
-    using NServiceBus.Pipeline;
+    using ObjectBuilder;
+    using Pipeline;
 
     /// <summary>
     /// Base implementation for contexts implementing <see cref="IIncomingContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestableIncomingLogicalMessageContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableIncomingLogicalMessageContext.cs
@@ -19,7 +19,7 @@
         /// <summary>
         /// Message being handled.
         /// </summary>
-        public LogicalMessage Message { get; set; }
+        public LogicalMessage Message { get; set; } = new LogicalMessage(new MessageMetadata(typeof(object)), new object());
 
         /// <summary>
         /// Headers for the incoming message.

--- a/src/NServiceBus.Testing.Fakes/TestableIncomingLogicalMessageContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableIncomingLogicalMessageContext.cs
@@ -1,7 +1,7 @@
 ﻿namespace NServiceBus.Testing
 {
     using System.Collections.Generic;
-    using NServiceBus.Pipeline;
+    using Pipeline;
     using Unicast.Messages;
 
     /// <summary>

--- a/src/NServiceBus.Testing.Fakes/TestableIncomingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableIncomingPhysicalMessageContext.cs
@@ -3,8 +3,8 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using NServiceBus.Pipeline;
-    using NServiceBus.Transports;
+    using Pipeline;
+    using Transports;
 
     /// <summary>
     /// A testable implementation of <see cref="IIncomingPhysicalMessageContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestableInvokeHandlerContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableInvokeHandlerContext.cs
@@ -2,9 +2,9 @@
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using NServiceBus.Persistence;
-    using NServiceBus.Pipeline;
-    using NServiceBus.Unicast.Messages;
+    using Persistence;
+    using Pipeline;
+    using Unicast.Messages;
 
     /// <summary>
     /// A testable implementation of <see cref="IInvokeHandlerContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestableInvokeHandlerContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableInvokeHandlerContext.cs
@@ -56,7 +56,7 @@
         /// <summary>
         /// The current <see cref="T:NServiceBus.IHandleMessages`1" /> being executed.
         /// </summary>
-        public MessageHandler MessageHandler { get; set; }
+        public MessageHandler MessageHandler { get; set; } = new MessageHandler((instance, message, context) => Task.FromResult(0), typeof(object));
 
         /// <summary>
         /// Message headers.
@@ -78,6 +78,6 @@
         /// <summary>
         /// Metadata for the incoming message.
         /// </summary>
-        public MessageMetadata MessageMetadata { get; set; }
+        public MessageMetadata MessageMetadata { get; set; } = new MessageMetadata(typeof(object));
     }
 }

--- a/src/NServiceBus.Testing.Fakes/TestableMessageProcessingContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableMessageProcessingContext.cs
@@ -77,8 +77,8 @@ namespace NServiceBus.Testing
         public string ReplyToAddress { get; set; } = "reply address";
 
         IReadOnlyDictionary<string, string> IMessageProcessingContext.MessageHeaders => new ReadOnlyDictionary<string, string>(MessageHeaders);
+        ConcurrentQueue<string> forwardedMessages = new ConcurrentQueue<string>();
 
         ConcurrentQueue<RepliedMessage<object>> repliedMessages = new ConcurrentQueue<RepliedMessage<object>>();
-        ConcurrentQueue<string> forwardedMessages = new ConcurrentQueue<string>();
     }
 }

--- a/src/NServiceBus.Testing.Fakes/TestableOutgoingContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableOutgoingContext.cs
@@ -2,8 +2,8 @@
 {
     using System;
     using System.Collections.Generic;
-    using NServiceBus.ObjectBuilder;
-    using NServiceBus.Pipeline;
+    using ObjectBuilder;
+    using Pipeline;
 
     /// <summary>
     /// A base implementation for all behaviors implementing <see cref="IOutgoingContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestableOutgoingLogicalMessageContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableOutgoingLogicalMessageContext.cs
@@ -1,8 +1,8 @@
 ﻿namespace NServiceBus.Testing
 {
     using System.Collections.Generic;
-    using NServiceBus.Pipeline;
-    using NServiceBus.Routing;
+    using Pipeline;
+    using Routing;
 
     /// <summary>
     /// A testable implementation of <see cref="IOutgoingLogicalMessageContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestableOutgoingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableOutgoingPhysicalMessageContext.cs
@@ -1,8 +1,8 @@
 ﻿namespace NServiceBus.Testing
 {
     using System.Collections.Generic;
-    using NServiceBus.Pipeline;
-    using NServiceBus.Routing;
+    using Pipeline;
+    using Routing;
 
     /// <summary>
     /// A testable implementation of <see cref="IOutgoingPhysicalMessageContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestableOutgoingPublishContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableOutgoingPublishContext.cs
@@ -1,6 +1,6 @@
 ﻿namespace NServiceBus.Testing
 {
-    using NServiceBus.Pipeline;
+    using Pipeline;
 
     /// <summary>
     /// A testable implementation of <see cref="IOutgoingPublishContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestableOutgoingReplyContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableOutgoingReplyContext.cs
@@ -1,6 +1,6 @@
 ﻿namespace NServiceBus.Testing
 {
-    using NServiceBus.Pipeline;
+    using Pipeline;
 
     /// <summary>
     /// A testable implementation of <see cref="IOutgoingReplyContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestableOutgoingSendContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableOutgoingSendContext.cs
@@ -1,6 +1,6 @@
 ﻿namespace NServiceBus.Testing
 {
-    using NServiceBus.Pipeline;
+    using Pipeline;
 
     /// <summary>
     /// A testable implementation of <see cref="IOutgoingSendContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestablePipelineContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestablePipelineContext.cs
@@ -3,8 +3,8 @@
     using System;
     using System.Collections.Concurrent;
     using System.Threading.Tasks;
-    using NServiceBus.Extensibility;
-    using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+    using Extensibility;
+    using MessageInterfaces.MessageMapper.Reflection;
 
     /// <summary>
     /// A testable implementation of <see cref="IPipelineContext" />.
@@ -84,8 +84,8 @@
         /// </summary>
         protected IMessageCreator messageCreator;
 
-        ConcurrentQueue<SentMessage<object>> sentMessages = new ConcurrentQueue<SentMessage<object>>();
-
         ConcurrentQueue<PublishedMessage<object>> publishedMessages = new ConcurrentQueue<PublishedMessage<object>>();
+
+        ConcurrentQueue<SentMessage<object>> sentMessages = new ConcurrentQueue<SentMessage<object>>();
     }
 }

--- a/src/NServiceBus.Testing.Fakes/TestableRoutingContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableRoutingContext.cs
@@ -2,9 +2,9 @@
 {
     using System;
     using System.Collections.Generic;
-    using NServiceBus.Pipeline;
-    using NServiceBus.Routing;
-    using NServiceBus.Transports;
+    using Pipeline;
+    using Routing;
+    using Transports;
 
     /// <summary>
     /// A testable implementation of <see cref="IRoutingContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestableSatelliteProcessingContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableSatelliteProcessingContext.cs
@@ -3,8 +3,8 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using NServiceBus.Pipeline;
-    using NServiceBus.Transports;
+    using Pipeline;
+    using Transports;
 
     /// <summary>
     /// A testable implementation of <see cref="ISatelliteProcessingContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestableSubscribeContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableSubscribeContext.cs
@@ -1,7 +1,8 @@
 ﻿namespace NServiceBus.Testing
 {
     using System;
-    using NServiceBus.Pipeline;
+    using Pipeline;
+
     /// <summary>
     /// A testable implementation of <see cref="ISubscribeContext" />.
     /// </summary>

--- a/src/NServiceBus.Testing.Fakes/TestableTransportReceiveContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableTransportReceiveContext.cs
@@ -3,8 +3,8 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using NServiceBus.Pipeline;
-    using NServiceBus.Transports;
+    using Pipeline;
+    using Transports;
 
     /// <summary>
     /// A testable implementation for <see cref="ITransportReceiveContext" />.

--- a/src/NServiceBus.Testing.Fakes/TestableUnsubscribeContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableUnsubscribeContext.cs
@@ -1,7 +1,7 @@
 ﻿namespace NServiceBus.Testing
 {
     using System;
-    using NServiceBus.Pipeline;
+    using Pipeline;
 
     /// <summary>
     /// A testable implementation of <see cref="IUnsubscribeContext" />.


### PR DESCRIPTION
* Move source files to `App_Packages` folder. Used `NSB.Testing.Fakes` instead of the package id similar to acceptance test and container test sources. Fixes #3645  /cc @SimonCropp 
* Ran a code cleanup on all classes (mainly namespace cleanup)
* Added some missing default values for some context properties

@Particular/nservicebus-maintainers @hmemcpy please review

Connects to Particular/NServiceBus.Testing#29