### PR TITLE
Moved responsibility to wrap receive in Task.Run into the receive strategy for MSMQ

### DIFF
--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveWithNoTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveWithNoTransaction.cs
@@ -13,7 +13,7 @@ namespace NServiceBus
     {
         public override async Task ReceiveMessage(MessageQueue inputQueue, MessageQueue errorQueue, CancellationTokenSource cancellationTokenSource, Func<PushContext, Task> onMessage)
         {
-            var message = inputQueue.Receive(TimeSpan.FromMilliseconds(10), MessageQueueTransactionType.None);
+            var message = await Task.Factory.FromAsync(inputQueue.BeginReceive(TimeSpan.FromMilliseconds(10)), inputQueue.EndReceive).ConfigureAwait(false);
 
             Dictionary<string, string> headers;
 

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveWithTransactionScope.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveWithTransactionScope.cs
@@ -17,43 +17,46 @@ namespace NServiceBus
             this.transactionOptions = transactionOptions;
         }
 
-        public override async Task ReceiveMessage(MessageQueue inputQueue, MessageQueue errorQueue, CancellationTokenSource cancellationTokenSource, Func<PushContext, Task> onMessage)
+        public override Task ReceiveMessage(MessageQueue inputQueue, MessageQueue errorQueue, CancellationTokenSource cancellationTokenSource, Func<PushContext, Task> onMessage)
         {
-            using (var scope = new TransactionScope(TransactionScopeOption.Required, transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
+            return Task.Run(async () =>
             {
-                var message = inputQueue.Receive(TimeSpan.FromMilliseconds(10), MessageQueueTransactionType.Automatic);
-
-                Dictionary<string, string> headers;
-
-                try
+                using (var scope = new TransactionScope(TransactionScopeOption.Required, transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
                 {
-                    headers = MsmqUtilities.ExtractHeaders(message);
+                    var message = inputQueue.Receive(TimeSpan.FromMilliseconds(10), MessageQueueTransactionType.Automatic);
+
+                    Dictionary<string, string> headers;
+
+                    try
+                    {
+                        headers = MsmqUtilities.ExtractHeaders(message);
+                    }
+                    catch (Exception ex)
+                    {
+                        var error = $"Message '{message.Id}' is corrupt and will be moved to '{errorQueue.QueueName}'";
+                        Logger.Error(error, ex);
+
+                        errorQueue.Send(message, MessageQueueTransactionType.Automatic);
+
+                        scope.Complete();
+                        return;
+                    }
+
+                    using (var bodyStream = message.BodyStream)
+                    {
+                        var ambientTransaction = new TransportTransaction();
+                        ambientTransaction.Set(Transaction.Current);
+                        var pushContext = new PushContext(message.Id, headers, bodyStream, ambientTransaction, cancellationTokenSource, new ContextBag());
+
+                        await onMessage(pushContext).ConfigureAwait(false);
+                    }
+
+                    if (!cancellationTokenSource.Token.IsCancellationRequested)
+                    {
+                        scope.Complete();
+                    }
                 }
-                catch (Exception ex)
-                {
-                    var error = $"Message '{message.Id}' is corrupt and will be moved to '{errorQueue.QueueName}'";
-                    Logger.Error(error, ex);
-
-                    errorQueue.Send(message, MessageQueueTransactionType.Automatic);
-
-                    scope.Complete();
-                    return;
-                }
-
-                using (var bodyStream = message.BodyStream)
-                {
-                    var ambientTransaction = new TransportTransaction();
-                    ambientTransaction.Set(Transaction.Current);
-                    var pushContext = new PushContext(message.Id, headers, bodyStream, ambientTransaction, cancellationTokenSource, new ContextBag());
-
-                    await onMessage(pushContext).ConfigureAwait(false);
-                }
-
-                if (!cancellationTokenSource.Token.IsCancellationRequested)
-                {
-                    scope.Complete();
-                }
-            }
+            });
         }
 
         TransactionOptions transactionOptions;


### PR DESCRIPTION
Connects to https://github.com/Particular/EndToEnd/issues/3

* Moved responsibility to wrap receive in Task.Run into the receive strategy for MSMQ
* Implemented non-transactional receive with async only

This would push the responsibility of wrapping the receive in a Task.Run when required into the receive strategy, thus allowing the non transactional receive strategy to using the async API of MSMQ (which are only supported without transactions in place).

I tested this version locally on my machine with 10K messages and the async API with MSMQ is slightly more verbose it seems. I had on overhead of roughly 7ms for the 10K messages. But we would need to measure properly

@Particular/nservicebus-maintainers thoughts? see also #3684 
