### PR TITLE
add more parameters to custom retry policy

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_custom_policy.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_custom_policy.cs
@@ -1,34 +1,41 @@
 ﻿namespace NServiceBus.AcceptanceTests.Recoverability.Retries
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
     using Transports;
+    using ErrorContext= System.Tuple<Transports.IncomingMessage, System.Exception, int>;
 
     public class When_performing_slr_with_custom_policy : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_expose_headers_to_policy()
+        public async Task Should_expose_error_context_to_policy()
         {
             var context = await Scenario.Define<Context>()
-                .WithEndpoint<Endpoint>(b => 
+                .WithEndpoint<Endpoint>(b =>
                     b.When(bus => bus.SendLocal(new MessageToBeRetried()))
                      .DoNotFailOnErrorMessages())
-                .Done(c => c.MessageMovedToErrorQueue)
+                .Done(c => c.FailedMessages.Any())
                 .Run();
 
-            Assert.That(context.FLRetriesHeaderAvailable, Is.True, "Could not find FLRetries header");
-            Assert.That(context.RetriesHeaderAvailable, Is.True, "Could not find Retries header");
+            Assert.That(context.HeaderValues.Count, Is.EqualTo(2), "because the custom policy should have been invoked twice");
+            Assert.That(context.HeaderValues[0].Item1, Is.Not.Null);
+            Assert.That(context.HeaderValues[0].Item2, Is.TypeOf<SimulatedException>());
+            Assert.That(context.HeaderValues[0].Item3, Is.EqualTo(1));
+            Assert.That(context.HeaderValues[1].Item1, Is.Not.Null);
+            Assert.That(context.HeaderValues[1].Item2, Is.TypeOf<SimulatedException>());
+            Assert.That(context.HeaderValues[1].Item3, Is.EqualTo(2));
         }
 
         class Context : ScenarioContext
         {
-            public bool FLRetriesHeaderAvailable { get; set; }
             public bool MessageMovedToErrorQueue { get; set; }
-            public bool RetriesHeaderAvailable { get; set; }
+            public List<ErrorContext> HeaderValues { get; set; } = new List<ErrorContext>();
         }
 
         class Endpoint : EndpointConfigurationBuilder
@@ -42,7 +49,6 @@
                     config.EnableFeature<TimeoutManager>();
                     config.EnableFeature<FirstLevelRetries>();
                     config.EnableFeature<SecondLevelRetries>();
-                    config.Notifications.Errors.MessageSentToErrorQueue += (sender, message) => { testContext.MessageMovedToErrorQueue = true; };
                     config.SecondLevelRetries().CustomRetryPolicy(new CustomPolicy(testContext).GetDelay);
                 });
             }
@@ -54,10 +60,9 @@
                     this.context = context;
                 }
 
