### PR TITLE
add NonDurableDelivery to msmq supported delivery constraints

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -227,6 +227,7 @@
                 {
                     if (DateTime.UtcNow - startTime > maxTime)
                     {
+                        ThrowOnFailedMessages(runDescriptor, endpoints);
                         throw new ScenarioException(GenerateTestTimedOutMessage(maxTime));
                     }
 
@@ -238,6 +239,11 @@
                 await StopEndpoints(endpoints).ConfigureAwait(false);
             }
 
+            ThrowOnFailedMessages(runDescriptor, endpoints);
+        }
+
+        static void ThrowOnFailedMessages(RunDescriptor runDescriptor, List<EndpointRunner> endpoints)
+        {
             var unexpectedFailedMessages = runDescriptor.ScenarioContext.FailedMessages
                 .Where(kvp => endpoints.Single(e => e.Name() == kvp.Key).FailOnErrorMessage)
                 .SelectMany(kvp => kvp.Value)

--- a/src/NServiceBus.AcceptanceTests/FakeTransport/FakeTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTests/FakeTransport/FakeTransportInfrastructure.cs
@@ -31,7 +31,7 @@
 
         public override TransportReceiveInfrastructure ConfigureReceiveInfrastructure()
         {
-            return new TransportReceiveInfrastructure(() => new FakeReceiver(settings.Get<Exception>()), () => new FakeQueueCreator(), () => Task.FromResult(StartupCheckResult.Success));
+            return new TransportReceiveInfrastructure(() => new FakeReceiver(settings.GetOrDefault<Exception>()), () => new FakeQueueCreator(), () => Task.FromResult(StartupCheckResult.Success));
         }
 
         public override TransportSendInfrastructure ConfigureSendInfrastructure()

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -97,6 +97,8 @@
     <Compile Include="EndpointTemplates\DefaultPublisher.cs" />
     <Compile Include="EndpointTemplates\DefaultServer.cs" />
     <Compile Include="Mutators\When_using_outgoing_tm_mutator.cs" />
+    <Compile Include="Performance\MessageDurability\When_disabling_durable_messages_on_durable_transport.cs" />
+    <Compile Include="Performance\MessageDurability\When_using_non_durable_messages_on_durable_only_transport.cs" />
     <Compile Include="Performance\When_message_is_faulted.cs" />
     <Compile Include="Persistence\When_a_persistence_does_not_support_outbox.cs" />
     <Compile Include="Persistence\When_a_persistence_does_not_support_saga.cs" />

--- a/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_disabling_durable_messages_on_durable_transport.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_disabling_durable_messages_on_durable_transport.cs
@@ -1,0 +1,44 @@
+﻿namespace NServiceBus.AcceptanceTests.Performance.MessageDurability
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using FakeTransport;
+    using NUnit.Framework;
+
+    public class When_disabling_durable_messages_on_durable_transport : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_throw_exception_at_startup()
+        {
+            var exception = Assert.ThrowsAsync<AggregateException>(() => Scenario.Define<Context>()
+                .WithEndpoint<EndpointDisablingDurableMessages>(c => c
+                    .When(e => e.SendLocal(new RegularMessage())))
+                .Done(c => c.EndpointsStarted)
+                .Run());
+
+            Assert.That(exception.InnerException.InnerException, Is.TypeOf<Exception>());
+            Assert.That(exception.InnerException.InnerException.Message, Does.Contain("The configured transport does not support non durable messages but you have configured some messages to be non durable"));
+        }
+
+        class Context : ScenarioContext
+        {
+        }
+
+        class EndpointDisablingDurableMessages : EndpointConfigurationBuilder
+        {
+            public EndpointDisablingDurableMessages()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.DisableDurableMessages();
+                    c.UseTransport<FakeTransport>();
+                });
+            }
+        }
+
+        class RegularMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_disabling_durable_messages_on_durable_transport.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_disabling_durable_messages_on_durable_transport.cs
@@ -18,7 +18,7 @@
                 .Run());
 
             Assert.That(exception.InnerException.InnerException, Is.TypeOf<Exception>());
-            Assert.That(exception.InnerException.InnerException.Message, Does.Contain("The configured transport does not support non-durable messages but you have configured some messages to be non-durable"));
+            Assert.That(exception.InnerException.InnerException.Message, Does.Contain("The configured transport does not support non-durable messages but some messages have been configured to be non-durable"));
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_disabling_durable_messages_on_durable_transport.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_disabling_durable_messages_on_durable_transport.cs
@@ -18,7 +18,7 @@
                 .Run());
 
             Assert.That(exception.InnerException.InnerException, Is.TypeOf<Exception>());
