### PR TITLE
Recoverabiltiy use custom type for exception passing

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/FailTestOnErrorMessageFeature.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/FailTestOnErrorMessageFeature.cs
@@ -27,12 +27,12 @@
                     context.Settings.EndpointName(),
                     new[]
                     {
-                        new FailedMessage(m.Message.MessageId, m.Message.Headers, m.Message.Body, m.Exception)
+                        new FailedMessage(m.Message.MessageId, m.Message.Headers, m.Message.Body, m.ExceptionInfo)
                     },
                     (i, failed) =>
                     {
                         var result = failed.ToList();
-                        result.Add(new FailedMessage(m.Message.MessageId, m.Message.Headers, m.Message.Body, m.Exception));
+                        result.Add(new FailedMessage(m.Message.MessageId, m.Message.Headers, m.Message.Body, m.ExceptionInfo));
                         return result;
                     });
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_Subscribing_to_errors.cs
@@ -27,7 +27,7 @@
                 .Done(c => c.MessageSentToError)
                 .Run();
 
-            Assert.IsInstanceOf<SimulatedException>(context.MessageSentToErrorException);
+            Assert.AreEqual(typeof(SimulatedException).FullName, context.MessageSentToErrorException.TypeFullName);
             Assert.True(context.Logs.Any(l => l.Level == LogLevel.Error && l.Message.Contains("Simulated exception message")), "The last exception should be logged as `error` before sending it to the error queue");
 
             //FLR max retries = 3 means we will be processing 4 times. SLR max retries = 2 means we will do 3*FLR
@@ -43,7 +43,7 @@
             public int TotalNumberOfFLRTimesInvokedInHandler { get; set; }
             public int NumberOfSLRRetriesPerformed { get; set; }
             public bool MessageSentToError { get; set; }
-            public Exception MessageSentToErrorException { get; set; }
+            public ExceptionInfo MessageSentToErrorException { get; set; }
         }
 
         public class SLREndpoint : EndpointConfigurationBuilder
@@ -57,7 +57,7 @@
                     config.EnableFeature<TimeoutManager>();
                     notifications.Errors.MessageSentToErrorQueue += (sender, message) =>
                     {
-                        testContext.MessageSentToErrorException = message.Exception;
+                        testContext.MessageSentToErrorException = message.ExceptionInfo;
                         testContext.MessageSentToError = true;
                     };
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_message_fails_retries.cs
@@ -33,7 +33,7 @@
             var testContext = (Context) exception.ScenarioContext;
             Assert.AreEqual(typeof(MessageWhichFailsRetries).AssemblyQualifiedName, failedMessage.Headers[Headers.EnclosedMessageTypes]);
             Assert.AreEqual(testContext.PhysicalMessageId, failedMessage.MessageId);
-            Assert.IsAssignableFrom(typeof(SimulatedException), failedMessage.Exception);
+            Assert.AreEqual(typeof(SimulatedException).FullName, failedMessage.ExceptionInfo.TypeFullName);
 
             Assert.AreEqual(1, testContext.Logs.Count(l => l.Message
                 .StartsWith($"Moving message '{testContext.PhysicalMessageId}' to the error queue because processing failed due to an exception:")));

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_custom_policy.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Retries/When_performing_slr_with_custom_policy.cs
@@ -23,10 +23,10 @@
 
             Assert.That(context.SlrRetryContexts.Count, Is.EqualTo(2), "because the custom policy should have been invoked twice");
             Assert.That(context.SlrRetryContexts[0].Message, Is.Not.Null);
-            Assert.That(context.SlrRetryContexts[0].Exception, Is.TypeOf<SimulatedException>());
+            Assert.That(context.SlrRetryContexts[0].ExceptionInfo.TypeFullName, Is.EqualTo(typeof(SimulatedException).FullName));
             Assert.That(context.SlrRetryContexts[0].SecondLevelRetryAttempt, Is.EqualTo(1));
             Assert.That(context.SlrRetryContexts[1].Message, Is.Not.Null);
-            Assert.That(context.SlrRetryContexts[1].Exception, Is.TypeOf<SimulatedException>());
+            Assert.That(context.SlrRetryContexts[1].ExceptionInfo.TypeFullName, Is.EqualTo(typeof(SimulatedException).FullName));
             Assert.That(context.SlrRetryContexts[1].SecondLevelRetryAttempt, Is.EqualTo(2));
         }
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_message_is_moved_to_error_queue.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_message_is_moved_to_error_queue.cs
@@ -66,7 +66,7 @@
             .Done(c => c.MessageMovedToErrorQueue)
             .Run();
 
-            Assert.That(context.Logs, Has.Some.Message.Match("Moving message .+ to the error queue because processing failed due to an exception: NServiceBus.AcceptanceTesting.SimulatedException:"));
+            Assert.That(context.Logs, Has.Some.Message.Match("Moving message .+ to the error queue because processing failed due to an exception:\r\nNServiceBus.AcceptanceTesting.SimulatedException:"));
         }
 
         const string ErrorSpyQueueName = "error_spy_queue";

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_auto_correlated_property_is_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_auto_correlated_property_is_changed.cs
@@ -29,7 +29,7 @@
             Assert.AreEqual(1, exception.FailedMessages.Count);
             StringAssert.Contains(
                 "Changing the value of correlated properties at runtime is currently not supported",
-                exception.FailedMessages.Single().Exception.Message);
+                exception.FailedMessages.Single().ExceptionInfo.Message);
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
@@ -28,7 +28,7 @@
             Assert.That(exception.FailedMessages, Has.Count.EqualTo(1));
             var failedMessage = exception.FailedMessages.Single();
             Assert.That(((Context) exception.ScenarioContext).MessageId, Is.EqualTo(failedMessage.MessageId), "Message should be moved to errorqueue");
