### PR TITLE
Distribution strategy per endpoint singleton

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2486,6 +2486,7 @@ namespace NServiceBus.Routing
     public class SingleInstanceRoundRobinDistributionStrategy : NServiceBus.Routing.DistributionStrategy
     {
         public SingleInstanceRoundRobinDistributionStrategy() { }
+        [System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(NServiceBus.Routing.SingleInstanceRoundRobinDistributionStrategy.<SelectDestination>d__0))]
         public override System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> SelectDestination(System.Collections.Generic.IList<NServiceBus.UnicastRoutingTarget> currentAllInstances) { }
     }
     public class UnicastAddressTag : NServiceBus.Routing.AddressTag

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -170,6 +170,7 @@
     <Compile Include="Routing\Routers\UnicastReplyRouterConnectorTests.cs" />
     <Compile Include="Routing\Routers\UnicastPublishRouterConnectorTests.cs" />
     <Compile Include="Routing\RoutingOptionExtensionsTests.cs" />
+    <Compile Include="Routing\RoutingPolicyTests.cs" />
     <Compile Include="Routing\RoutingToDispatchConnectorTests.cs" />
     <Compile Include="Routing\SingleInstanceRoundRobinDistributionStrategyTests.cs" />
     <Compile Include="Routing\SubscriptionRouterTests.cs" />

--- a/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
@@ -1,0 +1,46 @@
+namespace NServiceBus.Core.Tests.Routing
+{
+    using System.Collections.Generic;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class RoutingPolicyTests
+    {
+        [Test]
+        public void ShouldScopeDistributionToEndpointName()
+        {
+            var endpointA = "endpointA";
+            var policy = new DistributionPolicy();
+            var endpointAInstances = new[]
+            {
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointA, "1")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointA, "2")),
+            };
+
+            var endpointB = "endpointB";
+            var endpointBInstances = new[]
+            {
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointB, "1")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointB, "2")),
+            };
+
+            var result = new List<UnicastRoutingTarget>();
+            result.AddRange(InvokeDistributionStrategy(policy, endpointAInstances));
+            result.AddRange(InvokeDistributionStrategy(policy, endpointBInstances));
+            result.AddRange(InvokeDistributionStrategy(policy, endpointAInstances));
+            result.AddRange(InvokeDistributionStrategy(policy, endpointBInstances));
+
+            Assert.That(result.Count, Is.EqualTo(4));
+            Assert.That(result, Has.Exactly(1).EqualTo(endpointAInstances[0]));
+            Assert.That(result, Has.Exactly(1).EqualTo(endpointAInstances[1]));
+            Assert.That(result, Has.Exactly(1).EqualTo(endpointBInstances[0]));
+            Assert.That(result, Has.Exactly(1).EqualTo(endpointBInstances[1]));
+        }
+
+        static IEnumerable<UnicastRoutingTarget> InvokeDistributionStrategy(DistributionPolicy policy, UnicastRoutingTarget[] instances)
+        {
+            return policy.GetDistributionStrategy(instances[0].Endpoint).SelectDestination(instances);
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
@@ -47,52 +47,19 @@
 
             var result = new List<UnicastRoutingTarget>();
             result.AddRange(strategy.SelectDestination(instances));
-            Enumerable.Range(1, 2).Select(_ => strategy.SelectDestination(instances)).ToList();
             result.AddRange(strategy.SelectDestination(instances));
-            Enumerable.Range(1, 2).Select(_ => strategy.SelectDestination(instances)).ToList();
+            result.AddRange(strategy.SelectDestination(instances));
             result.AddRange(strategy.SelectDestination(instances));
 
-            Assert.That(result, Has.All.SameAs(result.First()));
-        }
-
-        [Test]
-        public void ShouldScopeDistributionToEndpointName()
-        {
-            var strategy = new SingleInstanceRoundRobinDistributionStrategy();
-
-            var endpointA = "endpointA";
-            var endpointAInstances = new[]
-            {
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointA, "1")),
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointA, "2")),
-            };
-
-            var endpointB = "endpointB";
-            var endpointBInstances = new[]
-            {
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointB, "1")),
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointB, "2")),
-            };
-
-            var result = new List<UnicastRoutingTarget>();
-            result.AddRange(strategy.SelectDestination(endpointAInstances));
-            result.AddRange(strategy.SelectDestination(endpointBInstances));
-            result.AddRange(strategy.SelectDestination(endpointAInstances));
-            result.AddRange(strategy.SelectDestination(endpointBInstances));
-
-            Assert.That(result.Count, Is.EqualTo(4));
-            Assert.That(result, Has.Exactly(1).EqualTo(endpointAInstances[0]));
-            Assert.That(result, Has.Exactly(1).EqualTo(endpointAInstances[1]));
-            Assert.That(result, Has.Exactly(1).EqualTo(endpointBInstances[0]));
-            Assert.That(result, Has.Exactly(1).EqualTo(endpointBInstances[1]));
+            Assert.That(result.Last(), Is.EqualTo(result.First()));
         }
 
         [Test]
         public void WhenNewInstancesAdded_ShouldIncludeAllInstancesInDistribution()
         {
+            var endpointName = "endpointA";
             var strategy = new SingleInstanceRoundRobinDistributionStrategy();
 
-            var endpointName = "endpointA";
             var instances = new List<UnicastRoutingTarget>
             {
                 UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "1")),

