### PR TITLE
Optimize Message handler registry hot path

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -3243,7 +3243,7 @@ namespace NServiceBus.Unicast
             "r currently throws a NotImplementedException. Will be removed in version 7.0.0.", true)]
         public void CacheMethodForHandler(System.Type handler, System.Type messageType) { }
         public void Clear() { }
-        public System.Collections.Generic.IEnumerable<NServiceBus.Pipeline.MessageHandler> GetHandlersFor(System.Type messageType) { }
+        public System.Collections.Generic.List<NServiceBus.Pipeline.MessageHandler> GetHandlersFor(System.Type messageType) { }
         [System.ObsoleteAttribute("Use `MessageHandlerRegistry.GetHandlersFor(Type messageType)` instead. The member" +
             " currently throws a NotImplementedException. Will be removed in version 7.0.0.", true)]
         public System.Collections.Generic.IEnumerable<System.Type> GetHandlerTypes(System.Type messageType) { }


### PR DESCRIPTION
Will add more details soonish

## Plain tests
```ini

BenchmarkDotNet=v0.9.7.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-3615QM CPU 2.30GHz, ProcessorCount=8
Frequency=2240999 ticks, Resolution=446.2296 ns, Timer=TSC
HostCLR=MS.NET 4.0.30319.42000, Arch=32-bit RELEASE
JitModules=clrjit-v4.6.1080.0

Type=TypeAllocations  Mode=Throughput  

```
                      Method |     Median |    StdDev |    Gen 0 | Gen 1 | Gen 2 | Bytes Allocated/Op |
---------------------------- |----------- |---------- |--------- |------ |------ |------------------- |
 StructWithRuntimeTypeHandle | 13.9590 ns | 0.5826 ns |        - |     - |     - |               0,00 |
        StructWithTypeHandle |  6.9124 ns | 0.2468 ns |        - |     - |     - |               0,00 |
  ClassWithRuntimeTypeHandle |  9.9213 ns | 0.1792 ns | 1 611,00 |     - |     - |               6,35 |
         ClassWithTypeHandle |  8.0432 ns | 0.4950 ns | 1 759,64 |     - |     - |               6,92 |
                     RawType |  0.0011 ns | 0.0196 ns |        - |     - |     - |               0,00 |
                  TypeHandle |  1.6533 ns | 0.0922 ns |        - |     - |     - |               0,00 |

## Throughput Micro benchmarking on MessageHandlerRegistry

```ini

BenchmarkDotNet=v0.9.7.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Xeon(R) CPU E5-2673 v3 2.40GHz, ProcessorCount=8
Frequency=10000000 ticks, Resolution=100.0000 ns, Timer=UNKNOWN
HostCLR=MS.NET 4.0.30319.42000, Arch=64-bit RELEASE [RyuJIT]
JitModules=clrjit-v4.6.1055.0

Type=MessageHandlerRegistryPerf  Mode=Throughput  

```
                         Method | Calls |            Median |         StdDev | Scaled |              Mean |      StdError |         StdDev |       Op/s |               Min |                Q1 |            Median |                Q3 |               Max |  Gen 0 | Gen 1 | Gen 2 | Bytes Allocated/Op |
