### PR TITLE
Fix logging race condition

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
+++ b/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
@@ -46,11 +46,6 @@
             });
         }
 
-        static void AppendException(Exception exception)
-        {
-            context?.LoggedExceptions.Enqueue(exception);
-        }
-
         public void Debug(string message)
         {
             //we don't care about debug logs
@@ -58,7 +53,7 @@
 
         public void Debug(string message, Exception exception)
         {
-            AppendException(exception);
+            //we don't care about debug logs
         }
 
         public void DebugFormat(string format, params object[] args)
@@ -77,7 +72,6 @@
         {
             var fullMessage = $"{message} {exception}";
             Trace.WriteLine(fullMessage);
-            AppendException(exception);
             RecordLog(fullMessage, "info");
         }
 
@@ -98,7 +92,6 @@
         {
             var fullMessage = $"{message} {exception}";
             Trace.WriteLine(fullMessage);
-            AppendException(exception);
             RecordLog(fullMessage, "warn");
         }
 
@@ -120,7 +113,6 @@
         {
             var fullMessage = $"{message} {exception}";
             Trace.WriteLine(fullMessage);
-            AppendException(exception);
             RecordLog(fullMessage, "error");
         }
 
@@ -142,7 +134,6 @@
         {
             var fullMessage = $"{message} {exception}";
             Trace.WriteLine(fullMessage);
-            AppendException(exception);
             RecordLog(fullMessage, "fatal");
         }
 

--- a/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
@@ -20,8 +20,6 @@
             traceQueue.Enqueue($"{DateTime.Now:HH:mm:ss.ffffff} - {trace}");
         }
 