--- a/src/NServiceBus.Core/Routing/DistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionPolicy.cs
@@ -12,11 +12,20 @@ namespace NServiceBus
 
         public DistributionStrategy GetDistributionStrategy(string endpointName)
         {
+            //Following approch trades off absolute correctness for performance.
+            //There might be cases where two different strategies will be returned for a given endpoint but this is fine.
             DistributionStrategy configuredStrategy;
-            return configuredStrategies.TryGetValue(endpointName, out configuredStrategy) ? configuredStrategy : defaultStrategy;
+            if (configuredStrategies.TryGetValue(endpointName, out configuredStrategy))
+            {
+                return configuredStrategy;
+            }
+            var newConfiguredStrategies = new Dictionary<string, DistributionStrategy>(configuredStrategies);
+            var defaultStrategy = new SingleInstanceRoundRobinDistributionStrategy();
+            newConfiguredStrategies[endpointName] = defaultStrategy;
+            configuredStrategies = newConfiguredStrategies;
+            return defaultStrategy;
         }
 
         Dictionary<string, DistributionStrategy> configuredStrategies = new Dictionary<string, DistributionStrategy>();
-        DistributionStrategy defaultStrategy = new SingleInstanceRoundRobinDistributionStrategy();
     }
 }

--- a/src/NServiceBus.Core/Routing/DistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionPolicy.cs
@@ -15,7 +15,7 @@ namespace NServiceBus
             DistributionStrategy configuredStrategy;
             return configuredStrategies.TryGetValue(endpointName, out configuredStrategy) 
                 ? configuredStrategy 
-                : configuredStrategies.AddOrUpdate(endpointName, new SingleInstanceRoundRobinDistributionStrategy(), (e, strategy) => strategy);
+                : configuredStrategies.GetOrAdd(endpointName, key => new SingleInstanceRoundRobinDistributionStrategy());
         }
 
         ConcurrentDictionary<string, DistributionStrategy> configuredStrategies = new ConcurrentDictionary<string, DistributionStrategy>();

--- a/src/NServiceBus.Core/Routing/DistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionPolicy.cs
@@ -10,13 +10,7 @@ namespace NServiceBus
             configuredStrategies[endpointName] = distributionStrategy;
         }
 
-        public DistributionStrategy GetDistributionStrategy(string endpointName)
-        {
-            DistributionStrategy configuredStrategy;
-            return configuredStrategies.TryGetValue(endpointName, out configuredStrategy) 
-                ? configuredStrategy 
-                : configuredStrategies.GetOrAdd(endpointName, key => new SingleInstanceRoundRobinDistributionStrategy());
-        }
+        public DistributionStrategy GetDistributionStrategy(string endpointName) => configuredStrategies.GetOrAdd(endpointName, key => new SingleInstanceRoundRobinDistributionStrategy());
 
         ConcurrentDictionary<string, DistributionStrategy> configuredStrategies = new ConcurrentDictionary<string, DistributionStrategy>();
     }

--- a/src/NServiceBus.Core/Routing/SingleInstanceRoundRobinDistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/SingleInstanceRoundRobinDistributionStrategy.cs
@@ -17,8 +17,9 @@ namespace NServiceBus.Routing
             {
                 yield break;
             }
+            var result = currentAllInstances[(int)(index % currentAllInstances.Count)];
             Interlocked.Increment(ref index);
-            yield return currentAllInstances[(int) (index%currentAllInstances.Count)];
+            yield return result;
         }
 
         long index;


### PR DESCRIPTION
Replaces #3817 

Moved the responsibility for making strategy state per-endpoint based to the policy (from each strategy).