### PR TITLE
Acceptance test logging improvements.

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
+++ b/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
@@ -7,141 +7,120 @@
     /// <summary>
     /// This class is written under the assumption that acceptance tests are executed sequentially.
     /// </summary>
-    class ContextAppender : ILoggerFactory, ILog
+    class ContextAppender : ILog
     {
-        /// <summary>
-        /// Because ILoggerFactory interface methods are only used in a static context. This is the only way to set the currently executing context.
-        /// </summary>
-        /// <param name="newContext">The new context to be set</param>
-        public static void SetContext(ScenarioContext newContext)
+        public ContextAppender(LogLevel level, Func<ScenarioContext> context)
         {
-            context = newContext;
+            this.level = level;
+            this.context = context;
         }
 
-        static ScenarioContext context;
+        public bool IsDebugEnabled => level <= LogLevel.Debug;
+        public bool IsInfoEnabled => level <= LogLevel.Info;
+        public bool IsWarnEnabled => level <= LogLevel.Warn;
+        public bool IsErrorEnabled => level <= LogLevel.Error;
+        public bool IsFatalEnabled => level <= LogLevel.Fatal;
 
-        public ILog GetLogger(Type type)
-        {
-            return this;
-        }
-
-        public ILog GetLogger(string name)
-        {
-            return this;
-        }
-
-        public bool IsDebugEnabled => false;
-        public bool IsInfoEnabled => true;
-        public bool IsWarnEnabled => true;
-        public bool IsErrorEnabled => true;
-        public bool IsFatalEnabled => true;
-
-
-        static void RecordLog(string message, string level)
-        {
-            context?.Logs.Enqueue(new ScenarioContext.LogItem
-            {
-                Level = level,
-                Message = message
-            });
-        }
 
         public void Debug(string message)
         {
-            //we don't care about debug logs
+            Log(message, LogLevel.Debug);
         }
 
         public void Debug(string message, Exception exception)
         {
-            //we don't care about debug logs
+            Log(message, LogLevel.Debug);
         }
 
         public void DebugFormat(string format, params object[] args)
         {
-            //we don't care about debug logs
+            var fullMessage = string.Format(format, args);
+            Log(fullMessage, LogLevel.Debug);
         }
 
         public void Info(string message)
         {
-            Trace.WriteLine(message);
-            RecordLog(message, "info");
+            Log(message, LogLevel.Info);
         }
 
 
         public void Info(string message, Exception exception)
         {
             var fullMessage = $"{message} {exception}";
-            Trace.WriteLine(fullMessage);
-            RecordLog(fullMessage, "info");
+            Log(fullMessage, LogLevel.Info);
         }
 
         public void InfoFormat(string format, params object[] args)
         {
             var fullMessage = string.Format(format, args);
-            Trace.WriteLine(fullMessage);
-            RecordLog(fullMessage, "info");
+            Log(fullMessage, LogLevel.Info);
         }
 
         public void Warn(string message)
         {
-            Trace.WriteLine(message);
-            RecordLog(message, "warn");
+            Log(message, LogLevel.Warn);
         }
 
         public void Warn(string message, Exception exception)
         {
             var fullMessage = $"{message} {exception}";
-            Trace.WriteLine(fullMessage);
-            RecordLog(fullMessage, "warn");
+            Log(fullMessage, LogLevel.Warn);
         }
 
         public void WarnFormat(string format, params object[] args)
         {
             var fullMessage = string.Format(format, args);
-            Trace.WriteLine(fullMessage);
-            RecordLog(fullMessage, "warn");
+            Log(fullMessage, LogLevel.Warn);
         }
 
         public void Error(string message)
         {
-            Trace.WriteLine(message);
-
-            RecordLog(message, "error");
+            Log(message, LogLevel.Error);
         }
 
         public void Error(string message, Exception exception)
         {
             var fullMessage = $"{message} {exception}";
-            Trace.WriteLine(fullMessage);
-            RecordLog(fullMessage, "error");
+            Log(fullMessage, LogLevel.Error);
         }
 
         public void ErrorFormat(string format, params object[] args)
         {
             var fullMessage = string.Format(format, args);
-            Trace.WriteLine(fullMessage);
-            RecordLog(fullMessage, "error");
+            Log(fullMessage, LogLevel.Error);
         }
 
         public void Fatal(string message)
         {
-            Trace.WriteLine(message);
-
-            RecordLog(message, "fatal");
+            Log(message, LogLevel.Fatal);
         }
 
         public void Fatal(string message, Exception exception)
         {
             var fullMessage = $"{message} {exception}";
-            Trace.WriteLine(fullMessage);
-            RecordLog(fullMessage, "fatal");
+            Log(fullMessage, LogLevel.Fatal);
         }
 
         public void FatalFormat(string format, params object[] args)
         {
             var fullMessage = string.Format(format, args);
-            Trace.WriteLine(fullMessage);
-            RecordLog(fullMessage, "fatal");
+            Log(fullMessage, LogLevel.Fatal);
         }
+
+        void Log(string message, LogLevel messageSeverity)
+        {
+            if (level <= messageSeverity)
+            {
+                Trace.WriteLine(message);
+                context().Logs.Enqueue(new ScenarioContext.LogItem
+                {
+                    Level = messageSeverity,
+                    Message = message
+                });
+            }
+        }
+
+        LogLevel level;
+        Func<ScenarioContext> context;
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/ContextAppenderFactory.cs
+++ b/src/NServiceBus.AcceptanceTesting/ContextAppenderFactory.cs
@@ -1,0 +1,30 @@
+namespace NServiceBus.AcceptanceTesting
+{
+    using System;
+    using Logging;
+
+    class ContextAppenderFactory : ILoggerFactory
+    {
+        static ScenarioContext context;
+        
+
+        /// <summary>
+        /// Because ILoggerFactory interface methods are only used in a static context. This is the only way to set the currently executing context.
+        /// </summary>
+        /// <param name="newContext">The new context to be set</param>
+        public static void SetContext(ScenarioContext newContext)
+        {
+            context = newContext;
+        }
+
+        public ILog GetLogger(Type type)
+        {
+            return GetLogger(type.FullName);
+        }
+
+        public ILog GetLogger(string name)
+        {
+            return new ContextAppender(context.LogLevel, () => context);
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
+++ b/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
@@ -50,6 +50,7 @@
     <Reference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ContextAppenderFactory.cs" />
     <Compile Include="Customization\EndpointConfigurationExtensions.cs" />
     <Compile Include="Customization\Conventions.cs" />
     <Compile Include="IScenarioVerification.cs" />

--- a/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
@@ -4,6 +4,7 @@
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using Faults;
+    using Logging;
 
     public abstract class ScenarioContext
     {
@@ -26,10 +27,17 @@
 
         ConcurrentQueue<string> traceQueue = new ConcurrentQueue<string>();
 
+        internal LogLevel LogLevel { get; set; } = LogLevel.Info;
+
+        public void SetLogLevel(LogLevel level)
+        {
+            LogLevel = level;
+        }
+
         public class LogItem
         {
             public string Message { get; set; }
-            public string Level { get; set; }
+            public LogLevel Level { get; set; }
 
             public override string ToString()
             {

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -49,7 +49,7 @@ namespace NServiceBus.AcceptanceTesting
                 runDescriptor.Settings.Merge(settings);
             }
 
-            LogManager.UseFactory(new ContextAppender());
+            LogManager.UseFactory(new ContextAppenderFactory());
 
             var sw = new Stopwatch();
 

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -50,9 +50,9 @@
 
                     Console.WriteLine("{0} - Started @ {1}", runDescriptor.Key, DateTime.Now.ToString(CultureInfo.InvariantCulture));
 
-                    ContextAppender.SetContext(runDescriptor.ScenarioContext);
+                    ContextAppenderFactory.SetContext(runDescriptor.ScenarioContext);
                     var runResult = await PerformTestRun(behaviorDescriptors, shoulds, runDescriptor, done, allowedExceptions).ConfigureAwait(false);
-                    ContextAppender.SetContext(null);
+                    ContextAppenderFactory.SetContext(null);
 
                     Console.WriteLine("{0} - Finished @ {1}", runDescriptor.Key, DateTime.Now.ToString(CultureInfo.InvariantCulture));
 

--- a/src/NServiceBus.AcceptanceTests/Licensing/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Licensing/When_a_message_is_audited.cs
@@ -5,6 +5,7 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
+    using Logging;
     using NUnit.Framework;
 
     public class When_a_message_is_audited : NServiceBusAcceptanceTest
@@ -22,7 +23,7 @@
 
             if (Debugger.IsAttached)
             {
-                Assert.True(context.Logs.Any(m => m.Level == "error" && m.Message.StartsWith("Your license has expired")), "Error should be logged");
+                Assert.True(context.Logs.Any(m => m.Level == LogLevel.Error && m.Message.StartsWith("Your license has expired")), "Error should be logged");
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
@@ -6,6 +6,7 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using Features;
+    using Logging;
     using NServiceBus.Config;
     using NUnit.Framework;
 
@@ -27,7 +28,7 @@
                 .Run();
 
             Assert.IsInstanceOf<SimulatedException>(context.MessageSentToErrorException);
-            Assert.True(context.Logs.Any(l => l.Level == "error" && l.Message.Contains("Simulated exception message")), "The last exception should be logged as `error` before sending it to the error queue");
+            Assert.True(context.Logs.Any(l => l.Level == LogLevel.Error && l.Message.Contains("Simulated exception message")), "The last exception should be logged as `error` before sending it to the error queue");
 
             //FLR max retries = 3 means we will be processing 4 times. SLR max retries = 2 means we will do 3*FLR
             Assert.AreEqual(4*3, context.TotalNumberOfFLRTimesInvokedInHandler);

--- a/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_using_scope_suppress.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_using_scope_suppress.cs
@@ -5,6 +5,7 @@
     using System.Transactions;
     using AcceptanceTesting;
     using EndpointTemplates;
+    using Logging;
     using NUnit.Framework;
     using ScenarioDescriptors;
 
@@ -23,7 +24,7 @@
                 .Should(c =>
                 {
                     Assert.True(c.MessageDispatched, "Should dispatch the message immediately");
-                    Assert.True(c.Logs.Any(l => l.Level == "warn" && l.Message.Contains("We detected that you suppressed the ambient transaction")));
+                    Assert.True(c.Logs.Any(l => l.Level == LogLevel.Warn && l.Message.Contains("We detected that you suppressed the ambient transaction")));
                 })
                 .Run();
         }

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_a_corrupted_message_is_received.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_a_corrupted_message_is_received.cs
@@ -6,6 +6,7 @@
     using System.Text;
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using Logging;
     using NUnit.Framework;
 
     public class When_a_corrupted_message_is_received : NServiceBusAcceptanceTest
@@ -45,7 +46,7 @@
                             return Task.FromResult(0);
                         });
                     })
-                    .Done(c => c.Logs.Any(l => l.Level == "error"))
+                    .Done(c => c.Logs.Any(l => l.Level == LogLevel.Error))
                     .Run();
                 Assert.True(MessageExistsInErrorQueue(), "The message should have been moved to the error queue");
             }


### PR DESCRIPTION
Connects to Particular/PlatformDevelopment#814

The idea is to be able to specify the log level for individual loggers so that some acceptance tests will be allowed to output additional information in case it is needed.