### PR TITLE
Auto enable instance mapping

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -770,7 +770,6 @@ namespace NServiceBus
     public class static MsmqConfigurationExtensions
     {
         public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> ApplyLabelToMessages(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> transportExtensions, System.Func<System.Collections.Generic.IReadOnlyDictionary<string, string>, string> labelGenerator) { }
-        public static NServiceBus.FileRoutingTableSettings FileBasedEndpointInstanceMapping(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config, string filePath) { }
         public static void SetMessageDistributionStrategy(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config, string endpointName, NServiceBus.Routing.DistributionStrategy distributionStrategy) { }
         public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> TransactionScopeOptions(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> transportExtensions, System.Nullable<System.TimeSpan> timeout = null, System.Nullable<System.Transactions.IsolationLevel> isolationLevel = null) { }
     }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -392,6 +392,7 @@ namespace NServiceBus
     public class FileRoutingTableSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
         public FileRoutingTableSettings(NServiceBus.Settings.SettingsHolder settings) { }
+        public NServiceBus.FileRoutingTableSettings FilePath(string filePath) { }
         public NServiceBus.FileRoutingTableSettings MaxLoadAttempts(int maxLoadAttempts) { }
         public NServiceBus.FileRoutingTableSettings RefreshInterval(System.TimeSpan refreshInterval) { }
     }
@@ -770,6 +771,7 @@ namespace NServiceBus
     public class static MsmqConfigurationExtensions
     {
         public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> ApplyLabelToMessages(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> transportExtensions, System.Func<System.Collections.Generic.IReadOnlyDictionary<string, string>, string> labelGenerator) { }
+        public static NServiceBus.FileRoutingTableSettings InstanceMappingFile(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config) { }
         public static void SetMessageDistributionStrategy(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config, string endpointName, NServiceBus.Routing.DistributionStrategy distributionStrategy) { }
         public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> TransactionScopeOptions(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> transportExtensions, System.Nullable<System.TimeSpan> timeout = null, System.Nullable<System.Transactions.IsolationLevel> isolationLevel = null) { }
     }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -393,7 +393,6 @@ namespace NServiceBus
     {
         public FileRoutingTableSettings(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.FileRoutingTableSettings FilePath(string filePath) { }
-        public NServiceBus.FileRoutingTableSettings MaxLoadAttempts(int maxLoadAttempts) { }
         public NServiceBus.FileRoutingTableSettings RefreshInterval(System.TimeSpan refreshInterval) { }
     }
     public class FileShareDataBus : NServiceBus.DataBus.DataBusDefinition

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -161,6 +161,7 @@
     <Compile Include="Routing\BestPracticesOptionExtensionsTests.cs" />
     <Compile Include="Routing\DetermineRouteForPublishBehaviorTests.cs" />
     <Compile Include="Routing\DistributionPolicyTests.cs" />
+    <Compile Include="Routing\FileBasedDynamicRouting\FileRoutingTableFeatureTests.cs" />
     <Compile Include="Routing\Routers\UnicastSendRouterConnectorTests.cs" />
     <Compile Include="Routing\EndpointInstanceTests.cs" />
     <Compile Include="Routing\EndpointInstancesTests.cs" />

--- a/src/NServiceBus.Core.Tests/Routing/FileBasedDynamicRouting/FileRoutingTableFeatureTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/FileBasedDynamicRouting/FileRoutingTableFeatureTests.cs
@@ -1,0 +1,32 @@
+﻿namespace NServiceBus.Core.Tests.Routing.FileBasedDynamicRouting
+{
+    using System;
+    using System.Linq;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+    using Settings;
+
+    [TestFixture]
+    public class FileRoutingTableFeatureTests
+    {
+        [Test]
+        public void Should_configure_default_values()
+        {
+            var feature = new FileRoutingTableFeature();
+            var settings = new SettingsHolder();
+
+            feature.ConfigureDefaults(settings);
+
+            Assert.That(settings.Get<string>(FileRoutingTableFeature.FilePathSettingsKey), Is.EqualTo("instance-mapping.xml"));
+            Assert.That(settings.Get<TimeSpan>(FileRoutingTableFeature.CheckIntervalSettingsKey), Is.EqualTo(TimeSpan.FromSeconds(30)));
+        }
+
+        [Test]
+        public void Requires_routing_enabled()
+        {
+            var feature = new FileRoutingTableFeature();
+
+            Assert.That(feature.Dependencies.Any(dependencies => dependencies.Any(dependency => dependency == typeof(RoutingFeature).FullName)));
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Routing/FileRoutingTableParserTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/FileRoutingTableParserTests.cs
@@ -34,7 +34,7 @@
         }
 
         [Test]
-        public void It_requires_at_least_one_endpoint()
+        public void It_allows_empty_endpoints_element()
         {
             const string xml = @"
 <endpoints>
@@ -43,8 +43,7 @@
             var doc = XDocument.Parse(xml);
             var parser = new FileRoutingTableParser();
 
-            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc));
-            Assert.That(exception.Message, Does.Contain("The element 'endpoints' has incomplete content."));
+            Assert.DoesNotThrow(() => parser.Parse(doc));
         }
 
         [Test]
@@ -63,7 +62,7 @@
         }
 
         [Test]
-        public void It_requires_endpoint_to_have_at_least_one_instance()
+        public void It_allows_endpoint_to_not_have_an_instance()
         {
             const string xml = @"
 <endpoints>
@@ -73,8 +72,7 @@
             var doc = XDocument.Parse(xml);
             var parser = new FileRoutingTableParser();
 
-            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc));
-            Assert.That(exception.Message, Does.Contain("The element 'endpoint' has incomplete content."));
+            Assert.DoesNotThrow(() => parser.Parse(doc));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/FileRoutingTableParserTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/FileRoutingTableParserTests.cs
@@ -23,7 +23,7 @@
 </endpoints>
 ";
             var doc = XDocument.Parse(xml);
-            var result = new FileRoutingTableParser().Parse(doc);
+            var result = new FileRoutingTableParser().Parse(doc, true);
 
             CollectionAssert.AreEqual(new[]
             {
@@ -43,7 +43,7 @@
             var doc = XDocument.Parse(xml);
             var parser = new FileRoutingTableParser();
 
-            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc));
+            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc, true));
             Assert.That(exception.Message, Does.Contain("The element 'endpoints' has incomplete content."));
         }
 
@@ -58,7 +58,7 @@
             var doc = XDocument.Parse(xml);
             var parser = new FileRoutingTableParser();
 
-            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc));
+            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc, true));
             Assert.That(exception.Message, Does.Contain("The required attribute 'name' is missing."));
         }
 
