### PR TITLE
Fix XmlSerializer config

### DIFF
--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
@@ -8,7 +8,7 @@
     using Configuration.AdvanceExtensibility;
     using Features;
     using NServiceBus.Config.ConfigurationSource;
-    using Serialization;
+    using NServiceBus.Serialization;
 
     public class DefaultServer : IEndpointSetupTemplate
     {

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
     <Compile Include="Basic\When_depending_on_untyped_feature.cs" />
     <Compile Include="Basic\When_extending_behavior_context.cs" />
+    <Compile Include="Serialization\When_configuring_custom_xml_namespace.cs" />
     <Compile Include="Serialization\When_registering_additional_deserializers.cs" />
     <Compile Include="Basic\When_no_content_type.cs" />
     <Compile Include="Basic\When_registering_handlers_explicitly.cs" />

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -166,6 +166,7 @@
     <Compile Include="Satellites\When_a_message_is_available.cs" />
     <Compile Include="Serialization\When_sanitizing_xml_messages.cs" />
     <Compile Include="Serialization\When_skip_wrapping_xml.cs" />
+    <Compile Include="Serialization\When_wrapping_is_not_skipped.cs" />
     <Compile Include="UnicastPubSubExtensions.cs" />
     <Compile Include="Routing\When_multi_subscribing_to_a_polymorphic_event_on_multicast_transports.cs" />
     <Compile Include="Routing\When_handler_exists_but_routing_information_is_missing.cs" />

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -57,7 +57,7 @@
   <ItemGroup>
     <Compile Include="Basic\When_depending_on_untyped_feature.cs" />
     <Compile Include="Basic\When_extending_behavior_context.cs" />
-    <Compile Include="Basic\When_registering_additional_deserializers.cs" />
+    <Compile Include="Serialization\When_registering_additional_deserializers.cs" />
     <Compile Include="Basic\When_no_content_type.cs" />
     <Compile Include="Basic\When_registering_handlers_explicitly.cs" />
     <Compile Include="Causation\When_a_message_is_faulted.cs" />
@@ -133,7 +133,7 @@
     <Compile Include="Performance\When_message_is_audited.cs" />
     <Compile Include="Basic\When_receiving_with_catch_all_handlers_registered.cs" />
     <Compile Include="Basic\When_handling_message_with_several_messagehandlers.cs" />
-    <Compile Include="Basic\When_registering_custom_serializer.cs" />
+    <Compile Include="Serialization\When_registering_custom_serializer.cs" />
     <Compile Include="ApiExtension\When_extending_sendoptions.cs" />
     <Compile Include="Basic\When_sending_with_conventions.cs" />
     <Compile Include="Basic\When_sending_from_a_send_only.cs" />

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -164,6 +164,8 @@
     <Compile Include="Routing\SubscriptionBehaviorExtensions.cs" />
     <Compile Include="Sagas\When_saga_handles_unmapped_message.cs" />
     <Compile Include="Satellites\When_a_message_is_available.cs" />
+    <Compile Include="Serialization\When_sanitizing_xml_messages.cs" />
+    <Compile Include="Serialization\When_skip_wrapping_xml.cs" />
     <Compile Include="UnicastPubSubExtensions.cs" />
     <Compile Include="Routing\When_multi_subscribing_to_a_polymorphic_event_on_multicast_transports.cs" />
     <Compile Include="Routing\When_handler_exists_but_routing_information_is_missing.cs" />

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_configuring_custom_xml_namespace.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_configuring_custom_xml_namespace.cs
@@ -13,7 +13,7 @@
         const string CustomXmlNamespace = "http://particular.net";
 
         [Test]
-        public async Task Should_use_namespace_in_messages()
+        public async Task Should_use_as_root_namespace_in_messages()
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointUsingCustomNamespace>(e => e
@@ -21,7 +21,7 @@
                 .Done(c => c.MessageReceived)
                 .Run();
 
-            Assert.AreEqual(CustomXmlNamespace, context.MessageNamespace);
+            Assert.AreEqual($"{CustomXmlNamespace}/{typeof(SimpleMessage).Namespace}", context.MessageNamespace);
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_configuring_custom_xml_namespace.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_configuring_custom_xml_namespace.cs
@@ -1,0 +1,83 @@
+﻿namespace NServiceBus.AcceptanceTests.Serialization
+{
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Xml.Linq;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class When_configuring_custom_xml_namespace : NServiceBusAcceptanceTest
+    {
+        const string CustomXmlNamespace = "http://particular.net";
+
+        [Test]
+        public async Task Should_use_namespace_in_messages()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointUsingCustomNamespace>(e => e
+                    .When(session => session.SendLocal(new SimpleMessage())))
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            Assert.AreEqual(CustomXmlNamespace, context.MessageNamespace);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool MessageReceived { get; set; }
+            public string MessageNamespace { get; set; }
+        }
+
+        class EndpointUsingCustomNamespace : EndpointConfigurationBuilder
+        {
+            public EndpointUsingCustomNamespace()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseSerialization<XmlSerializer>().Namespace(CustomXmlNamespace);
+                    c.RegisterComponents(r => r.ConfigureComponent<IncomingMutator>(DependencyLifecycle.SingleInstance));
+                });
+            }
+
+            class SimpleMessageHandler : IHandleMessages<SimpleMessage>
+            {
+                public SimpleMessageHandler(Context scenarioContext)
+                {
+                    this.scenarioContext = scenarioContext;
+                }
+
+                public Task Handle(SimpleMessage message, IMessageHandlerContext context)
+                {
+                    scenarioContext.MessageReceived = true;
+                    return Task.FromResult(0);
+                }
+
+                Context scenarioContext;
+            }
+
+            public class IncomingMutator : IMutateIncomingTransportMessages
+            {
+                public IncomingMutator(Context scenarioContext)
+                {
+                    this.scenarioContext = scenarioContext;
+                }
+
+                public Task MutateIncoming(MutateIncomingTransportMessageContext context)
+                {
+                    var document = XDocument.Parse(Encoding.UTF8.GetString(context.Body));
+                    var defaultNamespace = document.Root?.GetDefaultNamespace();
+                    scenarioContext.MessageNamespace = defaultNamespace?.NamespaceName;
+                    return Task.FromResult(0);
+                }
+
+                Context scenarioContext;
+            }
+        }
+
+        class SimpleMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_registering_additional_deserializers.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_registering_additional_deserializers.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.Basic
+﻿namespace NServiceBus.AcceptanceTests.Serialization
 {
     using System;
     using System.Collections.Generic;
@@ -8,8 +8,8 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using MessageInterfaces;
+    using NServiceBus.Serialization;
     using NUnit.Framework;
-    using Serialization;
     using Settings;
 
     public class When_registering_additional_deserializers : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_registering_custom_serializer.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_registering_custom_serializer.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.Basic
+﻿namespace NServiceBus.AcceptanceTests.Serialization
 {
     using System;
     using System.Collections.Generic;
@@ -8,8 +8,8 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using MessageInterfaces;
+    using NServiceBus.Serialization;
     using NUnit.Framework;
-    using Serialization;
     using Settings;
 
     public class When_registering_custom_serializer : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_sanitizing_xml_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_sanitizing_xml_messages.cs
@@ -1,0 +1,85 @@
+﻿namespace NServiceBus.AcceptanceTests.Serialization
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class When_sanitizing_xml_messages : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_sanitize_illegal_characters_from_messages()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointSanitizingInput>(e => e
+                    .When(session => session.SendLocal(new SimpleMessage {Value = "Hello World!"})))
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            Assert.That(context.Input, Is.EqualTo("Hello World!"));
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool MessageReceived { get; set; }
+            public string Input { get; set; }
+        }
+
+        class EndpointSanitizingInput : EndpointConfigurationBuilder
+        {
+            public EndpointSanitizingInput()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseSerialization<XmlSerializer>().SanitizeInput();
+                    c.RegisterComponents(r => r.ConfigureComponent<IncomingMutator>(DependencyLifecycle.SingleInstance));
+                });
+            }
+
+            class SimpleMessageHandler : IHandleMessages<SimpleMessage>
+            {
+                public SimpleMessageHandler(Context scenarioContext)
+                {
+                    this.scenarioContext = scenarioContext;
+                }
+
+                public Task Handle(SimpleMessage message, IMessageHandlerContext context)
+                {
+                    scenarioContext.MessageReceived = true;
+                    scenarioContext.Input = message.Value;
+
+                    return Task.FromResult(0);
+                }
+
+                Context scenarioContext;
+            }
+
+            public class IncomingMutator : IMutateIncomingTransportMessages
+            {
+                public IncomingMutator(Context scenarioContext)
+                {
+                    this.scenarioContext = scenarioContext;
+                }
+
+                public Task MutateIncoming(MutateIncomingTransportMessageContext context)
+                {
+                    //TODO: add illegal character to body content
+//                    var body = Encoding.UTF8.GetString(context.Body);
+//                    char x = \u10FFFF;
+//
+//                    context.Body = Encoding.UTF8.GetBytes(invalidXmlContext);
+
+                    return Task.FromResult(0);
+                }
+
+                Context scenarioContext;
+            }
+        }
+
+        class SimpleMessage : ICommand
+        {
+            public string Value { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_sanitizing_xml_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_sanitizing_xml_messages.cs
@@ -14,7 +14,10 @@
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointSanitizingInput>(e => e
-                    .When(session => session.SendLocal(new SimpleMessage {Value = "Hello World!"})))
+                    .When(session => session.SendLocal(new SimpleMessage
+                    {
+                        Value = "Hello World!"
+                    })))
                 .Done(c => c.MessageReceived)
                 .Run();
 

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_sanitizing_xml_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_sanitizing_xml_messages.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Serialization
 {
+    using System.Text;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -9,7 +10,7 @@
     public class When_sanitizing_xml_messages : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_sanitize_illegal_characters_from_messages()
+        public async Task Should_remove_illegal_characters_from_messages()
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointSanitizingInput>(e => e
@@ -64,11 +65,10 @@
 
                 public Task MutateIncoming(MutateIncomingTransportMessageContext context)
                 {
-                    //TODO: add illegal character to body content
-//                    var body = Encoding.UTF8.GetString(context.Body);
-//                    char x = \u10FFFF;
-//
-//                    context.Body = Encoding.UTF8.GetBytes(invalidXmlContext);
+                    var body = Encoding.UTF8.GetString(context.Body);
+                    var invalidChar = char.ConvertFromUtf32(0x8);
+
+                    context.Body = Encoding.UTF8.GetBytes(body.Replace("Hello World!", $"{invalidChar}Hello {invalidChar}World!{invalidChar}"));
 
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_skip_wrapping_xml.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_skip_wrapping_xml.cs
@@ -1,0 +1,92 @@
+﻿namespace NServiceBus.AcceptanceTests.Serialization
+{
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Xml.Linq;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class When_skip_wrapping_xml : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_not_wrap_xml_content()
+        {
+            XNamespace ns = "demoNamepsace";
+            var xmlContent = new XDocument(new XElement(ns + "Document", new XElement(ns + "Value", "content")));
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<NonWrappingEndpoint>(e => e
+                    .When(session => session.SendLocal(new MessageWithRawXml { Document = xmlContent })))
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            Assert.That(context.XmlPropertyValue.ToString(), Is.EqualTo(xmlContent.ToString()));
+            Assert.That(context.XmlMessage.Root.Name.LocalName, Is.EqualTo(nameof(MessageWithRawXml)));
+            Assert.That(context.XmlMessage.Root.Elements().Single().ToString(), Is.EqualTo(xmlContent.ToString()));
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool MessageReceived { get; set; }
+
+            public XDocument XmlMessage { get; set; }
+
+            public XDocument XmlPropertyValue { get; set; }
+        }
+
+        class NonWrappingEndpoint : EndpointConfigurationBuilder
+        {
+            public NonWrappingEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseSerialization<XmlSerializer>().DontWrapRawXml();
+                    c.RegisterComponents(r => r.ConfigureComponent<IncomingMutator>(DependencyLifecycle.SingleInstance));
+                });
+            }
+
+            class RawXmlMessageHandler : IHandleMessages<MessageWithRawXml>
+            {
+                public RawXmlMessageHandler(Context scenarioContext)
+                {
+                    this.scenarioContext = scenarioContext;
+                }
+
+                public Task Handle(MessageWithRawXml messageWithRawXml, IMessageHandlerContext context)
+                {
+                    scenarioContext.MessageReceived = true;
+                    scenarioContext.XmlPropertyValue = messageWithRawXml.Document;
+
+                    return Task.FromResult(0);
+                }
+
+                Context scenarioContext;
+            }
+
+            public class IncomingMutator : IMutateIncomingTransportMessages
+            {
+                public IncomingMutator(Context scenarioContext)
+                {
+                    this.scenarioContext = scenarioContext;
+                }
+
+                public Task MutateIncoming(MutateIncomingTransportMessageContext context)
+                {
+                    scenarioContext.XmlMessage = XDocument.Parse(Encoding.UTF8.GetString(context.Body));
+
+                    return Task.FromResult(0);
+                }
+
+                Context scenarioContext;
+            }
+        }
+
+        class MessageWithRawXml : ICommand
+        {
+            public XDocument Document { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_wrapping_is_not_skipped.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_wrapping_is_not_skipped.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus.AcceptanceTests.Serialization
+{
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Xml.Linq;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class When_wrapping_is_not_skipped : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_wrap_xml_content()
+        {
+            XNamespace ns = "demoNamepsace";
+            var xmlContent = new XDocument(new XElement(ns + "Document", new XElement(ns + "Value", "content")));
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<WrappingEndpoint>(e => e
+                    .When(session => session.SendLocal(new MessageWithRawXml { Document = xmlContent })))
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            Assert.That(context.XmlPropertyValue.ToString(), Is.EqualTo(xmlContent.ToString()));
+            Assert.That(context.XmlMessage.Root.Name.LocalName, Is.EqualTo(nameof(MessageWithRawXml)));
+            Assert.That(context.XmlMessage.Root.Elements().Single().Name.LocalName, Is.EqualTo("Document"));
+            Assert.That(context.XmlMessage.Root.Elements().Single().Elements().Single().Name.LocalName, Is.EqualTo("Document"));
+            Assert.That(context.XmlMessage.Root.Elements().Single().Elements().Single().ToString(), Is.EqualTo(xmlContent.ToString()));
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool MessageReceived { get; set; }
+
+            public XDocument XmlMessage { get; set; }
+
+            public XDocument XmlPropertyValue { get; set; }
+        }
+
+        class WrappingEndpoint : EndpointConfigurationBuilder
+        {
+            public WrappingEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseSerialization<XmlSerializer>(); // wrapping is enabled by default
+                    c.RegisterComponents(r => r.ConfigureComponent<IncomingMutator>(DependencyLifecycle.SingleInstance));
+                });
+            }
+
+            class RawXmlMessageHandler : IHandleMessages<MessageWithRawXml>
+            {
+                public RawXmlMessageHandler(Context scenarioContext)
+                {
+                    this.scenarioContext = scenarioContext;
+                }
+
+                public Task Handle(MessageWithRawXml messageWithRawXml, IMessageHandlerContext context)
+                {
+                    scenarioContext.MessageReceived = true;
+                    scenarioContext.XmlPropertyValue = messageWithRawXml.Document;
+
+                    return Task.FromResult(0);
+                }
+
+                Context scenarioContext;
+            }
+
+            public class IncomingMutator : IMutateIncomingTransportMessages
+            {
+                public IncomingMutator(Context scenarioContext)
+                {
+                    this.scenarioContext = scenarioContext;
+                }
+
+                public Task MutateIncoming(MutateIncomingTransportMessageContext context)
+                {
+                    scenarioContext.XmlMessage = XDocument.Parse(Encoding.UTF8.GetString(context.Body));
+
+                    return Task.FromResult(0);
+                }
+
+                Context scenarioContext;
+            }
+        }
+
+        class MessageWithRawXml : ICommand
+        {
+            public XDocument Document { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2814,7 +2814,11 @@ namespace NServiceBus.Settings
         public void SetDefault<T>(object value) { }
         public void SetDefault<T>(System.Action value) { }
         public void SetDefault(string key, object value) { }
+        [System.ObsoleteAttribute("Set(string key, object value). The member currently throws a NotImplementedExcept" +
+            "ion. Will be removed in version 7.0.0.", true)]
         public void SetProperty<T>(System.Linq.Expressions.Expression<System.Func<T, object>> property, object value) { }
+        [System.ObsoleteAttribute("Set(string key, object value). The member currently throws a NotImplementedExcept" +
+            "ion. Will be removed in version 7.0.0.", true)]
         public void SetPropertyDefault<T>(System.Linq.Expressions.Expression<System.Func<T, object>> property, object value) { }
         public bool TryGet<T>(out T val) { }
         public bool TryGet<T>(string key, out T val) { }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2814,11 +2814,11 @@ namespace NServiceBus.Settings
         public void SetDefault<T>(object value) { }
         public void SetDefault<T>(System.Action value) { }
         public void SetDefault(string key, object value) { }
-        [System.ObsoleteAttribute("Set(string key, object value). The member currently throws a NotImplementedExcept" +
-            "ion. Will be removed in version 7.0.0.", true)]
+        [System.ObsoleteAttribute("Use `Set(string key, object value)` instead. The member currently throws a NotImp" +
+            "lementedException. Will be removed in version 7.0.0.", true)]
         public void SetProperty<T>(System.Linq.Expressions.Expression<System.Func<T, object>> property, object value) { }
-        [System.ObsoleteAttribute("Set(string key, object value). The member currently throws a NotImplementedExcept" +
-            "ion. Will be removed in version 7.0.0.", true)]
+        [System.ObsoleteAttribute("Use `Set(string key, object value)` instead. The member currently throws a NotImp" +
+            "lementedException. Will be removed in version 7.0.0.", true)]
         public void SetPropertyDefault<T>(System.Linq.Expressions.Expression<System.Func<T, object>> property, object value) { }
         public bool TryGet<T>(out T val) { }
         public bool TryGet<T>(string key, out T val) { }

--- a/src/NServiceBus.Core/Serializers/XML/Config/XmlSerializationExtensions.cs
+++ b/src/NServiceBus.Core/Serializers/XML/Config/XmlSerializationExtensions.cs
@@ -39,7 +39,8 @@
         public static SerializationExtensions<XmlSerializer> DontWrapRawXml(this SerializationExtensions<XmlSerializer> config)
         {
             Guard.AgainstNull(nameof(config), config);
-            config.Settings.SetProperty<XmlMessageSerializer>(s => s.SkipWrappingRawXml, true);
+
+            config.Settings.Set(XmlSerializer.SkipWrappingRawXml, true);
 
             return config;
         }

--- a/src/NServiceBus.Core/Serializers/XML/Config/XmlSerializationExtensions.cs
+++ b/src/NServiceBus.Core/Serializers/XML/Config/XmlSerializationExtensions.cs
@@ -59,7 +59,7 @@
         {
             Guard.AgainstNull(nameof(config), config);
 
-            config.Settings.SetProperty<XmlMessageSerializer>(s => s.Namespace, namespaceToUse);
+            config.Settings.Set(XmlSerializer.CustomNamespaceConfigurationKey, namespaceToUse);
 
             return config;
         }

--- a/src/NServiceBus.Core/Serializers/XML/Config/XmlSerializationExtensions.cs
+++ b/src/NServiceBus.Core/Serializers/XML/Config/XmlSerializationExtensions.cs
@@ -71,7 +71,8 @@
         public static SerializationExtensions<XmlSerializer> SanitizeInput(this SerializationExtensions<XmlSerializer> config)
         {
             Guard.AgainstNull(nameof(config), config);
-            config.Settings.SetProperty<XmlMessageSerializer>(s => s.SanitizeInput, true);
+
+            config.Settings.Set(XmlSerializer.SanitizeInput, true);
 
             return config;
         }

--- a/src/NServiceBus.Core/Serializers/XML/XmlSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlSerializer.cs
@@ -30,11 +30,18 @@
                     serializer.Namespace = customNamespace;
                 }
 
+                bool skipWrappingRawXml;
+                if (settings.TryGet(SkipWrappingRawXml, out skipWrappingRawXml))
+                {
+                    serializer.SkipWrappingRawXml = skipWrappingRawXml;
+                }
+
                 serializer.Initialize(messageTypes);
                 return serializer;
             };
         }
 
         internal const string CustomNamespaceConfigurationKey = "XmlSerializer.CustomNamespace";
+        internal const string SkipWrappingRawXml = "XmlSerializer.SkipWrappingRawXml";
     }
 }

