### PR TITLE
Added missing xml docs to Testing.Fakes

### DIFF
--- a/src/NServiceBus.Testing.Fakes/NServiceBus.Testing.Fakes.csproj
+++ b/src/NServiceBus.Testing.Fakes/NServiceBus.Testing.Fakes.csproj
@@ -18,10 +18,13 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\binaries\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <DocumentationFile>..\..\binaries\NServiceBus.Testing.Fakes.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -82,7 +85,9 @@
     <None Include="..\..\packaging\nuget\nservicebus.testing.fakes.nuspec">
       <Link>nservicebus.testing.fakes.nuspec</Link>
     </None>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\GitVersionTask.3.4.1\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.4.1\build\dotnet\GitVersionTask.targets')" />

--- a/src/NServiceBus.Testing.Fakes/TestingLoggerFactory.cs
+++ b/src/NServiceBus.Testing.Fakes/TestingLoggerFactory.cs
@@ -19,7 +19,7 @@
         }
 
         /// <summary>
-        /// Controls the <see cref="LogLevel" />.
+        /// Controls the <see cref="Logging.LogLevel" />.
         /// </summary>
         public void Level(LogLevel level)
         {
@@ -35,6 +35,9 @@
             this.writer = new Lazy<TextWriter>(() => writer);
         }
 
+        /// <summary>
+        /// Constructs an instance of <see cref="ILoggerFactory" /> for use by <see cref="LogManager.Use{T}" />.
+        /// </summary>
         protected override ILoggerFactory GetLoggingFactory()
         {
             var loggerFactory = new DefaultTestingLoggerFactory(level.Value, writer.Value);


### PR DESCRIPTION
* Added a missing xml doc to `TestingLoggerFactory`
* Enabled xml docs for this project. This is needed because this option is enabled on NServiceBus.Testing which pulls in these classes as a source and may run into compilation errors because the source files don't provide the required documentation.
* Changed binary output bath to /binaries instead of bin/debug to align with the rest of the projects.

@Particular/nservicebus-maintainers ping

Connects to Particular/NServiceBus.Testing#29