-            Assert.That(failedMessage.Exception.Message, Contains.Substring("A modification of IContainSagaData.Id has been detected. This property is for infrastructure purposes only and should not be modified. SagaType:"));
+            Assert.That(failedMessage.ExceptionInfo.Message, Contains.Substring("A modification of IContainSagaData.Id has been detected. This property is for infrastructure purposes only and should not be modified. SagaType:"));
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
@@ -27,7 +27,7 @@
             Assert.AreEqual(1, exception.FailedMessages.Count);
             StringAssert.Contains(
                 "Changing the value of correlated properties at runtime is currently not supported",
-                exception.FailedMessages.Single().Exception.Message);
+                exception.FailedMessages.Single().ExceptionInfo.Message);
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -385,11 +385,10 @@ namespace NServiceBus
     }
     public class ExceptionInfo
     {
-        public ExceptionInfo(string typeFullName, string innerExceptionTypeFullName, string helpLink, string message, string source, string legacyStackTrace, string stackTrace, string timeOfFailure, System.Collections.Generic.Dictionary<string, string> data) { }
+        public ExceptionInfo(string typeFullName, string innerExceptionTypeFullName, string helpLink, string message, string source, string stackTrace, string timeOfFailure, System.Collections.Generic.Dictionary<string, string> data) { }
         public System.Collections.Generic.Dictionary<string, string> Data { get; }
         public string HelpLink { get; }
         public string InnerExceptionTypeFullName { get; }
-        public string LegacyStackTrace { get; }
         public string Message { get; }
         public string Source { get; }
         public string StackTrace { get; }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -365,9 +365,37 @@ namespace NServiceBus
     {
         public static NServiceBus.Routing.EndpointInstance AtMachine(this NServiceBus.Routing.EndpointInstance instance, string machineName) { }
     }
+    public class ErrorContext
+    {
+        public ErrorContext(NServiceBus.ExceptionInfo exceptionInfo, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, System.IO.Stream bodyStream, NServiceBus.Transport.TransportTransaction transportTransaction, int numberOfDeliveryAttempts) { }
+        public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, System.IO.Stream bodyStream, NServiceBus.Transport.TransportTransaction transportTransaction, int numberOfDeliveryAttempts) { }
+        public NServiceBus.ExceptionInfo ExceptionInfo { get; }
+        public NServiceBus.Transport.IncomingMessage Message { get; }
+        public int NumberOfDeliveryAttempts { get; }
+        public NServiceBus.Transport.TransportTransaction TransportTransaction { get; }
+    }
+    public enum ErrorHandleResult
+    {
+        Handled = 0,
+        RetryRequired = 1,
+    }
     public class static ErrorQueueSettings
     {
         public static string ErrorQueueAddress(this NServiceBus.Settings.ReadOnlySettings settings) { }
+    }
+    public class ExceptionInfo
+    {
+        public ExceptionInfo(string typeFullName, string innerExceptionTypeFullName, string helpLink, string message, string source, string legacyStackTrace, string stackTrace, string timeOfFailure, System.Collections.Generic.Dictionary<string, string> data) { }
+        public System.Collections.Generic.Dictionary<string, string> Data { get; }
+        public string HelpLink { get; }
+        public string InnerExceptionTypeFullName { get; }
+        public string LegacyStackTrace { get; }
+        public string Message { get; }
+        public string Source { get; }
+        public string StackTrace { get; }
+        public string TimeOfFailure { get; }
+        public string TypeFullName { get; }
+        public static NServiceBus.ExceptionInfo FromException(System.Exception e) { }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface | System.AttributeTargets.All)]
     public sealed class ExpressAttribute : System.Attribute
@@ -679,7 +707,7 @@ namespace NServiceBus
     public interface IRecoverabilityPolicy
     {
         bool RaiseRecoverabilityNotifications { get; }
-        NServiceBus.RecoverabilityAction Invoke(NServiceBus.Transport.ErrorContext errorContext);
+        NServiceBus.RecoverabilityAction Invoke(NServiceBus.ErrorContext errorContext);
     }
     [System.ObsoleteAttribute("Use IEndpointInstance to create sending session. Will be removed in version 7.0.0" +
         ".", true)]
@@ -1035,7 +1063,7 @@ namespace NServiceBus
     public class SecondLevelRetryContext
     {
         public SecondLevelRetryContext() { }
-        public System.Exception Exception { get; set; }
+        public NServiceBus.ExceptionInfo ExceptionInfo { get; set; }
         public NServiceBus.Transport.IncomingMessage Message { get; set; }
         public int SecondLevelRetryAttempt { get; set; }
     }
@@ -1578,9 +1606,9 @@ namespace NServiceBus.Faults
     }
     public struct FailedMessage
     {
-        public FailedMessage(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, System.Exception exception) { }
+        public FailedMessage(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, NServiceBus.ExceptionInfo exceptionInfo) { }
         public byte[] Body { get; }
-        public System.Exception Exception { get; }
+        public NServiceBus.ExceptionInfo ExceptionInfo { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public string MessageId { get; }
     }
@@ -1590,9 +1618,9 @@ namespace NServiceBus.Faults
     }
     public struct FirstLevelRetry
     {
-        public FirstLevelRetry(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, System.Exception exception, int retryAttempt) { }
+        public FirstLevelRetry(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, NServiceBus.ExceptionInfo exceptionInfo, int retryAttempt) { }
         public byte[] Body { get; }
-        public System.Exception Exception { get; }
+        public NServiceBus.ExceptionInfo ExceptionInfo { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public string MessageId { get; }
         public int RetryAttempt { get; }
@@ -1603,9 +1631,9 @@ namespace NServiceBus.Faults
     public interface IManageMessageFailures { }
     public struct SecondLevelRetry
     {
-        public SecondLevelRetry(System.Collections.Generic.Dictionary<string, string> headers, byte[] body, System.Exception exception, int retryAttempt) { }
+        public SecondLevelRetry(System.Collections.Generic.Dictionary<string, string> headers, byte[] body, NServiceBus.ExceptionInfo exceptionInfo, int retryAttempt) { }
         public byte[] Body { get; }
-        public System.Exception Exception { get; }
+        public NServiceBus.ExceptionInfo ExceptionInfo { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public int RetryAttempt { get; }
     }
@@ -2953,19 +2981,6 @@ namespace NServiceBus.Transport
         Default = 1,
         Isolated = 2,
     }
-    public class ErrorContext
-    {
-        public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, System.IO.Stream bodyStream, NServiceBus.Transport.TransportTransaction transportTransaction, int numberOfDeliveryAttempts) { }
-        public System.Exception Exception { get; }
-        public NServiceBus.Transport.IncomingMessage Message { get; }
-        public int NumberOfDeliveryAttempts { get; }
-        public NServiceBus.Transport.TransportTransaction TransportTransaction { get; }
-    }
-    public enum ErrorHandleResult
-    {
-        Handled = 0,
-        RetryRequired = 1,
-    }
     public interface ICancelDeferredMessages
     {
         System.Threading.Tasks.Task CancelDeferredMessages(string messageKey, NServiceBus.Pipeline.IBehaviorContext context);
@@ -3004,7 +3019,7 @@ namespace NServiceBus.Transport
     }
     public interface IPushMessages
     {
-        System.Threading.Tasks.Task Init(System.Func<NServiceBus.Transport.MessageContext, System.Threading.Tasks.Task> onMessage, System.Func<NServiceBus.Transport.ErrorContext, System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult>> onError, NServiceBus.CriticalError criticalError, NServiceBus.Transport.PushSettings settings);
+        System.Threading.Tasks.Task Init(System.Func<NServiceBus.Transport.MessageContext, System.Threading.Tasks.Task> onMessage, System.Func<NServiceBus.ErrorContext, System.Threading.Tasks.Task<NServiceBus.ErrorHandleResult>> onError, NServiceBus.CriticalError criticalError, NServiceBus.Transport.PushSettings settings);
         void Start(NServiceBus.Transport.PushRuntimeSettings limitations);
         System.Threading.Tasks.Task Stop();
     }

--- a/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
@@ -27,7 +27,7 @@
             var transportTransaction = new TransportTransaction();
             var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), Stream.Null);
 
-            await moveToErrorsExecutor.MoveToErrorQueue(incomingMessage, new Exception(), transportTransaction);
+            await moveToErrorsExecutor.MoveToErrorQueue(incomingMessage, ExceptionInfo.FromException(new Exception()), transportTransaction);
 
             Assert.That(dispatcher.TransportOperations.MulticastTransportOperations.Count(), Is.EqualTo(0));
             Assert.That(dispatcher.TransportOperations.UnicastTransportOperations.Count(), Is.EqualTo(1));
@@ -49,7 +49,7 @@
 
             var incomingMessage = new IncomingMessage("messageId", incomingMessageHeaders, Stream.Null);
 
