### PR TITLE
[Spike] Remove RouteToAddress

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/When_broadcasting_a_command.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_broadcasting_a_command.cs
@@ -49,8 +49,8 @@
                 {
                     context.DistributionPolicy().SetDistributionStrategy(ReceiverEndpoint, new AllInstancesDistributionStrategy());
                     context.EndpointInstances().Add(
-                        new EndpointInstance(ReceiverEndpoint, "1"),
-                        new EndpointInstance(ReceiverEndpoint, "2"));
+                        new EndpointInstance(ReceiverEndpoint, ReceiverEndpoint + "-1"),
+                        new EndpointInstance(ReceiverEndpoint, ReceiverEndpoint + "-2"));
                 }
             }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/When_using_instance_ids.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_using_instance_ids.cs
@@ -49,7 +49,7 @@
                 EndpointSetup<DefaultServer>((c, r) =>
                 {
                     c.UseTransport(r.GetTransportType()).Routing().RouteToEndpoint(typeof(MyMessage), ReceiverEndpoint);
-                    c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverEndpoint, ReceiverEndpoint + "XYZ"));
+                    c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverEndpoint, ReceiverEndpoint + "-XYZ"));
                 });
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Routing/When_using_instance_ids.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_using_instance_ids.cs
@@ -49,7 +49,7 @@
                 EndpointSetup<DefaultServer>((c, r) =>
                 {
                     c.UseTransport(r.GetTransportType()).Routing().RouteToEndpoint(typeof(MyMessage), ReceiverEndpoint);
-                    c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverEndpoint, "XYZ"));
+                    c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverEndpoint, ReceiverEndpoint + "XYZ"));
                 });
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Routing/when_replying_to_a_message_sent_to_specific_instance.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/when_replying_to_a_message_sent_to_specific_instance.cs
@@ -36,7 +36,7 @@
                 EndpointSetup<DefaultServer>((c, r) =>
                 {
                     c.UseTransport(r.GetTransportType()).Routing().RouteToEndpoint(typeof(MyRequest), ReceiverEndpoint);
-                    c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverEndpoint, ReceiverEndpoint + "XYZ"));
+                    c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverEndpoint, ReceiverEndpoint + "-XYZ"));
                 });
             }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/when_replying_to_a_message_sent_to_specific_instance.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/when_replying_to_a_message_sent_to_specific_instance.cs
@@ -36,7 +36,7 @@
                 EndpointSetup<DefaultServer>((c, r) =>
                 {
                     c.UseTransport(r.GetTransportType()).Routing().RouteToEndpoint(typeof(MyRequest), ReceiverEndpoint);
-                    c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverEndpoint, "XYZ"));
+                    c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverEndpoint, ReceiverEndpoint + "XYZ"));
                 });
             }
 

--- a/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
+++ b/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
@@ -4,6 +4,7 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using Features;
+    using NServiceBus.Routing;
     using NUnit.Framework;
     using Transport;
 
