### PR TITLE
Publisher cleanup

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2568,7 +2568,7 @@ namespace NServiceBus.Routing.MessageDrivenSubscriptions
         public void Add(System.Reflection.Assembly eventAssembly, string publisher) { }
         public void Add(System.Reflection.Assembly eventAssembly, string eventNamespace, string publisher) { }
         public void AddByAddress(System.Type eventType, string publisherAddress) { }
-        public void AddDynamic(System.Func<System.Type, NServiceBus.Routing.MessageDrivenSubscriptions.PublisherAddress> dynamicRule, string description = null) { }
+        public void AddDynamic(System.Func<System.Type, NServiceBus.Routing.MessageDrivenSubscriptions.PublisherAddress> dynamicRule) { }
     }
 }
 namespace NServiceBus.Routing.StorageDrivenPublishing

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Routing\DetermineRouteForPublishBehaviorTests.cs" />
     <Compile Include="Routing\DistributionPolicyTests.cs" />
     <Compile Include="Routing\FileBasedDynamicRouting\FileRoutingTableFeatureTests.cs" />
+    <Compile Include="Routing\MessageDrivenSubscriptions\PublishersTests.cs" />
     <Compile Include="Routing\Routers\UnicastSendRouterConnectorTests.cs" />
     <Compile Include="Routing\EndpointInstanceTests.cs" />
     <Compile Include="Routing\EndpointInstancesTests.cs" />

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/PublishersTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/PublishersTests.cs
@@ -24,10 +24,10 @@
         public void Should_return_all_routes_registered_for_type()
         {
             var publishers = new Publishers();
-            publishers.Add("logicalEndpoint", typeof(BaseMessage));
-            publishers.Add("logicalEndpoint", typeof(BaseMessage));
-            publishers.Add("logicalEndpoint2", typeof(BaseMessage));
-            publishers.AddByAddress("address1", typeof(BaseMessage));
+            publishers.Add(typeof(BaseMessage), "logicalEndpoint");
+            publishers.Add(typeof(BaseMessage), "logicalEndpoint");
+            publishers.Add(typeof(BaseMessage), "logicalEndpoint2");
+            publishers.AddByAddress(typeof(BaseMessage), "address1");
 
             var result = publishers.GetPublisherFor(typeof(BaseMessage));
 
@@ -38,7 +38,7 @@
         public void Should_register_all_types_in_assembly_when_not_specifying_namespace()
         {
             var publishers = new Publishers();
-            publishers.Add("someAddress", Assembly.GetExecutingAssembly());
+            publishers.Add(Assembly.GetExecutingAssembly(), "someAddress");
 
             var result1 = publishers.GetPublisherFor(typeof(BaseMessage));
             var result2 = publishers.GetPublisherFor(typeof(SubMessage));
@@ -55,7 +55,7 @@
         public void Should_only_register_types_in_specified_namespace()
         {
             var publishers = new Publishers();
-            publishers.Add("someAddress", Assembly.GetExecutingAssembly(), "MessageNameSpace");
+            publishers.Add(Assembly.GetExecutingAssembly(), "MessageNameSpace", "someAddress");
 
             var result1 = publishers.GetPublisherFor(typeof(BaseMessage));
             var result2 = publishers.GetPublisherFor(typeof(SubMessage));
@@ -73,7 +73,7 @@
         public void Should_support_empty_namespace(string eventNamespace)
         {
             var publishers = new Publishers();
-            publishers.Add("someAddress", Assembly.GetExecutingAssembly(), eventNamespace);
+            publishers.Add(Assembly.GetExecutingAssembly(), eventNamespace, "someAddress");
 
             var result1 = publishers.GetPublisherFor(typeof(BaseMessage));
             var result2 = publishers.GetPublisherFor(typeof(SubMessage));
@@ -90,7 +90,7 @@
         public void Should_return_static_and_dynamic_routes_for_registered_type()
         {
             var publishers = new Publishers();
-            publishers.Add("logicalEndpoint", typeof(BaseMessage));
+            publishers.Add(typeof(BaseMessage), "logicalEndpoint");
             publishers.AddDynamic(e => PublisherAddress.CreateFromEndpointName(e.ToString()));
 
             var result = publishers.GetPublisherFor(typeof(BaseMessage));
@@ -126,7 +126,7 @@
         public void Should_not_return_rules_for_subclasses()
         {
             var publishers = new Publishers();
-            publishers.Add("address", typeof(SubMessage));
+            publishers.Add(typeof(SubMessage), "address");
 
             var result = publishers.GetPublisherFor(typeof(BaseMessage));
 
@@ -137,7 +137,7 @@
         public void Should_not_return_rules_for_baseclasses()
         {
             var publishers = new Publishers();
-            publishers.Add("address", typeof(BaseMessage));
+            publishers.Add(typeof(BaseMessage), "address");
 
             var result = publishers.GetPublisherFor(typeof(SubMessage));
 
@@ -148,7 +148,7 @@
         public void Should_not_return_rules_for_implemented_interfaces()
         {
             var publishers = new Publishers();
-            publishers.Add("address", typeof(IMessageInterface));
+            publishers.Add(typeof(IMessageInterface), "address");
 
             var result = publishers.GetPublisherFor(typeof(BaseMessage));
 
@@ -160,7 +160,7 @@
         {
             var calledOnce = false;
             var publishers = new Publishers();
-            publishers.Add("address", typeof(BaseMessage));
+            publishers.Add(typeof(BaseMessage), "address");
             publishers.AddDynamic(e =>
             {
                 if (calledOnce)

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/PublishersTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/PublishersTests.cs
@@ -1,0 +1,206 @@
+﻿namespace NServiceBus.Core.Tests.Routing.MessageDrivenSubscriptions
+{
+    using System.Linq;
+    using System.Reflection;
+    using MessageNameSpace;
+    using NServiceBus.Routing.MessageDrivenSubscriptions;
+    using NUnit.Framework;
+    using OtherMesagenameSpace;
+
+    [TestFixture]
+    public class PublishersTests
+    {
+        [Test]
+        public void Should_return_empty_list_for_events_with_no_routes()
+        {
+            var publishers = new Publishers();
+
+            var result = publishers.GetPublisherFor(typeof(BaseMessage));
+
+            Assert.IsEmpty(result);
+        }
+
+        [Test]
+        public void Should_return_all_routes_registered_for_type()
+        {
+            var publishers = new Publishers();
+            publishers.Add("logicalEndpoint", typeof(BaseMessage));
+            publishers.Add("logicalEndpoint", typeof(BaseMessage));
+            publishers.Add("logicalEndpoint2", typeof(BaseMessage));
+            publishers.AddByAddress("address1", typeof(BaseMessage));
+
+            var result = publishers.GetPublisherFor(typeof(BaseMessage));
+
+            Assert.AreEqual(4, result.Count());
+        }
+
+        [Test]
+        public void Should_register_all_types_in_assembly_when_not_specifying_namespace()
+        {
+            var publishers = new Publishers();
+            publishers.Add("someAddress", Assembly.GetExecutingAssembly());
+
+            var result1 = publishers.GetPublisherFor(typeof(BaseMessage));
+            var result2 = publishers.GetPublisherFor(typeof(SubMessage));
+            var result3 = publishers.GetPublisherFor(typeof(EventWithoutNamespace));
+            var result4 = publishers.GetPublisherFor(typeof(IMessageInterface));
+
+            Assert.AreEqual(1, result1.Count());
+            Assert.AreEqual(1, result2.Count());
+            Assert.AreEqual(1, result3.Count());
+            Assert.AreEqual(1, result4.Count());
+        }
+
+        [Test]
+        public void Should_only_register_types_in_specified_namespace()
+        {
+            var publishers = new Publishers();
+            publishers.Add("someAddress", Assembly.GetExecutingAssembly(), "MessageNameSpace");
+
+            var result1 = publishers.GetPublisherFor(typeof(BaseMessage));
+            var result2 = publishers.GetPublisherFor(typeof(SubMessage));
+            var result3 = publishers.GetPublisherFor(typeof(EventWithoutNamespace));
+            var result4 = publishers.GetPublisherFor(typeof(IMessageInterface));
+
+            Assert.AreEqual(1, result1.Count());
+            Assert.AreEqual(1, result4.Count());
+            Assert.IsEmpty(result2);
+            Assert.IsEmpty(result3);
+        }
+
+        [TestCase("")]
+        [TestCase(null)]
+        public void Should_support_empty_namespace(string eventNamespace)
+        {
+            var publishers = new Publishers();
+            publishers.Add("someAddress", Assembly.GetExecutingAssembly(), eventNamespace);
+
+            var result1 = publishers.GetPublisherFor(typeof(BaseMessage));
+            var result2 = publishers.GetPublisherFor(typeof(SubMessage));
+            var result3 = publishers.GetPublisherFor(typeof(EventWithoutNamespace));
+            var result4 = publishers.GetPublisherFor(typeof(IMessageInterface));
+
+            Assert.AreEqual(1, result3.Count());
+            Assert.IsEmpty(result1);
+            Assert.IsEmpty(result2);
+            Assert.IsEmpty(result4);
+        }
+
+        [Test]
+        public void Should_return_static_and_dynamic_routes_for_registered_type()
+        {
+            var publishers = new Publishers();
+            publishers.Add("logicalEndpoint", typeof(BaseMessage));
+            publishers.AddDynamic(e => PublisherAddress.CreateFromEndpointName(e.ToString()));
+
+            var result = publishers.GetPublisherFor(typeof(BaseMessage));
+
+            Assert.AreEqual(2, result.Count());
+        }
+
+        [Test]
+        public void Should_evaluate_dynamic_rules_on_each_call()
+        {
+            var c = 0;
+            var publishers = new Publishers();
+            publishers.AddDynamic(t => PublisherAddress.CreateFromEndpointName((++c).ToString()));
+
+            publishers.GetPublisherFor(typeof(BaseMessage));
+            publishers.GetPublisherFor(typeof(BaseMessage));
+
+            Assert.AreEqual(2, c);
+        }
+
+        [Test]
+        public void Should_not_return_null_results_from_dynamic_rules()
+        {
+            var publishers = new Publishers();
+            publishers.AddDynamic(t => null);
+
+            var result = publishers.GetPublisherFor(typeof(BaseMessage));
+
+            Assert.IsEmpty(result);
+        }
+
+        [Test]
+        public void Should_not_return_rules_for_subclasses()
+        {
+            var publishers = new Publishers();
+            publishers.Add("address", typeof(SubMessage));
+
+            var result = publishers.GetPublisherFor(typeof(BaseMessage));
+
+            Assert.IsEmpty(result);
+        }
+
+        [Test]
+        public void Should_not_return_rules_for_baseclasses()
+        {
+            var publishers = new Publishers();
+            publishers.Add("address", typeof(BaseMessage));
+
+            var result = publishers.GetPublisherFor(typeof(SubMessage));
+
+            Assert.IsEmpty(result);
+        }
+
+        [Test]
+        public void Should_not_return_rules_for_implemented_interfaces()
+        {
+            var publishers = new Publishers();
+            publishers.Add("address", typeof(IMessageInterface));
+
+            var result = publishers.GetPublisherFor(typeof(BaseMessage));
+
+            Assert.IsEmpty(result);
+        }
+
+        [Test]
+        public void Dynamic_rules_should_not_leak_into_static_rules()
+        {
+            var calledOnce = false;
+            var publishers = new Publishers();
+            publishers.Add("address", typeof(BaseMessage));
+            publishers.AddDynamic(e =>
+            {
+                if (calledOnce)
+                {
+                    return null;
+                }
+
+                calledOnce = true;
+                return PublisherAddress.CreateFromEndpointName("x");
+            });
+
+            var result1 = publishers.GetPublisherFor(typeof(BaseMessage));
+            var result2 = publishers.GetPublisherFor(typeof(BaseMessage));
+
+            Assert.AreEqual(2, result1.Count());
+            Assert.AreEqual(1, result2.Count());
+        }
+    }
+}
+
+namespace MessageNameSpace
+{
+    interface IMessageInterface
+    {
+    }
+
+    class BaseMessage : IMessageInterface
+    {
+    }
+}
+
+namespace OtherMesagenameSpace
+{
+    using MessageNameSpace;
+
+    class SubMessage : BaseMessage
+    {
+    }
+}
+
+class EventWithoutNamespace
+{
+}

--- a/src/NServiceBus.Core.Tests/Routing/SubscriptionRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SubscriptionRouterTests.cs
@@ -65,14 +65,19 @@ namespace NServiceBus.Core.Tests.Routing
             const string address = "address";
             var publishers = new Publishers();
             publishers.Add(address, typeof(BaseMessage));
+            publishers.Add(address, typeof(BaseMessage));
             publishers.Add(address, typeof(InheritedMessage));
+            publishers.AddDynamic(t => PublisherAddress.CreateFromEndpointName(address));
+
             var knownEndpoints = new EndpointInstances();
             knownEndpoints.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(e, null, null))));
             var physicalAddresses = new TransportAddresses(a => null);
             physicalAddresses.AddRule(i => i.EndpointInstance.Endpoint);
             var router = new SubscriptionRouter(publishers, knownEndpoints, physicalAddresses);
 
-            Assert.AreEqual(1, (await router.GetAddressesForEventType(typeof(BaseMessage))).Count());
+            var result = await router.GetAddressesForEventType(typeof(BaseMessage));
+
+            Assert.AreEqual(1, result.Count());
         }
 
         public class Message1

--- a/src/NServiceBus.Core.Tests/Routing/SubscriptionRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SubscriptionRouterTests.cs
@@ -64,9 +64,9 @@ namespace NServiceBus.Core.Tests.Routing
         {
             const string address = "address";
             var publishers = new Publishers();
-            publishers.Add(address, typeof(BaseMessage));
-            publishers.Add(address, typeof(BaseMessage));
-            publishers.Add(address, typeof(InheritedMessage));
+            publishers.Add(typeof(BaseMessage), address);
+            publishers.Add(typeof(BaseMessage), address);
+            publishers.Add(typeof(InheritedMessage), address);
             publishers.AddDynamic(t => PublisherAddress.CreateFromEndpointName(address));
 
             var knownEndpoints = new EndpointInstances();

--- a/src/NServiceBus.Core.Tests/Routing/SubscriptionRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SubscriptionRouterTests.cs
@@ -60,8 +60,19 @@ namespace NServiceBus.Core.Tests.Routing
         }
 
         [Test]
-        public void Should_not_generate_duplicate_addresses()
+        public async Task Should_not_generate_duplicate_addresses()
         {
+            const string address = "address";
+            var publishers = new Publishers();
+            publishers.Add(address, typeof(BaseMessage));
+            publishers.Add(address, typeof(InheritedMessage));
+            var knownEndpoints = new EndpointInstances();
+            knownEndpoints.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(e, null, null))));
+            var physicalAddresses = new TransportAddresses(a => null);
+            physicalAddresses.AddRule(i => i.EndpointInstance.Endpoint);
+            var router = new SubscriptionRouter(publishers, knownEndpoints, physicalAddresses);
+
+            Assert.AreEqual(1, (await router.GetAddressesForEventType(typeof(BaseMessage))).Count());
         }
 
         public class Message1

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionRouter.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionRouter.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using Routing;
     using Routing.MessageDrivenSubscriptions;
@@ -25,7 +26,7 @@
                     ResolveInstances,
                     i => physicalAddresses.GetTransportAddress(new LogicalAddress(i))).ConfigureAwait(false));
             }
-            return results;
+            return results.Distinct();
         }
 
         Task<IEnumerable<EndpointInstance>> ResolveInstances(string endpoint)


### PR DESCRIPTION
Connects to Particular/V6Launch#68

Refactoring of the `Publisher` class + some additional tests

* dedicated overloads for assembly + namespace configuration to avoid optional parameter on the public API.
* reduce the amount of publisher routing rules which need to be invoked at runtime by "compiling" static rules into a dictionary, reducing the effort to a lookup instead of invoking every single rule.

@Particular/nservicebus-maintainers @SzymonPobiega  please review