### PR TITLE
Remove redundant EndpointName parameters from instance configuration

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/When_broadcasting_a_command.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_broadcasting_a_command.cs
@@ -40,7 +40,7 @@
                     c.UnicastRouting().RouteToEndpoint(typeof(Request), ReceiverEndpoint);
 
                     c.UnicastRouting().Mapping.SetMessageDistributionStrategy(new AllInstancesDistributionStrategy(), t => t == typeof(Request));
-                    c.UnicastRouting().Mapping.Physical.Add(new EndpointName(ReceiverEndpoint),
+                    c.UnicastRouting().Mapping.Physical.Add(
                         new EndpointInstance(ReceiverEndpoint, "1"),
                         new EndpointInstance(ReceiverEndpoint, "2"));
                 });

--- a/src/NServiceBus.AcceptanceTests/Routing/When_using_instance_ids.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_using_instance_ids.cs
@@ -48,7 +48,7 @@
                 EndpointSetup<DefaultServer>(c =>
                 {
                     c.UnicastRouting().RouteToEndpoint(typeof(MyMessage), GetReceiverEndpoint());
-                    c.UnicastRouting().Mapping.Physical.Add(new EndpointName(GetReceiverEndpoint()), new EndpointInstance(GetReceiverEndpoint(), "XYZ"));
+                    c.UnicastRouting().Mapping.Physical.Add(new EndpointInstance(GetReceiverEndpoint(), "XYZ"));
                 });
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Routing/when_replying_to_a_message_sent_to_specific_instance.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/when_replying_to_a_message_sent_to_specific_instance.cs
@@ -35,7 +35,7 @@
                 EndpointSetup<DefaultServer>(c =>
                 {
                     c.UnicastRouting().RouteToEndpoint(typeof(MyRequest), ReceiverEndpoint);
-                    c.UnicastRouting().Mapping.Physical.Add(new EndpointName(ReceiverEndpoint), new EndpointInstance(ReceiverEndpoint, "XYZ"));
+                    c.UnicastRouting().Mapping.Physical.Add(new EndpointInstance(ReceiverEndpoint, "XYZ"));
                 });
             }
 

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2318,7 +2318,8 @@ namespace NServiceBus.Routing
     public class EndpointInstances
     {
         public EndpointInstances() { }
-        public void Add(NServiceBus.Routing.EndpointName endpoint, params NServiceBus.Routing.EndpointInstance[] instances) { }
+        public void Add(params NServiceBus.Routing.EndpointInstance[] instances) { }
+        public void Add(System.Collections.Generic.IEnumerable<NServiceBus.Routing.EndpointInstance> instances) { }
         public void AddDynamic(System.Func<NServiceBus.Routing.EndpointName, System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.Routing.EndpointInstance>>> dynamicRule) { }
     }
     public sealed class EndpointName

--- a/src/NServiceBus.Core.Tests/Routing/EndpointInstancesTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/EndpointInstancesTests.cs
@@ -13,7 +13,7 @@
         public void Should_throw_when_trying_to_configure_instances_that_do_not_match_endpoint_name()
         {
             var instances = new EndpointInstances();
-            TestDelegate action = () => instances.Add(new EndpointName("Sales"), new EndpointInstance(new EndpointName("A")));
+            TestDelegate action = () => instances.Add(new EndpointInstance(new EndpointName("Sales")), new EndpointInstance(new EndpointName("A")));
             Assert.Throws<ArgumentException>(action);
         }
 