@@ -73,7 +73,7 @@
             var doc = XDocument.Parse(xml);
             var parser = new FileRoutingTableParser();
 
-            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc));
+            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc, true));
             Assert.That(exception.Message, Does.Contain("The element 'endpoint' has incomplete content."));
         }
     }

--- a/src/NServiceBus.Core.Tests/Routing/FileRoutingTableParserTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/FileRoutingTableParserTests.cs
@@ -23,13 +23,13 @@
 </endpoints>
 ";
             var doc = XDocument.Parse(xml);
-            var result = new FileRoutingTableParser().Parse(doc, true);
+            var result = new FileRoutingTableParser().Parse(doc);
 
             CollectionAssert.AreEqual(new[]
             {
                 new EndpointInstance("A", "D1").SetProperty("prop1", "V1").SetProperty("prop2","V2"),
                 new EndpointInstance("A").SetProperty("prop3", "V3").SetProperty("prop4", "V4"),
-                new EndpointInstance("B", "D2").SetProperty("prop5", "V5").SetProperty("prop6", "V6"),
+                new EndpointInstance("B", "D2").SetProperty("prop5", "V5").SetProperty("prop6", "V6")
             }, result);
         }
 
@@ -43,7 +43,7 @@
             var doc = XDocument.Parse(xml);
             var parser = new FileRoutingTableParser();
 
-            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc, true));
+            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc));
             Assert.That(exception.Message, Does.Contain("The element 'endpoints' has incomplete content."));
         }
 
@@ -58,7 +58,7 @@
             var doc = XDocument.Parse(xml);
             var parser = new FileRoutingTableParser();
 
-            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc, true));
+            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc));
             Assert.That(exception.Message, Does.Contain("The required attribute 'name' is missing."));
         }
 
@@ -73,7 +73,7 @@
             var doc = XDocument.Parse(xml);
             var parser = new FileRoutingTableParser();
 
-            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc, true));
+            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc));
             Assert.That(exception.Message, Does.Contain("The element 'endpoint' has incomplete content."));
         }
     }

--- a/src/NServiceBus.Core.Tests/Routing/FileRoutingTableTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/FileRoutingTableTests.cs
@@ -9,34 +9,18 @@
     public class FileRoutingTableTests
     {
         [Test]
-        public void If_file_does_not_exist_when_starting_up_it_fails()
+        public void Reload_should_throw_when_file_does_not_exist()
         {
             var timer = new FakeTimer();
             var fileAccess = new FakeFileAccess(() =>
             {
                 throw new Exception("Simulated");
             });
-
             var table = new FileRoutingTable("unused", TimeSpan.Zero, timer, fileAccess, 3);
 
-            var exception = Assert.ThrowsAsync<Exception>(async () => await table.PerformStartup(null));
-            Assert.That(exception.Message, Does.Contain("The endpoint instance mapping file"));
-            Assert.That(exception.Message, Does.Contain("does not exist."));
-        }
+            var exception = Assert.Throws<Exception>(() => table.ReloadData());
 
-        [Test]
-        public void If_file_does_not_exist_when_resolving_for_the_first_time_it_fails()
-        {
-            var timer = new FakeTimer();
-            var fileAccess = new FakeFileAccess(() =>
-            {
-                throw new Exception("Simulated");
-            });
-
-            var table = new FileRoutingTable("unused", TimeSpan.Zero, timer, fileAccess, 3);
-
-            var exception = Assert.ThrowsAsync<Exception>(async () => await table.FindInstances("SomeEndpoint"));
-            Assert.That(exception.InnerException.Message, Does.Contain("Simulated"));
+            Assert.That(exception.Message, Does.Contain("Simulated"));
         }
 
         [Test]
@@ -59,11 +43,11 @@
             });
 
             var table = new FileRoutingTable("unused", TimeSpan.Zero, timer, fileAccess, 1);
-            await table.FindInstances("SomeEndpoint");
+            await table.PerformStartup(null);
 
             fail = true;
-
             await timer.Trigger();
+
             Assert.IsTrue(errorCallbackInvoked);
         }
 

--- a/src/NServiceBus.Core.Tests/Routing/FileRoutingTableTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/FileRoutingTableTests.cs
@@ -1,36 +1,13 @@
 ﻿namespace NServiceBus.Core.Tests.Routing
 {
     using System;
-    using System.Linq;
     using System.Threading.Tasks;
     using System.Xml.Linq;
-    using NServiceBus.Routing;
     using NUnit.Framework;
 
     [TestFixture]
     public class FileRoutingTableTests
     {
-        [Test]
-        public async Task It_retries_loading_the_file_in_case_of_error()
-        {
-            var timer = new FakeTimer();
-            var firstAttempt = true;
-            var fileAccess = new FakeFileAccess(() =>
-            {
-                if (firstAttempt)
-                {
-                    firstAttempt = false;
-                    throw new Exception("Simulated");
-                }
-                return XDocument.Parse(@"<endpoints><endpoint name=""A""><instance/></endpoint></endpoints>");
-            });
-
-            var table = new FileRoutingTable("unused", TimeSpan.Zero, timer, fileAccess, 2);
-
-            var instance = (await table.FindInstances("A")).Single();
-            Assert.AreEqual(new EndpointInstance("A"), instance);
-        }
-
         [Test]
         public void If_file_does_not_exist_when_starting_up_it_fails()
         {

--- a/src/NServiceBus.Core/Routing/EndpointInstances.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstances.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.Routing
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -43,7 +42,7 @@ namespace NServiceBus.Routing
                 }
             }
 
-            if (!dynamicInstances.Any())
+            if (dynamicInstances.Count == 0)
             {
                 return new[]
                 {

--- a/src/NServiceBus.Core/Routing/EndpointInstances.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstances.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Routing
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -40,6 +41,14 @@ namespace NServiceBus.Routing
                 {
                     dynamicInstances.Add(instance);
                 }
+            }
+
+            if (!dynamicInstances.Any())
+            {
+                return new[]
+                {
+                    new EndpointInstance(endpoint)
+                };
             }
 
             return dynamicInstances;

--- a/src/NServiceBus.Core/Routing/EndpointInstances.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstances.cs
@@ -44,10 +44,7 @@ namespace NServiceBus.Routing
 
             if (dynamicInstances.Count == 0)
             {
-                return new[]
-                {
-                    new EndpointInstance(endpoint)
-                };
+                dynamicInstances.Add(new EndpointInstance(endpoint));
             }
 
             return dynamicInstances;

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTable.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTable.cs
@@ -20,6 +20,11 @@ namespace NServiceBus
             this.fileAccess = fileAccess;
             this.maxLoadAttempts = maxLoadAttempts;
 
+            if (!Path.IsPathRooted(filePath))
+            {
+                this.filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, filePath);
+            }
+
             errorMessage = $"An error occurred while reading the endpoint instance mapping file at {filePath}. See the inner exception for more details.";
         }
 
