### PR TITLE
Timeout dispatch tests: potentially flaky assert fixed

### DIFF
--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails.cs
@@ -30,10 +30,7 @@
                             options.RouteToThisEndpoint();
                             options.SetMessageId(c.TestRunId.ToString());
 
-                            return bus.Send(new MyMessage
-                            {
-                                Id = c.TestRunId
-                            }, options);
+                            return bus.Send(new MyMessage(), options);
                         }))
                 .Done(c => c.FailedTimeoutMovedToError)
                 .Repeat(r => r.For<AllTransportsWithoutNativeDeferral>())
@@ -63,7 +60,6 @@
                     config.SendFailedMessagesTo(Conventions.EndpointNamingConvention(typeof(Endpoint)));
                     config.RegisterComponents(c => c.ConfigureComponent<FakeTimeoutStorage>(DependencyLifecycle.SingleInstance));
                     config.Pipeline.Register<BehaviorThatLogsControlMessageDelivery.Registration>();
-                    config.LimitMessageProcessingConcurrencyTo(1);
                 });
             }
 
@@ -164,7 +160,6 @@
 
         public class MyMessage : IMessage
         {
-            public Guid Id { get; set; }
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails.cs
@@ -1,20 +1,22 @@
 ﻿namespace NServiceBus.AcceptanceTests.DelayedDelivery
 {
     using System;
-    using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
     using EndpointTemplates;
     using Extensibility;
     using Features;
     using NServiceBus.Persistence;
+    using NServiceBus.Pipeline;
     using NUnit.Framework;
     using ScenarioDescriptors;
     using Timeout.Core;
-    using Conventions = AcceptanceTesting.Customization.Conventions;
 
     public class When_timeout_dispatch_fails : NServiceBusAcceptanceTest
     {
+        static readonly TimeSpan VeryLongTimeSpan = TimeSpan.FromMinutes(10);
+
         [Test]
         public async Task Should_retry_and_move_to_error()
         {
@@ -24,14 +26,21 @@
                         .When((bus, c) =>
                         {
                             var options = new SendOptions();
-                            options.SetHeader("Timeout.Id", Guid.NewGuid().ToString());
-                            options.SetDestination(Conventions.EndpointNamingConvention(typeof(Endpoint)) + ".TimeoutsDispatcher");
-                            return bus.Send(new MyMessage(), options);
+                            options.DelayDeliveryWith(VeryLongTimeSpan);
+                            options.RouteToThisEndpoint();
+                            options.SetMessageId(c.TestRunId.ToString());
+
+                            return bus.Send(new MyMessage
+                            {
+                                Id = c.TestRunId
+                            }, options);
                         }))
-                .WithEndpoint<ErrorSpy>()
                 .Done(c => c.FailedTimeoutMovedToError)
                 .Repeat(r => r.For<AllTransportsWithoutNativeDeferral>())
-                .Should(c => Assert.AreEqual(5, c.NumTimesStorageCalled))
+                .Should(c =>
+                {
+                    Assert.IsFalse(c.DelayedMessageDeliveredToHandler, "Message was unexpectedly delivered to the handler");
+                })
                 .Run();
         }
 
@@ -40,7 +49,7 @@
         public class Context : ScenarioContext
         {
             public bool FailedTimeoutMovedToError { get; set; }
-            public int NumTimesStorageCalled { get; set; }
+            public bool DelayedMessageDeliveredToHandler { get; set; }
         }
 
         public class Endpoint : EndpointConfigurationBuilder
@@ -51,9 +60,22 @@
                 {
                     config.EnableFeature<TimeoutManager>();
                     config.UsePersistence<FakeTimeoutPersistence>();
-                    config.SendFailedMessagesTo(ErrorQueueForTimeoutErrors);
+                    config.SendFailedMessagesTo(Conventions.EndpointNamingConvention(typeof(Endpoint)));
                     config.RegisterComponents(c => c.ConfigureComponent<FakeTimeoutStorage>(DependencyLifecycle.SingleInstance));
+                    config.Pipeline.Register<BehaviorThatLogsControlMessageDelivery.Registration>();
+                    config.LimitMessageProcessingConcurrencyTo(1);
                 });
+            }
+
+            class Handler : IHandleMessages<MyMessage>
+            {
+                public Context TestContext { get; set; }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    TestContext.DelayedMessageDeliveredToHandler = true;
+                    return Task.FromResult(0);
+                }
             }
 
             class FakeTimeoutPersistence : PersistenceDefinition
