### PR TITLE
Make routing configurations chainable

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -905,10 +905,13 @@ namespace NServiceBus
     }
     public class RoutingSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
-        public void RouteToEndpoint(System.Type messageType, string destination) { }
+        public NServiceBus.RoutingSettings RouteToEndpoint(System.Type messageType, string destination) { }
     }
-    public class RoutingSettings<T> : NServiceBus.RoutingSettings
-        where T : NServiceBus.Transports.TransportDefinition { }
+    public class RoutingSettings<T> : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
+        where T : NServiceBus.Transports.TransportDefinition
+    {
+        public NServiceBus.RoutingSettings<T> RouteToEndpoint(System.Type messageType, string destination) { }
+    }
     public class static RoutingSettingsExtensions
     {
         public static NServiceBus.RoutingSettings Routing(this NServiceBus.TransportExtensions config) { }

--- a/src/NServiceBus.Core/Routing/RoutingSettings.cs
+++ b/src/NServiceBus.Core/Routing/RoutingSettings.cs
@@ -21,21 +21,32 @@
         /// </summary>
         /// <param name="messageType">Message type.</param>
         /// <param name="destination">Destination endpoint.</param>
-        public void RouteToEndpoint(Type messageType, string destination)
+        public RoutingSettings RouteToEndpoint(Type messageType, string destination)
         {
             Settings.GetOrCreate<UnicastRoutingTable>().RouteToEndpoint(messageType, destination);
+            return this;
         }
     }
 
     /// <summary>
     /// Exposes settings related to routing.
     /// </summary>
-    public class RoutingSettings<T> : RoutingSettings
-        where T : TransportDefinition
+    public class RoutingSettings<T> : ExposeSettings where T : TransportDefinition
     {
         internal RoutingSettings(SettingsHolder settings)
             : base(settings)
         {
+        }
+
+        /// <summary>
+        /// Adds a static unicast route.
+        /// </summary>
+        /// <param name="messageType">Message type.</param>
+        /// <param name="destination">Destination endpoint.</param>
+        public RoutingSettings<T> RouteToEndpoint(Type messageType, string destination)
+        {
+            Settings.GetOrCreate<UnicastRoutingTable>().RouteToEndpoint(messageType, destination);
+            return this;
         }
     }
 }

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_a_command.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_a_command.cs
@@ -72,10 +72,10 @@
 
                 EndpointSetup<DefaultServer>(c =>
                 {
-                    var routing = c.UseTransport<MsmqTransport>().Routing();
-                    routing.FileBasedEndpointInstanceMapping(filePath);
-                    routing.RouteToEndpoint(typeof(RequestA), ReceiverAEndpoint);
-                    routing.RouteToEndpoint(typeof(RequestB), ReceiverBEndpoint);
+                    c.UseTransport<MsmqTransport>().Routing()
+                        .RouteToEndpoint(typeof(RequestA), ReceiverAEndpoint)
+                        .RouteToEndpoint(typeof(RequestB), ReceiverBEndpoint)
+                        .FileBasedEndpointInstanceMapping(filePath);
                 });
             }
 

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_replying_to_a_message_sent_via_a_distributor.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_replying_to_a_message_sent_via_a_distributor.cs
@@ -35,8 +35,8 @@
             {
                 EndpointSetup<DefaultServer>(c =>
                 {
-                    var routing = c.UseTransport<MsmqTransport>().Routing();
-                    routing.RouteToEndpoint(typeof(MyRequest), ReceiverEndpoint);
+                    c.UseTransport<MsmqTransport>().Routing()
+                        .RouteToEndpoint(typeof(MyRequest), ReceiverEndpoint);
                     c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverEndpoint, "XYZ"));
                     c.AddHeaderToAllOutgoingMessages("NServiceBus.Distributor.WorkerSessionId", "SomeID");
                 });


### PR DESCRIPTION
Connects to Particular/V6Launch#68

Should we allow to chain routing configs?

e.g.
```
config.UseTransport<Xyz>().Routing()
    .RouteToEnpoint(msg1, "dest1")
    .RouteToEndpoint(msg2, "dest2")
    .InstanceMapping()....
```

ping @bording @DavidBoike @Particular/nservicebus-maintainers 