### PR TITLE
Fix round robin distribution

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2296,12 +2296,12 @@ namespace NServiceBus.Routing
     public class AllInstancesDistributionStrategy : NServiceBus.Routing.DistributionStrategy
     {
         public AllInstancesDistributionStrategy() { }
-        public override System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> SelectDestination(System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> allInstances) { }
+        public override System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> SelectDestination(System.Collections.Generic.IList<NServiceBus.UnicastRoutingTarget> allInstances) { }
     }
     public abstract class DistributionStrategy
     {
         protected DistributionStrategy() { }
-        public abstract System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> SelectDestination(System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> allInstances);
+        public abstract System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> SelectDestination(System.Collections.Generic.IList<NServiceBus.UnicastRoutingTarget> allInstances);
     }
     public sealed class EndpointInstance
     {
@@ -2350,8 +2350,7 @@ namespace NServiceBus.Routing
     public class SingleInstanceRoundRobinDistributionStrategy : NServiceBus.Routing.DistributionStrategy
     {
         public SingleInstanceRoundRobinDistributionStrategy() { }
-        [System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(NServiceBus.Routing.SingleInstanceRoundRobinDistributionStrategy.<SelectDestination>d__0))]
-        public override System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> SelectDestination(System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> currentAllInstances) { }
+        public override System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> SelectDestination(System.Collections.Generic.IList<NServiceBus.UnicastRoutingTarget> currentAllInstances) { }
     }
     public class UnicastAddressTag : NServiceBus.Routing.AddressTag
     {

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Routing\Routers\UnicastPublishRouterConnectorTests.cs" />
     <Compile Include="Routing\RoutingOptionExtensionsTests.cs" />
     <Compile Include="Routing\RoutingToDispatchConnectorTests.cs" />
+    <Compile Include="Routing\SingleInstanceRoundRobinDistributionStrategyTests.cs" />
     <Compile Include="Routing\SubscriptionRouterTests.cs" />
     <Compile Include="Sagas\CustomFinderAdapterTests.cs" />
     <Compile Include="Sagas\InvokeSagaNotFoundBehaviorTests.cs" />

--- a/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
@@ -1,0 +1,138 @@
+﻿namespace NServiceBus.Core.Tests.Routing
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class SingleInstanceRoundRobinDistributionStrategyTests
+    {
+        [Test]
+        public void ShouldRoundRobinOverAllProvidedInstances()
+        {
+            var strategy = new SingleInstanceRoundRobinDistributionStrategy();
+
+            var endpointName = new EndpointName("endpointA");
+            var instances = new[]
+            {
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "1")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "2")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "3"))
+            };
+
+            var result = new List<UnicastRoutingTarget>();
+            result.AddRange(strategy.SelectDestination(instances));
+            result.AddRange(strategy.SelectDestination(instances));
+            result.AddRange(strategy.SelectDestination(instances));
+
+            Assert.That(result.Count, Is.EqualTo(3));
+            Assert.That(result, Has.Exactly(1).EqualTo(instances[0]));
+            Assert.That(result, Has.Exactly(1).EqualTo(instances[1]));
+            Assert.That(result, Has.Exactly(1).EqualTo(instances[2]));
+        }
+
+        [Test]
+        public void ShouldRestartAtFirstInstance()
+        {
+            var strategy = new SingleInstanceRoundRobinDistributionStrategy();
+
+            var endpointName = new EndpointName("endpointA");
+            var instances = new[]
+            {
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "1")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "2")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "3"))
+            };
+
+            var result = new List<UnicastRoutingTarget>();
+            result.AddRange(strategy.SelectDestination(instances));
+            Enumerable.Range(1, 2).Select(_ => strategy.SelectDestination(instances)).ToList();
+            result.AddRange(strategy.SelectDestination(instances));
+            Enumerable.Range(1, 2).Select(_ => strategy.SelectDestination(instances)).ToList();
+            result.AddRange(strategy.SelectDestination(instances));
+
+            Assert.That(result, Has.All.SameAs(result.First()));
+        }
+
+        [Test]
+        public void ShouldScopeDistributionToEndpointName()
+        {
+            var strategy = new SingleInstanceRoundRobinDistributionStrategy();
+
+            var endpointA = new EndpointName("endpointA");
+            var endpointAInstances = new[]
+            {
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointA, "1")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointA, "2")),
+            };
+
+            var endpointB = new EndpointName("endpointB");
+            var endpointBInstances = new[]
+            {
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointB, "1")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointB, "2")),
+            };
+
+            var result = new List<UnicastRoutingTarget>();
+            result.AddRange(strategy.SelectDestination(endpointAInstances));
+            result.AddRange(strategy.SelectDestination(endpointBInstances));
+            result.AddRange(strategy.SelectDestination(endpointAInstances));
+            result.AddRange(strategy.SelectDestination(endpointBInstances));
+
+            Assert.That(result.Count, Is.EqualTo(4));
+            Assert.That(result, Has.Exactly(1).EqualTo(endpointAInstances[0]));
+            Assert.That(result, Has.Exactly(1).EqualTo(endpointAInstances[1]));
+            Assert.That(result, Has.Exactly(1).EqualTo(endpointBInstances[0]));
+            Assert.That(result, Has.Exactly(1).EqualTo(endpointBInstances[1]));
+        }
+
+        [Test]
+        public void WhenNewInstancesAdded_ShouldIncludeAllInstancesInDistribution()
+        {
+            var strategy = new SingleInstanceRoundRobinDistributionStrategy();
+
+            var endpointName = new EndpointName("endpointA");
+            var instances = new List<UnicastRoutingTarget>
+            {
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "1")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "2")),
+            };
+
+            var result = new List<UnicastRoutingTarget>();
+            result.AddRange(strategy.SelectDestination(instances));
+            result.AddRange(strategy.SelectDestination(instances));
+            instances.Add(UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "3"))); // add new instance
+            result.AddRange(strategy.SelectDestination(instances));
+
+            Assert.That(result.Count, Is.EqualTo(3));
+            Assert.That(result, Has.Exactly(1).EqualTo(instances[0]));
+            Assert.That(result, Has.Exactly(1).EqualTo(instances[1]));
+            Assert.That(result, Has.Exactly(1).EqualTo(instances[2]));
+        }
+
+        [Test]
+        public void WhenInstancesRemoved_ShouldOnlyDistributeAcrossRemainingInstances()
+        {
+            var strategy = new SingleInstanceRoundRobinDistributionStrategy();
+
+            var endpointName = new EndpointName("endpointA");
+            var instances = new List<UnicastRoutingTarget>
+            {
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "1")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "2")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "3"))
+            };
+
+            var result = new List<UnicastRoutingTarget>();
+            result.AddRange(strategy.SelectDestination(instances));
+            result.AddRange(strategy.SelectDestination(instances));
+            instances.RemoveAt(2); // remove last instance.
+            result.AddRange(strategy.SelectDestination(instances));
+
+            Assert.That(result.Count, Is.EqualTo(3));
+            Assert.That(result, Has.Exactly(2).EqualTo(instances[0]));
+            Assert.That(result, Has.Exactly(1).EqualTo(instances[1]));
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Routing/UnicastRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastRouterTests.cs
@@ -113,11 +113,10 @@
 
         class TestDistributionStrategy : DistributionStrategy
         {
-            public override IEnumerable<UnicastRoutingTarget> SelectDestination(IEnumerable<UnicastRoutingTarget> allInstances)
+            public override IEnumerable<UnicastRoutingTarget> SelectDestination(IList<UnicastRoutingTarget> allInstances)
             {
-                var instances = allInstances.ToList();
-                Assert.AreEqual(1, instances.Count);
-                return instances;
+                Assert.AreEqual(1, allInstances.Count);
+                return allInstances;
             }
         }
 

