### PR TITLE
respect full type name of features

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostid.cs
+++ b/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostid.cs
@@ -35,7 +35,6 @@ namespace NServiceBus.AcceptanceTests.Hosting
             public MyFeatureThatOverridesHostInformationDefaults()
             {
                 EnableByDefault();
-                DependsOn("UnicastBus");
                 Defaults(s =>
                 {
                     // remove the override, we need to hack it via reflection!

--- a/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostinfo.cs
+++ b/src/NServiceBus.AcceptanceTests/Hosting/When_feature_overrides_hostinfo.cs
@@ -37,7 +37,6 @@ namespace NServiceBus.AcceptanceTests.Hosting
             public MyFeatureThatOverridesHostInformationDefaults()
             {
                 EnableByDefault();
-                DependsOn("UnicastBus");
                 Defaults(s =>
                 {
                     s.SetDefault("NServiceBus.HostInformation.HostId", hostId);

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1531,7 +1531,7 @@ namespace NServiceBus.Features
         protected void Defaults(System.Action<NServiceBus.Settings.SettingsHolder> settings) { }
         protected void DependsOn<T>()
             where T : NServiceBus.Features.Feature { }
-        protected void DependsOn(string featureName) { }
+        protected void DependsOn(string featureTypeName) { }
         protected void DependsOnAtLeastOne(params System.Type[] features) { }
         protected void DependsOnAtLeastOne(params string[] featureNames) { }
         protected void DependsOnOptionally(string featureName) { }

--- a/src/NServiceBus.Core.Tests/Features/FeatureDifferingOnlyByNamespaceTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDifferingOnlyByNamespaceTests.cs
@@ -1,0 +1,64 @@
+﻿namespace NServiceBus.Core.Tests.Features
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+    using Settings;
+
+    [TestFixture]
+    public class FeatureDifferingOnlyByNamespaceTests
+    {
+        [Test]
+        public void Should_activate_upstream_dependencies_first()
+        {
+            var order = new List<Feature>();
+
+            var dependingFeature = new NamespaceB.MyFeature
+            {
+                OnActivation = f => order.Add(f)
+            };
+            var feature = new NamespaceA.MyFeature
+            {
+                OnActivation = f => order.Add(f)
+            };
+
+            var settings = new SettingsHolder();
+            var featureSettings = new FeatureActivator(settings);
+
+            featureSettings.Add(dependingFeature);
+            featureSettings.Add(feature);
+
+            settings.EnableFeatureByDefault<NamespaceA.MyFeature>();
+
+            featureSettings.SetupFeatures(null, null);
+
+            Assert.True(dependingFeature.IsActive);
+
+            Assert.IsInstanceOf<NamespaceA.MyFeature>(order.First(), "Upstream dependencies should be activated first");
+        }
+    }
+}
+
+namespace NamespaceA
+{
+    using NServiceBus.Core.Tests.Features;
+
+    public class MyFeature : TestFeature
+    {
+    }
+}
+
+namespace NamespaceB
+{
+    using NServiceBus.Core.Tests.Features;
+
+    public class MyFeature : TestFeature
+    {
+        public MyFeature()
+        {
+            EnableByDefault();
+            DependsOn<NamespaceA.MyFeature>();
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Fakes\TestableMessageHandlerContextTests.cs" />
     <Compile Include="Fakes\TestableMessageSessionTests.cs" />
     <Compile Include="Faults\AddExceptionHeadersBehaviorTests.cs" />
+    <Compile Include="Features\FeatureDifferingOnlyByNamespaceTests.cs" />
     <Compile Include="MessageMapper\MessageMapperTests.cs" />
     <Compile Include="Msmq\TimeToBeReceivedOverrideCheckerTest.cs" />
     <Compile Include="Msmq\MsmqExtensionsTests.cs" />

--- a/src/NServiceBus.Core/Features/Feature.cs
+++ b/src/NServiceBus.Core/Features/Feature.cs
@@ -96,15 +96,14 @@
 
         /// <summary>
         /// Registers this feature as depending on the given feature. This means that this feature won't be activated unless
-        /// the dependant feature is active.
-        /// This also causes this feature to be activated after the other feature.
+        /// the dependant feature is active. This also causes this feature to be activated after the other feature.
         /// </summary>
-        /// <param name="featureName">The name of the feature that this feature depends on.</param>
-        protected void DependsOn(string featureName)
+        /// <param name="featureTypeName">The <see cref="Type.FullName"/> of the feature that this feature depends on.</param>
+        protected void DependsOn(string featureTypeName)
         {
             Dependencies.Add(new List<string>
             {
-                featureName
+                featureTypeName
             });
         }
 

--- a/src/NServiceBus.Core/Features/Feature.cs
+++ b/src/NServiceBus.Core/Features/Feature.cs
@@ -217,7 +217,7 @@
 
         static string GetFeatureName(Type featureType)
         {
-            var name = featureType.Name;
+            var name = featureType.FullName;
 
             if (name.EndsWith("Feature"))
             {

--- a/src/NServiceBus.Core/Persistence/InMemory/Gateway/InMemoryGatewayPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Gateway/InMemoryGatewayPersistence.cs
@@ -7,7 +7,7 @@
     {
         internal InMemoryGatewayPersistence()
         {
-            DependsOn("Gateway");
+            DependsOn("NServiceBus.Features.Gateway");
         }
 
         /// <summary>


### PR DESCRIPTION
I found this because i had a feature named "Outbox" in different namespace in a downstream. which causes a cyclic dependency fail. 

Connects to #3702 