### PR TITLE
Moving Fake tests from NServicebus.Testing to core tests

### DIFF
--- a/src/NServiceBus.Core.Tests/Fakes/TestableContextChecker.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/TestableContextChecker.cs
@@ -1,0 +1,36 @@
+﻿namespace NServiceBus.Testing.Tests.Fakes
+{
+    using System.Linq;
+    using System.Reflection;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class TestableContextChecker
+    {
+        [Test]
+        public void ShouldProvideTestableImplementationForAllBehaviorContexts()
+        {
+            var nservicebusAssembly = Assembly.GetAssembly(typeof(IMessageHandlerContext));
+            var testingAssembly = Assembly.GetAssembly(typeof(TestableMessageSession));
+            var behaviorContextType = typeof(IBehaviorContext);
+
+            var behaviorContextInterfaces = nservicebusAssembly.DefinedTypes
+                .Where(x => x.IsInterface && behaviorContextType.IsAssignableFrom(x))
+                .Except(new[]
+                {
+                    typeof(PipelineTerminator<>.ITerminatingContext)
+                });
+
+            foreach (var behaviorContextInterface in behaviorContextInterfaces)
+            {
+                var testableImplementationName = "Testable" + behaviorContextInterface.Name.Substring(1);
+
+                if (!testingAssembly.DefinedTypes.Any(t => t.Name == testableImplementationName && behaviorContextInterface.IsAssignableFrom(t)))
+                {
+                    Assert.Fail($"Found no testable implementation for {behaviorContextInterface.FullName}. Expecting an implementation named {testableImplementationName}.");
+                }
+            }
+        } 
+    }
+}