-            await moveToErrorsExecutor.MoveToErrorQueue(incomingMessage, new Exception(), new TransportTransaction());
+            await moveToErrorsExecutor.MoveToErrorQueue(incomingMessage, ExceptionInfo.FromException(new Exception()), new TransportTransaction());
 
             var outgoingMessage = dispatcher.TransportOperations.UnicastTransportOperations.Single();
             Assert.That(incomingMessage.Headers, Is.SubsetOf(outgoingMessage.Message.Headers));
@@ -62,7 +62,7 @@
             var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), new MemoryStream(originalMessageBody));
             incomingMessage.Body = Encoding.UTF8.GetBytes("new body");
 
-            await moveToErrorsExecutor.MoveToErrorQueue(incomingMessage, new Exception(), new TransportTransaction());
+            await moveToErrorsExecutor.MoveToErrorQueue(incomingMessage, ExceptionInfo.FromException(new Exception()), new TransportTransaction());
 
             var outgoingMessage = dispatcher.TransportOperations.UnicastTransportOperations.Single();
             Assert.That(outgoingMessage.Message.Body, Is.EqualTo(originalMessageBody));
@@ -78,7 +78,7 @@
             };
             var incomingMessage = new IncomingMessage("messageId", retryHeaders, Stream.Null);
 
-            await moveToErrorsExecutor.MoveToErrorQueue(incomingMessage, new Exception(), new TransportTransaction());
+            await moveToErrorsExecutor.MoveToErrorQueue(incomingMessage, ExceptionInfo.FromException(new Exception()), new TransportTransaction());
 
             var outgoingMessage = dispatcher.TransportOperations.UnicastTransportOperations.Single();
             Assert.That(outgoingMessage.Message.Headers.Keys, Does.Not.Contain(Headers.FLRetries));
@@ -91,7 +91,7 @@
             var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), Stream.Null);
             var exception = new InvalidOperationException("test exception");
 
-            await moveToErrorsExecutor.MoveToErrorQueue(incomingMessage, exception, new TransportTransaction());
+            await moveToErrorsExecutor.MoveToErrorQueue(incomingMessage, ExceptionInfo.FromException(exception), new TransportTransaction());
 
             var outgoingMessageHeaders = dispatcher.TransportOperations.UnicastTransportOperations.Single().Message.Headers;
             // we only test presence of some exception headers set by ExceptionHeaderHelper
@@ -108,7 +108,7 @@
             staticFaultMetadata.Add("staticFaultMetadataKey", "staticFaultMetadataValue");
             var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), Stream.Null);
 
-            await moveToErrorsExecutor.MoveToErrorQueue(incomingMessage, new Exception(), new TransportTransaction());
+            await moveToErrorsExecutor.MoveToErrorQueue(incomingMessage, ExceptionInfo.FromException(new Exception()), new TransportTransaction());
 
             var outgoingMessageHeaders = dispatcher.TransportOperations.UnicastTransportOperations.Single().Message.Headers;
             Assert.That(outgoingMessageHeaders, Contains.Item(new KeyValuePair<string, string>("staticFaultMetadataKey", "staticFaultMetadataValue")));

--- a/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
@@ -79,7 +79,7 @@
 
             Assert.AreEqual(0, failure.Attempt);
             Assert.IsTrue(failure.IsImmediateRetry);
-            Assert.AreEqual("test", failure.Exception.Message);
+            Assert.AreEqual("test", failure.ExceptionInfo.Message);
             Assert.AreEqual("message-id", failure.Message.MessageId);
         }
 
@@ -95,7 +95,7 @@
 
             Assert.AreEqual(1, failure.Attempt);
             Assert.IsFalse(failure.IsImmediateRetry);
-            Assert.AreEqual("test", failure.Exception.Message);
+            Assert.AreEqual("test", failure.ExceptionInfo.Message);
             Assert.AreEqual("message-id", failure.Message.MessageId);
         }
 
@@ -109,7 +109,7 @@
 
             var failure = eventAggregator.GetNotification<MessageFaulted>();
 
-            Assert.AreEqual("test", failure.Exception.Message);
+            Assert.AreEqual("test", failure.ExceptionInfo.Message);
             Assert.AreEqual("message-id", failure.Message.MessageId);
         }
 

--- a/src/NServiceBus.Core.Tests/Utils/ExceptionHeaderHelperTests.cs
+++ b/src/NServiceBus.Core.Tests/Utils/ExceptionHeaderHelperTests.cs
@@ -14,7 +14,7 @@ namespace NServiceBus.Core.Tests.Utils
             var exception = GetAnException();
             var dictionary = new Dictionary<string, string>();
 
-            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, exception, false);
+            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, ExceptionInfo.FromException(exception), false);
 
             Assert.AreEqual("System.AggregateException", dictionary["NServiceBus.ExceptionInfo.ExceptionType"]);
             Assert.AreEqual(exception.ToString(), dictionary["NServiceBus.ExceptionInfo.StackTrace"]);
@@ -33,7 +33,7 @@ namespace NServiceBus.Core.Tests.Utils
             var exception = GetAnException();
             var dictionary = new Dictionary<string, string>();
 
-            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, exception, true);
+            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, ExceptionInfo.FromException(exception), true);
 
             Assert.AreEqual("System.AggregateException", dictionary["NServiceBus.ExceptionInfo.ExceptionType"]);
             Assert.AreEqual(exception.StackTrace, dictionary["NServiceBus.ExceptionInfo.StackTrace"]);
@@ -82,7 +82,7 @@ namespace NServiceBus.Core.Tests.Utils
             var exception = new Exception(new string('x', (int)Math.Pow(2, 15)));
             var dictionary = new Dictionary<string, string>();
 
-            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, exception, false);
+            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, ExceptionInfo.FromException(exception), false);
 
             Assert.AreEqual((int)Math.Pow(2, 14), dictionary["NServiceBus.ExceptionInfo.Message"].Length);
         }

--- a/src/NServiceBus.Core.Tests/Utils/ExceptionHeaderHelperTests.cs
+++ b/src/NServiceBus.Core.Tests/Utils/ExceptionHeaderHelperTests.cs
@@ -56,16 +56,5 @@ namespace NServiceBus.Core.Tests.Utils
         {
             throw new Exception("My Inner Exception");
         }
-
-        [Test]
-        public void ExceptionMessageIsTruncated()
-        {
-            var exception = new Exception(new string('x', (int)Math.Pow(2, 15)));
-            var dictionary = new Dictionary<string, string>();
-
-            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, ExceptionInfo.FromException(exception));
-
-            Assert.AreEqual((int)Math.Pow(2, 14), dictionary["NServiceBus.ExceptionInfo.Message"].Length);
-        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Utils/ExceptionHeaderHelperTests.cs
+++ b/src/NServiceBus.Core.Tests/Utils/ExceptionHeaderHelperTests.cs
@@ -14,29 +14,10 @@ namespace NServiceBus.Core.Tests.Utils
             var exception = GetAnException();
             var dictionary = new Dictionary<string, string>();
 
-            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, ExceptionInfo.FromException(exception), false);
+            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, ExceptionInfo.FromException(exception));
 
             Assert.AreEqual("System.AggregateException", dictionary["NServiceBus.ExceptionInfo.ExceptionType"]);
             Assert.AreEqual(exception.ToString(), dictionary["NServiceBus.ExceptionInfo.StackTrace"]);
