### PR TITLE
Testing logger factory which allows to log to a text writer

### DIFF
--- a/src/NServiceBus.Testing.Fakes/DefaultTestingLoggerFactory.cs
+++ b/src/NServiceBus.Testing.Fakes/DefaultTestingLoggerFactory.cs
@@ -1,0 +1,62 @@
+namespace NServiceBus.Testing
+{
+    using System;
+    using System.IO;
+    using Logging;
+
+    class DefaultTestingLoggerFactory : ILoggerFactory
+    {
+        public DefaultTestingLoggerFactory(LogLevel filterLevel, TextWriter textWriter)
+        {
+            this.filterLevel = filterLevel;
+            textWriterLogger = new TextWriterLogger(textWriter);
+            isDebugEnabled = LogLevel.Debug >= filterLevel;
+            isInfoEnabled = LogLevel.Info >= filterLevel;
+            isWarnEnabled = LogLevel.Warn >= filterLevel;
+            isErrorEnabled = LogLevel.Error >= filterLevel;
+            isFatalEnabled = LogLevel.Fatal >= filterLevel;
+        }
+
+        public ILog GetLogger(Type type)
+        {
+            return GetLogger(type.FullName);
+        }
+
+        public ILog GetLogger(string name)
+        {
+            return new NamedLogger(name, this)
+            {
+                IsDebugEnabled = isDebugEnabled,
+                IsInfoEnabled = isInfoEnabled,
+                IsWarnEnabled = isWarnEnabled,
+                IsErrorEnabled = isErrorEnabled,
+                IsFatalEnabled = isFatalEnabled
+            };
+        }
+
+        public void Write(string name, LogLevel messageLevel, string message)
+        {
+            if (messageLevel < filterLevel)
+            {
+                return;
+            }
+            var datePart = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
+            var paddedLevel = messageLevel.ToString().ToUpper().PadRight(5);
+            var fullMessage = $"{datePart} {paddedLevel} {name} {message}";
+            lock (locker)
+            {
+                textWriterLogger.Write(fullMessage);
+            }
+        }
+
+        LogLevel filterLevel;
+        bool isDebugEnabled;
+        bool isErrorEnabled;
+        bool isFatalEnabled;
+        bool isInfoEnabled;
+        bool isWarnEnabled;
+
+        object locker = new object();
+        TextWriterLogger textWriterLogger;
+    }
+}

--- a/src/NServiceBus.Testing.Fakes/NServiceBus.Testing.Fakes.csproj
+++ b/src/NServiceBus.Testing.Fakes/NServiceBus.Testing.Fakes.csproj
@@ -37,7 +37,9 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DefaultTestingLoggerFactory.cs" />
     <Compile Include="FakeBuilder.cs" />
+    <Compile Include="NamedLogger.cs" />
     <Compile Include="OutgoingMessage.cs" />
     <Compile Include="OutgoingMessageExtensions.cs" />
     <Compile Include="PublishedMessage.cs" />
@@ -67,6 +69,8 @@
     <Compile Include="TestableSubscribeContext.cs" />
     <Compile Include="TestableTransportReceiveContext.cs" />
     <Compile Include="TestableUnsubscribeContext.cs" />
+    <Compile Include="TestingLoggerFactory.cs" />
+    <Compile Include="TextWriterLogger.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NServiceBus.Core\NServiceBus.Core.csproj">

--- a/src/NServiceBus.Testing.Fakes/NamedLogger.cs
+++ b/src/NServiceBus.Testing.Fakes/NamedLogger.cs
@@ -1,0 +1,98 @@
+namespace NServiceBus.Testing
+{
+    using System;
+    using Logging;
+
+    class NamedLogger : ILog
+    {
+        public NamedLogger(string name, DefaultTestingLoggerFactory defaultLoggerFactory)
+        {
+            this.name = name;
+            this.defaultLoggerFactory = defaultLoggerFactory;
+        }
+
+        public bool IsDebugEnabled { get; internal set; }
+        public bool IsInfoEnabled { get; internal set; }
+        public bool IsWarnEnabled { get; internal set; }
+        public bool IsErrorEnabled { get; internal set; }
+        public bool IsFatalEnabled { get; internal set; }
+
+        public void Debug(string message)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Debug, message);
+        }
+
+        public void Debug(string message, Exception exception)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Debug, message + Environment.NewLine + exception);
+        }
+
+        public void DebugFormat(string format, params object[] args)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Debug, string.Format(format, args));
+        }
+
+        public void Info(string message)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Info, message);
+        }
+
+        public void Info(string message, Exception exception)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Info, message + Environment.NewLine + exception);
+        }
+
+        public void InfoFormat(string format, params object[] args)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Info, string.Format(format, args));
+        }
+
+        public void Warn(string message)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Warn, message);
+        }
+
+        public void Warn(string message, Exception exception)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Warn, message + Environment.NewLine + exception);
+        }
+
+        public void WarnFormat(string format, params object[] args)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Warn, string.Format(format, args));
+        }
+
+        public void Error(string message)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Error, message);
+        }
+
+        public void Error(string message, Exception exception)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Error, message + Environment.NewLine + exception);
+        }
+
+        public void ErrorFormat(string format, params object[] args)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Error, string.Format(format, args));
+        }
+
+        public void Fatal(string message)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Fatal, message);
+        }
+
+        public void Fatal(string message, Exception exception)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Error, message + Environment.NewLine + exception);
+        }
+
+        public void FatalFormat(string format, params object[] args)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Fatal, string.Format(format, args));
+        }
+
+        DefaultTestingLoggerFactory defaultLoggerFactory;
+        string name;
+    }
+}

