### PR TITLE
Use separate routers for unicast sends and publishes

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Routing\When_publishing_to_scaled_out_subscribers_on_multicast_transports.cs" />
     <Compile Include="Routing\When_broadcasting_a_command.cs" />
     <Compile Include="Routing\When_replying_to_a_message_sent_to_specific_instance.cs" />
+    <Compile Include="Routing\When_using_assembly_level_message_mapping_for_pub_sub.cs" />
     <Compile Include="Routing\When_using_legacy_routing_configuration_combined_with_message_driven_pub_sub.cs" />
     <Compile Include="Routing\When_publishing_an_interface.cs" />
     <Compile Include="Routing\When_publishing_from_sendonly.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/When_using_assembly_level_message_mapping_for_pub_sub.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_using_assembly_level_message_mapping_for_pub_sub.cs
@@ -1,0 +1,115 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using Features;
+    using NServiceBus.Config;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_using_assembly_level_message_mapping_for_pub_sub : NServiceBusAcceptanceTest
+    {
+        static string OtherEndpointName => Conventions.EndpointNamingConvention(typeof(OtherEndpoint));
+
+        [Test]
+        public async Task The_mapping_should_not_cause_publishing_to_non_subscribers()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<OtherEndpoint>()
+                .WithEndpoint<Publisher>(b =>
+                    b.When(c => c.EndpointsStarted, async session =>
+                    {
+                        await session.Publish(new MyEvent());
+                        await session.Send(new DoneCommand());
+                    })
+                )
+                .Done(c => c.CommandReceived || c.EventReceived)
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Should(c =>
+                {
+                    Assert.IsFalse(c.EventReceived);
+                    Assert.IsTrue(c.CommandReceived);
+                })
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool EventReceived { get; set; }
+            public bool CommandReceived { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>()
+                    .WithConfig<UnicastBusConfig>(c =>
+                    {
+                        c.MessageEndpointMappings = new MessageEndpointMappingCollection();
+                        c.MessageEndpointMappings.Add(new MessageEndpointMapping
+                        {
+                            Endpoint = OtherEndpointName,
+                            AssemblyName = typeof(Publisher).Assembly.GetName().Name
+                        });
+                    })
+                    .AddMapping<DoneCommand>(typeof(OtherEndpoint));
+            }
+        }
+
+        public class OtherEndpoint : EndpointConfigurationBuilder
+        {
+            public OtherEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    // do not subscribe to the event since we don't want to receive it.
+                    c.DisableFeature<AutoSubscribe>();
+                });
+            }
+
+            public class EventHandler : IHandleMessages<MyEvent>
+            {
+                Context testContext;
+
+                public EventHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyEvent message, IMessageHandlerContext context)
+                {
+                    testContext.EventReceived = true;
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class DoneHandler : IHandleMessages<DoneCommand>
+            {
+                Context testContext;
+
+                public DoneHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(DoneCommand message, IMessageHandlerContext context)
+                {
+                    testContext.CommandReceived = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+        
+        public class MyEvent : IEvent
+        {
+        }
+        
+        public class DoneCommand : ICommand
+        {
+            
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Routing/UnicastRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastRouterTests.cs
@@ -136,7 +136,7 @@
             routingTable = new UnicastRoutingTable();
             endpointInstances = new EndpointInstances();
             transportAddresses = new TransportAddresses(address => null);
-            router = new UnicastRouter(
+            router = new UnicastSendRouter(
                 metadataRegistry,
                 routingTable,
                 endpointInstances,

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -128,6 +128,8 @@
     <Compile Include="ReleaseDateAttribute.cs" />
     <Compile Include="Recoverability\ProcessingFailureInfo.cs" />
     <Compile Include="Routing\RoutingMappingSettings.cs" />
+    <Compile Include="Routing\UnicastPublishRouter.cs" />
+    <Compile Include="Routing\UnicastSendRouter.cs" />
     <Compile Include="Serialization\SerializationFeature.cs" />
     <Compile Include="Serializers\XML\XmlSerialization.cs" />
     <Compile Include="Settings\ScaleOutSettings.cs" />

--- a/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
@@ -1,0 +1,52 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using Routing;
+    using Transports;
+    using Unicast.Messages;
+    using Unicast.Subscriptions;
+    using Unicast.Subscriptions.MessageDrivenSubscriptions;
+
+    class UnicastPublishRouter : UnicastRouter
+    {
+        public UnicastPublishRouter(MessageMetadataRegistry messageMetadataRegistry, ISubscriptionStorage subscriptionStorage, EndpointInstances endpointInstances, TransportAddresses physicalAddresses) : base(messageMetadataRegistry, endpointInstances, physicalAddresses)
+        {
+            this.subscriptionStorage = subscriptionStorage;
+        }
+
+        protected override async Task<IEnumerable<IUnicastRoute>> GetDestinations(ContextBag contextBag, List<Type> typesToRoute)
+        {
+            var messageTypes = typesToRoute.Select(t => new MessageType(t));
+            var subscribers = await subscriptionStorage.GetSubscriberAddressesForMessage(messageTypes, contextBag).ConfigureAwait(false);
+            return subscribers.Select(s => new SubscriberDestination(s));
+        }
+
+        ISubscriptionStorage subscriptionStorage;
+
+        class SubscriberDestination : IUnicastRoute
+        {
+            public SubscriberDestination(Subscriber subscriber)
+            {
+                if (subscriber.Endpoint != null)
+                {
+                    target = UnicastRoutingTarget.ToAnonymousInstance(subscriber.Endpoint, subscriber.TransportAddress);
+                }
+                else
+                {
+                    target = UnicastRoutingTarget.ToTransportAddress(subscriber.TransportAddress);
+                }
+            }
+
+            public Task<IEnumerable<UnicastRoutingTarget>> Resolve(Func<EndpointName, Task<IEnumerable<EndpointInstance>>> instanceResolver)
+            {
+                return Task.FromResult(EnumerableEx.Single(target));
+            }
+
+            UnicastRoutingTarget target;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
@@ -1,0 +1,26 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using Routing;
+    using Transports;
+    using Unicast.Messages;
+
+    class UnicastSendRouter : UnicastRouter
+    {
+        public UnicastSendRouter(MessageMetadataRegistry messageMetadataRegistry, UnicastRoutingTable unicastRoutingTable, EndpointInstances endpointInstances, TransportAddresses physicalAddresses) 
+            : base(messageMetadataRegistry, endpointInstances, physicalAddresses)
+        {
+            this.unicastRoutingTable = unicastRoutingTable;
+        }
+
+        protected override Task<IEnumerable<IUnicastRoute>> GetDestinations(ContextBag contextBag, List<Type> typesToRoute)
+        {
+            return unicastRoutingTable.GetDestinationsFor(typesToRoute, contextBag);
+        }
+
+        UnicastRoutingTable unicastRoutingTable;
+    }
+}


### PR DESCRIPTION
Connects to Particular/PlatformDevelopment#814

Fixes https://github.com/Particular/NServiceBus/issues/3670

Splits the existing `UnicastRouter` into dedicated routers for publishes and sends where the `UnicastPublishRouter` only consults the subscription storage whereas the `UnicastSendRouter` only consults the routingtable.