### PR TITLE
Using EnvironmentHelper consistently in persistence and transport descriptor

### DIFF
--- a/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/Persistence.cs
+++ b/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/Persistence.cs
@@ -44,7 +44,7 @@
                     var runDescriptor = new RunDescriptor(key);
                     runDescriptor.Settings.Set("Persistence", definition);
 
-                    var connectionString = Environment.GetEnvironmentVariable(key + ".ConnectionString");
+                    var connectionString = EnvironmentHelper.GetEnvironmentVariable(key + ".ConnectionString");
 
                     if (!string.IsNullOrEmpty(connectionString))
                     {

--- a/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/Transports.cs
+++ b/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/Transports.cs
@@ -19,7 +19,7 @@
                     var runDescriptor = new RunDescriptor(key);
                     runDescriptor.Settings.Set("Transport", transportDefinitionType);
 
-                    var connectionString = Environment.GetEnvironmentVariable(key + ".ConnectionString");
+                    var connectionString = EnvironmentHelper.GetEnvironmentVariable(key + ".ConnectionString");
 
                     if (string.IsNullOrEmpty(connectionString) && DefaultConnectionStrings.ContainsKey(key))
                     {


### PR DESCRIPTION
I ran into this today. Acceptance tests were failing until I saw that we do not use the `EnvironmentHelper` consistently.

@Particular/nservicebus-maintainers please review