### PR TITLE
PendingTransportOperations and OutboxMessage use array instead of IEnumerable or IList

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_clearing_saga_timeouts.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_clearing_saga_timeouts.cs
@@ -93,7 +93,7 @@
 
             public Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag context)
             {
-                testContext.NumberOfOps += message.TransportOperations.Count;
+                testContext.NumberOfOps += message.TransportOperations.Length;
                 return Task.FromResult(0);
             }
 

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -808,9 +808,9 @@ namespace NServiceBus
     {
         public PendingTransportOperations() { }
         public bool HasOperations { get; }
-        public System.Collections.Generic.IReadOnlyCollection<NServiceBus.Transports.TransportOperation> Operations { get; }
+        public NServiceBus.Transports.TransportOperation[] Operations { get; }
         public void Add(NServiceBus.Transports.TransportOperation transportOperation) { }
-        public void AddRange(System.Collections.Generic.IEnumerable<NServiceBus.Transports.TransportOperation> transportOperations) { }
+        public void AddRange(NServiceBus.Transports.TransportOperation[] transportOperations) { }
     }
     public class static PersistenceConfig
     {
@@ -2039,9 +2039,9 @@ namespace NServiceBus.Outbox
     }
     public class OutboxMessage
     {
-        public OutboxMessage(string messageId, System.Collections.Generic.IList<NServiceBus.Outbox.TransportOperation> operations) { }
+        public OutboxMessage(string messageId, NServiceBus.Outbox.TransportOperation[] operations) { }
         public string MessageId { get; }
-        public System.Collections.Generic.IList<NServiceBus.Outbox.TransportOperation> TransportOperations { get; }
+        public NServiceBus.Outbox.TransportOperation[] TransportOperations { get; }
     }
     public class OutboxSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {

--- a/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageProcessingConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageProcessingConnectorTests.cs
@@ -34,7 +34,7 @@
             options["DelayDeliveryFor"] = TimeSpan.FromSeconds(10).ToString();
             options["TimeToBeReceived"] = maxTime.ToString();
 
-            fakeOutbox.ExistingMessage = new OutboxMessage(messageId, new List<NServiceBus.Outbox.TransportOperation>
+            fakeOutbox.ExistingMessage = new OutboxMessage(messageId, new[]
             {
                 new NServiceBus.Outbox.TransportOperation("x", options, new byte[0], new Dictionary<string, string>())
             });
@@ -71,7 +71,7 @@
 
             options["Destination"] = "myEndpoint";
 
-            fakeOutbox.ExistingMessage = new OutboxMessage(messageId, new List<NServiceBus.Outbox.TransportOperation>
+            fakeOutbox.ExistingMessage = new OutboxMessage(messageId, new []
             {
                 new NServiceBus.Outbox.TransportOperation("x", options, new byte[0], new Dictionary<string, string>())
             });
@@ -95,7 +95,7 @@
 
             options["EventType"] = typeof(MyEvent).AssemblyQualifiedName;
 
-            fakeOutbox.ExistingMessage = new OutboxMessage(messageId, new List<NServiceBus.Outbox.TransportOperation>
+            fakeOutbox.ExistingMessage = new OutboxMessage(messageId, new []
             {
                 new NServiceBus.Outbox.TransportOperation("x", options, new byte[0], new Dictionary<string, string>())
             });

--- a/src/NServiceBus.Core/Pipeline/Incoming/PendingTransportOperations.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/PendingTransportOperations.cs
@@ -1,12 +1,11 @@
 namespace NServiceBus
 {
     using System.Collections.Concurrent;
-    using System.Collections.Generic;
-    using System.Linq;
     using Transports;
 
     /// <summary>
-    /// Represents the currently pending transport operations. The transport operations that are collected here will be dispatched in the batched dispatch stage of the pipeline.
+    /// Represents the currently pending transport operations. The transport operations that are collected here will be
+    /// dispatched in the batched dispatch stage of the pipeline.
     /// </summary>
     /// <remarks>This class is threadsafe.</remarks>
     public class PendingTransportOperations
@@ -14,7 +13,7 @@ namespace NServiceBus
         /// <summary>
         /// Gets the currently pending transport operations.
         /// </summary>
-        public IReadOnlyCollection<TransportOperation> Operations => new List<TransportOperation>(operations);
+        public TransportOperation[] Operations => operations.ToArray();
 
         /// <summary>
         /// Indicates whether there are transport operations pending.
@@ -34,10 +33,9 @@ namespace NServiceBus
         /// Adds a range of transport operations.
         /// </summary>
         /// <param name="transportOperations">The transport operations to be added.</param>
-        public void AddRange(IEnumerable<TransportOperation> transportOperations)
+        public void AddRange(TransportOperation[] transportOperations)
         {
-
-            operations.PushRange(transportOperations.ToArray());
+            operations.PushRange(transportOperations);
         }
 
         ConcurrentStack<TransportOperation> operations = new ConcurrentStack<TransportOperation>();

--- a/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
@@ -23,7 +23,7 @@
                     var addressLabel = rs.Apply(context.Message.Headers);
                     var message = new OutgoingMessage(context.Message.MessageId, context.Message.Headers, context.Message.Body);
                     return new TransportOperation(message, addressLabel, dispatchConsistency, context.Extensions.GetDeliveryConstraints());
-                }).ToList();
+                }).ToArray();
 
             if (log.IsDebugEnabled)
             {
@@ -49,7 +49,7 @@
                 return TaskEx.CompletedTask;
             }
 
-            return stage(this.CreateDispatchContext(operations.ToArray(), context));
+            return stage(this.CreateDispatchContext(operations, context));
         }
 
         static ILog log = LogManager.GetLogger<RoutingToDispatchConnector>();

--- a/src/NServiceBus.Core/Reliability/Outbox/OutboxMessage.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/OutboxMessage.cs
@@ -1,8 +1,5 @@
 ﻿namespace NServiceBus.Outbox
 {
-    using System.Collections.Generic;
-    using System.Linq;
-
     /// <summary>
     /// The Outbox message type.
     /// </summary>
@@ -13,13 +10,13 @@
         /// </summary>
         /// <param name="messageId">The message identifier of the incoming message.</param>
         /// <param name="operations">The outgoing transport operations to execute as part of this incoming message.</param>
-        public OutboxMessage(string messageId, IList<TransportOperation> operations)
+        public OutboxMessage(string messageId, TransportOperation[] operations)
         {
             Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
             Guard.AgainstNull(nameof(operations), operations);
 
             MessageId = messageId;
-            TransportOperations = operations.ToList();
+            TransportOperations = operations;
         }
 
         /// <summary>
@@ -30,6 +27,6 @@
         /// <summary>
         /// The list of operations performed during the processing of the incoming message.
         /// </summary>
-        public IList<TransportOperation> TransportOperations { get; private set; }
+        public TransportOperation[] TransportOperations { get; private set; }
     }
 }


### PR DESCRIPTION
Removes unnecessary allocations on PendingTransportOperations and OutboxMessage

This time it is possible to use array. So we are not consistent on the lower level interfaces. But I think we should strive for right type for the use case on this low-level abstractions.

Changing the OutboxMessage has downstream implications for the persisters. When we agree with the proposal of this PR I'll link the downstream PRs.

## Downstream

* [RavenDB](https://github.com/Particular/NServiceBus.RavenDB/pull/251)
* [NHibernate](https://github.com/Particular/NServiceBus.NHibernate/pull/204)