### PR TITLE
Fixes the saga finder test 

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_found_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_found_saga.cs
@@ -41,13 +41,18 @@
                 // ReSharper disable once MemberCanBePrivate.Global
                 public Context Context { get; set; }
 
-                public Task<TestSaga08.SagaData08> FindBy(SomeOtherMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context)
+                public ISagaPersister SagaPersister { get; set; }
+
+                public async Task<TestSaga08.SagaData08> FindBy(SomeOtherMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context)
                 {
                     Context.FinderUsed = true;
-                    return Task.FromResult(new TestSaga08.SagaData08
+                    var sagaInstance = new TestSaga08.SagaData08
                     {
                         Property = "jfbsjdfbsdjh"
-                    });
+                    };
+                    //Make sure saga exists in the store. Persisters expect it there when they save saga instance after processing a message.
+                    await SagaPersister.Save(sagaInstance, SagaCorrelationProperty.None, storageSession, new ContextBag()).ConfigureAwait(false);
+                    return sagaInstance;
                 }
             }
 


### PR DESCRIPTION
By ensuring the instance returned by a custom finder has been stored in the store prior to returning. This is because saga persisters expect this instance to be persistence when they save the changes.