### PR TITLE
[WIP] - spike - Headers performance spike

### DIFF
--- a/src/NServiceBus.Core.Tests/Msmq/MsmqUtilitiesTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqUtilitiesTests.cs
@@ -3,6 +3,10 @@
     using System;
     using System.Collections.Generic;
     using System.Messaging;
+    using BenchmarkDotNet.Attributes;
+    using BenchmarkDotNet.Configs;
+    using BenchmarkDotNet.Diagnostics.Windows;
+    using BenchmarkDotNet.Running;
     using DeliveryConstraints;
     using NServiceBus.Performance.TimeToBeReceived;
     using NServiceBus.Transports;
@@ -85,6 +89,99 @@
 
             Assert.False(MsmqUtilities.Convert(new OutgoingMessage("message id", new Dictionary<string, string>(), new byte[0]), nonDurableDeliveryConstraint).Recoverable);
             Assert.True(MsmqUtilities.Convert(new OutgoingMessage("message id", new Dictionary<string, string>(), new byte[0]), durableDeliveryConstraint).Recoverable);
+        }
+
+        [Test]
+        public void Ensure_fast_method_deserializes_properly()
+        {
+            var expected = MsmqUtilities.DeserializeMessageHeaders(HeadersPerformanceTests.Msg);
+            var parsed = MsmqUtilities.DeserializeMessageHeadersFast(HeadersPerformanceTests.Msg);
+
+            CollectionAssert.AreEquivalent(expected, parsed);
+        }
+
+        [Test]
+        [Explicit]
+        public void BenchmarkParsing()
+        {
+            BenchmarkRunner.Run<HeadersPerformanceTests>();
+        }
+    }
+
+    [Config(typeof(Config))]
+    public class HeadersPerformanceTests
+    {
+        [Benchmark]
+        public Dictionary<string, string> Current()
+        {
+            return MsmqUtilities.DeserializeMessageHeaders(Msg);
+        }
+
+        [Benchmark]
+        public Dictionary<string, string> Fast()
+        {
+            return MsmqUtilities.DeserializeMessageHeadersFast(Msg);
+        }
+
+//<?xml version = "1.0" ?>
+//< ArrayOfHeaderInfo xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+//  <HeaderInfo>
+//    <Key>NServiceBus.ControlMessage</Key>
+//    <Value>True</Value>
+//  </HeaderInfo>
+//  <HeaderInfo>
+//    <Key>NServiceBus.MessageIntent</Key>
+//    <Value>Subscribe</Value>
+//  </HeaderInfo>
+//  <HeaderInfo>
+//    <Key>SubscriptionMessageType</Key>
+//    <Value>NServiceBus.AcceptanceTests.Routing.When_subscribing_with_address_containing_host_name+MyEvent, NServiceBus.Msmq.AcceptanceTests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null</Value>
+//  </HeaderInfo>
+//  <HeaderInfo>
+//    <Key>NServiceBus.ReplyToAddress</Key>
+//    <Value>SubscribingWithAddressContainingHostName.Subscriber @DESKTOP-VFHGG46</Value>
+//  </HeaderInfo>
+//  <HeaderInfo>
+//    <Key>NServiceBus.SubscriberAddress</Key>
+//    <Value>SubscribingWithAddressContainingHostName.Subscriber @DESKTOP-VFHGG46</Value>
+//  </HeaderInfo>
+//  <HeaderInfo>
+//    <Key>NServiceBus.SubscriberEndpoint</Key>
+//    <Value>SubscribingWithAddressContainingHostName.Subscriber</Value>
+//  </HeaderInfo>
+//  <HeaderInfo>
+//    <Key>NServiceBus.TimeSent</Key>
+//    <Value>2016-06-30 13:02:46:369296 Z</Value>
+//  </HeaderInfo>
+//  <HeaderInfo>
+//    <Key>NServiceBus.Version</Key>
+//    <Value>6.0.0</Value>
+//  </HeaderInfo>
+//  <HeaderInfo>
+//    <Key>CorrId</Key>
+//    <Value />
+//  </HeaderInfo>
+//</ArrayOfHeaderInfo>
+
+        internal static readonly Message Msg = MsmqUtilities.Convert(new OutgoingMessage("message id", new Dictionary<string, string>
+        {
+            {Headers.ControlMessageHeader, "True"},
+            {Headers.MessageIntent, MessageIntentEnum.Subscribe.ToString()},
+            {Headers.SubscriptionMessageType, "NServiceBus.AcceptanceTests.Routing.When_subscribing_with_address_containing_host_name+MyEvent, NServiceBus.Msmq.AcceptanceTests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"},
+            {Headers.ReplyToAddress, "SubscribingWithAddressContainingHostName.Subscriber@DESKTOP"},
+            {Headers.SubscriberTransportAddress, "SubscribingWithAddressContainingHostName.Subscriber@DESKTOP"},
+            {Headers.SubscriberEndpoint, "SubscribingWithAddressContainingHostName.Subscriber"},
+            {Headers.TimeSent, "2016-06-30 13:02:46:369296 Z"},
+            {Headers.NServiceBusVersion, "6.0.0"},
+            {Headers.CorrelationId, ""}
+        }, new byte[0]), new List<DeliveryConstraint>());
+
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                Add(new MemoryDiagnoser());
+            }
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -15,7 +15,8 @@
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>27189a06</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -56,7 +57,19 @@
       <HintPath>..\packages\ApprovalUtilities.3.0.11\lib\net45\ApprovalUtilities.Net45.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="BenchmarkDotNet, Version=0.9.7.0, Culture=neutral, PublicKeyToken=aa0ca2f9092cefc4, processorArchitecture=MSIL">