-                public TimeSpan GetDelay(IncomingMessage msg)
+                public TimeSpan GetDelay(IncomingMessage msg, Exception exception, int retryAttempt)
                 {
-                    context.FLRetriesHeaderAvailable |= msg.Headers.ContainsKey(Headers.FLRetries);
-                    context.RetriesHeaderAvailable |= msg.Headers.ContainsKey(Headers.Retries);
+                    context.HeaderValues.Add(new ErrorContext(msg, exception, retryAttempt));
 
                     if (slrRetries++ == 1)
                     {

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_custom_policy.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_custom_policy.cs
@@ -21,19 +21,19 @@
                 .Done(c => c.FailedMessages.Any())
                 .Run();
 
-            Assert.That(context.HeaderValues.Count, Is.EqualTo(2), "because the custom policy should have been invoked twice");
-            Assert.That(context.HeaderValues[0].Message, Is.Not.Null);
-            Assert.That(context.HeaderValues[0].Exception, Is.TypeOf<SimulatedException>());
-            Assert.That(context.HeaderValues[0].SecondLevelRetryAttempt, Is.EqualTo(1));
-            Assert.That(context.HeaderValues[1].Message, Is.Not.Null);
-            Assert.That(context.HeaderValues[1].Exception, Is.TypeOf<SimulatedException>());
-            Assert.That(context.HeaderValues[1].SecondLevelRetryAttempt, Is.EqualTo(2));
+            Assert.That(context.SlrRetryContexts.Count, Is.EqualTo(2), "because the custom policy should have been invoked twice");
+            Assert.That(context.SlrRetryContexts[0].Message, Is.Not.Null);
+            Assert.That(context.SlrRetryContexts[0].Exception, Is.TypeOf<SimulatedException>());
+            Assert.That(context.SlrRetryContexts[0].SecondLevelRetryAttempt, Is.EqualTo(1));
+            Assert.That(context.SlrRetryContexts[1].Message, Is.Not.Null);
+            Assert.That(context.SlrRetryContexts[1].Exception, Is.TypeOf<SimulatedException>());
+            Assert.That(context.SlrRetryContexts[1].SecondLevelRetryAttempt, Is.EqualTo(2));
         }
 
         class Context : ScenarioContext
         {
             public bool MessageMovedToErrorQueue { get; set; }
-            public List<SecondLevelRetryContext> HeaderValues { get; } = new List<SecondLevelRetryContext>();
+            public List<SecondLevelRetryContext> SlrRetryContexts { get; } = new List<SecondLevelRetryContext>();
         }
 
         class Endpoint : EndpointConfigurationBuilder
@@ -60,7 +60,7 @@
 
                 public TimeSpan GetDelay(SecondLevelRetryContext slrRetryContext)
                 {
-                    context.HeaderValues.Add(slrRetryContext);
+                    context.SlrRetryContexts.Add(slrRetryContext);
 
                     if (slrRetries++ == 1)
                     {

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_min_policy.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_min_policy.cs
@@ -7,7 +7,6 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
     using Features;
     using NServiceBus.Config;
     using NUnit.Framework;
-    using Transports;
 
     public class When_performing_slr_with_min_policy : NServiceBusAcceptanceTest
     {
@@ -46,7 +45,7 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
                     .WithConfig<SecondLevelRetriesConfig>(c => c.TimeIncrease = TimeSpan.FromMilliseconds(1));
             }
 
-            static TimeSpan RetryPolicy(IncomingMessage transportMessage)
+            static TimeSpan RetryPolicy(SecondLevelRetryContext slrRetryContext)
             {
                 return TimeSpan.MinValue;
             }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_non_min_policy.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_non_min_policy.cs
@@ -7,7 +7,6 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
     using Features;
     using NServiceBus.Config;
     using NUnit.Framework;
-    using Transports;
 
     public class When_performing_slr_with_non_min_policy : NServiceBusAcceptanceTest
     {
@@ -46,7 +45,7 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
                     .WithConfig<SecondLevelRetriesConfig>(c => c.TimeIncrease = TimeSpan.FromMilliseconds(1));
             }
 
-            TimeSpan RetryPolicy(IncomingMessage transportMessage)
+            TimeSpan RetryPolicy(SecondLevelRetryContext slrRetryContext)
             {
                 if (count == 0)
                 {

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_non_min_policy.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_non_min_policy.cs
@@ -5,7 +5,6 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
     using AcceptanceTesting;
     using EndpointTemplates;
     using Features;
-    using NServiceBus.Config;
     using NUnit.Framework;
 
     public class When_performing_slr_with_non_min_policy : NServiceBusAcceptanceTest
@@ -41,8 +40,7 @@ namespace NServiceBus.AcceptanceTests.Recoverability.Retries
                     configure.EnableFeature<TimeoutManager>();
                     configure.SecondLevelRetries().CustomRetryPolicy(RetryPolicy);
                     configure.Notifications.Errors.MessageSentToErrorQueue += (sender, message) => { scenarioContext.MessageSentToErrorQueue = true; };
-                })
-                    .WithConfig<SecondLevelRetriesConfig>(c => c.TimeIncrease = TimeSpan.FromMilliseconds(1));
+                });
             }
 
             TimeSpan RetryPolicy(SecondLevelRetryContext slrRetryContext)

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2674,6 +2674,8 @@ namespace NServiceBus.SecondLevelRetries.Config
             "7.0.0.", true)]
         public void CustomRetryPolicy(System.Func<NServiceBus.TransportMessage, System.TimeSpan> customPolicy) { }
         public void CustomRetryPolicy(System.Func<NServiceBus.Transports.IncomingMessage, System.TimeSpan> customPolicy) { }
