### PR TITLE
PerformanceMonitorUsersInstaller info message

### DIFF
--- a/src/NServiceBus.Core/Performance/Counters/PerformanceMonitorUsersInstaller.cs
+++ b/src/NServiceBus.Core/Performance/Counters/PerformanceMonitorUsersInstaller.cs
@@ -29,7 +29,7 @@ namespace NServiceBus
             {
                 if (!ElevateChecker.IsCurrentUserElevated())
                 {
-                    logger.InfoFormat(@"Did not attempt to add user '{0}' to group '{1}' since process is not running with elevate privileges. Processing will continue. To manually perform this action run the following command from an admin console:
+                    logger.InfoFormat(@"Did not attempt to add user '{0}' to group '{1}' since the process is not running with elevated privileges. Processing will continue. To manually perform this action, run the following command from an admin console:
 net localgroup ""{1}"" ""{0}"" /add", identity, builtinPerformanceMonitoringUsersName);
                     return TaskEx.CompletedTask;
                 }


### PR DESCRIPTION
Basic grammar in a message that shows up regularly when developing locally.

@Particular/nservicebus-maintainers should be an easy review.