--- a/src/NServiceBus.Core/Serializers/XML/XmlSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlSerializer.cs
@@ -23,9 +23,18 @@
                     .Where(conventions.IsMessageType).ToList();
 
                 var serializer = new XmlMessageSerializer(mapper, conventions);
+
+                string customNamespace;
+                if (settings.TryGet(CustomNamespaceConfigurationKey, out customNamespace))
+                {
+                    serializer.Namespace = customNamespace;
+                }
+
                 serializer.Initialize(messageTypes);
                 return serializer;
             };
         }
+
+        internal const string CustomNamespaceConfigurationKey = "XmlSerializer.CustomNamespace";
     }
 }

--- a/src/NServiceBus.Core/Serializers/XML/XmlSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlSerializer.cs
@@ -36,6 +36,12 @@
                     serializer.SkipWrappingRawXml = skipWrappingRawXml;
                 }
 
+                bool sanitizeInput;
+                if (settings.TryGet(SanitizeInput, out sanitizeInput))
+                {
+                    serializer.SanitizeInput = sanitizeInput;
+                }
+
                 serializer.Initialize(messageTypes);
                 return serializer;
             };
@@ -43,5 +49,6 @@
 
         internal const string CustomNamespaceConfigurationKey = "XmlSerializer.CustomNamespace";
         internal const string SkipWrappingRawXml = "XmlSerializer.SkipWrappingRawXml";
