### PR TITLE
Configure distribution strategy per endpoint

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/When_broadcasting_a_command.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_broadcasting_a_command.cs
@@ -39,7 +39,7 @@
                 {
                     c.UnicastRouting().RouteToEndpoint(typeof(Request), ReceiverEndpoint);
 
-                    c.UnicastRouting().Mapping.SetMessageDistributionStrategy(new AllInstancesDistributionStrategy(), t => t == typeof(Request));
+                    c.UnicastRouting().Mapping.SetMessageDistributionStrategy(ReceiverEndpoint, new AllInstancesDistributionStrategy());
                     c.UnicastRouting().Mapping.Physical.Add(
                         new EndpointInstance(ReceiverEndpoint, "1"),
                         new EndpointInstance(ReceiverEndpoint, "2"));

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -849,7 +849,7 @@ namespace NServiceBus
         public NServiceBus.Routing.UnicastRoutingTable Logical { get; }
         public NServiceBus.Routing.EndpointInstances Physical { get; }
         public NServiceBus.Routing.MessageDrivenSubscriptions.Publishers Publishers { get; }
-        public void SetMessageDistributionStrategy(NServiceBus.Routing.DistributionStrategy distributionStrategy, System.Func<System.Type, bool> typeMatchingRule) { }
+        public void SetMessageDistributionStrategy(string endpointName, NServiceBus.Routing.DistributionStrategy distributionStrategy) { }
     }
     public class static RoutingOptionExtensions
     {

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -157,6 +157,7 @@
     <Compile Include="Routing\ApplyReplyToAddressBehaviorTests.cs" />
     <Compile Include="Routing\BestPracticesOptionExtensionsTests.cs" />
     <Compile Include="Routing\DetermineRouteForPublishBehaviorTests.cs" />
+    <Compile Include="Routing\DistributionPolicyTests.cs" />
     <Compile Include="Routing\Routers\UnicastSendRouterConnectorTests.cs" />
     <Compile Include="Routing\EndpointInstanceTests.cs" />
     <Compile Include="Routing\EndpointInstancesTests.cs" />

--- a/src/NServiceBus.Core.Tests/Routing/DistributionPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DistributionPolicyTests.cs
@@ -1,0 +1,54 @@
+﻿namespace NServiceBus.Core.Tests.Routing
+{
+    using System.Collections.Generic;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class DistributionPolicyTests
+    {
+        [Test]
+        public void When_no_strategy_configured_for_endpoint_should_use_round_robbin_strategy()
+        {
+            var policy = new DistributionPolicy();
+
+            var result = policy.GetDistributionStrategy("SomeEndpoint");
+
+            Assert.That(result, Is.TypeOf<SingleInstanceRoundRobinDistributionStrategy>());
+        }
+
+        [Test]
+        public void When_strategy_configured_for_endpoint_should_use_configured_strategy()
+        {
+            var policy = new DistributionPolicy();
+            var configuredStrategy = new FakeDistributionStrategy();
+            policy.SetDistributionStrategy("SomeEndpoint", configuredStrategy);
+
+            var result = policy.GetDistributionStrategy("SomeEndpoint");
+
+            Assert.That(result, Is.EqualTo(configuredStrategy));
+        }
+
+        [Test]
+        public void When_multiple_strategies_configured_endpoint_should_use_last_configured_strategy()
+        {
+            var policy = new DistributionPolicy();
+            var strategy = new FakeDistributionStrategy();
+            policy.SetDistributionStrategy("SomeEndpoint", new FakeDistributionStrategy());
+            policy.SetDistributionStrategy("SomeEndpoint", new FakeDistributionStrategy());
+            policy.SetDistributionStrategy("SomeEndpoint", strategy);
+
+            var result = policy.GetDistributionStrategy("SomeEndpoint");
+
+            Assert.That(result, Is.EqualTo(strategy));
+        }
+
+        class FakeDistributionStrategy : DistributionStrategy
+        {
+            public override IEnumerable<UnicastRoutingTarget> SelectDestination(IList<UnicastRoutingTarget> allInstances)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastPublishRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastPublishRouterConnectorTests.cs
@@ -25,7 +25,7 @@
 
         class Router : IUnicastRouter
         {
-            public Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, DistributionStrategy distributionStrategy, ContextBag contextBag)
+            public Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, IDistributionPolicy distributionPolicy, ContextBag contextBag)
             {
                 IEnumerable<UnicastRoutingStrategy> unicastRoutingStrategies = new List<UnicastRoutingStrategy>
                 {

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
@@ -237,7 +237,7 @@
         {
             public IEnumerable<UnicastRoutingStrategy> FixedDestination { get; set; }
 
-            public Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, DistributionStrategy distributionStrategy, ContextBag contextBag)
+            public Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, IDistributionPolicy distributionPolicy, ContextBag contextBag)
             {
                 return Task.FromResult(FixedDestination);
             }

--- a/src/NServiceBus.Core.Tests/Routing/UnicastRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastRouterTests.cs
@@ -27,7 +27,7 @@
             endpointInstances.Add(new EndpointInstance(sales, null, null));
             transportAddresses.AddRule(i => i.ToString());
 
-            var routes = router.Route(typeof(Command), new SingleInstanceRoundRobinDistributionStrategy(), new ContextBag()).Result.ToArray();
+            var routes = router.Route(typeof(Command), new DistributionPolicy(), new ContextBag()).Result.ToArray();
 
             Assert.AreEqual(1, routes.Length);
             var headers = new Dictionary<string, string>();
@@ -44,7 +44,7 @@
             endpointInstances.Add(new EndpointInstance(sales));
             transportAddresses.AddRule(i => i.ToString());
 
-            var routes = router.Route(typeof(Event), new SingleInstanceRoundRobinDistributionStrategy(), new ContextBag()).Result.ToArray();
+            var routes = router.Route(typeof(Event), new DistributionPolicy(), new ContextBag()).Result.ToArray();
 
             Assert.AreEqual(1, routes.Length);
             Assert.AreEqual("Sales", ExtractDestination(routes[0]));
@@ -65,7 +65,7 @@
 
             transportAddresses.AddRule(i => i.ToString());
 
-            var routes = router.Route(typeof(Event), new SingleInstanceRoundRobinDistributionStrategy(), new ContextBag()).Result.ToArray();
+            var routes = router.Route(typeof(Event), new DistributionPolicy(), new ContextBag()).Result.ToArray();
 
             Assert.AreEqual(2, routes.Length);
             Assert.AreEqual("Sales-1", ExtractDestination(routes[0]));
@@ -83,7 +83,7 @@
             endpointInstances.Add(new EndpointInstance(sales, "1"));
             transportAddresses.AddRule(i => i.ToString());
 
-            var routes = router.Route(typeof(Event), new SingleInstanceRoundRobinDistributionStrategy(), new ContextBag()).Result.ToArray();
+            var routes = router.Route(typeof(Event), new DistributionPolicy(), new ContextBag()).Result.ToArray();
 
             Assert.AreEqual(1, routes.Length);
         }
@@ -106,7 +106,7 @@
             });
             transportAddresses.AddRule(i => i.ToString());
 
-            var routes = router.Route(typeof(Event), new TestDistributionStrategy(), new ContextBag()).Result.ToArray();
+            var routes = router.Route(typeof(Event), new DistributionPolicy(), new ContextBag()).Result.ToArray();
 
             Assert.AreEqual(1, routes.Length);
         }