+      <HintPath>..\packages\BenchmarkDotNet.0.9.7\lib\net40\BenchmarkDotNet.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="BenchmarkDotNet.Diagnostics.Windows, Version=0.9.7.0, Culture=neutral, PublicKeyToken=aa0ca2f9092cefc4, processorArchitecture=MSIL">
+      <HintPath>..\packages\BenchmarkDotNet.Diagnostics.Windows.0.9.7\lib\net40\BenchmarkDotNet.Diagnostics.Windows.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.Diagnostics.Tracing.TraceEvent, Version=1.0.41.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.41\lib\net40\Microsoft.Diagnostics.Tracing.TraceEvent.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Cecil.0.9.6.1\lib\net45\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
@@ -85,6 +98,7 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Messaging" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Transactions" />
@@ -329,6 +343,7 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="packages.config" />
+    <None Include="_TraceEventProgrammersGuide.docx" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NServiceBus.Core\NServiceBus.Core.csproj">
@@ -385,10 +400,19 @@
   <ItemGroup>
     <Content Include="TestDlls\NServiceBus.NewCompilerBits.dll" />
     <Content Include="TestDlls\NServiceBus.OldCompilerBits.dll" />
+    <Content Include="TraceEvent.ReadMe.txt" />
+    <Content Include="TraceEvent.ReleaseNotes.txt" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.41\build\Microsoft.Diagnostics.Tracing.TraceEvent.targets" Condition="Exists('..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.41\build\Microsoft.Diagnostics.Tracing.TraceEvent.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.41\build\Microsoft.Diagnostics.Tracing.TraceEvent.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Diagnostics.Tracing.TraceEvent.1.0.41\build\Microsoft.Diagnostics.Tracing.TraceEvent.targets'))" />
+  </Target>
 </Project>

--- a/src/NServiceBus.Core.Tests/packages.config
+++ b/src/NServiceBus.Core.Tests/packages.config
@@ -3,6 +3,9 @@
   <package id="ApiApprover" version="3.0.1" targetFramework="net45" />
   <package id="ApprovalTests" version="3.0.11" targetFramework="net452" />
   <package id="ApprovalUtilities" version="3.0.11" targetFramework="net452" />
