### PR TITLE
Prevent HasSupportFor from throwing when SendOnly endpoint

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Msmq\MsmqAddressTests.cs" />
     <Compile Include="Msmq\MsmqSubscriptionStorageQueueTests.cs" />
     <Compile Include="Persistence\InMemory\When_persisting_a_saga_with_InMemory_and_an_escalated_DTC_transaction.cs" />
+    <Compile Include="Persistence\PersistenceStartupTests.cs" />
     <Compile Include="Pipeline\HeaderOptionExtensionsTests.cs" />
     <Compile Include="Pipeline\Incoming\InvokeHandlerTerminatorTest.cs" />
     <Compile Include="Pipeline\MutateInstanceMessage\MutateIncomingMessageBehaviorTests.cs" />

--- a/src/NServiceBus.Core.Tests/Persistence/PersistenceStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/PersistenceStartupTests.cs
@@ -1,0 +1,20 @@
+﻿namespace NServiceBus.Core.Tests.Persistence
+{
+    using NServiceBus.Persistence;
+    using NUnit.Framework;
+    using Settings;
+
+    [TestFixture]
+    public class When_no_persistence_has_been_configured
+    {
+        [Test]
+        public void Should_return_false_when_checking_if_persistence_supports_storage_type()
+        {
+            var settings = new SettingsHolder();
+
+            var supported = PersistenceStartup.HasSupportFor<StorageType.Subscriptions>(settings);
+
+            Assert.IsFalse(supported);
+        }
+    }
+}

--- a/src/NServiceBus.Core/Persistence/PersistenceStartup.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceStartup.cs
@@ -45,8 +45,10 @@
 
         internal static bool HasSupportFor<T>(ReadOnlySettings settings) where T : StorageType
         {
-            return settings.Get<List<Type>>("ResultingSupportedStorages")
-                .Contains(typeof(T));
+            List<Type> supportedStorages;
+            settings.TryGet("ResultingSupportedStorages", out supportedStorages);
+
+            return supportedStorages?.Contains(typeof(T)) ?? false;
         }
 
         const string errorMessage = "No persistence has been selected, select a persistence by calling endpointConfiguration.UsePersistence<T>() in the class that implements either IConfigureThisEndpoint or INeedInitialization, where T can be any of the supported persistence option. If previously using RavenDB, note that it has been moved to its own stand alone nuget 'NServiceBus.RavenDB'. This package will need to be installed and then enabled by calling endpointConfiguration.UsePersistence<RavenDBPersistence>().";


### PR DESCRIPTION
This makes sure `HasSupportFor` will return false if being called when the `ResultingSupportedStorages` setting hasn't been set, which happens when an endpoint is SendOnly.

I haven't included a test around this, wasn't sure if it needed one. If it does, what would be the best approach for testing it?

@Particular/nservicebus-maintainers 

Connects to #3748 