### PR TITLE
Encryption service tests

### DIFF
--- a/src/NServiceBus.Core.Tests/Encryption/RijndaelEncryptionServiceTest.cs
+++ b/src/NServiceBus.Core.Tests/Encryption/RijndaelEncryptionServiceTest.cs
@@ -14,7 +14,10 @@
         public void Should_encrypt_and_decrypt()
         {
             var encryptionKey = Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6");
-            var service = new TestableRijndaelEncryptionService("encryptionKey", encryptionKey, new[] { encryptionKey });
+            var service = new TestableRijndaelEncryptionService("encryptionKey", encryptionKey, new[]
+            {
+                encryptionKey
+            });
             var encryptedValue = service.Encrypt("string to encrypt", null);
             Assert.AreNotEqual("string to encrypt", encryptedValue.EncryptedBase64Value);
             var decryptedValue = service.Decrypt(encryptedValue, null);
@@ -25,10 +28,12 @@
         public void Should_encrypt_and_decrypt_for_expired_key()
         {
             var encryptionKey1 = Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6");
-            var service1 = new TestableRijndaelEncryptionService("encryptionKey1", encryptionKey1, new[] { encryptionKey1 });
+            var service1 = new TestableRijndaelEncryptionService("encryptionKey1", encryptionKey1, new[]
+            {
+                encryptionKey1
+            });
             var encryptedValue = service1.Encrypt("string to encrypt", null);
             Assert.AreNotEqual("string to encrypt", encryptedValue.EncryptedBase64Value);
-
 
             var encryptionKey2 = Encoding.ASCII.GetBytes("vznkynwuvateefgduvsqjsufqfrrfcya");
             var expiredKeys = new List<byte[]>
@@ -79,7 +84,10 @@
         public void Should_throw_for_invalid_expired_key()
         {
             var validKey = Encoding.ASCII.GetBytes("adDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6");
-            var expiredKeys = new List<byte[]> { Encoding.ASCII.GetBytes("invalidKey") };
+            var expiredKeys = new List<byte[]>
+            {
+                Encoding.ASCII.GetBytes("invalidKey")
+            };
             var exception = Assert.Throws<Exception>(() => new TestableRijndaelEncryptionService("keyid", validKey, expiredKeys));
             Assert.AreEqual("The expired key at index 0 has an invalid length of 10 bytes.", exception.Message);
         }
@@ -102,7 +110,10 @@
             var service1 = new TestableRijndaelEncryptionService("encryptionKey1", encryptionKey1, new List<byte[]>());
             var encryptedValue = service1.Encrypt("string to encrypt", null);
 
-            var expiredKeys = new List<byte[]> { Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6") };
+            var expiredKeys = new List<byte[]>
+            {
+                Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6")
+            };
             var service2 = new TestableRijndaelEncryptionService("encryptionKey1", encryptionKey1, expiredKeys)
             {
                 IncomingKeyIdentifier = "encryptionKey1"
@@ -112,7 +123,6 @@
             Assert.AreEqual("string to encrypt", decryptedValue);
         }
 
-
         [Test]
         public void Decrypt_using_missing_key_identifier_must_throw()
         {
@@ -121,16 +131,16 @@
             var encryptedValue = service1.Encrypt("string to encrypt", null);
 
             var encryptionKey2 = Encoding.ASCII.GetBytes("vznkynwuvateefgduvsqjsufqfrrfcya");
-            var expiredKeys = new List<byte[]> { Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6") };
+            var expiredKeys = new List<byte[]>
+            {
+                Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6")
+            };
             var service2 = new TestableRijndaelEncryptionService("encryptionKey1", encryptionKey2, expiredKeys)
             {
                 IncomingKeyIdentifier = "missingKey"
             };
 
-            Assert.Catch<InvalidOperationException>(() =>
-            {
-                service2.Decrypt(encryptedValue, null);
-            }, "Decryption key not available for key identifier 'missingKey'. Add this key to the rijndael encryption service configuration. Key identifiers are case sensitive.");
+            Assert.Catch<InvalidOperationException>(() => { service2.Decrypt(encryptedValue, null); }, "Decryption key not available for key identifier 'missingKey'. Add this key to the rijndael encryption service configuration. Key identifiers are case sensitive.");
         }
 
         [Test]
@@ -148,10 +158,7 @@
         [Test]
         public void Should_throw_when_passing_non_existing_key_identifier()
         {
-            Assert.Catch<ArgumentException>(() =>
-            {
-                new RijndaelEncryptionService("not-in-keys", new Dictionary<string, byte[]>(), null);
-            });
+            Assert.Catch<ArgumentException>(() => { new RijndaelEncryptionService("not-in-keys", new Dictionary<string, byte[]>(), null); });
         }
 
         [Test]
@@ -169,24 +176,24 @@
                 IncomingKeyIdentifier = "encryptionKey1"
             };
 
-            Assert.Catch<InvalidOperationException>(() =>
-            {
-                service2.Decrypt(encryptedValue, null);
-            }, "Unable to decrypt property using configured decryption key specified in key identifier header.");
+            Assert.Catch<InvalidOperationException>(() => { service2.Decrypt(encryptedValue, null); }, "Unable to decrypt property using configured decryption key specified in key identifier header.");
         }
 
         class TestableRijndaelEncryptionService : RijndaelEncryptionService
         {
-            public bool OutgoingKeyIdentifierSet { get; private set; }
-            public string IncomingKeyIdentifier { private get; set; }
-
             public TestableRijndaelEncryptionService(
                 string encryptionKeyIdentifier,
                 byte[] encryptionKey,
                 IList<byte[]> decryptionKeys)
-                : base(encryptionKeyIdentifier, new Dictionary<string, byte[]> { { encryptionKeyIdentifier, encryptionKey } }, decryptionKeys)
+                : base(encryptionKeyIdentifier, new Dictionary<string, byte[]>
+                {
+                    {encryptionKeyIdentifier, encryptionKey}
+                }, decryptionKeys)
             {
             }
+
+            public bool OutgoingKeyIdentifierSet { get; private set; }
+            public string IncomingKeyIdentifier { private get; set; }
 
             protected override void AddKeyIdentifierHeader(IOutgoingLogicalMessageContext context)
             {

--- a/src/NServiceBus.Core.Tests/Encryption/RijndaelEncryptionServiceTest.cs
+++ b/src/NServiceBus.Core.Tests/Encryption/RijndaelEncryptionServiceTest.cs
@@ -14,7 +14,7 @@
         public void Should_encrypt_and_decrypt()
         {
             var encryptionKey = Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6");
-            var service = new RijndaelEncryptionServiceWithFakeBus("encryptionKey", encryptionKey, new[] { encryptionKey });
+            var service = new TestableRijndaelEncryptionService("encryptionKey", encryptionKey, new[] { encryptionKey });
             var encryptedValue = service.Encrypt("string to encrypt", null);
             Assert.AreNotEqual("string to encrypt", encryptedValue.EncryptedBase64Value);
             var decryptedValue = service.Decrypt(encryptedValue, null);
@@ -25,7 +25,7 @@
         public void Should_encrypt_and_decrypt_for_expired_key()
         {
             var encryptionKey1 = Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6");
-            var service1 = new RijndaelEncryptionServiceWithFakeBus("encryptionKey1", encryptionKey1, new[] { encryptionKey1 });
+            var service1 = new TestableRijndaelEncryptionService("encryptionKey1", encryptionKey1, new[] { encryptionKey1 });
             var encryptedValue = service1.Encrypt("string to encrypt", null);
             Assert.AreNotEqual("string to encrypt", encryptedValue.EncryptedBase64Value);
 
@@ -36,7 +36,7 @@
                 encryptionKey2,
                 encryptionKey1
             };
-            var service2 = new RijndaelEncryptionServiceWithFakeBus("encryptionKey1", encryptionKey2, expiredKeys);
+            var service2 = new TestableRijndaelEncryptionService("encryptionKey1", encryptionKey2, expiredKeys);
 
             var decryptedValue = service2.Decrypt(encryptedValue, null);
             Assert.AreEqual("string to encrypt", decryptedValue);
@@ -46,7 +46,7 @@
         public void Should_throw_when_decrypt_with_wrong_key()
         {
             var usedKey = Encoding.ASCII.GetBytes("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-            var service1 = new RijndaelEncryptionServiceWithFakeBus("should-be-ignored-in-next-arrange", usedKey, new List<byte[]>());
+            var service1 = new TestableRijndaelEncryptionService("should-be-ignored-in-next-arrange", usedKey, new List<byte[]>());
             var encryptedValue = service1.Encrypt("string to encrypt", null);
             Assert.AreNotEqual("string to encrypt", encryptedValue.EncryptedBase64Value);
 
@@ -56,7 +56,7 @@
                 Encoding.ASCII.GetBytes("cccccccccccccccccccccccccccccccc")
             };
 
-            var service2 = new RijndaelEncryptionServiceWithFakeBus("should-be-ignored", usedKey, unusedExpiredKeys);
+            var service2 = new TestableRijndaelEncryptionService("should-be-ignored", usedKey, unusedExpiredKeys);
 
             var exception = Assert.Throws<AggregateException>(() => service2.Decrypt(encryptedValue, null));
             Assert.AreEqual("Could not decrypt message. Tried 2 keys.", exception.Message);
@@ -71,7 +71,7 @@
         public void Should_throw_for_invalid_key()
         {
             var invalidKey = Encoding.ASCII.GetBytes("invalidKey");
-            var exception = Assert.Throws<Exception>(() => new RijndaelEncryptionServiceWithFakeBus("keyid", invalidKey, new List<byte[]>()));
+            var exception = Assert.Throws<Exception>(() => new TestableRijndaelEncryptionService("keyid", invalidKey, new List<byte[]>()));
             Assert.AreEqual("The encryption key has an invalid length of 10 bytes.", exception.Message);
         }
 
@@ -80,7 +80,7 @@
         {
             var validKey = Encoding.ASCII.GetBytes("adDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6");
             var expiredKeys = new List<byte[]> { Encoding.ASCII.GetBytes("invalidKey") };
-            var exception = Assert.Throws<Exception>(() => new RijndaelEncryptionServiceWithFakeBus("keyid", validKey, expiredKeys));
+            var exception = Assert.Throws<Exception>(() => new TestableRijndaelEncryptionService("keyid", validKey, expiredKeys));
             Assert.AreEqual("The expired key at index 0 has an invalid length of 10 bytes.", exception.Message);
         }
 
@@ -88,7 +88,7 @@
         public void Encrypt_must_set_header()
         {
             var encryptionKey1 = Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6");
-            var service1 = new RijndaelEncryptionServiceWithFakeBus("encryptionKey1", encryptionKey1, new List<byte[]>());
+            var service1 = new TestableRijndaelEncryptionService("encryptionKey1", encryptionKey1, new List<byte[]>());
 
             Assert.AreEqual(false, service1.OutgoingKeyIdentifierSet);
             service1.Encrypt("string to encrypt", null);
@@ -99,11 +99,11 @@
         public void Decrypt_using_key_identifier()
         {
             var encryptionKey1 = Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6");
-            var service1 = new RijndaelEncryptionServiceWithFakeBus("encryptionKey1", encryptionKey1, new List<byte[]>());
+            var service1 = new TestableRijndaelEncryptionService("encryptionKey1", encryptionKey1, new List<byte[]>());
             var encryptedValue = service1.Encrypt("string to encrypt", null);
 
             var expiredKeys = new List<byte[]> { Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6") };
-            var service2 = new RijndaelEncryptionServiceWithFakeBus("encryptionKey1", encryptionKey1, expiredKeys)
+            var service2 = new TestableRijndaelEncryptionService("encryptionKey1", encryptionKey1, expiredKeys)
             {
                 IncomingKeyIdentifier = "encryptionKey1"
             };
@@ -117,12 +117,12 @@
         public void Decrypt_using_missing_key_identifier_must_throw()
         {
             var encryptionKey1 = Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6");
-            var service1 = new RijndaelEncryptionServiceWithFakeBus("encryptionKey1", encryptionKey1, new List<byte[]>());
+            var service1 = new TestableRijndaelEncryptionService("encryptionKey1", encryptionKey1, new List<byte[]>());
             var encryptedValue = service1.Encrypt("string to encrypt", null);
 
             var encryptionKey2 = Encoding.ASCII.GetBytes("vznkynwuvateefgduvsqjsufqfrrfcya");
             var expiredKeys = new List<byte[]> { Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6") };
-            var service2 = new RijndaelEncryptionServiceWithFakeBus("encryptionKey1", encryptionKey2, expiredKeys)
+            var service2 = new TestableRijndaelEncryptionService("encryptionKey1", encryptionKey2, expiredKeys)
             {
                 IncomingKeyIdentifier = "missingKey"
             };
@@ -137,7 +137,10 @@
         public void Encrypt_using_missing_key_identifier_must_throw()
         {
             var encryptionKey1 = Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6");
-            var service1 = new RijndaelEncryptionServiceWithFakeBus(null, encryptionKey1, new List<byte[]>());
+            var service1 = new RijndaelEncryptionService(null, new Dictionary<string, byte[]>
+            {
+                {"some-key", encryptionKey1}
+            }, new List<byte[]>());
 
             Assert.Catch<InvalidOperationException>(() => service1.Encrypt("string to encrypt", null), "It is required to set the rijndael key identifier.");
         }
@@ -145,11 +148,9 @@
         [Test]
         public void Should_throw_when_passing_non_existing_key_identifier()
         {
-            var encryptionKey1 = Encoding.ASCII.GetBytes("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-
             Assert.Catch<ArgumentException>(() =>
             {
-                new RijndaelEncryptionServiceWithFakeBus("not-in-keys", encryptionKey1, null, new Dictionary<string, byte[]>());
+                new RijndaelEncryptionService("not-in-keys", new Dictionary<string, byte[]>(), null);
             });
         }
 
@@ -159,11 +160,11 @@
             var keyIdentier = "encryptionKey1";
 
             var key1 = Encoding.ASCII.GetBytes("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-            var service1 = new RijndaelEncryptionServiceWithFakeBus(keyIdentier, key1, new List<byte[]>());
+            var service1 = new TestableRijndaelEncryptionService(keyIdentier, key1, new List<byte[]>());
             var encryptedValue = service1.Encrypt("string to encrypt", null);
 
             var key2 = Encoding.ASCII.GetBytes("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-            var service2 = new RijndaelEncryptionServiceWithFakeBus(keyIdentier, key2, new List<byte[]>())
+            var service2 = new TestableRijndaelEncryptionService(keyIdentier, key2, new List<byte[]>())
             {
                 IncomingKeyIdentifier = "encryptionKey1"
             };
@@ -174,18 +175,16 @@
             }, "Unable to decrypt property using configured decryption key specified in key identifier header.");
         }
 
-        class RijndaelEncryptionServiceWithFakeBus : RijndaelEncryptionService
+        class TestableRijndaelEncryptionService : RijndaelEncryptionService
         {
             public bool OutgoingKeyIdentifierSet { get; private set; }
             public string IncomingKeyIdentifier { private get; set; }
 
-            public RijndaelEncryptionServiceWithFakeBus(
+            public TestableRijndaelEncryptionService(
                 string encryptionKeyIdentifier,
                 byte[] encryptionKey,
-                IList<byte[]> expiredKeys,
-                IDictionary<string, byte[]> keys = null
-                )
-                : base(encryptionKeyIdentifier, encryptionKeyIdentifier != null ? keys ?? new Dictionary<string, byte[]> { { encryptionKeyIdentifier, encryptionKey } } : null, expiredKeys)
+                IList<byte[]> decryptionKeys)
+                : base(encryptionKeyIdentifier, new Dictionary<string, byte[]> { { encryptionKeyIdentifier, encryptionKey } }, decryptionKeys)
             {
             }
 
@@ -201,5 +200,4 @@
             }
         }
     }
-
 }


### PR DESCRIPTION
small code refactoring to simplify the complex ctor logic (`encryptionKeyIdentifier, encryptionKeyIdentifier != null ? keys ?? new Dictionary<string, byte[]> { { encryptionKeyIdentifier, encryptionKey } } : null, expiredKeys`) to make the tests more understandable.
+ code reformat

Note: can be further simplified when https://github.com/Particular/NServiceBus/pull/3658 is merged. (remove overrides and use testable context instead)

@Particular/nservicebus-maintainers ping