@@ -42,7 +43,7 @@
                 protected override void Setup(FeatureConfigurationContext context)
                 {
                     var instanceName = context.Settings.EndpointInstanceName();
-                    var satelliteLogicalAddress = new LogicalAddress(instanceName, "MySatellite");
+                    var satelliteLogicalAddress = new LogicalAddress(new EndpointInstance(instanceName.Endpoint), "MySatellite");
                     var satelliteAddress = context.Settings.GetTransportAddress(satelliteLogicalAddress);
 
                     context.AddSatelliteReceiver("Test satellite", satelliteAddress, TransportTransactionMode.ReceiveOnly, PushRuntimeSettings.Default, new SatelliteRecoverabilityPolicy(),

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2495,9 +2495,9 @@ namespace NServiceBus.Routing
     public sealed class EndpointInstance
     {
         public EndpointInstance(string endpoint) { }
-        public EndpointInstance(string endpoint, string instanceName) { }
+        public EndpointInstance(string endpoint, string instanceAddress) { }
         public string Endpoint { get; }
-        public string InstanceName { get; }
+        public string InstanceAddress { get; }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
     }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2494,15 +2494,12 @@ namespace NServiceBus.Routing
     }
     public sealed class EndpointInstance
     {
-        public EndpointInstance(string endpoint, System.Collections.Generic.IReadOnlyDictionary<string, string> properties = null) { }
-        public EndpointInstance(string endpoint, string instanceName, System.Collections.Generic.IReadOnlyDictionary<string, string> properties = null) { }
+        public EndpointInstance(string endpoint) { }
+        public EndpointInstance(string endpoint, string instanceName) { }
         public string Endpoint { get; }
         public string InstanceName { get; }
-        public System.Collections.Generic.IReadOnlyDictionary<string, string> Properties { get; }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
-        public NServiceBus.Routing.EndpointInstance SetProperty(string key, string value) { }
-        public override string ToString() { }
     }
     public class EndpointInstances
     {
@@ -2545,7 +2542,6 @@ namespace NServiceBus.Routing
     }
     public class UnicastRoute : NServiceBus.Routing.IUnicastRoute
     {
-        public static NServiceBus.Routing.UnicastRoute CreateFromEndpointInstance(NServiceBus.Routing.EndpointInstance instance) { }
         public static NServiceBus.Routing.UnicastRoute CreateFromEndpointName(string endpoint) { }
     }
     public class UnicastRoutingStrategy : NServiceBus.Routing.RoutingStrategy

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2494,9 +2494,10 @@ namespace NServiceBus.Routing
     }
     public sealed class EndpointInstance
     {
-        public EndpointInstance(string endpoint, string discriminator = null, System.Collections.Generic.IReadOnlyDictionary<string, string> properties = null) { }
-        public string Discriminator { get; }
+        public EndpointInstance(string endpoint, System.Collections.Generic.IReadOnlyDictionary<string, string> properties = null) { }
+        public EndpointInstance(string endpoint, string instanceName, System.Collections.Generic.IReadOnlyDictionary<string, string> properties = null) { }
         public string Endpoint { get; }
+        public string InstanceName { get; }
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Properties { get; }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
@@ -2546,7 +2547,6 @@ namespace NServiceBus.Routing
     {
         public static NServiceBus.Routing.UnicastRoute CreateFromEndpointInstance(NServiceBus.Routing.EndpointInstance instance) { }
         public static NServiceBus.Routing.UnicastRoute CreateFromEndpointName(string endpoint) { }
-        public static NServiceBus.Routing.UnicastRoute CreateFromPhysicalAddress(string physicalAddress) { }
     }
     public class UnicastRoutingStrategy : NServiceBus.Routing.RoutingStrategy
     {
@@ -2558,7 +2558,6 @@ namespace NServiceBus.Routing
         public UnicastRoutingTable() { }
         public void AddDynamic(System.Func<System.Type[], NServiceBus.Extensibility.ContextBag, System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.Routing.IUnicastRoute>>> dynamicRule) { }
         public void AddDynamic(System.Func<System.Type[], NServiceBus.Extensibility.ContextBag, System.Collections.Generic.IEnumerable<NServiceBus.Routing.IUnicastRoute>> dynamicRule) { }
-        public void RouteToAddress(System.Type messageType, string destinationAddress) { }
         public void RouteToEndpoint(System.Type messageType, string destination) { }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/EndpointInstanceTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/EndpointInstanceTests.cs
@@ -9,8 +9,8 @@
         [Test]
         public void Two_instances_with_same_properties_are_equal()
         {
-            var i1 = new EndpointInstance("Endpoint").SetProperty("P1", "V1").SetProperty("P2", "V2");            
-            var i2 = new EndpointInstance("Endpoint").SetProperty("P2", "V2").SetProperty("P1", "V1");            
+            var i1 = new EndpointInstance("Endpoint").SetProperty("P1", "V1").SetProperty("P2", "V2");
+            var i2 = new EndpointInstance("Endpoint").SetProperty("P2", "V2").SetProperty("P1", "V1");
 
             Assert.IsTrue(i1.Equals(i2));
         }

--- a/src/NServiceBus.Core.Tests/Routing/EndpointInstanceTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/EndpointInstanceTests.cs
@@ -7,10 +7,10 @@
     public class EndpointInstanceTests
     {
         [Test]
-        public void Two_instances_with_same_properties_are_equal()
+        public void Two_instances_with_same_addresses_are_equal()
         {
-            var i1 = new EndpointInstance("Endpoint").SetProperty("P1", "V1").SetProperty("P2", "V2");
-            var i2 = new EndpointInstance("Endpoint").SetProperty("P2", "V2").SetProperty("P1", "V1");
+            var i1 = new EndpointInstance("Endpoint", "InstanceX");
+            var i2 = new EndpointInstance("Endpoint", "InstanceX");
 
             Assert.IsTrue(i1.Equals(i2));
         }

--- a/src/NServiceBus.Core.Tests/Routing/EndpointInstancesTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/EndpointInstancesTests.cs
@@ -29,7 +29,7 @@
         {
             var instances = new EndpointInstances();
             var sales = "Sales";
-            instances.Add(new EndpointInstance(sales, "1"), new EndpointInstance(sales, "2"));
+            instances.Add(new EndpointInstance(sales, sales + "1"), new EndpointInstance(sales, sales + "2"));
 
             var salesInstances = await instances.FindInstances(sales);
             Assert.AreEqual(2, salesInstances.Count());
@@ -40,8 +40,8 @@
         {
             var instances = new EndpointInstances();
             var sales = "Sales";
-            instances.Add(new EndpointInstance(sales, "dup"), new EndpointInstance(sales, "dup"));
-            instances.AddDynamic(e => Task.FromResult(new List<EndpointInstance> { new EndpointInstance(sales, "dup") }.AsEnumerable()));
+            instances.Add(new EndpointInstance(sales, sales + "dup"), new EndpointInstance(sales, sales + "dup"));
+            instances.AddDynamic(e => Task.FromResult(new List<EndpointInstance> { new EndpointInstance(sales, sales + "dup") }.AsEnumerable()));
 
             var salesInstances = await instances.FindInstances(sales);
             Assert.AreEqual(1, salesInstances.Count());
@@ -54,7 +54,6 @@
             var salesInstancess = await instances.FindInstances("Sales");
 
             var singleInstance = salesInstancess.Single();
-            Assert.IsNull(singleInstance.Discriminator);
             Assert.IsEmpty(singleInstance.Properties);
         }
 
@@ -63,9 +62,9 @@
         {
             var instances = new EndpointInstances();
             var endpointName = "endpointA";
-            instances.Add(new EndpointInstance(endpointName, "1"));
+            instances.Add(new EndpointInstance(endpointName, endpointName + "1"));
             var invocationCounter = 0;
-            instances.AddDynamic(e => Task.FromResult(e == endpointName && invocationCounter++ == 0 ? new [] { new EndpointInstance(endpointName, "2") }.AsEnumerable() : Enumerable.Empty<EndpointInstance>()));
+            instances.AddDynamic(e => Task.FromResult(e == endpointName && invocationCounter++ == 0 ? new [] { new EndpointInstance(endpointName, endpointName + "2") }.AsEnumerable() : Enumerable.Empty<EndpointInstance>()));
 
             var result1 = await instances.FindInstances(endpointName);
             var result2 = await instances.FindInstances(endpointName);

--- a/src/NServiceBus.Core.Tests/Routing/EndpointInstancesTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/EndpointInstancesTests.cs
@@ -54,7 +54,8 @@
             var salesInstancess = await instances.FindInstances("Sales");
 
             var singleInstance = salesInstancess.Single();
-            Assert.IsEmpty(singleInstance.Properties);
+            Assert.AreEqual("Sales", singleInstance.Endpoint);
+            Assert.AreEqual("Sales", singleInstance.InstanceName);
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Routing/EndpointInstancesTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/EndpointInstancesTests.cs
@@ -55,7 +55,7 @@
 
             var singleInstance = salesInstancess.Single();
             Assert.AreEqual("Sales", singleInstance.Endpoint);
-            Assert.AreEqual("Sales", singleInstance.InstanceName);
+            Assert.AreEqual("Sales", singleInstance.InstanceAddress);
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Routing/FileRoutingTableParserTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/FileRoutingTableParserTests.cs
@@ -8,17 +8,19 @@
     [TestFixture]
     public class FileRoutingTableParserTests
     {
+        //TODO: add test for machine name
+
         [Test]
         public void It_can_parse_valid_file()
         {
             const string xml = @"
 <endpoints>
     <endpoint name=""A"">
-        <instance discriminator=""D1"" prop1=""V1"" prop2=""V2""/>
-        <instance prop3=""V3"" prop4=""V4""/>
+        <instance discriminator=""D1""/>
+        <instance />
     </endpoint>
     <endpoint name=""B"">
-        <instance discriminator=""D2"" prop5=""V5"" prop6=""V6""/>
+        <instance discriminator=""D2""/>
     </endpoint>
 </endpoints>
 ";
@@ -27,9 +29,9 @@
 
             CollectionAssert.AreEqual(new[]
             {
-                new EndpointInstance("A", "A-D1").SetProperty("prop1", "V1").SetProperty("prop2","V2"),
-                new EndpointInstance("A", "A").SetProperty("prop3", "V3").SetProperty("prop4", "V4"),
-                new EndpointInstance("B", "B-D2").SetProperty("prop5", "V5").SetProperty("prop6", "V6")
+                new EndpointInstance("A", "A-D1"),
+                new EndpointInstance("A", "A"),
+                new EndpointInstance("B", "B-D2")
             }, result);
         }
 

--- a/src/NServiceBus.Core.Tests/Routing/FileRoutingTableParserTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/FileRoutingTableParserTests.cs
@@ -27,9 +27,9 @@
 
             CollectionAssert.AreEqual(new[]
             {
-                new EndpointInstance("A", "D1").SetProperty("prop1", "V1").SetProperty("prop2","V2"),
-                new EndpointInstance("A").SetProperty("prop3", "V3").SetProperty("prop4", "V4"),
-                new EndpointInstance("B", "D2").SetProperty("prop5", "V5").SetProperty("prop6", "V6")
+                new EndpointInstance("A", "A-D1").SetProperty("prop1", "V1").SetProperty("prop2","V2"),
+                new EndpointInstance("A", "A").SetProperty("prop3", "V3").SetProperty("prop4", "V4"),
+                new EndpointInstance("B", "B-D2").SetProperty("prop5", "V5").SetProperty("prop6", "V6")
             }, result);
         }
 

--- a/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
@@ -14,15 +14,15 @@ namespace NServiceBus.Core.Tests.Routing
             var policy = new DistributionPolicy();
             var endpointAInstances = new[]
             {
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointA, "1")),
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointA, "2")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointA, endpointA+"1")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointA, endpointA+"2"))
             };
 
             var endpointB = "endpointB";
             var endpointBInstances = new[]
             {
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointB, "1")),
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointB, "2")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointB, endpointB+"1")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointB, endpointB+"2"))
             };
 
             var result = new List<UnicastRoutingTarget>();

