### PR TITLE
Detect modifications to MessageId header via message mutators and throw

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1975,7 +1975,7 @@ namespace NServiceBus.MessageMutator
     public class MutateOutgoingMessageContext
     {
         public MutateOutgoingMessageContext(object outgoingMessage, System.Collections.Generic.Dictionary<string, string> outgoingHeaders, object incomingMessage, System.Collections.Generic.IReadOnlyDictionary<string, string> incomingHeaders) { }
-        public System.Collections.Generic.Dictionary<string, string> OutgoingHeaders { get; }
+        public System.Collections.Generic.IDictionary<string, string> OutgoingHeaders { get; }
         public object OutgoingMessage { get; set; }
         public bool TryGetIncomingHeaders(out System.Collections.Generic.IReadOnlyDictionary<, > incomingHeaders) { }
         public bool TryGetIncomingMessage(out object incomingMessage) { }
@@ -1984,7 +1984,7 @@ namespace NServiceBus.MessageMutator
     {
         public MutateOutgoingTransportMessageContext(byte[] outgoingBody, object outgoingMessage, System.Collections.Generic.Dictionary<string, string> outgoingHeaders, object incomingMessage, System.Collections.Generic.IReadOnlyDictionary<string, string> incomingHeaders) { }
         public byte[] OutgoingBody { get; set; }
-        public System.Collections.Generic.Dictionary<string, string> OutgoingHeaders { get; }
+        public System.Collections.Generic.IDictionary<string, string> OutgoingHeaders { get; }
         public object OutgoingMessage { get; }
         public bool TryGetIncomingHeaders(out System.Collections.Generic.IReadOnlyDictionary<, > incomingHeaders) { }
         public bool TryGetIncomingMessage(out object incomingMessage) { }

--- a/src/NServiceBus.Core.Tests/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageBehaviorTests.cs
@@ -29,6 +29,28 @@
             }
         }
 
+        [Test]
+        public void Should_throw_friendly_exception_when_IMutateOutgoingTransportMessages_MutateOutgoing_modifies_MessageId_header()
+        {
+            var behavior = new MutateOutgoingTransportMessageBehavior();
+
+            var physicalContext = new TestableOutgoingPhysicalMessageContext();
+            physicalContext.Extensions.Set(new OutgoingLogicalMessage(typeof(FakeMessage), new FakeMessage()));
+            physicalContext.Builder.Register<IMutateOutgoingTransportMessages>(() => new MutateOutgoingTransportMessagesModifiesMessageIdHeader());
+
+            Assert.That(async () => await behavior.Invoke(physicalContext, () => TaskEx.CompletedTask), Throws.Exception.With.Message.EqualTo("Setting Message Id by manipulating the `NServiceBus.MessageId` header is not supported. Use `sendOptions.SetMessageId(...)` instead."));
+        }
+
+        class MutateOutgoingTransportMessagesModifiesMessageIdHeader : IMutateOutgoingTransportMessages
+        {
+            public Task MutateOutgoing(MutateOutgoingTransportMessageContext context)
+            {
+                context.OutgoingHeaders[Headers.MessageId] = "Some new value";
+                return TaskEx.CompletedTask;
+            }
+        }
+
+
         class FakeMessage : IMessage { }
     }
 }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Pipeline\IPipelineCache.cs" />
     <Compile Include="Pipeline\IPipelineExecutor.cs" />
     <Compile Include="Pipeline\MainPipelineExecutor.cs" />
+    <Compile Include="Pipeline\Outgoing\OutgoingMessageHeaders.cs" />
     <Compile Include="Pipeline\Outgoing\AttachSenderRelatedInfoOnMessageBehavior.cs" />
     <Compile Include="Pipeline\PipelineCache.cs" />
     <Compile Include="Pipeline\satellitePipelineExecutor.cs" />
@@ -547,6 +548,7 @@
     <Compile Include="Hosting\AuditHostInformationBehavior.cs" />
     <Compile Include="UnitOfWork\UnitOfWorkSettings.cs" />
     <Compile Include="UnitOfWork\UnitOfWorkSettingsExtensions.cs" />
+    <Compile Include="Utils\DictionaryWrapper.cs" />
     <Compile Include="Utils\MessageQueueExtensions.cs" />
     <Compile Include="Utils\PathUtilities.cs" />
     <Compile Include="Routing\FileBasedDynamicRouting\FileRoutingTable.cs" />

