### PR TITLE
Move responsibility for error queue and fault exception headers into fault context

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -159,7 +159,7 @@ namespace NServiceBus
         public static NServiceBus.Pipeline.IBatchDispatchContext CreateBatchDispatchContext(this NServiceBus.Pipeline.StageForkConnector<NServiceBus.Pipeline.ITransportReceiveContext, NServiceBus.Pipeline.IIncomingPhysicalMessageContext, NServiceBus.Pipeline.IBatchDispatchContext> stageForkConnector, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Transports.TransportOperation> transportOperations, NServiceBus.Pipeline.IIncomingPhysicalMessageContext sourceContext) { }
         public static NServiceBus.Pipeline.IDispatchContext CreateDispatchContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.Pipeline.IBatchDispatchContext, NServiceBus.Pipeline.IDispatchContext> stageConnector, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Transports.TransportOperation> transportOperations, NServiceBus.Pipeline.IBatchDispatchContext sourceContext) { }
         public static NServiceBus.Pipeline.IDispatchContext CreateDispatchContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.Pipeline.IRoutingContext, NServiceBus.Pipeline.IDispatchContext> stageConnector, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Transports.TransportOperation> transportOperations, NServiceBus.Pipeline.IRoutingContext sourceContext) { }
-        public static NServiceBus.Pipeline.IFaultContext CreateFaultContext(this NServiceBus.Pipeline.ForkConnector<NServiceBus.Pipeline.ITransportReceiveContext, NServiceBus.Pipeline.IFaultContext> forkConnector, NServiceBus.Pipeline.ITransportReceiveContext sourceContext, NServiceBus.Transports.OutgoingMessage outgoingMessage, string errorQueueAddress, System.Exception exception) { }
+        public static NServiceBus.Pipeline.IFaultContext CreateFaultContext(this NServiceBus.Pipeline.ForkConnector<NServiceBus.Pipeline.ITransportReceiveContext, NServiceBus.Pipeline.IFaultContext> forkConnector, NServiceBus.Pipeline.ITransportReceiveContext sourceContext, NServiceBus.Transports.OutgoingMessage outgoingMessage, string sourceQueueAddress, System.Exception exception) { }
         public static NServiceBus.Pipeline.IForwardingContext CreateForwardingContext(this NServiceBus.Pipeline.ForkConnector<NServiceBus.Pipeline.IIncomingPhysicalMessageContext, NServiceBus.Pipeline.IForwardingContext> forwardingContext, NServiceBus.Transports.OutgoingMessage message, string forwardingAddress, NServiceBus.Pipeline.IIncomingPhysicalMessageContext sourceContext) { }
         public static NServiceBus.Pipeline.IIncomingLogicalMessageContext CreateIncomingLogicalMessageContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.Pipeline.IIncomingPhysicalMessageContext, NServiceBus.Pipeline.IIncomingLogicalMessageContext> stageConnector, NServiceBus.Pipeline.LogicalMessage logicalMessage, NServiceBus.Pipeline.IIncomingPhysicalMessageContext sourceContext) { }
         public static NServiceBus.Pipeline.IIncomingPhysicalMessageContext CreateIncomingPhysicalMessageContext(this NServiceBus.Pipeline.StageForkConnector<NServiceBus.Pipeline.ITransportReceiveContext, NServiceBus.Pipeline.IIncomingPhysicalMessageContext, NServiceBus.Pipeline.IBatchDispatchContext> stageForkConnector, NServiceBus.Transports.IncomingMessage incomingMessage, NServiceBus.Pipeline.ITransportReceiveContext sourceContext) { }
@@ -2061,9 +2061,9 @@ namespace NServiceBus.Pipeline
     }
     public interface IFaultContext : NServiceBus.Extensibility.IExtendable, NServiceBus.Pipeline.IBehaviorContext
     {
-        string ErrorQueueAddress { get; }
         System.Exception Exception { get; }
         NServiceBus.Transports.OutgoingMessage Message { get; }
+        string SourceQueueAddress { get; }
         void AddFaultData(string key, string value);
     }
     public interface IForwardingContext : NServiceBus.Extensibility.IExtendable, NServiceBus.Pipeline.IBehaviorContext