--- a/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
@@ -16,9 +16,9 @@
             var endpointName = "endpointA";
             var instances = new[]
             {
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "1")),
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "2")),
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "3"))
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, endpointName+"1")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, endpointName+"2")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, endpointName+"3"))
             };
 
             var result = new List<UnicastRoutingTarget>();
@@ -40,9 +40,9 @@
             var endpointName = "endpointA";
             var instances = new[]
             {
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "1")),
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "2")),
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "3"))
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, endpointName+"1")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, endpointName+"2")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, endpointName+"3"))
             };
 
             var result = new List<UnicastRoutingTarget>();
@@ -62,14 +62,14 @@
 
             var instances = new List<UnicastRoutingTarget>
             {
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "1")),
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "2")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, endpointName+"1")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, endpointName+"2")),
             };
 
             var result = new List<UnicastRoutingTarget>();
             result.AddRange(strategy.SelectDestination(instances));
             result.AddRange(strategy.SelectDestination(instances));
-            instances.Add(UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "3"))); // add new instance
+            instances.Add(UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, endpointName + "3"))); // add new instance
             result.AddRange(strategy.SelectDestination(instances));
 
             Assert.That(result.Count, Is.EqualTo(3));
@@ -86,9 +86,9 @@
             var endpointName = "endpointA";
             var instances = new List<UnicastRoutingTarget>
             {
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "1")),
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "2")),
-                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "3"))
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, endpointName+"1")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, endpointName+"2")),
+                UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, endpointName+"3"))
             };
 
             var result = new List<UnicastRoutingTarget>();

--- a/src/NServiceBus.Core.Tests/Routing/SubscriptionRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SubscriptionRouterTests.cs
@@ -51,7 +51,7 @@ namespace NServiceBus.Core.Tests.Routing
             publishers.Add(baseType, "addressB");
             publishers.Add(inheritedType, "addressB");
             var knownEndpoints = new EndpointInstances();
-            knownEndpoints.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(e, null))));
+            knownEndpoints.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(e))));
             var physicalAddresses = new TransportAddresses(address => null);
             physicalAddresses.AddRule(i => i.EndpointInstance.Endpoint);
             var router = new SubscriptionRouter(publishers, knownEndpoints, physicalAddresses);
@@ -70,7 +70,7 @@ namespace NServiceBus.Core.Tests.Routing
             publishers.AddDynamic(t => PublisherAddress.CreateFromEndpointName(address));
 
             var knownEndpoints = new EndpointInstances();
-            knownEndpoints.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(e, null))));
+            knownEndpoints.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(e))));
             var physicalAddresses = new TransportAddresses(a => null);
             physicalAddresses.AddRule(i => i.EndpointInstance.Endpoint);
             var router = new SubscriptionRouter(publishers, knownEndpoints, physicalAddresses);

--- a/src/NServiceBus.Core.Tests/Routing/SubscriptionRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SubscriptionRouterTests.cs
@@ -51,7 +51,7 @@ namespace NServiceBus.Core.Tests.Routing
             publishers.Add(baseType, "addressB");
             publishers.Add(inheritedType, "addressB");
             var knownEndpoints = new EndpointInstances();
-            knownEndpoints.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(e, null, null))));
+            knownEndpoints.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(e, null))));
             var physicalAddresses = new TransportAddresses(address => null);
             physicalAddresses.AddRule(i => i.EndpointInstance.Endpoint);
             var router = new SubscriptionRouter(publishers, knownEndpoints, physicalAddresses);
@@ -70,7 +70,7 @@ namespace NServiceBus.Core.Tests.Routing
             publishers.AddDynamic(t => PublisherAddress.CreateFromEndpointName(address));
 
             var knownEndpoints = new EndpointInstances();
-            knownEndpoints.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(e, null, null))));
+            knownEndpoints.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(e, null))));
             var physicalAddresses = new TransportAddresses(a => null);
             physicalAddresses.AddRule(i => i.EndpointInstance.Endpoint);
             var router = new SubscriptionRouter(publishers, knownEndpoints, physicalAddresses);

