### PR TITLE
Fix for #3854 unhandled exception in SubscriptionManager Threadpool task.

### DIFF
--- a/src/NServiceBus.Core/Unicast/Subscriptions/MessageDrivenSubscriptions/SubscriptionManager.cs
+++ b/src/NServiceBus.Core/Unicast/Subscriptions/MessageDrivenSubscriptions/SubscriptionManager.cs
@@ -65,17 +65,19 @@
                     ReplyToAddress = Configure.PublicReturnAddress
                 });
             }
-            catch (QueueNotFoundException ex)
+            catch (Exception ex)
             {
-                if (retriesCount < 10)
+                if (ex is QueueNotFoundException)
                 {
-                    Thread.Sleep(TimeSpan.FromSeconds(2));
-                    SendSubscribeMessageWithRetries(destination, subscriptionMessage, messageType, ++retriesCount);
+                    if (retriesCount < 10)
+                    {
+                        Thread.Sleep(TimeSpan.FromSeconds(2));
+                        SendSubscribeMessageWithRetries(destination, subscriptionMessage, messageType, ++retriesCount);
+                        return;
+                    }
                 }
-                else
-                {
-                    Logger.ErrorFormat("Failed to subscribe to {0} at publisher queue {1}", ex, messageType, destination);
-                }
+
+                Logger.FatalFormat("Failed to subscribe to {0} at publisher queue {1}. Error: {2}", messageType, destination, ex);
             }
         }
 


### PR DESCRIPTION
* Catch made generic to prevent process to crash due to unhandled exception
* Changed log event from Error to Fatal
* Log event format string was incorrect. Previously the exception string was written for the message type argument.