### PR TITLE
Fixing test for SLR when FLR is disabled.

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_flr_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_flr_disabled.cs
@@ -20,13 +20,14 @@
                 .Done(c => c.MessageRetried)
                 .Run();
 
-            Assert.AreEqual("0", context.FLRetriesHeader);
+            Assert.AreEqual(4, context.ReceiveCount, "Message should be delivered 4 times. Once initially and retried 3 times by SLR");
+            Assert.AreEqual("0", context.FLRetriesHeader, "When FLR is disabled no FLRRetries header should be '0'");
         }
 
         class Context : ScenarioContext
         {
             public Guid Id { get; set; }
-            public bool MessageRetried => ReceiveCount == 2;
+            public bool MessageRetried => ReceiveCount == 4;
             public int ReceiveCount { get; set; }
             public string FLRetriesHeader { get; set; }
         }


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/719
Previous condition for test stop caused it be flaky. On fast transports e.g. RabbitMQ it is possible for transport to re-deliver message 2 times before ATT does a single check for `Done` condition.

@Particular/nservicebus-maintainers 