--- a/src/NServiceBus.Core.Tests/Routing/TransportAddressesTest.cs
+++ b/src/NServiceBus.Core.Tests/Routing/TransportAddressesTest.cs
@@ -13,7 +13,7 @@
         {
             var addresses = new TransportAddresses(address => null);
             addresses.AddRule(i => "Rule");
-            addresses.AddSpecialCase(new EndpointInstance("Sales", null, null), "SpecialCase");
+            addresses.AddSpecialCase(new EndpointInstance("Sales", null), "SpecialCase");
 
             Assert.AreEqual("SpecialCase", addresses.GetTransportAddress(new LogicalAddress(new EndpointInstance("Sales"))));
             Assert.AreEqual("Rule", addresses.GetTransportAddress(new LogicalAddress(new EndpointInstance("Billing"))));

--- a/src/NServiceBus.Core.Tests/Routing/TransportAddressesTest.cs
+++ b/src/NServiceBus.Core.Tests/Routing/TransportAddressesTest.cs
@@ -13,7 +13,7 @@
         {
             var addresses = new TransportAddresses(address => null);
             addresses.AddRule(i => "Rule");
-            addresses.AddSpecialCase(new EndpointInstance("Sales", null), "SpecialCase");
+            addresses.AddSpecialCase(new EndpointInstance("Sales"), "SpecialCase");
 
             Assert.AreEqual("SpecialCase", addresses.GetTransportAddress(new LogicalAddress(new EndpointInstance("Sales"))));
             Assert.AreEqual("Rule", addresses.GetTransportAddress(new LogicalAddress(new EndpointInstance("Billing"))));

--- a/src/NServiceBus.Core.Tests/Routing/UnicastRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastRouterTests.cs
@@ -24,7 +24,7 @@
             var sales = "Sales";
             metadataRegistry.RegisterMessageType(typeof(Command));
             routingTable.RouteToEndpoint(typeof(Command), sales);
-            endpointInstances.Add(new EndpointInstance(sales, null));
+            endpointInstances.Add(new EndpointInstance(sales));
             transportAddresses.AddRule(i => i.ToString());
 
             var routes = router.Route(typeof(Command), new DistributionPolicy(), new ContextBag()).Result.ToArray();

--- a/src/NServiceBus.Core.Tests/Routing/UnicastRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastRouterTests.cs
@@ -24,7 +24,7 @@
             var sales = "Sales";
             metadataRegistry.RegisterMessageType(typeof(Command));
             routingTable.RouteToEndpoint(typeof(Command), sales);
-            endpointInstances.Add(new EndpointInstance(sales, null, null));
+            endpointInstances.Add(new EndpointInstance(sales, null));
             transportAddresses.AddRule(i => i.ToString());
 
             var routes = router.Route(typeof(Command), new DistributionPolicy(), new ContextBag()).Result.ToArray();
@@ -59,9 +59,9 @@
             routingTable.RouteToEndpoint(typeof(Event), sales);
             routingTable.RouteToEndpoint(typeof(Event), shipping);
 
-            endpointInstances.Add(new EndpointInstance(sales, "1"));
-            endpointInstances.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(sales, "2"))));
-            endpointInstances.Add(new EndpointInstance(shipping, "1", null), new EndpointInstance(shipping, "2"));
+            endpointInstances.Add(new EndpointInstance(sales, sales + "-1"));
+            endpointInstances.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(sales, sales + "-2"))));
+            endpointInstances.Add(new EndpointInstance(shipping, shipping + "-1"), new EndpointInstance(shipping, shipping + "-2"));
 
             transportAddresses.AddRule(i => i.ToString());
 
@@ -73,34 +73,18 @@
         }
 
         [Test]