@@ -67,9 +89,18 @@
             class FakeTimeoutStorage : IQueryTimeouts, IPersistTimeouts
             {
                 public Context TestContext { get; set; }
+                TimeoutData timeoutData;
 
                 public Task Add(TimeoutData timeout, ContextBag context)
                 {
+                    if (TestContext.TestRunId.ToString() == timeout.Headers[Headers.MessageId])
+                    {
+                        timeout.Id = TestContext.TestRunId.ToString();
+                        timeout.Time = DateTime.UtcNow;
+
+                        timeoutData = timeout;
+                    }
+
                     return Task.FromResult(0);
                 }
 
@@ -80,7 +111,11 @@
 
                 public Task<TimeoutData> Peek(string timeoutId, ContextBag context)
                 {
-                    TestContext.NumTimesStorageCalled++;
+                    if (timeoutId != TestContext.TestRunId.ToString())
+                    {
+                        throw new ArgumentException("The timeoutId is different from one registered in the test context", "timeoutId");
+                    }
+
                     throw new Exception("Ooops. Timeout storage went bust");
                 }
 
@@ -91,33 +126,45 @@
 
                 public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice)
                 {
-                    return Task.FromResult(new TimeoutsChunk(Enumerable.Empty<TimeoutsChunk.Timeout>(), DateTime.MaxValue));
+                    var timeouts = timeoutData != null
+                        ? new[]
+                        {
+                            new TimeoutsChunk.Timeout(timeoutData.Id, timeoutData.Time)
+                        }
+                        : new TimeoutsChunk.Timeout[0];
+
+                    return Task.FromResult(new TimeoutsChunk(timeouts, DateTime.UtcNow + TimeSpan.FromSeconds(10)));
                 }
             }
-        }
 
-        public class ErrorSpy : EndpointConfigurationBuilder
-        {
-            public ErrorSpy()
-            {
-                EndpointSetup<DefaultServer>()
-                    .CustomEndpointName(ErrorQueueForTimeoutErrors);
-            }
-
-            class Handler : IHandleMessages<MyMessage>
+            class BehaviorThatLogsControlMessageDelivery : Behavior<ITransportReceiveContext>
             {
                 public Context TestContext { get; set; }
 
-                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                public override async Task Invoke(ITransportReceiveContext context, Func<Task> next)
                 {
-                    TestContext.FailedTimeoutMovedToError = true;
-                    return Task.FromResult(0);
+                    if (context.Message.Headers.ContainsKey(Headers.ControlMessageHeader) &&
+                        context.Message.Headers["Timeout.Id"] == TestContext.TestRunId.ToString())
+                    {
+                        TestContext.FailedTimeoutMovedToError = true;
+                        return;
+                    }
+
+                    await next().ConfigureAwait(false);
+                }
+
+                public class Registration : RegisterStep
+                {
+                    public Registration() : base("BehaviorThatLogsControlMessageDelivery", typeof(BehaviorThatLogsControlMessageDelivery), "BehaviorThatLogsControlMessageDelivery")
+                    {
+                    }
                 }
             }
         }
 
         public class MyMessage : IMessage
         {
+            public Guid Id { get; set; }
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails.cs
@@ -37,6 +37,7 @@
                 .Should(c =>
                 {
                     Assert.IsFalse(c.DelayedMessageDeliveredToHandler, "Message was unexpectedly delivered to the handler");
+                    Assert.IsTrue(c.FailedTimeoutMovedToError, "Message should have been moved to the error queue");
                 })
                 .Run();
         }

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails.cs
@@ -30,7 +30,12 @@
                 .WithEndpoint<ErrorSpy>()
                 .Done(c => c.FailedTimeoutMovedToError)
                 .Repeat(r => r.For<AllTransportsWithoutNativeDeferral>())
-                .Should(c => Assert.AreEqual(5, c.NumTimesStorageCalled))
+                .Should(c =>
+                {
+                    // depending on the latency the warm up can take more and some queries might be not executed
+                    Assert.LessOrEqual(1, c.NumTimesStorageCalled);
+                    Assert.GreaterOrEqual(5, c.NumTimesStorageCalled);
+                })
                 .Run();
         }
 


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/723

Timeout dispatch tests: the test `When_timeout_dispatch_fails` is flaky and uses a different strategy for testing failures than `When_timeout_dispatch_fails_on_timeout_data_removal`. Align it to the latter.

When this is merged, PR should be merged as well: https://github.com/Particular/NServiceBus.AzureStorageQueues/pull/104

\cc @WojcikMike @andreasohlund