@@ -27,7 +32,8 @@ namespace NServiceBus
         {
             if (!File.Exists(filePath))
             {
-                throw new Exception($"The endpoint instance mapping file {filePath} does not exist.");
+
+                throw new Exception($"The endpoint instance mapping file {filePath} does not exist");
             }
 
             return TaskEx.CompletedTask;

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTable.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTable.cs
@@ -48,7 +48,7 @@ namespace NServiceBus
             // ReSharper disable once PossibleNullReferenceException
             return instanceMap.TryGetValue(endpoint, out result)
                 ? Task.FromResult<IEnumerable<EndpointInstance>>(result)
-                : Task.FromResult(noInstances);
+                : noInstances;
         }
 
         protected override Task OnStop(IMessageSession session) => timer.Stop();
@@ -60,7 +60,7 @@ namespace NServiceBus
         Dictionary<string, HashSet<EndpointInstance>> instanceMap;
         FileRoutingTableParser parser = new FileRoutingTableParser();
         IAsyncTimer timer;
-        IEnumerable<EndpointInstance> noInstances = new EndpointInstance[0];
+        Task<IEnumerable<EndpointInstance>> noInstances = Task.FromResult(Enumerable.Empty<EndpointInstance>());
 
         static readonly ILog log = LogManager.GetLogger(typeof(FileRoutingTable));
     }

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTable.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTable.cs
@@ -46,16 +46,12 @@ namespace NServiceBus
             HashSet<EndpointInstance> result;
 
             // ReSharper disable once PossibleNullReferenceException
-            if (instanceMap.TryGetValue(endpoint, out result))
-                return Task.FromResult((IEnumerable<EndpointInstance>) result);
-
-            return Task.FromResult(noInstances);
+            return instanceMap.TryGetValue(endpoint, out result)
+                ? Task.FromResult<IEnumerable<EndpointInstance>>(result)
+                : Task.FromResult(noInstances);
         }
 
-        protected override Task OnStop(IMessageSession session)
-        {
-            return timer.Stop();
-        }
+        protected override Task OnStop(IMessageSession session) => timer.Stop();
 
         TimeSpan checkInterval;
         IRoutingFileAccess fileAccess;

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTable.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTable.cs
@@ -10,8 +10,7 @@ namespace NServiceBus
 
     class FileRoutingTable : FeatureStartupTask
     {
-        //TODO: remove maxLoadAttempts?
-        public FileRoutingTable(string filePath, TimeSpan checkInterval, IAsyncTimer timer, IRoutingFileAccess fileAccess, int maxLoadAttempts)
+        public FileRoutingTable(string filePath, TimeSpan checkInterval, IAsyncTimer timer, IRoutingFileAccess fileAccess)
         {
             this.filePath = filePath;
             this.checkInterval = checkInterval;

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTable.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTable.cs
@@ -37,7 +37,7 @@ namespace NServiceBus
         public async Task ReloadData()
         {
             var doc = await ReadFileWithRetries().ConfigureAwait(false);
-            var instances = parser.Parse(doc, true);
+            var instances = parser.Parse(doc);
 
             var newInstanceMap = instances
                 .GroupBy(i => i.Endpoint)

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
@@ -36,8 +36,7 @@ namespace NServiceBus.Features
             var endpointInstances = context.Settings.Get<EndpointInstances>();
 
             var fileRoutingTable = new FileRoutingTable(filePath, checkInterval, new AsyncTimer(), new RoutingFileAccess(), maxLoadAttempts);
-            //TODO fix this:
-            fileRoutingTable.ReloadData().GetAwaiter().GetResult();
+            fileRoutingTable.ReloadData();
             endpointInstances.AddDynamic(fileRoutingTable.FindInstances);
             context.RegisterStartupTask(fileRoutingTable);
         }

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
@@ -11,6 +11,7 @@ namespace NServiceBus.Features
             {
                 s.SetDefault(CheckIntervalSettingsKey, TimeSpan.FromSeconds(30));
                 s.SetDefault(MaxLoadAttemptsSettingsKey, 10);
+                s.SetDefault(FilePathSettingsKey, "instance-mapping.xml");
             });
             DependsOn<RoutingFeature>();
         }

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
@@ -11,7 +11,6 @@ namespace NServiceBus.Features
             Defaults(s =>
             {
                 s.SetDefault(CheckIntervalSettingsKey, TimeSpan.FromSeconds(30));
-                s.SetDefault(MaxLoadAttemptsSettingsKey, 10);
                 s.SetDefault(FilePathSettingsKey, "instance-mapping.xml");
             });
             DependsOn<RoutingFeature>();
@@ -31,18 +30,15 @@ namespace NServiceBus.Features
             }
 
             var checkInterval = context.Settings.Get<TimeSpan>(CheckIntervalSettingsKey);
-            var maxLoadAttempts = context.Settings.Get<int>(MaxLoadAttemptsSettingsKey);
-
             var endpointInstances = context.Settings.Get<EndpointInstances>();
 
-            var fileRoutingTable = new FileRoutingTable(filePath, checkInterval, new AsyncTimer(), new RoutingFileAccess(), maxLoadAttempts);
+            var fileRoutingTable = new FileRoutingTable(filePath, checkInterval, new AsyncTimer(), new RoutingFileAccess());
             fileRoutingTable.ReloadData();
             endpointInstances.AddDynamic(fileRoutingTable.FindInstances);
             context.RegisterStartupTask(fileRoutingTable);
         }
 
         public const string CheckIntervalSettingsKey = "FileBasedRouting.CheckInterval";
-        public const string MaxLoadAttemptsSettingsKey = "FileBasedRouting.MaxLoadAttempts";
         public const string FilePathSettingsKey = "FileBasedRouting.FilePath";
     }
 }

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableParser.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableParser.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Xml;
@@ -20,22 +19,9 @@ namespace NServiceBus
             }
         }
 
-        public IEnumerable<EndpointInstance> Parse(XDocument document, bool throwOnValidationError)
+        public IEnumerable<EndpointInstance> Parse(XDocument document)
         {
-            try
-            {
-                document.Validate(schema, null, true);
-            }
-            catch (Exception)
-            {
-                if (throwOnValidationError)
-                {
-                    throw;
-                }
-
-                //TODO log exception
-                return new EndpointInstance[0];
-            }
+            document.Validate(schema, null, true);
 
             var root = document.Root;
             var endpointElements = root.Descendants("endpoint");

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableParser.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableParser.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Xml;
@@ -19,9 +20,22 @@ namespace NServiceBus
             }
         }
 