+        public void CustomRetryPolicy(System.Func<NServiceBus.Transports.IncomingMessage, System.Exception, System.TimeSpan> customPolicy) { }
+        public void CustomRetryPolicy(System.Func<NServiceBus.Transports.IncomingMessage, System.Exception, int, System.TimeSpan> customPolicy) { }
     }
 }
 namespace NServiceBus.Serialization

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -975,6 +975,13 @@ namespace NServiceBus
     {
         public static NServiceBus.SecondLevelRetries.Config.SecondLevelRetriesSettings SecondLevelRetries(this NServiceBus.EndpointConfiguration config) { }
     }
+    public class SecondLevelRetryContext
+    {
+        public SecondLevelRetryContext() { }
+        public System.Exception Exception { get; set; }
+        public NServiceBus.Transports.IncomingMessage Message { get; set; }
+        public int SecondLevelRetryAttempt { get; set; }
+    }
     public class SendOptions : NServiceBus.Extensibility.ExtendableOptions
     {
         public SendOptions() { }
@@ -2669,13 +2676,11 @@ namespace NServiceBus.SecondLevelRetries.Config
 {
     public class SecondLevelRetriesSettings
     {
-        [System.ObsoleteAttribute("Use `CustomRetryPolicy(Func<IncomingMessage, TimeSpan> customPolicy)` instead. Th" +
-            "e member currently throws a NotImplementedException. Will be removed in version " +
-            "7.0.0.", true)]
+        [System.ObsoleteAttribute("Use `CustomRetryPolicy(Func<SecondLevelRetryContext, TimeSpan> customPolicy)` ins" +
+            "tead. The member currently throws a NotImplementedException. Will be removed in " +
+            "version 7.0.0.", true)]
         public void CustomRetryPolicy(System.Func<NServiceBus.TransportMessage, System.TimeSpan> customPolicy) { }
-        public void CustomRetryPolicy(System.Func<NServiceBus.Transports.IncomingMessage, System.TimeSpan> customPolicy) { }
-        public void CustomRetryPolicy(System.Func<NServiceBus.Transports.IncomingMessage, System.Exception, System.TimeSpan> customPolicy) { }
-        public void CustomRetryPolicy(System.Func<NServiceBus.Transports.IncomingMessage, System.Exception, int, System.TimeSpan> customPolicy) { }
+        public void CustomRetryPolicy(System.Func<NServiceBus.SecondLevelRetryContext, System.TimeSpan> customPolicy) { }
     }
 }
 namespace NServiceBus.Serialization

--- a/src/NServiceBus.Core.Tests/Recoverability/SecondLevelRetries/DefaultRetryPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/SecondLevelRetries/DefaultRetryPolicyTests.cs
@@ -12,16 +12,17 @@
         [Test]
         public void ShouldRetryTheSpecifiedTimesWithIncreasedDelay()
         {
+            var message = new IncomingMessage("someid", new Dictionary<string, string>(), Stream.Null);
             var baseDelay = TimeSpan.FromSeconds(10);
 
             var policy = new DefaultSecondLevelRetryPolicy(2, baseDelay);
             TimeSpan delay;
 
-            Assert.True(policy.TryGetDelay(new IncomingMessage("someid", new Dictionary<string, string>(), Stream.Null), new Exception(""), 1, out delay));
+            Assert.True(policy.TryGetDelay(new SecondLevelRetryContext { Message = message, SecondLevelRetryAttempt = 1 }, out delay));
             Assert.AreEqual(baseDelay, delay);
-            Assert.True(policy.TryGetDelay(new IncomingMessage("someid", new Dictionary<string, string>(), Stream.Null), new Exception(""), 2, out delay));
+            Assert.True(policy.TryGetDelay(new SecondLevelRetryContext { Message = message, SecondLevelRetryAttempt = 2 }, out delay));
             Assert.AreEqual(TimeSpan.FromSeconds(20), delay);
-            Assert.False(policy.TryGetDelay(new IncomingMessage("someid", new Dictionary<string, string>(), Stream.Null), new Exception(""), 3, out delay));
+            Assert.False(policy.TryGetDelay(new SecondLevelRetryContext { Message = message, SecondLevelRetryAttempt = 3 }, out delay));
         }
 
         [Test]
@@ -38,8 +39,9 @@
             {
                 {Headers.RetriesTimestamp, DateTimeExtensions.ToWireFormattedString(moreThanADayAgo)}
             };
+            var message = new IncomingMessage("someid", headers, Stream.Null);
 
-            Assert.False(policy.TryGetDelay(new IncomingMessage("someid", headers, Stream.Null), new Exception(""), 1, out delay));
+            Assert.False(policy.TryGetDelay(new SecondLevelRetryContext { Message = message, SecondLevelRetryAttempt = 1 }, out delay));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Recoverability/When_message_is_deferred_by_slr.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/When_message_is_deferred_by_slr.cs
@@ -112,7 +112,7 @@
 
         class FakePolicy : SecondLevelRetryPolicy
         {
-            public override bool TryGetDelay(IncomingMessage message, Exception ex, int currentRetry, out TimeSpan delay)
+            public override bool TryGetDelay(SecondLevelRetryContext slrRetryContext, out TimeSpan delay)
             {
                 delay = TimeSpan.FromSeconds(10);
                 return true;
@@ -143,7 +143,7 @@
             public string MessageId => RoutingContext.Message.MessageId;
 
             public Dictionary<string, string> Headers => RoutingContext.Message.Headers;
-            
+
             public Task Invoke(IRoutingContext context)
             {
                 RoutingContext = context;

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Recoverability\Faults\MessageProcessingFailed.cs" />
     <Compile Include="Recoverability\Faults\MessageToBeRetried.cs" />
     <Compile Include="Recoverability\Faults\MessageFaulted.cs" />
+    <Compile Include="Recoverability\SecondLevelRetries\SecondLevelRetryContext.cs" />
     <Compile Include="ReleaseDateAttribute.cs" />
     <Compile Include="Recoverability\ProcessingFailureInfo.cs" />
     <Compile Include="Routing\RoutingMappingSettings.cs" />

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/Config/SecondLevelRetriesSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/Config/SecondLevelRetriesSettings.cs
@@ -28,7 +28,28 @@ namespace NServiceBus.SecondLevelRetries.Config
         /// <summary>
         /// Register a custom retry policy.
         /// </summary>
+        /// <param name="customPolicy">the function which is invoked on a failed message to determine the delay until the message is retried.</param>
         public void CustomRetryPolicy(Func<IncomingMessage, TimeSpan> customPolicy)
+        {
+            Guard.AgainstNull(nameof(customPolicy), customPolicy);
+            CustomRetryPolicy((message, exception, retryAttempt) => customPolicy(message));
+        }
+
+        /// <summary>
+        /// Register a custom retry policy. The callback receives the failed message and the exception.
+        /// </summary>
+        /// <param name="customPolicy">the function which is invoked on a failed message to determine the delay until the message is retried.</param>
+        public void CustomRetryPolicy(Func<IncomingMessage, Exception, TimeSpan> customPolicy)
+        {
+            Guard.AgainstNull(nameof(customPolicy), customPolicy);
+            CustomRetryPolicy((message, exception, retryAttempt) => customPolicy(message, exception));
+        }
+
+        /// <summary>
+        /// Register a custom retry policy. The callback receives the failed message, the exception and the current second level retry attempt.
+        /// </summary>
+        /// <param name="customPolicy">the function which is invoked on a failed message to determine the delay until the message is retried.</param>
+        public void CustomRetryPolicy(Func<IncomingMessage, Exception, int, TimeSpan> customPolicy)
         {
             Guard.AgainstNull(nameof(customPolicy), customPolicy);
             config.Settings.Set("SecondLevelRetries.RetryPolicy", customPolicy);

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/Config/SecondLevelRetriesSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/Config/SecondLevelRetriesSettings.cs
@@ -13,7 +13,7 @@ namespace NServiceBus.SecondLevelRetries.Config
         }
 
         /// <summary>
-        /// Register a custom retry policy.
+        /// Registers a custom retry policy.
         /// </summary>
         [ObsoleteEx(
             RemoveInVersion = "7.0",
@@ -25,9 +25,9 @@ namespace NServiceBus.SecondLevelRetries.Config
         }
 
         /// <summary>
-        /// Register a custom retry policy. The callback receives the failed message, the exception and the current second level retry attempt.
+        /// Registers a custom retry policy. The callback receives the failed message, the exception, and the current second level retry attempt.
         /// </summary>
-        /// <param name="customPolicy">the function which is invoked on a failed message to determine the delay until the message is retried.</param>
+        /// <param name="customPolicy">The function that is invoked on a failed message to determine the delay until the message is retried.</param>
         public void CustomRetryPolicy(Func<SecondLevelRetryContext, TimeSpan> customPolicy)
         {
             Guard.AgainstNull(nameof(customPolicy), customPolicy);

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/Config/SecondLevelRetriesSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/Config/SecondLevelRetriesSettings.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.SecondLevelRetries.Config
 {
     using System;
-    using Transports;
 
     /// <summary>
     /// Configuration settings for second level retries.
@@ -19,37 +18,17 @@ namespace NServiceBus.SecondLevelRetries.Config
         [ObsoleteEx(
             RemoveInVersion = "7.0",
             TreatAsErrorFromVersion = "6.0",
-            ReplacementTypeOrMember = "CustomRetryPolicy(Func<IncomingMessage, TimeSpan> customPolicy)")]
+            ReplacementTypeOrMember = "CustomRetryPolicy(Func<SecondLevelRetryContext, TimeSpan> customPolicy)")]
         public void CustomRetryPolicy(Func<TransportMessage, TimeSpan> customPolicy)
         {
             throw new NotImplementedException();
         }
 
         /// <summary>
-        /// Register a custom retry policy.
-        /// </summary>
-        /// <param name="customPolicy">the function which is invoked on a failed message to determine the delay until the message is retried.</param>
-        public void CustomRetryPolicy(Func<IncomingMessage, TimeSpan> customPolicy)
-        {
-            Guard.AgainstNull(nameof(customPolicy), customPolicy);
-            CustomRetryPolicy((message, exception, retryAttempt) => customPolicy(message));
-        }
-
-        /// <summary>
-        /// Register a custom retry policy. The callback receives the failed message and the exception.
-        /// </summary>
-        /// <param name="customPolicy">the function which is invoked on a failed message to determine the delay until the message is retried.</param>
-        public void CustomRetryPolicy(Func<IncomingMessage, Exception, TimeSpan> customPolicy)
-        {
-            Guard.AgainstNull(nameof(customPolicy), customPolicy);
-            CustomRetryPolicy((message, exception, retryAttempt) => customPolicy(message, exception));
-        }
-
-        /// <summary>
         /// Register a custom retry policy. The callback receives the failed message, the exception and the current second level retry attempt.
         /// </summary>
         /// <param name="customPolicy">the function which is invoked on a failed message to determine the delay until the message is retried.</param>
-        public void CustomRetryPolicy(Func<IncomingMessage, Exception, int, TimeSpan> customPolicy)
+        public void CustomRetryPolicy(Func<SecondLevelRetryContext, TimeSpan> customPolicy)
         {
             Guard.AgainstNull(nameof(customPolicy), customPolicy);
             config.Settings.Set("SecondLevelRetries.RetryPolicy", customPolicy);

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/CustomSecondLevelRetryPolicy.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/CustomSecondLevelRetryPolicy.cs
@@ -1,22 +1,20 @@
 namespace NServiceBus
 {
     using System;
-    using Transports;
 
     class CustomSecondLevelRetryPolicy : SecondLevelRetryPolicy
     {
-        public CustomSecondLevelRetryPolicy(Func<IncomingMessage, Exception, int, TimeSpan> customRetryPolicy)
+        public CustomSecondLevelRetryPolicy(Func<SecondLevelRetryContext, TimeSpan> customRetryPolicy)
         {
             this.customRetryPolicy = customRetryPolicy;
         }
 
-        public override bool TryGetDelay(IncomingMessage message, Exception ex, int currentRetry, out TimeSpan delay)
+        Func<SecondLevelRetryContext, TimeSpan> customRetryPolicy;
+        public override bool TryGetDelay(SecondLevelRetryContext slrRetryContext, out TimeSpan delay)
         {
-            delay = customRetryPolicy(message, ex, currentRetry);
+            delay = customRetryPolicy(slrRetryContext);
 
             return delay != TimeSpan.MinValue;
         }
-
-        Func<IncomingMessage, Exception, int, TimeSpan> customRetryPolicy;
     }
 }

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/CustomSecondLevelRetryPolicy.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/CustomSecondLevelRetryPolicy.cs
@@ -5,18 +5,18 @@ namespace NServiceBus
 
     class CustomSecondLevelRetryPolicy : SecondLevelRetryPolicy
     {
-        public CustomSecondLevelRetryPolicy(Func<IncomingMessage, TimeSpan> customRetryPolicy)
+        public CustomSecondLevelRetryPolicy(Func<IncomingMessage, Exception, int, TimeSpan> customRetryPolicy)
         {
             this.customRetryPolicy = customRetryPolicy;
         }
 
         public override bool TryGetDelay(IncomingMessage message, Exception ex, int currentRetry, out TimeSpan delay)
         {
-            delay = customRetryPolicy(message);
+            delay = customRetryPolicy(message, ex, currentRetry);
 
             return delay != TimeSpan.MinValue;
         }
 
-        Func<IncomingMessage, TimeSpan> customRetryPolicy;
+        Func<IncomingMessage, Exception, int, TimeSpan> customRetryPolicy;
     }
 }

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/CustomSecondLevelRetryPolicy.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/CustomSecondLevelRetryPolicy.cs
@@ -9,12 +9,13 @@ namespace NServiceBus
             this.customRetryPolicy = customRetryPolicy;
         }
 
-        Func<SecondLevelRetryContext, TimeSpan> customRetryPolicy;
         public override bool TryGetDelay(SecondLevelRetryContext slrRetryContext, out TimeSpan delay)
         {
             delay = customRetryPolicy(slrRetryContext);
 
             return delay != TimeSpan.MinValue;
         }
+
+        Func<SecondLevelRetryContext, TimeSpan> customRetryPolicy;
     }
 }

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetries.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetries.cs
@@ -58,7 +58,7 @@ namespace NServiceBus.Features
 
         static SecondLevelRetryPolicy GetRetryPolicy(ReadOnlySettings settings)
         {
-            var customRetryPolicy = settings.GetOrDefault<Func<IncomingMessage, TimeSpan>>("SecondLevelRetries.RetryPolicy");
+            var customRetryPolicy = settings.GetOrDefault<Func<IncomingMessage, Exception, int, TimeSpan>>("SecondLevelRetries.RetryPolicy");
 
             if (customRetryPolicy != null)
             {

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetries.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetries.cs
@@ -4,7 +4,6 @@ namespace NServiceBus.Features
     using Config;
     using ConsistencyGuarantees;
     using Settings;
-    using Transports;
 
     /// <summary>
     /// Used to configure Second Level Retries.
@@ -58,7 +57,7 @@ namespace NServiceBus.Features
 
         static SecondLevelRetryPolicy GetRetryPolicy(ReadOnlySettings settings)
         {
-            var customRetryPolicy = settings.GetOrDefault<Func<IncomingMessage, Exception, int, TimeSpan>>("SecondLevelRetries.RetryPolicy");
+            var customRetryPolicy = settings.GetOrDefault<Func<SecondLevelRetryContext, TimeSpan>>("SecondLevelRetries.RetryPolicy");
 
             if (customRetryPolicy != null)
             {

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetriesBehavior.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetriesBehavior.cs
@@ -55,7 +55,7 @@
 
             TimeSpan delay;
 
-            if (retryPolicy.TryGetDelay(message, failureInfo.Exception, currentRetry, out delay))
+            if (retryPolicy.TryGetDelay(new SecondLevelRetryContext { Message = message, Exception = failureInfo.Exception, SecondLevelRetryAttempt = currentRetry }, out delay))
             {
                 message.RevertToOriginalBodyIfNeeded();
                 var messageToRetry = new OutgoingMessage(message.MessageId, message.Headers, message.Body);

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetryContext.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetryContext.cs
@@ -1,0 +1,26 @@
+namespace NServiceBus
+{
+    using System;
+    using Transports;
+
+    /// <summary>
+    /// Contains information available for custom second level retry policies.
+    /// </summary>
+    public class SecondLevelRetryContext
+    {
+        /// <summary>
+        /// The message which failed to process.
+        /// </summary>
+        public IncomingMessage Message { get; set; }
+
+        /// <summary>
+        /// The occured exception.
+        /// </summary>
+        public Exception Exception { get; set; }
+
+        /// <summary>
+        /// The current second level retry attempt.
+        /// </summary>
+        public int SecondLevelRetryAttempt { get; set; }
+    }
+}

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetryContext.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetryContext.cs
@@ -9,12 +9,12 @@ namespace NServiceBus
     public class SecondLevelRetryContext
     {
         /// <summary>
-        /// The message which failed to process.
+        /// The message that failed to process.
         /// </summary>
         public IncomingMessage Message { get; set; }
 
         /// <summary>
-        /// The occured exception.
+        /// The exception that occurred.
         /// </summary>
         public Exception Exception { get; set; }
 

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetryPolicy.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetryPolicy.cs
@@ -1,10 +1,9 @@
 namespace NServiceBus
 {
     using System;
-    using Transports;
 
     abstract class SecondLevelRetryPolicy
     {
-        public abstract bool TryGetDelay(IncomingMessage message, Exception ex, int currentRetry, out TimeSpan delay);
+        public abstract bool TryGetDelay(SecondLevelRetryContext slrRetryContext, out TimeSpan delay);
     }
 }


### PR DESCRIPTION
fixes https://github.com/Particular/NServiceBus/issues/3831 by adding additional overloads for the custom retry policy which also grants access to the causing exception and the retry attempt.

There are now 3 overloads available:
* `Func<IncomingMessage, TimeSpan> customPolicy`
* `Func<IncomingMessage, Exception, TimeSpan> customPolicy`
* `Func<IncomingMessage, Exception, int, TimeSpan> customPolicy`

I made one only using the exception with the int parameter because I think the int value not very intuitive (should probably a custom type called `SlrRetryAttempt` to make more sense).

Also fixed the acceptance test which missed that bug all the time.

@Particular/nservicebus-maintainers @mauroservienti please review

docs PR: https://github.com/Particular/docs.particular.net/pull/1602