--- a/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateOutgoingMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateOutgoingMessageContext.cs
@@ -14,7 +14,7 @@ namespace NServiceBus.MessageMutator
         {
             Guard.AgainstNull(nameof(outgoingHeaders), outgoingHeaders);
             Guard.AgainstNull(nameof(outgoingMessage), outgoingMessage);
-            OutgoingHeaders = outgoingHeaders;
+            OutgoingHeaders = new OutgoingMessageHeaders(outgoingHeaders);
             this.incomingMessage = incomingMessage;
             this.incomingHeaders = incomingHeaders;
             this.outgoingMessage = outgoingMessage;
@@ -37,7 +37,7 @@ namespace NServiceBus.MessageMutator
         /// <summary>
         /// The current outgoing headers.
         /// </summary>
-        public Dictionary<string, string> OutgoingHeaders { get; private set; }
+        public IDictionary<string, string> OutgoingHeaders { get; private set; }
 
         /// <summary>
         /// Gets the incoming message that initiated the current send if it exists.

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageContext.cs
@@ -15,7 +15,7 @@ namespace NServiceBus.MessageMutator
             Guard.AgainstNull(nameof(outgoingHeaders), outgoingHeaders);
             Guard.AgainstNull(nameof(outgoingBody), outgoingBody);
             Guard.AgainstNull(nameof(outgoingMessage), outgoingMessage);
-            OutgoingHeaders = outgoingHeaders;
+            OutgoingHeaders = new OutgoingMessageHeaders(outgoingHeaders);
             OutgoingBody = outgoingBody;
             OutgoingMessage = outgoingMessage;
             this.incomingHeaders = incomingHeaders;
@@ -44,7 +44,7 @@ namespace NServiceBus.MessageMutator
         /// <summary>
         /// The current outgoing headers.
         /// </summary>
-        public Dictionary<string, string> OutgoingHeaders { get; private set; }
+        public IDictionary<string, string> OutgoingHeaders { get; private set; }
 
         /// <summary>
         /// Gets the incoming message that initiated the current send if it exists.

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingMessageHeaders.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingMessageHeaders.cs
@@ -1,0 +1,36 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+
+    class OutgoingMessageHeaders : DictionaryWrapper<string, string>
+    {
+        public OutgoingMessageHeaders(IDictionary<string, string> inner) : base(inner)
+        {
+        }
+
+        public override string this[string key]
+        {
+            get { return base[key]; }
+            set { base[CheckKey(key)] = value; }
+        }
+
+        public override void Add(KeyValuePair<string, string> item)
+        {
+            CheckKey(item.Key);
+            base.Add(item);
+        }
+
+        public override void Add(string key, string value)
+        {
+            base.Add(CheckKey(key), value);
+        }
+
+        static string CheckKey(string key)
+        {
+            if(string.Equals(Headers.MessageId, key, StringComparison.InvariantCultureIgnoreCase))
+                throw new Exception($"Setting Message Id by manipulating the `{Headers.MessageId}` header is not supported. Use `sendOptions.SetMessageId(...)` instead.");
+            return key;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Utils/DictionaryWrapper.cs
+++ b/src/NServiceBus.Core/Utils/DictionaryWrapper.cs
@@ -1,0 +1,38 @@
+﻿namespace NServiceBus
+{
+    using System.Collections;
+    using System.Collections.Generic;
+
+    abstract class DictionaryWrapper<TKey, TValue> : IDictionary<TKey, TValue>
+    {
+        IDictionary<TKey, TValue> inner;
+
+        protected DictionaryWrapper(IDictionary<TKey, TValue> inner)
+        {
+            this.inner = inner;
+        }
+
+        public virtual IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => inner.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)inner).GetEnumerator();
+        public virtual void Add(KeyValuePair<TKey, TValue> item) => inner.Add(item);
+        public virtual void Clear() => inner.Clear();
+        public virtual bool Contains(KeyValuePair<TKey, TValue> item) => inner.Contains(item);
+        public virtual void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex) => inner.CopyTo(array, arrayIndex);
+        public virtual bool Remove(KeyValuePair<TKey, TValue> item) => inner.Remove(item);
+        public virtual int Count => inner.Count;
+        public virtual bool IsReadOnly => inner.IsReadOnly;
+        public virtual bool ContainsKey(TKey key) => inner.ContainsKey(key);
+        public virtual void Add(TKey key, TValue value) => inner.Add(key, value);
+        public virtual bool Remove(TKey key) => inner.Remove(key);
+        public virtual bool TryGetValue(TKey key, out TValue value) => inner.TryGetValue(key, out value);
+
+        public virtual TValue this[TKey key]
+        {
+            get { return inner[key]; }
+            set { inner[key] = value; }
+        }
+
+        public virtual ICollection<TKey> Keys => inner.Keys;
+        public virtual ICollection<TValue> Values => inner.Values;
+    }
+}

--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -72,6 +72,9 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\GitVersionTask.3.4.1\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.4.1\build\dotnet\GitVersionTask.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
Connects to #3907 

Detect when a customer attempts to set the Message Id header via an outgoing message mutator and throw an exception.