@@ -114,7 +114,7 @@
         [Test]
         public void Should_return_empty_list_when_no_routes_found()
         {
-            var routes = router.Route(typeof(Event), new TestDistributionStrategy(), new ContextBag()).Result.ToArray();
+            var routes = router.Route(typeof(Event), new DistributionPolicy(), new ContextBag()).Result.ToArray();
 
             Assert.IsEmpty(routes);
         }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -130,7 +130,9 @@
     <Compile Include="Recoverability\Faults\MessageFaulted.cs" />
     <Compile Include="ReleaseDateAttribute.cs" />
     <Compile Include="Recoverability\ProcessingFailureInfo.cs" />
+    <Compile Include="Routing\IDistributionPolicy.cs" />
     <Compile Include="Routing\RoutingMappingSettings.cs" />
+    <Compile Include="Routing\SpecificInstanceDistributionPolicy.cs" />
     <Compile Include="Routing\UnicastPublishRouter.cs" />
     <Compile Include="Routing\UnicastSendRouter.cs" />
     <Compile Include="Serialization\SerializationFeature.cs" />

--- a/src/NServiceBus.Core/Routing/DistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionPolicy.cs
@@ -1,27 +1,22 @@
 namespace NServiceBus
 {
-    using System;
     using System.Collections.Generic;
-    using System.Linq;
     using Routing;
 
-    class DistributionPolicy
+    class DistributionPolicy : IDistributionPolicy
     {
-        public DistributionPolicy()
+        public void SetDistributionStrategy(string endpointName, DistributionStrategy distributionStrategy)
         {
-            strategies.Add(new Tuple<Func<Type, bool>, DistributionStrategy>(_ => true, new SingleInstanceRoundRobinDistributionStrategy()));
+            configuredStrategies[endpointName] = distributionStrategy;
         }
 
-        internal void SetDistributionStrategy(DistributionStrategy distributionStrategy, Func<Type, bool> typeMatchingRule)
+        public DistributionStrategy GetDistributionStrategy(string endpointName)
         {
-            strategies.Insert(0, Tuple.Create(typeMatchingRule, distributionStrategy));
+            DistributionStrategy configuredStrategy;
+            return configuredStrategies.TryGetValue(endpointName, out configuredStrategy) ? configuredStrategy : defaultStrategy;
         }
 
-        internal DistributionStrategy GetDistributionStrategy(Type messageType)
-        {
-            return strategies.Where(s => s.Item1(messageType)).Select(s => s.Item2).FirstOrDefault();
-        }
-
-        List<Tuple<Func<Type, bool>, DistributionStrategy>> strategies = new List<Tuple<Func<Type, bool>, DistributionStrategy>>();
+        Dictionary<string, DistributionStrategy> configuredStrategies = new Dictionary<string, DistributionStrategy>();
+        DistributionStrategy defaultStrategy = new SingleInstanceRoundRobinDistributionStrategy();
     }
 }