--- a/src/NServiceBus.Core.Tests/Faults/AddExceptionHeadersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Faults/AddExceptionHeadersBehaviorTests.cs
@@ -1,0 +1,48 @@
+namespace NServiceBus.Core.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Faults;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class AddExceptionHeadersBehaviorTests
+    {
+        [Test]
+        public async Task ShouldEnrichHeadersWithExceptionDetails()
+        {
+            var sourceQueue = "public-receive-address";
+            var exception = new Exception("exception-message");
+            var messageId = "message-id";
+
+            var context = CreateContext(messageId, sourceQueue, exception);
+            var behavior = CreateBehavior();
+
+            await behavior.Invoke(context, c => Task.FromResult(0));
+
+            Assert.AreEqual("public-receive-address", context.Message.Headers[FaultsHeaderKeys.FailedQ]);
+            Assert.AreEqual("exception-message", context.Message.Headers["NServiceBus.ExceptionInfo.Message"]);
+        }
+
+        static IFaultContext CreateContext(string messageId, string sourceQueue, Exception exception)
+        {
+            var context = new FaultContext(
+                new OutgoingMessage(messageId, new Dictionary<string, string>(), new byte[0]), 
+                sourceQueue, 
+                exception, 
+                null);
+
+            return context;
+        }
+
+        AddExceptionHeadersBehavior CreateBehavior()
+        {
+            var behavior = new AddExceptionHeadersBehavior();
+
+            return behavior;
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Fakes\TestableContextChecker.cs" />
     <Compile Include="Fakes\TestableMessageHandlerContextTests.cs" />
     <Compile Include="Fakes\TestableMessageSessionTests.cs" />
+    <Compile Include="Faults\AddExceptionHeadersBehaviorTests.cs" />
     <Compile Include="MessageMapper\MessageMapperTests.cs" />
     <Compile Include="Msmq\TimeToBeReceivedOverrideCheckerTest.cs" />
     <Compile Include="Msmq\MsmqExtensionsTests.cs" />

--- a/src/NServiceBus.Core.Tests/Recoverability/When_message_is_deferred_by_slr.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/When_message_is_deferred_by_slr.cs
@@ -63,7 +63,7 @@
 
             var chain = new BehaviorChain(new[]
            {
-                new BehaviorInstance(typeof(MoveFaultsToErrorQueueBehavior), new MoveFaultsToErrorQueueBehavior(criticalError, "error", "", TransportTransactionMode.None, failureStorage)),
+                new BehaviorInstance(typeof(MoveFaultsToErrorQueueBehavior), new MoveFaultsToErrorQueueBehavior(criticalError, "", TransportTransactionMode.None, failureStorage)),
                 new BehaviorInstance(typeof(SecondLevelRetriesBehavior), new SecondLevelRetriesBehavior(policy, "", failureStorage)),
                 new BehaviorInstance(typeof(FirstLevelRetriesBehavior), new FirstLevelRetriesBehavior(failureStorage, new FirstLevelRetryPolicy(0))),
                 new BehaviorInstance(typeof(LastBehaviorT), lastBehavior)

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Pipeline\StageForkConnector.cs" />
     <Compile Include="Pipeline\ConnectorContextExtensions.cs" />
     <Compile Include="Recoverability\FailureInfoStorage.cs" />
+    <Compile Include="Recoverability\Faults\AddExceptionHeadersBehavior.cs" />
     <Compile Include="Recoverability\Faults\MessageProcessingFailed.cs" />
     <Compile Include="Recoverability\Faults\MessageToBeRetried.cs" />
     <Compile Include="Recoverability\Faults\MessageFaulted.cs" />

--- a/src/NServiceBus.Core/Pipeline/ConnectorContextExtensions.cs
+++ b/src/NServiceBus.Core/Pipeline/ConnectorContextExtensions.cs
@@ -158,9 +158,9 @@ namespace NServiceBus
         /// <summary>
         /// Creates a <see cref="IFaultContext" /> based on the current context.
         /// </summary>
-        public static IFaultContext CreateFaultContext(this ForkConnector<ITransportReceiveContext, IFaultContext> forkConnector, ITransportReceiveContext sourceContext, OutgoingMessage outgoingMessage, string errorQueueAddress, Exception exception)
+        public static IFaultContext CreateFaultContext(this ForkConnector<ITransportReceiveContext, IFaultContext> forkConnector, ITransportReceiveContext sourceContext, OutgoingMessage outgoingMessage, string sourceQueueAddress, Exception exception)
         {
-            return new FaultContext(outgoingMessage, errorQueueAddress, exception, sourceContext);
+            return new FaultContext(outgoingMessage, sourceQueueAddress, exception, sourceContext);
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Recoverability/Faults/AddExceptionHeadersBehavior.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/AddExceptionHeadersBehavior.cs
@@ -1,0 +1,16 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.Threading.Tasks;
+    using Pipeline;
+
+    class AddExceptionHeadersBehavior : Behavior<IFaultContext>
+    {
+        public override Task Invoke(IFaultContext context, Func<Task> next)
+        {
+            context.Message.SetExceptionHeaders(context.Exception, context.SourceQueueAddress);
+
+            return next();
+        }
+    }
+}

--- a/src/NServiceBus.Core/Recoverability/Faults/FaultContext.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/FaultContext.cs
@@ -6,20 +6,20 @@
 
     class FaultContext : BehaviorContext, IFaultContext
     {
-        public FaultContext(OutgoingMessage message, string errorQueueAddress, Exception exception, IBehaviorContext parent)
+        public FaultContext(OutgoingMessage message, string sourceQueueAddress, Exception exception, IBehaviorContext parent)
             : base(parent)
         {
             Guard.AgainstNull(nameof(message), message);
-            Guard.AgainstNullAndEmpty(nameof(errorQueueAddress), errorQueueAddress);
+            Guard.AgainstNullAndEmpty(nameof(sourceQueueAddress), sourceQueueAddress);
             Guard.AgainstNull(nameof(exception), exception);
             Message = message;
-            ErrorQueueAddress = errorQueueAddress;
+            SourceQueueAddress = sourceQueueAddress;
             Exception = exception;
         }
 
         public OutgoingMessage Message { get; }
 
-        public string ErrorQueueAddress { get; }
+        public string SourceQueueAddress { get; }
 
         public Exception Exception { get; }
 

--- a/src/NServiceBus.Core/Recoverability/Faults/FaultToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/FaultToDispatchConnector.cs
@@ -8,6 +8,13 @@ namespace NServiceBus
 
     class FaultToDispatchConnector : StageConnector<IFaultContext, IRoutingContext>
     {
+        string errorQueueAddress;
+
+        public FaultToDispatchConnector(string errorQueueAddress)
+        {
+            this.errorQueueAddress = errorQueueAddress;
+        }
+
         public override Task Invoke(IFaultContext context, Func<IRoutingContext, Task> stage)
         {
             var message = context.Message;
@@ -23,7 +30,7 @@ namespace NServiceBus
                 }
             }
 
-            var dispatchContext = this.CreateRoutingContext(context.Message, new UnicastRoutingStrategy(context.ErrorQueueAddress), context);
+            var dispatchContext = this.CreateRoutingContext(context.Message, new UnicastRoutingStrategy(errorQueueAddress), context);
 
             return stage(dispatchContext);
         }

--- a/src/NServiceBus.Core/Recoverability/Faults/IFaultContext.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/IFaultContext.cs
@@ -14,9 +14,9 @@
         OutgoingMessage Message { get; }
 
         /// <summary>
-        /// Address of the error queue.
+        /// Address of the source queue for the faulted message.
         /// </summary>
-        string ErrorQueueAddress { get; }
+        string SourceQueueAddress { get; }
 
         /// <summary>
         /// Exception that occurred while processing the message.

--- a/src/NServiceBus.Core/Recoverability/Faults/MoveFaultsToErrorQueueBehavior.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/MoveFaultsToErrorQueueBehavior.cs
@@ -9,10 +9,9 @@
 
     class MoveFaultsToErrorQueueBehavior : ForkConnector<ITransportReceiveContext, IFaultContext>
     {
-        public MoveFaultsToErrorQueueBehavior(CriticalError criticalError, string errorQueueAddress, string localAddress, TransportTransactionMode transportTransactionMode, FailureInfoStorage failureInfoStorage)
+        public MoveFaultsToErrorQueueBehavior(CriticalError criticalError, string localAddress, TransportTransactionMode transportTransactionMode, FailureInfoStorage failureInfoStorage)
         {
             this.criticalError = criticalError;
-            this.errorQueueAddress = errorQueueAddress;
             this.localAddress = localAddress;
             this.transportTransactionMode = transportTransactionMode;
             this.failureInfoStorage = failureInfoStorage;
@@ -60,13 +59,11 @@
 
                 message.RevertToOriginalBodyIfNeeded();
 
-                message.SetExceptionHeaders(exception, localAddress);
-
                 message.Headers.Remove(Headers.Retries);
                 message.Headers.Remove(Headers.FLRetries);
 
                 var outgoingMessage = new OutgoingMessage(message.MessageId, message.Headers, message.Body);
-                var faultContext = this.CreateFaultContext(context, outgoingMessage, errorQueueAddress, exception);
+                var faultContext = this.CreateFaultContext(context, outgoingMessage, localAddress, exception);
 
                 failureInfoStorage.ClearFailureInfoForMessage(message.MessageId);
 
@@ -83,7 +80,6 @@
         }
 
         CriticalError criticalError;
-        string errorQueueAddress;
         FailureInfoStorage failureInfoStorage;
         string localAddress;
         TransportTransactionMode transportTransactionMode;
@@ -91,10 +87,9 @@
 
         public class Registration : RegisterStep
         {
-            public Registration(string errorQueueAddress, string localAddress, TransportTransactionMode transportTransactionMode)
+            public Registration(string localAddress, TransportTransactionMode transportTransactionMode)
                 : base("MoveFaultsToErrorQueue", typeof(MoveFaultsToErrorQueueBehavior), "Moved failing messages to the configured error queue", b => new MoveFaultsToErrorQueueBehavior(
                     b.Build<CriticalError>(),
-                    errorQueueAddress,
                     localAddress,
                     transportTransactionMode,
                     b.Build<FailureInfoStorage>()))

--- a/src/NServiceBus.Core/Recoverability/Faults/StoreFaultsInErrorQueue.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/StoreFaultsInErrorQueue.cs
@@ -27,8 +27,9 @@ namespace NServiceBus.Features
             context.Container.RegisterSingleton(failureInfoStorage);
 
             var transportTransactionMode = context.Settings.GetRequiredTransactionModeForReceives();
-            context.Pipeline.Register(new MoveFaultsToErrorQueueBehavior.Registration(errorQueue, context.Settings.LocalAddress(), transportTransactionMode));
-            context.Pipeline.Register("FaultToDispatchConnector", new FaultToDispatchConnector(), "Connector to dispatch faulted messages");
+            context.Pipeline.Register(new MoveFaultsToErrorQueueBehavior.Registration(context.Settings.LocalAddress(), transportTransactionMode));
+            context.Pipeline.Register("AddExceptionHeaders", new AddExceptionHeadersBehavior(), "Adds the exception headers to the message");
+            context.Pipeline.Register("FaultToDispatchConnector", new FaultToDispatchConnector(errorQueue), "Connector to dispatch faulted messages");
 
             RaiseLegacyNotifications(context);
         }

--- a/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
+++ b/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
@@ -15,6 +15,12 @@
             SetExceptionHeaders(headers, e, failedQueue, reason, useLegacyStackTrace);
         }
 
+        public static void SetExceptionHeaders(this OutgoingMessage message, Exception e, string failedQueue, string reason = null)
+        {
+            var headers = message.Headers;
+            SetExceptionHeaders(headers, e, failedQueue, reason, useLegacyStackTrace);
+        }
+
         internal static void SetExceptionHeaders(Dictionary<string, string> headers, Exception e, string failedQueue, string reason, bool legacyStackTrace)
         {
             if (!string.IsNullOrWhiteSpace(reason))

--- a/src/NServiceBus.Testing.Fakes/TestableFaultContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableFaultContext.cs
@@ -32,9 +32,9 @@ namespace NServiceBus.Testing
         public OutgoingMessage Message { get; set; } = new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]);
 
         /// <summary>
-        /// Address of the error queue.
+        /// Address of the source queue.
         /// </summary>
-        public string ErrorQueueAddress { get; set; } = "error queue address";
+        public string SourceQueueAddress { get; set; } = "source queue address";
 
         /// <summary>
         /// Exception that occurred while processing the message.


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus.Gateway/issues/41

Let FaultContext track the error queue and set failure headers to enable reuse of it outside the core. (GW for example)

Alternative for https://github.com/Particular/NServiceBus/pull/3688