+  <package id="BenchmarkDotNet" version="0.9.7" targetFramework="net452" />
+  <package id="BenchmarkDotNet.Diagnostics.Windows" version="0.9.7" targetFramework="net452" />
+  <package id="Microsoft.Diagnostics.Tracing.TraceEvent" version="1.0.41" targetFramework="net452" />
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net452" />
   <package id="NuDoq" version="1.2.5" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net452" />

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -31,6 +31,7 @@
     <DocumentationFile>..\..\binaries\NServiceBus.Core.xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -42,6 +43,7 @@
     <DocumentationFile>..\..\binaries\NServiceBus.Core.xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <None Include="FodyWeavers.xml">
@@ -148,6 +150,7 @@
     <Compile Include="Routing\ConfigureUniquelyAddressableInstanceExtensions.cs" />
     <Compile Include="Transports\IOutgoingTransportOperation.cs" />
     <Compile Include="Transports\LogicalAddressExtensions.cs" />
+    <Compile Include="Transports\Msmq\MsmqFastHeadersParser.cs" />
     <Compile Include="Transports\Msmq\MsmqScopeOptions.cs" />
     <Compile Include="Transports\Msmq\MsmqTransportInfrastructure.cs" />
     <Compile Include="Transports\MulticastTransportOperation.cs" />

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqFastHeadersParser.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqFastHeadersParser.cs
@@ -1,0 +1,239 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Runtime.Serialization;
+    using System.Text;
+
+    sealed class MsmqFastHeadersParser
+    {
+        static MsmqFastHeadersParser()
+        {
+            var headerKeys = typeof(Headers).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+                .Where(fi => fi.IsLiteral && !fi.IsInitOnly)
+                .Select(fi => fi.GetRawConstantValue())
+                .Cast<string>()
+                .ToArray();
+
+            KnownHeaders = new Dictionary<ArraySegment<byte>, string>(new KeyArraySegmentComparer());
+
+            foreach (var headerKey in headerKeys)
+            {
+                KnownHeaders.Add(new ArraySegment<byte>(Encoding.UTF8.GetBytes(headerKey)), headerKey);
+            }
+        }
+
+        MsmqFastHeadersParser(byte[] bytes)
+        {
+            this.bytes = bytes;
+        }
+
+        public static Dictionary<string, string> ParseHeaders(byte[] bytes)
+        {
+            return new MsmqFastHeadersParser(bytes).ParseHeaders();
+        }
+
+        Dictionary<string, string> ParseHeaders()
+        {
+            var result = new Dictionary<string, string>();
+            var byteCount = bytes.Length;
+
+            if (byteCount == 0)
+            {
+                return result;
+            }
+
+            // <xml
+            if (TryMoveToNext(Open) == false)
+            {
+                return result;
+            }
+            pos += 1;
+
+            // <ArrayOfHeaderInfo
+            if (TryMoveToNext(Open) == false)
+            {
+                return result;
+            }
+            pos += 1;
+
+            // loop over <HeaderInfo>, moving to the starting tag
+            while (TryMoveToNext(Open))
+            {
+                if (TryConsumeTag(HeaderInfo) == false)
+                {
+                    // this is not a header info
+                    break;
+                }
+                // inside <HeaderInfo>...
+                //                    ^
+
+                ConsumeTag(HeaderKey);
+                // <Key>...
+                //      ^
+                var keyStart = pos;
+                MoveToNext(Open);
+
+                var key = GetKey(new ArraySegment<byte>(bytes, keyStart, pos - keyStart));
+
+                ConsumeTag(HeaderKeyEnd);
+                // </Key>...
+                //       ^
+
+                MoveToNext(Open);
+
+                if (TryConsumeTag(HeaderValue))
+                {
+                    // <Value>...
+                    //        ^
+
+                    var valueStart = pos;
+                    MoveToNext(Open);
+
+                    var value = GetValue(new ArraySegment<byte>(bytes, valueStart, pos - valueStart));
+                    result.Add(key, value);
+
+                    TryConsumeTag(HeaderValueEnd);
+                    // </Value>...
+                    //         ^
+                }
+                else
+                {
+                    if (TryConsumeTag(HeaderValueEmpty))
+                    {
+                        // <Value />...
+                        //          ^
+                        result.Add(key, "");
+                    }
+                    else
+                    {
+                        throw new SerializationException();
+                    }
+                }
+                ConsumeTag(HeaderInfoEnd);
+                // </HeaderInfo>...
+                //              ^
+            }
+
+            return result;
+        }
+
+        static string GetKey(ArraySegment<byte> s)
+        {
+            string key;
+            return KnownHeaders.TryGetValue(s, out key) ? key : Encoding.UTF8.GetString(s.Array, s.Offset, s.Count);
+        }
+
+        static string GetValue(ArraySegment<byte> s)
+        {
+            return Encoding.UTF8.GetString(s.Array, s.Offset, s.Count);
+        }
+
+        /// <summary>
+        /// Consumes a tag moving the <see cref="pos" /> rigth after the tag.
+        /// </summary>
+        void ConsumeTag(ArraySegment<byte> tag)
+        {
+            if (TryConsumeTag(tag) == false)
+            {
+                throw new SerializationException();
+            }
+        }
+
+        bool TryConsumeTag(ArraySegment<byte> tag)
+        {
+            // preserve position in case of failure
+            var tempPosition = pos;
+
+            MoveToNext(Open);
+            var start = pos + 1;
+            MoveToNext(Close);
+            var end = pos - 1;
+
+            var headerInfo = new ArraySegment<byte>(bytes, start, end - start + 1);
+            if (UnsafeCompare(headerInfo, tag))
+            {
+                pos += 1;
+                return true;
+            }
+
+            pos = tempPosition;
+            return false;
+        }
+
+        bool TryMoveToNext(byte b)
+        {
+            if (pos < 0)
+            {
+                return false;
+            }
+            pos = Array.IndexOf(bytes, b, pos);
+            return true;
+        }
+
+        void MoveToNext(byte b)
+        {
+            if (TryMoveToNext(b) == false)
+            {
+                throw new SerializationException();
+            }
+        }
+
+        static unsafe bool UnsafeCompare(ArraySegment<byte> a1, ArraySegment<byte> a2)
+        {
+            if (a1.Count != a2.Count)
+                return false;
+            fixed(byte* p1 = a1.Array, p2 = a2.Array)
+            {
+                var x1 = p1 + a1.Offset;
+                var x2 = p2 + a2.Offset;
+                var l = a1.Count;
+                for (var i = 0; i < l/8; i++, x1 += 8, x2 += 8)
+                    if (*((long*) x1) != *((long*) x2)) return false;
+                if ((l & 4) != 0)
+                {
+                    if (*((int*) x1) != *((int*) x2)) return false;
+                    x1 += 4;
+                    x2 += 4;
+                }
+                if ((l & 2) != 0)
+                {
+                    if (*((short*) x1) != *((short*) x2)) return false;
+                    x1 += 2;
+                    x2 += 2;
+                }
+                if ((l & 1) != 0) if (*x1 != *x2) return false;
+                return true;
+            }
+        }
+
+        readonly byte[] bytes;
+        int pos;
+
+        static byte Open = Encoding.UTF8.GetBytes("<").Single();
+        static byte Close = Encoding.UTF8.GetBytes(">").Single();
+        static readonly ArraySegment<byte> HeaderInfo = new ArraySegment<byte>(Encoding.UTF8.GetBytes("HeaderInfo"));
+        static readonly ArraySegment<byte> HeaderInfoEnd = new ArraySegment<byte>(Encoding.UTF8.GetBytes("/HeaderInfo"));
+        static readonly ArraySegment<byte> HeaderKey = new ArraySegment<byte>(Encoding.UTF8.GetBytes("Key"));
+        static readonly ArraySegment<byte> HeaderKeyEnd = new ArraySegment<byte>(Encoding.UTF8.GetBytes("/Key"));
+        static readonly ArraySegment<byte> HeaderValue = new ArraySegment<byte>(Encoding.UTF8.GetBytes("Value"));
+        static readonly ArraySegment<byte> HeaderValueEnd = new ArraySegment<byte>(Encoding.UTF8.GetBytes("/Value"));
+        static readonly ArraySegment<byte> HeaderValueEmpty = new ArraySegment<byte>(Encoding.UTF8.GetBytes("Value /"));
+        static Dictionary<ArraySegment<byte>, string> KnownHeaders;
+
+        class KeyArraySegmentComparer : IEqualityComparer<ArraySegment<byte>>
+        {
+            public bool Equals(ArraySegment<byte> x, ArraySegment<byte> y)
+            {
+                return UnsafeCompare(x, y);
+            }
+
+            public int GetHashCode(ArraySegment<byte> obj)
+            {
+                return obj.Count;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqUtilities.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqUtilities.cs
@@ -84,18 +84,19 @@ namespace NServiceBus
             return message.CorrelationId.Replace("\\0", string.Empty);
         }
 
-        static Dictionary<string, string> DeserializeMessageHeaders(Message m)
+        public static Dictionary<string, string> DeserializeMessageHeaders(Message m)
         {
+            var bytes = m.Extension;
             var result = new Dictionary<string, string>();
 
-            if (m.Extension.Length == 0)
+            if (bytes.Length == 0)
             {
                 return result;
             }
 
             //This is to make us compatible with v3 messages that are affected by this bug:
             //http://stackoverflow.com/questions/3779690/xml-serialization-appending-the-0-backslash-0-or-null-character
-            var extension = Encoding.UTF8.GetString(m.Extension).TrimEnd('\0');
+            var extension = Encoding.UTF8.GetString(bytes).TrimEnd('\0');
             object o;
             using (var stream = new StringReader(extension))
             {
@@ -117,6 +118,12 @@ namespace NServiceBus
             }
 
             return result;
+        }
+
+        public static Dictionary<string, string> DeserializeMessageHeadersFast(Message m)
+        {
+            var bytes = m.Extension;
+            return MsmqFastHeadersParser.ParseHeaders(bytes);
         }
 
         public static Message Convert(OutgoingMessage message, List<DeliveryConstraint> deliveryConstraints)

--- a/src/NServiceBus.Msmq.AcceptanceTests/NServiceBus.Msmq.AcceptanceTests.csproj
+++ b/src/NServiceBus.Msmq.AcceptanceTests/NServiceBus.Msmq.AcceptanceTests.csproj
@@ -31,6 +31,10 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BenchmarkDotNet, Version=0.9.7.0, Culture=neutral, PublicKeyToken=aa0ca2f9092cefc4, processorArchitecture=MSIL">
+      <HintPath>..\packages\BenchmarkDotNet.0.9.7\lib\net40\BenchmarkDotNet.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
@@ -38,6 +42,7 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Messaging" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Xml.Linq" />

--- a/src/NServiceBus.Msmq.AcceptanceTests/packages.config
+++ b/src/NServiceBus.Msmq.AcceptanceTests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="BenchmarkDotNet" version="0.9.7" targetFramework="net46" />
   <package id="NUnit" version="3.2.1" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
This PR spikes a different approach of deserializing headers. Currently it's MSMQ only, but this serializerless approach can be provided for others as well. This spike is based on:

1. No more decoding of the whole string with UTF8.
1. `XmlSerializer` replaced with a custom code, using internalized headers keys. It uses comparison of UTF8 encoded `ArraySegment<byte>` keys rather than decoding then over and over again. If UTF8 representation is equal, then an already allocated string is used. This decreases the execution time (no decoding) as well as # of allocated bytes.

See the results below:
```
BenchmarkDotNet=v0.9.7.0
OS=Microsoft Windows NT 10.0.10586.0
Processor=Intel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
Frequency=2531250 ticks, Resolution=395.0617 ns, Timer=TSC
HostCLR=MS.NET 4.0.30319.42000, Arch=64-bit RELEASE [RyuJIT]
JitModules=clrjit-v4.6.1080.0

Type=HeadersPerformanceTests  Mode=Throughput  
```

  Method |     Median |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Bytes Allocated/Op |
-------- |----------- |---------- |------- |------ |------ |------------------- |
 Current | 26.4583 us | 1.9512 us | 914.00 |     - |     - |          10,540.56 |
    Fast |  9.6449 us | 0.4290 us | 166.00 |     - |     - |           1,620.50 |