### PR TITLE
[WIP] - Let FaultContext track the error queue and set failure headers.

### DIFF
--- a/src/NServiceBus.Core.Tests/Faults/MoveFaultsToErrorQueueTests.cs
+++ b/src/NServiceBus.Core.Tests/Faults/MoveFaultsToErrorQueueTests.cs
@@ -159,7 +159,6 @@ namespace NServiceBus.Core.Tests
         {
             var behavior = new MoveFaultsToErrorQueueBehavior(
                 criticalError,
-                errorQueueAddress,
                 "public-receive-address",
                 transactionMode,
                 new FailureInfoStorage(10));

--- a/src/NServiceBus.Core.Tests/Faults/MoveFaultsToErrorQueueTests.cs
+++ b/src/NServiceBus.Core.Tests/Faults/MoveFaultsToErrorQueueTests.cs
@@ -6,6 +6,7 @@ namespace NServiceBus.Core.Tests
     using System.Threading.Tasks;
     using Faults;
     using NServiceBus.Pipeline;
+    using NServiceBus.Recoverability.Faults;
     using NServiceBus.Transports;
     using NUnit.Framework;
     using Testing;
@@ -32,11 +33,13 @@ namespace NServiceBus.Core.Tests
 
             IFaultContext faultContext = null;
 
-            await behavior.Invoke(context, () => { throw new Exception(); }, c => CaptureFaultContext(c, out faultContext));
+            Func<IFaultContext, Task> captureFaultContext = c => CaptureFaultContext(c, out faultContext, "errors-queue", "local");
+
+            await behavior.Invoke(context, () => { throw new Exception(); }, captureFaultContext);
 
             if (transactionMode != TransportTransactionMode.None)
             {
-                await behavior.Invoke(context, () => Task.FromResult(0), c => CaptureFaultContext(c, out faultContext));
+                await behavior.Invoke(context, () => Task.FromResult(0), captureFaultContext);
             }
 
             Assert.AreEqual("errors-queue", faultContext.ErrorQueueAddress);
@@ -78,11 +81,13 @@ namespace NServiceBus.Core.Tests
 
             IFaultContext faultContext = null;
 
-            await behavior.Invoke(context, () => { throw new Exception("exception-message"); }, c => CaptureFaultContext(c, out faultContext));
+            Func<IFaultContext, Task> captureFault = c => CaptureFaultContext(c, out faultContext, "errors", "public-receive-address");
+
+            await behavior.Invoke(context, () => { throw new Exception("exception-message"); }, captureFault);
 
             if (transactionMode != TransportTransactionMode.None)
             {
-                await behavior.Invoke(context, () => Task.FromResult(0), c => CaptureFaultContext(c, out faultContext));
+                await behavior.Invoke(context, () => Task.FromResult(0), captureFault);
             }
 
             Assert.AreEqual("public-receive-address", faultContext.Message.Headers[FaultsHeaderKeys.FailedQ]);
@@ -159,17 +164,23 @@ namespace NServiceBus.Core.Tests
         {
             var behavior = new MoveFaultsToErrorQueueBehavior(
                 criticalError,
-                "public-receive-address",
                 transactionMode,
                 new FailureInfoStorage(10));
 
             return behavior;
         }
 
-        static Task CaptureFaultContext(IFaultContext ctx, out IFaultContext context)
+        static Task CaptureFaultContext(IFaultContext ctx, out IFaultContext context, string errorQueueAddress, string localAddress)
         {
             context = ctx;
-            return TaskEx.CompletedTask;
+
+            var chain = new BehaviorChain(new[]
+            {
+                new BehaviorInstance(typeof(SetErrorQueueBehavior), new SetErrorQueueBehavior(errorQueueAddress)),
+                new BehaviorInstance(typeof(AddExceptionHeadersBehavior), new AddExceptionHeadersBehavior(localAddress)),
+            });
+
+            return chain.Invoke(ctx);
         }
 
         static TestableTransportReceiveContext CreateContext(string messageId = "message-id", FakeEventAggregator eventAggregator = null)

--- a/src/NServiceBus.Core.Tests/Recoverability/When_message_is_deferred_by_slr.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/When_message_is_deferred_by_slr.cs
@@ -63,7 +63,7 @@
 
             var chain = new BehaviorChain(new[]
            {
-                new BehaviorInstance(typeof(MoveFaultsToErrorQueueBehavior), new MoveFaultsToErrorQueueBehavior(criticalError, "error", "", TransportTransactionMode.None, failureStorage)),
+                new BehaviorInstance(typeof(MoveFaultsToErrorQueueBehavior), new MoveFaultsToErrorQueueBehavior(criticalError, "", TransportTransactionMode.None, failureStorage)),
                 new BehaviorInstance(typeof(SecondLevelRetriesBehavior), new SecondLevelRetriesBehavior(policy, "", failureStorage)),
                 new BehaviorInstance(typeof(FirstLevelRetriesBehavior), new FirstLevelRetriesBehavior(failureStorage, new FirstLevelRetryPolicy(0))),
                 new BehaviorInstance(typeof(LastBehaviorT), lastBehavior)

--- a/src/NServiceBus.Core.Tests/Recoverability/When_message_is_deferred_by_slr.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/When_message_is_deferred_by_slr.cs
@@ -63,7 +63,7 @@
 
             var chain = new BehaviorChain(new[]
            {
-                new BehaviorInstance(typeof(MoveFaultsToErrorQueueBehavior), new MoveFaultsToErrorQueueBehavior(criticalError, "", TransportTransactionMode.None, failureStorage)),
+                new BehaviorInstance(typeof(MoveFaultsToErrorQueueBehavior), new MoveFaultsToErrorQueueBehavior(criticalError, TransportTransactionMode.None, failureStorage)),
                 new BehaviorInstance(typeof(SecondLevelRetriesBehavior), new SecondLevelRetriesBehavior(policy, "", failureStorage)),
                 new BehaviorInstance(typeof(FirstLevelRetriesBehavior), new FirstLevelRetriesBehavior(failureStorage, new FirstLevelRetryPolicy(0))),
                 new BehaviorInstance(typeof(LastBehaviorT), lastBehavior)
@@ -143,7 +143,7 @@
             public string MessageId => RoutingContext.Message.MessageId;
 
             public Dictionary<string, string> Headers => RoutingContext.Message.Headers;
-            
+
             public Task Invoke(IRoutingContext context)
             {
                 RoutingContext = context;

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutRecoverabilityBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutRecoverabilityBehavior.cs
@@ -59,9 +59,10 @@ namespace NServiceBus
             {
                 Logger.Error($"Moving timeout message '{message.MessageId}' from '{localAddress}' to '{errorQueueAddress}' because processing failed due to an exception:", failureInfo.Exception);
 
-                message.SetExceptionHeaders(failureInfo.Exception, localAddress);
+                var headers = message.Headers;
+                ExceptionHeaderHelper.SetExceptionHeaders(headers, failureInfo.Exception, localAddress);
 
-                var outgoingMessage = new OutgoingMessage(message.MessageId, message.Headers, message.Body);
+                var outgoingMessage = new OutgoingMessage(message.MessageId, headers, message.Body);
                 var addressTag = new UnicastAddressTag(errorQueueAddress);
 
                 var transportOperations = new TransportOperations(new TransportOperation(outgoingMessage, addressTag));

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -121,9 +121,11 @@
     <Compile Include="Pipeline\StageForkConnector.cs" />
     <Compile Include="Pipeline\ConnectorContextExtensions.cs" />
     <Compile Include="Recoverability\FailureInfoStorage.cs" />
+    <Compile Include="Recoverability\Faults\AddExceptionHeadersBehavior.cs" />
     <Compile Include="Recoverability\Faults\MessageProcessingFailed.cs" />
     <Compile Include="Recoverability\Faults\MessageToBeRetried.cs" />
     <Compile Include="Recoverability\Faults\MessageFaulted.cs" />
+    <Compile Include="Recoverability\Faults\SetErrorQueueBehavior.cs" />
     <Compile Include="ReleaseDateAttribute.cs" />
     <Compile Include="Recoverability\ProcessingFailureInfo.cs" />
     <Compile Include="Routing\RoutingMappingSettings.cs" />

--- a/src/NServiceBus.Core/Pipeline/ConnectorContextExtensions.cs
+++ b/src/NServiceBus.Core/Pipeline/ConnectorContextExtensions.cs
@@ -158,9 +158,9 @@ namespace NServiceBus
         /// <summary>
         /// Creates a <see cref="IFaultContext" /> based on the current context.
         /// </summary>
-        public static IFaultContext CreateFaultContext(this ForkConnector<ITransportReceiveContext, IFaultContext> forkConnector, ITransportReceiveContext sourceContext, OutgoingMessage outgoingMessage, Exception exception, string localAddress)
+        public static IFaultContext CreateFaultContext(this ForkConnector<ITransportReceiveContext, IFaultContext> forkConnector, ITransportReceiveContext sourceContext, OutgoingMessage outgoingMessage, Exception exception)
         {
-            return new FaultContext(outgoingMessage, localAddress, exception, sourceContext);
+            return new FaultContext(outgoingMessage, exception, sourceContext);
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Pipeline/ConnectorContextExtensions.cs
+++ b/src/NServiceBus.Core/Pipeline/ConnectorContextExtensions.cs
@@ -158,9 +158,9 @@ namespace NServiceBus
         /// <summary>
         /// Creates a <see cref="IFaultContext" /> based on the current context.
         /// </summary>
-        public static IFaultContext CreateFaultContext(this ForkConnector<ITransportReceiveContext, IFaultContext> forkConnector, ITransportReceiveContext sourceContext, OutgoingMessage outgoingMessage, string errorQueueAddress, Exception exception)
+        public static IFaultContext CreateFaultContext(this ForkConnector<ITransportReceiveContext, IFaultContext> forkConnector, ITransportReceiveContext sourceContext, OutgoingMessage outgoingMessage, Exception exception, string localAddress)
         {
-            return new FaultContext(outgoingMessage, errorQueueAddress, exception, sourceContext);
+            return new FaultContext(outgoingMessage, localAddress, exception, sourceContext);
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Recoverability/Faults/AddExceptionHeadersBehavior.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/AddExceptionHeadersBehavior.cs
@@ -1,0 +1,29 @@
+﻿namespace NServiceBus.Recoverability.Faults
+{
+    using System;
+    using System.Threading.Tasks;
+    using Pipeline;
+
+    class AddExceptionHeadersBehavior : Behavior<IFaultContext>
+    {
+        public AddExceptionHeadersBehavior(string localAddress)
+        {
+            Guard.AgainstNullAndEmpty(nameof(localAddress), localAddress);
+
+            this.localAddress = localAddress;
+        }
+
+        public override Task Invoke(IFaultContext context, Func<Task> next)
+        {
+            var headers = context.Message.Headers;
+            ExceptionHeaderHelper.SetExceptionHeaders(headers, context.Exception, localAddress);
+
+            headers.Remove(Headers.Retries);
+            headers.Remove(Headers.FLRetries);
+
+            return next();
+        }
+
+        readonly string localAddress;
+    }
+}

--- a/src/NServiceBus.Core/Recoverability/Faults/FaultContext.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/FaultContext.cs
@@ -4,32 +4,30 @@
     using Pipeline;
     using Transports;
 
+    /// <summary>
+    ///
+    /// </summary>
     class FaultContext : BehaviorContext, IFaultContext
     {
-        public FaultContext(OutgoingMessage message, string localAddress, Exception exception, IBehaviorContext parent)
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="exception"></param>
+        /// <param name="parent"></param>
+        public FaultContext(OutgoingMessage message, Exception exception, IBehaviorContext parent)
             : base(parent)
         {
             Guard.AgainstNull(nameof(message), message);
-            Guard.AgainstNullAndEmpty(nameof(localAddress), localAddress);
             Guard.AgainstNull(nameof(exception), exception);
 
-            var errorQueueAddress = ErrorQueueSettings.GetConfiguredErrorQueue(Builder.Build<Settings.ReadOnlySettings>());
-            Guard.AgainstNullAndEmpty(nameof(errorQueueAddress), errorQueueAddress);
-
             Message = message;
-            ErrorQueueAddress = errorQueueAddress;
             Exception = exception;
-
-            var headers = message.Headers;
-            ExceptionHeaderHelper.SetExceptionHeaders(headers, exception, localAddress);
-
-            headers.Remove(Headers.Retries);
-            headers.Remove(Headers.FLRetries);
         }
 
         public OutgoingMessage Message { get; }
 
-        public string ErrorQueueAddress { get; }
+        public string ErrorQueueAddress { get; set; }
 
         public Exception Exception { get; }
 

--- a/src/NServiceBus.Core/Recoverability/Faults/IFaultContext.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/IFaultContext.cs
@@ -16,7 +16,7 @@
         /// <summary>
         /// Address of the error queue.
         /// </summary>
-        string ErrorQueueAddress { get; }
+        string ErrorQueueAddress { get; set; }
 
         /// <summary>
         /// Exception that occurred while processing the message.

--- a/src/NServiceBus.Core/Recoverability/Faults/MoveFaultsToErrorQueueBehavior.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/MoveFaultsToErrorQueueBehavior.cs
@@ -9,10 +9,9 @@
 
     class MoveFaultsToErrorQueueBehavior : ForkConnector<ITransportReceiveContext, IFaultContext>
     {
-        public MoveFaultsToErrorQueueBehavior(CriticalError criticalError, string localAddress, TransportTransactionMode transportTransactionMode, FailureInfoStorage failureInfoStorage)
+        public MoveFaultsToErrorQueueBehavior(CriticalError criticalError, TransportTransactionMode transportTransactionMode, FailureInfoStorage failureInfoStorage)
         {
             this.criticalError = criticalError;
-            this.localAddress = localAddress;
             this.transportTransactionMode = transportTransactionMode;
             this.failureInfoStorage = failureInfoStorage;
         }
@@ -60,7 +59,7 @@
                 message.RevertToOriginalBodyIfNeeded();
 
                 var outgoingMessage = new OutgoingMessage(message.MessageId, message.Headers, message.Body);
-                var faultContext = this.CreateFaultContext(context, outgoingMessage, exception, localAddress);
+                var faultContext = this.CreateFaultContext(context, outgoingMessage, exception);
 
                 failureInfoStorage.ClearFailureInfoForMessage(message.MessageId);
 
@@ -78,16 +77,14 @@
 
         CriticalError criticalError;
         FailureInfoStorage failureInfoStorage;
-        string localAddress;
         TransportTransactionMode transportTransactionMode;
         static ILog Logger = LogManager.GetLogger<MoveFaultsToErrorQueueBehavior>();
 
         public class Registration : RegisterStep
         {
-            public Registration(string localAddress, TransportTransactionMode transportTransactionMode)
+            public Registration(TransportTransactionMode transportTransactionMode)
                 : base("MoveFaultsToErrorQueue", typeof(MoveFaultsToErrorQueueBehavior), "Moved failing messages to the configured error queue", b => new MoveFaultsToErrorQueueBehavior(
                     b.Build<CriticalError>(),
-                    localAddress,
                     transportTransactionMode,
                     b.Build<FailureInfoStorage>()))
             {

--- a/src/NServiceBus.Core/Recoverability/Faults/SetErrorQueueBehavior.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/SetErrorQueueBehavior.cs
@@ -1,0 +1,26 @@
+namespace NServiceBus.Recoverability.Faults
+{
+    using System;
+    using System.Threading.Tasks;
+    using Pipeline;
+
+    class SetErrorQueueBehavior : Behavior<IFaultContext>
+    {
+        public SetErrorQueueBehavior(string errorQueueAddress)
+        {
+            Guard.AgainstNullAndEmpty(nameof(errorQueueAddress), errorQueueAddress);
+
+            this.errorQueueAddress = errorQueueAddress;
+        }
+
+
+        public override Task Invoke(IFaultContext context, Func<Task> next)
+        {
+            context.ErrorQueueAddress = errorQueueAddress;
+
+            return next();
+        }
+
+        readonly string errorQueueAddress;
+    }
+}

--- a/src/NServiceBus.Core/Recoverability/Faults/StoreFaultsInErrorQueue.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/StoreFaultsInErrorQueue.cs
@@ -27,7 +27,7 @@ namespace NServiceBus.Features
             context.Container.RegisterSingleton(failureInfoStorage);
 
             var transportTransactionMode = context.Settings.GetRequiredTransactionModeForReceives();
-            context.Pipeline.Register(new MoveFaultsToErrorQueueBehavior.Registration(errorQueue, context.Settings.LocalAddress(), transportTransactionMode));
+            context.Pipeline.Register(new MoveFaultsToErrorQueueBehavior.Registration(context.Settings.LocalAddress(), transportTransactionMode));
             context.Pipeline.Register("FaultToDispatchConnector", new FaultToDispatchConnector(), "Connector to dispatch faulted messages");
 
             RaiseLegacyNotifications(context);

--- a/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
+++ b/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
@@ -5,13 +5,11 @@
     using System.Collections.Generic;
     using System.Configuration;
     using Faults;
-    using Transports;
-
+    
     static class ExceptionHeaderHelper
     {
-        public static void SetExceptionHeaders(this IncomingMessage message, Exception e, string failedQueue, string reason = null)
+        public static void SetExceptionHeaders(Dictionary<string, string> headers, Exception e, string failedQueue, string reason = null)
         {
-            var headers = message.Headers;
             SetExceptionHeaders(headers, e, failedQueue, reason, useLegacyStackTrace);
         }
 


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus.Gateway/issues/41

Let FaultContext track the error queue and set failure headers to enable reuse of it outside the core. (GW for example)