### PR TITLE
Cannot set error queue on a remote server for MSMQ

### DIFF
--- a/src/NServiceBus.Core.Tests/Msmq/MsmqMessagePumpTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqMessagePumpTests.cs
@@ -1,0 +1,25 @@
+namespace NServiceBus.Core.Tests.Msmq
+{
+    using System;
+    using NServiceBus.Transports;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class MsmqMessagePumpTests
+    {
+
+        [Test]
+        public void Should_throw_an_exception()
+        {
+            var messagePump = new MessagePump(mode => null);
+            var pushSettings = new PushSettings("queue@remote", "error", false, TransportTransactionMode.None);
+
+            var exception = Assert.Throws<Exception>(() =>
+            {
+                messagePump.Init(context => null, null, pushSettings);
+            });
+
+            Assert.That(exception.Message, Does.Contain($"MSMQ Dequeuing can only run against the local machine. Invalid inputQueue name '{pushSettings.InputQueue}'."));
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqMessagePumpTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqMessagePumpTests.cs
@@ -9,7 +9,7 @@ namespace NServiceBus.Core.Tests.Msmq
     {
 
         [Test]
-        public void Should_throw_an_exception()
+        public void ShouldThrowIfConfiguredToReceiveFromRemoteQueue()
         {
             var messagePump = new MessagePump(mode => null);
             var pushSettings = new PushSettings("queue@remote", "error", false, TransportTransactionMode.None);

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -132,6 +132,7 @@
     <Compile Include="Faults\AddExceptionHeadersBehaviorTests.cs" />
     <Compile Include="Features\FeatureDifferingOnlyByNamespaceTests.cs" />
     <Compile Include="MessageMapper\MessageMapperTests.cs" />
+    <Compile Include="Msmq\MsmqMessagePumpTests.cs" />
     <Compile Include="Msmq\TimeToBeReceivedOverrideCheckerTest.cs" />
     <Compile Include="Msmq\MsmqExtensionsTests.cs" />
     <Compile Include="Msmq\MsmqHelpers.cs" />

--- a/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
@@ -34,10 +34,9 @@ namespace NServiceBus
             var inputAddress = MsmqAddress.Parse(settings.InputQueue);
             var errorAddress = MsmqAddress.Parse(settings.ErrorQueue);
 
-            if (!string.Equals(errorAddress.Machine, Environment.MachineName, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(inputAddress.Machine, Environment.MachineName, StringComparison.OrdinalIgnoreCase))
             {
-                var message = $"MSMQ Dequeuing can only run against the local machine. Invalid inputQueue name '{settings.InputQueue}'";
-                throw new Exception(message);
+                throw new Exception($"MSMQ Dequeuing can only run against the local machine. Invalid inputQueue name '{settings.InputQueue}'");
             }
 
             inputQueue = new MessageQueue(inputAddress.FullPath, false, true, QueueAccessMode.Receive);
@@ -45,7 +44,7 @@ namespace NServiceBus
 
             if (settings.RequiredTransactionMode != TransportTransactionMode.None && !QueueIsTransactional())
             {
-                throw new ArgumentException("Queue must be transactional if you configure the endpoint to be transactional (" + settings.InputQueue + ").");
+                throw new ArgumentException($"Queue must be transactional if you configure the endpoint to be transactional ({settings.InputQueue}).");
             }
 
             inputQueue.MessageReadPropertyFilter = DefaultReadPropertyFilter;

--- a/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
@@ -36,7 +36,7 @@ namespace NServiceBus
 
             if (!string.Equals(inputAddress.Machine, Environment.MachineName, StringComparison.OrdinalIgnoreCase))
             {
-                throw new Exception($"MSMQ Dequeuing can only run against the local machine. Invalid inputQueue name '{settings.InputQueue}'");
+                throw new Exception($"MSMQ Dequeuing can only run against the local machine. Invalid inputQueue name '{settings.InputQueue}'.");
             }
 
             inputQueue = new MessageQueue(inputAddress.FullPath, false, true, QueueAccessMode.Receive);


### PR DESCRIPTION
Connects to #3787

## Description

Validation of the input queue is causing valid remote error queue to be discarded and skipping real input queue validation rule (must be local).