### PR TITLE
Set correct message types when using proxy interfaces

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Basic/When_sending_with_conventions.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_sending_with_conventions.cs
@@ -12,19 +12,22 @@
         public async Task Should_receive_the_message()
         {
             var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
-                .WithEndpoint<Endpoint>(b => b.When((session, c) => session.SendLocal(new MyMessage
+                .WithEndpoint<Endpoint>(b => b.When(async(session, c) =>
                 {
-                    Id = c.Id
-                })))
-                .Done(c => c.WasCalled)
+                    await session.SendLocal<MyMessage>(m => m.Id = c.Id);
+                    await session.SendLocal<IMyInterfaceMessage>(m => m.Id = c.Id);
+                }))
+                .Done(c => c.MessageClassReceived && c.MessageInterfaceReceived)
                 .Run();
 
-            Assert.True(context.WasCalled);
+            Assert.True(context.MessageClassReceived);
+            Assert.True(context.MessageInterfaceReceived);
         }
 
         public class Context : ScenarioContext
         {
-            public bool WasCalled { get; set; }
+            public bool MessageClassReceived { get; set; }
+            public bool MessageInterfaceReceived { get; set; }
             public Guid Id { get; set; }
         }
 
@@ -32,14 +35,18 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>(b => b.Conventions().DefiningMessagesAs(type => type == typeof(MyMessage)));
+                EndpointSetup<DefaultServer>(b => b.Conventions().DefiningMessagesAs(type => type.Name.EndsWith("Message")));
             }
         }
 
-        [Serializable]
         public class MyMessage
         {
             public Guid Id { get; set; }
+        }
+
+        public interface IMyInterfaceMessage
+        {
+            Guid Id { get; set; }
         }
 
         public class MyMessageHandler : IHandleMessages<MyMessage>
@@ -53,7 +60,24 @@
                     return Task.FromResult(0);
                 }
 
