### PR TITLE
Avoid async calls in UnicastRoutingTable

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2554,8 +2554,8 @@ namespace NServiceBus.Routing
     public class UnicastRoutingTable
     {
         public UnicastRoutingTable() { }
-        public void AddDynamic(System.Func<System.Collections.Generic.List<System.Type>, NServiceBus.Extensibility.ContextBag, System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.Routing.IUnicastRoute>>> dynamicRule) { }
-        public void AddDynamic(System.Func<System.Collections.Generic.List<System.Type>, NServiceBus.Extensibility.ContextBag, System.Collections.Generic.IEnumerable<NServiceBus.Routing.IUnicastRoute>> dynamicRule) { }
+        public void AddDynamic(System.Func<System.Type[], NServiceBus.Extensibility.ContextBag, System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.Routing.IUnicastRoute>>> dynamicRule) { }
+        public void AddDynamic(System.Func<System.Type[], NServiceBus.Extensibility.ContextBag, System.Collections.Generic.IEnumerable<NServiceBus.Routing.IUnicastRoute>> dynamicRule) { }
         public void RouteToAddress(System.Type messageType, string destinationAddress) { }
         public void RouteToEndpoint(System.Type messageType, string destination) { }
     }

--- a/src/NServiceBus.Core.Tests/Routing/RoutingSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingSettingsTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Core.Tests.Routing
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
@@ -23,7 +22,7 @@
             routingSettings.RouteToEndpoint(typeof(SomeMessageType), "destination");
 
             var routingTable = routingSettings.Settings.Get<UnicastRoutingTable>();