-            Assert.IsTrue(dictionary.ContainsKey("NServiceBus.TimeOfFailure"));
-
-            Assert.AreEqual("System.Exception", dictionary["NServiceBus.ExceptionInfo.InnerExceptionType"]);
-            Assert.AreEqual("A fake help link", dictionary["NServiceBus.ExceptionInfo.HelpLink"]);
-            Assert.AreEqual("NServiceBus.Core.Tests", dictionary["NServiceBus.ExceptionInfo.Source"]);
-        }
-
-
-
-        [Test]
-        public void VerifyLegacyHeadersAreSet()
-        {
-            var exception = GetAnException();
-            var dictionary = new Dictionary<string, string>();
-
-            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, ExceptionInfo.FromException(exception), true);
-
-            Assert.AreEqual("System.AggregateException", dictionary["NServiceBus.ExceptionInfo.ExceptionType"]);
-            Assert.AreEqual(exception.StackTrace, dictionary["NServiceBus.ExceptionInfo.StackTrace"]);
             Assert.IsTrue(dictionary.ContainsKey("NServiceBus.TimeOfFailure"));
 
             Assert.AreEqual("System.Exception", dictionary["NServiceBus.ExceptionInfo.InnerExceptionType"]);
@@ -82,7 +63,7 @@ namespace NServiceBus.Core.Tests.Utils
             var exception = new Exception(new string('x', (int)Math.Pow(2, 15)));
             var dictionary = new Dictionary<string, string>();
 
-            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, ExceptionInfo.FromException(exception), false);
+            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, ExceptionInfo.FromException(exception));
 
             Assert.AreEqual((int)Math.Pow(2, 14), dictionary["NServiceBus.ExceptionInfo.Message"].Length);
         }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManagerRecoverabilityPolicy.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManagerRecoverabilityPolicy.cs
@@ -1,7 +1,5 @@
 ﻿namespace NServiceBus
 {
-    using Transport;
-
     class TimeoutManagerRecoverabilityPolicy : IRecoverabilityPolicy
     {
         public TimeoutManagerRecoverabilityPolicy()

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -128,6 +128,8 @@
     <Compile Include="Pipeline\ConnectorContextExtensions.cs" />
     <Compile Include="Recoverability\DelayedRetriesHeaderExtensions.cs" />
     <Compile Include="Recoverability\DelayedRetry.cs" />
+    <Compile Include="Recoverability\ErrorContext.cs" />
+    <Compile Include="Recoverability\ErrorHandleResult.cs" />
     <Compile Include="Recoverability\Faults\MessageProcessingFailed.cs" />
     <Compile Include="Recoverability\Faults\MessageToBeRetried.cs" />
     <Compile Include="Recoverability\Faults\MessageFaulted.cs" />
@@ -154,8 +156,6 @@
     <Compile Include="Serialization\SerializationFeature.cs" />
     <Compile Include="Serializers\XML\XmlSerialization.cs" />
     <Compile Include="Routing\ConfigureUniquelyAddressableInstanceExtensions.cs" />
-    <Compile Include="Transports\ErrorContext.cs" />
-    <Compile Include="Transports\ErrorHandleResult.cs" />
     <Compile Include="Transports\IOutgoingTransportOperation.cs" />
     <Compile Include="Transports\LogicalAddressExtensions.cs" />
     <Compile Include="Transports\Msmq\MsmqScopeOptions.cs" />

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Recoverability\DelayedRetry.cs" />
     <Compile Include="Recoverability\ErrorContext.cs" />
     <Compile Include="Recoverability\ErrorHandleResult.cs" />
+    <Compile Include="Recoverability\ExceptionInfo.cs" />
     <Compile Include="Recoverability\Faults\MessageProcessingFailed.cs" />
     <Compile Include="Recoverability\Faults\MessageToBeRetried.cs" />
     <Compile Include="Recoverability\Faults\MessageFaulted.cs" />

--- a/src/NServiceBus.Core/Recoverability/DefaultRecoverabilityPolicy.cs
+++ b/src/NServiceBus.Core/Recoverability/DefaultRecoverabilityPolicy.cs
@@ -31,7 +31,7 @@ namespace NServiceBus
             {
                 var slrRetryContext = new SecondLevelRetryContext
                 {
-                    Exception = errorContext.Exception,
+                    ExceptionInfo = errorContext.ExceptionInfo,
                     Message = errorContext.Message,
                     SecondLevelRetryAttempt = errorContext.Message.GetCurrentDelayedRetries() + 1
                 };

--- a/src/NServiceBus.Core/Recoverability/DefaultRecoverabilityPolicy.cs
+++ b/src/NServiceBus.Core/Recoverability/DefaultRecoverabilityPolicy.cs
@@ -2,7 +2,6 @@ namespace NServiceBus
 {
     using System;
     using Logging;
-    using Transport;
 
     class DefaultRecoverabilityPolicy : IRecoverabilityPolicy
     {

--- a/src/NServiceBus.Core/Recoverability/ErrorContext.cs
+++ b/src/NServiceBus.Core/Recoverability/ErrorContext.cs
@@ -11,9 +11,9 @@
     public class ErrorContext
     {
         /// <summary>
-        /// Exception that caused the message processing to fail.
+        /// Details of the exception that caused the message processing to fail.
         /// </summary>
-        public Exception Exception { get; }
+        public ExceptionInfo ExceptionInfo { get; }
 
         /// <summary>
         /// Transport transaction for failed receive message.
@@ -31,11 +31,11 @@
         public IncomingMessage Message { get; }
 
         /// <summary>
-        /// Initializes the error context.
+        /// Creates <see cref="ErrorContext"/>.
         /// </summary>
-        public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, Stream bodyStream, TransportTransaction transportTransaction, int numberOfDeliveryAttempts)
+        public ErrorContext(ExceptionInfo exceptionInfo, Dictionary<string, string> headers, string transportMessageId, Stream bodyStream, TransportTransaction transportTransaction, int numberOfDeliveryAttempts)
         {
-            Exception = exception;
+            ExceptionInfo = exceptionInfo;
             TransportTransaction = transportTransaction;
             NumberOfDeliveryAttempts = numberOfDeliveryAttempts;
 
@@ -43,6 +43,15 @@
 
             //Incoming message reads the body stream so we need to rewind it
             Message.BodyStream.Position = 0;
+        }
+
+        /// <summary>
+        /// Creates <see cref="ErrorContext"/>.
+        /// </summary>
+        public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, Stream bodyStream, TransportTransaction transportTransaction, int numberOfDeliveryAttempts)
+            : this(ExceptionInfo.FromException(exception), headers, transportMessageId, bodyStream, transportTransaction, numberOfDeliveryAttempts)
+        {
+            
         }
     }
 }

--- a/src/NServiceBus.Core/Recoverability/ErrorContext.cs
+++ b/src/NServiceBus.Core/Recoverability/ErrorContext.cs
@@ -1,8 +1,9 @@
-﻿namespace NServiceBus.Transport
+﻿namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using Transport;
 
     /// <summary>
     /// The context for messages that has failed processing.

--- a/src/NServiceBus.Core/Recoverability/ErrorHandleResult.cs
+++ b/src/NServiceBus.Core/Recoverability/ErrorHandleResult.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Transport
+﻿namespace NServiceBus
 {
     /// <summary>
     /// Provides information about error handling.

--- a/src/NServiceBus.Core/Recoverability/ExceptionInfo.cs
+++ b/src/NServiceBus.Core/Recoverability/ExceptionInfo.cs
@@ -35,11 +35,6 @@
         public string Source { get; }
 
         /// <summary>
-        /// Exception <see cref="Exception.StackTrace"/>.
-        /// </summary>
-        public string LegacyStackTrace { get; }
-
-        /// <summary>
         /// Exception <see cref="Exception.ToString"/>.
         /// </summary>
         public string StackTrace { get; }
@@ -58,14 +53,13 @@
         /// <summary>
         /// Creates new instance of <see cref="ExceptionInfo"/>.
         /// </summary>
-        public ExceptionInfo(string typeFullName, string innerExceptionTypeFullName, string helpLink, string message, string source, string legacyStackTrace, string stackTrace, string timeOfFailure, Dictionary<string, string> data)
+        public ExceptionInfo(string typeFullName, string innerExceptionTypeFullName, string helpLink, string message, string source, string stackTrace, string timeOfFailure, Dictionary<string, string> data)
         {
             TypeFullName = typeFullName;
             InnerExceptionTypeFullName = innerExceptionTypeFullName;
             HelpLink = helpLink;
             Message = message;
             Source = source;
-            LegacyStackTrace = legacyStackTrace;
             StackTrace = stackTrace;
             TimeOfFailure = timeOfFailure;
             Data = data;
@@ -100,7 +94,6 @@
                 e.HelpLink,
                 e.Message,
                 e.Source,
-                e.StackTrace,
                 e.ToString(),
                 DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow),
                 data

--- a/src/NServiceBus.Core/Recoverability/ExceptionInfo.cs
+++ b/src/NServiceBus.Core/Recoverability/ExceptionInfo.cs
@@ -1,0 +1,110 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Exception details for failing message.
+    /// </summary>
+    public class ExceptionInfo
+    {
+        /// <summary>
+        /// Exception type full name.
+        /// </summary>
+        public string TypeFullName { get; }
+
+        /// <summary>
+        /// Inner exception type full name.
+        /// </summary>
+        public string InnerExceptionTypeFullName { get; }
+
+        /// <summary>
+        /// Exception <see cref="Exception.HelpLink"/>.
+        /// </summary>
+        public string HelpLink { get; }
+
+        /// <summary>
+        /// Exception <see cref="Exception.Message"/>.
+        /// </summary>
+        public string Message { get;}
+
+        /// <summary>
+        /// Exception <see cref="Exception.Source"/>.
+        /// </summary>
+        public string Source { get; }
+
+        /// <summary>
+        /// Exception <see cref="Exception.StackTrace"/>.
+        /// </summary>
+        public string LegacyStackTrace { get; }
+
+        /// <summary>
+        /// Exception <see cref="Exception.ToString"/>.
+        /// </summary>
+        public string StackTrace { get; }
+
+        /// <summary>
+        /// Time of failure in 'yyyy-MM-dd HH:mm:ss:ffffff Z' format.
+        /// </summary>
+        public string TimeOfFailure { get; }
+
+        /// <summary>
+        /// Exception <see cref="Exception.Data"/>.
+        /// </summary>
+        public Dictionary<string, string> Data { get; }
+
+
+        /// <summary>
+        /// Creates new instance of <see cref="ExceptionInfo"/>.
+        /// </summary>
+        public ExceptionInfo(string typeFullName, string innerExceptionTypeFullName, string helpLink, string message, string source, string legacyStackTrace, string stackTrace, string timeOfFailure, Dictionary<string, string> data)
+        {
+            TypeFullName = typeFullName;
+            InnerExceptionTypeFullName = innerExceptionTypeFullName;
+            HelpLink = helpLink;
+            Message = message;
+            Source = source;
+            LegacyStackTrace = legacyStackTrace;
+            StackTrace = stackTrace;
+            TimeOfFailure = timeOfFailure;
+            Data = data;
+        }
+
+        /// <summary>
+        /// Crates <see cref="ExceptionInfo"/> from and instance of <see cref="Exception"/>.
+        /// </summary>
+        public static ExceptionInfo FromException(Exception e)
+        {
+            Dictionary<string, string> data = null;
+
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
+            if (e.Data != null)
+            {
+                data = new Dictionary<string, string>();
+
+                foreach (DictionaryEntry entry in e.Data)
+                {
+                    if (entry.Value == null)
+                    {
+                        continue;
+                    }
+
+                    data.Add(entry.Value.ToString(), entry.Value.ToString());
+                }
+            }
+
+            return new ExceptionInfo(
+                e.GetType().FullName,
+                e.InnerException?.GetType().FullName,
+                e.HelpLink,
+                e.Message,
+                e.Source,
+                e.StackTrace,
+                e.ToString(),
+                DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow),
+                data
+            );
+        }
+    }
+}

--- a/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
@@ -24,32 +24,32 @@ namespace NServiceBus.Faults
         /// </summary>
         public event EventHandler<SecondLevelRetry> MessageHasBeenSentToSecondLevelRetries;
 
-        internal void InvokeMessageHasBeenSentToErrorQueue(IncomingMessage message, Exception exception)
+        internal void InvokeMessageHasBeenSentToErrorQueue(IncomingMessage message, ExceptionInfo exceptionInfo)
         {
             var failedMessage = new FailedMessage(
                 message.MessageId,
                 new Dictionary<string, string>(message.Headers),
-                CopyOfBody(message.Body), exception);
+                CopyOfBody(message.Body), exceptionInfo);
             MessageSentToErrorQueue?.Invoke(this, failedMessage);
         }
 
