### PR TITLE
Copy headers when auditing.

### DIFF
--- a/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Pipeline;
     using Transports;
@@ -18,7 +19,7 @@
 
             context.Message.RevertToOriginalBodyIfNeeded();
 
-            var processedMessage = new OutgoingMessage(context.Message.MessageId, context.Message.Headers, context.Message.Body);
+            var processedMessage = new OutgoingMessage(context.Message.MessageId, new Dictionary<string, string>(context.Message.Headers), context.Message.Body);
 
             var auditContext = this.CreateAuditContext(processedMessage, auditAddress, context);
 


### PR DESCRIPTION
Otherwise any modification of header in the audit pipe affect the `IncomingMessage` as well which comes as a nasty surprise to behaviors which do processing after calling `next()`