-        public IEnumerable<EndpointInstance> Parse(XDocument document)
+        public IEnumerable<EndpointInstance> Parse(XDocument document, bool throwOnValidationError)
         {
-            document.Validate(schema, null, true);
+            try
+            {
+                document.Validate(schema, null, true);
+            }
+            catch (Exception)
+            {
+                if (throwOnValidationError)
+                {
+                    throw;
+                }
+
+                //TODO log exception
+                return new EndpointInstance[0];
+            }
 
             var root = document.Root;
             var endpointElements = root.Descendants("endpoint");

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableSettings.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableSettings.cs
@@ -55,7 +55,7 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Specifies the path and file name for the instance mapping XML. The default is <value>instance-mapping.xml</value>.
+        /// Specifies the path and file name for the instance mapping XML. The default is <code>instance-mapping.xml</code>.
         /// </summary>
         /// <param name="filePath">The relative or absolute file path to the instance mapping XML file.</param>
         public FileRoutingTableSettings FilePath(string filePath)

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableSettings.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableSettings.cs
@@ -39,22 +39,6 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Specifies the maximum number of attempts to load contents of a file before logging an error.
-        /// The default value is 10 attempts.
-        /// Valid values must be at least 1.
-        /// </summary>
-        /// <param name="maxLoadAttempts">Max load attempts.</param>
-        public FileRoutingTableSettings MaxLoadAttempts(int maxLoadAttempts)
-        {
-            if (maxLoadAttempts < 1)
-            {
-                throw new ArgumentOutOfRangeException(nameof(maxLoadAttempts), "Value must be at least 1.");
-            }
-            Settings.Set(FileRoutingTableFeature.MaxLoadAttemptsSettingsKey, maxLoadAttempts);
-            return this;
-        }
-
-        /// <summary>
         /// Specifies the path and file name for the instance mapping XML. The default is <code>instance-mapping.xml</code>.
         /// </summary>
         /// <param name="filePath">The relative or absolute file path to the instance mapping XML file.</param>

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableSettings.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableSettings.cs
@@ -53,5 +53,17 @@ namespace NServiceBus
             Settings.Set(FileRoutingTableFeature.MaxLoadAttemptsSettingsKey, maxLoadAttempts);
             return this;
         }