-        public void Should_not_send_multiple_copies_of_message_to_one_physical_destination()
-        {
-            var sales = "Sales";
-            metadataRegistry.RegisterMessageType(typeof(Event));
-
-            routingTable.RouteToEndpoint(typeof(Event), sales);
-            routingTable.RouteToAddress(typeof(Event), "Sales-1");
-            endpointInstances.Add(new EndpointInstance(sales, "1"));
-            transportAddresses.AddRule(i => i.ToString());
-
-            var routes = router.Route(typeof(Event), new DistributionPolicy(), new ContextBag()).Result.ToArray();
-
-            Assert.AreEqual(1, routes.Length);
-        }
-
-        [Test]
         public void Should_not_pass_duplicate_routes_to_distribution_strategy()
         {
             var sales = "Sales";
             metadataRegistry.RegisterMessageType(typeof(Event));
 
             routingTable.RouteToEndpoint(typeof(Event), sales);
-            endpointInstances.Add(new EndpointInstance(sales, "1"));
+            endpointInstances.Add(new EndpointInstance(sales, sales + "1"));
             endpointInstances.AddDynamic(name =>
             {
                 IEnumerable<EndpointInstance> results = new[]
                 {
-                    new EndpointInstance(sales, "1")
+                    new EndpointInstance(sales, sales+"1")
                 };
                 return Task.FromResult(results);
             });

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
@@ -5,6 +5,7 @@
     using DelayedDelivery;
     using DeliveryConstraints;
     using Persistence;
+    using Routing;
     using Settings;
     using Timeout.Core;
     using Transport;
@@ -64,7 +65,7 @@
         static string SetupDispatcherSatellite(FeatureConfigurationContext context, TransportTransactionMode requiredTransactionSupport)
         {
             var instanceName = context.Settings.EndpointInstanceName();
-            var satelliteLogicalAddress = new LogicalAddress(instanceName, "TimeoutsDispatcher");
+            var satelliteLogicalAddress = new LogicalAddress(new EndpointInstance(instanceName.Endpoint), "TimeoutsDispatcher");
             var satelliteAddress = context.Settings.GetTransportAddress(satelliteLogicalAddress);
 
             context.AddSatelliteReceiver("Timeout Dispatcher Processor", satelliteAddress, requiredTransactionSupport, PushRuntimeSettings.Default, new TimeoutManagerRecoverabilityPolicy(),
@@ -84,7 +85,7 @@
         static void SetupStorageSatellite(FeatureConfigurationContext context, TransportTransactionMode requiredTransactionSupport)
         {
             var instanceName = context.Settings.EndpointInstanceName();
-            var satelliteLogicalAddress = new LogicalAddress(instanceName, "Timeouts");
+            var satelliteLogicalAddress = new LogicalAddress(new EndpointInstance(instanceName.Endpoint), "Timeouts");
             var satelliteAddress = context.Settings.GetTransportAddress(satelliteLogicalAddress);
 
             context.AddSatelliteReceiver("Timeout Message Processor", satelliteAddress, requiredTransactionSupport, PushRuntimeSettings.Default, new TimeoutManagerRecoverabilityPolicy(),

--- a/src/NServiceBus.Core/LogicalAddress.cs
+++ b/src/NServiceBus.Core/LogicalAddress.cs
@@ -59,9 +59,9 @@
         {
             if (Qualifier != null)
             {
-                return EndpointInstance.InstanceName + "." + Qualifier;
+                return EndpointInstance.InstanceAddress + "." + Qualifier;
             }
-            return EndpointInstance.InstanceName;
+            return EndpointInstance.InstanceAddress;
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/LogicalAddress.cs
+++ b/src/NServiceBus.Core/LogicalAddress.cs
@@ -59,9 +59,9 @@
         {
             if (Qualifier != null)
             {
-                return EndpointInstance + "." + Qualifier;
+                return EndpointInstance.InstanceName + "." + Qualifier;
             }
-            return EndpointInstance.ToString();
+            return EndpointInstance.InstanceName;
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Routing/EndpointInstance.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstance.cs
@@ -12,15 +12,28 @@
         /// Creates a new endpoint name for a given discriminator.
         /// </summary>
         /// <param name="endpoint">The name of the endpoint.</param>
-        /// <param name="discriminator">A specific discriminator for scale-out purposes.</param>
         /// <param name="properties">A bag of additional properties that differentiate this endpoint instance from other instances.</param>
-        public EndpointInstance(string endpoint, string discriminator = null, IReadOnlyDictionary<string, string> properties = null)
+        public EndpointInstance(string endpoint, IReadOnlyDictionary<string, string> properties = null)
         {
             Guard.AgainstNull(nameof(endpoint), endpoint);
 
             Properties = properties ?? new Dictionary<string, string>();
             Endpoint = endpoint;
-            Discriminator = discriminator;
+        }
+
+        /// <summary>
+        /// Creates a new endpoint name for a given discriminator.
+        /// </summary>
+        /// <param name="endpoint">The name of the endpoint.</param>
+        /// <param name="instanceName">The name of the this instance.</param>
+        /// <param name="properties">A bag of additional properties that differentiate this endpoint instance from other instances.</param>
+        public EndpointInstance(string endpoint, string instanceName, IReadOnlyDictionary<string, string> properties = null)
+        {
+            Guard.AgainstNull(nameof(endpoint), endpoint);
+
+            Properties = properties ?? new Dictionary<string, string>();
+            Endpoint = endpoint;
+            InstanceName = instanceName;
         }
 
         /// <summary>
@@ -29,9 +42,9 @@
         public string Endpoint { get; }
 
         /// <summary>
-        /// A specific discriminator for scale-out purposes.
+        /// The configured instance name.
         /// </summary>
-        public string Discriminator { get; }
+        public string InstanceName { get; }
 
         /// <summary>
         /// Returns all the differentiating properties of this instance.
@@ -52,7 +65,7 @@
                 newProperties[property.Key] = property.Value;
             }
             newProperties[key] = value;
-            return new EndpointInstance(Endpoint, Discriminator, newProperties);
+            return new EndpointInstance(Endpoint, InstanceName, newProperties);
         }
 
         /// <summary>
@@ -64,9 +77,7 @@
         public override string ToString()
         {
             var propsFormatted = Properties.Select(kvp => $"{kvp.Key}:{kvp.Value}");
-            var instanceId = Discriminator != null
-                ? $"{Endpoint}-{Discriminator}"
-                : Endpoint;
+            var instanceId = Endpoint;
 
             var parts = new[]
             {
@@ -78,8 +89,8 @@
         bool Equals(EndpointInstance other)
         {
             return PropertiesEqual(Properties, other.Properties)
-                   && Equals(Endpoint, other.Endpoint)
-                   && string.Equals(Discriminator, other.Discriminator);
+                   && Equals(InstanceName, other.InstanceName)
+                   && Equals(Endpoint, other.Endpoint);
         }
 
         static bool PropertiesEqual(IReadOnlyDictionary<string, string> left, IReadOnlyDictionary<string, string> right)
@@ -130,8 +141,8 @@
             unchecked
             {
                 var hashCode = Properties.Aggregate(Endpoint.GetHashCode(), (i, pair) => (i*397) ^ propertyComparer.GetHashCode(pair));
-                hashCode = (hashCode*397) ^ (Discriminator?.GetHashCode() ?? 0);
-                return hashCode;
+                hashCode = (hashCode*397);
+                return hashCode ^ (InstanceName?.GetHashCode() ?? 0);
             }
         }
 

--- a/src/NServiceBus.Core/Routing/EndpointInstance.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstance.cs
@@ -17,14 +17,14 @@
         /// Creates a new endpoint name for a given discriminator.
         /// </summary>
         /// <param name="endpoint">The name of the endpoint.</param>
-        /// <param name="instanceName">The name of the this instance.</param>
-        public EndpointInstance(string endpoint, string instanceName)
+        /// <param name="instanceAddress">The name of the this instance.</param>
+        public EndpointInstance(string endpoint, string instanceAddress)
         {
             Guard.AgainstNull(nameof(endpoint), endpoint);
-            Guard.AgainstNull(nameof(instanceName), instanceName);
+            Guard.AgainstNull(nameof(instanceAddress), instanceAddress);
 
             Endpoint = endpoint;
-            InstanceName = instanceName;
+            InstanceAddress = instanceAddress;
         }
 
         /// <summary>
@@ -35,11 +35,11 @@
         /// <summary>
         /// The configured instance name.
         /// </summary>
-        public string InstanceName { get; }
+        public string InstanceAddress { get; }
 
         bool Equals(EndpointInstance other)
         {
-            return string.Equals(Endpoint, other.Endpoint) && string.Equals(InstanceName, other.InstanceName);
+            return string.Equals(Endpoint, other.Endpoint) && string.Equals(InstanceAddress, other.InstanceAddress);
         }
 
         /// <summary>
@@ -62,7 +62,7 @@
         {
             unchecked
             {
-                return ((Endpoint != null ? Endpoint.GetHashCode() : 0)*397) ^ (InstanceName != null ? InstanceName.GetHashCode() : 0);
+                return ((Endpoint != null ? Endpoint.GetHashCode() : 0)*397) ^ (InstanceAddress != null ? InstanceAddress.GetHashCode() : 0);
             }
         }
 

--- a/src/NServiceBus.Core/Routing/EndpointInstance.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstance.cs
@@ -1,8 +1,5 @@
 ﻿namespace NServiceBus.Routing
 {
-    using System.Collections.Generic;
-    using System.Linq;
-
     /// <summary>
     /// Represents a name of an endpoint instance.
     /// </summary>
@@ -12,13 +9,8 @@
         /// Creates a new endpoint name for a given discriminator.
         /// </summary>
         /// <param name="endpoint">The name of the endpoint.</param>
-        /// <param name="properties">A bag of additional properties that differentiate this endpoint instance from other instances.</param>
-        public EndpointInstance(string endpoint, IReadOnlyDictionary<string, string> properties = null)
+        public EndpointInstance(string endpoint) : this(endpoint, endpoint)
         {
-            Guard.AgainstNull(nameof(endpoint), endpoint);
-
-            Properties = properties ?? new Dictionary<string, string>();
-            Endpoint = endpoint;
         }
 
         /// <summary>
@@ -26,12 +18,11 @@
         /// </summary>
         /// <param name="endpoint">The name of the endpoint.</param>
         /// <param name="instanceName">The name of the this instance.</param>
-        /// <param name="properties">A bag of additional properties that differentiate this endpoint instance from other instances.</param>
-        public EndpointInstance(string endpoint, string instanceName, IReadOnlyDictionary<string, string> properties = null)
+        public EndpointInstance(string endpoint, string instanceName)
         {
             Guard.AgainstNull(nameof(endpoint), endpoint);
+            Guard.AgainstNull(nameof(instanceName), instanceName);
 
-            Properties = properties ?? new Dictionary<string, string>();
             Endpoint = endpoint;
             InstanceName = instanceName;
         }
@@ -46,108 +37,37 @@
         /// </summary>
         public string InstanceName { get; }
 
-        /// <summary>
-        /// Returns all the differentiating properties of this instance.
-        /// </summary>
-        public IReadOnlyDictionary<string, string> Properties { get; }
-
-        /// <summary>
-        /// Sets a property for an endpoint instance returning a new instance with the given property set.
-        /// </summary>
-        /// <param name="key">Key.</param>
-        /// <param name="value">Value.</param>
-        public EndpointInstance SetProperty(string key, string value)
-        {
-            Guard.AgainstNull(nameof(key), key);
-            var newProperties = new Dictionary<string, string>();
-            foreach (var property in Properties)
-            {
-                newProperties[property.Key] = property.Value;
-            }
-            newProperties[key] = value;
-            return new EndpointInstance(Endpoint, InstanceName, newProperties);
-        }
-
-        /// <summary>
-        /// Returns a string that represents the current object.
-        /// </summary>
-        /// <returns>
-        /// A string that represents the current object.
-        /// </returns>
-        public override string ToString()
-        {
-            var propsFormatted = Properties.Select(kvp => $"{kvp.Key}:{kvp.Value}");
-            var instanceId = Endpoint;
-
-            var parts = new[]
-            {
-                instanceId
-            }.Concat(propsFormatted);
-            return string.Join(";", parts);
-        }
-
         bool Equals(EndpointInstance other)
         {
-            return PropertiesEqual(Properties, other.Properties)
-                   && Equals(InstanceName, other.InstanceName)
-                   && Equals(Endpoint, other.Endpoint);
-        }
-
-        static bool PropertiesEqual(IReadOnlyDictionary<string, string> left, IReadOnlyDictionary<string, string> right)
-        {
-            foreach (var p in left)
-            {
-                string equivalent;
-                if (!right.TryGetValue(p.Key, out equivalent))
-                {
-                    return false;
-                }
-                if (p.Value != equivalent)
-                {
-                    return false;
-                }
-            }
-            return true;
+            return string.Equals(Endpoint, other.Endpoint) && string.Equals(InstanceName, other.InstanceName);
         }
 
         /// <summary>
         /// Determines whether the specified object is equal to the current object.
         /// </summary>
-        /// <returns>
-        /// true if the specified object  is equal to the current object; otherwise, false.
-        /// </returns>
-        /// <param name="obj">The object to compare with the current object. </param>
+        /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
+        /// <param name="obj">The object to compare with the current object.</param>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-            if (ReferenceEquals(this, obj))
-            {
-                return true;
-            }
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
             return obj is EndpointInstance && Equals((EndpointInstance) obj);
         }
 
         /// <summary>
         /// Serves as the default hash function.
         /// </summary>
-        /// <returns>
-        /// A hash code for the current object.
-        /// </returns>
+        /// <returns>A hash code for the current object.</returns>
         public override int GetHashCode()
         {
             unchecked
             {
-                var hashCode = Properties.Aggregate(Endpoint.GetHashCode(), (i, pair) => (i*397) ^ propertyComparer.GetHashCode(pair));
-                hashCode = (hashCode*397);
-                return hashCode ^ (InstanceName?.GetHashCode() ?? 0);
+                return ((Endpoint != null ? Endpoint.GetHashCode() : 0)*397) ^ (InstanceName != null ? InstanceName.GetHashCode() : 0);
             }
         }
 
         /// <summary>
-        /// Checks for equality.
+        /// Determines whether the specified object is equal to the current object.
         /// </summary>
         public static bool operator ==(EndpointInstance left, EndpointInstance right)
         {
@@ -155,32 +75,11 @@
         }
 
         /// <summary>
-        /// Checks for inequality.
+        /// Determines whether the specified object is not equal to the current object.
         /// </summary>
         public static bool operator !=(EndpointInstance left, EndpointInstance right)
         {
             return !Equals(left, right);
-        }
-
-        static readonly IEqualityComparer<KeyValuePair<string, string>> propertyComparer = new PropertyComparer();
-
-        class PropertyComparer : IEqualityComparer<KeyValuePair<string, string>>
-        {
-            public bool Equals(KeyValuePair<string, string> x, KeyValuePair<string, string> y)
-            {
-                return Equals(x.Key, y.Key)
-                       && Equals(x.Value, y.Value);
-            }
-
-            public int GetHashCode(KeyValuePair<string, string> obj)
-            {
-                var hashCode = obj.Key.GetHashCode();
-                if (obj.Value != null)
-                {
-                    hashCode ^= 397*obj.Value.GetHashCode();
-                }
-                return hashCode;
-            }
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/EndpointInstances.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstances.cs
@@ -26,7 +26,7 @@ namespace NServiceBus.Routing
 
             return Task.FromResult<IEnumerable<EndpointInstance>>(new[]
             {
-                new EndpointInstance(endpoint)
+                new EndpointInstance(endpoint, endpoint)
             });
         }
 
@@ -44,7 +44,7 @@ namespace NServiceBus.Routing
 
             if (dynamicInstances.Count == 0)
             {
-                dynamicInstances.Add(new EndpointInstance(endpoint));
+                dynamicInstances.Add(new EndpointInstance(endpoint, endpoint));
             }
 
             return dynamicInstances;

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableParser.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableParser.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus
 {
     using System.Collections.Generic;
-    using System.Linq;
     using System.Xml;
     using System.Xml.Linq;
     using System.Xml.Schema;
@@ -34,13 +33,24 @@ namespace NServiceBus
 
                 foreach (var i in e.Descendants("instance"))
                 {
+                    var instanceAddress = endpointName;
+
                     var discriminatorAttribute = i.Attribute("discriminator");
                     var discriminator = discriminatorAttribute?.Value;
+                    if (!string.IsNullOrWhiteSpace(discriminator))
+                    {
+                        instanceAddress += $"-{discriminator}";
+                    }
 
-                    var properties = i.Attributes().Where(a => a.Name != "discriminator");
-                    var propertyDictionary = properties.ToDictionary(a => a.Name.LocalName, a => a.Value);
 
-                    instances.Add(new EndpointInstance(endpointName, $"{endpointName}-{discriminator}", propertyDictionary));
+                    var machineAttribute = i.Attribute("machine");
+                    var machine = machineAttribute?.Value;
+                    if (!string.IsNullOrWhiteSpace(machine))
+                    {
+                        instanceAddress += $"@{machine}";
+                    }
+
+                    instances.Add(new EndpointInstance(endpointName, instanceAddress));
                 }
             }
 

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableParser.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableParser.cs
@@ -40,7 +40,7 @@ namespace NServiceBus
                     var properties = i.Attributes().Where(a => a.Name != "discriminator");
                     var propertyDictionary = properties.ToDictionary(a => a.Name.LocalName, a => a.Value);
 
-                    instances.Add(new EndpointInstance(endpointName, discriminator, propertyDictionary));
+                    instances.Add(new EndpointInstance(endpointName, $"{endpointName}-{discriminator}", propertyDictionary));
                 }
             }
 

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -116,7 +116,10 @@
 
         static void ConfigureSendDestination(TransportInfrastructure transportInfrastructure, UnicastRoutingTable unicastRoutingTable, Type type, string address)
         {
-            unicastRoutingTable.RouteToAddress(type, transportInfrastructure.MakeCanonicalForm(address));
+            // needs to be optimized for duplicates by assembly/hierachy traversal
+            var canonicalAddress = transportInfrastructure.MakeCanonicalForm(address);
+            unicastRoutingTable.RouteToEndpoint(type, canonicalAddress);
+
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/SpecificInstanceDistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/SpecificInstanceDistributionPolicy.cs
@@ -28,7 +28,7 @@ namespace NServiceBus
 
             public override IEnumerable<UnicastRoutingTarget> SelectDestination(IList<UnicastRoutingTarget> allInstances)
             {
-                var target = allInstances.FirstOrDefault(t => t.Instance != null && t.Instance.Discriminator == specificInstance);
+                var target = allInstances.FirstOrDefault(t => t.Instance != null && t.Instance.Endpoint.EndsWith("." + specificInstance));
                 if (target == null)
                 {
                     throw new Exception($"Specified instance {specificInstance} has not been configured in the routing tables.");

--- a/src/NServiceBus.Core/Routing/UnicastRoute.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRoute.cs
@@ -21,27 +21,16 @@ namespace NServiceBus.Routing
             return new UnicastRoute { endpoint = endpoint };
         }
 
-        /// <summary>
-        /// Creates a destination based on the name of the endpoint instance.
-        /// </summary>
-        /// <param name="instance">Destination instance name.</param>
-        /// <returns>The new destination route.</returns>
-        public static UnicastRoute CreateFromEndpointInstance(EndpointInstance instance)
-        {
-            Guard.AgainstNull(nameof(instance), instance);
-            return new UnicastRoute { instance = instance };
-        }
-
-        /// <summary>
-        /// Creates a destination based on the physical address.
-        /// </summary>
-        /// <param name="physicalAddress">Destination physical address.</param>
-        /// <returns>The new destination route.</returns>
-        public static UnicastRoute CreateFromPhysicalAddress(string physicalAddress)
-        {
-            Guard.AgainstNullAndEmpty(nameof(physicalAddress), physicalAddress);
-            return new UnicastRoute { physicalAddress = physicalAddress };
-        }
+        ///// <summary>
+        ///// Creates a destination based on the name of the endpoint instance.
+        ///// </summary>
+        ///// <param name="instance">Destination instance name.</param>
+        ///// <returns>The new destination route.</returns>
+        //public static UnicastRoute CreateFromEndpointInstance(EndpointInstance instance)
+        //{
+        //    Guard.AgainstNull(nameof(instance), instance);
+        //    return new UnicastRoute { instance = instance };
+        //}
 
         private UnicastRoute()
         {
@@ -49,20 +38,15 @@ namespace NServiceBus.Routing
 
         async Task<IEnumerable<UnicastRoutingTarget>> IUnicastRoute.Resolve(Func<string, Task<IEnumerable<EndpointInstance>>> instanceResolver)
         {
-            if (physicalAddress != null)
-            {
-                return EnumerableEx.Single(UnicastRoutingTarget.ToTransportAddress(physicalAddress));
-            }
-            if (instance != null)
-            {
-                return EnumerableEx.Single(UnicastRoutingTarget.ToEndpointInstance(instance));
-            }
+            //if (instance != null)
+            //{
+            //    return EnumerableEx.Single(UnicastRoutingTarget.ToEndpointInstance(instance));
+            //}
             var instances = await instanceResolver(endpoint).ConfigureAwait(false);
             return instances.Select(UnicastRoutingTarget.ToEndpointInstance);
         }
 
         string endpoint;
-        EndpointInstance instance;
-        string physicalAddress;
+        //EndpointInstance instance;
     }
 }

--- a/src/NServiceBus.Core/Routing/UnicastRoutingTable.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRoutingTable.cs
@@ -47,16 +47,6 @@ namespace NServiceBus.Routing
         }
 
         /// <summary>
-        /// Adds a static unicast route.
-        /// </summary>
-        /// <param name="messageType">Message type.</param>
-        /// <param name="destinationAddress">Destination endpoint instance address.</param>
-        public void RouteToAddress(Type messageType, string destinationAddress)
-        {
-            AddStaticRoute(messageType, UnicastRoute.CreateFromPhysicalAddress(destinationAddress));
-        }
-
-        /// <summary>
         /// Adds an external provider of routes.
         /// </summary>
         /// <remarks>For dynamic routes that do not require async use <see cref="AddDynamic(System.Func{Type[],NServiceBus.Extensibility.ContextBag,System.Collections.Generic.IEnumerable{NServiceBus.Routing.IUnicastRoute}})" />.</remarks>

--- a/src/NServiceBus.Core/Transports/Msmq/EndpointInstanceExtensions.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/EndpointInstanceExtensions.cs
@@ -14,7 +14,7 @@ namespace NServiceBus
         /// <param name="machineName">Machine name.</param>
         public static EndpointInstance AtMachine(this EndpointInstance instance, string machineName)
         {
-            return instance.SetProperty("Machine", machineName);
+            return new EndpointInstance(instance.Endpoint, instance.InstanceName + $"@{machineName}");
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/EndpointInstanceExtensions.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/EndpointInstanceExtensions.cs
@@ -14,7 +14,7 @@ namespace NServiceBus
         /// <param name="machineName">Machine name.</param>
         public static EndpointInstance AtMachine(this EndpointInstance instance, string machineName)
         {
-            return new EndpointInstance(instance.Endpoint, instance.InstanceName + $"@{machineName}");
+            return new EndpointInstance(instance.Endpoint, instance.InstanceAddress + $"@{machineName}");
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
@@ -50,12 +50,6 @@ namespace NServiceBus
 
         public override string ToTransportAddress(LogicalAddress logicalAddress)
         {
-            string machine;
-            if (!logicalAddress.EndpointInstance.Properties.TryGetValue("Machine", out machine))
-            {
-                machine = RuntimeEnvironment.MachineName;
-            }
-
             var queue = new StringBuilder(logicalAddress.EndpointInstance.InstanceName);
             if (logicalAddress.Qualifier != null)
             {
@@ -67,7 +61,7 @@ namespace NServiceBus
                 return queue.ToString();
             }
 
-            return queue + "@" + machine;
+            return queue + "@" + RuntimeEnvironment.MachineName;
         }
 
         public override string MakeCanonicalForm(string transportAddress)

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
@@ -56,15 +56,17 @@ namespace NServiceBus
                 machine = RuntimeEnvironment.MachineName;
             }
 
-            var queue = new StringBuilder(logicalAddress.EndpointInstance.Endpoint);
-            if (logicalAddress.EndpointInstance.Discriminator != null)
-            {
-                queue.Append("-" + logicalAddress.EndpointInstance.Discriminator);
-            }
+            var queue = new StringBuilder(logicalAddress.EndpointInstance.InstanceName);
             if (logicalAddress.Qualifier != null)
             {
                 queue.Append("." + logicalAddress.Qualifier);
             }
+
+            if (logicalAddress.EndpointInstance.InstanceName.Contains("@"))
+            {
+                return queue.ToString();
+            }
+
             return queue + "@" + machine;
         }
 

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
@@ -50,13 +50,13 @@ namespace NServiceBus
 
         public override string ToTransportAddress(LogicalAddress logicalAddress)
         {
-            var queue = new StringBuilder(logicalAddress.EndpointInstance.InstanceName);
+            var queue = new StringBuilder(logicalAddress.EndpointInstance.InstanceAddress);
             if (logicalAddress.Qualifier != null)
             {
                 queue.Append("." + logicalAddress.Qualifier);
             }
 
-            if (logicalAddress.EndpointInstance.InstanceName.Contains("@"))
+            if (logicalAddress.EndpointInstance.InstanceAddress.Contains("@"))
             {
                 return queue.ToString();
             }

--- a/src/NServiceBus.Core/Transports/Receiving.cs
+++ b/src/NServiceBus.Core/Transports/Receiving.cs
@@ -20,10 +20,11 @@ namespace NServiceBus
 
                 if (userDiscriminator != null)
                 {
-                    var p = s.Get<TransportInfrastructure>().BindToLocalEndpoint(new EndpointInstance(s.EndpointName(), userDiscriminator));
+                    var endpoint = $"{s.EndpointName()}-{userDiscriminator}";
+                    var p = s.Get<TransportInfrastructure>().BindToLocalEndpoint(new EndpointInstance(endpoint, endpoint));
                     s.SetDefault("NServiceBus.EndpointSpecificQueue", transportAddresses.GetTransportAddress(new LogicalAddress(p)));
                 }
-                var instanceProperties = s.Get<TransportInfrastructure>().BindToLocalEndpoint(new EndpointInstance(s.EndpointName()));
+                var instanceProperties = s.Get<TransportInfrastructure>().BindToLocalEndpoint(new EndpointInstance(s.EndpointName(), s.EndpointName()));
                 s.SetDefault("NServiceBus.SharedQueue", transportAddresses.GetTransportAddress(new LogicalAddress(instanceProperties)));
 
                 s.SetDefault<EndpointInstance>(instanceProperties);

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_a_command.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_a_command.cs
@@ -63,8 +63,9 @@
                     routing.RouteToEndpoint(typeof(RequestA), ReceiverAEndpoint);
                     routing.RouteToEndpoint(typeof(RequestB), ReceiverBEndpoint);
 
-                    routing.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverAEndpoint, "1"), new EndpointInstance(ReceiverAEndpoint, "2"));
-                    routing.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverBEndpoint, "1"), new EndpointInstance(ReceiverBEndpoint, "2"));
+                    // problematic because of transports currently decide how to translate the discriminator into an address
+                    routing.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverAEndpoint, ReceiverAEndpoint + "-1"), new EndpointInstance(ReceiverAEndpoint, ReceiverAEndpoint + "-2"));
+                    routing.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverBEndpoint, ReceiverBEndpoint + "-1"), new EndpointInstance(ReceiverBEndpoint, ReceiverBEndpoint + "-2"));
                 });
             }
 

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_replying_to_a_message_sent_via_a_distributor.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_replying_to_a_message_sent_via_a_distributor.cs
@@ -37,7 +37,7 @@
                 {
                     var routing = c.UseTransport<MsmqTransport>().Routing();
                     routing.RouteToEndpoint(typeof(MyRequest), ReceiverEndpoint);
-                    c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverEndpoint, "XYZ"));
+                    c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverEndpoint, ReceiverEndpoint + "XYZ"));
                     c.AddHeaderToAllOutgoingMessages("NServiceBus.Distributor.WorkerSessionId", "SomeID");
                 });
             }

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_replying_to_a_message_sent_via_a_distributor.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_replying_to_a_message_sent_via_a_distributor.cs
@@ -37,7 +37,7 @@
                 {
                     var routing = c.UseTransport<MsmqTransport>().Routing();
                     routing.RouteToEndpoint(typeof(MyRequest), ReceiverEndpoint);
-                    c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverEndpoint, ReceiverEndpoint + "XYZ"));
+                    c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverEndpoint, ReceiverEndpoint + "-XYZ"));
                     c.AddHeaderToAllOutgoingMessages("NServiceBus.Distributor.WorkerSessionId", "SomeID");
                 });
             }


