### PR TITLE
Moved the pipeline invocation runtime concern away from the startable endpoint

### DIFF
--- a/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
@@ -2,12 +2,11 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading.Tasks;
     using Features;
     using NServiceBus.Routing;
-    using Settings;
     using NUnit.Framework;
+    using Settings;
     using Testing;
     using Transports;
 
@@ -20,7 +19,7 @@
             var testee = new RunningEndpointInstance(
                 new SettingsHolder(),
                 new FakeBuilder(),
-                new PipelineCollection(Enumerable.Empty<TransportReceiver>()),
+                new PipelineCollection(),
                 new FeatureRunner(new FeatureActivator(new SettingsHolder())),
                 new MessageSession(new RootContext(null, null, null)), new FakeTransportInfrastructure());
 
@@ -34,6 +33,7 @@
             public override IEnumerable<Type> DeliveryConstraints { get; }
             public override TransportTransactionMode TransactionMode { get; }
             public override OutboundRoutingPolicy OutboundRoutingPolicy { get; }
+
             public override TransportReceiveInfrastructure ConfigureReceiveInfrastructure()
             {
                 throw new NotImplementedException();

--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -57,7 +57,7 @@ namespace NServiceBus
 
             await RunInstallers(concreteTypes).ConfigureAwait(false);
 
-            var startableEndpoint = new StartableEndpoint(settings, builder, featureActivator, pipelineConfiguration, new EventAggregator(settings.Get<NotificationSubscriptions>()), transportInfrastructure);
+            var startableEndpoint = new StartableEndpoint(settings, builder, featureActivator, pipelineConfiguration, new EventAggregator(settings.Get<NotificationSubscriptions>()), transportInfrastructure, criticalError);
             return startableEndpoint;
         }
 
@@ -99,7 +99,8 @@ namespace NServiceBus
         {
             Func<ICriticalErrorContext, Task> errorAction;
             settings.TryGet("onCriticalErrorAction", out errorAction);
-            container.ConfigureComponent(() => new CriticalError(errorAction), DependencyLifecycle.SingleInstance);
+            criticalError = new CriticalError(errorAction);
+            container.RegisterSingleton(criticalError);
         }
 
         void RunUserRegistrations(List<Action<IConfigureComponents>> registrations)
@@ -182,5 +183,6 @@ namespace NServiceBus
         PipelineConfiguration pipelineConfiguration;
         PipelineSettings pipelineSettings;
         SettingsHolder settings;
+        CriticalError criticalError;
     }
 }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -120,8 +120,11 @@
     <Compile Include="Pipeline\Incoming\SatelliteProcessingContext.cs" />
     <Compile Include="Pipeline\Incoming\TransportReceiveToSatelliteConnector.cs" />
     <Compile Include="Pipeline\IPipelineCache.cs" />
+    <Compile Include="Pipeline\IPipelineInvoker.cs" />
     <Compile Include="Pipeline\Outgoing\AttachSenderRelatedInfoOnMessageBehavior.cs" />
     <Compile Include="Pipeline\PipelineCache.cs" />
+    <Compile Include="Pipeline\PipelineInvoker.cs" />
+    <Compile Include="Pipeline\SatellitePipelineInvoker.cs" />
     <Compile Include="Pipeline\StageForkConnector.cs" />
     <Compile Include="Pipeline\ConnectorContextExtensions.cs" />
     <Compile Include="Recoverability\FailureInfoStorage.cs" />

