### PR TITLE
Attempt to fix in-memory saga persistence

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_found_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_a_finder_exists_and_found_saga.cs
@@ -42,7 +42,7 @@
 
                 public ISagaPersister SagaPersister { get; set; }
 
-                public Task<TestSaga08.SagaData08> FindBy(SomeOtherMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context)
+                public async Task<TestSaga08.SagaData08> FindBy(SomeOtherMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context)
                 {
                     Context.FinderUsed = true;
                     var sagaInstance = new TestSaga08.SagaData08
@@ -50,8 +50,8 @@
                         Property = "jfbsjdfbsdjh"
                     };
                     //Make sure saga exists in the store. Persisters expect it there when they save saga instance after processing a message.
-                    //await SagaPersister.Save(sagaInstance, SagaCorrelationProperty.None, storageSession, new ContextBag()).ConfigureAwait(false);
-                    return Task.FromResult(sagaInstance);
+                    await SagaPersister.Save(sagaInstance, SagaCorrelationProperty.None, storageSession, new ContextBag()).ConfigureAwait(false);
+                    return sagaInstance;
                 }
             }
 


### PR DESCRIPTION
With the new recoverability seam we detected that the `When_a_finder_exists_and_found_saga` test is always failing with the InMemorySagaPersister. @tmasternak and I tried to fix the persister. Just before our heads exploded we could (hopefully, fingers crossed, wish us luck) come up with a potential fix for the persistence. 

Start shooting holes into it @Particular/nservicebus-maintainers 