+        internal const string SanitizeInput = "XmlSerializer.SkipWrappingRawXml";
     }
 }

--- a/src/NServiceBus.Core/Settings/SettingsHolder.cs
+++ b/src/NServiceBus.Core/Settings/SettingsHolder.cs
@@ -4,7 +4,6 @@ namespace NServiceBus.Settings
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Configuration;
-    using System.Linq.Expressions;
 
     /// <summary>
     /// Setting container.
@@ -220,28 +219,6 @@ namespace NServiceBus.Settings
         public void Set<T>(Action value)
         {
             Set(typeof(T).FullName, value);
-        }
-
-        /// <summary>
-        /// Sets the value of the given property.
-        /// </summary>
-        public void SetProperty<T>(Expression<Func<T, object>> property, object value)
-        {
-            Guard.AgainstNull(nameof(property), property);
-            var prop = Reflect<T>.GetProperty(property);
-
-            Set(typeof(T).FullName + "." + prop.Name, value);
-        }
-
-        /// <summary>
-        /// Sets the default value of the given property.
-        /// </summary>
-        public void SetPropertyDefault<T>(Expression<Func<T, object>> property, object value)
-        {
-            Guard.AgainstNull(nameof(property), property);
-            var prop = Reflect<T>.GetProperty(property);
-
-            SetDefault(typeof(T).FullName + "." + prop.Name, value);
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/obsoletes.cs
+++ b/src/NServiceBus.Core/obsoletes.cs
@@ -2259,7 +2259,7 @@ namespace NServiceBus.Settings
         [ObsoleteEx(
           RemoveInVersion = "7.0",
           TreatAsErrorFromVersion = "6.0",
-          Message = "Set(string key, object value)")]
+          ReplacementTypeOrMember = "Set(string key, object value)")]
         public void SetProperty<T>(Expression<Func<T, object>> property, object value)
         {
             throw new NotImplementedException();
@@ -2268,7 +2268,7 @@ namespace NServiceBus.Settings
         [ObsoleteEx(
           RemoveInVersion = "7.0",
           TreatAsErrorFromVersion = "6.0",
-          Message = "Set(string key, object value)")]
+          ReplacementTypeOrMember = "Set(string key, object value)")]
         public void SetPropertyDefault<T>(Expression<Func<T, object>> property, object value)
         {
             throw new NotImplementedException();

--- a/src/NServiceBus.Core/obsoletes.cs
+++ b/src/NServiceBus.Core/obsoletes.cs
@@ -2233,6 +2233,7 @@ namespace NServiceBus.ObjectBuilder
 namespace NServiceBus.Settings
 {
     using System;
+    using System.Linq.Expressions;
     using ObjectBuilder;
 
     public partial class SettingsHolder
@@ -2251,6 +2252,24 @@ namespace NServiceBus.Settings
           TreatAsErrorFromVersion = "6.0",
           Message = "Setting property values explicitly is no longer supported via this API. Use `.ConfigureComponent(b=> new MyMessageHandler(){ MyProperty = X})` to get full control over handler creation.")]
         public void ApplyTo(Type componentType, IComponentConfig config)
