### PR TITLE
Fix untyped DependsOn

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Basic/When_depending_on_typed_feature.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_depending_on_typed_feature.cs
@@ -1,0 +1,76 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_depending_on_typed_feature : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_enable_when_typed_dependency_enabled()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithFeatures>(b => b.CustomConfig(c =>
+                {
+                    c.EnableFeature<TypedDependentFeature>();
+                    c.EnableFeature<DependencyFeature>();
+                }))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.That(context.TypedDpendencyFeatureSetUp, Is.True);
+        }
+
+        [Test]
+        public async Task Should_disable_when_typed_dependency_disabled()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithFeatures>(b => b.CustomConfig(c =>
+                {
+                    c.DisableFeature<TypedDependentFeature>();
+                    c.EnableFeature<DependencyFeature>();
+                }))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.That(context.TypedDpendencyFeatureSetUp, Is.False);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool TypedDpendencyFeatureSetUp { get; set; }
+            public bool UntypedDpendencyFeatureSetUp { get; set; }
+        }
+
+        public class EndpointWithFeatures : EndpointConfigurationBuilder
+        {
+            public EndpointWithFeatures()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class TypedDependentFeature : Feature
+        {
+            public TypedDependentFeature()
+            {
+                DependsOn<DependencyFeature>();
+            }
+
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                var testContext = (Context) context.Settings.Get<ScenarioContext>();
+                testContext.TypedDpendencyFeatureSetUp = true;
+            }
+        }
+
+        public class DependencyFeature : Feature
+        {
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Basic/When_depending_on_untyped_feature.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_depending_on_untyped_feature.cs
@@ -1,0 +1,76 @@
+namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_depending_on_untyped_feature : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_enable_when_untyped_dependency_enabled()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithFeatures>(b => b.CustomConfig(c =>
+                {
+                    c.EnableFeature<UntypedDependentFeature>();
+                    c.EnableFeature<DependencyFeature>();
+                }))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.That(context.UntypedDpendencyFeatureSetUp, Is.True);
+        }
+
+        [Test]
+        public async Task Should_disable_when_untyped_dependency_disabled()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithFeatures>(b => b.CustomConfig(c =>
+                {
+                    c.DisableFeature<UntypedDependentFeature>();
+                    c.EnableFeature<DependencyFeature>();
+                }))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.That(context.UntypedDpendencyFeatureSetUp, Is.False);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool UntypedDpendencyFeatureSetUp { get; set; }
+        }
+
+        public class EndpointWithFeatures : EndpointConfigurationBuilder
+        {
+            public EndpointWithFeatures()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class UntypedDependentFeature : Feature
+        {
+            public UntypedDependentFeature()
+            {
+                var featureTypeFullName = typeof(DependencyFeature).FullName;
+                DependsOn(featureTypeFullName);
+            }
+
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                var testContext = (Context) context.Settings.Get<ScenarioContext>();
+                testContext.UntypedDpendencyFeatureSetUp = true;
+            }
+        }
+
+        public class DependencyFeature : Feature
+        {
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -55,6 +55,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Basic\When_depending_on_untyped_feature.cs" />
     <Compile Include="Basic\When_extending_behavior_context.cs" />
     <Compile Include="Basic\When_registering_additional_deserializers.cs" />
     <Compile Include="Basic\When_no_content_type.cs" />
@@ -78,6 +79,7 @@
     <Compile Include="FakeTransport\FakeTransportInfrastructure.cs" />
     <Compile Include="FakeTransport\FakeTransportSetingsExtensions.cs" />
     <Compile Include="FakeTransport\ProcessingOptimizations\When_using_concurrency_limit.cs" />
+    <Compile Include="Basic\When_depending_on_typed_feature.cs" />
     <Compile Include="Hosting\When_overriding_local_addresses.cs" />
     <Compile Include="Hosting\When_a_message_is_faulted.cs" />
     <Compile Include="MessageId\When_message_has_empty_id_header.cs" />
@@ -301,6 +303,7 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\GitVersionTask.3.4.1\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.4.1\build\dotnet\GitVersionTask.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
@@ -141,7 +141,7 @@
         {
             var order = new List<Feature>();
 
-           
+
             var level1 = new Level1
             {
                 OnActivation = f => order.Add(f)

--- a/src/NServiceBus.Core/Features/Feature.cs
+++ b/src/NServiceBus.Core/Features/Feature.cs
@@ -216,17 +216,7 @@
 
         static string GetFeatureName(Type featureType)
         {
-            var name = featureType.FullName;
-
-            if (name.EndsWith("Feature"))
-            {
-                if (name.Length > featureStringLength)
-                {
-                    name = name.Substring(0, name.Length - featureStringLength);
-                }
-            }
-
-            return name;
+            return featureType.FullName;
         }
 
         readonly List<Action<SettingsHolder>> registeredDefaults = new List<Action<SettingsHolder>>();


### PR DESCRIPTION
We provide a `DependsOn` overload which accepts a string parameter for features to define a dependency on a feature whose type is not available at compile time (e.g. Gateway for many persistence packages).

https://github.com/Particular/NServiceBus/commit/1da5619bfab3450166bff15c8d80ab7abc1fe87d changed the parameter to require the full type name instead of the simple type name. But we actually didn't really expect the simple type name when the dependency feature had a "Feature" postfix (then this part was stripped away when using the **typed** `DependsOn` API and for internal feature representation.

`When_depending_on_untyped_feature` reproduces a bug where a feature wasn't loaded although it's dependency which was correctly defined according to the API (using the full type name) and dependency is enabled.

Changes:
* Removes the logic with strips away the "Feature" postfix. It adds unnecessary complexity. This means that when printing out enabled features this would now also show the full type name, which I don't see as an issue?

The two tests are currently in the basic namespace. I want to move them to a `Features` folder. This will break a lot if imports and therefore touch many files. I'll do this as a separate commit.

Todo:
* [ ] update docs
* [ ] move tests to `Features` folder

ping @Particular/nservicebus-maintainers @SimonCropp 