### PR TITLE
File routing xml schema

### DIFF
--- a/src/NServiceBus.Core.Tests/Routing/FileRoutingTableParserTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/FileRoutingTableParserTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace NServiceBus.Core.Tests.Routing
 {
-    using System;
     using System.Xml.Linq;
+    using System.Xml.Schema;
     using NServiceBus.Routing;
     using NUnit.Framework;
 
@@ -24,13 +24,27 @@
 ";
             var doc = XDocument.Parse(xml);
             var result = new FileRoutingTableParser().Parse(doc);
-            
+
             CollectionAssert.AreEqual(new[]
             {
-                new EndpointInstance("A", "D1").SetProperty("prop1", "V1").SetProperty("prop2","V2"), 
+                new EndpointInstance("A", "D1").SetProperty("prop1", "V1").SetProperty("prop2","V2"),
                 new EndpointInstance("A").SetProperty("prop3", "V3").SetProperty("prop4", "V4"),
-                new EndpointInstance("B", "D2").SetProperty("prop5", "V5").SetProperty("prop6", "V6"),  
+                new EndpointInstance("B", "D2").SetProperty("prop5", "V5").SetProperty("prop6", "V6"),
             }, result);
+        }
+
+        [Test]
+        public void It_requires_at_least_one_endpoint()
+        {
+            const string xml = @"
+<endpoints>
+</endpoints>
+";
+            var doc = XDocument.Parse(xml);
+            var parser = new FileRoutingTableParser();
+
+            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc));
+            Assert.That(exception.Message, Does.Contain("The element 'endpoints' has incomplete content."));
         }
 
         [Test]
@@ -38,19 +52,29 @@
         {
             const string xml = @"
 <endpoints>
-    <endpoint someUnusedAttribute=""A""/>
+    <endpoint/>
 </endpoints>
 ";
             var doc = XDocument.Parse(xml);
-            try
-            {
-                new FileRoutingTableParser().Parse(doc);
-                Assert.Fail("Expected error.");
-            }
-            catch (Exception)
-            {
-                Assert.Pass();
-            }
+            var parser = new FileRoutingTableParser();
+
+            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc));
+            Assert.That(exception.Message, Does.Contain("The required attribute 'name' is missing."));
+        }
+
+        [Test]
+        public void It_requires_endpoint_to_have_at_least_one_instance()
+        {
+            const string xml = @"
+<endpoints>
+    <endpoint name=""A""/>
+</endpoints>
+";
+            var doc = XDocument.Parse(xml);
+            var parser = new FileRoutingTableParser();
+
+            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc));
+            Assert.That(exception.Message, Does.Contain("The element 'endpoint' has incomplete content."));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/FileRoutingTableTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/FileRoutingTableTests.cs
@@ -36,7 +36,7 @@
         }
 
         [Test]
-        public async Task If_file_does_not_exist_when_starting_up_it_fails()
+        public void If_file_does_not_exist_when_starting_up_it_fails()
         {
             var timer = new FakeTimer();
             var fileAccess = new FakeFileAccess(() =>
@@ -47,15 +47,9 @@
             var instances = new EndpointInstances();
             settings.Set<EndpointInstances>(instances);
             var table = new FileRoutingTable("unused", TimeSpan.Zero, timer, fileAccess, 3, settings);
-            try
-            {
-                await table.PerformStartup(null);
-                Assert.Fail("Expected exception saying file could not be loaded.");
-            }
-            catch (Exception ex)
-            {
-                Assert.AreEqual("Simulated", ex.Message);
-            }
+
+            var exception = Assert.ThrowsAsync<Exception>(async () => await table.PerformStartup(null));
+            Assert.That(exception.InnerException.Message, Does.Contain("Simulated"));
         }
 
         [Test]

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -47,6 +47,9 @@
     <None Include="FodyWeavers.xml">
       <SubType>Designer</SubType>
     </None>
+    <EmbeddedResource Include="Routing\FileBasedDynamicRouting\endpoints.xsd">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <Reference Include="Autofac">
       <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/endpoints.xsd
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/endpoints.xsd
@@ -1,0 +1,21 @@
+﻿<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="endpoints">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element minOccurs="1" maxOccurs="unbounded" name="endpoint">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element minOccurs="1" maxOccurs="unbounded" name="instance">
+                <xs:complexType>
+                  <xs:attribute name="discriminator" type="xs:string" use="optional" />
+                  <xs:anyAttribute processContents="lax" />
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required" />
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
This adds XML schema validation to the FileBasedDynamicRouting parser. The schema file is loaded as an embedded resource.

I did start out with the schema defined as as string in the class, so it maybe it makes sense to squash some of these commits before merging?

While getting the schema working, I did end up making a tweak to the version currently on the docs page. I've made it require at least once instance if their is an endpoint defined, because otherwise there's no point in the endpoint being defined in the file in the first place.

@timbussmann See anything else you'd want to add to this?

Connects to Particular/PlatformDevelopment#814