### PR TITLE
Redesigned RouteDeferredMessageToTimeoutManagerBehavior to be a fork

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -743,6 +743,14 @@ namespace NServiceBus
     {
         public static NServiceBus.Outbox.OutboxSettings EnableOutbox(this NServiceBus.EndpointConfiguration config) { }
     }
+    public class PendingTransportOperations
+    {
+        public PendingTransportOperations() { }
+        public bool HasOperations { get; }
+        public System.Collections.Generic.IReadOnlyCollection<NServiceBus.Transports.TransportOperation> Operations { get; }
+        public void Add(NServiceBus.Transports.TransportOperation transportOperation) { }
+        public void AddRange(System.Collections.Generic.IEnumerable<NServiceBus.Transports.TransportOperation> transportOperations) { }
+    }
     public class static PersistenceConfig
     {
         public static NServiceBus.PersistenceExtentions<T> UsePersistence<T>(this NServiceBus.EndpointConfiguration config)
@@ -1366,6 +1374,8 @@ namespace NServiceBus.DeliveryConstraints
         public static System.Collections.Generic.IEnumerable<NServiceBus.DeliveryConstraints.DeliveryConstraint> GetDeliveryConstraints(this NServiceBus.Extensibility.ContextBag context) { }
         public static void RemoveDeliveryConstaint(this NServiceBus.Extensibility.ContextBag context, NServiceBus.DeliveryConstraints.DeliveryConstraint constraint) { }
         public static bool TryGetDeliveryConstraint<T>(this NServiceBus.Extensibility.ContextBag context, out T constraint)
+            where T : NServiceBus.DeliveryConstraints.DeliveryConstraint { }
+        public static bool TryRemoveDeliveryConstraint<T>(this NServiceBus.Extensibility.ContextBag context, out T constraint)
             where T : NServiceBus.DeliveryConstraints.DeliveryConstraint { }
     }
 }

--- a/src/NServiceBus.Core.Tests/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehaviorTests.cs
@@ -14,26 +14,31 @@
     class RouteDeferredMessageToTimeoutManagerBehaviorTests
     {
         [Test]
-        public async Task Should_reroute_to_tm()
+        public async Task Should_reroute_to_the_timeout_manager()
         {
             var behavior = new RouteDeferredMessageToTimeoutManagerBehavior("tm");
             var delay = TimeSpan.FromDays(1);
             var message = new OutgoingMessage("id", new Dictionary<string, string>(), new byte[0]);
 
+            var headers = new Dictionary<string, string>();
+            string destination = null;
             var context = new RoutingContext(message, new UnicastRoutingStrategy("target"), null);
-
             context.AddDeliveryConstraint(new DelayDeliveryWith(delay));
 
-            await behavior.Invoke(context, () => TaskEx.CompletedTask);
+            await behavior.Invoke(context, c =>
+            {
+                var addressTag = (UnicastAddressTag) c.RoutingStrategies.First().Apply(headers);
+                destination = addressTag.Destination;
+                return TaskEx.CompletedTask;
+            });
 
-            Assert.AreEqual("tm", ((UnicastAddressTag)context.RoutingStrategies.First().Apply(new Dictionary<string, string>())).Destination);
-
-            Assert.AreEqual(message.Headers[TimeoutManagerHeaders.RouteExpiredTimeoutTo], "target");
+            Assert.AreEqual("tm", destination);
+            Assert.AreEqual(headers[TimeoutManagerHeaders.RouteExpiredTimeoutTo], "target");
         }
 
 
         [Test]
-        public void Delayed_delivery_using_the_tm_is_only_supported_for_sends()
+        public void Supports_only_unicast_routing()
         {
             var behavior = new RouteDeferredMessageToTimeoutManagerBehavior("tm");
             var delay = TimeSpan.FromDays(1);
@@ -43,11 +48,11 @@
             var context = new RoutingContext(message, new MulticastRoutingStrategy(null), null);
             context.AddDeliveryConstraint(new DelayDeliveryWith(delay));
 
-            Assert.That(async () => await behavior.Invoke(context, () => TaskEx.CompletedTask), Throws.InstanceOf<Exception>().And.Message.Contains("unicast routing"));
+            Assert.That(async () => await behavior.Invoke(context, () => TaskEx.CompletedTask), Throws.InstanceOf<Exception>().And.Message.Contains("Delayed delivery using the Timeout Manager is only supported for messages with unicast routing"));
         }
 
         [Test]
-        public void Delayed_delivery_cant_be_combined_with_ttbr()
+        public void Cannot_be_combined_with_time_to_be_received()
         {
             var behavior = new RouteDeferredMessageToTimeoutManagerBehavior("tm");
             var delay = TimeSpan.FromDays(1);
@@ -58,7 +63,7 @@
             context.AddDeliveryConstraint(new DelayDeliveryWith(delay));
             context.AddDeliveryConstraint(new DiscardIfNotReceivedBefore(TimeSpan.FromSeconds(30)));
 
-            Assert.That(async () => await behavior.Invoke(context, () => TaskEx.CompletedTask), Throws.InstanceOf<Exception>().And.Message.Contains("TimeToBeReceived"));
+            Assert.That(async () => await behavior.Invoke(context, () => TaskEx.CompletedTask), Throws.InstanceOf<Exception>().And.Message.Contains("Postponed delivery of messages with TimeToBeReceived set is not supported. Remove the TimeToBeReceived attribute to postpone messages of this type."));
         }
 
         [Test]
@@ -69,12 +74,17 @@
 
             var message = new OutgoingMessage("id", new Dictionary<string, string>(), new byte[0]);
 
+            var headers = new Dictionary<string, string>();
             var context = new RoutingContext(message, new UnicastRoutingStrategy("target"), null);
             context.AddDeliveryConstraint(new DelayDeliveryWith(delay));
 
-            await behavior.Invoke(context, () => TaskEx.CompletedTask);
+            await behavior.Invoke(context, c =>
+            {
+                c.RoutingStrategies.First().Apply(headers);
+                return TaskEx.CompletedTask;
+            });
 
-            Assert.LessOrEqual(DateTimeExtensions.ToUtcDateTime(message.Headers[TimeoutManagerHeaders.Expire]), DateTime.UtcNow + delay);
+            Assert.LessOrEqual(DateTimeExtensions.ToUtcDateTime(headers[TimeoutManagerHeaders.Expire]), DateTime.UtcNow + delay);
         }
 
         [Test]
