### PR TITLE
Fixed file instance mapping to be available when running FSTs.

### DIFF
--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/AsyncTimer.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/AsyncTimer.cs
@@ -22,7 +22,7 @@ namespace NServiceBus
                     }
                     catch (OperationCanceledException)
                     {
-                        // nop	 
+                        // nop
                     }
                     catch (Exception ex)
                     {
@@ -34,9 +34,15 @@ namespace NServiceBus
 
         public Task Stop()
         {
+            if (tokenSource == null)
+            {
+                return TaskEx.CompletedTask;
+            }
+
             tokenSource.Cancel();
             tokenSource.Dispose();
-            return task;
+
+            return task ?? TaskEx.CompletedTask;
         }
 
         Task task;

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Features
 {
     using System;
+    using Routing;
 
     class FileRoutingTableFeature : Feature
     {
@@ -20,7 +21,10 @@ namespace NServiceBus.Features
             var checkInterval = context.Settings.Get<TimeSpan>(CheckIntervalSettingsKey);
             var maxLoadAttempts = context.Settings.Get<int>(MaxLoadAttemptsSettingsKey);
 
-            var fileRoutingTable = new FileRoutingTable(filePath, checkInterval, new AsyncTimer(), new RoutingFileAccess(), maxLoadAttempts, context.Settings);
+            var endpointInstances = context.Settings.Get<EndpointInstances>();
+
+            var fileRoutingTable = new FileRoutingTable(filePath, checkInterval, new AsyncTimer(), new RoutingFileAccess(), maxLoadAttempts);
+            endpointInstances.AddDynamic(fileRoutingTable.FindInstances);
             context.RegisterStartupTask(fileRoutingTable);
         }
 


### PR DESCRIPTION
Previous design of file instance mapping attached itself to the routing in the `FeatureStartupTask` (FST). That meant that other FST that happened to be run before (e.g. AutoSubscribe), when sending out messages, would not go through the file instance map.

In case of AutoSubscribe it meant that all subscriptions are routed using default instance mapping (to local machine).

The new design load the file when it is first accessed.


