### PR TITLE
remove unnecessary null check for WindowsIdentity.GetCurrent()

### DIFF
--- a/src/NServiceBus.Core/Utils/ElevateChecker.cs
+++ b/src/NServiceBus.Core/Utils/ElevateChecker.cs
@@ -8,10 +8,6 @@ namespace NServiceBus
         {
             using (var windowsIdentity = WindowsIdentity.GetCurrent())
             {
-                if (windowsIdentity == null)
-                {
-                    return false;
-                }
                 var windowsPrincipal = new WindowsPrincipal(windowsIdentity);
                 return windowsPrincipal.IsInRole(WindowsBuiltInRole.Administrator);
             }


### PR DESCRIPTION
R# constantly yells at me for this unnecessary check. Since R# is right and the result can never be null, we can safely remove the check and get rid of the warning.

(see http://referencesource.microsoft.com/#mscorlib/system/security/principal/windowsidentity.cs,797 [note that `threadOnly` is always false when called using `WindowsIdentity.GetCurrent()`])