### PR TITLE
Fix flaky Acceptance Tests

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Sagas/When_auto_correlated_property_is_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_auto_correlated_property_is_changed.cs
@@ -21,10 +21,11 @@
                         {
                             DataId = Guid.NewGuid()
                         })))
-                    .Done(c => c.ModifiedCorrelationProperty)
+                    .Done(c => c.FailedMessages.Any())
                     .Run())
                 .ExpectFailedMessages();
 
+            Assert.IsTrue(((Context)exception.ScenarioContext).ModifiedCorrelationProperty);
             Assert.AreEqual(1, exception.FailedMessages.Count);
             StringAssert.Contains(
                 "Changing the value of correlated properties at runtime is currently not supported",

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
@@ -19,12 +19,12 @@
                     {
                         SomeId = Guid.NewGuid()
                     })))
-                    .Done(c => c.ModifiedCorrelationProperty)
+                    .Done(c => c.FailedMessages.Any())
                     .Run())
                 .ExpectFailedMessages();
 
+            Assert.IsTrue(((Context)exception.ScenarioContext).ModifiedCorrelationProperty);
             Assert.AreEqual(1, exception.FailedMessages.Count);
-
             StringAssert.Contains(
                 "Changing the value of correlated properties at runtime is currently not supported",
                 exception.FailedMessages.Single().Exception.Message);


### PR DESCRIPTION
temporary fix for `When_auto_correlated_property_is_changed` reported by #3711 :+1: - changed done condition to `FailedMessages.Any()`. Because of the changed mechanism how we send messages to error queues, it's possible that the done condition is met and the endpoint is shut down before the message to be sent to the error queue is consumed again by the endpoint. The new condition ends the test only if a (any) message has been sent to the error queue. This test also seemed to fail for RabbitMQ PR https://github.com/Particular/NServiceBus.RabbitMQ/pull/136

Also fixes `When_performing_slr_with_flr_disabled` which failed on https://github.com/Particular/NServiceBus.RabbitMQ/pull/136 too. I can't remember why the test assumes only 2 retries? Maybe @MarcinHoppe remembers?

/cc @johnsimons @bording @SimonCropp 

ping @Particular/nservicebus-maintainers 
