### PR TITLE
Avoid multiple enumerations

### DIFF
--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -135,7 +135,7 @@ namespace NServiceBus.Features
             return output;
         }
 
-        static bool DirectedCycleExistsFrom(Node node, IEnumerable<Node> visitedNodes)
+        static bool DirectedCycleExistsFrom(Node node, Node[] visitedNodes)
         {
             if (node.previous.Any())
             {
@@ -147,7 +147,7 @@ namespace NServiceBus.Features
                 var newVisitedNodes = visitedNodes.Union(new[]
                 {
                     node
-                });
+                }).ToArray();
 
                 foreach (var subNode in node.previous)
                 {

--- a/src/NServiceBus.Core/Serializers/XML/XmlSerializerCache.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlSerializerCache.cs
@@ -130,7 +130,7 @@ namespace NServiceBus
             }
         }
 
-        IEnumerable<PropertyInfo> GetAllPropertiesForType(Type t, bool isKeyValuePair)
+        PropertyInfo[] GetAllPropertiesForType(Type t, bool isKeyValuePair)
         {
             var result = new List<PropertyInfo>();
 
@@ -189,10 +189,10 @@ namespace NServiceBus
                 }
             }
 
-            return result.Distinct();
+            return result.Distinct().ToArray();
         }
 
-        IEnumerable<FieldInfo> GetAllFieldsForType(Type t)
+        FieldInfo[] GetAllFieldsForType(Type t)
         {
             return t.GetFields(BindingFlags.FlattenHierarchy | BindingFlags.Instance | BindingFlags.Public);
         }


### PR DESCRIPTION
Reduces unnecessary enumerations. 

We still have two of those

https://github.com/Particular/NServiceBus/blob/develop/src/NServiceBus.Core/Transports/Msmq/MsmqUtilities.cs#L133
https://github.com/Particular/NServiceBus/blob/develop/src/NServiceBus.Core/Transports/Msmq/MsmqUtilities.cs#L137

The bigger question we would need to ask ourselves is: Why does https://github.com/Particular/NServiceBus/blob/develop/src/NServiceBus.Core/Transports/UnicastTransportOperation.cs#L36 need to be an `IEnumerable` since this is a really low-level API we should optimize it for the fast path?

@Particular/nservicebus-maintainers thoughts?