### PR TITLE
Remove abstract modifier from ScenarioContext

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
@@ -6,7 +6,7 @@
     using Faults;
     using Logging;
 
-    public abstract class ScenarioContext
+    public class ScenarioContext
     {
         public Guid TestRunId { get; } = Guid.NewGuid();
 

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled.cs
@@ -10,7 +10,7 @@
         [Test]
         public async Task Should_allow_publishing_commands()
         {
-            var context = await Scenario.Define<Context>()
+            var context = await Scenario.Define<ScenarioContext>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) =>
                 {
                     var publishOptions = new PublishOptions();
@@ -22,10 +22,6 @@
                 .Run();
 
             Assert.True(context.EndpointsStarted);
-        }
-
-        public class Context : ScenarioContext
-        {
         }
 
         public class Endpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled_on_endpoint.cs
@@ -11,7 +11,7 @@
         [Test]
         public Task Should_allow_publishing_commands()
         {
-            return Scenario.Define<Context>()
+            return Scenario.Define<ScenarioContext>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) => session.Publish(new MyCommand())))
                 .Done(c => c.EndpointsStarted)
                 .Run();
@@ -20,14 +20,10 @@
         [Test]
         public Task Should_allow_sending_events()
         {
-            return Scenario.Define<Context>()
+            return Scenario.Define<ScenarioContext>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) => session.Send(new MyEvent())))
                 .Done(c => c.EndpointsStarted)
                 .Run();
-        }
-
-        public class Context : ScenarioContext
-        {
         }
 
         public class Endpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.AcceptanceTests.BestPractices
         [Test]
         public async Task Should_allow_sending_events()
         {
-            var context = await Scenario.Define<Context>()
+            var context = await Scenario.Define<ScenarioContext>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) =>
                 {
                     var sendOptions = new SendOptions();
@@ -24,9 +24,6 @@ namespace NServiceBus.AcceptanceTests.BestPractices
             Assert.True(context.EndpointsStarted);
         }
 
-        public class Context : ScenarioContext
-        {
-        }
 
         public class Endpoint : EndpointConfigurationBuilder
         {

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled_on_endpoint.cs
@@ -11,14 +11,10 @@
         [Test]
         public Task Should_allow_sending_events()
         {
-            return Scenario.Define<Context>()
+            return Scenario.Define<ScenarioContext>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) => session.Send(new MyEvent())))
                 .Done(c => c.EndpointsStarted)
                 .Run();
-        }
-
-        public class Context : ScenarioContext
-        {
         }
 
         public class Endpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command_bestpractices_disabled_on_endpoint.cs
@@ -11,7 +11,7 @@
         [Test]
         public Task Should_allow_subscribing_to_commands()
         {
-            return Scenario.Define<Context>()
+            return Scenario.Define<ScenarioContext>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) => session.Subscribe<MyCommand>()))
                 .Done(c => c.EndpointsStarted)
                 .Run();
@@ -20,7 +20,7 @@
         [Test]
         public Task Should_allow_publishing_commands()
         {
-            return Scenario.Define<Context>()
+            return Scenario.Define<ScenarioContext>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) => session.Publish(new MyCommand())))
                 .Done(c => c.EndpointsStarted)
                 .Run();
@@ -29,14 +29,10 @@
         [Test]
         public Task Should_allow_sending_events()
         {
-            return Scenario.Define<Context>()
+            return Scenario.Define<ScenarioContext>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) => session.Send(new MyEvent())))
                 .Done(c => c.EndpointsStarted)
                 .Run();
-        }
-
-        public class Context : ScenarioContext
-        {
         }
 
         public class Endpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command_bestpractices_disabled_on_endpoint.cs
@@ -11,14 +11,10 @@
         [Test]
         public Task Should_allow_unsubscribing_to_commands()
         {
-            return Scenario.Define<Context>()
+            return Scenario.Define<ScenarioContext>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) => session.Unsubscribe<MyCommand>()))
                 .Done(c => c.EndpointsStarted)
                 .Run();
