### PR TITLE
Align register publisher API

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_to_scaled_out_subscribers_on_unicast_transports.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_to_scaled_out_subscribers_on_unicast_transports.cs
@@ -71,7 +71,7 @@
         {
             public SubscriberA()
             {
-                EndpointSetup<DefaultServer>(c => { c.RegisterPublisherForType(PublisherEndpoint, typeof(MyEvent)); });
+                EndpointSetup<DefaultServer>(c => { c.RegisterPublisherForType(typeof(MyEvent), PublisherEndpoint); });
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>
@@ -90,7 +90,7 @@
         {
             public SubscriberB()
             {
-                EndpointSetup<DefaultServer>(c => { c.RegisterPublisherForType(PublisherEndpoint, typeof(MyEvent)); });
+                EndpointSetup<DefaultServer>(c => { c.RegisterPublisherForType(typeof(MyEvent), PublisherEndpoint); });
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.AcceptanceTests/UnicastPubSubExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/UnicastPubSubExtensions.cs
@@ -6,9 +6,9 @@ namespace NServiceBus.AcceptanceTests.Routing
 
     static class UnicastPubSubExtensions
     {
-        public static void RegisterPublisherForType(this EndpointConfiguration config, string publisherEndpoint, Type eventType)
+        public static void RegisterPublisherForType(this EndpointConfiguration config, Type eventType, string publisherEndpoint)
         {
-            config.GetSettings().GetOrCreate<Publishers>().Add(publisherEndpoint, eventType);
+            config.GetSettings().GetOrCreate<Publishers>().Add(eventType, publisherEndpoint);
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -743,9 +743,11 @@ namespace NServiceBus
     }
     public class static MessageDrivenSubscriptionsConfigExtensions
     {
-        public static void RegisterPublisherForAssembly<T>(this NServiceBus.RoutingSettings<T> routingSettings, string publisherEndpoint, System.Reflection.Assembly eventAssembly, string eventNamespace = null)
+        public static void RegisterPublisherForAssembly<T>(this NServiceBus.RoutingSettings<T> routingSettings, System.Reflection.Assembly eventAssembly, string publisherEndpoint)
             where T : NServiceBus.Transports.TransportDefinition, NServiceBus.Routing.IMessageDrivenSubscriptionTransport { }
-        public static void RegisterPublisherForType<T>(this NServiceBus.RoutingSettings<T> routingSettings, string publisherEndpoint, System.Type eventType)
+        public static void RegisterPublisherForAssembly<T>(this NServiceBus.RoutingSettings<T> routingSettings, System.Reflection.Assembly eventAssembly, string eventNamespace, string publisherEndpoint)
+            where T : NServiceBus.Transports.TransportDefinition, NServiceBus.Routing.IMessageDrivenSubscriptionTransport { }
+        public static void RegisterPublisherForType<T>(this NServiceBus.RoutingSettings<T> routingSettings, System.Type eventType, string publisherEndpoint)
             where T : NServiceBus.Transports.TransportDefinition, NServiceBus.Routing.IMessageDrivenSubscriptionTransport { }
         public static void SubscriptionAuthorizer<T>(this NServiceBus.TransportExtensions<T> transportExtensions, System.Func<NServiceBus.Pipeline.IIncomingPhysicalMessageContext, bool> authorizer)
             where T : NServiceBus.Transports.TransportDefinition, NServiceBus.Routing.IMessageDrivenSubscriptionTransport { }
@@ -2562,9 +2564,10 @@ namespace NServiceBus.Routing.MessageDrivenSubscriptions
     public class Publishers
     {
         public Publishers() { }
-        public void Add(string publisher, System.Type eventType) { }
-        public void Add(string publisher, System.Reflection.Assembly eventAssembly, string eventNamespace = null) { }
-        public void AddByAddress(string publisherAddress, System.Type eventType) { }
+        public void Add(System.Type eventType, string publisher) { }
+        public void Add(System.Reflection.Assembly eventAssembly, string publisher) { }
+        public void Add(System.Reflection.Assembly eventAssembly, string eventNamespace, string publisher) { }
+        public void AddByAddress(System.Type eventType, string publisherAddress) { }
         public void AddDynamic(System.Func<System.Type, NServiceBus.Routing.MessageDrivenSubscriptions.PublisherAddress> dynamicRule, string description = null) { }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
@@ -18,7 +18,7 @@
         public void SetUp()
         {
             var publishers = new Publishers();
-            publishers.AddByAddress("publisher1", typeof(object));
+            publishers.AddByAddress(typeof(object), "publisher1");
             router = new SubscriptionRouter(publishers, new EndpointInstances(), new TransportAddresses(address => null));
             dispatcher = new FakeDispatcher();
             subscribeTerminator = new MessageDrivenSubscribeTerminator(router, "replyToAddress", "Endpoint", dispatcher);

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
@@ -22,7 +22,7 @@
         public void SetUp()
         {
             var publishers = new Publishers();
-            publishers.AddByAddress("publisher1", typeof(object));
+            publishers.AddByAddress(typeof(object), "publisher1");
             router = new SubscriptionRouter(publishers, new EndpointInstances(), new TransportAddresses(address => null));
             dispatcher = new FakeDispatcher();
             terminator = new MessageDrivenUnsubscribeTerminator(router, "replyToAddress", "Endpoint", dispatcher);

--- a/src/NServiceBus.Core.Tests/Routing/SubscriptionRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SubscriptionRouterTests.cs
@@ -15,7 +15,7 @@ namespace NServiceBus.Core.Tests.Routing
             var router = new SubscriptionRouter(new Publishers(), new EndpointInstances(), new TransportAddresses(address => null));
             Assert.IsEmpty(await router.GetAddressesForEventType(typeof(Message1)));
         }
-     
+
         [Test]
         public async Task Should_return_correct_base_and_inherited_address_even_if_they_differ()
         {
@@ -26,9 +26,9 @@ namespace NServiceBus.Core.Tests.Routing
             var inheritedType = typeof(InheritedMessage);
 
             var publishers = new Publishers();
-            publishers.Add(baseAddress, baseType );
-            publishers.Add(inheritedAddress, baseType);
-            publishers.Add(inheritedAddress, inheritedType );
+            publishers.Add(baseType, baseAddress);
+            publishers.Add(baseType, inheritedAddress);
+            publishers.Add(inheritedType, inheritedAddress);
             var endpointInstances = new EndpointInstances();
             endpointInstances.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(e))));
             var physicalAddresses = new TransportAddresses(address => null);
@@ -47,9 +47,9 @@ namespace NServiceBus.Core.Tests.Routing
             var inheritedType = typeof(InheritedMessage);
 
             var publishers = new Publishers();
-            publishers.Add("addressA", baseType);
-            publishers.Add("addressB", baseType);
-            publishers.Add("addressB", inheritedType);
+            publishers.Add(baseType, "addressA");
+            publishers.Add(baseType, "addressB");
+            publishers.Add(inheritedType, "addressB");
             var knownEndpoints = new EndpointInstances();
             knownEndpoints.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(e, null, null))));
             var physicalAddresses = new TransportAddresses(address => null);
@@ -59,31 +59,25 @@ namespace NServiceBus.Core.Tests.Routing
             Assert.AreEqual(2, (await router.GetAddressesForEventType(baseType)).Count());
         }
 
-
         [Test]
         public void Should_not_generate_duplicate_addresses()
         {
         }
 
-
         public class Message1
         {
-
         }
 
         public class Message2
         {
-
         }
 
         public class BaseMessage : IEvent
         {
-
         }
 
         public class InheritedMessage : BaseMessage
         {
-
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
@@ -46,6 +46,8 @@ namespace NServiceBus
         /// <param name="publisherEndpoint">The publisher endpoint.</param>
         public static void RegisterPublisherForType<T>(this RoutingSettings<T> routingSettings, Type eventType, string publisherEndpoint) where T : TransportDefinition, IMessageDrivenSubscriptionTransport
         {
+            Guard.AgainstNullAndEmpty(nameof(publisherEndpoint), publisherEndpoint);
+
             routingSettings.Settings.GetOrCreate<Publishers>().Add(eventType, publisherEndpoint);
         }
 
@@ -57,6 +59,9 @@ namespace NServiceBus
         /// <param name="publisherEndpoint">The publisher endpoint.</param>
         public static void RegisterPublisherForAssembly<T>(this RoutingSettings<T> routingSettings, Assembly eventAssembly, string publisherEndpoint) where T : TransportDefinition, IMessageDrivenSubscriptionTransport
         {
+            Guard.AgainstNull(nameof(eventAssembly), eventAssembly);
+            Guard.AgainstNullAndEmpty(nameof(publisherEndpoint), publisherEndpoint);
+
             routingSettings.Settings.GetOrCreate<Publishers>().Add(eventAssembly, publisherEndpoint);
         }
 
@@ -69,6 +74,10 @@ namespace NServiceBus
         /// <param name="publisherEndpoint">The publisher endpoint.</param>
         public static void RegisterPublisherForAssembly<T>(this RoutingSettings<T> routingSettings, Assembly eventAssembly, string eventNamespace, string publisherEndpoint) where T : TransportDefinition, IMessageDrivenSubscriptionTransport
         {
+            Guard.AgainstNull(nameof(eventAssembly), eventAssembly);
+            Guard.AgainstNull(nameof(eventNamespace), eventNamespace);
+            Guard.AgainstNullAndEmpty(nameof(publisherEndpoint), publisherEndpoint);
+
             routingSettings.Settings.GetOrCreate<Publishers>().Add(eventAssembly, eventNamespace, publisherEndpoint);
         }
     }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
@@ -42,23 +42,34 @@ namespace NServiceBus
         /// Registers a publisher endpoint for a given event type.
         /// </summary>
         /// <param name="routingSettings">The <see cref="RoutingSettings&lt;T&gt;" /> to extend.</param>
-        /// <param name="publisherEndpoint">The publisher endpoint.</param>
         /// <param name="eventType">The event type.</param>
-        public static void RegisterPublisherForType<T>(this RoutingSettings<T> routingSettings, string publisherEndpoint, Type eventType) where T : TransportDefinition, IMessageDrivenSubscriptionTransport
+        /// <param name="publisherEndpoint">The publisher endpoint.</param>
+        public static void RegisterPublisherForType<T>(this RoutingSettings<T> routingSettings, Type eventType, string publisherEndpoint) where T : TransportDefinition, IMessageDrivenSubscriptionTransport
         {
-            routingSettings.Settings.GetOrCreate<Publishers>().Add(publisherEndpoint, eventType);
+            routingSettings.Settings.GetOrCreate<Publishers>().Add(eventType, publisherEndpoint);
         }
 
         /// <summary>
         /// Registers a publisher endpoint for all event types in a given assembly and, optionally, namespace.
         /// </summary>
         /// <param name="routingSettings">The <see cref="RoutingSettings&lt;T&gt;" /> to extend.</param>
+        /// <param name="eventAssembly">The assembly containing the event types.</param>
         /// <param name="publisherEndpoint">The publisher endpoint.</param>
+        public static void RegisterPublisherForAssembly<T>(this RoutingSettings<T> routingSettings, Assembly eventAssembly, string publisherEndpoint) where T : TransportDefinition, IMessageDrivenSubscriptionTransport
+        {
+            routingSettings.Settings.GetOrCreate<Publishers>().Add(eventAssembly, publisherEndpoint);
+        }
+
+        /// <summary>
+        /// Registers a publisher endpoint for all event types in a given assembly and, optionally, namespace.
+        /// </summary>
+        /// <param name="routingSettings">The <see cref="RoutingSettings&lt;T&gt;" /> to extend.</param>
         /// <param name="eventAssembly">The assembly containing the event types.</param>
         /// <param name="eventNamespace">The namespace containing the event types.</param>
-        public static void RegisterPublisherForAssembly<T>(this RoutingSettings<T> routingSettings, string publisherEndpoint, Assembly eventAssembly, string eventNamespace = null) where T : TransportDefinition, IMessageDrivenSubscriptionTransport
+        /// <param name="publisherEndpoint">The publisher endpoint.</param>
+        public static void RegisterPublisherForAssembly<T>(this RoutingSettings<T> routingSettings, Assembly eventAssembly, string eventNamespace, string publisherEndpoint) where T : TransportDefinition, IMessageDrivenSubscriptionTransport
         {
-            routingSettings.Settings.GetOrCreate<Publishers>().Add(publisherEndpoint, eventAssembly, eventNamespace);
+            routingSettings.Settings.GetOrCreate<Publishers>().Add(eventAssembly, eventNamespace, publisherEndpoint);
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
@@ -70,7 +70,7 @@ namespace NServiceBus
         /// </summary>
         /// <param name="routingSettings">The <see cref="RoutingSettings&lt;T&gt;" /> to extend.</param>
         /// <param name="eventAssembly">The assembly containing the event types.</param>
-        /// <param name="eventNamespace">The namespace containing the event types.</param>
+        /// <param name="eventNamespace">The namespace containing the event types. The given value must exactly match the target namespace.</param>
         /// <param name="publisherEndpoint">The publisher endpoint.</param>
         public static void RegisterPublisherForAssembly<T>(this RoutingSettings<T> routingSettings, Assembly eventAssembly, string eventNamespace, string publisherEndpoint) where T : TransportDefinition, IMessageDrivenSubscriptionTransport
         {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
@@ -52,7 +52,7 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Registers a publisher endpoint for all event types in a given assembly and, optionally, namespace.
+        /// Registers a publisher endpoint for all event types in a given assembly.
         /// </summary>
         /// <param name="routingSettings">The <see cref="RoutingSettings&lt;T&gt;" /> to extend.</param>
         /// <param name="eventAssembly">The assembly containing the event types.</param>
@@ -66,7 +66,7 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Registers a publisher endpoint for all event types in a given assembly and, optionally, namespace.
+        /// Registers a publisher endpoint for all event types in a given assembly and namespace.
         /// </summary>
         /// <param name="routingSettings">The <see cref="RoutingSettings&lt;T&gt;" /> to extend.</param>
         /// <param name="eventAssembly">The assembly containing the event types.</param>

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/Publishers.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/Publishers.cs
@@ -17,41 +17,41 @@ namespace NServiceBus.Routing.MessageDrivenSubscriptions
         }
 
         /// <summary>
-        /// Registers a publisher endpoint for a given endpoint type.
+        /// Registers a publisher endpoint for a given event type.
         /// </summary>
-        /// <param name="eventType">Event type.</param>
-        /// <param name="publisher">Publisher endpoint.</param>
+        /// <param name="eventType">The event type.</param>
+        /// <param name="publisher">The publisher endpoint.</param>
         public void Add(Type eventType, string publisher)
         {
             rules.Add(new Rule(type => StaticTypeRule(type, eventType, PublisherAddress.CreateFromEndpointName(publisher)), $"{eventType.FullName} -> {publisher}"));
         }
 
         /// <summary>
-        /// Registers a publisher address for a given endpoint type.
+        /// Registers a publisher address for a given event type.
         /// </summary>
-        /// <param name="eventType">Event type.</param>
-        /// <param name="publisherAddress">Publisher physical address.</param>
+        /// <param name="eventType">The event type.</param>
+        /// <param name="publisherAddress">The publisher's physical address.</param>
         public void AddByAddress(Type eventType, string publisherAddress)
         {
             rules.Add(new Rule(type => StaticTypeRule(type, eventType, PublisherAddress.CreateFromPhysicalAddresses(publisherAddress)), $"{eventType.FullName} -> {publisherAddress}"));
         }
 
         /// <summary>
-        /// Registers a publisher for all events in a given assembly (and optionally namespace).
+        /// Registers a publisher endpoint for all event types in a given assembly.
         /// </summary>
-        /// <param name="publisher">Publisher endpoint.</param>
-        /// <param name="eventAssembly">Assembly containing events.</param>
+        /// <param name="eventAssembly">The assembly containing the event types.</param>
+        /// <param name="publisher">The publisher endpoint.</param>
         public void Add(Assembly eventAssembly, string publisher)
         {
             rules.Add(new Rule(type => StaticAssemblyRule(type, eventAssembly, null, PublisherAddress.CreateFromEndpointName(publisher)), $"{eventAssembly.GetName().Name}/* -> {publisher}"));
         }
 
         /// <summary>
-        /// Registers a publisher for all events in a given assembly (and optionally namespace).
+        /// Registers a publisher endpoint for all event types in a given assembly and namespace.
         /// </summary>
-        /// <param name="eventAssembly">Assembly containing events.</param>
-        /// <param name="eventNamespace">Optional namespace containing events.</param>
-        /// <param name="publisher">Publisher endpoint.</param>
+        /// <param name="eventAssembly">The assembly containing the event types.</param>
+        /// <param name="eventNamespace">The namespace containing the event types.</param>
+        /// <param name="publisher">The publisher endpoint.</param>
         public void Add(Assembly eventAssembly, string eventNamespace, string publisher)
         {
             rules.Add(new Rule(type => StaticAssemblyRule(type, eventAssembly, eventNamespace, PublisherAddress.CreateFromEndpointName(publisher)), $"{eventAssembly.GetName().Name}/{eventNamespace} -> {publisher}"));

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/Publishers.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/Publishers.cs
@@ -19,9 +19,9 @@ namespace NServiceBus.Routing.MessageDrivenSubscriptions
         /// <summary>
         /// Registers a publisher endpoint for a given endpoint type.
         /// </summary>
-        /// <param name="publisher">Publisher endpoint.</param>
         /// <param name="eventType">Event type.</param>
-        public void Add(string publisher, Type eventType)
+        /// <param name="publisher">Publisher endpoint.</param>
+        public void Add(Type eventType, string publisher)
         {
             rules.Add(new Rule(type => StaticTypeRule(type, eventType, PublisherAddress.CreateFromEndpointName(publisher)), $"{eventType.FullName} -> {publisher}"));
         }
@@ -29,9 +29,9 @@ namespace NServiceBus.Routing.MessageDrivenSubscriptions
         /// <summary>
         /// Registers a publisher address for a given endpoint type.
         /// </summary>
-        /// <param name="publisherAddress">Publisher physical address.</param>
         /// <param name="eventType">Event type.</param>
-        public void AddByAddress(string publisherAddress, Type eventType)
+        /// <param name="publisherAddress">Publisher physical address.</param>
+        public void AddByAddress(Type eventType, string publisherAddress)
         {
             rules.Add(new Rule(type => StaticTypeRule(type, eventType, PublisherAddress.CreateFromPhysicalAddresses(publisherAddress)), $"{eventType.FullName} -> {publisherAddress}"));
         }
@@ -41,10 +41,20 @@ namespace NServiceBus.Routing.MessageDrivenSubscriptions
         /// </summary>
         /// <param name="publisher">Publisher endpoint.</param>
         /// <param name="eventAssembly">Assembly containing events.</param>
-        /// <param name="eventNamespace">Optional namespace containing events.</param>
-        public void Add(string publisher, Assembly eventAssembly, string eventNamespace = null)
+        public void Add(Assembly eventAssembly, string publisher)
         {
-            rules.Add(new Rule(type => StaticAssemblyRule(type, eventAssembly, eventNamespace, PublisherAddress.CreateFromEndpointName(publisher)), $"{eventAssembly.GetName().Name}/{eventNamespace ?? "*"} -> {publisher}"));
+            rules.Add(new Rule(type => StaticAssemblyRule(type, eventAssembly, null, PublisherAddress.CreateFromEndpointName(publisher)), $"{eventAssembly.GetName().Name}/* -> {publisher}"));
+        }
+
+        /// <summary>
+        /// Registers a publisher for all events in a given assembly (and optionally namespace).
+        /// </summary>
+        /// <param name="eventAssembly">Assembly containing events.</param>
+        /// <param name="eventNamespace">Optional namespace containing events.</param>
+        /// <param name="publisher">Publisher endpoint.</param>
+        public void Add(Assembly eventAssembly, string eventNamespace, string publisher)
+        {
+            rules.Add(new Rule(type => StaticAssemblyRule(type, eventAssembly, eventNamespace, PublisherAddress.CreateFromEndpointName(publisher)), $"{eventAssembly.GetName().Name}/{eventNamespace} -> {publisher}"));
         }
 
         static PublisherAddress StaticAssemblyRule(Type typeBeingQueried, Assembly configuredAssembly, string configuredNamespace, PublisherAddress configuredAddress)

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -97,26 +97,26 @@
 
             foreach (MessageEndpointMapping m in legacyRoutingConfig)
             {
-                m.Configure((type, s) =>
+                m.Configure((type, endpointAddress) =>
                 {
-                    ConfigureSendDestination(transportInfrastructure, unicastRoutingTable, type, s);
-                    ConfigureSubscribeDestination(publishers, knownMessageTypes, type, s);
+                    ConfigureSendDestination(transportInfrastructure, unicastRoutingTable, type, endpointAddress);
+                    ConfigureSubscribeDestination(publishers, knownMessageTypes, type, endpointAddress);
                 });
             }
         }
 
-        static void ConfigureSubscribeDestination(Publishers publishers, List<Type> knownMessageTypes, Type type, string s)
+        static void ConfigureSubscribeDestination(Publishers publishers, List<Type> knownMessageTypes, Type type, string address)
         {
             var typesEnclosed = knownMessageTypes.Where(t => t.IsAssignableFrom(type));
             foreach (var t in typesEnclosed)
             {
-                publishers.AddByAddress(s, t);
+                publishers.AddByAddress(t, address);
             }
         }
 
-        static void ConfigureSendDestination(TransportInfrastructure transportInfrastructure, UnicastRoutingTable unicastRoutingTable, Type type, string s)
+        static void ConfigureSendDestination(TransportInfrastructure transportInfrastructure, UnicastRoutingTable unicastRoutingTable, Type type, string address)
         {
-            unicastRoutingTable.RouteToAddress(type, transportInfrastructure.MakeCanonicalForm(s));
+            unicastRoutingTable.RouteToAddress(type, transportInfrastructure.MakeCanonicalForm(address));
         }
     }
 }

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_an_event.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_an_event.cs
@@ -81,7 +81,7 @@
                 EndpointSetup<DefaultServer>(c =>
                 {
                     var transport = c.UseTransport<MsmqTransport>();
-                    transport.Routing().RegisterPublisherForType(PublisherEndpoint, typeof(MyEvent));
+                    transport.Routing().RegisterPublisherForType(typeof(MyEvent), PublisherEndpoint);
                     transport.AddAddressTranslationException(new EndpointInstance(SubscriberEndpoint).AtMachine(RuntimeEnvironment.MachineName), SubscriberEndpoint + "-1");
                 }).CustomEndpointName(SubscriberEndpoint);
             }
@@ -105,7 +105,7 @@
                 EndpointSetup<DefaultServer>(c =>
                 {
                     var transport = c.UseTransport<MsmqTransport>();
-                    transport.Routing().RegisterPublisherForType(PublisherEndpoint, typeof(MyEvent));
+                    transport.Routing().RegisterPublisherForType(typeof(MyEvent), PublisherEndpoint);
                     transport.AddAddressTranslationException(new EndpointInstance(SubscriberEndpoint).AtMachine(RuntimeEnvironment.MachineName), SubscriberEndpoint + "-2");
                 }).CustomEndpointName(SubscriberEndpoint);
             }


### PR DESCRIPTION
Connects to Particular/V6Launch#68

Makes publisher API have the same signatures as the routing API, e.g.

`routing.RouteToEndpoint(typeof(MyMessage), "myEndpoint");`
`routing.RegisterPublisherForType(typeof(MyMessage), "myPublisher");`

And makes the namespace configuration when configuring messages for assembly non-optional but added a new overload, one accepting a namespace, one not.

@SzymonPobiega @bording @DavidBoike 
we talked about not using different methods but only overloads for types/assembly/namespace config., e.g. instead of 

```
routing.RegisterPublisherForType(typeof(MyMessage), "myPublisher");
routing.RegisterPublisherForAssembly(eventAssembly, "eventnamespace", "myPublisher");
```

this:

```
routing.RegisterPublisherFor(typeof(MyMessage), "myPublisher");
routing.RegisterPublisherFor(eventAssembly, "eventnamespace", "myPublisher");
```

with the disadvantage that we probably don't want a

`routing.RegisterPublisherFor<MyMessage>("myPublisher");`

which would work better with the `RegisterPublisherForType` method.

Are you good with treating this as a different PR?