--- a/src/NServiceBus.Core/Routing/AllInstancesDistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/AllInstancesDistributionStrategy.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.Routing
         /// <summary>
         /// Selects destination instances from all known instances of a given endpoint.
         /// </summary>
-        public override IEnumerable<UnicastRoutingTarget> SelectDestination(IEnumerable<UnicastRoutingTarget> allInstances)
+        public override IEnumerable<UnicastRoutingTarget> SelectDestination(IList<UnicastRoutingTarget> allInstances)
         {
             return allInstances;
         }

--- a/src/NServiceBus.Core/Routing/DistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionStrategy.cs
@@ -10,6 +10,6 @@ namespace NServiceBus.Routing
         /// <summary>
         /// Selects destination instances from all known instances of a given endpoint.
         /// </summary>
-        public abstract IEnumerable<UnicastRoutingTarget> SelectDestination(IEnumerable<UnicastRoutingTarget> allInstances);
+        public abstract IEnumerable<UnicastRoutingTarget> SelectDestination(IList<UnicastRoutingTarget> allInstances);
     }
 }

--- a/src/NServiceBus.Core/Routing/Routers/UnicastSendRouterConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/UnicastSendRouterConnector.cs
@@ -95,7 +95,7 @@ namespace NServiceBus
                 this.specificInstance = specificInstance;
             }
 
