### PR TITLE
Removed ScenarioContext.Exception checks in Done conditions

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
+++ b/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
@@ -48,7 +48,7 @@
 
         static void AppendException(Exception exception)
         {
-            context?.Exceptions.Enqueue(exception);
+            context?.LoggedExceptions.Enqueue(exception);
         }
 
         public void Debug(string message)

--- a/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
@@ -20,7 +20,7 @@
             traceQueue.Enqueue($"{DateTime.Now:HH:mm:ss.ffffff} - {trace}");
         }
 
-        public ConcurrentQueue<Exception> Exceptions = new ConcurrentQueue<Exception>();
+        public ConcurrentQueue<Exception> LoggedExceptions = new ConcurrentQueue<Exception>();
 
         public ConcurrentDictionary<string, IReadOnlyCollection<FailedMessage>> FailedMessages = new ConcurrentDictionary<string, IReadOnlyCollection<FailedMessage>>();
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_auto_correlated_property_is_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_auto_correlated_property_is_changed.cs
@@ -21,7 +21,7 @@
                         {
                             DataId = Guid.NewGuid()
                         })))
-                    .Done(c => c.Exceptions.Any())
+                    .Done(c => c.ModifiedCorrelationProperty)
                     .Run())
                 .ExpectFailedMessages();
 
@@ -33,6 +33,7 @@
 
         public class Context : ScenarioContext
         {
+            public bool ModifiedCorrelationProperty { get; set; }
         }
 
         public class Endpoint : EndpointConfigurationBuilder
@@ -45,9 +46,12 @@
             public class CorrIdChangedSaga : Saga<CorrIdChangedSaga.CorrIdChangedSagaData>,
                 IAmStartedByMessages<StartSaga>
             {
+                public Context TestContext { get; set; }
+
                 public Task Handle(StartSaga message, IMessageHandlerContext context)
                 {
                     Data.DataId = Guid.NewGuid();
+                    TestContext.ModifiedCorrelationProperty = true;
                     return Task.FromResult(0);
                 }
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_forgetting_to_set_a_corr_property.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_forgetting_to_set_a_corr_property.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Sagas
 {
     using System;
-    using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -19,7 +18,7 @@
                 {
                     SomeId = id
                 })))
-                .Done(c => c.Done || c.Exceptions.Any())
+                .Done(c => c.Done)
                 .Run();
 
             Assert.AreEqual(context.SomeId, id);

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
@@ -28,7 +28,7 @@
             Assert.AreEqual(1, exception.FailedMessages.Count);
             Assert.AreEqual(((Context) exception.ScenarioContext).MessageId, exception.FailedMessages.Single().MessageId, "Message should be moved to errorqueue");
 
-            Assert.True(exception.ScenarioContext.Exceptions.Any(e =>
+            Assert.True(exception.ScenarioContext.LoggedExceptions.Any(e =>
                 e.Message.Contains("A modification of IContainSagaData.Id has been detected. This property is for infrastructure purposes only and should not be modified. SagaType: " + typeof(Endpoint.SagaIdChangedSaga))));
         }
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
@@ -19,7 +19,7 @@
                     {
                         SomeId = Guid.NewGuid()
                     })))
-                    .Done(c => c.Exceptions.Any())
+                    .Done(c => c.ModifiedCorrelationProperty)
                     .Run())
                 .ExpectFailedMessages();
 
@@ -32,6 +32,7 @@
 
         public class Context : ScenarioContext
         {
+            public bool ModifiedCorrelationProperty { get; set; }
         }
 
         public class ChangePropertyEndpoint : EndpointConfigurationBuilder
@@ -43,11 +44,14 @@
 
             public class ChangeCorrPropertySaga : Saga<ChangeCorrPropertySagaData>, IAmStartedByMessages<StartSagaMessage>
             {
+                public Context TestContext { get; set; }
+
                 public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
                 {
                     if (message.SecondMessage)
                     {
                         Data.SomeId = Guid.NewGuid(); //this is not allowed
+                        TestContext.ModifiedCorrelationProperty = true;
                         return Task.FromResult(0);
                     }
 

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_TimeToBeReceived_set_and_native_receivetransaction.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_TimeToBeReceived_set_and_native_receivetransaction.cs
@@ -15,7 +15,7 @@
             var exception = Assert.Throws<AggregateException>(async () =>
                 await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(b => b.When(async (session, c) => await session.SendLocal(new MyMessage())))
-                    .Done(c => c.Exceptions.Any())
+                    .Done(c => c.HandlerInvoked)
                     .Run())
                 .ExpectFailedMessages();
 
@@ -27,7 +27,9 @@
 
         public class Context : ScenarioContext
         {
+            public bool HandlerInvoked { get; set; }
         }
+
         public class Endpoint : EndpointConfigurationBuilder
         {
             public Endpoint()
@@ -43,6 +45,7 @@
 
                 public async Task Handle(MyMessage message, IMessageHandlerContext context)
                 {
+                    Context.HandlerInvoked = true;
                     await context.SendLocal(new MyTimeToBeReceivedMessage());
                 }
             }


### PR DESCRIPTION
Done checks in Acceptance Tests using `.Done(c => c.Exceptions.Any())` are not safe. `ScenarioContext.Exceptions` is a list of all exceptions being logged (even if catched and handled internally). Therefore I renamed the property to make this a bit more apparent. Tests can easily become flaky (on downstreams) if some exceptions are logged and the tests may end too soon therefore I removed all usages in `Done` checks.

@Particular/nservicebus-maintainers please review