-        }
-
-        public class Context : ScenarioContext
-        {
         }
 
         public class Endpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Config/When_injecting_message_session_into_handlers.cs
+++ b/src/NServiceBus.AcceptanceTests/Config/When_injecting_message_session_into_handlers.cs
@@ -11,16 +11,12 @@
         [Test]
         public void Should_throw_on_startup()
         {
-            var exception = Assert.ThrowsAsync<AggregateException>(async () => await Scenario.Define<Context>()
+            var exception = Assert.ThrowsAsync<AggregateException>(async () => await Scenario.Define<ScenarioContext>()
                 .WithEndpoint<StartedEndpoint>()
                 .Done(c => c.EndpointsStarted)
                 .Run());
 
             StringAssert.Contains("IMessageSession", exception.ToString());
-        }
-
-        class Context : ScenarioContext
-        {
         }
 
         public class StartedEndpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Config/When_only_abstract_config_override_is_found.cs
+++ b/src/NServiceBus.AcceptanceTests/Config/When_only_abstract_config_override_is_found.cs
@@ -13,13 +13,9 @@
         [Test]
         public Task Should_not_invoke_it()
         {
-            return Scenario.Define<Context>()
+            return Scenario.Define<ScenarioContext>()
                 .WithEndpoint<ConfigOverrideEndpoint>().Done(c => c.EndpointsStarted)
                 .Run();
-        }
-
-        public class Context : ScenarioContext
-        {
         }
 
         public class ConfigOverrideEndpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -18,16 +18,12 @@
         [Test]
         public Task Should_pass_it_to_the_transport()
         {
-            return Scenario.Define<Context>()
+            return Scenario.Define<ScenarioContext>()
                 .WithEndpoint<ThrottledEndpoint>(b => b.CustomConfig(c => c.LimitMessageProcessingConcurrencyTo(10)))
                 .Done(c => c.EndpointsStarted)
                 .Run();
 
             //Assert in FakeReceiver.Start
-        }
-
-        public class Context : ScenarioContext
-        {
         }
 
         class ThrottledEndpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_disabling_durable_messages_on_durable_transport.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_disabling_durable_messages_on_durable_transport.cs
@@ -11,7 +11,7 @@
         [Test]
         public void Should_throw_exception_at_startup()
         {
-            var exception = Assert.ThrowsAsync<AggregateException>(() => Scenario.Define<Context>()
+            var exception = Assert.ThrowsAsync<AggregateException>(() => Scenario.Define<ScenarioContext>()
                 .WithEndpoint<EndpointDisablingDurableMessages>(c => c
                     .When(e => e.SendLocal(new RegularMessage())))
                 .Done(c => c.EndpointsStarted)
@@ -19,10 +19,6 @@
 
             Assert.That(exception.InnerException.InnerException, Is.TypeOf<Exception>());
             Assert.That(exception.InnerException.InnerException.Message, Does.Contain("The configured transport does not support non-durable messages but some messages have been configured to be non-durable"));
-        }
-
-        class Context : ScenarioContext
-        {
         }
 
         class EndpointDisablingDurableMessages : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_using_non_durable_messages_on_durable_only_transport.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/MessageDurability/When_using_non_durable_messages_on_durable_only_transport.cs
@@ -11,7 +11,7 @@
         [Test]
         public void Should_throw_exception_at_startup()
         {
-            var exception = Assert.ThrowsAsync<AggregateException>(() => Scenario.Define<Context>()
+            var exception = Assert.ThrowsAsync<AggregateException>(() => Scenario.Define<ScenarioContext>()
                 .WithEndpoint<EndpointUsingNonDurableMessage>(c => c
                     .When(e => e.SendLocal(new NonDurableMessage())))
                 .Done(c => c.EndpointsStarted)
@@ -19,10 +19,6 @@
 
             Assert.That(exception.InnerException.InnerException, Is.TypeOf<Exception>());
             Assert.That(exception.InnerException.InnerException.Message, Does.Contain("The configured transport does not support non-durable messages but some messages have been configured to be non-durable"));
-        }
-
-        class Context : ScenarioContext
-        {
         }
 
         class EndpointUsingNonDurableMessage : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Routing/When_handler_exists_but_routing_information_is_missing.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_handler_exists_but_routing_information_is_missing.cs
@@ -11,16 +11,12 @@
         [Test]
         public Task Should_skip_events_with_missing_routes()
         {
-            return Scenario.Define<Context>()
+            return Scenario.Define<ScenarioContext>()
                 .WithEndpoint<Subscriber>()
                 .Done(c => c.EndpointsStarted)
                 .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
                 .Should(c => { Assert.True(c.EndpointsStarted); })
                 .Run();
-        }
-
-        public class Context : ScenarioContext
-        {
         }
 
         public class Subscriber : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/UnitOfWork/TransactionScope/When_used_with_default_transaction_mode.cs
+++ b/src/NServiceBus.AcceptanceTests/UnitOfWork/TransactionScope/When_used_with_default_transaction_mode.cs
@@ -12,7 +12,7 @@
         [Test]
         public async Task Should_work()
         {
-            var context = await Scenario.Define<Context>()
+            var context = await Scenario.Define<ScenarioContext>()
                  .WithEndpoint<ScopeEndpoint>(b => b.CustomConfig(c =>
                  {
                      c.GetSettings().Set("FakeTransport.SupportedTransactionMode", TransportTransactionMode.ReceiveOnly);
@@ -24,10 +24,6 @@
                  .Run();
 
             Assert.True(context.EndpointsStarted);
-        }
-
-        public class Context : ScenarioContext
-        {
         }
 
         public class ScopeEndpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/UnitOfWork/TransactionScope/When_used_with_transport_scopes.cs
+++ b/src/NServiceBus.AcceptanceTests/UnitOfWork/TransactionScope/When_used_with_transport_scopes.cs
@@ -13,7 +13,7 @@
         {
             var aex = Assert.ThrowsAsync<AggregateException>(async () =>
             {
-                await Scenario.Define<Context>()
+                await Scenario.Define<ScenarioContext>()
                     .WithEndpoint<ScopeEndpoint>(b => b.CustomConfig(c =>
                     {
                         c.UseTransport<FakeTransport>()
@@ -25,10 +25,6 @@
             });
 
             Assert.True(aex.InnerException.InnerException.Message.Contains("A Transaction scope unit of work can't be used when the transport already uses a scope"));
-        }
-
-        public class Context : ScenarioContext
-        {
         }
 
         public class ScopeEndpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/UnitOfWork/TransactionScope/When_using_timeout_greater_than_machine_max.cs
+++ b/src/NServiceBus.AcceptanceTests/UnitOfWork/TransactionScope/When_using_timeout_greater_than_machine_max.cs
@@ -12,16 +12,12 @@
         {
             var aex = Assert.ThrowsAsync<AggregateException>(async () =>
             {
-                await Scenario.Define<Context>()
+                await Scenario.Define<ScenarioContext>()
                     .WithEndpoint<ScopeEndpoint>()
                     .Run();
             });
 
             Assert.True(aex.InnerException.InnerException.Message.Contains("Timeout requested is longer than the maximum value for this machine"));
-        }
-
-        public class Context : ScenarioContext
-        {
         }
 
         public class ScopeEndpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_using_scope_timeout_greater_than_machine_max.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_using_scope_timeout_greater_than_machine_max.cs
@@ -11,16 +11,12 @@
         {
             var aex = Assert.ThrowsAsync<AggregateException>(async () =>
             {
-                await Scenario.Define<Context>()
+                await Scenario.Define<ScenarioContext>()
                         .WithEndpoint<ScopeEndpoint>()
                         .Run();
             });
 
             Assert.True(aex.InnerException.InnerException.Message.Contains("Timeout requested is longer than the maximum value for this machine"));
-        }
-
-        public class Context : ScenarioContext
-        {
         }
 
         public class ScopeEndpoint : EndpointConfigurationBuilder


### PR DESCRIPTION
Makes `ScenarioContext` no longer abstract which allows to remove the many empty subclasses we have.

@Particular/nservicebus-maintainers what do you think?