--- a/src/NServiceBus.Core.Tests/Fakes/TestableMessageHandlerContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/TestableMessageHandlerContextTests.cs
@@ -1,0 +1,152 @@
+﻿namespace NServiceBus.Testing.Tests.Fakes
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class TestableMessageHandlerContextTests
+    {
+        [Test]
+        public async Task Send_ShouldContainMessageInSentMessages()
+        {
+            var context = new TestableMessageHandlerContext();
+            var messageInstance = new TestMessage();
+            var sendOptions = new SendOptions();
+
+            await context.Send(messageInstance, sendOptions);
+
+            Assert.AreEqual(1, context.SentMessages.Length);
+            Assert.AreSame(messageInstance, context.SentMessages[0].Message);
+            Assert.AreSame(sendOptions, context.SentMessages[0].Options);
+        }
+
+        [Test]
+        public async Task Send_ShouldInvokeMessageInitializer()
+        {
+            var context = new TestableMessageHandlerContext();
+
+            await context.Send<ITestMessage>(m => m.Value = "initialized value");
+
+            Assert.AreEqual("initialized value", context.SentMessages[0].Message<ITestMessage>().Value);
+        }
+
+        [Test]
+        public async Task Publish_ShouldContainMessageInPublishedMessages()
+        {
+            var context = new TestableMessageHandlerContext();
+            var messageInstance = new TestMessage();
+            var publishOptions = new PublishOptions();
+
+            await context.Publish(messageInstance, publishOptions);
+
+            Assert.AreEqual(1, context.PublishedMessages.Length);
+            Assert.AreSame(messageInstance, context.PublishedMessages[0].Message);
+            Assert.AreSame(publishOptions, context.PublishedMessages[0].Options);
+        }
+
+        [Test]
+        public async Task Publish_ShouldInvokeMessageInitializer()
+        {
+            var context = new TestableMessageHandlerContext();
+
+            await context.Publish<ITestMessage>(m => m.Value = "initialized value");
+
+            Assert.AreEqual("initialized value", context.PublishedMessages[0].Message<ITestMessage>().Value);
+        }
+
+        [Test]
+        public async Task Reply_ShouldContainMessageInRepliedMessages()
+        {
+            var context = new TestableMessageHandlerContext();
+            var messageInstance = new TestMessage();
+            var publishOptions = new ReplyOptions();
+
+            await context.Reply(messageInstance, publishOptions);
+
+            Assert.AreEqual(1, context.RepliedMessages.Length);
+            Assert.AreSame(messageInstance, context.RepliedMessages[0].Message);
+            Assert.AreSame(publishOptions, context.RepliedMessages[0].Options);
+        }
+
+        [Test]
+        public async Task Reply_ShouldInvokeMessageInitializer()
+        {
+            var context = new TestableMessageHandlerContext();
+
+            await context.Reply<ITestMessage>(m => m.Value = "initialized value");
+
+            Assert.AreEqual("initialized value", context.RepliedMessages[0].Message<ITestMessage>().Value);
+        }
+
+        [Test]
+        public async Task ForwardCurrentMessageTo_ShouldContainDestinationsInForwardDestinations()
+        {
+            var context = new TestableMessageHandlerContext();
+
+            await context.ForwardCurrentMessageTo("destination1");
+            await context.ForwardCurrentMessageTo("destination2");
+
+            Assert.Contains("destination1", context.ForwardedMessages);
+            Assert.Contains("destination2", context.ForwardedMessages);
+        }
+
+        [Test]
+        public void DoNotContinueDispatchingCurrentMessageToHandlers_WhenNotCalled_ShouldNotIndicateInvocation()
+        {
+            var context = new TestableMessageHandlerContext();
+
+            Assert.IsFalse(context.DoNotContinueDispatchingCurrentMessageToHandlersWasCalled);
+        }
+
+        [Test]
+        public void DoNotContinueDispatchingCurrentMessageToHandlers_WhenCalled_ShouldIndicateInvocation()
+        {
+            var context = new TestableMessageHandlerContext();
+
+            context.DoNotContinueDispatchingCurrentMessageToHandlers();
+
+            Assert.IsTrue(context.DoNotContinueDispatchingCurrentMessageToHandlersWasCalled);
+        }
+
+        [Test]
+        public void HandleCurrentMessageLater_WhenNotCalled_ShouldNotIndicateInvocation()
+        {
+            var context = new TestableMessageHandlerContext();
+
+            Assert.IsFalse(context.HandleCurrentMessageLaterWasCalled);
+        }
+
+        [Test]
+        public void HandleCurrentMessageLater_WhenCalled_ShouldIndicateInvocation()
+        {
+            var context = new TestableMessageHandlerContext();
+
+            context.HandleCurrentMessageLater();
+
+            Assert.IsTrue(context.HandleCurrentMessageLaterWasCalled);
+        }
+
+        [Test]
+        public void ShouldAllowSettingMessageProperties()
+        {
+            var context = new TestableMessageHandlerContext();
+
+            context.MessageId = "custom message id";
+            context.ReplyToAddress = "custom reply address";
+            context.MessageHeaders = new Dictionary<string, string>();
+            context.MessageHeaders.Add("custom header", "custom value");
+            context.Extensions = new ContextBag();
+        }
+
+        class TestMessage
+        {
+        }
+
+        public interface ITestMessage
+        {
+            string Value { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -125,6 +125,8 @@
     <Compile Include="DelayedDelivery\TimeoutManager\RecordingFakeDispatcher.cs" />
     <Compile Include="DeliveryConstraintContextExtensions\DeliveryConstraintContextExtensionsTests.cs" />
     <Compile Include="FakeEventAggregator.cs" />
+    <Compile Include="Fakes\TestableContextChecker.cs" />
+    <Compile Include="Fakes\TestableMessageHandlerContextTests.cs" />
     <Compile Include="Fakes\TestableMessageSessionTests.cs" />
     <Compile Include="MessageMapper\MessageMapperTests.cs" />
     <Compile Include="Msmq\TimeToBeReceivedOverrideCheckerTest.cs" />
@@ -376,5 +378,6 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
These are some tests relating to the `NServiceBus.Testing.Fakes` that were originally in the `NServicebus.Testing` repository. They would be better suited to being in the core solution as that is where the fakes reside.

Connects to https://github.com/Particular/NServiceBus.Testing/issues/29