+
+        /// <summary>
+        /// Specifies the path and file name for the instance mapping XML. The default is <value>instance-mapping.xml</value>.
+        /// </summary>
+        /// <param name="filePath">The relative or absolute file path to the instance mapping XML file.</param>
+        public FileRoutingTableSettings FilePath(string filePath)
+        {
+            Guard.AgainstNullAndEmpty(nameof(filePath), filePath);
+
+            Settings.Set(FileRoutingTableFeature.FilePathSettingsKey, filePath);
+            return this;
+        }
     }
 }

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/RoutingFileAccess.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/RoutingFileAccess.cs
@@ -9,7 +9,7 @@ namespace NServiceBus
         public XDocument Load(string path)
         {
             XDocument doc;
-            using (var file = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var file = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 using (var reader = XmlReader.Create(file))
                 {

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/RoutingFileAccess.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/RoutingFileAccess.cs
@@ -11,7 +11,7 @@ namespace NServiceBus
             XDocument doc;
             using (var file = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
-                using (var reader = XmlReader.Create(new StreamReader(file)))
+                using (var reader = XmlReader.Create(file))
                 {
                     doc = XDocument.Load(reader);
                 }

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/RoutingFileAccess.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/RoutingFileAccess.cs
@@ -9,7 +9,7 @@ namespace NServiceBus
         public XDocument Load(string path)
         {
             XDocument doc;
-            using (var file = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            using (var file = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 using (var reader = XmlReader.Create(new StreamReader(file)))
                 {

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/endpoints.xsd
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/endpoints.xsd
@@ -2,10 +2,10 @@
   <xs:element name="endpoints">
     <xs:complexType>
       <xs:sequence>
-        <xs:element minOccurs="1" maxOccurs="unbounded" name="endpoint">
+        <xs:element minOccurs="0" maxOccurs="unbounded" name="endpoint">
           <xs:complexType>
             <xs:sequence>
-              <xs:element minOccurs="1" maxOccurs="unbounded" name="instance">
+              <xs:element minOccurs="0" maxOccurs="unbounded" name="instance">
                 <xs:complexType>
                   <xs:attribute name="discriminator" type="xs:string" use="optional" />
                   <xs:anyAttribute processContents="lax" />

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqConfigurationExtensions.cs
@@ -4,7 +4,6 @@ namespace NServiceBus
     using System.Collections.Generic;
     using System.Messaging;
     using System.Transactions;
-    using Features;
     using Routing;
 
     /// <summary>
@@ -43,18 +42,18 @@ namespace NServiceBus
             return transportExtensions;
         }
 
-        /// <summary>
-        /// Enables a file-based routing table source that is automatically refreshed whenever the file gets updated.
-        /// </summary>
-        public static FileRoutingTableSettings FileBasedEndpointInstanceMapping(this RoutingSettings<MsmqTransport> config, string filePath)
-        {
-            Guard.AgainstNull(nameof(filePath), filePath);
-
-            config.Settings.EnableFeature(typeof(FileRoutingTableFeature));
-            config.Settings.Set(FileRoutingTableFeature.FilePathSettingsKey, filePath);
-
-            return new FileRoutingTableSettings(config.Settings);
-        }
+//        /// <summary>
+//        /// Enables a file-based routing table source that is automatically refreshed whenever the file gets updated.
+//        /// </summary>
+//        public static FileRoutingTableSettings FileBasedEndpointInstanceMapping(this RoutingSettings<MsmqTransport> config, string filePath)
+//        {
+//            Guard.AgainstNull(nameof(filePath), filePath);
+//
+//            config.Settings.EnableFeature(typeof(FileRoutingTableFeature));
+//            config.Settings.Set(FileRoutingTableFeature.FilePathSettingsKey, filePath);
+//
+//            return new FileRoutingTableSettings(config.Settings);
+//        }
 
         /// <summary>
         /// Sets a distribution strategy for a given endpoint.

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqConfigurationExtensions.cs
@@ -52,5 +52,13 @@ namespace NServiceBus
         {
             config.Settings.GetOrCreate<DistributionPolicy>().SetDistributionStrategy(endpointName, distributionStrategy);
         }
+
+        /// <summary>
+        /// Returns the configuration options for the file based instance mapping file.
+        /// </summary>
+        public static FileRoutingTableSettings InstanceMappingFile(this RoutingSettings<MsmqTransport> config)
+        {
+            return new FileRoutingTableSettings(config.Settings);
+        }
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqConfigurationExtensions.cs
@@ -42,19 +42,6 @@ namespace NServiceBus
             return transportExtensions;
         }
 
-//        /// <summary>
-//        /// Enables a file-based routing table source that is automatically refreshed whenever the file gets updated.
-//        /// </summary>
-//        public static FileRoutingTableSettings FileBasedEndpointInstanceMapping(this RoutingSettings<MsmqTransport> config, string filePath)
-//        {
-//            Guard.AgainstNull(nameof(filePath), filePath);
-//
-//            config.Settings.EnableFeature(typeof(FileRoutingTableFeature));
-//            config.Settings.Set(FileRoutingTableFeature.FilePathSettingsKey, filePath);
-//
-//            return new FileRoutingTableSettings(config.Settings);
-//        }
-
         /// <summary>
         /// Sets a distribution strategy for a given endpoint.
         /// </summary>

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransport.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransport.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus
 {
+    using Features;
     using Routing;
     using Settings;
     using Transports;
@@ -27,6 +28,8 @@ namespace NServiceBus
         /// <returns>the transport infrastructure for msmq.</returns>
         protected internal override TransportInfrastructure Initialize(SettingsHolder settings, string connectionString)
         {
+            settings.EnableFeature(typeof(FileRoutingTableFeature));
+
             return new MsmqTransportInfrastructure(settings, connectionString);
         }
     }

--- a/src/NServiceBus.Msmq.AcceptanceTests/ConfigureMsmqTransport.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/ConfigureMsmqTransport.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Messaging;
 using System.Threading.Tasks;
@@ -54,15 +53,6 @@ public class ConfigureEndpointMsmqTransport : IConfigureEndpointTestExecution
             {
                 Console.WriteLine("Could not delete queue '{0}'", queuePath);
             }
-        }
-
-        try
-        {
-            File.Delete(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "instance-mapping.xml"));
-        }
-        catch (Exception)
-        {
-            // ignore
         }
 
         MessageQueue.ClearConnectionCache();

--- a/src/NServiceBus.Msmq.AcceptanceTests/ConfigureMsmqTransport.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/ConfigureMsmqTransport.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Messaging;
 using System.Threading.Tasks;
@@ -53,6 +54,15 @@ public class ConfigureEndpointMsmqTransport : IConfigureEndpointTestExecution
             {
                 Console.WriteLine("Could not delete queue '{0}'", queuePath);
             }
+        }
+
+        try
+        {
+            File.Delete(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "instance-mapping.xml"));
+        }
+        catch (Exception)
+        {
+            // ignore
         }
 
         MessageQueue.ClearConnectionCache();

--- a/src/NServiceBus.Msmq.AcceptanceTests/NServiceBus.Msmq.AcceptanceTests.csproj
+++ b/src/NServiceBus.Msmq.AcceptanceTests/NServiceBus.Msmq.AcceptanceTests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="When_customizing_scope_isolation_level.cs" />
     <Compile Include="When_distributing_an_event.cs" />
     <Compile Include="When_distributing_a_command.cs" />
+    <Compile Include="When_not_using_instance_mapping_file.cs" />
     <Compile Include="When_publishing.cs" />
     <Compile Include="When_publishing_with_authorizer.cs" />
     <Compile Include="When_receiving_control_message_with_body.cs" />
@@ -68,12 +69,15 @@
     <Compile Include="When_replying_to_a_message_sent_via_a_distributor.cs" />
     <Compile Include="When_setting_label_generator.cs" />
     <Compile Include="When_starting_up_the_endpoint.cs" />
+    <Compile Include="When_starting_with_invalid_instance_mapping_file.cs" />
     <Compile Include="When_subscribing_with_address_containing_host_name.cs" />
     <Compile Include="When_subscribing_from_a_worker.cs" />
     <Compile Include="When_TimeToBeReceivedOnForwardedMessages_set_and_tx_scope_receives.cs" />
     <Compile Include="When_timetobereceived_set_and_dtc.cs" />
     <Compile Include="When_TimeToBeReceived_set_and_native_receivetransaction.cs" />
     <Compile Include="When_unsubscribing_with_authorizer.cs" />
+    <Compile Include="When_using_empty_instance_mapping_file.cs" />
+    <Compile Include="When_using_instance_mapping_file.cs" />
     <Compile Include="When_using_scope_timeout_greater_than_machine_max.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NServiceBus.Msmq.AcceptanceTests/NServiceBusAcceptanceTest.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/NServiceBusAcceptanceTest.cs
@@ -1,5 +1,7 @@
 namespace NServiceBus.AcceptanceTests
 {
+    using System;
+    using System.IO;
     using System.Linq;
     using AcceptanceTesting.Customization;
     using NUnit.Framework;
@@ -22,12 +24,18 @@ namespace NServiceBus.AcceptanceTests
                 testName = testName.Replace("When_", "");
 
                 var endpointBuilder = classAndEndpoint.Split('+').Last();
-                
+
                 testName = System.Threading.Thread.CurrentThread.CurrentCulture.TextInfo.ToTitleCase(testName);
                 testName = testName.Replace("_", "");
 
                 return testName +"."+ endpointBuilder;
             };
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            File.Delete(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "instance-mapping.xml"));
         }
     }
 }

--- a/src/NServiceBus.Msmq.AcceptanceTests/NServiceBusAcceptanceTest.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/NServiceBusAcceptanceTest.cs
@@ -1,7 +1,5 @@
 namespace NServiceBus.AcceptanceTests
 {
-    using System;
-    using System.IO;
     using System.Linq;
     using AcceptanceTesting.Customization;
     using NUnit.Framework;
@@ -30,12 +28,6 @@ namespace NServiceBus.AcceptanceTests
 
                 return testName +"."+ endpointBuilder;
             };
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            File.Delete(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "instance-mapping.xml"));
         }
     }
 }

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_customizing_scope_isolation_level.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_customizing_scope_isolation_level.cs
@@ -5,7 +5,7 @@
     using AcceptanceTesting;
     using NUnit.Framework;
 