### PR DESCRIPTION
* Simplified `EndpointInstance` by making it essentially a key/value pair where the key is the logical endpoint name and the value is the address of the instance
  * Removed it's property bag which allows for transport specific configuration (e.g. machine name). Instead the extensions need to apply their modifications to the address directly (`AtMache(..)` therefore still works).
  * Removed the instance discriminator parameter. Instance discriminator must be added "manually". E.g. the instance mapping file adds the instance discriminator to the address as it does with the machine attribute. (we could think about adding a method to `Conventions` which concatenates the name with a discriminator to centralize that logic a bit)
  * This would also allow to use client side distribution with specific addresses for each instance instead of only allowing different discriminators.
* RouteToAddress has gone. You can now only route to a logical endpoint. The name of the logical endpoint is an arbitrary string (even a connection string). If no endpoint instance has been configured by the routing API, it will generate a default `EndointInstance` with the same value as the logical endpoint. For the unicast message mapping types we no longer register the value as an address, but as a logical endpoint too. This means that it will try to lookup an instance for these endpoints (which then may end up in the same value as the logical endpoint).
  * This should even allow to use client side distribution logic with the unicast message mappings.
  * we still don't allow to configure an address on the endpoint configuration routing API, but it would be possible on the advanced API (currently also possible using `RouteToAddress`).
* allows quite a lot of follow up refactorings (e.g. removing EndpointInstance from LogicalAddress, eliminating IUnicastRoute interface and much more)
* We could also remove `Publishers.AddByAddress(...)` and use the same principle, which means you always configure an instance for custom destinations.

@DavidBoike @bording @SzymonPobiega please have a look at this and comment whether we should polish that PR further or stop following that idea.

