### PR TITLE
Enables extension points for additional deserializers

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1033,8 +1033,10 @@ namespace NServiceBus
     }
     public class static SerializationConfigExtensions
     {
-        public static void AddDeserializer<T>(this NServiceBus.EndpointConfiguration config)
+        public static NServiceBus.Serialization.SerializationExtensions<T> AddDeserializer<T>(this NServiceBus.EndpointConfiguration config)
             where T : NServiceBus.Serialization.SerializationDefinition, new () { }
+        public static NServiceBus.Serialization.SerializationExtensions<T> AddDeserializer<T>(this NServiceBus.EndpointConfiguration config, T serializationDefinition)
+            where T : NServiceBus.Serialization.SerializationDefinition { }
         public static NServiceBus.Serialization.SerializationExtensions<T> UseSerialization<T>(this NServiceBus.EndpointConfiguration config)
             where T : NServiceBus.Serialization.SerializationDefinition, new () { }
         public static NServiceBus.Serialization.SerializationExtensions<T> UseSerialization<T>(this NServiceBus.EndpointConfiguration config, T serializationDefinition)

--- a/src/NServiceBus.Core/Serialization/SerializationConfigExtensions.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationConfigExtensions.cs
@@ -32,12 +32,10 @@
         {
             Guard.AgainstNull(nameof(config), config);
             Guard.AgainstNull(nameof(serializationDefinition), serializationDefinition);
-            var type = typeof(SerializationExtensions<>).MakeGenericType(typeof(T));
-            var extension = (SerializationExtensions<T>) Activator.CreateInstance(type, config.Settings);
 
             config.Settings.Set<SerializationDefinition>(serializationDefinition);
 
-            return extension;
+            return CreateSerializationExtension<T>(config);
         }
 
         /// <summary>
@@ -45,18 +43,41 @@
         /// </summary>
         /// <typeparam name="T">The serializer definition eg <see cref="JsonSerializer" />, <see cref="XmlSerializer" />, etc.</typeparam>
         /// <param name="config">The <see cref="EndpointConfiguration" /> instance to apply the settings to.</param>
-        public static void AddDeserializer<T>(this EndpointConfiguration config) where T : SerializationDefinition, new()
+        public static SerializationExtensions<T> AddDeserializer<T>(this EndpointConfiguration config) where T : SerializationDefinition, new()
         {
             Guard.AgainstNull(nameof(config), config);
+            var definition = (T) Activator.CreateInstance(typeof(T));
+
+            return AddDeserializer(config, definition);
+        }
+
+        /// <summary>
+        /// Configures additional deserializers to be considered when processing messages. Can be called multiple times.
+        /// </summary>
+        /// <typeparam name="T">The serializer definition eg <see cref="JsonSerializer" />, <see cref="XmlSerializer" />, etc.</typeparam>
+        /// <param name="serializationDefinition">An instance of serialization definition.</param>
+        /// <param name="config">The <see cref="EndpointConfiguration" /> instance to apply the settings to.</param>
+        public static SerializationExtensions<T> AddDeserializer<T>(this EndpointConfiguration config, T serializationDefinition) where T : SerializationDefinition
+        {
+            Guard.AgainstNull(nameof(config), config);
+            Guard.AgainstNull(nameof(serializationDefinition), serializationDefinition);
 
             List<SerializationDefinition> deserializers;
-            var instance = Activator.CreateInstance<T>();
             if (!config.Settings.TryGet("AdditionalDeserializers", out deserializers))
             {
                 deserializers = new List<SerializationDefinition>();
                 config.Settings.Set("AdditionalDeserializers", deserializers);
             }
-            deserializers.Add(instance);
+
+            deserializers.Add(serializationDefinition);
+            return CreateSerializationExtension<T>(config);
+        }
+
+        static SerializationExtensions<T> CreateSerializationExtension<T>(EndpointConfiguration config) where T : SerializationDefinition
+        {
+            var type = typeof(SerializationExtensions<>).MakeGenericType(typeof(T));
+            var extension = (SerializationExtensions<T>) Activator.CreateInstance(type, config.Settings);
+            return extension;
         }
     }
 }


### PR DESCRIPTION
Closes #3919 

@dloukola rightfully pointed out that our `AddDeserializer` API is restrictive since it doesn't allow to use the normal configuration extension points you'd normally expect when configuring a serializer. This PR would add those. 

## Doco PR
* Not necessary

## Caveat of the current design (unrelated to this PR)

The API (has always been like that) doesn't restrict doing things like

```
config.UseSerializer<SomeSerializer>().;
config.AddDeserializer<SomeSerializer>();
```

but since we now enable settings over the `SettingsHolder` in theory the last call would override the settings of both the main serializer and the deserializer. I.ex.

```
config.UseSerializer<JSon>().Settings("foobar");
config.AddDeserializer<Json>().Settings("bar");
```

The serializer would see `bar` as the configured last value. Should we address this? If yes then I think we should consider this as a separate PR.