-        public ConcurrentQueue<Exception> LoggedExceptions = new ConcurrentQueue<Exception>();
-
         public ConcurrentDictionary<string, IReadOnlyCollection<FailedMessage>> FailedMessages = new ConcurrentDictionary<string, IReadOnlyCollection<FailedMessage>>();
 
         public ConcurrentQueue<LogItem> Logs = new ConcurrentQueue<LogItem>();

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_message_is_moved_to_error_queue.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_message_is_moved_to_error_queue.cs
@@ -17,13 +17,12 @@
         {
             return Scenario.Define<Context>(c =>
             {
-                c.Id = Guid.NewGuid();
                 c.TransactionMode = transactionMode;
             })
-            .WithEndpoint<Endpoint>(b => b.DoNotFailOnErrorMessages()
+            .WithEndpoint<EndpointWithOutgoingMessages>(b => b.DoNotFailOnErrorMessages()
                 .When((session, context) => session.SendLocal(new InitiatingMessage
                 {
-                    Id = context.Id
+                    Id = context.TestRunId
                 }))
             )
             .WithEndpoint<ErrorSpy>()
@@ -39,13 +38,12 @@
         {
             return Scenario.Define<Context>(c =>
             {
-                c.Id = Guid.NewGuid();
                 c.TransactionMode = transactionMode;
             })
-            .WithEndpoint<Endpoint>(b => b.DoNotFailOnErrorMessages()
+            .WithEndpoint<EndpointWithOutgoingMessages>(b => b.DoNotFailOnErrorMessages()
                 .When((session, context) => session.SendLocal(new InitiatingMessage
                 {
-                    Id = context.Id
+                    Id = context.TestRunId
                 }))
             )
             .WithEndpoint<ErrorSpy>()
@@ -54,43 +52,36 @@
             .Run();
         }
 
-        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
-        [TestCase(TransportTransactionMode.TransactionScope)]
-        [TestCase(TransportTransactionMode.ReceiveOnly)]
-        [TestCase(TransportTransactionMode.None)]
-        public Task Should_log_exception(TransportTransactionMode transactionMode)
+        [Test]
+        public async Task Should_log_exception()
         {
-            return Scenario.Define<Context>(c =>
-            {
-                c.Id = Guid.NewGuid();
-                c.TransactionMode = transactionMode;
-            })
-            .WithEndpoint<Endpoint>(b => b.DoNotFailOnErrorMessages()
-                .When((session, context) => session.SendLocal(new InitiatingMessage
+            var context = await Scenario.Define<Context>()
+            .WithEndpoint<EndpointWithOutgoingMessages>(b => b
+                .DoNotFailOnErrorMessages()
+                .When((session, ctx) => session.SendLocal(new InitiatingMessage
                 {
-                    Id = context.Id
+                    Id = ctx.TestRunId
                 }))
             )
             .WithEndpoint<ErrorSpy>()
             .Done(c => c.MessageMovedToErrorQueue)
-            .Repeat(r => r.For<AllDtcTransports>())
-            .Should(c => Assert.That(c.Logs, Has.Some.Message.Match("Moving message .+ to the error queue because processing failed due to an exception: NServiceBus.AcceptanceTesting.SimulatedException:")))
             .Run();
+
+            Assert.That(context.Logs, Has.Some.Message.Match("Moving message .+ to the error queue because processing failed due to an exception: NServiceBus.AcceptanceTesting.SimulatedException:"));
         }
 
         const string ErrorSpyQueueName = "error_spy_queue";
 
         class Context : ScenarioContext
         {
-            public Guid Id { get; set; }
             public bool MessageMovedToErrorQueue { get; set; }
             public bool OutgoingMessageSent { get; set; }
             public TransportTransactionMode TransactionMode { get; set; }
         }
 
-        class Endpoint : EndpointConfigurationBuilder
+        class EndpointWithOutgoingMessages : EndpointConfigurationBuilder
         {
-            public Endpoint()
+            public EndpointWithOutgoingMessages()
             {
                 EndpointSetup<DefaultServer>((config, context) =>
                 {
@@ -111,13 +102,34 @@
 
                 public async Task Handle(InitiatingMessage initiatingMessage, IMessageHandlerContext context)
                 {
-                    if (initiatingMessage.Id == TestContext.Id)
+                    if (initiatingMessage.Id == TestContext.TestRunId)
                     {
                         await context.Send(ErrorSpyQueueName, new SubsequentMessage
                         {
                             Id = initiatingMessage.Id
                         });
                     }
+                }
+            }
+        }
+
+        class EndpointWithFailingHandler : EndpointConfigurationBuilder
+        {
+            public EndpointWithFailingHandler()
+            {
+                EndpointSetup<DefaultServer>((config, context) =>
+                {
+                    config.DisableFeature<FirstLevelRetries>();
+                    config.DisableFeature<SecondLevelRetries>();
+                    config.SendFailedMessagesTo(ErrorSpyQueueName);
+                });
+            }
+
+            class InitiatingMessageHandler : IHandleMessages<InitiatingMessage>
+            {
+                public Task Handle(InitiatingMessage message, IMessageHandlerContext context)
+                {
+                    throw new SimulatedException("message should be moved to the error queue");
                 }
             }
         }
@@ -136,7 +148,7 @@
 
                 public Task Handle(InitiatingMessage initiatingMessage, IMessageHandlerContext context)
                 {
-                    if (initiatingMessage.Id == TestContext.Id)
+                    if (initiatingMessage.Id == TestContext.TestRunId)
                     {
                         TestContext.MessageMovedToErrorQueue = true;
                     }
@@ -151,7 +163,7 @@
 
                 public Task Handle(SubsequentMessage message, IMessageHandlerContext context)
                 {
-                    if (message.Id == TestContext.Id)
+                    if (message.Id == TestContext.TestRunId)
                     {
                         TestContext.OutgoingMessageSent = true;
                     }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
@@ -26,10 +26,9 @@
                 .ExpectFailedMessages();
 
             Assert.AreEqual(1, exception.FailedMessages.Count);
-            Assert.AreEqual(((Context) exception.ScenarioContext).MessageId, exception.FailedMessages.Single().MessageId, "Message should be moved to errorqueue");
-
-            Assert.True(exception.ScenarioContext.LoggedExceptions.Any(e =>
-                e.Message.Contains("A modification of IContainSagaData.Id has been detected. This property is for infrastructure purposes only and should not be modified. SagaType: " + typeof(Endpoint.SagaIdChangedSaga))));
+            var failedMessage = exception.FailedMessages.Single();
+            Assert.AreEqual(((Context) exception.ScenarioContext).MessageId, failedMessage.MessageId, "Message should be moved to errorqueue");
+            StringAssert.Contains("A modification of IContainSagaData.Id has been detected. This property is for infrastructure purposes only and should not be modified. SagaType:", failedMessage.Exception.Message);
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
@@ -25,10 +25,10 @@
                     .Run())
                 .ExpectFailedMessages();
 
-            Assert.AreEqual(1, exception.FailedMessages.Count);
+            Assert.That(exception.FailedMessages, Has.Count.EqualTo(1));
             var failedMessage = exception.FailedMessages.Single();
-            Assert.AreEqual(((Context) exception.ScenarioContext).MessageId, failedMessage.MessageId, "Message should be moved to errorqueue");
-            StringAssert.Contains("A modification of IContainSagaData.Id has been detected. This property is for infrastructure purposes only and should not be modified. SagaType:", failedMessage.Exception.Message);
+            Assert.That(((Context) exception.ScenarioContext).MessageId, Is.EqualTo(failedMessage.MessageId), "Message should be moved to errorqueue");
+            Assert.That(failedMessage.Exception.Message, Contains.Substring("A modification of IContainSagaData.Id has been detected. This property is for infrastructure purposes only and should not be modified. SagaType:"));
         }
 
         public class Context : ScenarioContext


### PR DESCRIPTION
`When_saga_id_changed` has a race condition when using transactions because it verifies on a log message which is written when the message is handled by the `MoveFaultsToErrorQueueBehavior`. But since the test is done on the first failed message, it is possible that the error queue behavior never gets invoked when using transactions (because the endpoint is already shut down) and therefore the log entry isn't written.
This is fixed by verifying the exception message on the failed message instead from the log (better anyway).

further changes:
* removed `ScenarioContextLoggedExceptions `: this one was ugly anyway, since it only contained exceptions using the exception parameter overload (which we sometimes can't use when logging exceptions). This test was the only usage of it, so it could be safely removed.
* Added a test which verifies that an appropriate message is logged when the message is moved to the error queue.