### PR TITLE
Cache value instead of repeatedly calling Environment.MachineName

### DIFF
--- a/src/NServiceBus.Core/Support/RuntimeEnvironment.cs
+++ b/src/NServiceBus.Core/Support/RuntimeEnvironment.cs
@@ -9,7 +9,9 @@
     {
         static RuntimeEnvironment()
         {
-            MachineNameAction = () => Environment.MachineName;
+            var machineName = Environment.MachineName;
+
+            MachineNameAction = () => machineName;
         }
 
         /// <summary>


### PR DESCRIPTION
While working on https://github.com/Particular/NServiceBus.RabbitMQ/pull/136, I was profiling some code that was doing a lot of sends, and I saw that the call to `Environment.MachineName` was taking up a lot of time. In fact, it was the 2nd most expensive function in the entire profile run!

Now it only gets called once and we use the cached value instead.
