### PR TITLE
Add TestableMessageSession and TestableEndpointInstance

### DIFF
--- a/src/NServiceBus.Core.Tests/Fakes/TestableMessageSessionTests.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/TestableMessageSessionTests.cs
@@ -1,0 +1,39 @@
+﻿namespace NServiceBus.Core.Tests.Fakes
+{
+    using NUnit.Framework;
+    using Testing;
+
+    [TestFixture]
+    public class TestableMessageSessionTests
+    {
+        [Test]
+        public void Subscribe_ShouldTrackSubscriptions()
+        {
+            var session = new TestableMessageSession();
+            var options = new SubscribeOptions();
+
+            session.Subscribe(typeof(MyEvent), options);
+
+            Assert.AreEqual(1, session.Subscriptions.Length);
+            Assert.AreSame(options, session.Subscriptions[0].Options);
+            Assert.AreEqual(typeof(MyEvent), session.Subscriptions[0].Message);
+        }
+
+        [Test]
+        public void Unsubscribe_ShouldTrackUnsubscriptions()
+        {
+            var session = new TestableMessageSession();
+            var options = new UnsubscribeOptions();
+
+            session.Unsubscribe(typeof(MyEvent), options);
+
+            Assert.AreEqual(1, session.Unsubscription.Length);
+            Assert.AreSame(options, session.Unsubscription[0].Options);
+            Assert.AreEqual(typeof(MyEvent), session.Unsubscription[0].Message);
+        }
+
+        class MyEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -125,6 +125,7 @@
     <Compile Include="DelayedDelivery\TimeoutManager\RecordingFakeDispatcher.cs" />
     <Compile Include="DeliveryConstraintContextExtensions\DeliveryConstraintContextExtensionsTests.cs" />
     <Compile Include="FakeEventAggregator.cs" />
+    <Compile Include="Fakes\TestableMessageSessionTests.cs" />
     <Compile Include="MessageMapper\MessageMapperTests.cs" />
     <Compile Include="Msmq\TimeToBeReceivedOverrideCheckerTest.cs" />
     <Compile Include="Msmq\MsmqExtensionsTests.cs" />

--- a/src/NServiceBus.Testing.Fakes/NServiceBus.Testing.Fakes.csproj
+++ b/src/NServiceBus.Testing.Fakes/NServiceBus.Testing.Fakes.csproj
@@ -54,10 +54,12 @@
     <Compile Include="PublishedMessage.cs" />
     <Compile Include="RepliedMessage.cs" />
     <Compile Include="SentMessage.cs" />
+    <Compile Include="Subscription.cs" />
     <Compile Include="TestableAuditContext.cs" />
     <Compile Include="TestableBatchDispatchContext.cs" />
     <Compile Include="TestableBehaviorContext.cs" />
     <Compile Include="TestableDispatchContext.cs" />
+    <Compile Include="TestableEndpointInstance.cs" />
     <Compile Include="TestableFaultContext.cs" />
     <Compile Include="TestableForwardingContext.cs" />
     <Compile Include="TestableIncomingContext.cs" />
@@ -66,6 +68,7 @@
     <Compile Include="TestableInvokeHandlerContext.cs" />
     <Compile Include="TestableMessageHandlerContext.cs" />
     <Compile Include="TestableMessageProcessingContext.cs" />
+    <Compile Include="TestableMessageSession.cs" />
     <Compile Include="TestableOutgoingContext.cs" />
     <Compile Include="TestableOutgoingLogicalMessageContext.cs" />
     <Compile Include="TestableOutgoingPhysicalMessageContext.cs" />
@@ -80,6 +83,7 @@
     <Compile Include="TestableUnsubscribeContext.cs" />
     <Compile Include="TestingLoggerFactory.cs" />
     <Compile Include="TextWriterLogger.cs" />
+    <Compile Include="Unsubscription.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NServiceBus.Core\NServiceBus.Core.csproj">

--- a/src/NServiceBus.Testing.Fakes/Subscription.cs
+++ b/src/NServiceBus.Testing.Fakes/Subscription.cs
@@ -1,0 +1,19 @@
+namespace NServiceBus.Testing
+{
+    using System;
+
+    /// <summary>
+    /// Represents an event subscription.
+    /// </summary>
+    public class Subscription : OutgoingMessage<Type, SubscribeOptions>
+    {
+        /// <summary>
+        /// Creates a new <see cref="Subscription" /> instance for the given event type and it's options.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="options"></param>
+        public Subscription(Type message, SubscribeOptions options) : base(message, options)
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Testing.Fakes/TestableEndpointInstance.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableEndpointInstance.cs
@@ -1,0 +1,25 @@
+﻿// ReSharper disable PartialTypeWithSinglePart
+namespace NServiceBus.Testing
+{
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A testable implementation of <see cref="IEndpointInstance" />.
+    /// </summary>
+    public partial class TestableEndpointInstance : TestableMessageSession, IEndpointInstance
+    {
+        /// <summary>
+        /// Indicates whether <see cref="Stop" /> has been called or not.
+        /// </summary>
+        public bool EndpointStopped { get; private set; }
+
+        /// <summary>
+        /// Stops the endpoint.
+        /// </summary>
+        public virtual Task Stop()
+        {
+            EndpointStopped = true;
+            return Task.FromResult(0);
+        }
+    }
+}

--- a/src/NServiceBus.Testing.Fakes/TestableMessageSession.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableMessageSession.cs
@@ -1,0 +1,51 @@
+﻿// ReSharper disable PartialTypeWithSinglePart
+
+namespace NServiceBus.Testing
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A testable <see cref="IMessageSession"/> implementation.
+    /// </summary>
+    public partial class TestableMessageSession : TestablePipelineContext, IMessageSession
+    {
+        /// <summary>
+        /// A list of all event subscriptions made from this session.
+        /// </summary>
+        public virtual Subscription[] Subscriptions => subscriptions.ToArray();
+
+        /// <summary>
+        /// A list of all event subscriptions canceled from this session.
+        /// </summary>
+        public virtual Unsubscription[] Unsubscription => unsubscriptions.ToArray();
+
+        /// <summary>
+        /// Subscribes to receive published messages of the specified type.
+        /// This method is only necessary if you turned off auto-subscribe.
+        /// </summary>
+        /// <param name="eventType">The type of event to subscribe to.</param>
+        /// <param name="options">Options for the subscribe.</param>
+        public virtual Task Subscribe(Type eventType, SubscribeOptions options)
+        {
+            subscriptions.Enqueue(new Subscription(eventType, options));
+            return Task.FromResult(0);
+        }
+
+        /// <summary>
+        /// Unsubscribes to receive published messages of the specified type.
+        /// </summary>
+        /// <param name="eventType">The type of event to unsubscribe to.</param>
+        /// <param name="options">Options for the subscribe.</param>
+        public virtual Task Unsubscribe(Type eventType, UnsubscribeOptions options)
+        {
+            unsubscriptions.Enqueue(new Unsubscription(eventType, options));
+            return Task.FromResult(0);
+        }
+
+        ConcurrentQueue<Subscription> subscriptions = new ConcurrentQueue<Subscription>();
+
+        ConcurrentQueue<Unsubscription> unsubscriptions = new ConcurrentQueue<Unsubscription>();
+    }
+}

--- a/src/NServiceBus.Testing.Fakes/Unsubscription.cs
+++ b/src/NServiceBus.Testing.Fakes/Unsubscription.cs
@@ -1,0 +1,17 @@
+namespace NServiceBus.Testing
+{
+    using System;
+
+    /// <summary>
+    /// Represents an event subscription cancelation.
+    /// </summary>
+    public class Unsubscription : OutgoingMessage<Type, UnsubscribeOptions>
+    {
+        /// <summary>
+        /// Creates a new <see cref="Unsubscription" /> instance for the given event type and it's options.
+        /// </summary>
+        public Unsubscription(Type message, UnsubscribeOptions options) : base(message, options)
+        {
+        }
+    }
+}


### PR DESCRIPTION
testable implementation for `IMessageSession` and `IEndpointInstance` (implementing `IMessageSession`) aligned with the implementation for `TestableMessageHandlerContext`

Connects to Particular/NServiceBus.Testing#29