### PR TITLE
Use behavior instead of notifications to capture failed messages

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/MessagesFailedException.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/MessagesFailedException.cs
@@ -3,15 +3,14 @@ namespace NServiceBus.AcceptanceTesting.Support
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using System.Linq;
     using Faults;
 
     public class MessagesFailedException : Exception
     {
-        public MessagesFailedException(ScenarioContext scenarioContext) : base("One or more messages have been moved to the error queue.")
+        public MessagesFailedException(IList<FailedMessage> failedMessages, ScenarioContext scenarioContext) : base("One or more messages have been moved to the error queue.")
         {
             ScenarioContext = scenarioContext;
-            FailedMessages = new ReadOnlyCollection<FailedMessage>(ScenarioContext.FailedMessages.Values.SelectMany(f => f).ToList());
+            FailedMessages = new ReadOnlyCollection<FailedMessage>(failedMessages);
         }
 
         public ScenarioContext ScenarioContext { get; }

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -238,9 +238,14 @@
                 await StopEndpoints(endpoints).ConfigureAwait(false);
             }
 
-            if (runDescriptor.ScenarioContext.FailedMessages.Any(kvp => endpoints.Single(e => e.Name() == kvp.Key).FailOnErrorMessage))
+            var unexpectedFailedMessages = runDescriptor.ScenarioContext.FailedMessages
+                .Where(kvp => endpoints.Single(e => e.Name() == kvp.Key).FailOnErrorMessage)
+                .SelectMany(kvp => kvp.Value)
+                .ToList();
+
+            if (unexpectedFailedMessages.Any())
             {
-                throw new MessagesFailedException(runDescriptor.ScenarioContext);
+                throw new MessagesFailedException(unexpectedFailedMessages, runDescriptor.ScenarioContext);
             }
         }
 


### PR DESCRIPTION
Instead of relying on the notifications API we can use a custom behavior to capture unhandled message processing exceptions before the "MoveToErrorQueueBehavior" handles them.

This should resolve race conditions where fast endpoint shutdowns prevent the error message to notify the ATT framework properly as described in #3714 