-            var routes = await routingTable.GetDestinationsFor(new List<Type>
+            var routes = await routingTable.GetDestinationsFor(new[]
             {
                 typeof(SomeMessageType)
             }, new ContextBag());
@@ -40,7 +39,7 @@
             routingSettings.RouteToEndpoint(Assembly.GetExecutingAssembly(), "destination");
             var routingTable = routingSettings.Settings.Get<UnicastRoutingTable>();
 
-            var routes = await routingTable.GetDestinationsFor(new List<Type>
+            var routes = await routingTable.GetDestinationsFor(new []
             {
                 typeof(SomeMessageType),
                 typeof(OtherMessageType),
@@ -59,12 +58,12 @@
             routingSettings.RouteToEndpoint(Assembly.GetExecutingAssembly(), nameof(MessageNamespaceA), "destination");
             var routingTable = routingSettings.Settings.Get<UnicastRoutingTable>();
 
-            var result1 = await routingTable.GetDestinationsFor(new List<Type>
+            var result1 = await routingTable.GetDestinationsFor(new[]
             {
                 typeof(SomeMessageType)
             }, new ContextBag());
 
-            var result2 = await routingTable.GetDestinationsFor(new List<Type>
+            var result2 = await routingTable.GetDestinationsFor(new[]
             {
                 typeof(OtherMessageType),
                 typeof(MessageWithoutNamespace)
@@ -83,11 +82,11 @@
             routingSettings.RouteToEndpoint(Assembly.GetExecutingAssembly(), emptyNamespace, "destination");
             var routingTable = routingSettings.Settings.Get<UnicastRoutingTable>();
 
-            var result1 = await routingTable.GetDestinationsFor(new List<Type>
+            var result1 = await routingTable.GetDestinationsFor(new[]
             {
                 typeof(MessageWithoutNamespace)
             }, new ContextBag());
-            var result2 = await routingTable.GetDestinationsFor(new List<Type>
+            var result2 = await routingTable.GetDestinationsFor(new[]
             {
                 typeof(SomeMessageType),
                 typeof(OtherMessageType)

--- a/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
@@ -18,7 +18,7 @@ namespace NServiceBus
             this.subscriptionStorage = subscriptionStorage;
         }
 
-        protected override async Task<IEnumerable<IUnicastRoute>> GetDestinations(ContextBag contextBag, List<Type> typesToRoute)
+        protected override async Task<IEnumerable<IUnicastRoute>> GetDestinations(ContextBag contextBag, Type[] typesToRoute)
         {
             var messageTypes = typesToRoute.Select(t => new MessageType(t));
             var subscribers = await subscriptionStorage.GetSubscriberAddressesForMessage(messageTypes, contextBag).ConfigureAwait(false);

--- a/src/NServiceBus.Core/Routing/UnicastRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRouter.cs
@@ -25,7 +25,7 @@ namespace NServiceBus
             var typesToRoute = messageMetadataRegistry.GetMessageMetadata(messageType)
                 .MessageHierarchy
                 .Distinct()
-                .ToList();
+                .ToArray();
 
             var routes = await GetDestinations(contextBag, typesToRoute).ConfigureAwait(false);
             var destinations = new List<UnicastRoutingTarget>();
@@ -42,7 +42,7 @@ namespace NServiceBus
                 .Select(destination => new UnicastRoutingStrategy(destination));
         }
 
-        protected abstract Task<IEnumerable<IUnicastRoute>> GetDestinations(ContextBag contextBag, List<Type> typesToRoute);
+        protected abstract Task<IEnumerable<IUnicastRoute>> GetDestinations(ContextBag contextBag, Type[] types);
 
         Task<IEnumerable<EndpointInstance>> InstanceResolver(string endpoint)
         {

--- a/src/NServiceBus.Core/Routing/UnicastRoutingTable.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRoutingTable.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.Routing
     /// </summary>
     public class UnicastRoutingTable
     {
-        internal Task<IEnumerable<IUnicastRoute>> GetDestinationsFor(List<Type> messageTypes, ContextBag contextBag)
+        internal Task<IEnumerable<IUnicastRoute>> GetDestinationsFor(Type[] messageTypes, ContextBag contextBag)
         {
             var routes = new List<IUnicastRoute>();
 
@@ -59,9 +59,9 @@ namespace NServiceBus.Routing
         /// <summary>
         /// Adds an external provider of routes.
         /// </summary>
-        /// <remarks>For dynamic routes that do not require async use <see cref="AddDynamic(System.Func{System.Collections.Generic.List{System.Type},NServiceBus.Extensibility.ContextBag,System.Collections.Generic.IEnumerable{NServiceBus.Routing.IUnicastRoute}})" />.</remarks>
+        /// <remarks>For dynamic routes that do not require async use <see cref="AddDynamic(System.Func{Type[],NServiceBus.Extensibility.ContextBag,System.Collections.Generic.IEnumerable{NServiceBus.Routing.IUnicastRoute}})" />.</remarks>
         /// <param name="dynamicRule">The rule.</param>
-        public void AddDynamic(Func<List<Type>, ContextBag, Task<IEnumerable<IUnicastRoute>>> dynamicRule)
+        public void AddDynamic(Func<Type[], ContextBag, Task<IEnumerable<IUnicastRoute>>> dynamicRule)
         {
             asyncDynamicRules.Add(dynamicRule);
         }
@@ -69,9 +69,9 @@ namespace NServiceBus.Routing
         /// <summary>
         /// Adds an external provider of routes.
         /// </summary>
-        /// <remarks>For dynamic routes that require async use <see cref="AddDynamic(System.Func{System.Collections.Generic.List{System.Type},NServiceBus.Extensibility.ContextBag,System.Threading.Tasks.Task{System.Collections.Generic.IEnumerable{NServiceBus.Routing.IUnicastRoute}}})" />.</remarks>
+        /// <remarks>For dynamic routes that require async use <see cref="AddDynamic(System.Func{Type[],NServiceBus.Extensibility.ContextBag,System.Threading.Tasks.Task{System.Collections.Generic.IEnumerable{NServiceBus.Routing.IUnicastRoute}}})" />.</remarks>
         /// <param name="dynamicRule">The rule.</param>
-        public void AddDynamic(Func<List<Type>, ContextBag, IEnumerable<IUnicastRoute>> dynamicRule)
+        public void AddDynamic(Func<Type[], ContextBag, IEnumerable<IUnicastRoute>> dynamicRule)
         {
             dynamicRules.Add(dynamicRule);
         }
@@ -92,7 +92,7 @@ namespace NServiceBus.Routing
             }
         }
 
-        async Task<IEnumerable<IUnicastRoute>> AddAsyncDynamicRules(List<Type> messageTypes, ContextBag contextBag, List<IUnicastRoute> routes)
+        async Task<IEnumerable<IUnicastRoute>> AddAsyncDynamicRules(Type[] messageTypes, ContextBag contextBag, List<IUnicastRoute> routes)
         {
             foreach (var rule in asyncDynamicRules)
             {
@@ -102,8 +102,8 @@ namespace NServiceBus.Routing
             return routes;
         }
 
-        List<Func<List<Type>, ContextBag, Task<IEnumerable<IUnicastRoute>>>> asyncDynamicRules = new List<Func<List<Type>, ContextBag, Task<IEnumerable<IUnicastRoute>>>>();
-        List<Func<List<Type>, ContextBag, IEnumerable<IUnicastRoute>>> dynamicRules = new List<Func<List<Type>, ContextBag, IEnumerable<IUnicastRoute>>>();
+        List<Func<Type[], ContextBag, Task<IEnumerable<IUnicastRoute>>>> asyncDynamicRules = new List<Func<Type[], ContextBag, Task<IEnumerable<IUnicastRoute>>>>();
+        List<Func<Type[], ContextBag, IEnumerable<IUnicastRoute>>> dynamicRules = new List<Func<Type[], ContextBag, IEnumerable<IUnicastRoute>>>();
         Dictionary<Type, List<IUnicastRoute>> staticRoutes = new Dictionary<Type, List<IUnicastRoute>>();
     }
 }

--- a/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
@@ -10,13 +10,13 @@ namespace NServiceBus
 
     class UnicastSendRouter : UnicastRouter
     {
-        public UnicastSendRouter(MessageMetadataRegistry messageMetadataRegistry, UnicastRoutingTable unicastRoutingTable, EndpointInstances endpointInstances, TransportAddresses physicalAddresses) 
+        public UnicastSendRouter(MessageMetadataRegistry messageMetadataRegistry, UnicastRoutingTable unicastRoutingTable, EndpointInstances endpointInstances, TransportAddresses physicalAddresses)
             : base(messageMetadataRegistry, endpointInstances, physicalAddresses)
         {
             this.unicastRoutingTable = unicastRoutingTable;
         }
 
-        protected override Task<IEnumerable<IUnicastRoute>> GetDestinations(ContextBag contextBag, List<Type> typesToRoute)
+        protected override Task<IEnumerable<IUnicastRoute>> GetDestinations(ContextBag contextBag, Type[] typesToRoute)
         {
             return unicastRoutingTable.GetDestinationsFor(typesToRoute, contextBag);
         }


### PR DESCRIPTION
Connects to Particular/V6Launch#68

UnicastRoutingTable allows to define async rules to resolve routes. Since this is an advanced API which isn't used by default, we can try to avoid the async overhead when possible.

Also changing some parameters to an array to make the read-only nature a bit more apparent.

Question: do we really want to allow async rules to be defined? this can result in a major performance hit when someone tries to lookup these data on a database on every outgoing message, a better approach would usually be to read the database from time to time and keep the read data in memory for faster lookups?

@Particular/nservicebus-maintainers @SzymonPobiega @DavidBoike  