------------------------------- |------ |------------------ |--------------- |------- |------------------ |-------------- |--------------- |----------- |------------------ |------------------ |------------------ |------------------ |------------------ |------- |------ |------ |------------------- |
 **V6_RegistryBeforeOptimizations** |     **2** |     **2,057.1548 ns** |     **71.5193 ns** |   **1.00** |     **2,077.2322 ns** |    **15.9922 ns** |     **71.5193 ns** |  **481409.83** |     **1,995.9213 ns** |     **2,031.7680 ns** |     **2,057.1548 ns** |     **2,098.5973 ns** |     **2,268.7294 ns** |   **1.56** |     **-** |     **-** |             **896.95** |
  V6_RegistryAfterOptimizations |     2 |       910.8729 ns |     10.1351 ns |   0.44 |       911.4366 ns |     2.2663 ns |     10.1351 ns | 1097169.05 |       889.8506 ns |       905.5404 ns |       910.8729 ns |       920.2448 ns |       925.9861 ns |   0.73 |     - |     - |             424.75 |
 **V6_RegistryBeforeOptimizations** |     **4** |     **4,143.2083 ns** |     **88.4706 ns** |   **1.00** |     **4,137.6639 ns** |    **19.7826 ns** |     **88.4706 ns** |  **241682.27** |     **3,989.0564 ns** |     **4,065.4854 ns** |     **4,143.2083 ns** |     **4,201.5930 ns** |     **4,303.0884 ns** |   **3.02** |     **-** |     **-** |           **1,734.64** |
  V6_RegistryAfterOptimizations |     4 |     1,796.1514 ns |     27.5977 ns |   0.43 |     1,798.9689 ns |     6.1710 ns |     27.5977 ns |  555873.97 |     1,734.5654 ns |     1,782.9113 ns |     1,796.1514 ns |     1,807.5418 ns |     1,864.2567 ns |   1.27 |     - |     - |             734.73 |
 **V6_RegistryBeforeOptimizations** |     **8** |     **8,111.2503 ns** |    **159.8473 ns** |   **1.00** |     **8,141.8021 ns** |    **35.7430 ns** |    **159.8473 ns** |  **122822.93** |     **7,941.2567 ns** |     **8,059.7931 ns** |     **8,111.2503 ns** |     **8,189.1174 ns** |     **8,651.2451 ns** |   **6.50** |     **-** |     **-** |           **3,726.08** |
  V6_RegistryAfterOptimizations |     8 |     3,564.7713 ns |    126.5522 ns |   0.44 |     3,589.3187 ns |    28.2979 ns |    126.5522 ns |  278604.41 |     3,478.1265 ns |     3,501.5244 ns |     3,564.7713 ns |     3,607.5157 ns |     4,011.9766 ns |   2.82 |     - |     - |           1,629.66 |
 **V6_RegistryBeforeOptimizations** |    **16** |    **16,398.6664 ns** |    **539.1000 ns** |   **1.00** |    **16,492.2656 ns** |   **120.5464 ns** |    **539.1000 ns** |   **60634.48** |    **15,991.0400 ns** |    **16,197.2473 ns** |    **16,398.6664 ns** |    **16,630.8960 ns** |    **18,538.3484 ns** |  **12.34** |     **-** |     **-** |           **7,079.86** |
  V6_RegistryAfterOptimizations |    16 |     7,101.0864 ns |    134.9001 ns |   0.43 |     7,125.1959 ns |    30.1646 ns |    134.9001 ns |  140347.02 |     6,892.2791 ns |     7,034.3857 ns |     7,101.0864 ns |     7,201.5381 ns |     7,451.6876 ns |   5.55 |     - |     - |           3,211.06 |
 **V6_RegistryBeforeOptimizations** |    **32** |    **32,757.1106 ns** |    **871.7207 ns** |   **1.00** |    **32,899.7290 ns** |   **194.9227 ns** |    **871.7207 ns** |   **30395.39** |    **31,794.3604 ns** |    **32,254.3518 ns** |    **32,757.1106 ns** |    **33,318.8416 ns** |    **35,779.9561 ns** |  **24.43** |     **-** |     **-** |          **14,024.07** |
  V6_RegistryAfterOptimizations |    32 |    14,083.8013 ns |    428.2162 ns |   0.43 |    14,232.0435 ns |    95.7521 ns |    428.2162 ns |   70263.98 |    13,896.3989 ns |    13,998.7061 ns |    14,083.8013 ns |    14,302.5635 ns |    15,864.6179 ns |   8.05 |     - |     - |           4,663.14 |
 **V6_RegistryBeforeOptimizations** |    **64** |    **65,889.5386 ns** |  **1,222.7904 ns** |   **1.00** |    **65,490.0903 ns** |   **273.4242 ns** |  **1,222.7904 ns** |   **15269.49** |    **63,409.7412 ns** |    **64,426.4526 ns** |    **65,889.5386 ns** |    **66,211.7554 ns** |    **67,856.7383 ns** |  **45.09** |     **-** |     **-** |          **25,903.35** |
  V6_RegistryAfterOptimizations |    64 |    28,306.3385 ns |    511.2355 ns |   0.43 |    28,402.2437 ns |   114.3157 ns |    511.2355 ns |   35208.49 |    27,560.8826 ns |    28,115.7379 ns |    28,306.3385 ns |    28,629.9713 ns |    29,831.7749 ns |  23.38 |     - |     - |          13,518.70 |
 **V6_RegistryBeforeOptimizations** |   **128** |   **130,621.5820 ns** |  **2,644.0173 ns** |   **1.00** |   **130,581.5942 ns** |   **591.2202 ns** |  **2,644.0173 ns** |    **7658.05** |   **125,041.6992 ns** |   **128,469.3115 ns** |   **130,621.5820 ns** |   **132,312.8906 ns** |   **135,315.0391 ns** | **100.91** |     **-** |     **-** |          **57,892.82** |
  V6_RegistryAfterOptimizations |   128 |    56,452.0508 ns |    997.9079 ns |   0.43 |    56,621.0742 ns |   223.1390 ns |    997.9079 ns |   17661.27 |    55,281.1157 ns |    55,885.5225 ns |    56,452.0508 ns |    57,201.0498 ns |    58,606.7017 ns |  41.11 |     - |     - |          23,807.78 |
 **V6_RegistryBeforeOptimizations** |   **256** |   **258,801.6357 ns** |  **7,857.6587 ns** |   **1.00** |   **261,784.9414 ns** | **1,757.0259 ns** |  **7,857.6587 ns** |    **3819.93** |   **254,107.0801 ns** |   **257,706.1035 ns** |   **258,801.6357 ns** |   **263,146.9482 ns** |   **290,622.6563 ns** | **191.11** |     **-** |     **-** |         **109,693.37** |
  V6_RegistryAfterOptimizations |   256 |   113,893.2373 ns |  2,324.1837 ns |   0.44 |   113,785.1880 ns |   519.7033 ns |  2,324.1837 ns |    8788.49 |   109,637.1582 ns |   112,262.5000 ns |   113,893.2373 ns |   115,148.1689 ns |   119,089.9414 ns |  81.13 |     - |     - |          47,013.78 |
 **V6_RegistryBeforeOptimizations** |   **512** |   **517,407.7148 ns** |  **8,439.0570 ns** |   **1.00** |   **518,589.1016 ns** | **1,887.0305 ns** |  **8,439.0570 ns** |    **1928.31** |   **505,537.8906 ns** |   **513,359.7656 ns** |   **517,407.7148 ns** |   **523,020.0195 ns** |   **538,358.2031 ns** | **382.25** |     **-** |     **-** |         **219,378.11** |
  V6_RegistryAfterOptimizations |   512 |   224,435.7422 ns |  8,533.5732 ns |   0.43 |   227,314.3604 ns | 1,908.1650 ns |  8,533.5732 ns |    4399.19 |   221,481.6895 ns |   223,101.7090 ns |   224,435.7422 ns |   227,138.7207 ns |   256,711.7676 ns | 177.57 |     - |     - |         102,739.43 |
 **V6_RegistryBeforeOptimizations** |  **1024** | **1,040,722.4609 ns** | **23,446.1414 ns** |   **1.00** | **1,046,629.7266 ns** | **5,242.7166 ns** | **23,446.1414 ns** |     **955.45** | **1,019,065.6250 ns** | **1,030,313.6719 ns** | **1,040,722.4609 ns** | **1,059,478.9063 ns** | **1,112,438.2813 ns** | **790.00** |     **-** |     **-** |         **453,025.14** |
  V6_RegistryAfterOptimizations |  1024 |   457,202.6367 ns | 10,995.8568 ns |   0.44 |   462,546.9727 ns | 2,458.7483 ns | 10,995.8568 ns |    2161.94 |   447,911.9141 ns |   455,527.7344 ns |   457,202.6367 ns |   468,253.4180 ns |   491,035.5469 ns | 350.69 |     - |     - |         202,767.97 |