--- a/src/NServiceBus.Core/Pipeline/IPipelineInvoker.cs
+++ b/src/NServiceBus.Core/Pipeline/IPipelineInvoker.cs
@@ -1,0 +1,10 @@
+namespace NServiceBus
+{
+    using System.Threading.Tasks;
+    using Transports;
+
+    interface IPipelineInvoker
+    {
+        Task Invoke(PushContext pushContext);
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/PipelineCollection.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineCollection.cs
@@ -8,13 +8,22 @@ namespace NServiceBus
 
     class PipelineCollection
     {
-        public PipelineCollection(IEnumerable<TransportReceiver> pipelines)
+        public PipelineCollection()
         {
-            this.pipelines = pipelines.ToArray();
+        }
+
+        public PipelineCollection(List<TransportReceiver> pipelines)
+        {
+            this.pipelines = pipelines;
         }
 
         public async Task Start()
         {
+            if (pipelines == null)
+            {
+                return;
+            }
+
             foreach (var pipeline in pipelines)
             {
                 Logger.DebugFormat("Starting {0} pipeline", pipeline.Id);
@@ -33,6 +42,11 @@ namespace NServiceBus
 
         public Task Stop()
         {
+            if (pipelines == null)
+            {
+                return TaskEx.CompletedTask;
+            }
+
             var pipelineStopTasks = pipelines.Select(async pipeline =>
             {
                 Logger.DebugFormat("Stopping {0} pipeline", pipeline.Id);
@@ -43,7 +57,7 @@ namespace NServiceBus
             return Task.WhenAll(pipelineStopTasks);
         }
 
-        TransportReceiver[] pipelines;
+        List<TransportReceiver> pipelines;
 
 
         static ILog Logger = LogManager.GetLogger<PipelineCollection>();

--- a/src/NServiceBus.Core/Pipeline/PipelineInvoker.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineInvoker.cs
@@ -1,0 +1,43 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Threading.Tasks;
+    using ObjectBuilder;
+    using Pipeline;
+    using Transports;
+
+    class PipelineInvoker : IPipelineInvoker
+    {
+        public PipelineInvoker(IBuilder builder, IPipelineCache pipelineCache, IPipeline<ITransportReceiveContext> pipeline, IEventAggregator eventAggregator)
+        {
+            this.builder = builder;
+            this.pipelineCache = pipelineCache;
+            this.pipeline = pipeline;
+            this.eventAggregator = eventAggregator;
+        }
+
+        public async Task Invoke(PushContext pushContext)
+        {
+            var pipelineStartedAt = DateTime.UtcNow;
+
+            using (var childBuilder = builder.CreateChildBuilder())
+            {
+                var rootContext = new RootContext(childBuilder, pipelineCache, eventAggregator);
+
+                var message = new IncomingMessage(pushContext.MessageId, pushContext.Headers, pushContext.BodyStream);
+                var context = new TransportReceiveContext(message, pushContext.TransportTransaction, pushContext.ReceiveCancellationTokenSource, rootContext);
+
+                context.Extensions.Merge(pushContext.Context);
+
+                await pipeline.Invoke(context).ConfigureAwait(false);
+
+                await context.RaiseNotification(new ReceivePipelineCompleted(message, pipelineStartedAt, DateTime.UtcNow)).ConfigureAwait(false);
+            }
+        }
+
+        IBuilder builder;
+        IPipelineCache pipelineCache;
+        IPipeline<ITransportReceiveContext> pipeline;
+        IEventAggregator eventAggregator;
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/SatelliteDefinition.cs
+++ b/src/NServiceBus.Core/Pipeline/SatelliteDefinition.cs
@@ -7,7 +7,7 @@
 
     class SatelliteDefinition
     {
-        public SatelliteDefinition(string name, string receiveAddress, TransportTransactionMode requiredTransportTransactionMode, PushRuntimeSettings runtimeSettings, Func<IBuilder,PushContext, Task> onMessage)
+        public SatelliteDefinition(string name, string receiveAddress, TransportTransactionMode requiredTransportTransactionMode, PushRuntimeSettings runtimeSettings, Func<IBuilder, PushContext, Task> onMessage)
         {
             Name = name;
             ReceiveAddress = receiveAddress;
@@ -24,6 +24,6 @@
 
         public PushRuntimeSettings RuntimeSettings { get; private set; }
 
-        public Func<IBuilder,PushContext,Task> OnMessage{ get; private set; }
+        public Func<IBuilder, PushContext, Task> OnMessage { get; private set; }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/SatellitePipelineInvoker.cs
+++ b/src/NServiceBus.Core/Pipeline/SatellitePipelineInvoker.cs
@@ -1,0 +1,23 @@
+namespace NServiceBus
+{
+    using System.Threading.Tasks;
+    using ObjectBuilder;
+    using Transports;
+
+    class SatellitePipelineInvoker : IPipelineInvoker
+    {
+        public SatellitePipelineInvoker(IBuilder builder, SatelliteDefinition definition)
+        {
+            this.builder = builder;
+            this.definition = definition;
+        }
+
+        public Task Invoke(PushContext pushContext)
+        {
+            return definition.OnMessage(builder, pushContext);
+        }
+
+        SatelliteDefinition definition;
+        IBuilder builder;
+    }
+}


### PR DESCRIPTION
Moves the pipeline invocation runtime concern away from `StartableEndpoint` into dedicated responsibilities. 

@Particular/nservicebus-maintainers please review