### PR TITLE
[WIP] AT Pubsub to self broken with purge on startup

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -166,6 +166,7 @@
     <Compile Include="UnicastPubSubExtensions.cs" />
     <Compile Include="Routing\When_multi_subscribing_to_a_polymorphic_event_on_multicast_transports.cs" />
     <Compile Include="Routing\When_handler_exists_but_routing_information_is_missing.cs" />
+    <Compile Include="Routing\When_publishing_an_event_to_self.cs" />
     <Compile Include="Routing\When_publishing_to_scaled_out_subscribers_on_unicast_transports.cs" />
     <Compile Include="Routing\When_publishing_to_scaled_out_subscribers_on_multicast_transports.cs" />
     <Compile Include="Routing\When_broadcasting_a_command.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_event_to_self.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_event_to_self.cs
@@ -1,0 +1,78 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_publishing_an_event_to_self : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Event_should_be_received()
+        {
+            var ctx = await Scenario.Define<Context>(x => x.Id = Guid.NewGuid())
+                .WithEndpoint<PublisherAndSubscriber>(b => b
+                .When((session, context) =>
+                {
+                    if (context.HasNativePubSubSupport)
+                    {
+                        context.EventSubscribed = true;
+                    }
+                    return Task.FromResult(0);
+                })
+                .When(c => c.EventSubscribed || c.HasNativePubSubSupport, (session, context) => session.Publish(new Event { ContextId = context.Id })))
+                .Done(c => c.GotEvent)
+                .Run(TimeSpan.FromSeconds(20)).ConfigureAwait(false);
+
+            Assert.True(ctx.GotEvent);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+            public bool GotEvent { get; set; }
+            public bool EventSubscribed { get; set; }
+        }
+
+        public class PublisherAndSubscriber : EndpointConfigurationBuilder
+        {
+            public PublisherAndSubscriber()
+            {
+                EndpointSetup<DefaultPublisher>(b =>
+                {
+                    b.OnEndpointSubscribed<Context>((s, context) =>
+                    {
+                        if (s.MessageType == typeof(Event).AssemblyQualifiedName)
+                        {
+                            context.EventSubscribed = true;
+                        }
+                    });
+                })
+                .AddMapping<Event>(typeof(PublisherAndSubscriber));
+
+            }
+
+            public class EventHandler : IHandleMessages<Event>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(Event @event, IMessageHandlerContext context)
+                {
+                    if (@event.ContextId != Context.Id)
+                    {
+                        return Task.FromResult(0);
+                    }
+                    Context.GotEvent = true;
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Event : IEvent
+        {
+            public Guid ContextId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_event_to_self.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_event_to_self.cs
@@ -41,6 +41,7 @@
             {
                 EndpointSetup<DefaultPublisher>(b =>
                 {
+                    b.PurgeOnStartup(true);
                     b.OnEndpointSubscribed<Context>((s, context) =>
                     {
                         if (s.MessageType == typeof(Event).AssemblyQualifiedName)


### PR DESCRIPTION
Pubsub to self using auto subscription is broken when using purge on startup. This is broken since V6 Beta 3.

The likely cause is an ordering issue. Purging must take place before sending the subscription message.