## Size Micro benchmarking

Registered 5 handlers, no additional permutations

```ini

BenchmarkDotNet=v0.9.7.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Xeon(R) CPU E5-2673 v3 2.40GHz, ProcessorCount=8
Frequency=10000000 ticks, Resolution=100.0000 ns, Timer=UNKNOWN
HostCLR=MS.NET 4.0.30319.42000, Arch=64-bit RELEASE [RyuJIT]
JitModules=clrjit-v4.6.1055.0

Type=MessageHandlerRegistrySize  Mode=Throughput  

```
                         Method |    Median |    StdDev | Scaled |      Mean |  StdError |    StdDev |   Op/s |       Min |        Q1 |    Median |        Q3 |       Max | Gen 0 | Gen 1 | Gen 2 | Bytes Allocated/Op |
------------------------------- |---------- |---------- |------- |---------- |---------- |---------- |------- |---------- |---------- |---------- |---------- |---------- |------ |------ |------ |------------------- |
 V6_RegistryBeforeOptimizations | 1.4944 ms | 0.0317 ms |   1.00 | 1.4990 ms | 0.0071 ms | 0.0317 ms |  667.1 | 1.4492 ms | 1.4743 ms | 1.4944 ms | 1.5236 ms | 1.5571 ms |     - |     - |     - |          19,333.53 |
  V6_RegistryAfterOptimizations | 1.4957 ms | 0.0222 ms |   1.00 | 1.4956 ms | 0.0050 ms | 0.0222 ms | 668.64 | 1.4628 ms | 1.4754 ms | 1.4957 ms | 1.5091 ms | 1.5410 ms |     - |     - |     - |          22,661.42 |
