### PR TITLE
Fixing `when_message_is_moved_to_error_queue` test

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_message_is_moved_to_error_queue.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_message_is_moved_to_error_queue.cs
@@ -11,7 +11,6 @@
 
     public class When_message_is_moved_to_error_queue : NServiceBusAcceptanceTest
     {
-        [TestCase(TransportTransactionMode.ReceiveOnly)]
         [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
         [TestCase(TransportTransactionMode.TransactionScope)]
         public Task Should_not_send_outgoing_messages(TransportTransactionMode transactionMode)
@@ -34,13 +33,14 @@
             .Run();
         }
 
-        [Test]
-        public Task May_send_outgoing_messages_without_transport_transactions()
+        [TestCase(TransportTransactionMode.ReceiveOnly)]
+        [TestCase(TransportTransactionMode.None)]
+        public Task May_send_outgoing_messages(TransportTransactionMode transactionMode)
         {
             return Scenario.Define<Context>(c =>
             {
                 c.Id = Guid.NewGuid();
-                c.TransactionMode = TransportTransactionMode.None;
+                c.TransactionMode = transactionMode;
             })
             .WithEndpoint<Endpoint>(b => b.DoNotFailOnErrorMessages()
                 .When((session, context) => session.SendLocal(new InitiatingMessage


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/732

The `Should_not_send_outgoing_messages` test should not be run for `TransportTransactionMode.ReceiveMode`. This is because in such case send and receive operations are not performed atomically. This has not been spotted until `SqlServer` has been updated because `MSMQ` shares the same implementation for `AtomicSendWithReceive` and `ReceiveOnly` transaction modes.

`ReceiveOnly` and `None` need to be treated in the same way.

/cc: @Particular/nservicebus-maintainers 