### PR TITLE
Settings per serializer

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -167,6 +167,7 @@
     <Compile Include="Routing\SubscriptionBehaviorExtensions.cs" />
     <Compile Include="Sagas\When_saga_handles_unmapped_message.cs" />
     <Compile Include="Satellites\When_a_message_is_available.cs" />
+    <Compile Include="Serialization\When_registering_deserializers_with_settings.cs" />
     <Compile Include="Serialization\When_sanitizing_xml_messages.cs" />
     <Compile Include="Serialization\When_skip_wrapping_xml.cs" />
     <Compile Include="Serialization\When_wrapping_is_not_skipped.cs" />

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_registering_deserializers_with_settings.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_registering_deserializers_with_settings.cs
@@ -1,0 +1,139 @@
+namespace NServiceBus.AcceptanceTests.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Runtime.Serialization.Formatters.Binary;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Configuration.AdvanceExtensibility;
+    using EndpointTemplates;
+    using MessageInterfaces;
+    using NServiceBus.Serialization;
+    using NUnit.Framework;
+    using Settings;
+
+    public class When_registering_deserializers_with_settings : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_not_override_serializer_settings()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<XmlCustomSerializationReceiver>(b => b.When(
+                    (session, c) =>
+                    {
+                        var sendOptions = new SendOptions();
+                        sendOptions.SetHeader("ContentType", "MyCustomSerializer");
+                        return session.SendLocal(new MyRequest());
+                    }))
+                .WithEndpoint<XmlCustomSerializationReceiver>()
+                .Done(c => c.DeserializeCalled)
+                .Run();
+
+            Assert.True(context.HandlerGotTheRequest);
+            Assert.True(context.SerializeCalled);
+            Assert.True(context.DeserializeCalled);
+            Assert.AreEqual("SomeFancySettingsForMainSerializer", context.ValueFromSettingsForMainSerializer);
+            Assert.AreEqual("SomeFancySettingsForDeserializer", context.ValueFromSettingsForDeserializer);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool HandlerGotTheRequest { get; set; }
+            public bool SerializeCalled { get; set; }
+            public bool DeserializeCalled { get; set; }
+            public string ValueFromSettingsForMainSerializer { get; set; }
+            public string ValueFromSettingsForDeserializer { get; set; }
+        }
+
+        class XmlCustomSerializationReceiver : EndpointConfigurationBuilder
+        {
+            public XmlCustomSerializationReceiver()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseSerialization<MyCustomSerializer>().Settings("SomeFancySettingsForMainSerializer");
+                    c.AddDeserializer<MyCustomSerializer>().Settings("SomeFancySettingsForDeserializer");
+                });
+            }
+
+            class MyRequestHandler : IHandleMessages<MyRequest>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyRequest request, IMessageHandlerContext context)
+                {
+                    Context.HandlerGotTheRequest = true;
+                    Context.DeserializeCalled = request.DeserializerCalled;
+                    Context.SerializeCalled = request.SerializerCalled;
+                    Context.ValueFromSettingsForMainSerializer = request.ValueFromSettingsForMainSerializer;
+                    Context.ValueFromSettingsForDeserializer = request.ValueFromSettingsForDeserializer;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        [Serializable]
+        class MyRequest : IMessage
+        {
+            public bool DeserializerCalled { get; set; }
+            public bool SerializerCalled { get; set; }
+            public string ValueFromSettingsForMainSerializer { get; set; }
+            public string ValueFromSettingsForDeserializer { get; set; }
+        }
+
+
+        public class MyCustomSerializer : SerializationDefinition
+        {
+            public override Func<IMessageMapper, IMessageSerializer> Configure(ReadOnlySettings settings)
+            {
+                return mapper => new MyCustomMessageSerializer(settings.GetOrDefault<string>("MyCustomSerializer.Settings"));
+            }
+        }
+
+        class MyCustomMessageSerializer : IMessageSerializer
+        {
+            readonly string valueFromSettings;
+
+            public MyCustomMessageSerializer(string valueFromSettings)
+            {
+                this.valueFromSettings = valueFromSettings;
+            }
+
+            public void Serialize(object message, Stream stream)
+            {
+                var serializer = new BinaryFormatter();
+
+                ((MyRequest)message).SerializerCalled = true;
+                ((MyRequest)message).ValueFromSettingsForMainSerializer = valueFromSettings;
+
+                serializer.Serialize(stream, message);
+            }
+
+            public object[] Deserialize(Stream stream, IList<Type> messageTypes = null)
+            {
+                var serializer = new BinaryFormatter();
+
+                stream.Position = 0;
+                var msg = serializer.Deserialize(stream);
+                ((MyRequest)msg).DeserializerCalled = true;
+                ((MyRequest)msg).ValueFromSettingsForDeserializer = valueFromSettings;
+                return new[]
+                {
+                    msg
+                };
+            }
+
+            public string ContentType => "MyCustomSerializer";
+        }
+    }
+
+    static class CustomSettingsForMyCustomSerializer2
+    {
+        public static SerializationExtensions<When_registering_deserializers_with_settings.MyCustomSerializer> Settings(this SerializationExtensions<When_registering_deserializers_with_settings.MyCustomSerializer> extensions, string valueFromSettings)
+        {
+            extensions.GetSettings().Set("MyCustomSerializer.Settings", valueFromSettings);
+            return extensions;
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Settings/SettingsHolderTests.cs
+++ b/src/NServiceBus.Core.Tests/Settings/SettingsHolderTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Settings
 {
     using System;
+    using System.Configuration;
     using System.Linq;
     using NUnit.Framework;
 
@@ -34,14 +35,45 @@
             Assert.IsTrue(all.All(x => x.Disposed));
         }
 
+        [Test]
+        public void Merge_ShouldMergeContentFromSource()
+        {
+            var settings = new SettingsHolder();
+            settings.SetDefault("SomeDefaultSetting", "Value1");
+            settings.Set("SomeSetting", "Value1");
+
+            var mergeFrom = new SettingsHolder();
+            mergeFrom.SetDefault("SomeDefaultSettingThatGetsMerged", "Value1");
+            mergeFrom.Set("SomeSettingThatGetsMerged", "Value1");
+
+            settings.Merge(mergeFrom);
+
+            var result1 = settings.Get<string>("SomeDefaultSettingThatGetsMerged");
+            var result2 = settings.Get<string>("SomeSettingThatGetsMerged");
+
+            Assert.AreEqual("Value1", result1);
+            Assert.AreEqual("Value1", result2);
+        }
+
+        [Test]
+        public void Merge_ThrowsWhenChangesArePrevented()
+        {
+            var settings = new SettingsHolder();
+            var mergeFrom = new SettingsHolder();
+
+            settings.PreventChanges();
+
+            Assert.Throws<ConfigurationErrorsException>(() => settings.Merge(mergeFrom));
+        }
+
         class SomeDisposable : IDisposable
         {
-            public bool Disposed;
-
             public void Dispose()
             {
                 Disposed = true;
             }
+
+            public bool Disposed;
         }
     }
 }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Routing\UnicastPublishRouter.cs" />
     <Compile Include="Routing\UnicastSendRouter.cs" />
     <Compile Include="Serialization\SerializationFeature.cs" />
