### PR TITLE
removing legacy stacktrace support from failure headers

### DIFF
--- a/src/NServiceBus.Core.Tests/Utils/ExceptionHeaderHelperTests.cs
+++ b/src/NServiceBus.Core.Tests/Utils/ExceptionHeaderHelperTests.cs
@@ -14,29 +14,10 @@ namespace NServiceBus.Core.Tests.Utils
             var exception = GetAnException();
             var dictionary = new Dictionary<string, string>();
 
-            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, exception, false);
+            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, exception);
 
             Assert.AreEqual("System.AggregateException", dictionary["NServiceBus.ExceptionInfo.ExceptionType"]);
             Assert.AreEqual(exception.ToString(), dictionary["NServiceBus.ExceptionInfo.StackTrace"]);
-            Assert.IsTrue(dictionary.ContainsKey("NServiceBus.TimeOfFailure"));
-
-            Assert.AreEqual("System.Exception", dictionary["NServiceBus.ExceptionInfo.InnerExceptionType"]);
-            Assert.AreEqual("A fake help link", dictionary["NServiceBus.ExceptionInfo.HelpLink"]);
-            Assert.AreEqual("NServiceBus.Core.Tests", dictionary["NServiceBus.ExceptionInfo.Source"]);
-        }
-
-
-
-        [Test]
-        public void VerifyLegacyHeadersAreSet()
-        {
-            var exception = GetAnException();
-            var dictionary = new Dictionary<string, string>();
-
-            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, exception, true);
-
-            Assert.AreEqual("System.AggregateException", dictionary["NServiceBus.ExceptionInfo.ExceptionType"]);
-            Assert.AreEqual(exception.StackTrace, dictionary["NServiceBus.ExceptionInfo.StackTrace"]);
             Assert.IsTrue(dictionary.ContainsKey("NServiceBus.TimeOfFailure"));
 
             Assert.AreEqual("System.Exception", dictionary["NServiceBus.ExceptionInfo.InnerExceptionType"]);
@@ -82,7 +63,7 @@ namespace NServiceBus.Core.Tests.Utils
             var exception = new Exception(new string('x', (int)Math.Pow(2, 15)));
             var dictionary = new Dictionary<string, string>();
 
-            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, exception, false);
+            ExceptionHeaderHelper.SetExceptionHeaders(dictionary, exception);
 
             Assert.AreEqual((int)Math.Pow(2, 14), dictionary["NServiceBus.ExceptionInfo.Message"].Length);
         }

--- a/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
+++ b/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
@@ -3,16 +3,10 @@
     using System;
     using System.Collections;
     using System.Collections.Generic;
-    using System.Configuration;
 
     static class ExceptionHeaderHelper
     {
         public static void SetExceptionHeaders(Dictionary<string, string> headers, Exception e)
-        {
-            SetExceptionHeaders(headers, e, useLegacyStackTrace);
-        }
-
-        public static void SetExceptionHeaders(Dictionary<string, string> headers, Exception e, bool legacyStacktrace)
         {
             headers["NServiceBus.ExceptionInfo.ExceptionType"] = e.GetType().FullName;
 
@@ -24,15 +18,7 @@
             headers["NServiceBus.ExceptionInfo.HelpLink"] = e.HelpLink;
             headers["NServiceBus.ExceptionInfo.Message"] = e.GetMessage().Truncate(16384);
             headers["NServiceBus.ExceptionInfo.Source"] = e.Source;
-
-            if (legacyStacktrace)
-            {
-                headers["NServiceBus.ExceptionInfo.StackTrace"] = e.StackTrace;
-            }
-            else
-            {
-                headers["NServiceBus.ExceptionInfo.StackTrace"] = e.ToString();
-            }
+            headers["NServiceBus.ExceptionInfo.StackTrace"] = e.ToString();
             headers["NServiceBus.TimeOfFailure"] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
 
             // ReSharper disable once ConditionIsAlwaysTrueOrFalse
@@ -59,7 +45,5 @@
                 : (value.Length <= maxLength
                     ? value
                     : value.Substring(0, maxLength));
-
-        static bool useLegacyStackTrace = string.Equals(ConfigurationManager.AppSettings["NServiceBus/Headers/UseLegacyExceptionStackTrace"], "true", StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
Connects to https://github.com/Particular/V6Launch/issues/69

This is a clean-up that was originally part of the [PR](https://github.com/Particular/NServiceBus/pull/3929). The PR was closed but this clean-up should still be be merged.