-        internal void InvokeMessageHasFailedAFirstLevelRetryAttempt(int firstLevelRetryAttempt, IncomingMessage message, Exception exception)
+        internal void InvokeMessageHasFailedAFirstLevelRetryAttempt(int firstLevelRetryAttempt, IncomingMessage message, ExceptionInfo exceptionInfo)
         {
             var firstLevelRetry = new FirstLevelRetry(
                 message.MessageId,
                 new Dictionary<string, string>(message.Headers),
                 CopyOfBody(message.Body),
-                exception,
+                exceptionInfo,
                 firstLevelRetryAttempt);
             MessageHasFailedAFirstLevelRetryAttempt?.Invoke(this, firstLevelRetry);
         }
 
-        internal void InvokeMessageHasBeenSentToSecondLevelRetries(int secondLevelRetryAttempt, IncomingMessage message, Exception exception)
+        internal void InvokeMessageHasBeenSentToSecondLevelRetries(int secondLevelRetryAttempt, IncomingMessage message, ExceptionInfo exceptionInfo)
         {
             var secondLevelRetry = new SecondLevelRetry(
                 new Dictionary<string, string>(message.Headers),
                 CopyOfBody(message.Body),
-                exception,
+                exceptionInfo,
                 secondLevelRetryAttempt);
 
             MessageHasBeenSentToSecondLevelRetries?.Invoke(this, secondLevelRetry);

--- a/src/NServiceBus.Core/Recoverability/Faults/FailedMessage.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/FailedMessage.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus.Faults
 {
-    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -14,13 +13,13 @@ namespace NServiceBus.Faults
         /// <param name="messageId">The id of the failed message.</param>
         /// <param name="headers">Message headers.</param>
         /// <param name="body">Message body.</param>
-        /// <param name="exception">Exception thrown.</param>
-        public FailedMessage(string messageId, Dictionary<string, string> headers, byte[] body, Exception exception)
+        /// <param name="exceptionInfo">Exception thrown.</param>
+        public FailedMessage(string messageId, Dictionary<string, string> headers, byte[] body, ExceptionInfo exceptionInfo)
         {
             MessageId = messageId;
             Headers = headers;
             Body = body;
-            Exception = exception;
+            ExceptionInfo = exceptionInfo;
         }
 
         /// <summary>
@@ -36,7 +35,7 @@ namespace NServiceBus.Faults
         /// <summary>
         /// The exception that caused this message to fail.
         /// </summary>
-        public Exception Exception { get; }
+        public ExceptionInfo ExceptionInfo { get; }
 
         /// <summary>
         /// The id of the failed message.

--- a/src/NServiceBus.Core/Recoverability/Faults/MessageFaulted.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/MessageFaulted.cs
@@ -1,11 +1,10 @@
 namespace NServiceBus
 {
-    using System;
     using Transport;
 
     class MessageFaulted : MessageProcessingFailed
     {
-        public MessageFaulted(IncomingMessage message, Exception exception) : base(message, exception)
+        public MessageFaulted(IncomingMessage message, ExceptionInfo exceptionInfo) : base(message, exceptionInfo)
         {
         }
     }

--- a/src/NServiceBus.Core/Recoverability/Faults/MessageProcessingFailed.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/MessageProcessingFailed.cs
@@ -1,17 +1,16 @@
 namespace NServiceBus
 {
-    using System;
     using Transport;
 
     abstract class MessageProcessingFailed
     {
         public IncomingMessage Message { get; }
-        public Exception Exception { get; }
+        public ExceptionInfo ExceptionInfo { get; }
 
-        protected MessageProcessingFailed(IncomingMessage message, Exception exception)
+        protected MessageProcessingFailed(IncomingMessage message, ExceptionInfo exceptionInfo)
         {
             Message = message;
-            Exception = exception;
+            ExceptionInfo = exceptionInfo;
         }
     }
 }

--- a/src/NServiceBus.Core/Recoverability/Faults/MessageToBeRetried.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/MessageToBeRetried.cs
@@ -9,7 +9,7 @@ namespace NServiceBus
         public TimeSpan Delay { get; }
         public bool IsImmediateRetry => Delay == TimeSpan.Zero;
 
-        public MessageToBeRetried(int attempt, TimeSpan delay, IncomingMessage message, Exception exception) : base(message, exception)
+        public MessageToBeRetried(int attempt, TimeSpan delay, IncomingMessage message, ExceptionInfo exceptionInfo) : base(message, exceptionInfo)
         {
             Attempt = attempt;
             Delay = delay;

--- a/src/NServiceBus.Core/Recoverability/FirstLevelRetries/FirstLevelRetry.cs
+++ b/src/NServiceBus.Core/Recoverability/FirstLevelRetries/FirstLevelRetry.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus.Faults
 {
-    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -14,19 +13,19 @@ namespace NServiceBus.Faults
         /// <param name="messageId">The id of the failed message.</param>
         /// <param name="headers">Message headers.</param>
         /// <param name="body">Message body.</param>
-        /// <param name="exception">Exception thrown.</param>
+        /// <param name="exceptionInfo">Exception thrown.</param>
         /// <param name="retryAttempt">Number of retry attempt.</param>
-        public FirstLevelRetry(string messageId, Dictionary<string, string> headers, byte[] body, Exception exception, int retryAttempt)
+        public FirstLevelRetry(string messageId, Dictionary<string, string> headers, byte[] body, ExceptionInfo exceptionInfo, int retryAttempt)
         {
             Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
             Guard.AgainstNull(nameof(headers), headers);
             Guard.AgainstNull(nameof(body), body);
-            Guard.AgainstNull(nameof(exception), exception);
+            Guard.AgainstNull(nameof(exceptionInfo), exceptionInfo);
 
             MessageId = messageId;
             Headers = headers;
             Body = body;
-            Exception = exception;
+            ExceptionInfo = exceptionInfo;
             RetryAttempt = retryAttempt;
         }
 
@@ -48,7 +47,7 @@ namespace NServiceBus.Faults
         /// <summary>
         /// The exception that caused this message to fail.
         /// </summary>
-        public Exception Exception { get; }
+        public ExceptionInfo ExceptionInfo { get; }
 
         /// <summary>
         /// Number of retry attempt.

--- a/src/NServiceBus.Core/Recoverability/IRecoverabilityPolicy.cs
+++ b/src/NServiceBus.Core/Recoverability/IRecoverabilityPolicy.cs
@@ -1,7 +1,5 @@
 namespace NServiceBus
 {
-    using Transport;
-
     /// <summary>
     /// Abstraction for deciding on recoverability action based on failure context.
     /// </summary>

--- a/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus
 {
-    using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Extensibility;
@@ -16,7 +15,7 @@
             this.staticFaultMetadata = staticFaultMetadata;
         }
 
-        public Task MoveToErrorQueue(IncomingMessage message, Exception exception, TransportTransaction transportTransaction)
+        public Task MoveToErrorQueue(IncomingMessage message, ExceptionInfo exception, TransportTransaction transportTransaction)
         {
             message.RevertToOriginalBodyIfNeeded();
 

--- a/src/NServiceBus.Core/Recoverability/Recoverability.cs
+++ b/src/NServiceBus.Core/Recoverability/Recoverability.cs
@@ -162,11 +162,11 @@
             {
                 if (e.IsImmediateRetry)
                 {
-                    legacyNotifications.Errors.InvokeMessageHasFailedAFirstLevelRetryAttempt(e.Attempt, e.Message, e.Exception);
+                    legacyNotifications.Errors.InvokeMessageHasFailedAFirstLevelRetryAttempt(e.Attempt, e.Message, e.ExceptionInfo);
                 }
                 else
                 {
-                    legacyNotifications.Errors.InvokeMessageHasBeenSentToSecondLevelRetries(e.Attempt, e.Message, e.Exception);
+                    legacyNotifications.Errors.InvokeMessageHasBeenSentToSecondLevelRetries(e.Attempt, e.Message, e.ExceptionInfo);
                 }
 
                 return TaskEx.CompletedTask;
@@ -174,7 +174,7 @@
 
             notifications.Subscribe<MessageFaulted>(e =>
             {
-                legacyNotifications.Errors.InvokeMessageHasBeenSentToErrorQueue(e.Message, e.Exception);
+                legacyNotifications.Errors.InvokeMessageHasBeenSentToErrorQueue(e.Message, e.ExceptionInfo);
                 return TaskEx.CompletedTask;
             });
         }

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Threading.Tasks;
     using Logging;
-    using Transport;
 
     class RecoverabilityExecutor
     {

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
@@ -6,7 +6,6 @@
 
     class RecoverabilityExecutor
     {
-        //TODO: figure out proper logging for ExceptionInfo
         public RecoverabilityExecutor(IRecoverabilityPolicy recoverabilityPolicy, IEventAggregator eventAggregator, DelayedRetryExecutor delayedRetryExecutor, MoveToErrorsExecutor moveToErrorsExecutor, bool transactionsOn)
         {
             this.recoverabilityPolicy = recoverabilityPolicy;
@@ -21,7 +20,7 @@
 
         public Task<ErrorHandleResult> Invoke(ErrorContext errorContext)
         {
-            if (transactionsOn == false || 
+            if (transactionsOn == false ||
                 errorContext.ExceptionInfo.TypeFullName == typeof(MessageDeserializationException).FullName)
             {
                 return MoveToError(errorContext);
@@ -64,7 +63,7 @@
         {
             var message = errorContext.Message;
 
-            Logger.Info($"First Level Retry is going to retry message '{message.MessageId}' because of an exception:" + Environment.NewLine + errorContext.ExceptionInfo.StackTrace);
+            Logger.Info($"First Level Retry is going to retry message '{message.MessageId}' because of an exception:{Environment.NewLine}{errorContext.ExceptionInfo.StackTrace}");
 
             if (raiseNotifications)
             {
@@ -78,7 +77,7 @@
         {
             var message = errorContext.Message;
 
-            Logger.Error($"Moving message '{message.MessageId}' to the error queue because processing failed due to an exception:" + Environment.NewLine + errorContext.ExceptionInfo.StackTrace);
+            Logger.Error($"Moving message '{message.MessageId}' to the error queue because processing failed due to an exception:{Environment.NewLine}{errorContext.ExceptionInfo.StackTrace}");
 
             await moveToErrorsExecutor.MoveToErrorQueue(message, errorContext.ExceptionInfo, errorContext.TransportTransaction).ConfigureAwait(false);
 
@@ -93,7 +92,7 @@
         {
             var message = errorContext.Message;
 
-            Logger.Warn($"Second Level Retry will reschedule message '{message.MessageId}' after a delay of {action.Delay} because of an exception:" + Environment.NewLine + errorContext.ExceptionInfo.StackTrace);
+            Logger.Warn($"Second Level Retry will reschedule message '{message.MessageId}' after a delay of {action.Delay} because of an exception:{Environment.NewLine}{errorContext.ExceptionInfo.StackTrace}");
 
             var currentSlrAttempts = await delayedRetryExecutor.Retry(message, action.Delay, errorContext.TransportTransaction).ConfigureAwait(false);
 

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetry.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetry.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus.Faults
 {
-    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -13,13 +12,13 @@ namespace NServiceBus.Faults
         /// </summary>
         /// <param name="headers">Message headers.</param>
         /// <param name="body">Message body.</param>
-        /// <param name="exception">Exception thrown.</param>
+        /// <param name="exceptionInfo">Exception thrown.</param>
         /// <param name="retryAttempt">Number of retry attempt.</param>
-        public SecondLevelRetry(Dictionary<string, string> headers, byte[] body, Exception exception, int retryAttempt)
+        public SecondLevelRetry(Dictionary<string, string> headers, byte[] body, ExceptionInfo exceptionInfo, int retryAttempt)
         {
             Headers = headers;
             Body = body;
-            Exception = exception;
+            ExceptionInfo = exceptionInfo;
             RetryAttempt = retryAttempt;
         }
 
@@ -36,7 +35,7 @@ namespace NServiceBus.Faults
         /// <summary>
         /// The exception that caused this message to fail.
         /// </summary>
-        public Exception Exception { get; }
+        public ExceptionInfo ExceptionInfo { get; }
 
         /// <summary>
         /// Number of retry attempt.

--- a/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetryContext.cs
+++ b/src/NServiceBus.Core/Recoverability/SecondLevelRetries/SecondLevelRetryContext.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus
 {
-    using System;
     using Transport;
 
     /// <summary>
@@ -14,9 +13,9 @@ namespace NServiceBus
         public IncomingMessage Message { get; set; }
 
         /// <summary>
-        /// The exception that occurred.
+        /// Details of the exception that occurred.
         /// </summary>
-        public Exception Exception { get; set; }
+        public ExceptionInfo ExceptionInfo { get; set; }
 
         /// <summary>
         /// The current second level retry attempt.

--- a/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
+++ b/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
@@ -1,55 +1,47 @@
 ﻿namespace NServiceBus
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Configuration;
 
     static class ExceptionHeaderHelper
     {
-        public static void SetExceptionHeaders(Dictionary<string, string> headers, Exception e)
+        public static void SetExceptionHeaders(Dictionary<string, string> headers, ExceptionInfo exceptionInfo)
         {
-            SetExceptionHeaders(headers, e, useLegacyStackTrace);
+            SetExceptionHeaders(headers, exceptionInfo, useLegacyStackTrace);
         }
 
-        public static void SetExceptionHeaders(Dictionary<string, string> headers, Exception e, bool legacyStacktrace)
+        public static void SetExceptionHeaders(Dictionary<string, string> headers, ExceptionInfo exceptionInfo, bool legacyStacktrace)
         {
-            headers["NServiceBus.ExceptionInfo.ExceptionType"] = e.GetType().FullName;
+            headers["NServiceBus.ExceptionInfo.ExceptionType"] = exceptionInfo.TypeFullName;
 
-            if (e.InnerException != null)
+            if (exceptionInfo.InnerExceptionTypeFullName != null)
             {
-                headers["NServiceBus.ExceptionInfo.InnerExceptionType"] = e.InnerException.GetType().FullName;
+                headers["NServiceBus.ExceptionInfo.InnerExceptionType"] = exceptionInfo.InnerExceptionTypeFullName;
             }
 
-            headers["NServiceBus.ExceptionInfo.HelpLink"] = e.HelpLink;
-            headers["NServiceBus.ExceptionInfo.Message"] = e.GetMessage().Truncate(16384);
-            headers["NServiceBus.ExceptionInfo.Source"] = e.Source;
+            headers["NServiceBus.ExceptionInfo.HelpLink"] = exceptionInfo.HelpLink;
+            headers["NServiceBus.ExceptionInfo.Message"] = exceptionInfo.Message.Truncate(16384);
+            headers["NServiceBus.ExceptionInfo.Source"] = exceptionInfo.Source;
 
             if (legacyStacktrace)
             {
-                headers["NServiceBus.ExceptionInfo.StackTrace"] = e.StackTrace;
+                headers["NServiceBus.ExceptionInfo.StackTrace"] = exceptionInfo.LegacyStackTrace;
             }
             else
             {
-                headers["NServiceBus.ExceptionInfo.StackTrace"] = e.ToString();
+                headers["NServiceBus.ExceptionInfo.StackTrace"] = exceptionInfo.StackTrace;
             }
-            headers["NServiceBus.TimeOfFailure"] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
+            headers["NServiceBus.TimeOfFailure"] = exceptionInfo.TimeOfFailure;
 
-            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
-            if (e.Data == null)
-            // ReSharper disable HeuristicUnreachableCode
+            if (exceptionInfo.Data == null)
             {
                 return;
             }
-            // ReSharper restore HeuristicUnreachableCode
 
-            foreach (DictionaryEntry entry in e.Data)
+            foreach (var entry in exceptionInfo.Data)
             {
-                if (entry.Value == null)
-                {
-                    continue;
-                }
-                headers["NServiceBus.ExceptionInfo.Data." + entry.Key] = entry.Value.ToString();
+                headers["NServiceBus.ExceptionInfo.Data." + entry.Key] = entry.Value;
             }
         }
 

--- a/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
+++ b/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
@@ -1,17 +1,10 @@
 ﻿namespace NServiceBus
 {
-    using System;
     using System.Collections.Generic;
-    using System.Configuration;
 
     static class ExceptionHeaderHelper
     {
         public static void SetExceptionHeaders(Dictionary<string, string> headers, ExceptionInfo exceptionInfo)
-        {
-            SetExceptionHeaders(headers, exceptionInfo, useLegacyStackTrace);
-        }
-
-        public static void SetExceptionHeaders(Dictionary<string, string> headers, ExceptionInfo exceptionInfo, bool legacyStacktrace)
         {
             headers["NServiceBus.ExceptionInfo.ExceptionType"] = exceptionInfo.TypeFullName;
 
@@ -23,15 +16,7 @@
             headers["NServiceBus.ExceptionInfo.HelpLink"] = exceptionInfo.HelpLink;
             headers["NServiceBus.ExceptionInfo.Message"] = exceptionInfo.Message.Truncate(16384);
             headers["NServiceBus.ExceptionInfo.Source"] = exceptionInfo.Source;
-
-            if (legacyStacktrace)
-            {
-                headers["NServiceBus.ExceptionInfo.StackTrace"] = exceptionInfo.LegacyStackTrace;
-            }
-            else
-            {
-                headers["NServiceBus.ExceptionInfo.StackTrace"] = exceptionInfo.StackTrace;
-            }
+            headers["NServiceBus.ExceptionInfo.StackTrace"] = exceptionInfo.StackTrace;
             headers["NServiceBus.TimeOfFailure"] = exceptionInfo.TimeOfFailure;
 
             if (exceptionInfo.Data == null)
@@ -51,7 +36,5 @@
                 : (value.Length <= maxLength
                     ? value
                     : value.Substring(0, maxLength));
-
-        static bool useLegacyStackTrace = string.Equals(ConfigurationManager.AppSettings["NServiceBus/Headers/UseLegacyExceptionStackTrace"], "true", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
+++ b/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
@@ -14,7 +14,7 @@
             }
 
             headers["NServiceBus.ExceptionInfo.HelpLink"] = exceptionInfo.HelpLink;
-            headers["NServiceBus.ExceptionInfo.Message"] = exceptionInfo.Message.Truncate(16384);
+            headers["NServiceBus.ExceptionInfo.Message"] = exceptionInfo.Message;
             headers["NServiceBus.ExceptionInfo.Source"] = exceptionInfo.Source;
             headers["NServiceBus.ExceptionInfo.StackTrace"] = exceptionInfo.StackTrace;
             headers["NServiceBus.TimeOfFailure"] = exceptionInfo.TimeOfFailure;

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_TimeToBeReceived_set_and_native_receivetransaction.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_TimeToBeReceived_set_and_native_receivetransaction.cs
@@ -22,7 +22,7 @@
             Assert.AreEqual(1, exception.FailedMessages.Count);
             StringAssert.EndsWith(
                 "Sending messages with a custom TimeToBeReceived is not supported on transactional MSMQ.",
-                exception.FailedMessages.Single().Exception.Message);
+                exception.FailedMessages.Single().ExceptionInfo.Message);
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.TransportTests/When_failure_happens_after_send.cs
+++ b/src/NServiceBus.TransportTests/When_failure_happens_after_send.cs
@@ -4,7 +4,6 @@ namespace NServiceBus.TransportTests
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using NUnit.Framework;
-    using Transport;
 
     public class When_failure_happens_after_send : NServiceBusTransportTest
     {

--- a/src/NServiceBus.TransportTests/When_on_message_throws.cs
+++ b/src/NServiceBus.TransportTests/When_on_message_throws.cs
@@ -33,7 +33,7 @@ namespace NServiceBus.TransportTests
 
             var errorContext = await onErrorCalled.Task;
 
-            Assert.AreEqual(errorContext.Exception.Message, "Simulated exception", "Should preserve the exception");
+            Assert.AreEqual(errorContext.ExceptionInfo.Message, "Simulated exception", "Should preserve the exception");
             Assert.AreEqual(1, errorContext.NumberOfDeliveryAttempts, "Should track the number of delivery attempts");
             Assert.AreEqual(0, errorContext.Message.BodyStream.Position, "Should rewind the stream");
             Assert.AreEqual("MyValue", errorContext.Message.Headers["MyHeader"], "Should pass the message headers");

--- a/src/NServiceBus.TransportTests/When_on_message_throws.cs
+++ b/src/NServiceBus.TransportTests/When_on_message_throws.cs
@@ -4,7 +4,6 @@ namespace NServiceBus.TransportTests
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using NUnit.Framework;
-    using Transport;
 
     public class When_on_message_throws : NServiceBusTransportTest
     {

--- a/src/NServiceBus.TransportTests/When_on_message_throws_after_delayed_retry.cs
+++ b/src/NServiceBus.TransportTests/When_on_message_throws_after_delayed_retry.cs
@@ -4,7 +4,6 @@
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using NUnit.Framework;
-    using Transport;
 
     public class When_on_message_throws_after_delayed_retry : NServiceBusTransportTest
     {

--- a/src/NServiceBus.TransportTests/When_on_message_throws_after_immediate_retry.cs
+++ b/src/NServiceBus.TransportTests/When_on_message_throws_after_immediate_retry.cs
@@ -4,7 +4,6 @@
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using NUnit.Framework;
-    using Transport;
 
     public class When_on_message_throws_after_immediate_retry : NServiceBusTransportTest
     {

--- a/src/NServiceBus.TransportTests/When_requesting_immediate_retry.cs
+++ b/src/NServiceBus.TransportTests/When_requesting_immediate_retry.cs
@@ -3,7 +3,6 @@ namespace NServiceBus.TransportTests
     using System;
     using System.Threading.Tasks;
     using NUnit.Framework;
-    using Transport;
 
     public class When_requesting_immediate_retry : NServiceBusTransportTest
     {

--- a/src/NServiceBus.TransportTests/When_scope_dispose_throws.cs
+++ b/src/NServiceBus.TransportTests/When_scope_dispose_throws.cs
@@ -32,7 +32,7 @@
 
             var errorContext = await onErrorCalled.Task;
 
-            Assert.IsInstanceOf<TransactionAbortedException>(errorContext.Exception);
+            Assert.AreEqual(typeof(TransactionAbortedException).FullName, errorContext.ExceptionInfo.TypeFullName);
 
             // since some transports doesn't have native retry counters we can't expect the attempts to be fully consistent since if
             // dispose throws the message might be picked up before the counter is incremented

--- a/src/NServiceBus.TransportTests/When_scope_dispose_throws.cs
+++ b/src/NServiceBus.TransportTests/When_scope_dispose_throws.cs
@@ -4,7 +4,6 @@
     using System.Threading.Tasks;
     using System.Transactions;
     using NUnit.Framework;
-    using Transport;
 
     public class When_scope_dispose_throws : NServiceBusTransportTest
     {

--- a/src/NServiceBus.TransportTests/When_sending_from_on_error.cs
+++ b/src/NServiceBus.TransportTests/When_sending_from_on_error.cs
@@ -4,7 +4,6 @@ namespace NServiceBus.TransportTests
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using NUnit.Framework;
-    using Transport;
 
     public class When_sending_from_on_error : NServiceBusTransportTest
     {

--- a/src/NServiceBus.TransportTests/When_user_aborts_processing.cs
+++ b/src/NServiceBus.TransportTests/When_user_aborts_processing.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.TransportTests
 {
     using System.Threading.Tasks;
     using NUnit.Framework;
-    using Transport;
 
     public class When_user_aborts_processing : NServiceBusTransportTest
     {


### PR DESCRIPTION
Moving await from Exception instance in ErrorContext. This makes it easier for transport seams to store exception information outside of process (e.g. ASB can store it in headers) and makes more explicit what data is required by recoverability. In addition this changes aligns us better with .Net Core which does not support exception serialization in 1.0 release.

Connects to https://github.com/Particular/V6Launch/issues/69

