### PR TITLE
TimeoutsChunk uses array for timeouts and timeouts is a struct to reduce garbage

### DIFF
--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails.cs
@@ -15,8 +15,6 @@
 
     public class When_timeout_dispatch_fails : NServiceBusAcceptanceTest
     {
-        static readonly TimeSpan VeryLongTimeSpan = TimeSpan.FromMinutes(10);
-
         [Test]
         public Task Should_retry_and_move_to_error()
         {
@@ -43,6 +41,7 @@
         }
 
         const string ErrorQueueForTimeoutErrors = "timeout_dispatch_errors";
+        static readonly TimeSpan VeryLongTimeSpan = TimeSpan.FromMinutes(10);
 
         public class Context : ScenarioContext
         {
@@ -86,7 +85,6 @@
             class FakeTimeoutStorage : IQueryTimeouts, IPersistTimeouts
             {
                 public Context TestContext { get; set; }
-                TimeoutData timeoutData;
 
                 public Task Add(TimeoutData timeout, ContextBag context)
                 {
@@ -132,6 +130,8 @@
 
                     return Task.FromResult(new TimeoutsChunk(timeouts, DateTime.UtcNow + TimeSpan.FromSeconds(10)));
                 }
+
+                TimeoutData timeoutData;
             }
 
             class BehaviorThatLogsControlMessageDelivery : Behavior<ITransportReceiveContext>

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails_on_timeout_data_removal.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails_on_timeout_data_removal.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.DelayedDelivery
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
@@ -123,11 +122,11 @@
                 public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice)
                 {
                     var timeouts = timeoutData != null
-                        ? new List<TimeoutsChunk.Timeout>
+                        ? new[]
                         {
                             new TimeoutsChunk.Timeout(timeoutData.Id, timeoutData.Time)
                         }
-                        : new List<TimeoutsChunk.Timeout>();
+                        : new TimeoutsChunk.Timeout[0];
 
                     return Task.FromResult(new TimeoutsChunk(timeouts, DateTime.UtcNow + TimeSpan.FromSeconds(10)));
                 }

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_storage_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/TimeoutManager/When_timeout_storage_fails.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.DelayedDelivery
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -96,7 +95,7 @@
 
                 public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice)
                 {
-                    return Task.FromResult(new TimeoutsChunk(new List<TimeoutsChunk.Timeout>(), DateTime.UtcNow + TimeSpan.FromSeconds(10)));
+                    return Task.FromResult(new TimeoutsChunk(new TimeoutsChunk.Timeout[0], DateTime.UtcNow + TimeSpan.FromSeconds(10)));
                 }
 
                 Context testContext;

--- a/src/NServiceBus.AcceptanceTests/Timeout/CyclingOutageTimeoutPersister.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeout/CyclingOutageTimeoutPersister.cs
@@ -71,7 +71,7 @@
                 }
             }
 
-            var chunk = new TimeoutsChunk(timeoutsDue, DateTime.Now.AddSeconds(5));
+            var chunk = new TimeoutsChunk(timeoutsDue.ToArray(), DateTime.Now.AddSeconds(5));
 
             return Task.FromResult(chunk);
         }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2939,10 +2939,10 @@ namespace NServiceBus.Timeout.Core
     }
     public class TimeoutsChunk
     {
-        public TimeoutsChunk(System.Collections.Generic.IEnumerable<NServiceBus.Timeout.Core.TimeoutsChunk.Timeout> dueTimeouts, System.DateTime nextTimeToQuery) { }
-        public System.Collections.Generic.IEnumerable<NServiceBus.Timeout.Core.TimeoutsChunk.Timeout> DueTimeouts { get; }
+        public TimeoutsChunk(Timeout[] dueTimeouts, System.DateTime nextTimeToQuery) { }
+        public Timeout[] DueTimeouts { get; }
         public System.DateTime NextTimeToQuery { get; }
-        public class Timeout
+        public struct Timeout
         {
             public Timeout(string id, System.DateTime dueTime) { }
             public System.DateTime DueTime { get; }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Persistence/TimeoutsChunk.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/Persistence/TimeoutsChunk.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Timeout.Core
 {
     using System;
-    using System.Collections.Generic;
 
     /// <summary>
     /// Contains a collection of timeouts that are due and when to query for timeouts again.
@@ -13,7 +12,7 @@ namespace NServiceBus.Timeout.Core
         /// </summary>
         /// <param name="dueTimeouts">timeouts that are due.</param>
         /// <param name="nextTimeToQuery">the next time to query for due timeouts again.</param>
-        public TimeoutsChunk(IEnumerable<Timeout> dueTimeouts, DateTime nextTimeToQuery)
+        public TimeoutsChunk(Timeout[] dueTimeouts, DateTime nextTimeToQuery)
         {
             DueTimeouts = dueTimeouts;
             NextTimeToQuery = nextTimeToQuery;
@@ -22,7 +21,7 @@ namespace NServiceBus.Timeout.Core
         /// <summary>
         /// timeouts that are due.
         /// </summary>
-        public IEnumerable<Timeout> DueTimeouts { get; private set; }
+        public Timeout[] DueTimeouts { get; private set; }
 
         /// <summary>
         /// the next time to query for due timeouts again.
@@ -32,7 +31,7 @@ namespace NServiceBus.Timeout.Core
         /// <summary>
         /// Represents a timeout.
         /// </summary>
-        public class Timeout
+        public struct Timeout
         {
             /// <summary>
             /// Creates a new instance of a timeout representation.

--- a/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
@@ -128,7 +128,7 @@ namespace NServiceBus
                 nextTimeToRunQuery = now.Add(EmptyResultsNextTimeToRunQuerySpan);
             }
 
-            return Task.FromResult(new TimeoutsChunk(dueTimeouts, nextTimeToRunQuery));
+            return Task.FromResult(new TimeoutsChunk(dueTimeouts.ToArray(), nextTimeToRunQuery));
         }
 
         Func<DateTime> currentTimeProvider;


### PR DESCRIPTION
@Particular/nhibernate-persistence-maintainers @Particular/ravendb-persistence-maintainers This would introduce a breaking change towards the persisters. The benefit of this is that we would produce less Gen 0 garbage due to enumerator boxing/unboxing as well as the timeout data being a struct (it only wraps a string and a datetime). Thoughts?

# Ravendb

https://github.com/Particular/NServiceBus.RavenDB/pull/253

# NHibernate

https://github.com/Particular/NServiceBus.NHibernate/pull/205

// cc @Particular/nservicebus-maintainers 