### PR TITLE
Properly obsoleting Bus property on Saga base class

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -907,6 +907,10 @@ namespace NServiceBus
     public abstract class Saga
     {
         protected Saga() { }
+        [System.ObsoleteAttribute("Sagas no longer provide access to bus operations via the .Bus property. Use the c" +
+            "ontext parameter on the Handle method. The member currently throws a NotImplemen" +
+            "tedException. Will be removed in version 7.0.0.", true)]
+        public NServiceBus.IBus Bus { get; set; }
         public bool Completed { get; }
         public NServiceBus.IContainSagaData Entity { get; set; }
         protected internal abstract void ConfigureHowToFindSaga(NServiceBus.IConfigureHowToFindSagaWithMessage sagaMessageFindingConfiguration);

--- a/src/NServiceBus.Core/obsoletes.cs
+++ b/src/NServiceBus.Core/obsoletes.cs
@@ -1796,6 +1796,16 @@ namespace NServiceBus
     public partial class Saga
     {
         [ObsoleteEx(
+            Message = "Sagas no longer provide access to bus operations via the .Bus property. Use the context parameter on the Handle method.",
+            RemoveInVersion = "7.0",
+            TreatAsErrorFromVersion = "6.0")]
+        public IBus Bus
+        {
+            get { throw new NotImplementedException(); }
+            set { throw new NotImplementedException(); }
+        }
+
+        [ObsoleteEx(
             RemoveInVersion = "7.0",
             TreatAsErrorFromVersion = "6.0",
             ReplacementTypeOrMember = "RequestTimeout<TTimeoutMessageType>(IMessageHandlerContext, DateTime)")]


### PR DESCRIPTION
Closes #3855 

```
class MySaga: Saga<MySaga.MyEntity>, IAmStartedByMessages<Message1>
        {
            public async Task Handle(Message1 message, IMessageHandlerContext context) {
                Bus.SendLocal(new MyMessage());
            }

            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySaga.MyEntity> mapper)
            {
            }
        }
```

will now lead to

![image](https://cloud.githubusercontent.com/assets/174258/16454473/2779fb04-3e11-11e6-9b0f-8edf90ba8aea.png)