-                Context.WasCalled = true;
+                Context.MessageClassReceived = true;
+
+                return Task.FromResult(0);
+            }
+        }
+
+        public class MyMessageInterfaceHandler : IHandleMessages<IMyInterfaceMessage>
+        {
+            public Context Context { get; set; }
+
+            public Task Handle(IMyInterfaceMessage interfaceMessage, IMessageHandlerContext context)
+            {
+                if (Context.Id != interfaceMessage.Id)
+                {
+                    return Task.FromResult(0);
+                }
+
+                Context.MessageInterfaceReceived = true;
 
                 return Task.FromResult(0);
             }

--- a/src/NServiceBus.AcceptanceTests/Basic/When_using_a_greedy_convention.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_using_a_greedy_convention.cs
@@ -5,24 +5,21 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using NUnit.Framework;
-    using ScenarioDescriptors;
 
     public class When_using_a_greedy_convention : NServiceBusAcceptanceTest
     {
         [Test]
-        public Task Should_receive_the_message()
+        public async Task Should_receive_the_message()
         {
-            return Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
                 .WithEndpoint<Endpoint>(b => b.When((session, c) => session.SendLocal(new MyMessage
                 {
                     Id = c.Id
                 })))
                 .Done(c => c.WasCalled)
-                .Repeat(r => r
-                    .For(Transports.Default)
-                )
-                .Should(c => Assert.True(c.WasCalled, "The message handler should be called"))
                 .Run();
+
+            Assert.True(context.WasCalled, "The message handler should be called");
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -310,6 +310,7 @@
     <Compile Include="Unicast\Contexts\EventMessage.cs" />
     <Compile Include="Unicast\Contexts\InterfaceMessage.cs" />
     <Compile Include="Unicast\LoadHandlersBehaviorTests.cs" />
+    <Compile Include="Unicast\MessageOperationsTests.cs" />
     <Compile Include="Unicast\RunningEndpointInstanceTest.cs" />
     <Compile Include="Pipeline\Outgoing\AttachSenderRelatedInfoOnMessageTests.cs" />
     <Compile Include="Unicast\MessageTypeTests.cs" />

--- a/src/NServiceBus.Core.Tests/Unicast/MessageOperationsTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/MessageOperationsTests.cs
@@ -1,0 +1,131 @@
+﻿namespace NServiceBus.Unicast.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using MessageInterfaces;
+    using MessageInterfaces.MessageMapper.Reflection;
+    using NUnit.Framework;
+    using Pipeline;
+    using Testing;
+    using PublishOptions = NServiceBus.PublishOptions;
+    using ReplyOptions = NServiceBus.ReplyOptions;
+    using SendOptions = NServiceBus.SendOptions;
+
+    [TestFixture]
+    public class MessageOperationsTests
+    {
+        [Test]
+        public void When_sending_message_interface_should_set_interface_as_message_type()
+        {
+            var sendPipeline = new FakePipeline<IOutgoingSendContext>();
+            var context = CreateContext(sendPipeline);
+
+            MessageOperations.Send<IMyMessage>(context, m => { }, new SendOptions());
+
+            Assert.That(sendPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(IMyMessage)));
+        }
+
+        [Test]
+        public void When_sending_message_class_should_set_class_as_message_type()
+        {
+            var sendPipeline = new FakePipeline<IOutgoingSendContext>();
+            var context = CreateContext(sendPipeline);
+
+            MessageOperations.Send<MyMessage>(context, m => { }, new SendOptions());
+
+            Assert.That(sendPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(MyMessage)));
+        }
+
+        [Test]
+        public void When_replying_message_interface_should_set_interface_as_message_type()
+        {
+            var replyPipeline = new FakePipeline<IOutgoingReplyContext>();
+            var context = CreateContext(replyPipeline);
+
+            MessageOperations.Reply<IMyMessage>(context, m => { }, new ReplyOptions());
+
+            Assert.That(replyPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(IMyMessage)));
+        }
+
+        [Test]
+        public void When_replying_message_class_should_set_class_as_message_type()
+        {
+            var replyPipeline = new FakePipeline<IOutgoingReplyContext>();
+            var context = CreateContext(replyPipeline);
+
+            MessageOperations.Reply<MyMessage>(context, m => { }, new ReplyOptions());
+
+            Assert.That(replyPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(MyMessage)));
+        }
+
+        [Test]
+        public void When_publishing_event_interface_should_set_interface_as_message_type()
+        {
+            var publishPipeline = new FakePipeline<IOutgoingPublishContext>();
+            var context = CreateContext(publishPipeline);
+
+            MessageOperations.Publish<IMyMessage>(context, m => { }, new PublishOptions());
+
+            Assert.That(publishPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(IMyMessage)));
+        }
+
+        [Test]
+        public void When_publishing_event_class_should_set_class_as_message_type()
+        {
+            var publishPipeline = new FakePipeline<IOutgoingPublishContext>();
+            var context = CreateContext(publishPipeline);
+
+            MessageOperations.Publish<MyMessage>(context, m => { }, new PublishOptions());
+
+            Assert.That(publishPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(MyMessage)));
+        }
+
+        IBehaviorContext CreateContext<TContext>(IPipeline<TContext> pipeline) where TContext : IBehaviorContext
+        {
+            var pipelineCache = new FakePipelineCache();
+            pipelineCache.RegisterPipeline(pipeline);
+
+            var context = new TestableMessageHandlerContext();
+            context.Builder.Register<IMessageMapper>(() => new MessageMapper());
+            context.Extensions.Set<IPipelineCache>(pipelineCache);
+
+            return context;
+        }
+
+        // ReSharper disable once MemberCanBePrivate.Global
+        public interface IMyMessage
+        {
+        }
+
+        class MyMessage
+        {
+        }
+
+        class FakePipelineCache : IPipelineCache
+        {
+            Dictionary<Type, object> pipelines = new Dictionary<Type, object>();
+
+            public void RegisterPipeline<TContext>(IPipeline<TContext> pipeline) where TContext : IBehaviorContext
+            {
+                pipelines.Add(typeof(TContext), pipeline);
+            }
+
+            public IPipeline<TContext> Pipeline<TContext>() where TContext : IBehaviorContext
+            {
+                return pipelines[typeof(TContext)] as IPipeline<TContext>;
+            }
+        }
+
+        class FakePipeline<TContext> : IPipeline<TContext> where TContext : IBehaviorContext
+        {
+            public TContext ReceivedContext { get; set; }
+
+            public Task Invoke(TContext context)
+            {
+                ReceivedContext = context;
+                return TaskEx.CompletedTask;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Connects to Particular/V6Launch#68

Sends and replies set the message type of the generated proxy class instead of the interface which resulted in issues during message metadata lookup and the message conventions in case they were based on the type name.

repro was raised by @ramonsmits https://github.com/ramonsmits/docs.particular.net/pull/1 and this will be working correctly with these changes (tested locally).

@Particular/nservicebus-maintainers @ramonsmits please review