--- a/src/NServiceBus.Testing.Fakes/TestingLoggerFactory.cs
+++ b/src/NServiceBus.Testing.Fakes/TestingLoggerFactory.cs
@@ -1,0 +1,49 @@
+﻿namespace NServiceBus.Testing
+{
+    using System;
+    using System.IO;
+    using Logging;
+
+    /// <summary>
+    /// Logger factory which allows to log to a text writer.
+    /// </summary>
+    public class TestingLoggerFactory : LoggingFactoryDefinition
+    {
+        /// <summary>
+        /// Creates a new instance of a testing logger factory.
+        /// </summary>
+        public TestingLoggerFactory()
+        {
+            level = new Lazy<LogLevel>(() => LogLevel.Debug);
+            writer = new Lazy<TextWriter>(() => TextWriter.Null);
+        }
+
+        /// <summary>
+        /// Controls the <see cref="LogLevel" />.
+        /// </summary>
+        public void Level(LogLevel level)
+        {
+            this.level = new Lazy<LogLevel>(() => level);
+        }
+
+        /// <summary>
+        /// Instructs the logger to write to the provided text writer.
+        /// </summary>
+        /// <param name="writer">The text writer to be used.</param>
+        public void WriteTo(TextWriter writer)
+        {
+            this.writer = new Lazy<TextWriter>(() => writer);
+        }
+
+        protected override ILoggerFactory GetLoggingFactory()
+        {
+            var loggerFactory = new DefaultTestingLoggerFactory(level.Value, writer.Value);
+            var message = $"Logging to testing logger with level {level}";
+            loggerFactory.Write(GetType().Name, LogLevel.Info, message);
+            return loggerFactory;
+        }
+
+        Lazy<LogLevel> level;
+        Lazy<TextWriter> writer;
+    }
+}

--- a/src/NServiceBus.Testing.Fakes/TextWriterLogger.cs
+++ b/src/NServiceBus.Testing.Fakes/TextWriterLogger.cs
@@ -1,0 +1,19 @@
+﻿namespace NServiceBus.Testing
+{
+    using System.IO;
+
+    class TextWriterLogger
+    {
+        public TextWriterLogger(TextWriter textWriter)
+        {
+            writer = textWriter;
+        }
+
+        public void Write(string message)
+        {
+            writer.WriteLine(message);
+        }
+
+        TextWriter writer;
+    }
+}


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus.Testing/issues/29

While reviewing the [NServiceBus.Host PR which introduces the logger warning ](https://github.com/Particular/NServiceBus.Host/pull/72) @colin-higgins had to pull in Moq to be able to properly test the log warnings. This PR introduces a simple basic infrastructure to be able to pass in a text writer into a logger factory specifically designed for testing.

I first had the reaction to introduce more than a text writer. For example we could strongly typed capture all log messages, exceptions etc. I decided to not do this for now since the string based version fits the majority of use cases.

## Caveats

Because of the static nature of the logging infrastructure there is always a caveat associated when you use the logging infrastructure. You basically have to choice between two necessary evils:

* Make the logger in the class a field (instance based) which might have a runtime overhead based on the runtime usage of the class
* Make the logger in the class a static field which has side effects when you run tests in parallel.

## Samples

### Usage instance based

```
    var sw = new StringWriter()
    var factory = LogManager.Use<TestingLoggerFactory>();
    factory.Level(LogLevel.Warn);
    factory.WriteTo(sw);

    var runner = new StartableAndStoppableRunner(thingsToBeStarted);

    class StartableAndStoppableRunner
    {
        public StartableAndStoppableRunner(...)
        {
            log = LogManager.GetLogger<StartableAndStoppableRunner>();
        }
    }
```

### Usage static

```
    StringWriter writer = new StringWriter();

    [TestFixtureSetUp]
    public void FixtureSetup()
    {
        var factory = LogManager.Use<TestingLoggerFactory>();
        factory.Level(LogLevel.Warn);
        factory.WriteTo(writer);
    }

    [SetUp]
    public void SetUp()
    {
        writer.GetStringBuilder().Clear();
    }

    class StartableAndStoppableRunner
    {
        static ILog log = LogManager.GetLogger<StartableAndStoppableRunner>();
    }
```