+        {
+            throw new NotImplementedException();
+        }
+
+        [ObsoleteEx(
+          RemoveInVersion = "7.0",
+          TreatAsErrorFromVersion = "6.0",
+          Message = "Set(string key, object value)")]
+        public void SetProperty<T>(Expression<Func<T, object>> property, object value)
+        {
+            throw new NotImplementedException();
+        }
+
+        [ObsoleteEx(
+          RemoveInVersion = "7.0",
+          TreatAsErrorFromVersion = "6.0",
+          Message = "Set(string key, object value)")]
+        public void SetPropertyDefault<T>(Expression<Func<T, object>> property, object value)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
fixes https://github.com/Particular/NServiceBus/issues/3852

Turns out that all xml serializer config settings don't work.

Todo:
* [x] Acceptance tests for the remaining XmlSerializer config extensions
* [x] Fixing the remaining XmlSerializer config extensions
* [x] Remove `SetProperty` on the SettingsHolder class

@Particular/nservicebus-maintainers while it shouldn't be a big deal to fix this, I'm a bit worried about the impact on ASQ in case they use the `XmlSerializer` and are these config extensions. The settings are currently shared on all instances of the serializer, although that probably shouldn't have an impact? Even `DontWrapRawXml` shouldn't be an issue as long as the wrapper message doesn't use XContainer properties, right?