### PR TITLE
MsmqUtilities lazy load headerSerializer

### DIFF
--- a/src/NServiceBus.Core/Transports/Msmq/MsmqUtilities.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqUtilities.cs
@@ -104,7 +104,7 @@ namespace NServiceBus
                     CheckCharacters = false
                 }))
                 {
-                    o = headerSerializer.Deserialize(reader);
+                    o = GetHeaderSerializer().Deserialize(reader);
                 }
             }
 
@@ -158,7 +158,7 @@ namespace NServiceBus
                     });
                 }
 
-                headerSerializer.Serialize(stream, headers);
+                GetHeaderSerializer().Serialize(stream, headers);
                 result.Extension = stream.ToArray();
             }
 
@@ -296,7 +296,15 @@ namespace NServiceBus
         const string DIRECTPREFIX_TCP = "DIRECT=TCP:";
         internal const string PRIVATE = "\\private$\\";
 
-        static System.Xml.Serialization.XmlSerializer headerSerializer = new System.Xml.Serialization.XmlSerializer(typeof(List<HeaderInfo>));
+        static System.Xml.Serialization.XmlSerializer GetHeaderSerializer()
+        {
+            if (headerSerializer == null)
+                headerSerializer = new System.Xml.Serialization.XmlSerializer(typeof(List<HeaderInfo>));
+            return headerSerializer;
+        }
+
+        static System.Xml.Serialization.XmlSerializer headerSerializer;
         static ILog Logger = LogManager.GetLogger<MsmqUtilities>();
     }
+
 }


### PR DESCRIPTION
If we load the headerSerializer lazy we gain ~450ms on startup time using msmq.

![image](https://cloud.githubusercontent.com/assets/1522516/16007242/89038112-3171-11e6-84c5-ea958f9741c5.png)
