### PR TITLE
Refactor FindInstances query

### DIFF
--- a/src/NServiceBus.Core/Routing/EndpointInstances.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstances.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.Routing
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -10,20 +9,41 @@ namespace NServiceBus.Routing
     /// </summary>
     public class EndpointInstances
     {
-        internal async Task<IEnumerable<EndpointInstance>> FindInstances(string endpoint)
+        internal Task<IEnumerable<EndpointInstance>> FindInstances(string endpoint)
         {
-            var instances = new HashSet<EndpointInstance>();
-            foreach (var rule in rules)
+            HashSet<EndpointInstance> staticInstances;
+            staticRules.TryGetValue(endpoint, out staticInstances);
+
+            if (dynamicRules.Count > 0)
+            {
+                return FindDynamicInstances(endpoint, staticInstances);
+            }
+
+            if (staticInstances != null)
+            {
+                return Task.FromResult<IEnumerable<EndpointInstance>>(staticInstances);
+            }
+
+            return Task.FromResult<IEnumerable<EndpointInstance>>(new[]
+            {
+                new EndpointInstance(endpoint)
+            });
+        }
+
+        async Task<IEnumerable<EndpointInstance>> FindDynamicInstances(string endpoint, HashSet<EndpointInstance> staticInstances)
+        {
+            var dynamicInstances = staticInstances != null ? new HashSet<EndpointInstance>(staticInstances) : new HashSet<EndpointInstance>();
+            foreach (var rule in dynamicRules)
             {
                 var instancesFromRule = await rule.Invoke(endpoint).ConfigureAwait(false);
                 foreach (var instance in instancesFromRule)
                 {
-                    instances.Add(instance);
+                    dynamicInstances.Add(instance);
                 }
             }
-            return instances.EnsureNonEmpty(() => new EndpointInstance(endpoint));
-        }
 
+            return dynamicInstances;
+        }
 
         /// <summary>
         /// Adds a dynamic rule for determining endpoint instances.
@@ -31,7 +51,7 @@ namespace NServiceBus.Routing
         /// <param name="dynamicRule">The rule.</param>
         public void AddDynamic(Func<string, Task<IEnumerable<EndpointInstance>>> dynamicRule)
         {
-            rules.Add(dynamicRule);
+            dynamicRules.Add(dynamicRule);
         }
 
         /// <summary>
@@ -47,30 +67,30 @@ namespace NServiceBus.Routing
         public void Add(IEnumerable<EndpointInstance> instances)
         {
             Guard.AgainstNull(nameof(instances), instances);
-            var endpointsByName = instances.Select(i =>
+
+            foreach (var instance in instances)
             {
-                if (i == null)
+                if (instance == null)
                 {
                     throw new ArgumentNullException(nameof(instances), "One of the elements of collection is null");
                 }
-                return i;
-            }).GroupBy(i => i.Endpoint);
-            foreach (var instanceGroup in endpointsByName)
-            {
-                rules.Add(e => StaticRule(e, instanceGroup.Key, instanceGroup));
+
+                HashSet<EndpointInstance> existingInstances;
+                if (staticRules.TryGetValue(instance.Endpoint, out existingInstances))
+                {
+                    existingInstances.Add(instance);
+                }
+                else
+                {
+                    staticRules.Add(instance.Endpoint, new HashSet<EndpointInstance>
+                    {
+                        instance
+                    });
+                }
             }
         }
 
-        static Task<IEnumerable<EndpointInstance>> StaticRule(string endpointBeingQueried, string configuredEndpoint, IEnumerable<EndpointInstance> configuredInstances)
-        {
-            if (endpointBeingQueried == configuredEndpoint)
-            {
-                return Task.FromResult(configuredInstances);
-            }
-            return EmptyStaticRuleTask;
-        }
-
-        List<Func<string, Task<IEnumerable<EndpointInstance>>>> rules = new List<Func<string, Task<IEnumerable<EndpointInstance>>>>();
-        static Task<IEnumerable<EndpointInstance>> EmptyStaticRuleTask = Task.FromResult(Enumerable.Empty<EndpointInstance>());
+        Dictionary<string, HashSet<EndpointInstance>> staticRules = new Dictionary<string, HashSet<EndpointInstance>>();
+        List<Func<string, Task<IEnumerable<EndpointInstance>>>> dynamicRules = new List<Func<string, Task<IEnumerable<EndpointInstance>>>>();
     }
 }


### PR DESCRIPTION
tried to refactor the FindInstances query which is invoked from the routing during the outgoing message pipeline.

Goal: Moving time consuming operations for static instance routing configuration to startup time

* Splitting static and dynamic rules: static rules no longer need any async operations.
* Reducing number of loops by checking whether static or dynamic rules even exist.
* use array instead of `NonEmptyEnumerable`
* static rules are computed when adding new instances to a "ready-to-consume" `Dictionary<string, HashSet<EndpointInstance>>`

@Particular/nservicebus-maintainers @SzymonPobiega @DavidBoike please review

Connects to Particular/PlatformDevelopment#814