+    <Compile Include="Serialization\SerializationSettingsExtensions.cs" />
     <Compile Include="Serializers\XML\XmlSerialization.cs" />
     <Compile Include="Routing\ConfigureUniquelyAddressableInstanceExtensions.cs" />
     <Compile Include="Transports\ErrorContext.cs" />

--- a/src/NServiceBus.Core/Serialization/SerializationSettingsExtensions.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationSettingsExtensions.cs
@@ -1,0 +1,49 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using Serialization;
+    using Settings;
+
+    static class SerializationSettingsExtensions
+    {
+        const string AdditionalSerializersSettingsKey = "AdditionalDeserializers";
+        const string MainSerializerSettingsKey = "MainSerializer";
+
+        public static List<Tuple<SerializationDefinition, SettingsHolder>> GetAdditionalSerializers(this SettingsHolder settings)
+        {
+            List<Tuple<SerializationDefinition, SettingsHolder>> deserializers;
+            if (!settings.TryGet(AdditionalSerializersSettingsKey, out deserializers))
+            {
+                deserializers = new List<Tuple<SerializationDefinition, SettingsHolder>>();
+                settings.Set(AdditionalSerializersSettingsKey, deserializers);
+            }
+            return deserializers;
+        }
+
+        public static List<Tuple<SerializationDefinition, SettingsHolder>> GetAdditionalSerializers(this ReadOnlySettings settings)
+        {
+            List<Tuple<SerializationDefinition, SettingsHolder>> deserializers;
+            if (settings.TryGet(AdditionalSerializersSettingsKey, out deserializers))
+            {
+                return deserializers;
+            }
+            return new List<Tuple<SerializationDefinition, SettingsHolder>>(0);
+        }
+
+        public static void SetMainSerializer(this SettingsHolder settings, SerializationDefinition definition, SettingsHolder serializerSpecificSettings)
+        {
+            settings.Set(MainSerializerSettingsKey, Tuple.Create(definition, serializerSpecificSettings));
+        }
+
+        public static Tuple<SerializationDefinition, SettingsHolder> GetMainSerializer(this ReadOnlySettings settings)
+        {
+            Tuple<SerializationDefinition, SettingsHolder> defaultSerializerAndSettings;
+            if (!settings.TryGet(MainSerializerSettingsKey, out defaultSerializerAndSettings))
+            {
+                defaultSerializerAndSettings = Tuple.Create<SerializationDefinition, SettingsHolder>(new XmlSerializer(), new SettingsHolder());
+            }
+            return defaultSerializerAndSettings;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Settings/SettingsHolder.cs
+++ b/src/NServiceBus.Core/Settings/SettingsHolder.cs
@@ -262,6 +262,33 @@ namespace NServiceBus.Settings
             locked = true;
         }
 
+        internal void Merge(ReadOnlySettings settings)
+        {
+            Guard.AgainstNull(nameof(settings), settings);
+
+            EnsureMergingIsPossible();
+
+            var holder = settings as SettingsHolder ?? new SettingsHolder();
+
+            foreach (var @default in holder.Defaults)
+            {
+                Defaults[@default.Key] = @default.Value;
+            }
+
+            foreach (var @override in holder.Overrides)
+            {
+                Overrides[@override.Key] = @override.Value;
+            }
+        }
+
+        void EnsureMergingIsPossible()
+        {
+            if (locked)
+            {
+                throw new ConfigurationErrorsException("Unable to merge settings. The settings has been locked for modifications. Move any configuration code earlier in the configuration pipeline");
+            }
+        }
+
         void EnsureWriteEnabled(string key)
         {
             if (locked)
@@ -291,7 +318,9 @@ namespace NServiceBus.Settings
         }
 
         ConcurrentDictionary<string, object> Defaults = new ConcurrentDictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+
         bool locked;
+
         ConcurrentDictionary<string, object> Overrides = new ConcurrentDictionary<string, object>(StringComparer.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
Based on https://github.com/Particular/NServiceBus/pull/3923

As outlined in the other PR the following problem exists

The API (has always been like that) doesn't restrict doing things like

```
config.UseSerializer<SomeSerializer>().;
config.AddDeserializer<SomeSerializer>();
```

but since we now enable settings over the `SettingsHolder` in theory the last call would override the settings of both the main serializer and the deserializer. I.ex.

```
config.UseSerializer<JSon>().Settings("foobar");
config.AddDeserializer<Json>().Settings("bar");
```

The serializer would see `bar` as the configured last value. This PR attempts to fix this by introducing a settings holder per serializer. Extensions will set the extended settings on that specific settings holder. When the serialization feature is built the main settings will get merged into the instance specific settings holder (this was unavoidable since XmlSerializer, Json need access to Conventions, AvailableTypes...). 