--- a/src/NServiceBus.Core/Routing/IDistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/IDistributionPolicy.cs
@@ -1,0 +1,9 @@
+namespace NServiceBus
+{
+    using Routing;
+
+    interface IDistributionPolicy
+    {
+        DistributionStrategy GetDistributionStrategy(string endpointName);
+    }
+}

--- a/src/NServiceBus.Core/Routing/IUnicastRouter.cs
+++ b/src/NServiceBus.Core/Routing/IUnicastRouter.cs
@@ -8,6 +8,6 @@ namespace NServiceBus
 
     interface IUnicastRouter
     {
-        Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, DistributionStrategy distributionStrategy, ContextBag contextBag);
+        Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, IDistributionPolicy distributionPolicy, ContextBag contextBag);
     }
 }

--- a/src/NServiceBus.Core/Routing/Routers/UnicastPublishRouterConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/UnicastPublishRouterConnector.cs
@@ -40,8 +40,7 @@ namespace NServiceBus
 
         async Task<List<UnicastRoutingStrategy>> GetRoutingStrategies(IOutgoingPublishContext context, Type eventType)
         {
-            var distributionStrategy = distributionPolicy.GetDistributionStrategy(eventType);
-            var addressLabels = await unicastRouter.Route(eventType, distributionStrategy, context.Extensions).ConfigureAwait(false);
+            var addressLabels = await unicastRouter.Route(eventType, distributionPolicy, context.Extensions).ConfigureAwait(false);
             return addressLabels.ToList();
         }
 

--- a/src/NServiceBus.Core/Routing/RoutingMappingSettings.cs
+++ b/src/NServiceBus.Core/Routing/RoutingMappingSettings.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus
 {
-    using System;
     using Configuration.AdvanceExtensibility;
     using Routing;
     using Routing.MessageDrivenSubscriptions;
@@ -32,13 +31,13 @@ namespace NServiceBus
         public Publishers Publishers => GetOrCreate<Publishers>();
 
         /// <summary>
-        /// Sets a distribution strategy for a given subset of message types.
+        /// Sets a distribution strategy for a given endpoint.
         /// </summary>
+        /// <param name="endpointName">The name of the logical endpoint the given strategy should apply to.</param>
         /// <param name="distributionStrategy">The instance of a distribution strategy.</param>
-        /// <param name="typeMatchingRule">A predicate for determining the set of types.</param>
-        public void SetMessageDistributionStrategy(DistributionStrategy distributionStrategy, Func<Type, bool> typeMatchingRule)
+        public void SetMessageDistributionStrategy(string endpointName, DistributionStrategy distributionStrategy)
         {
-            GetOrCreate<DistributionPolicy>().SetDistributionStrategy(distributionStrategy, typeMatchingRule);
+            GetOrCreate<DistributionPolicy>().SetDistributionStrategy(endpointName, distributionStrategy);
         }
 
         T GetOrCreate<T>()

--- a/src/NServiceBus.Core/Routing/SpecificInstanceDistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/SpecificInstanceDistributionPolicy.cs
@@ -1,0 +1,42 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Routing;
+
+    class SpecificInstanceDistributionPolicy : IDistributionPolicy
+    {
+        readonly string specificInstance;
+
+        public SpecificInstanceDistributionPolicy(string specificInstance)
+        {
+            this.specificInstance = specificInstance;
+        }
+
+        public DistributionStrategy GetDistributionStrategy(string endpointName)
+        {
+            return new SpecificInstanceDistributionStrategy(specificInstance);
+        }
+
+        class SpecificInstanceDistributionStrategy : DistributionStrategy
+        {
+            public SpecificInstanceDistributionStrategy(string specificInstance)
+            {
+                this.specificInstance = specificInstance;
+            }
+
+            public override IEnumerable<UnicastRoutingTarget> SelectDestination(IList<UnicastRoutingTarget> allInstances)
+            {
+                var target = allInstances.FirstOrDefault(t => t.Instance != null && t.Instance.Discriminator == specificInstance);
+                if (target == null)
+                {
+                    throw new Exception($"Specified instance {specificInstance} has not been configured in the routing tables.");
+                }
+                yield return target;
+            }
+
+            string specificInstance;
+        }
+    }
+}


### PR DESCRIPTION
Connects to Particular/PlatformDevelopment#814

enables to configure a custom `DistributionStrategy` per endpoint instead of per type.

@SzymonPobiega @bording @DavidBoike what do you think?