### PR TITLE
Throw when saga handles message, but message is unmapped+uncorrelated

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -160,6 +160,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Routing\SubscriptionBehaviorExtensions.cs" />
+    <Compile Include="Sagas\When_saga_handles_unmapped_message.cs" />
     <Compile Include="Satellites\When_a_message_is_available.cs" />
     <Compile Include="UnicastPubSubExtensions.cs" />
     <Compile Include="Routing\When_multi_subscribing_to_a_polymorphic_event_on_multicast_transports.cs" />

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_handles_unmapped_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_handles_unmapped_message.cs
@@ -1,0 +1,123 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_saga_handles_unmapped_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_throw_on_unmapped_uncorrelated_msg()
+        {
+            var id = Guid.NewGuid();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<UnmappedMsgEndpoint>(b =>
+                {
+                    b.DoNotFailOnErrorMessages();
+
+                    b.When(session => session.SendLocal(new StartSagaMessage
+                    {
+                        SomeId = id
+                    }));
+                })
+                .Done(c => c.MappedEchoReceived && (c.EchoReceived || c.FailedMessages.Any()))
+                .Run();
+
+            Assert.AreEqual(true, context.StartReceived);
+            Assert.AreEqual(true, context.OutboundReceived);
+            Assert.AreEqual(true, context.MappedEchoReceived);
+            Assert.AreEqual(false, context.EchoReceived);
+            Assert.AreEqual(1, context.FailedMessages.Count);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool StartReceived { get; set; }
+            public bool OutboundReceived { get; set; }
+            public bool EchoReceived { get; set; }
+            public bool MappedEchoReceived { get; set; }
+        }
+
+        public class UnmappedMsgEndpoint : EndpointConfigurationBuilder
+        {
+            public UnmappedMsgEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class UnmappedMsgSaga : Saga<UnmappedMsgSagaData>,
+                IAmStartedByMessages<StartSagaMessage>,
+                IHandleMessages<MappedEchoMessage>,
+                IHandleMessages<EchoMessage>
+            {
+                public Context Context { get; set; }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<UnmappedMsgSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartSagaMessage>(msg => msg.SomeId).ToSaga(saga => saga.SomeId);
+                    mapper.ConfigureMapping<MappedEchoMessage>(msg => msg.SomeId).ToSaga(saga => saga.SomeId);
+                    // No mapping for EchoMessage, so saga can't possibly be found
+                }
+
+                public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
+                {
+                    Context.StartReceived = true;
+                    return context.SendLocal(new OutboundMessage { SomeId = message.SomeId });
+                }
+
+                public Task Handle(MappedEchoMessage message, IMessageHandlerContext context)
+                {
+                    Context.MappedEchoReceived = true;
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(EchoMessage message, IMessageHandlerContext context)
+                {
+                    Context.EchoReceived = true;
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class UnmappedMsgSagaData : ContainSagaData
+            {
+                public virtual Guid SomeId { get; set; }
+            }
+
+            public class OutboundMessageHandler : IHandleMessages<OutboundMessage>
+            {
+                public Context Context { get; set; }
+
+                public async Task Handle(OutboundMessage message, IMessageHandlerContext context)
+                {
+                    Context.OutboundReceived = true;
+                    await context.SendLocal(new EchoMessage { SomeId = message.SomeId });
+                    await context.SendLocal(new MappedEchoMessage {  SomeId = message.SomeId });
+                }
+            }
+        }
+
+        public class StartSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+
+        public class OutboundMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+
+        public class EchoMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+
+        public class MappedEchoMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Connects to https://github.com/Particular/Stories/pull/339

We added startup validation for `IAmStartedByMessages` mappings, making sure they would exist. `IAmHandledBy` is a little more tricky. It could be an auto-correlated reply message that contains SagaId in a header.

However...

If a saga handles a message type, and that message comes in with:

* No SagaId header
* No ConfigureHowToFindSagas mapping
* No custom finder

Then there's really no way we can successfully map the message to a saga at all, but the message we're currently providing is:

> INFO  NServiceBus.InvokeSagaNotFoundBehavior Could not find a started saga for 'TestV6Saga.SendBack' message type. Going to invoke SagaNotFoundHandlers.

That's just wrong. Isn't it?

@Particular/nservicebus-maintainers this PR isn't complete (no tests) but I'm looking to get feedback on if you think this is a good idea, and see how many existing tests break.

I think throwing is the correct action here, but I'm not 100% sure. It does seem that if we don't do something about this case, then we can't really claim we've fixed all the common V5 saga mistakes users make. We would have just fixed them *if you happen to make all messages start the saga*.