-    public class When_customizing_scope_isolation_level
+    public class When_customizing_scope_isolation_level : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_honor_configured_level()

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_a_command.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_a_command.cs
@@ -1,10 +1,10 @@
 ﻿namespace NServiceBus.AcceptanceTests
 {
-    using System;
-    using System.IO;
     using System.Threading.Tasks;
     using AcceptanceTesting.Customization;
     using AcceptanceTesting;
+    using Configuration.AdvanceExtensibility;
+    using NServiceBus.Routing;
     using NUnit.Framework;
     using Settings;
 
@@ -57,25 +57,27 @@
         {
             public Sender()
             {
-                var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "routes.xml");
-                File.WriteAllText(filePath, string.Format(@"<endpoints>
-    <endpoint name=""{0}"">
-        <instance discriminator=""1""/>
-        <instance discriminator=""2""/>
-    </endpoint>
-    <endpoint name=""{1}"">
-        <instance discriminator=""1""/>
-        <instance discriminator=""2""/>
-    </endpoint>
-</endpoints>
-", ReceiverAEndpoint, ReceiverBEndpoint));
+//                var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "routes.xml");
+//                File.WriteAllText(filePath, string.Format(@"<endpoints>
+//    <endpoint name=""{0}"">
+//        <instance discriminator=""1""/>
+//        <instance discriminator=""2""/>
+//    </endpoint>
+//    <endpoint name=""{1}"">
+//        <instance discriminator=""1""/>
+//        <instance discriminator=""2""/>
+//    </endpoint>
+//</endpoints>
+//", ReceiverAEndpoint, ReceiverBEndpoint));
 
                 EndpointSetup<DefaultServer>(c =>
                 {
                     var routing = c.UseTransport<MsmqTransport>().Routing();
-                    routing.FileBasedEndpointInstanceMapping(filePath);
                     routing.RouteToEndpoint(typeof(RequestA), ReceiverAEndpoint);
                     routing.RouteToEndpoint(typeof(RequestB), ReceiverBEndpoint);
+
+                    routing.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverAEndpoint, "1"), new EndpointInstance(ReceiverAEndpoint, "2"));
+                    routing.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverBEndpoint, "1"), new EndpointInstance(ReceiverBEndpoint, "2"));
                 });
             }
 

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_a_command.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_a_command.cs
@@ -57,19 +57,6 @@
         {
             public Sender()
             {
-//                var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "routes.xml");
-//                File.WriteAllText(filePath, string.Format(@"<endpoints>
-//    <endpoint name=""{0}"">
-//        <instance discriminator=""1""/>
-//        <instance discriminator=""2""/>
-//    </endpoint>
-//    <endpoint name=""{1}"">
-//        <instance discriminator=""1""/>
-//        <instance discriminator=""2""/>
-//    </endpoint>
-//</endpoints>
-//", ReceiverAEndpoint, ReceiverBEndpoint));
-
                 EndpointSetup<DefaultServer>(c =>
                 {
                     var routing = c.UseTransport<MsmqTransport>().Routing();

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_not_using_instance_mapping_file.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_not_using_instance_mapping_file.cs
@@ -1,0 +1,62 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using NUnit.Framework;
+
+    public class When_not_using_instance_mapping_file : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_use_logical_endpoint_name_as_address()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<SenderWithoutMappingFile>(e => e.When(c => c.Send(new Message())))
+                .WithEndpoint<ReceiverWithoutMappingFile>()
+                .Done(c => c.ReceivedMessage)
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool ReceivedMessage { get; set; }
+        }
+
+        public class SenderWithoutMappingFile : EndpointConfigurationBuilder
+        {
+            public SenderWithoutMappingFile()
+            {
+                EndpointSetup<DefaultServer>(c => c.UseTransport<MsmqTransport>().Routing()
+                    .RouteToEndpoint(typeof(Message), Conventions.EndpointNamingConvention(typeof(ReceiverWithoutMappingFile))));
+            }
+        }
+
+        public class ReceiverWithoutMappingFile : EndpointConfigurationBuilder
+        {
+            public ReceiverWithoutMappingFile()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MessageHandler : IHandleMessages<Message>
+            {
+                Context testContext;
+
+                public MessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(Message message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedMessage = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Message : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_not_using_instance_mapping_file.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_not_using_instance_mapping_file.cs
@@ -10,11 +10,13 @@
         [Test]
         public async Task Should_use_logical_endpoint_name_as_address()
         {
-            await Scenario.Define<Context>()
+            var context = await Scenario.Define<Context>()
                 .WithEndpoint<SenderWithoutMappingFile>(e => e.When(c => c.Send(new Message())))
                 .WithEndpoint<ReceiverWithoutMappingFile>()
                 .Done(c => c.ReceivedMessage)
                 .Run();
+
+            Assert.That(context.ReceivedMessage, Is.True);
         }
 
         public class Context : ScenarioContext
@@ -27,6 +29,7 @@
             public SenderWithoutMappingFile()
             {
                 EndpointSetup<DefaultServer>(c => c.UseTransport<MsmqTransport>().Routing()
+                    // only configure logical endpoint
                     .RouteToEndpoint(typeof(Message), Conventions.EndpointNamingConvention(typeof(ReceiverWithoutMappingFile))));
             }
         }

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_starting_with_invalid_instance_mapping_file.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_starting_with_invalid_instance_mapping_file.cs
@@ -1,0 +1,50 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_starting_with_invalid_instance_mapping_file
+    {
+        [Test]
+        public async Task Should_throw_at_startup()
+        {
+            var exception = Assert.ThrowsAsync<AggregateException>(() => Scenario.Define<ScenarioContext>()
+                .WithEndpoint<SenderWithInvalidMappingFile>()
+                .Done(c => c.EndpointsStarted)
+                .Run());
+
+            //TODO improve exception assertion
+            Assert.That(exception.InnerException, Is.Not.Null);
+        }
+
+        public class SenderWithInvalidMappingFile : EndpointConfigurationBuilder
+        {
+            public SenderWithInvalidMappingFile()
+            {
+                var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "instance-mapping.xml");
+
+                // e.g. spelling error in endpoint:
+                File.WriteAllText(filePath,
+$@"<endpoints>
+    <endpoind name=""someReceiver"">
+        <instance discriminator=""1""/>
+        <instance discriminator=""2""/>
+    </endpoind>
+</endpoints>");
+
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseTransport<MsmqTransport>().Routing()
+                        .RouteToEndpoint(typeof(Message), "someReceiver");
+                });
+            }
+        }
+
+        public class Message : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_starting_with_invalid_instance_mapping_file.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_starting_with_invalid_instance_mapping_file.cs
@@ -38,7 +38,8 @@
                 .Done(c => c.EndpointsStarted)
                 .Run());
 
-            Assert.That(exception.InnerException.InnerException, Is.TypeOf<XmlSchemaValidationException>());
+            Assert.That(exception.InnerException.InnerException.Message, Does.Contain($"An error occurred while reading the endpoint instance mapping file at {mappingFilePath}. See the inner exception for more details."));
+            Assert.That(exception.InnerException.InnerException.InnerException, Is.TypeOf<XmlSchemaValidationException>());
         }
 
         public class SenderWithInvalidMappingFile : EndpointConfigurationBuilder

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_starting_with_invalid_instance_mapping_file.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_starting_with_invalid_instance_mapping_file.cs
@@ -28,7 +28,7 @@
 
                 // e.g. spelling error in endpoint:
                 File.WriteAllText(filePath,
-$@"<endpoints>
+@"<endpoints>
     <endpoind name=""someReceiver"">
         <instance discriminator=""1""/>
         <instance discriminator=""2""/>

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_starting_with_invalid_instance_mapping_file.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_starting_with_invalid_instance_mapping_file.cs
@@ -3,6 +3,7 @@
     using System;
     using System.IO;
     using System.Threading.Tasks;
+    using System.Xml.Schema;
     using AcceptanceTesting;
     using NUnit.Framework;
 
@@ -16,8 +17,7 @@
                 .Done(c => c.EndpointsStarted)
                 .Run());
 
-            //TODO improve exception assertion
-            Assert.That(exception.InnerException, Is.Not.Null);
+            Assert.That(exception.InnerException.InnerException, Is.TypeOf<XmlSchemaValidationException>());
         }
 
         public class SenderWithInvalidMappingFile : EndpointConfigurationBuilder

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_starting_with_invalid_instance_mapping_file.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_starting_with_invalid_instance_mapping_file.cs
@@ -9,12 +9,11 @@
 
     public class When_starting_with_invalid_instance_mapping_file : NServiceBusAcceptanceTest
     {
-        static string mappingFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, nameof(When_starting_with_invalid_instance_mapping_file), "instance-mapping.xml");
+        static string mappingFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, nameof(When_starting_with_invalid_instance_mapping_file) + ".xml");
 
         [SetUp]
         public void SetupMappingFile()
         {
-            Directory.CreateDirectory(Path.GetDirectoryName(mappingFilePath));
             // e.g. spelling error in endpoint:
             File.WriteAllText(mappingFilePath,
 @"<endpoints>
@@ -28,7 +27,7 @@
         [TearDown]
         public void DeleteMappingFile()
         {
-            Directory.Delete(Path.GetDirectoryName(mappingFilePath), true);
+            File.Delete(mappingFilePath);
         }
 
         [Test]

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_starting_with_invalid_instance_mapping_file.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_starting_with_invalid_instance_mapping_file.cs
@@ -9,6 +9,28 @@
 
     public class When_starting_with_invalid_instance_mapping_file : NServiceBusAcceptanceTest
     {
+        static string mappingFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, nameof(When_starting_with_invalid_instance_mapping_file), "instance-mapping.xml");
+
+        [SetUp]
+        public void SetupMappingFile()
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(mappingFilePath));
+            // e.g. spelling error in endpoint:
+            File.WriteAllText(mappingFilePath,
+@"<endpoints>
+    <endpoind name=""someReceiver"">
+        <instance discriminator=""1""/>
+        <instance discriminator=""2""/>
+    </endpoind>
+</endpoints>");
+        }
+
+        [TearDown]
+        public void DeleteMappingFile()
+        {
+            Directory.Delete(Path.GetDirectoryName(mappingFilePath), true);
+        }
+
         [Test]
         public async Task Should_throw_at_startup()
         {
@@ -24,21 +46,11 @@
         {
             public SenderWithInvalidMappingFile()
             {
-                var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "instance-mapping.xml");
-
-                // e.g. spelling error in endpoint:
-                File.WriteAllText(filePath,
-@"<endpoints>
-    <endpoind name=""someReceiver"">
-        <instance discriminator=""1""/>
-        <instance discriminator=""2""/>
-    </endpoind>
-</endpoints>");
-
                 EndpointSetup<DefaultServer>(c =>
                 {
-                    c.UseTransport<MsmqTransport>().Routing()
-                        .RouteToEndpoint(typeof(Message), "someReceiver");
+                    var routingSettings = c.UseTransport<MsmqTransport>().Routing();
+                    routingSettings.RouteToEndpoint(typeof(Message), "someReceiver");
+                    routingSettings.InstanceMappingFile().FilePath(mappingFilePath);
                 });
             }
         }

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_starting_with_invalid_instance_mapping_file.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_starting_with_invalid_instance_mapping_file.cs
@@ -6,7 +6,7 @@
     using AcceptanceTesting;
     using NUnit.Framework;
 
-    public class When_starting_with_invalid_instance_mapping_file
+    public class When_starting_with_invalid_instance_mapping_file : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_throw_at_startup()

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_using_empty_instance_mapping_file.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_using_empty_instance_mapping_file.cs
@@ -1,0 +1,103 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using NUnit.Framework;
+    using Settings;
+
+    public class When_using_empty_instance_mapping_file
+    {
+        [Test]
+        public async Task Should_send_messages_to_logical_endpoint_address()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SenderWithEmptyMappingFile>(e => e.When(async c =>
+                {
+                    for (var i = 0; i < 10; i++)
+                    {
+                        await c.Send(new Message());
+                    }
+                }))
+                .WithEndpoint<ScaledOutReceiver>(e => e.CustomConfig(c => c.MakeInstanceUniquelyAddressable("1")))
+                .WithEndpoint<ScaledOutReceiver>(e => e.CustomConfig(c => c.MakeInstanceUniquelyAddressable("2")))
+                .Done(c => c.MessagesForInstance1 + c.MessagesForInstance2 >= 10)
+                .Run();
+
+            // it should send messages to the shared queue
+            Assert.That(context.MessagesForInstance1, Is.GreaterThanOrEqualTo(1));
+            Assert.That(context.MessagesForInstance2, Is.GreaterThanOrEqualTo(1));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int MessagesForInstance1;
+            public int MessagesForInstance2;
+        }
+
+        public class SenderWithEmptyMappingFile : EndpointConfigurationBuilder
+        {
+            public SenderWithEmptyMappingFile()
+            {
+                var logicalEndpointName = Conventions.EndpointNamingConvention(typeof(ScaledOutReceiver));
+
+                var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "instance-mapping.xml");
+
+                // only configure instance 2 for the routing to make sure messages aren't sent to the shared queue
+                File.WriteAllText(filePath,
+$@"<endpoints>
+    <endpoint name=""{logicalEndpointName}"">
+    </endpoint>
+</endpoints>");
+
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseTransport<MsmqTransport>().Routing()
+                        .RouteToEndpoint(typeof(Message), logicalEndpointName);
+                });
+            }
+        }
+
+        public class ScaledOutReceiver : EndpointConfigurationBuilder
+        {
+            public ScaledOutReceiver()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MessageHandler : IHandleMessages<Message>
+            {
+                Context testContext;
+                ReadOnlySettings settings;
+
+                public MessageHandler(Context testContext, ReadOnlySettings settings)
+                {
+                    this.testContext = testContext;
+                    this.settings = settings;
+                }
+
+                public Task Handle(Message message, IMessageHandlerContext context)
+                {
+                    var instanceDiscriminator = settings.Get<string>("EndpointInstanceDiscriminator");
+                    if (instanceDiscriminator == "1")
+                    {
+                        Interlocked.Increment(ref testContext.MessagesForInstance1);
+                    }
+                    if (instanceDiscriminator == "2")
+                    {
+                        Interlocked.Increment(ref testContext.MessagesForInstance2);
+                    }
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Message : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_using_empty_instance_mapping_file.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_using_empty_instance_mapping_file.cs
@@ -9,7 +9,7 @@
     using NUnit.Framework;
     using Settings;
 
-    public class When_using_empty_instance_mapping_file
+    public class When_using_empty_instance_mapping_file : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_send_messages_to_logical_endpoint_address()

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_using_empty_instance_mapping_file.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_using_empty_instance_mapping_file.cs
@@ -43,10 +43,8 @@
             public SenderWithEmptyMappingFile()
             {
                 var logicalEndpointName = Conventions.EndpointNamingConvention(typeof(ScaledOutReceiver));
-
                 var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "instance-mapping.xml");
 
-                // only configure instance 2 for the routing to make sure messages aren't sent to the shared queue
                 File.WriteAllText(filePath,
 $@"<endpoints>
     <endpoint name=""{logicalEndpointName}"">

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_using_instance_mapping_file.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_using_instance_mapping_file.cs
@@ -1,0 +1,103 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using NUnit.Framework;
+    using Settings;
+
+    public class When_using_instance_mapping_file
+    {
+        [Test]
+        public async Task Should_send_messages_to_configured_instances()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SenderWithMappingFile>(e => e.When(async c =>
+                {
+                    for (var i = 0; i < 5; i++)
+                    {
+                        await c.Send(new Message());
+                    }
+                }))
+                .WithEndpoint<ScaledOutReceiver>(e => e.CustomConfig(c => c.MakeInstanceUniquelyAddressable("1")))
+                .WithEndpoint<ScaledOutReceiver>(e => e.CustomConfig(c => c.MakeInstanceUniquelyAddressable("2")))
+                .Done(c => c.MessagesForInstance1 + c.MessagesForInstance2 >= 5)
+                .Run();
+
+            Assert.That(context.MessagesForInstance1, Is.EqualTo(0));
+            Assert.That(context.MessagesForInstance2, Is.EqualTo(5));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int MessagesForInstance1;
+            public int MessagesForInstance2;
+        }
+
+        public class SenderWithMappingFile : EndpointConfigurationBuilder
+        {
+            public SenderWithMappingFile()
+            {
+                var logicalEndpointName = Conventions.EndpointNamingConvention(typeof(ScaledOutReceiver));
+
+                var filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "instance-mapping.xml");
+
+                // only configure instance 2 for the routing to make sure messages aren't sent to the shared queue
+                File.WriteAllText(filePath,
+$@"<endpoints>
+    <endpoint name=""{logicalEndpointName}"">
+        <instance discriminator=""2""/>
+    </endpoint>
+</endpoints>");
+
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseTransport<MsmqTransport>().Routing()
+                        .RouteToEndpoint(typeof(Message), logicalEndpointName);
+                });
+            }
+        }
+
+        public class ScaledOutReceiver : EndpointConfigurationBuilder
+        {
+            public ScaledOutReceiver()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MessageHandler : IHandleMessages<Message>
+            {
+                Context testContext;
+                ReadOnlySettings settings;
+
+                public MessageHandler(Context testContext, ReadOnlySettings settings)
+                {
+                    this.testContext = testContext;
+                    this.settings = settings;
+                }
+
+                public Task Handle(Message message, IMessageHandlerContext context)
+                {
+                    var instanceDiscriminator = settings.Get<string>("EndpointInstanceDiscriminator");
+                    if (instanceDiscriminator == "1")
+                    {
+                        Interlocked.Increment(ref testContext.MessagesForInstance1);
+                    }
+                    if (instanceDiscriminator == "2")
+                    {
+                        Interlocked.Increment(ref testContext.MessagesForInstance2);
+                    }
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Message : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_using_instance_mapping_file.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_using_instance_mapping_file.cs
@@ -9,7 +9,7 @@
     using NUnit.Framework;
     using Settings;
 
-    public class When_using_instance_mapping_file
+    public class When_using_instance_mapping_file : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_send_messages_to_configured_instances()

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_using_scope_timeout_greater_than_machine_max.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_using_scope_timeout_greater_than_machine_max.cs
@@ -4,7 +4,7 @@
     using AcceptanceTesting;
     using NUnit.Framework;
 
-    public class When_using_scope_timeout_greater_than_machine_max
+    public class When_using_scope_timeout_greater_than_machine_max : NServiceBusAcceptanceTest
     {
         [Test]
         public void Should_blow_up()


### PR DESCRIPTION
Connects to Particular/V6Launch#68

Changes:

* Change schema to allow empty `endpoints` and `endpoint` elements
* Only use one attempt to read instance mapping file. If it fails it will blow at startup or try again after the configured checkInterval. Is there a valid scenario which requires the `maxLoadAttempts` configuration?
* Load mapping file initially during feature setup for validation and initial data purpose
* uses AppDomain.CurrentDomain.BaseDirectory as root path for relative mapping file paths
* remove `FileBasedEndpointInstanceMapping`
* Auto-enables the mapping file when using Msmq transport
  * it will not read the file and not set up dynamic rules when there is no file at startup time (can be empty though)
  * if a file is found, the dynamic rule is added and a timer will constantly reread the mapping file

Todos:

* [x] Cleanup mapping file in tests
* [x] Avoid dynamic rules and other performance impacts when no instance mapping file is used.
* [x] Add API for custom mapping file path
* [x] Update docs to changed API: https://github.com/Particular/docs.particular.net/pull/1672