### PR TITLE
Tracking unhandled failed messages before endpoint shutdown.

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
@@ -29,6 +29,8 @@
 
         internal LogLevel LogLevel { get; set; } = LogLevel.Info;
 
+        internal ConcurrentDictionary<string, int> UnfinishedFailedMessages = new ConcurrentDictionary<string, int>();
+
         public void SetLogLevel(LogLevel level)
         {
             LogLevel = level;

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -113,7 +113,7 @@
                     await Task.Run(async () =>
                     {
                         var executedWhens = new List<Guid>();
-                        
+
                         while (!token.IsCancellationRequested)
                         {
                             if (executedWhens.Count == behavior.Whens.Count)

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_custom_policy.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_custom_policy.cs
@@ -14,7 +14,7 @@
         public async Task Should_expose_headers_to_policy()
         {
             var context = await Scenario.Define<Context>()
-                .WithEndpoint<Endpoint>(b => 
+                .WithEndpoint<Endpoint>(b =>
                     b.When(bus => bus.SendLocal(new MessageToBeRetried()))
                      .DoNotFailOnErrorMessages())
                 .Done(c => c.MessageMovedToErrorQueue)

--- a/src/NServiceBus.Core/Transports/TransportReceiver.cs
+++ b/src/NServiceBus.Core/Transports/TransportReceiver.cs
@@ -68,7 +68,7 @@ namespace NServiceBus
             using (var childBuilder = builder.CreateChildBuilder())
             {
                 var rootContext = new RootContext(childBuilder, pipelineCache, eventAggregator);
-                
+
                 var message = new IncomingMessage(pushContext.MessageId, pushContext.Headers, pushContext.BodyStream);
                 var context = new TransportReceiveContext(message, pushContext.TransportTransaction, pushContext.ReceiveCancellationTokenSource, rootContext);
 


### PR DESCRIPTION
Connects to Particular/PlatformDevelopment#832

With the change of the pipeline/transport seam the acceptance test can no longer "inject" `CaptureExceptionBehavior ` between retries and the error queue handling to intercept & track failed messages. Therefore we need another approach. I can currently come up with two solutions:
* Solely listen to the events raised by FLR/SLR/ErrorQ and fail the test if a `MessageFailed` event is raised (message moved to the errorqueue). This has the disadvantage of possible race conditions since the event may only be fired after the message is consumed the second time (in transactional scenarios) and we may miss that because tests can stop the endpoint before if the done condition is already met, resulting in us not reliably detecting failed messages.
* Tracking failed messages very early in the pipeline and then correlating those failed messages with events from the notifications API. Since every failed message should be handled by either FLR, SLR or the ErrorQ, we can delay endpoint shutdown until we know that all failed messages are handled by one of the recoverability steps.

This spike explores option2.