-            Assert.That(exception.InnerException.InnerException.Message, Does.Contain("The configured transport does not support non durable messages but you have configured some messages to be non durable"));
+            Assert.That(exception.InnerException.InnerException.Message, Does.Contain("The configured transport does not support non-durable messages but you have configured some messages to be non-durable"));
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_sending_a_non_durable_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_sending_a_non_durable_message.cs
@@ -16,7 +16,7 @@
                 .Done(c => c.WasCalled)
                 .Run(TimeSpan.FromSeconds(10));
 
-            Assert.IsTrue(context.NonDurabilityHeader, "Message should be flagged as non durable");
+            Assert.IsTrue(context.NonDurabilityHeader, "Message should be flagged as non-durable");
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_using_non_durable_messages_on_durable_only_transport.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_using_non_durable_messages_on_durable_only_transport.cs
@@ -9,7 +9,7 @@
     public class When_using_non_durable_messages_on_durable_only_transport : NServiceBusAcceptanceTest
     {
         [Test]
-        public void Should_throw_exception_at_startupe()
+        public void Should_throw_exception_at_startup()
         {
             var exception = Assert.ThrowsAsync<AggregateException>(() => Scenario.Define<Context>()
                 .WithEndpoint<EndpointUsingNonDurableMessage>(c => c
@@ -18,7 +18,7 @@
                 .Run());
 
             Assert.That(exception.InnerException.InnerException, Is.TypeOf<Exception>());
-            Assert.That(exception.InnerException.InnerException.Message, Does.Contain("The configured transport does not support non-durable messages but you have configured some messages to be non-durable"));
+            Assert.That(exception.InnerException.InnerException.Message, Does.Contain("The configured transport does not support non-durable messages but some messages have been configured to be non-durable"));
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_using_non_durable_messages_on_durable_only_transport.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_using_non_durable_messages_on_durable_only_transport.cs
@@ -1,0 +1,41 @@
+﻿namespace NServiceBus.AcceptanceTests.Performance.MessageDurability
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using FakeTransport;
+    using NUnit.Framework;
+
+    public class When_using_non_durable_messages_on_durable_only_transport : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_throw_exception_at_startupe()
+        {
+            var exception = Assert.ThrowsAsync<AggregateException>(() => Scenario.Define<Context>()
+                .WithEndpoint<EndpointUsingNonDurableMessage>(c => c
+                    .When(e => e.SendLocal(new NonDurableMessage())))
+                .Done(c => c.EndpointsStarted)
+                .Run());
+
+            Assert.That(exception.InnerException.InnerException, Is.TypeOf<Exception>());
+            Assert.That(exception.InnerException.InnerException.Message, Does.Contain("The configured transport does not support non durable messages but you have configured some messages to be non durable"));
+        }
+
+        class Context : ScenarioContext
+        {
+        }
+
+        class EndpointUsingNonDurableMessage : EndpointConfigurationBuilder
+        {
+            public EndpointUsingNonDurableMessage()
+            {
+                EndpointSetup<DefaultServer>(c => c.UseTransport<FakeTransport>());
+            }
+        }
+
+        [Express]
+        class NonDurableMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_using_non_durable_messages_on_durable_only_transport.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_using_non_durable_messages_on_durable_only_transport.cs
@@ -18,7 +18,7 @@
                 .Run());
 
             Assert.That(exception.InnerException.InnerException, Is.TypeOf<Exception>());
-            Assert.That(exception.InnerException.InnerException.Message, Does.Contain("The configured transport does not support non durable messages but you have configured some messages to be non durable"));
+            Assert.That(exception.InnerException.InnerException.Message, Does.Contain("The configured transport does not support non-durable messages but you have configured some messages to be non-durable"));
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.Core.Tests/Faults/AddExceptionHeadersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Faults/AddExceptionHeadersBehaviorTests.cs
@@ -30,9 +30,9 @@ namespace NServiceBus.Core.Tests
         static IFaultContext CreateContext(string messageId, string sourceQueue, Exception exception)
         {
             var context = new FaultContext(
-                new OutgoingMessage(messageId, new Dictionary<string, string>(), new byte[0]), 
-                sourceQueue, 
-                exception, 
+                new OutgoingMessage(messageId, new Dictionary<string, string>(), new byte[0]),
+                sourceQueue,
+                exception,
                 null);
 
             return context;

--- a/src/NServiceBus.Core/Headers.cs
+++ b/src/NServiceBus.Core/Headers.cs
@@ -229,7 +229,7 @@
         public const string TimeToBeReceived = "NServiceBus.TimeToBeReceived";
 
         /// <summary>
-        /// Indicates that the message was sent as a non durable message.
+        /// Indicates that the message was sent as a non-durable message.
         /// </summary>
         public const string NonDurableMessage = "NServiceBus.NonDurableMessage";
     }

--- a/src/NServiceBus.Core/Performance/MessageDurability/DetermineMessageDurabilityBehavior.cs
+++ b/src/NServiceBus.Core/Performance/MessageDurability/DetermineMessageDurabilityBehavior.cs
@@ -8,15 +8,14 @@ namespace NServiceBus
 
     class DetermineMessageDurabilityBehavior : Behavior<IOutgoingLogicalMessageContext>
     {
-        public DetermineMessageDurabilityBehavior(Dictionary<Type, bool> durabilitySettings)
+        public DetermineMessageDurabilityBehavior(HashSet<Type> nonDurableMessages)
         {
-            this.durabilitySettings = durabilitySettings;
+            this.nonDurableMessages = nonDurableMessages;
         }
 
         public override Task Invoke(IOutgoingLogicalMessageContext context, Func<Task> next)
         {
-            bool isDurable;
-            if (durabilitySettings.TryGetValue(context.Message.MessageType, out isDurable) && !isDurable)
+            if (nonDurableMessages.Contains(context.Message.MessageType))
             {
                 context.Extensions.AddDeliveryConstraint(new NonDurableDelivery());
 
@@ -26,6 +25,6 @@ namespace NServiceBus
             return next();
         }
 
-        Dictionary<Type, bool> durabilitySettings;
+        readonly HashSet<Type> nonDurableMessages;
     }
 }

--- a/src/NServiceBus.Core/Performance/MessageDurability/MessageDurabilityFeature.cs
+++ b/src/NServiceBus.Core/Performance/MessageDurability/MessageDurabilityFeature.cs
@@ -47,7 +47,7 @@
             {
                 if (!context.DoesTransportSupportConstraint<NonDurableDelivery>())
                 {
-                    throw new Exception("The configured transport does not support non-durable messages but you have configured some messages to be non-durable (e.g. by using the [Express] attribute). Make the messages durable or use a transport supporting non-durable messages.");
+                    throw new Exception("The configured transport does not support non-durable messages but some messages have been configured to be non-durable (e.g. by using the [Express] attribute). Make the messages durable, or use a transport supporting non-durable messages.");
                 }
 
                 context.Pipeline.Register(b => new DetermineMessageDurabilityBehavior(nonDurableMessages), "Adds the NonDurableDelivery constraint for messages that have requested to be delivered in non-durable mode");

--- a/src/NServiceBus.Core/Performance/MessageDurability/MessageDurabilityFeature.cs
+++ b/src/NServiceBus.Core/Performance/MessageDurability/MessageDurabilityFeature.cs
@@ -47,10 +47,10 @@
             {
                 if (!context.DoesTransportSupportConstraint<NonDurableDelivery>())
                 {
-                    throw new Exception("The configured transport does not support non durable messages but you have configured some messages to be non durable (e.g. by using the [Express] attribute). Make the non durable messages durable or use a transport supporting non durable messages.");
+                    throw new Exception("The configured transport does not support non-durable messages but you have configured some messages to be non-durable (e.g. by using the [Express] attribute). Make the messages durable or use a transport supporting non-durable messages.");
                 }
 
-                context.Pipeline.Register(b => new DetermineMessageDurabilityBehavior(nonDurableMessages), "Adds the NonDurableDelivery constraint for messages that have requested to be delivered in non durable mode");
+                context.Pipeline.Register(b => new DetermineMessageDurabilityBehavior(nonDurableMessages), "Adds the NonDurableDelivery constraint for messages that have requested to be delivered in non-durable mode");
             }
         }
     }

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
@@ -23,7 +23,8 @@ namespace NServiceBus
 
         public override IEnumerable<Type> DeliveryConstraints { get; } = new[]
         {
-            typeof(DiscardIfNotReceivedBefore)
+            typeof(DiscardIfNotReceivedBefore),
+            typeof(NonDurableDelivery)
         };
 
         public override TransportTransactionMode TransactionMode { get; } = TransportTransactionMode.TransactionScope;


### PR DESCRIPTION
Adds the missing `NonDurableDelivery` to the list of supported constraints for MSMQ transport.

fixes https://github.com/Particular/NServiceBus/issues/3236
also fixes  #3820 
@Particular/nservicebus-maintainers it seems like the `MessageDurabilityFeature` is enabled by default and does not check whether the transport actually supports non durable messages. I think we should either:
* disable the feature (and the behavior) when the transport does not support non durable delivery or
* throw an exception when a message is configured to be non durable but the transport doesn't support it

what do you think?