-            public override IEnumerable<UnicastRoutingTarget> SelectDestination(IEnumerable<UnicastRoutingTarget> allInstances)
+            public override IEnumerable<UnicastRoutingTarget> SelectDestination(IList<UnicastRoutingTarget> allInstances)
             {
                 var target = allInstances.FirstOrDefault(t => t.Instance != null && t.Instance.Discriminator == specificInstance);
                 if (target == null)

--- a/src/NServiceBus.Core/Routing/UnicastRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRouter.cs
@@ -67,7 +67,7 @@ namespace NServiceBus
                 else
                 {
                     //Use the distribution strategy to select subset of instances of a given endpoint
-                    foreach (var destination in distributionStrategy.SelectDestination(@group))
+                    foreach (var destination in distributionStrategy.SelectDestination(@group.ToArray()))
                     {
                         yield return destination;
                     }

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_a_command.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_a_command.cs
@@ -87,17 +87,22 @@
                 IHandleMessages<ResponseA>,
                 IHandleMessages<ResponseB>
             {
-                public Context Context { get; set; }
+                private Context testContext;
+
+                public ResponseHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
 
                 public Task Handle(ResponseA message, IMessageHandlerContext context)
                 {
                     switch (message.EndpointName)
                     {
                         case "ReceiverA1":
-                            Context.ReceiverA1TimesCalled++;
+                            testContext.ReceiverA1TimesCalled++;
                             break;
                         case "ReceiverA2":
-                            Context.ReceiverA2TimesCalled++;
+                            testContext.ReceiverA2TimesCalled++;
                             break;
                     }
 
@@ -109,15 +114,15 @@
                     switch (message.EndpointName)
                     {
                         case "ReceiverB1":
-                            Context.ReceiverB1TimesCalled++;
+                            testContext.ReceiverB1TimesCalled++;
                             break;
                         case "ReceiverB2":
-                            Context.ReceiverB2TimesCalled++;
+                            testContext.ReceiverB2TimesCalled++;
                             break;
                     }
 
-                    Context.MessagesReceivedPerEndpoint++;
-                    if (Context.MessagesReceivedPerEndpoint < numberOfMessagesToSendPerEndpoint)
+                    testContext.MessagesReceivedPerEndpoint++;
+                    if (testContext.MessagesReceivedPerEndpoint < numberOfMessagesToSendPerEndpoint)
                     {
                         return context.Send(new RequestA());
                     }

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_a_command.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_a_command.cs
@@ -11,34 +11,51 @@
 
     public class When_distributing_a_command : NServiceBusAcceptanceTest
     {
-        static string ReceiverEndpoint => Conventions.EndpointNamingConvention(typeof(Receiver));
+        const int numberOfMessagesToSendPerEndpoint = 20;
+        static string ReceiverAEndpoint => Conventions.EndpointNamingConvention(typeof(ReceiverA));
+        static string ReceiverBEndpoint => Conventions.EndpointNamingConvention(typeof(ReceiverB));
 
         [Test]
         public async Task Should_round_robin()
         {
             var context = await Scenario.Define<Context>()
-                .WithEndpoint<Sender>(b => b.When((session, c) => session.Send(new Request())))
-                .WithEndpoint<Receiver>(b => b.CustomConfig(c =>
+                .WithEndpoint<Sender>(b => b.When((session, c) => session.Send(new RequestA())))
+                .WithEndpoint<ReceiverA>(b => b.CustomConfig(c =>
                 {
                     c.ScaleOut().InstanceDiscriminator("1");
-                    c.GetSettings().Set("Name", "Receiver1");
+                    c.GetSettings().Set("Name", "ReceiverA1");
                 }))
-                .WithEndpoint<Receiver>(b => b.CustomConfig(c =>
+                .WithEndpoint<ReceiverA>(b => b.CustomConfig(c =>
                 {
                     c.ScaleOut().InstanceDiscriminator("2");
-                    c.GetSettings().Set("Name", "Receiver2");
+                    c.GetSettings().Set("Name", "ReceiverA2");
                 }))
-                .Done(c => c.Receiver1TimesCalled > 4 && c.Receiver2TimesCalled > 4)
+                .WithEndpoint<ReceiverB>(b => b.CustomConfig(c =>
+                {
+                    c.ScaleOut().InstanceDiscriminator("1");
+                    c.GetSettings().Set("Name", "ReceiverB1");
+                }))
+                .WithEndpoint<ReceiverB>(b => b.CustomConfig(c =>
+                {
+                    c.ScaleOut().InstanceDiscriminator("2");
+                    c.GetSettings().Set("Name", "ReceiverB2");
+                }))
+                .Done(c => c.MessagesReceivedPerEndpoint == numberOfMessagesToSendPerEndpoint)
                 .Run();
 
-            Assert.IsTrue(context.Receiver1TimesCalled > 4);
-            Assert.IsTrue(context.Receiver2TimesCalled > 4);
+            Assert.That(context.ReceiverA1TimesCalled, Is.EqualTo(10));
+            Assert.That(context.ReceiverA2TimesCalled, Is.EqualTo(10));
+            Assert.That(context.ReceiverB1TimesCalled, Is.EqualTo(10));
+            Assert.That(context.ReceiverB2TimesCalled, Is.EqualTo(10));
         }
 
         public class Context : ScenarioContext
         {
-            public int Receiver1TimesCalled { get; set; }
-            public int Receiver2TimesCalled { get; set; }
+            public int MessagesReceivedPerEndpoint { get; set; }
+            public int ReceiverA1TimesCalled { get; set; }
+            public int ReceiverA2TimesCalled { get; set; }
+            public int ReceiverB1TimesCalled { get; set; }
+            public int ReceiverB2TimesCalled { get; set; }
         }
 
         public class Sender : EndpointConfigurationBuilder
@@ -46,56 +63,84 @@
             public Sender()
             {
                 var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "routes.xml");
-                File.WriteAllText(filePath, @"<endpoints>
-    <endpoint name=""DistributingACommand.Receiver"">
+                File.WriteAllText(filePath, string.Format(@"<endpoints>
+    <endpoint name=""{0}"">
+        <instance discriminator=""1""/>
+        <instance discriminator=""2""/>
+    </endpoint>
+    <endpoint name=""{1}"">
         <instance discriminator=""1""/>
         <instance discriminator=""2""/>
     </endpoint>
 </endpoints>
-");
+", ReceiverAEndpoint, ReceiverBEndpoint));
 
                 EndpointSetup<DefaultServer>(c =>
                 {
                     c.UseTransport<MsmqTransport>().DistributeMessagesUsingFileBasedEndpointInstanceMapping(filePath);
-                    c.UnicastRouting().RouteToEndpoint(typeof(Request), ReceiverEndpoint);
+                    c.UnicastRouting().RouteToEndpoint(typeof(RequestA), ReceiverAEndpoint);
+                    c.UnicastRouting().RouteToEndpoint(typeof(RequestB), ReceiverBEndpoint);
                 });
             }
 
-            public class ResponseHandler : IHandleMessages<Response>
+            public class ResponseHandler :
+                IHandleMessages<ResponseA>,
+                IHandleMessages<ResponseB>
             {
                 public Context Context { get; set; }
 
-                public Task Handle(Response message, IMessageHandlerContext context)
+                public Task Handle(ResponseA message, IMessageHandlerContext context)
                 {
                     switch (message.EndpointName)
                     {
-                        case "Receiver1":
-                            Context.Receiver1TimesCalled++;
+                        case "ReceiverA1":
+                            Context.ReceiverA1TimesCalled++;
                             break;
-                        case "Receiver2":
-                            Context.Receiver2TimesCalled++;
+                        case "ReceiverA2":
+                            Context.ReceiverA2TimesCalled++;
                             break;
                     }
 
-                    return context.Send(new Request());
+                    return context.Send(new RequestB());
+                }
+
+                public Task Handle(ResponseB message, IMessageHandlerContext context)
+                {
+                    switch (message.EndpointName)
+                    {
+                        case "ReceiverB1":
+                            Context.ReceiverB1TimesCalled++;
+                            break;
+                        case "ReceiverB2":
+                            Context.ReceiverB2TimesCalled++;
+                            break;
+                    }
+
+                    Context.MessagesReceivedPerEndpoint++;
+                    if (Context.MessagesReceivedPerEndpoint < numberOfMessagesToSendPerEndpoint)
+                    {
+                        return context.Send(new RequestA());
+                    }
+
+                    return Task.CompletedTask;
                 }
             }
         }
 
-        public class Receiver : EndpointConfigurationBuilder
+        public class ReceiverA : EndpointConfigurationBuilder
         {
-            public Receiver()
+            public ReceiverA()
             {
                 EndpointSetup<DefaultServer>();
             }
 
-            public class MyMessageHandler : IHandleMessages<Request>
+            public class MyMessageHandler : IHandleMessages<RequestA>
             {
                 public ReadOnlySettings Settings { get; set; }
 
-                public Task Handle(Request message, IMessageHandlerContext context)
+                public Task Handle(RequestA message, IMessageHandlerContext context)
                 {
-                    return context.Reply(new Response
+                    return context.Reply(new ResponseA
                     {
                         EndpointName = Settings.Get<string>("Name")
                     });
@@ -103,11 +148,41 @@
             }
         }
 
-        public class Request : ICommand
+        public class ReceiverB : EndpointConfigurationBuilder
+        {
+            public ReceiverB()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyMessageHandler : IHandleMessages<RequestB>
+            {
+                public ReadOnlySettings Settings { get; set; }
+
+                public Task Handle(RequestB message, IMessageHandlerContext context)
+                {
+                    return context.Reply(new ResponseB
+                    {
+                        EndpointName = Settings.Get<string>("Name")
+                    });
+                }
+            }
+        }
+
+        public class RequestA : ICommand
         {
         }
 
-        public class Response : IMessage
+        public class RequestB : ICommand
+        {
+        }
+
+        public class ResponseA : IMessage
+        {
+            public string EndpointName { get; set; }
+        }
+
+        public class ResponseB : IMessage
         {
             public string EndpointName { get; set; }
         }

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_a_command.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_a_command.cs
@@ -4,7 +4,6 @@
     using System.IO;
     using System.Threading.Tasks;
     using AcceptanceTesting.Customization;
-    using Configuration.AdvanceExtensibility;
     using AcceptanceTesting;
     using NUnit.Framework;
     using Settings;
@@ -23,22 +22,18 @@
                 .WithEndpoint<ReceiverA>(b => b.CustomConfig(c =>
                 {
                     c.ScaleOut().InstanceDiscriminator("1");
-                    c.GetSettings().Set("Name", "ReceiverA1");
                 }))
                 .WithEndpoint<ReceiverA>(b => b.CustomConfig(c =>
                 {
                     c.ScaleOut().InstanceDiscriminator("2");
-                    c.GetSettings().Set("Name", "ReceiverA2");
                 }))
                 .WithEndpoint<ReceiverB>(b => b.CustomConfig(c =>
                 {
                     c.ScaleOut().InstanceDiscriminator("1");
-                    c.GetSettings().Set("Name", "ReceiverB1");
                 }))
                 .WithEndpoint<ReceiverB>(b => b.CustomConfig(c =>
                 {
                     c.ScaleOut().InstanceDiscriminator("2");
-                    c.GetSettings().Set("Name", "ReceiverB2");
                 }))
                 .Done(c => c.MessagesReceivedPerEndpoint == numberOfMessagesToSendPerEndpoint)
                 .Run();
@@ -96,12 +91,12 @@
 
                 public Task Handle(ResponseA message, IMessageHandlerContext context)
                 {
-                    switch (message.EndpointName)
+                    switch (message.EndpointInstance)
                     {
-                        case "ReceiverA1":
+                        case "1":
                             testContext.ReceiverA1TimesCalled++;
                             break;
-                        case "ReceiverA2":
+                        case "2":
                             testContext.ReceiverA2TimesCalled++;
                             break;
                     }
@@ -111,12 +106,12 @@
 
                 public Task Handle(ResponseB message, IMessageHandlerContext context)
                 {
-                    switch (message.EndpointName)
+                    switch (message.EndpointInstance)
                     {
-                        case "ReceiverB1":
+                        case "1":
                             testContext.ReceiverB1TimesCalled++;
                             break;
-                        case "ReceiverB2":
+                        case "2":
                             testContext.ReceiverB2TimesCalled++;
                             break;
                     }
@@ -147,7 +142,7 @@
                 {
                     return context.Reply(new ResponseA
                     {
-                        EndpointName = Settings.Get<string>("Name")
+                        EndpointInstance = Settings.Get<string>("EndpointInstanceDiscriminator")
                     });
                 }
             }
@@ -168,7 +163,7 @@
                 {
                     return context.Reply(new ResponseB
                     {
-                        EndpointName = Settings.Get<string>("Name")
+                        EndpointInstance = Settings.Get<string>("EndpointInstanceDiscriminator")
                     });
                 }
             }
@@ -184,12 +179,12 @@
 
         public class ResponseA : IMessage
         {
-            public string EndpointName { get; set; }
+            public string EndpointInstance { get; set; }
         }
 
         public class ResponseB : IMessage
         {
-            public string EndpointName { get; set; }
+            public string EndpointInstance { get; set; }
         }
     }
 }


### PR DESCRIPTION
Connects to Particular/Platformdevelopment#814

Fix round robin distribution strategy to work properly when the strategy is used with different endpoints.

Added unit tests for `SingleInstanceRoundRobinDistributionStrategyTests` and @SzymonPobiega acceptance test with slight modifications.