### PR TITLE
Allow assembly and namespace based routing

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -906,6 +906,8 @@ namespace NServiceBus
     public class RoutingSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
         public void RouteToEndpoint(System.Type messageType, string destination) { }
+        public void RouteToEndpoint(System.Reflection.Assembly assembly, string destination) { }
+        public void RouteToEndpoint(System.Reflection.Assembly assembly, string messageNamespace, string destination) { }
     }
     public class RoutingSettings<T> : NServiceBus.RoutingSettings
         where T : NServiceBus.Transports.TransportDefinition { }

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Routing\Routers\UnicastPublishRouterConnectorTests.cs" />
     <Compile Include="Routing\RoutingOptionExtensionsTests.cs" />
     <Compile Include="Routing\RoutingPolicyTests.cs" />
+    <Compile Include="Routing\RoutingSettingsTests.cs" />
     <Compile Include="Routing\RoutingToDispatchConnectorTests.cs" />
     <Compile Include="Routing\SingleInstanceRoundRobinDistributionStrategyTests.cs" />
     <Compile Include="Routing\SubscriptionRouterTests.cs" />

--- a/src/NServiceBus.Core.Tests/Routing/RoutingSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingSettingsTests.cs
@@ -1,0 +1,148 @@
+﻿namespace NServiceBus.Core.Tests.Routing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using MessageNamespaceA;
+    using MessageNamespaceB;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+    using Settings;
+
+    [TestFixture]
+    public class RoutingSettingsTests
+    {
+        [Test]
+        public async Task WhenRoutingMessageTypeToEndpoint_ShouldConfigureMessageTypeInRoutingTable()
+        {
+            var routingSettings = new RoutingSettings(new SettingsHolder());
+
+            routingSettings.RouteToEndpoint(typeof(SomeMessageType), "destination");
+
+            var routingTable = routingSettings.Settings.Get<UnicastRoutingTable>();
+            var result = await routingTable.GetDestinationsFor(new List<Type>
+            {
+                typeof(SomeMessageType)
+            }, new ContextBag());
+
+            Assert.That(result.Count(), Is.EqualTo(1));
+            var routingTargets = await RetrieveRoutingTargets(result);
+            Assert.That(routingTargets.Single().Endpoint, Is.EqualTo("destination"));
+        }
+
+        [Test]
+        public async Task WhenRoutingAssemblyToEndpoint_ShouldConfigureAllContainedMessagesInRoutingTable()
+        {
+            var routingSettings = new RoutingSettings(new SettingsHolder());
+
+            routingSettings.RouteToEndpoint(Assembly.GetExecutingAssembly(), "destination");
+
+            var routingTable = routingSettings.Settings.Get<UnicastRoutingTable>();
+            var result = await routingTable.GetDestinationsFor(new List<Type>
+            {
+                typeof(SomeMessageType),
+                typeof(OtherMessageType),
+                typeof(MessageWithoutNamespace)
+            }, new ContextBag());
+
+            Assert.That(result.Count(), Is.EqualTo(3));
+            var routingTargets = await RetrieveRoutingTargets(result);
+            Assert.That(routingTargets, Has.All.Property("Endpoint").EqualTo("destination"));
+        }
+
+        [Test]
+        public async Task WhenRoutingAssemblyWithNamespaceToEndpoint_ShouldOnlyConfigureMessagesWithinThatNamespace()
+        {
+            var routingSettings = new RoutingSettings(new SettingsHolder());
+
+            routingSettings.RouteToEndpoint(Assembly.GetExecutingAssembly(), nameof(MessageNamespaceA), "destination");
+
+            var routingTable = routingSettings.Settings.Get<UnicastRoutingTable>();
+            var result1 = await routingTable.GetDestinationsFor(new List<Type>
+            {
+                typeof(SomeMessageType)
+            }, new ContextBag());
+            Assert.That(result1.Count(), Is.EqualTo(1));
+
+            var result2 = await routingTable.GetDestinationsFor(new List<Type>
+            {
+                typeof(OtherMessageType),
+                typeof(MessageWithoutNamespace)
+            }, new ContextBag());
+            Assert.That(result2.Count(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task WhenRoutingAssemblyWithNamespaceToEndpointAndSpecifyingNullNamespace_ShouldOnlyConfigureMessagesWithinEmptyNamespace()
+        {
+            var routingSettings = new RoutingSettings(new SettingsHolder());
+
+            routingSettings.RouteToEndpoint(Assembly.GetExecutingAssembly(), null, "destination");
+
+            var routingTable = routingSettings.Settings.Get<UnicastRoutingTable>();
+            var result1 = await routingTable.GetDestinationsFor(new List<Type>
+            {
+                typeof(MessageWithoutNamespace)
+            }, new ContextBag());
+            Assert.That(result1.Count(), Is.EqualTo(1));
+
+            var result2 = await routingTable.GetDestinationsFor(new List<Type>
+            {
+                typeof(SomeMessageType),
+                typeof(OtherMessageType)
+            }, new ContextBag());
+            Assert.That(result2.Count(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task WhenRoutingAssemblyWithNamespaceToEndpointAndSpecifyingEmptyNamespace_ShouldOnlyConfigureMessagesWithinEmptyNamespace()
+        {
+            var routingSettings = new RoutingSettings(new SettingsHolder());
+
+            routingSettings.RouteToEndpoint(Assembly.GetExecutingAssembly(), String.Empty, "destination");
+
+            var routingTable = routingSettings.Settings.Get<UnicastRoutingTable>();
+            var result1 = await routingTable.GetDestinationsFor(new List<Type>
+            {
+                typeof(MessageWithoutNamespace)
+            }, new ContextBag());
+            Assert.That(result1.Count(), Is.EqualTo(1));
+
+            var result2 = await routingTable.GetDestinationsFor(new List<Type>
+            {
+                typeof(SomeMessageType),
+                typeof(OtherMessageType)
+            }, new ContextBag());
+            Assert.That(result2.Count(), Is.EqualTo(0));
+        }
+
+        static async Task<IEnumerable<UnicastRoutingTarget>> RetrieveRoutingTargets(IEnumerable<IUnicastRoute> result)
+        {
+            return (await Task.WhenAll(result.Select(x => x.Resolve(e => Task.FromResult<IEnumerable<EndpointInstance>>(new[]
+            {
+                new EndpointInstance(e)
+            }))))).SelectMany(x => x);
+        }
+    }
+}
+
+namespace MessageNamespaceA
+{
+    class SomeMessageType
+    {
+    }
+}
+
+namespace MessageNamespaceB
+{
+    class OtherMessageType
+    {
+    }
+}
+
+class MessageWithoutNamespace
+{
+}

--- a/src/NServiceBus.Core/Routing/RoutingSettings.cs
+++ b/src/NServiceBus.Core/Routing/RoutingSettings.cs
@@ -1,6 +1,8 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Linq;
+    using System.Reflection;
     using Configuration.AdvanceExtensibility;
     using Routing;
     using Settings;
@@ -24,6 +26,38 @@
         public void RouteToEndpoint(Type messageType, string destination)
         {
             Settings.GetOrCreate<UnicastRoutingTable>().RouteToEndpoint(messageType, destination);
+        }
+
+        /// <summary>
+        /// Adds a static unicast route for all types contained in the specified assembly.
+        /// </summary>
+        /// <param name="assembly">The assembly whose messages should be routed.</param>
+        /// <param name="destination">Destination endpoint.</param>
+        public void RouteToEndpoint(Assembly assembly, string destination)
+        {
+            var routingTable = Settings.GetOrCreate<UnicastRoutingTable>();
+            foreach (var type in assembly.GetTypes())
+            {
+                routingTable.RouteToEndpoint(type, destination);
+            }
+        }
+
+        /// <summary>
+        /// Adds a static unicast route for all types contained in the specified assembly within the given namespace.
+        /// </summary>
+        /// <param name="assembly">The assembly whose messages should be routed.</param>
+        /// <param name="messageNamespace">The namespace of the messages which should be routed.</param>
+        /// <param name="destination">Destination endpoint.</param>
+        public void RouteToEndpoint(Assembly assembly, string messageNamespace, string destination)
+        {
+            // empty namespace is null, not string.empty
+            messageNamespace = messageNamespace == string.Empty ? null : messageNamespace;
+
+            var routingTable = Settings.GetOrCreate<UnicastRoutingTable>();
+            foreach (var type in assembly.GetTypes().Where(t => t.Namespace == messageNamespace))
+            {
+                routingTable.RouteToEndpoint(type, destination);
+            }
         }
     }
 

--- a/src/NServiceBus.Msmq.AcceptanceTests/NServiceBusAcceptanceTest.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/NServiceBusAcceptanceTest.cs
@@ -22,7 +22,7 @@ namespace NServiceBus.AcceptanceTests
                 testName = testName.Replace("When_", "");
 
                 var endpointBuilder = classAndEndpoint.Split('+').Last();
-                
+
                 testName = System.Threading.Thread.CurrentThread.CurrentCulture.TextInfo.ToTitleCase(testName);
                 testName = testName.Replace("_", "");
 


### PR DESCRIPTION
Connects to Particular/V6Launch#68

Add the following two overloads for the routing API:
```
public void RouteToEndpoint(System.Reflection.Assembly assembly, string destination) { }
public void RouteToEndpoint(System.Reflection.Assembly assembly, string messageNamespace, string destination) { }
```

Open questions:
* The RegisterPublisherForAssembly does the namespace comparison using `StringComparison.InvariantCultureIgnoreCase`, we should align these, but should we really ignore cases instead of going for case sensitive equality?