@@ -85,12 +95,17 @@
 
             var message = new OutgoingMessage("id", new Dictionary<string, string>(), new byte[0]);
 
+            var headers = new Dictionary<string, string>();
             var context = new RoutingContext(message, new UnicastRoutingStrategy("target"), null);
             context.AddDeliveryConstraint(new DoNotDeliverBefore(at));
 
-            await behavior.Invoke(context, () => TaskEx.CompletedTask);
+            await behavior.Invoke(context, c =>
+            {
+                c.RoutingStrategies.First().Apply(headers);
+                return TaskEx.CompletedTask;
+            });
 
-            Assert.AreEqual(message.Headers[TimeoutManagerHeaders.Expire], DateTimeExtensions.ToWireFormattedString(at));
+            Assert.AreEqual(headers[TimeoutManagerHeaders.Expire], DateTimeExtensions.ToWireFormattedString(at));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/DeliveryConstraintContextExtensions/DeliveryConstraintContextExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/DeliveryConstraintContextExtensions/DeliveryConstraintContextExtensionsTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using Extensibility;
     using NServiceBus.DelayedDelivery;
     using NServiceBus.DeliveryConstraints;
     using NServiceBus.Features;
@@ -24,6 +25,21 @@
             var context = new FeatureConfigurationContext(settings, null, null);
             var result = context.DoesTransportSupportConstraint<DeliveryConstraint>();
             Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void Should_be_able_to_try_remove_constraints()
+        {
+            var context = new ContextBag();
+
+            DelayDeliveryWith with;
+            var resultBeforeAdd = context.TryRemoveDeliveryConstraint(out with);
+
+            context.AddDeliveryConstraint(new DelayDeliveryWith(TimeSpan.FromHours(1)));
+            var resultAfterAdd = context.TryRemoveDeliveryConstraint(out with);
+
+            Assert.IsFalse(resultBeforeAdd);
+            Assert.IsTrue(resultAfterAdd);
         }
 
         class FakeTransportDefinition : TransportDefinition
@@ -69,8 +85,6 @@
             public override TransportTransactionMode TransactionMode { get; } = TransportTransactionMode.None;
 
             public override OutboundRoutingPolicy OutboundRoutingPolicy { get; } = new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Unicast, OutboundRoutingType.Unicast);
-
-
         }
     }
 }

--- a/src/NServiceBus.Core/DelayedDelivery/DelayedDeliveryFeature.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/DelayedDeliveryFeature.cs
@@ -33,10 +33,7 @@
                 {
                     var timeoutManagerAddress = context.Settings.Get<TimeoutManagerAddressConfiguration>().TransportAddress;
 
-                    context.Pipeline.Register<RouteDeferredMessageToTimeoutManagerBehavior.Registration>();
-
-                    context.Container.ConfigureComponent(b => new RouteDeferredMessageToTimeoutManagerBehavior(timeoutManagerAddress), DependencyLifecycle.SingleInstance);
-
+                    context.Pipeline.Register("RouteDeferredMessageToTimeoutManager", new RouteDeferredMessageToTimeoutManagerBehavior(timeoutManagerAddress), "Reroutes deferred messages to the timeout manager");
                     context.Container.ConfigureComponent(b => new RequestCancelingOfDeferredMessagesFromTimeoutManager(timeoutManagerAddress), DependencyLifecycle.SingleInstance);
                 }
             }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManagerRoutingStrategy.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManagerRoutingStrategy.cs
