### PR TITLE
Remove default TestExecutionTimeout value from RunSettings

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/RunSettings.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/RunSettings.cs
@@ -7,15 +7,19 @@ namespace NServiceBus.AcceptanceTesting.Support
 
     public class RunSettings : IEnumerable<KeyValuePair<string, object>>
     {
-        public RunSettings()
+        public TimeSpan? TestExecutionTimeout
         {
-            TestExecutionTimeout = TimeSpan.FromSeconds(90); // default timeout
-        }
-
-        public TimeSpan TestExecutionTimeout
-        {
-            get { return Get<TimeSpan>("TestExecutionTimeout"); }
-            set { Set("TestExecutionTimeout", value); }
+            get
+            {
+                TimeSpan? timeout;
+                TryGet("TestExecutionTimeout", out timeout);
+                return timeout;
+            }
+            set
+            {
+                Guard.AgainstNull(nameof(value), value);
+                Set("TestExecutionTimeout", value);
+            }
         }
 
         public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
@@ -87,7 +91,6 @@ namespace NServiceBus.AcceptanceTesting.Support
             return TryGet(typeof(T).FullName, out result);
         }
 
-
         /// <summary>
         /// Stores the type instance in the settings.
         /// </summary>
@@ -97,7 +100,6 @@ namespace NServiceBus.AcceptanceTesting.Support
         {
             Set(typeof(T).FullName, t);
         }
-
 
         /// <summary>
         /// Removes the instance type from the settings.

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -221,7 +221,7 @@
                 await ExecuteWhens(endpoints, allowedExceptions, cts).ConfigureAwait(false);
 
                 var startTime = DateTime.UtcNow;
-                var maxTime = runDescriptor.Settings.TestExecutionTimeout;
+                var maxTime = runDescriptor.Settings.TestExecutionTimeout ?? TimeSpan.FromSeconds(90);
 
                 while (!done() && !cts.Token.IsCancellationRequested)
                 {
@@ -289,7 +289,7 @@
 
             if (completedTask.Equals(timeoutTask))
             {
-                throw new Exception("Executing given and whens took longer than 2 minutes");
+                throw new Exception("Executing given and whens took longer than 30 seconds.");
             }
 
             if (completedTask.IsFaulted && completedTask.Exception != null)

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
@@ -30,32 +30,32 @@
 
             typesToInclude.AddRange(types);
 
-            var builder = new EndpointConfiguration(endpointConfiguration.EndpointName);
+            var configuration = new EndpointConfiguration(endpointConfiguration.EndpointName);
 
-            builder.TypesToIncludeInScan(typesToInclude);
-            builder.CustomConfigurationSource(configSource);
-            builder.EnableInstallers();
+            configuration.TypesToIncludeInScan(typesToInclude);
+            configuration.CustomConfigurationSource(configSource);
+            configuration.EnableInstallers();
 
-            builder.DisableFeature<TimeoutManager>();
-            builder.DisableFeature<SecondLevelRetries>();
-            builder.DisableFeature<FirstLevelRetries>();
+            configuration.DisableFeature<TimeoutManager>();
+            configuration.DisableFeature<SecondLevelRetries>();
+            configuration.DisableFeature<FirstLevelRetries>();
 
-            await builder.DefineTransport(settings, endpointConfiguration.EndpointName).ConfigureAwait(false);
+            await configuration.DefineTransport(settings, endpointConfiguration.EndpointName).ConfigureAwait(false);
 
-            builder.DefineBuilder(settings);
-            builder.RegisterComponentsAndInheritanceHierarchy(runDescriptor);
+            configuration.DefineBuilder(settings);
+            configuration.RegisterComponentsAndInheritanceHierarchy(runDescriptor);
 
             Type serializerType;
             if (settings.TryGet("Serializer", out serializerType))
             {
-                builder.UseSerialization((SerializationDefinition) Activator.CreateInstance(serializerType));
+                configuration.UseSerialization((SerializationDefinition) Activator.CreateInstance(serializerType));
             }
-            await builder.DefinePersistence(settings, endpointConfiguration.EndpointName).ConfigureAwait(false);
+            await configuration.DefinePersistence(settings, endpointConfiguration.EndpointName).ConfigureAwait(false);
 
-            builder.GetSettings().SetDefault("ScaleOut.UseSingleBrokerQueue", true);
-            configurationBuilderCustomization(builder);
+            configuration.GetSettings().SetDefault("ScaleOut.UseSingleBrokerQueue", true);
+            configurationBuilderCustomization(configuration);
 
-            return builder;
+            return configuration;
         }
 
         List<Type> typesToInclude;

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_receiving_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_receiving_a_message.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Threading.Tasks;
     using AcceptanceTesting;
-    using AcceptanceTesting.Support;
     using Configuration.AdvanceExtensibility;
     using EndpointTemplates;
     using NUnit.Framework;
@@ -18,10 +17,7 @@
                 .WithEndpoint<NonDtcReceivingEndpoint>(b => b.When(session => session.SendLocal(new PlaceOrder())))
                 .Done(c => c.OrderAckReceived == 1)
                 .Repeat(r => r.For<AllOutboxCapableStorages>())
-                .Run(new RunSettings
-                {
-                    TestExecutionTimeout = TimeSpan.FromSeconds(20)
-                });
+                .Run(TimeSpan.FromSeconds(20));
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas_with_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_doing_request_response_between_sagas_with_timeout.cs
@@ -3,7 +3,6 @@ namespace NServiceBus.AcceptanceTests.Sagas
     using System;
     using System.Threading.Tasks;
     using AcceptanceTesting;
-    using AcceptanceTesting.Support;
     using NUnit.Framework;
 
     public class When_doing_request_response_between_sagas_with_timeout : When_doing_request_response_between_sagas
@@ -14,10 +13,7 @@ namespace NServiceBus.AcceptanceTests.Sagas
             var context = await Scenario.Define<Context>(c => { c.ReplyFromTimeout = true; })
                 .WithEndpoint<Endpoint>(b => b.When(session => session.SendLocal(new InitiateRequestingSaga())))
                 .Done(c => c.DidRequestingSagaGetTheResponse)
-                .Run(new RunSettings
-                {
-                    TestExecutionTimeout = TimeSpan.FromSeconds(15)
-                });
+                .Run(TimeSpan.FromSeconds(15));
 
             Assert.True(context.DidRequestingSagaGetTheResponse);
         }


### PR DESCRIPTION
The default value caused a bug which resulted in the the configured timeout to be overwritten by the default when merging two RunSettings. E.g. here: https://github.com/Particular/NServiceBus/blob/develop/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs#L27

Merging RunSettings seems to be quite dangerous.

@Particular/nservicebus-maintainers please review

/cc @johnsimons 