@@ -22,7 +22,7 @@
         {
             var instances = new EndpointInstances();
             var sales = new EndpointName("Sales");
-            instances.Add(sales, new EndpointInstance(sales, "1"), new EndpointInstance(sales, "2"));
+            instances.Add(new EndpointInstance(sales, "1"), new EndpointInstance(sales, "2"));
 
             var salesInstances = await instances.FindInstances(sales);
             Assert.AreEqual(2, salesInstances.Count());
@@ -33,7 +33,7 @@
         {
             var instances = new EndpointInstances();
             var sales = new EndpointName("Sales");
-            instances.Add(sales, new EndpointInstance(sales, "dup"), new EndpointInstance(sales, "dup"));
+            instances.Add(new EndpointInstance(sales, "dup"), new EndpointInstance(sales, "dup"));
 
             var salesInstances = await instances.FindInstances(sales);
             Assert.AreEqual(1, salesInstances.Count());

--- a/src/NServiceBus.Core.Tests/Routing/EndpointInstancesTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/EndpointInstancesTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Core.Tests.Routing
 {
-    using System;
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.Routing;
@@ -10,11 +9,18 @@
     public class EndpointInstancesTests
     {
         [Test]
-        public void Should_throw_when_trying_to_configure_instances_that_do_not_match_endpoint_name()
+        public async Task Should_add_instances_grouped_by_endpoint_name()
         {
             var instances = new EndpointInstances();
-            TestDelegate action = () => instances.Add(new EndpointInstance(new EndpointName("Sales")), new EndpointInstance(new EndpointName("A")));
-            Assert.Throws<ArgumentException>(action);
+            var endpointName1 = new EndpointName("EndpointA");
+            var endpointName2 = new EndpointName("EndpointB");
+            instances.Add(new EndpointInstance(endpointName1), new EndpointInstance(endpointName2));
+
+            var salesInstances = await instances.FindInstances(endpointName1);
+            Assert.AreEqual(1, salesInstances.Count());
+
+            var otherInstances = await instances.FindInstances(endpointName2);
+            Assert.AreEqual(1, otherInstances.Count());
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Routing/UnicastRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastRouterTests.cs
@@ -24,11 +24,11 @@
             var sales = new EndpointName("Sales");
             metadataRegistry.RegisterMessageType(typeof(Command));
             routingTable.RouteToEndpoint(typeof(Command), sales);
-            endpointInstances.Add(sales, new EndpointInstance(sales, null, null));
+            endpointInstances.Add(new EndpointInstance(sales, null, null));
             transportAddresses.AddRule(i => i.ToString());
 
             var routes = router.Route(typeof(Command), new SingleInstanceRoundRobinDistributionStrategy(), new ContextBag()).Result.ToArray();
-            
+
             Assert.AreEqual(1, routes.Length);
             var headers = new Dictionary<string, string>();
             var addressTag = (UnicastAddressTag) routes[0].Apply(headers);
@@ -41,7 +41,7 @@
             var sales = new EndpointName("Sales");
             metadataRegistry.RegisterMessageType(typeof(Event));
             routingTable.RouteToEndpoint(typeof(Event), sales);
-            endpointInstances.Add(sales, new EndpointInstance(sales));
+            endpointInstances.Add(new EndpointInstance(sales));
             transportAddresses.AddRule(i => i.ToString());
 
             var routes = router.Route(typeof(Event), new SingleInstanceRoundRobinDistributionStrategy(), new ContextBag()).Result.ToArray();
@@ -59,9 +59,9 @@
             routingTable.RouteToEndpoint(typeof(Event), sales);
             routingTable.RouteToEndpoint(typeof(Event), shipping);
 
-            endpointInstances.Add(sales, new EndpointInstance(sales, "1"));
+            endpointInstances.Add(new EndpointInstance(sales, "1"));
             endpointInstances.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(sales, "2"))));
-            endpointInstances.Add(shipping, new EndpointInstance(shipping, "1", null), new EndpointInstance(shipping, "2"));
+            endpointInstances.Add(new EndpointInstance(shipping, "1", null), new EndpointInstance(shipping, "2"));
 
             transportAddresses.AddRule(i => i.ToString());
 
@@ -80,7 +80,7 @@
 
             routingTable.RouteToEndpoint(typeof(Event), sales);
             routingTable.RouteToAddress(typeof(Event), "Sales-1");
-            endpointInstances.Add(sales, new EndpointInstance(sales, "1"));
+            endpointInstances.Add(new EndpointInstance(sales, "1"));
             transportAddresses.AddRule(i => i.ToString());
 
             var routes = router.Route(typeof(Event), new SingleInstanceRoundRobinDistributionStrategy(), new ContextBag()).Result.ToArray();
@@ -95,7 +95,7 @@
             metadataRegistry.RegisterMessageType(typeof(Event));
 
             routingTable.RouteToEndpoint(typeof(Event), sales);
-            endpointInstances.Add(sales, new EndpointInstance(sales, "1"));
+            endpointInstances.Add(new EndpointInstance(sales, "1"));
             endpointInstances.AddDynamic(name =>
             {
                 IEnumerable<EndpointInstance> results = new[]

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -377,6 +377,10 @@ namespace NServiceBus.Hosting.Helpers
                 {
                     continue;
                 }
+                catch (FileLoadException)
+                {
+                    continue;
+                }
                 if (ReferencesNServiceBus(refAssembly, processed))
                 {
                     return true;

--- a/src/NServiceBus.Core/Routing/EndpointInstances.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstances.cs
@@ -35,22 +35,26 @@ namespace NServiceBus.Routing
         }
 
         /// <summary>
-        /// Adds static information about an endpoint.
+        /// Registers provided endpoint instances.
         /// </summary>
-        /// <param name="instances">A static list of endpoint's instances.</param>
+        /// <param name="instances">A static list of endpoint instances.</param>
         public void Add(params EndpointInstance[] instances) => Add((IEnumerable<EndpointInstance>)instances);
 
         /// <summary>
-        /// Adds static information about an endpoint.
+        /// Registers provided endpoint instances.
         /// </summary>
-        /// <param name="instances">A static list of endpoint's instances.</param>
+        /// <param name="instances">A static list of endpoint instances.</param>
         public void Add(IEnumerable<EndpointInstance> instances)
         {
-            if (!instances.Any())
+            Guard.AgainstNull(nameof(instances), instances);
+            var endpointsByName = instances.Select(i =>
             {
-                throw new ArgumentException("The list of instances can't be empty.", nameof(instances));
-            }
-            var endpointsByName = instances.GroupBy(i => i.Endpoint);
+                if (i == null)
+                {
+                    throw new ArgumentNullException(nameof(instances), "One of the elements of collection is null");
+                }
+                return i;
+            }).GroupBy(i => i.Endpoint);
             foreach (var instanceGroup in endpointsByName)
             {
                 rules.Add(e => StaticRule(e, instanceGroup.Key, instanceGroup));

--- a/src/NServiceBus.Core/Routing/EndpointInstances.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstances.cs
@@ -50,12 +50,11 @@ namespace NServiceBus.Routing
             {
                 throw new ArgumentException("The list of instances can't be empty.", nameof(instances));
             }
-            var endpoint = instances.First().Endpoint;
-            if (instances.Any(i => i.Endpoint != endpoint))
+            var endpointsByName = instances.GroupBy(i => i.Endpoint);
+            foreach (var instanceGroup in endpointsByName)
             {
-                throw new ArgumentException("The instances belong to different endpoints. The endpoint names do not match.", nameof(instances));
+                rules.Add(e => StaticRule(e, instanceGroup.Key, instanceGroup));
             }
-            rules.Add(e => StaticRule(e, endpoint, instances));
         }
 
         static Task<IEnumerable<EndpointInstance>> StaticRule(EndpointName endpointBeingQueried, EndpointName configuredEndpoint, IEnumerable<EndpointInstance> configuredInstances)

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_replying_to_a_message_sent_via_a_distributor.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_replying_to_a_message_sent_via_a_distributor.cs
@@ -35,7 +35,7 @@
                 EndpointSetup<DefaultServer>(c =>
                 {
                     c.UnicastRouting().RouteToEndpoint(typeof(MyRequest), ReceiverEndpoint);
-                    c.UnicastRouting().Mapping.Physical.Add(new EndpointName(ReceiverEndpoint), new EndpointInstance(ReceiverEndpoint, "XYZ"));
+                    c.UnicastRouting().Mapping.Physical.Add(new EndpointInstance(ReceiverEndpoint, "XYZ"));
                     c.AddHeaderToAllOutgoingMessages("NServiceBus.Distributor.WorkerSessionId", "SomeID");
                 });
             }


### PR DESCRIPTION
Connects to Particular/PlatformDevelopment#814

Extracts (cherry picked) the changes cleaning up the endpoint instance configuration from https://github.com/Particular/NServiceBus/pull/3767 without the removal of `EndpointName` (to be addressed in another PR), so these changes aren't blocked by the discussion around `EndpointName`.

Changes:
* Remove EndpointName param where EndpointInstance is also passed (because EndpointInstance contains already the information about the name)
* rewrote EndpointInstances.FindInstances to not use LINQ converting to a List->Set->Array and instead just use a HashSet.

ping @bording @SzymonPobiega @distantcam 