@@ -1,0 +1,28 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using Routing;
+
+    class TimeoutManagerRoutingStrategy : RoutingStrategy
+    {
+        string timeoutManagerAddress;
+        string ultimateDestination;
+        DateTime deliverAt;
+
+        public TimeoutManagerRoutingStrategy(string timeoutManagerAddress, string ultimateDestination, DateTime deliverAt)
+        {
+            this.ultimateDestination = ultimateDestination;
+            this.deliverAt = deliverAt;
+            this.timeoutManagerAddress = timeoutManagerAddress;
+        }
+
+        public override AddressTag Apply(Dictionary<string, string> headers)
+        {
+            headers[TimeoutManagerHeaders.RouteExpiredTimeoutTo] = ultimateDestination;
+            headers[TimeoutManagerHeaders.Expire] = DateTimeExtensions.ToWireFormattedString(deliverAt);
+
+            return new UnicastAddressTag(timeoutManagerAddress);
+        }
+    }
+}

--- a/src/NServiceBus.Core/DeliveryConstraints/DeliveryConstraintContextExtensions.cs
+++ b/src/NServiceBus.Core/DeliveryConstraints/DeliveryConstraintContextExtensions.cs
@@ -48,6 +48,26 @@ namespace NServiceBus.DeliveryConstraints
             constraint = null;
             return false;
         }
+        
+        /// <summary>
+        /// Tries to remove an instance of <typeparamref name="T" /> from a <see cref="ContextBag" />.
+        /// </summary>
+        public static bool TryRemoveDeliveryConstraint<T>(this ContextBag context, out T constraint) where T : DeliveryConstraint
+        {
+            List<DeliveryConstraint> constraints;
+
+            if (context.TryGet(out constraints))
+            {
+                var result = constraints.TryGet(out constraint);
+                if (result)
+                {
+                    constraints.Remove(constraint);
+                }
+                return result;
+            }
+            constraint = null;
+            return false;
+        }
 
         /// <summary>
         /// Removes a <see cref="DeliveryConstraint" /> to a <see cref="ContextBag" />.

--- a/src/NServiceBus.Core/Headers.cs
+++ b/src/NServiceBus.Core/Headers.cs
@@ -223,7 +223,6 @@
         /// </summary>
         public const string TimeToBeReceived = "NServiceBus.TimeToBeReceived";
 
-
         /// <summary>
         /// Indicates that the message was sent as a non durable message.
         /// </summary>

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Audit\ConfigureAudit.cs" />
     <Compile Include="Audit\AuditToDispatchConnector.cs" />
     <Compile Include="Audit\InvokeAuditPipelineBehavior.cs" />
+    <Compile Include="DelayedDelivery\TimeoutManagerRoutingStrategy.cs" />
     <Compile Include="Notifications.cs" />
     <Compile Include="Notifications\EventAggregator.cs" />
     <Compile Include="Encryption\WireEncryptedStringConversions.cs" />

--- a/src/NServiceBus.Core/Pipeline/Incoming/PendingTransportOperations.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/PendingTransportOperations.cs
@@ -5,17 +5,35 @@ namespace NServiceBus
     using System.Linq;
     using Transports;
 
-    class PendingTransportOperations
+    /// <summary>
+    /// Represents the currently pending transport operations. The transport operations that are collected here will be dispatched in the batched dispatch stage of the pipeline.
+    /// </summary>
+    /// <remarks>This class is threadsafe.</remarks>
+    public class PendingTransportOperations
     {
+        /// <summary>
+        /// Gets the currently pending transport operations.
+        /// </summary>
         public IReadOnlyCollection<TransportOperation> Operations => new List<TransportOperation>(operations);
 
+        /// <summary>
+        /// Indicates whether there are transport operations pending.
+        /// </summary>
         public bool HasOperations => !operations.IsEmpty;
 
+        /// <summary>
+        /// Adds a transport operation.
+        /// </summary>
+        /// <param name="transportOperation">The transport operation to be added.</param>
         public void Add(TransportOperation transportOperation)
         {
             operations.Push(transportOperation);
         }
 
+        /// <summary>
+        /// Adds a range of transport operations.
+        /// </summary>
+        /// <param name="transportOperations">The transport operations to be added.</param>
         public void AddRange(IEnumerable<TransportOperation> transportOperations)
         {
 


### PR DESCRIPTION
...in order to remove a hack/technical debt introduced by https://github.com/Particular/PlatformDevelopment/issues/133.

The previous code did change the routing information in-place before calling the next behaviors.

The new code forks directly to the dispatch pipeline. That leaves a question if we really should allow for modification of the routing information in-place. For now I've left it as-was (and not used). 

This PR also adds tests for both RouteDeferredMessageToTimeoutManagerBehavior and RoutingToDispatchConnector behaviors that verify their behaviors in terms of immediate/batch dispatching.

Connects to https://github.com/Particular/NServiceBus/issues/3657