### PR TITLE
[WIP] Transport seam where transports deal with recoverability actions

### DIFF
--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveWithTransactionScope.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveWithTransactionScope.cs
@@ -19,45 +19,118 @@ namespace NServiceBus
 
         public override async Task ReceiveMessage(MessageQueue inputQueue, MessageQueue errorQueue, CancellationTokenSource cancellationTokenSource, Func<PushContext, Task> onMessage)
         {
-            using (var scope = new TransactionScope(TransactionScopeOption.Required, transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
+            Func<ErrorContext, Task<RecoveryAction>> onError = context => Task.FromResult(new RecoveryAction());
+
+            Dictionary<string, string> headers = null;
+            Message message = null;
+
+            try
             {
-                var message = inputQueue.Receive(TimeSpan.FromMilliseconds(10), MessageQueueTransactionType.Automatic);
-
-                Dictionary<string, string> headers;
-
-                try
+                using (var scope = new TransactionScope(TransactionScopeOption.Required, transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
                 {
-                    headers = MsmqUtilities.ExtractHeaders(message);
-                }
-                catch (Exception ex)
-                {
-                    var error = $"Message '{message.Id}' is corrupt and will be moved to '{errorQueue.QueueName}'";
-                    Logger.Error(error, ex);
+                    message = inputQueue.Receive(TimeSpan.FromMilliseconds(10), MessageQueueTransactionType.Automatic);
 
-                    errorQueue.Send(message, MessageQueueTransactionType.Automatic);
+                    if (PerformRecoverabilityAction(message))
+                    {
+                        scope.Complete();
+                        return;
+                    }
 
-                    scope.Complete();
-                    return;
-                }
+                    try
+                    {
+                        headers = MsmqUtilities.ExtractHeaders(message);
+                    }
+                    catch (Exception ex)
+                    {
+                        var error = $"Message '{message.Id}' is corrupt and will be moved to '{errorQueue.QueueName}'";
+                        Logger.Error(error, ex);
 
-                using (var bodyStream = message.BodyStream)
-                {
-                    var ambientTransaction = new TransportTransaction();
-                    ambientTransaction.Set(Transaction.Current);
-                    var pushContext = new PushContext(message.Id, headers, bodyStream, ambientTransaction, cancellationTokenSource, new ContextBag());
+                        errorQueue.Send(message, MessageQueueTransactionType.Automatic);
 
-                    await onMessage(pushContext).ConfigureAwait(false);
-                }
+                        scope.Complete();
+                        return;
+                    }
 
-                if (!cancellationTokenSource.Token.IsCancellationRequested)
-                {
-                    scope.Complete();
+                    using (var bodyStream = message.BodyStream)
+                    {
+                        var ambientTransaction = new TransportTransaction();
+                        ambientTransaction.Set(Transaction.Current);
+                        var pushContext = new PushContext(message.Id, headers, bodyStream, ambientTransaction, cancellationTokenSource, new ContextBag());
+
+                        await onMessage(pushContext).ConfigureAwait(false);
+                    }
+
+                    if (!cancellationTokenSource.Token.IsCancellationRequested)
+                    {
+                        scope.Complete();
+                    }
                 }
             }
+            catch (Exception ex)
+            {
+                if (message == null)
+                {
+                    throw;
+                }
+                var numberOfRetries = GetNumberOfRetries(message.Id);
+
+                var context = new ErrorContext(ex,
+                    message.Id,
+                    headers ?? new Dictionary<string, string>(),
+                    numberOfRetries
+                    );
+
+                var recoveryAction = await onError(context).ConfigureAwait(false);
+
+                AddToLRU(message.Id, recoveryAction);
+            }
         }
+
+        int GetNumberOfRetries(string messageId)
+        {
+            //get this from the LRU/headers etc
+            return 0;
+        }
+
+        void AddToLRU(string messageId, RecoveryAction recoveryAction)
+        {
+
+        }
+
+        bool PerformRecoverabilityAction(Message message)
+        {
+            //check LRU to see if we need to do anything, FLR == do nothing, SLR + Error == move it and return true
+            return false;
+        }
+
 
         TransactionOptions transactionOptions;
 
         static ILog Logger = LogManager.GetLogger<ReceiveWithTransactionScope>();
+    }
+
+    class ErrorContext
+    {
+        public Exception Exception { get; }
+        public string MessageId { get; }
+        public Dictionary<string, string> Headers { get; }
+
+        public  int NumberOfRetries{ get;  }
+
+        public ErrorContext(Exception exception, string messageId, Dictionary<string, string> headers, int numberOfRetries)
+        {
+            Exception = exception;
+            MessageId = messageId;
+            Headers = headers;
+            NumberOfRetries = numberOfRetries;
+        }
+    }
+
+    class RecoveryAction
+    {
+        public bool ImmediateRetry { get; set; }
+        public bool DelayedRetry { get; set; }
+
+        public Dictionary<string,string> AdditionalFaultDetailStuff{ get; set; }
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveWithTransactionScope.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveWithTransactionScope.cs
@@ -24,7 +24,7 @@ namespace NServiceBus
 
             //this is defaulted by the transport but users will be allowed to override using
             // .UseTransport<MsmqTransport>().RetryPolicy(c=>{....})
-            Func<MsmqRecoveryContext, RecoveryAction> determineRecoveryAction = c=> new MsmqImmediateRetry();
+            Func<MsmqRecoveryContext, RecoveryAction> determineRecoveryAction = c => new MsmqImmediateRetry();
 
 
             Dictionary<string, string> headers = null;
@@ -42,20 +42,7 @@ namespace NServiceBus
                         return;
                     }
 
-                    try
-                    {
-                        headers = MsmqUtilities.ExtractHeaders(message);
-                    }
-                    catch (Exception ex)
-                    {
-                        var error = $"Message '{message.Id}' is corrupt and will be moved to '{errorQueue.QueueName}'";
-                        Logger.Error(error, ex);
-
-                        errorQueue.Send(message, MessageQueueTransactionType.Automatic);
-
-                        scope.Complete();
-                        return;
-                    }
+                    headers = MsmqUtilities.ExtractHeaders(message);
 
                     using (var bodyStream = message.BodyStream)
                     {

--- a/src/NServiceBus.Core/obsoletes.cs
+++ b/src/NServiceBus.Core/obsoletes.cs
@@ -1697,7 +1697,7 @@ namespace NServiceBus.Settings
             TreatAsErrorFromVersion = "6.0",
             Message =
                 @"DoNotWrapHandlersExecutionInATransactionScope() has been removed since transaction scopes are no longer used by non DTC transports delay the dispatch of all outgoing operations until handlers have been executed.
-In Version 6 handlers will only be wrapped in a transactionscope if running the MSMQ or SQLServer transports in default mode. This means that performing storage operations against data sources also supporting transaction scopes 
+In Version 6 handlers will only be wrapped in a transactionscope if running the MSMQ or SQLServer transports in default mode. This means that performing storage operations against data sources also supporting transaction scopes
 will escalate to a distributed transaction. Previous versions allowed opting out of this behavior using config.Transactions().DoNotWrapHandlersExecutionInATransactionScope(). In Version 6 it's recommended to use `EndpointConfiguration.UseTransport<MyTransport>().Transactions(TransportTransactionMode.ReceiveOnly)` to lean on native transport transaction and the new batched dispatch support to achieve the same level of consistency with better performance.
 Suppressing the ambient transaction created by the MSMQ and SQL Server transports can still be achieved by creating a custom pipeline behavior with a suppressed transaction scope.")]
         public TransactionSettings DoNotWrapHandlersExecutionInATransactionScope()


### PR DESCRIPTION
This is a spike to aid the discussion around #3757 . This aims to show the "nirvana" state where we enable all transports to utilize their native capabilities around error queue, retries etc

The key change is that instead of letting the core decide both what to do in the case of a failure and also perform the action we now:

1. Let the core decide what action to take, ImmediateRetry, DelayedRetry, MoveToErrorQueue
2. Let the transport fullfill the action in the best possible way

Note: The FLR, SLR and MoveToErrorQueue behaviors would mostly be deleted and a new fault pipeline would deal with deciding what to do

### Benefits

* Transports like ASB can use its native retries, use native FLR counters etc.
* We only roll back when its actually needed, Rabbit, ASQ, ASB (mostly) doesn't have to rollback in order to safely perform a delayed retry/move to error

### Observations

* This highlights the nasty dependency between the timeout manager and the transports that can't do native defers (only ASB atm). My gut feeling is that we need to push deferrals into the transports going forwards. Eg. sqlserver can have a much more efficient native deferral compared to the current TM driven one that's using 2 satellites to move the message around. 
* Out of band audit and error details should be handled by the transport. In the spike I have the core send back a dictionary of "error details" and it's up to the transport to transport them safely in some way. This would IMO allow us to deal with oversized messages in the best possible way, sql could eg have a separate table for that type of extra info.