### PR TITLE
[WIP] Refactor routing

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ContextAppenderFactory.cs
+++ b/src/NServiceBus.AcceptanceTesting/ContextAppenderFactory.cs
@@ -1,0 +1,35 @@
+namespace NServiceBus.AcceptanceTesting
+{
+    using System;
+    using Logging;
+
+    class ContextAppenderFactory : ILoggerFactory
+    {
+        static ScenarioContext context;
+        
+
+        /// <summary>
+        /// Because ILoggerFactory interface methods are only used in a static context. This is the only way to set the currently executing context.
+        /// </summary>
+        /// <param name="newContext">The new context to be set</param>
+        public static void SetContext(ScenarioContext newContext)
+        {
+            context = newContext;
+        }
+
+        public ILog GetLogger(Type type)
+        {
+            return GetLogger(type.FullName);
+        }
+
+        public ILog GetLogger(string name)
+        {
+            LogLevel level;
+            if (!context.LogLevels.TryGetValue(name, out level))
+            {
+                level = LogLevel.Info;
+            }
+            return new ContextAppender(name, level, () => context);
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
+++ b/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
@@ -50,6 +50,7 @@
     <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ContextAppenderFactory.cs" />
     <Compile Include="Customization\EndpointConfigurationExtensions.cs" />
     <Compile Include="Customization\Conventions.cs" />
     <Compile Include="IScenarioVerification.cs" />

--- a/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
@@ -4,6 +4,7 @@
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using Faults;
+    using Logging;
 
     public abstract class ScenarioContext
     {
@@ -28,10 +29,17 @@
 
         ConcurrentQueue<string> traceQueue = new ConcurrentQueue<string>();
 
+        internal Dictionary<string, LogLevel> LogLevels = new Dictionary<string, LogLevel>();
+
+        public void SetLogLevel(string logger, LogLevel level)
+        {
+            LogLevels[logger] = level;
+        }
+
         public class LogItem
         {
             public string Message { get; set; }
-            public string Level { get; set; }
+            public LogLevel Level { get; set; }
 
             public override string ToString()
             {

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -49,7 +49,7 @@ namespace NServiceBus.AcceptanceTesting
                 runDescriptor.Settings.Merge(settings);
             }
 
-            LogManager.UseFactory(new ContextAppender());
+            LogManager.UseFactory(new ContextAppenderFactory());
 
             var sw = new Stopwatch();
 

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -50,9 +50,9 @@
 
                     Console.WriteLine("{0} - Started @ {1}", runDescriptor.Key, DateTime.Now.ToString(CultureInfo.InvariantCulture));
 
-                    ContextAppender.SetContext(runDescriptor.ScenarioContext);
+                    ContextAppenderFactory.SetContext(runDescriptor.ScenarioContext);
                     var runResult = await PerformTestRun(behaviorDescriptors, shoulds, runDescriptor, done, allowedExceptions).ConfigureAwait(false);
-                    ContextAppender.SetContext(null);
+                    ContextAppenderFactory.SetContext(null);
 
                     Console.WriteLine("{0} - Finished @ {1}", runDescriptor.Key, DateTime.Now.ToString(CultureInfo.InvariantCulture));
 

--- a/src/NServiceBus.AcceptanceTests/Licensing/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Licensing/When_a_message_is_audited.cs
@@ -5,6 +5,7 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
+    using Logging;
     using NUnit.Framework;
 
     public class When_a_message_is_audited : NServiceBusAcceptanceTest
@@ -22,7 +23,7 @@
 
             if (Debugger.IsAttached)
             {
-                Assert.True(context.Logs.Any(m => m.Level == "error" && m.Message.StartsWith("Your license has expired")), "Error should be logged");
+                Assert.True(context.Logs.Any(m => m.Level == LogLevel.Error && m.Message.StartsWith("Your license has expired")), "Error should be logged");
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Routing\When_publishing_to_scaled_out_subscribers_on_multicast_transports.cs" />
     <Compile Include="Routing\When_broadcasting_a_command.cs" />
     <Compile Include="Routing\When_replying_to_a_message_sent_to_specific_instance.cs" />
+    <Compile Include="Routing\When_using_assembly_level_message_mapping_for_pub_sub.cs" />
     <Compile Include="Routing\When_using_legacy_routing_configuration_combined_with_message_driven_pub_sub.cs" />
     <Compile Include="Routing\When_publishing_an_interface.cs" />
     <Compile Include="Routing\When_publishing_from_sendonly.cs" />

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
@@ -6,6 +6,7 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using Features;
+    using Logging;
     using NServiceBus.Config;
     using NUnit.Framework;
 
@@ -27,7 +28,7 @@
                 .Run();
 
             Assert.IsInstanceOf<SimulatedException>(context.MessageSentToErrorException);
-            Assert.True(context.Logs.Any(l => l.Level == "error" && l.Message.Contains("Simulated exception message")), "The last exception should be logged as `error` before sending it to the error queue");
+            Assert.True(context.Logs.Any(l => l.Level == LogLevel.Error && l.Message.Contains("Simulated exception message")), "The last exception should be logged as `error` before sending it to the error queue");
 
             //FLR max retries = 3 means we will be processing 4 times. SLR max retries = 2 means we will do 3*FLR
             Assert.AreEqual(4*3, context.TotalNumberOfFLRTimesInvokedInHandler);

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface.cs
@@ -5,6 +5,7 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using Features;
+    using Logging;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
     using ScenarioDescriptors;
@@ -14,7 +15,7 @@
         [Test]
         public async Task Should_receive_event_for_non_xml()
         {
-            await Scenario.Define<Context>()
+            await Scenario.Define<Context>(c => c.SetLogLevel("NServiceBus.UnicastRoutingTable", LogLevel.Debug))
                 .WithEndpoint<Publisher>(b =>
                     b.When(c => c.Subscribed, (session, ctx) => session.Publish<MyEvent>()))
                 .WithEndpoint<Subscriber>(b => b.When(async (session, context) =>

--- a/src/NServiceBus.AcceptanceTests/Routing/When_using_assembly_level_message_mapping_for_pub_sub.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_using_assembly_level_message_mapping_for_pub_sub.cs
@@ -1,0 +1,88 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using NServiceBus.Config;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_using_assembly_level_message_mapping_for_pub_sub : NServiceBusAcceptanceTest
+    {
+        static string OtherEndpointName => Conventions.EndpointNamingConvention(typeof(OtherEndpoint));
+
+        [Test]
+        public async Task The_mapping_should_not_cause_publishing_to_non_subscribers()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<OtherEndpoint>()
+                .WithEndpoint<Publisher>(b =>
+                    b.When(c => c.EndpointsStarted, async session =>
+                    {
+                        await session.Publish(new MyEvent());
+                        await session.Send(new DoneCommand());
+                    })
+                )
+                .Done(c => c.Done)
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int HandlerInvoked { get; set; }
+            public bool Subscribed { get; set; }
+            public bool Done { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) => { context.Subscribed = true; }))
+                    .WithConfig<UnicastBusConfig>(c =>
+                    {
+                        c.MessageEndpointMappings = new MessageEndpointMappingCollection();
+                        c.MessageEndpointMappings.Add(new MessageEndpointMapping
+                        {
+                            Endpoint = OtherEndpointName,
+                            AssemblyName = typeof(Publisher).Assembly.GetName().Name
+                        });
+                    })
+                    .AddMapping<DoneCommand>(typeof(OtherEndpoint));
+            }
+        }
+
+        public class OtherEndpoint : EndpointConfigurationBuilder
+        {
+            public OtherEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.LimitMessageProcessingConcurrencyTo(1);
+                });
+            }
+
+            public class DoneHandler : IHandleMessages<DoneCommand>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(DoneCommand message, IMessageHandlerContext context)
+                {
+                    Context.Done = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+        
+        public class MyEvent : IEvent
+        {
+        }
+        
+        public class DoneCommand : ICommand
+        {
+            
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_using_scope_suppress.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_using_scope_suppress.cs
@@ -5,6 +5,7 @@
     using System.Transactions;
     using AcceptanceTesting;
     using EndpointTemplates;
+    using Logging;
     using NUnit.Framework;
     using ScenarioDescriptors;
 
@@ -23,7 +24,7 @@
                 .Should(c =>
                 {
                     Assert.True(c.MessageDispatched, "Should dispatch the message immediately");
-                    Assert.True(c.Logs.Any(l => l.Level == "warn" && l.Message.Contains("We detected that you suppressed the ambient transaction")));
+                    Assert.True(c.Logs.Any(l => l.Level == LogLevel.Warn && l.Message.Contains("We detected that you suppressed the ambient transaction")));
                 })
                 .Run();
         }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -821,7 +821,7 @@ namespace NServiceBus
     }
     public class RoutingMappingSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
-        public NServiceBus.Routing.UnicastRoutingTable Logical { get; }
+        public NServiceBus.Routing.UnicastRoutingTableConfiguration Logical { get; }
         public NServiceBus.Routing.EndpointInstances Physical { get; }
         public NServiceBus.Routing.MessageDrivenSubscriptions.Publishers Publishers { get; }
         public void SetMessageDistributionStrategy(NServiceBus.Routing.DistributionStrategy distributionStrategy, System.Func<System.Type, bool> typeMatchingRule) { }
@@ -1074,6 +1074,7 @@ namespace NServiceBus
         public override int GetHashCode() { }
         public static NServiceBus.UnicastRoutingTarget ToAnonymousInstance(NServiceBus.Routing.EndpointName endpoint, string transportAddress) { }
         public static NServiceBus.UnicastRoutingTarget ToEndpointInstance(NServiceBus.Routing.EndpointInstance instance) { }
+        public override string ToString() { }
         public static NServiceBus.UnicastRoutingTarget ToTransportAddress(string transportAddress) { }
     }
     public class UnitOfWorkSettings
@@ -2296,12 +2297,12 @@ namespace NServiceBus.Routing
     public class AllInstancesDistributionStrategy : NServiceBus.Routing.DistributionStrategy
     {
         public AllInstancesDistributionStrategy() { }
-        public override System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> SelectDestination(System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> allInstances) { }
+        public override System.Func<NServiceBus.Extensibility.ContextBag, System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget>> SelectDestination(System.Collections.Generic.List<NServiceBus.UnicastRoutingTarget> allDestinations) { }
     }
     public abstract class DistributionStrategy
     {
         protected DistributionStrategy() { }
-        public abstract System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> SelectDestination(System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> allInstances);
+        public abstract System.Func<NServiceBus.Extensibility.ContextBag, System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget>> SelectDestination(System.Collections.Generic.List<NServiceBus.UnicastRoutingTarget> allDestinations);
     }
     public sealed class EndpointInstance
     {
@@ -2350,8 +2351,7 @@ namespace NServiceBus.Routing
     public class SingleInstanceRoundRobinDistributionStrategy : NServiceBus.Routing.DistributionStrategy
     {
         public SingleInstanceRoundRobinDistributionStrategy() { }
-        [System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(NServiceBus.Routing.SingleInstanceRoundRobinDistributionStrategy.<SelectDestination>d__0))]
-        public override System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> SelectDestination(System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> currentAllInstances) { }
+        public override System.Func<NServiceBus.Extensibility.ContextBag, System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget>> SelectDestination(System.Collections.Generic.List<NServiceBus.UnicastRoutingTarget> allDestinations) { }
     }
     public class UnicastAddressTag : NServiceBus.Routing.AddressTag
     {
@@ -2369,11 +2369,11 @@ namespace NServiceBus.Routing
         public UnicastRoutingStrategy(string destination) { }
         public override NServiceBus.Routing.AddressTag Apply(System.Collections.Generic.Dictionary<string, string> headers) { }
     }
-    public class UnicastRoutingTable
+    public class UnicastRoutingTableConfiguration
     {
-        public UnicastRoutingTable() { }
-        public void AddDynamic(System.Func<System.Collections.Generic.List<System.Type>, NServiceBus.Extensibility.ContextBag, System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.Routing.IUnicastRoute>>> dynamicRule) { }
-        public void AddDynamic(System.Func<System.Collections.Generic.List<System.Type>, NServiceBus.Extensibility.ContextBag, System.Collections.Generic.IEnumerable<NServiceBus.Routing.IUnicastRoute>> dynamicRule) { }
+        public UnicastRoutingTableConfiguration() { }
+        public void AddDynamic(System.Func<System.Collections.Generic.List<System.Type>, System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.Routing.IUnicastRoute>>> dynamicRule) { }
+        public void AddDynamic(System.Func<System.Collections.Generic.List<System.Type>, System.Collections.Generic.IEnumerable<NServiceBus.Routing.IUnicastRoute>> dynamicRule) { }
         public void RouteToAddress(System.Type messageType, string destinationAddress) { }
         public void RouteToEndpoint(System.Type messageType, NServiceBus.Routing.EndpointName destination) { }
         public void RouteToEndpoint(System.Type messageType, string destination) { }

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastPublishRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastPublishRouterConnectorTests.cs
@@ -14,7 +14,7 @@
         [Test]
         public async Task Should_set_messageintent_to_publish()
         {
-            var router = new UnicastPublishRouterConnector(new Router(), new DistributionPolicy());
+            var router = new UnicastPublishRouterConnector(new Router());
             var context = new TestableOutgoingPublishContext();
 
             await router.Invoke(context, ctx => TaskEx.CompletedTask);
@@ -25,7 +25,7 @@
 
         class Router : IUnicastRouter
         {
-            public Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, DistributionStrategy distributionStrategy, ContextBag contextBag)
+            public Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, ContextBag contextBag)
             {
                 IEnumerable<UnicastRoutingStrategy> unicastRoutingStrategies = new List<UnicastRoutingStrategy>
                 {

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
@@ -230,14 +230,14 @@
             var metadataRegistry = new MessageMetadataRegistry(new Conventions());
             metadataRegistry.RegisterMessageType(typeof(MyMessage));
             metadataRegistry.RegisterMessageType(typeof(MessageWithoutRouting));
-            return new UnicastSendRouterConnector(sharedQueue, instanceSpecificQueue, strategy ?? new FakeRoutingStrategy(), new DistributionPolicy());
+            return new UnicastSendRouterConnector(sharedQueue, instanceSpecificQueue, strategy ?? new FakeRoutingStrategy());
         }
 
         class FakeRoutingStrategy : IUnicastRouter
         {
             public IEnumerable<UnicastRoutingStrategy> FixedDestination { get; set; }
 
-            public Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, DistributionStrategy distributionStrategy, ContextBag contextBag)
+            public Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, ContextBag contextBag)
             {
                 return Task.FromResult(FixedDestination);
             }

--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -45,6 +45,7 @@ namespace NServiceBus
             var transportInfrastructure = transportDefinition.Initialize(settings, connectionString);
             settings.Set<TransportInfrastructure>(transportInfrastructure);
 
+            // ReSharper disable once AccessToModifiedClosure
             var featureStats = featureActivator.SetupFeatures(container, pipelineSettings);
 
             pipelineConfiguration.RegisterBehaviorsInContainer(settings, container);
@@ -53,7 +54,6 @@ namespace NServiceBus
             WireUpInstallers(concreteTypes);
 
             container.ConfigureComponent(b => settings.Get<Notifications>(), DependencyLifecycle.SingleInstance);
-
             var startableEndpoint = new StartableEndpoint(settings, builder, featureActivator, pipelineConfiguration, new EventAggregator(settings.Get<NotificationSubscriptions>()), transportInfrastructure);
             return Task.FromResult<IStartableEndpoint>(startableEndpoint);
         }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -127,7 +127,14 @@
     <Compile Include="Recoverability\Faults\MessageFaulted.cs" />
     <Compile Include="ReleaseDateAttribute.cs" />
     <Compile Include="Recoverability\ProcessingFailureInfo.cs" />
+    <Compile Include="Routing\DistributedUnicastRoutingTableEntry.cs" />
+    <Compile Include="Routing\IUnicastRoutingTableEntry.cs" />
     <Compile Include="Routing\RoutingMappingSettings.cs" />
+    <Compile Include="Routing\SingleUnicastRoutingTableEntry.cs" />
+    <Compile Include="Routing\UnicastPublishRouter.cs" />
+    <Compile Include="Routing\UnicastRouterTableUpdater.cs" />
+    <Compile Include="Routing\UnicastRoutingTable.cs" />
+    <Compile Include="Routing\UnicastSendRouter.cs" />
     <Compile Include="Serialization\SerializationFeature.cs" />
     <Compile Include="Serializers\XML\XmlSerialization.cs" />
     <Compile Include="Settings\ScaleOutSettings.cs" />
@@ -271,7 +278,7 @@
     <Compile Include="Transports\TransportTransactionMode.cs" />
     <Compile Include="Transports\Sending.cs" />
     <Compile Include="Transports\TransportAddresses.cs" />
-    <Compile Include="Routing\UnicastRoutingTable.cs" />
+    <Compile Include="Routing\UnicastRoutingTableConfiguration.cs" />
     <Compile Include="Routing\UnicastRoutingSettings.cs" />
     <Compile Include="Routing\RoutingSettingsExtensions.cs" />
     <Compile Include="TaskEx.cs" />

--- a/src/NServiceBus.Core/Routing/AllInstancesDistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/AllInstancesDistributionStrategy.cs
@@ -1,6 +1,8 @@
 namespace NServiceBus.Routing
 {
+    using System;
     using System.Collections.Generic;
+    using Extensibility;
 
     /// <summary>
     /// Selects all instances.
@@ -8,11 +10,11 @@ namespace NServiceBus.Routing
     public class AllInstancesDistributionStrategy : DistributionStrategy
     {
         /// <summary>
-        /// Selects destination instances from all known instances of a given endpoint.
+        /// Returns a function that selects the next target of a message.
         /// </summary>
-        public override IEnumerable<UnicastRoutingTarget> SelectDestination(IEnumerable<UnicastRoutingTarget> allInstances)
+        public override Func<ContextBag, IEnumerable<UnicastRoutingTarget>> SelectDestination(List<UnicastRoutingTarget> allDestinations)
         {
-            return allInstances;
+            return bag => allDestinations;
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/DistributedUnicastRoutingTableEntry.cs
+++ b/src/NServiceBus.Core/Routing/DistributedUnicastRoutingTableEntry.cs
@@ -1,0 +1,29 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Extensibility;
+
+    class DistributedUnicastRoutingTableEntry : IUnicastRoutingTableEntry
+    {
+        Func<ContextBag, IEnumerable<UnicastRoutingTarget>> distributionFunction;
+        List<UnicastRoutingTarget> targets;
+
+        public DistributedUnicastRoutingTableEntry(Func<ContextBag, IEnumerable<UnicastRoutingTarget>> distributionFunction, List<UnicastRoutingTarget> targets)
+        {
+            this.distributionFunction = distributionFunction;
+            this.targets = targets;
+        }
+
+        public IEnumerable<UnicastRoutingTarget> GetTargets(ContextBag contextBag)
+        {
+            return distributionFunction(contextBag);
+        }
+
+        public override string ToString()
+        {
+            return string.Join(",", targets.Select(t => t.ToString()));
+        }
+    }
+}

--- a/src/NServiceBus.Core/Routing/DistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionStrategy.cs
@@ -1,6 +1,8 @@
 namespace NServiceBus.Routing
 {
+    using System;
     using System.Collections.Generic;
+    using Extensibility;
 
     /// <summary>
     /// Governs to how many and which instances of a given endpoint a message is to be sent.
@@ -8,8 +10,8 @@ namespace NServiceBus.Routing
     public abstract class DistributionStrategy
     {
         /// <summary>
-        /// Selects destination instances from all known instances of a given endpoint.
+        /// Returns a function that selects the next target of a message.
         /// </summary>
-        public abstract IEnumerable<UnicastRoutingTarget> SelectDestination(IEnumerable<UnicastRoutingTarget> allInstances);
+        public abstract Func<ContextBag, IEnumerable<UnicastRoutingTarget>> SelectDestination(List<UnicastRoutingTarget> allDestinations);
     }
 }

--- a/src/NServiceBus.Core/Routing/IUnicastRouter.cs
+++ b/src/NServiceBus.Core/Routing/IUnicastRouter.cs
@@ -8,6 +8,6 @@ namespace NServiceBus
 
     interface IUnicastRouter
     {
-        Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, DistributionStrategy distributionStrategy, ContextBag contextBag);
+        Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, ContextBag contextBag);
     }
 }

--- a/src/NServiceBus.Core/Routing/IUnicastRoutingTableEntry.cs
+++ b/src/NServiceBus.Core/Routing/IUnicastRoutingTableEntry.cs
@@ -1,0 +1,10 @@
+namespace NServiceBus
+{
+    using System.Collections.Generic;
+    using Extensibility;
+
+    interface IUnicastRoutingTableEntry
+    {
+        IEnumerable<UnicastRoutingTarget> GetTargets(ContextBag contextBag);
+    }
+}

--- a/src/NServiceBus.Core/Routing/Routers/UnicastPublishRouterConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/UnicastPublishRouterConnector.cs
@@ -1,26 +1,25 @@
 namespace NServiceBus
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using Pipeline;
-    using Routing;
     using Unicast.Queuing;
 
     class UnicastPublishRouterConnector : StageConnector<IOutgoingPublishContext, IOutgoingLogicalMessageContext>
     {
-        public UnicastPublishRouterConnector(IUnicastRouter unicastRouter, DistributionPolicy distributionPolicy)
+
+        public UnicastPublishRouterConnector(IUnicastRouter unicastRouter)
         {
             this.unicastRouter = unicastRouter;
-            this.distributionPolicy = distributionPolicy;
         }
 
         public override async Task Invoke(IOutgoingPublishContext context, Func<IOutgoingLogicalMessageContext, Task> stage)
         {
             var eventType = context.Message.MessageType;
-            var addressLabels = await GetRoutingStrategies(context, eventType).ConfigureAwait(false);
-            if (addressLabels.Count == 0)
+            var routingStrategies = (await unicastRouter.Route(eventType, context.Extensions).ConfigureAwait(false)).ToList();
+
+            if (routingStrategies.Count == 0)
             {
                 //No subscribers for this message.
                 return;
@@ -30,22 +29,14 @@ namespace NServiceBus
 
             try
             {
-                await stage(this.CreateOutgoingLogicalMessageContext(context.Message, addressLabels, context)).ConfigureAwait(false);
+                await stage(this.CreateOutgoingLogicalMessageContext(context.Message, routingStrategies, context)).ConfigureAwait(false);
             }
             catch (QueueNotFoundException ex)
             {
                 throw new Exception($"The destination queue '{ex.Queue}' could not be found. The destination may be misconfigured for this kind of message ({eventType}) in the MessageEndpointMappings of the UnicastBusConfig section in the configuration file. It may also be the case that the given queue hasn\'t been created yet, or has been deleted.", ex);
             }
         }
-
-        async Task<List<UnicastRoutingStrategy>> GetRoutingStrategies(IOutgoingPublishContext context, Type eventType)
-        {
-            var distributionStrategy = distributionPolicy.GetDistributionStrategy(eventType);
-            var addressLabels = await unicastRouter.Route(eventType, distributionStrategy, context.Extensions).ConfigureAwait(false);
-            return addressLabels.ToList();
-        }
-
-        DistributionPolicy distributionPolicy;
+        
         IUnicastRouter unicastRouter;
     }
 }

--- a/src/NServiceBus.Core/Routing/RoutingMappingSettings.cs
+++ b/src/NServiceBus.Core/Routing/RoutingMappingSettings.cs
@@ -19,7 +19,7 @@ namespace NServiceBus
         /// <summary>
         /// Gets the routing table for the direct routing.
         /// </summary>
-        public UnicastRoutingTable Logical => GetOrCreate<UnicastRoutingTable>();
+        public UnicastRoutingTableConfiguration Logical => GetOrCreate<UnicastRoutingTableConfiguration>();
 
         /// <summary>
         /// Gets the known endpoints collection.

--- a/src/NServiceBus.Core/Routing/SingleUnicastRoutingTableEntry.cs
+++ b/src/NServiceBus.Core/Routing/SingleUnicastRoutingTableEntry.cs
@@ -1,0 +1,25 @@
+namespace NServiceBus
+{
+    using System.Collections.Generic;
+    using Extensibility;
+
+    class SingleUnicastRoutingTableEntry : IUnicastRoutingTableEntry
+    {
+        UnicastRoutingTarget target;
+
+        public SingleUnicastRoutingTableEntry(UnicastRoutingTarget target)
+        {
+            this.target = target;
+        }
+
+        public IEnumerable<UnicastRoutingTarget> GetTargets(ContextBag contextBag)
+        {
+            yield return target;
+        }
+
+        public override string ToString()
+        {
+            return target.ToString();
+        }
+    }
+}

--- a/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
@@ -1,0 +1,58 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using Routing;
+    using Transports;
+    using Unicast.Messages;
+    using Unicast.Subscriptions;
+    using Unicast.Subscriptions.MessageDrivenSubscriptions;
+
+    class UnicastPublishRouter : UnicastRouter
+    {
+        public UnicastPublishRouter(string name, MessageMetadataRegistry messageMetadataRegistry, ISubscriptionStorage subscriptionStorage, EndpointInstances endpointInstances, TransportAddresses physicalAddresses, DistributionPolicy distributionPolicy, List<Type> allMessageTypes) 
+            : base(name, messageMetadataRegistry, endpointInstances, physicalAddresses, distributionPolicy, allMessageTypes)
+        {
+            this.subscriptionStorage = subscriptionStorage;
+        }
+
+        protected override Task<IEnumerable<IUnicastRoute>> GetDestinationsFor(List<Type> messageTypeHierarchy)
+        {
+            return QuerySubscriptionStore(messageTypeHierarchy, new ContextBag());
+        }
+
+        async Task<IEnumerable<IUnicastRoute>> QuerySubscriptionStore(List<Type> types, ContextBag context)
+        {
+            var messageTypes = types.Select(t => new MessageType(t));
+            var subscribers = await subscriptionStorage.GetSubscriberAddressesForMessage(messageTypes, context).ConfigureAwait(false);
+            return subscribers.Select(s => new SubscriberDestination(s));
+        }
+
+        ISubscriptionStorage subscriptionStorage;
+
+        class SubscriberDestination : IUnicastRoute
+        {
+            public SubscriberDestination(Subscriber subscriber)
+            {
+                if (subscriber.Endpoint != null)
+                {
+                    target = UnicastRoutingTarget.ToAnonymousInstance(subscriber.Endpoint, subscriber.TransportAddress);
+                }
+                else
+                {
+                    target = UnicastRoutingTarget.ToTransportAddress(subscriber.TransportAddress);
+                }
+            }
+
+            public Task<IEnumerable<UnicastRoutingTarget>> Resolve(Func<EndpointName, Task<IEnumerable<EndpointInstance>>> instanceResolver)
+            {
+                return Task.FromResult(EnumerableEx.Single(target));
+            }
+
+            UnicastRoutingTarget target;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Routing/UnicastRouterTableUpdater.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRouterTableUpdater.cs
@@ -1,0 +1,42 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Features;
+    using Logging;
+
+    class UnicastRouterTableUpdater : FeatureStartupTask
+    {
+        public UnicastRouterTableUpdater(IAsyncTimer timer, IList<UnicastRouter> routers, TimeSpan checkInterval)
+        {
+            this.timer = timer;
+            this.routers = routers;
+            this.checkInterval = checkInterval;
+        }
+
+        protected override Task OnStart(IMessageSession session)
+        {
+            timer.Start(ReloadData, checkInterval, ex => log.Error("Error while updating routing table", ex));
+            return TaskEx.CompletedTask;
+        }
+
+        async Task ReloadData()
+        {
+            foreach (var router in routers)
+            {
+                await router.RebuildRoutingTable().ConfigureAwait(false);
+            }
+        }
+
+        protected override Task OnStop(IMessageSession session)
+        {
+            return timer.Stop();
+        }
+
+        static readonly ILog log = LogManager.GetLogger(typeof(UnicastRouterTableUpdater));
+        IAsyncTimer timer;
+        IList<UnicastRouter> routers;
+        TimeSpan checkInterval;
+    }
+}

--- a/src/NServiceBus.Core/Routing/UnicastRoutingSettings.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRoutingSettings.cs
@@ -25,7 +25,7 @@
         /// <param name="destination">Destination endpoint.</param>
         public void RouteToEndpoint(Type messageType, string destination)
         {
-            GetOrCreate<UnicastRoutingTable>().RouteToEndpoint(messageType, destination);
+            GetOrCreate<UnicastRoutingTableConfiguration>().RouteToEndpoint(messageType, destination);
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Routing/UnicastRoutingTableConfiguration.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRoutingTableConfiguration.cs
@@ -1,0 +1,94 @@
+namespace NServiceBus.Routing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Manages the unicast routing table.
+    /// </summary>
+    public class UnicastRoutingTableConfiguration
+    {
+        internal async Task<IEnumerable<IUnicastRoute>> GetDestinationsFor(List<Type> messageTypeHierarchy)
+        {
+            var routes = new List<IUnicastRoute>();
+            foreach (var rule in asyncDynamicRules)
+            {
+                routes.AddRange(await rule.Invoke(messageTypeHierarchy).ConfigureAwait(false));
+            }
+
+            foreach (var rule in dynamicRules)
+            {
+                routes.AddRange(rule.Invoke(messageTypeHierarchy));
+            }
+
+            var staticRoutes = messageTypeHierarchy
+                .SelectMany(type => staticRules, (type, rule) => rule.Invoke(type))
+                .Where(route => route != null);
+
+            routes.AddRange(staticRoutes);
+
+            return routes;
+        }
+
+        /// <summary>
+        /// Adds a static unicast route.
+        /// </summary>
+        /// <param name="messageType">Message type.</param>
+        /// <param name="destination">Destination endpoint.</param>
+        public void RouteToEndpoint(Type messageType, EndpointName destination)
+        {
+            staticRules.Add(t => StaticRule(t, messageType, new UnicastRoute(destination)));
+        }
+
+        /// <summary>
+        /// Adds a static unicast route.
+        /// </summary>
+        /// <param name="messageType">Message type.</param>
+        /// <param name="destination">Destination endpoint.</param>
+        public void RouteToEndpoint(Type messageType, string destination)
+        {
+            RouteToEndpoint(messageType, new EndpointName(destination));
+        }
+
+        /// <summary>
+        /// Adds a static unicast route.
+        /// </summary>
+        /// <param name="messageType">Message type.</param>
+        /// <param name="destinationAddress">Destination endpoint instance address.</param>
+        public void RouteToAddress(Type messageType, string destinationAddress)
+        {
+            staticRules.Add(t => StaticRule(t, messageType, new UnicastRoute(destinationAddress)));
+        }
+
+        /// <summary>
+        /// Adds an external provider of routes.
+        /// </summary>
+        /// <remarks>For dynamic routes that do not require async use <see cref="AddDynamic(System.Func{System.Collections.Generic.List{System.Type},System.Collections.Generic.IEnumerable{NServiceBus.Routing.IUnicastRoute}})"/>.</remarks>
+        /// <param name="dynamicRule">The rule.</param>
+        public void AddDynamic(Func<List<Type>, Task<IEnumerable<IUnicastRoute>>> dynamicRule)
+        {
+            asyncDynamicRules.Add(dynamicRule);
+        }
+
+        /// <summary>
+        /// Adds an external provider of routes.
+        /// </summary>
+        /// <remarks>For dynamic routes that require async use <see cref="AddDynamic(System.Func{System.Collections.Generic.List{System.Type},System.Threading.Tasks.Task{System.Collections.Generic.IEnumerable{NServiceBus.Routing.IUnicastRoute}}})"/>.</remarks>
+        /// <param name="dynamicRule">The rule.</param>
+        public void AddDynamic(Func<List<Type>, IEnumerable<IUnicastRoute>> dynamicRule)
+        {
+            dynamicRules.Add(dynamicRule);
+        }
+
+        static IUnicastRoute StaticRule(Type messageBeingRouted, Type configuredMessage, UnicastRoute configuredDestination)
+        {
+            return messageBeingRouted == configuredMessage ? configuredDestination : null;
+        }
+
+        List<Func<List<Type>, Task<IEnumerable<IUnicastRoute>>>> asyncDynamicRules = new List<Func<List<Type>, Task<IEnumerable<IUnicastRoute>>>>();
+        List<Func<List<Type>, IEnumerable<IUnicastRoute>>> dynamicRules = new List<Func<List<Type>, IEnumerable<IUnicastRoute>>>();
+        List<Func<Type, IUnicastRoute>> staticRules = new List<Func<Type, IUnicastRoute>>();
+    }
+}

--- a/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
@@ -1,0 +1,25 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Routing;
+    using Transports;
+    using Unicast.Messages;
+
+    class UnicastSendRouter : UnicastRouter
+    {
+        public UnicastSendRouter(string name, MessageMetadataRegistry messageMetadataRegistry, UnicastRoutingTableConfiguration routingTableConfiguration, EndpointInstances endpointInstances, TransportAddresses physicalAddresses, DistributionPolicy distributionPolicy, List<Type> allMessageTypes) 
+            : base(name, messageMetadataRegistry, endpointInstances, physicalAddresses, distributionPolicy, allMessageTypes)
+        {
+            this.routingTableConfiguration = routingTableConfiguration;
+        }
+
+        protected override Task<IEnumerable<IUnicastRoute>> GetDestinationsFor(List<Type> messageTypeHierarchy)
+        {
+            return routingTableConfiguration.GetDestinationsFor(messageTypeHierarchy);
+        }
+
+        UnicastRoutingTableConfiguration routingTableConfiguration;
+    }
+}

--- a/src/NServiceBus.Core/Serialization/SerializationFeature.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationFeature.cs
@@ -18,6 +18,17 @@
             Defaults(s =>
             {
                 s.SetDefault("AdditionalDeserializers", new List<SerializationDefinition>());
+                var conventions = s.Get<Conventions>();
+                var knownMessages = s.GetAvailableTypes()
+                    .Where(conventions.IsMessageType)
+                    .ToList();
+
+                var messageMetadataRegistry = new MessageMetadataRegistry(conventions);
+                foreach (var msg in knownMessages)
+                {
+                    messageMetadataRegistry.RegisterMessageType(msg);
+                }
+                s.SetDefault<MessageMetadataRegistry>(messageMetadataRegistry);
             });
         }
 
@@ -42,22 +53,13 @@
             var additionalDeserializers = additionalDeserializerDefinitions.Select(d => CreateMessageSerializer(d, mapper, context)).ToArray();
             var resolver = new MessageDeserializerResolver(defaultSerializer, additionalDeserializers);
 
-            var knownMessages = context.Settings.GetAvailableTypes()
-                .Where(context.Settings.Get<Conventions>().IsMessageType)
-                .ToList();
 
-            var messageMetadataRegistry = new MessageMetadataRegistry(context.Settings.Get<Conventions>());
-            foreach (var msg in knownMessages)
-            {
-                messageMetadataRegistry.RegisterMessageType(msg);
-            }
-
+            var messageMetadataRegistry = context.Settings.Get<MessageMetadataRegistry>();
             var logicalMessageFactory = new LogicalMessageFactory(messageMetadataRegistry, mapper);
             context.Pipeline.Register("DeserializeLogicalMessagesConnector", new DeserializeLogicalMessagesConnector(resolver, logicalMessageFactory, messageMetadataRegistry), "Deserializes the physical message body into logical messages");
             context.Pipeline.Register("SerializeMessageConnector", new SerializeMessageConnector(defaultSerializer, messageMetadataRegistry), "Converts a logical message into a physical message");
 
             context.Container.ConfigureComponent(_ => mapper, DependencyLifecycle.SingleInstance);
-            context.Container.ConfigureComponent(_ => messageMetadataRegistry, DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent(_ => logicalMessageFactory, DependencyLifecycle.SingleInstance);
 
             LogFoundMessages(messageMetadataRegistry.GetAllMessages().ToList());

--- a/src/NServiceBus.Core/UnicastRoutingTarget.cs
+++ b/src/NServiceBus.Core/UnicastRoutingTarget.cs
@@ -124,5 +124,24 @@
         {
             return !Equals(left, right);
         }
+
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>
+        /// A string that represents the current object.
+        /// </returns>
+        public override string ToString()
+        {
+            if (Instance != null)
+            {
+                return Instance.ToString();
+            }
+            if (Endpoint != null)
+            {
+                return string.Format($"{Endpoint}/{TransportAddress}");
+            }
+            return TransportAddress;
+        }
     }
 }

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_a_corrupted_message_is_received.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_a_corrupted_message_is_received.cs
@@ -6,6 +6,7 @@
     using System.Text;
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using Logging;
     using NUnit.Framework;
 
     public class When_a_corrupted_message_is_received : NServiceBusAcceptanceTest
@@ -45,7 +46,7 @@
                             return Task.FromResult(0);
                         });
                     })
-                    .Done(c => c.Logs.Any(l => l.Level == "error"))
+                    .Done(c => c.Logs.Any(l => l.Level == LogLevel.Error))
                     .Run();
                 Assert.True(MessageExistsInErrorQueue(), "The message should have been moved to the error queue");
             }


### PR DESCRIPTION
 * Created failing ATs for #3737 and #3670 
 * Fixed #3737 by using a pre-computed routing table with attached routing strategies
 * Fixed #3670 by splitting command and event routers
 * Beefed up logging in acceptance tests to allow selective `debug` logging
 
Notable and/or braking changes
 * **breaking** Changed the API for a `DistributionStrategy` (added `ContextBag` to allow for message-context-based decisions)
 * **breaking** Changed the API for dynamic route providers (removed the `ContextBag` as they are now not called in context of any specific message processing)
 * Introduced `FutureComponent<T>` class to allow features to instantiate types that have a dependency on a component that can only be resolved via a container in runtime. It is used to reference `ISubscriptionStorage` that is registered by a persistence feature. This class is internal and should be used to break reference chains before we can eventually get rid of all DI-only types and use factories (like we do in transports and serializers)