### PR TITLE
Replaced GetAvailableTypes().Where(Conventions.IsMessageType) with MessageMetadataRegistry

### DIFF
--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
@@ -228,8 +228,8 @@
             FakeRoutingStrategy strategy = null)
         {
             var metadataRegistry = new MessageMetadataRegistry(new Conventions());
-            metadataRegistry.RegisterMessageType(typeof(MyMessage));
-            metadataRegistry.RegisterMessageType(typeof(MessageWithoutRouting));
+            metadataRegistry.RegisterMessageTypesFoundIn(new List<Type> { typeof(MyMessage), typeof(MessageWithoutRouting) });
+
             return new UnicastSendRouterConnector(sharedQueue, instanceSpecificQueue, strategy ?? new FakeRoutingStrategy(), new DistributionPolicy());
         }
 

--- a/src/NServiceBus.Core.Tests/Serializers/SerializeMessagesBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/SerializeMessagesBehaviorTests.cs
@@ -15,7 +15,7 @@
         {
             var registry = new MessageMetadataRegistry(new Conventions());
 
-            registry.RegisterMessageType(typeof(MyMessage));
+            registry.RegisterMessageTypesFoundIn(new List<Type> { typeof(MyMessage) });
 
             var context = ContextHelpers.GetOutgoingContext(new MyMessage());
             var behavior = new SerializeMessageConnector(new FakeSerializer("myContentType"), registry);
@@ -45,6 +45,6 @@
             public string ContentType { get; }
         }
 
-        class MyMessage { }
+        class MyMessage : IMessage { }
     }
 }

--- a/src/NServiceBus.Core.Tests/Unicast/Messages/DefaultMessageRegistryTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/Messages/DefaultMessageRegistryTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Unicast.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using NUnit.Framework;
     using Unicast.Messages;
@@ -21,9 +22,14 @@
             [Test]
             public void Should_return_metadata_for_a_mapped_type()
             {
-                var defaultMessageRegistry = new MessageMetadataRegistry(new Conventions());
-                defaultMessageRegistry.RegisterMessageType(typeof(int));
+                var conventions = new Conventions();
+                conventions.IsMessageTypeAction = type => type == typeof(int);
+
+                var defaultMessageRegistry = new MessageMetadataRegistry(conventions);
+                defaultMessageRegistry.RegisterMessageTypesFoundIn(new List<Type> { typeof(int) });
+
                 var messageMetadata = defaultMessageRegistry.GetMessageMetadata(typeof(int));
+
                 Assert.AreEqual(typeof(int), messageMetadata.MessageType);
                 Assert.AreEqual(1, messageMetadata.MessageHierarchy.Count());
             }
@@ -34,7 +40,7 @@
             {
                 var defaultMessageRegistry = new MessageMetadataRegistry(new Conventions());
 
-                defaultMessageRegistry.RegisterMessageType(typeof(MyEvent));
+                defaultMessageRegistry.RegisterMessageTypesFoundIn(new List<Type> { typeof(MyEvent) });
                 var messageMetadata = defaultMessageRegistry.GetMessageMetadata(typeof(MyEvent));
 
                 Assert.AreEqual(5, messageMetadata.MessageHierarchy.Count());

--- a/src/NServiceBus.Core/Encryption/Encryptor.cs
+++ b/src/NServiceBus.Core/Encryption/Encryptor.cs
@@ -6,6 +6,7 @@
     using System.Reflection;
     using System.Text;
     using Logging;
+    using Unicast.Messages;
 
     /// <summary>
     /// Used to configure encryption.
@@ -40,7 +41,7 @@
                 if (encryptionServiceConstructorDefined)
                 {
                     var message =
-                        @"Encryption service has been configured via either endpointConfiguration.RijndaelEncryptionService or endpointConfiguration.RegisterEncryptionService however no properties were found on type that require encryption. 
+                        @"Encryption service has been configured via either endpointConfiguration.RijndaelEncryptionService or endpointConfiguration.RegisterEncryptionService however no properties were found on type that require encryption.
 Ensure that either encryption message conventions are defined or to define message properties using as WireEncryptedString.";
                     log.Warn(message);
                 }
@@ -51,8 +52,9 @@ Ensure that either encryption message conventions are defined or to define messa
         static List<PropertyInfo> GetEncryptedProperties(FeatureConfigurationContext context)
         {
             var conventions = context.Settings.Get<Conventions>();
-            return context.Settings.GetAvailableTypes()
-                .SelectMany(messageType => messageType.GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            var registry = context.Settings.Get<MessageMetadataRegistry>();
+            return registry.GetAllMessages()
+                .SelectMany(metadata => metadata.MessageType.GetProperties(BindingFlags.Instance | BindingFlags.Public))
                 .Where(conventions.IsEncryptedProperty)
                 .ToList();
         }

--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -15,6 +15,7 @@ namespace NServiceBus
     using Pipeline;
     using Settings;
     using Transport;
+    using Unicast.Messages;
 
     /// <summary>
     /// Configuration used to create an endpoint instance.
@@ -218,7 +219,12 @@ namespace NServiceBus
                 Settings.SetDefault("PublicReturnAddress", publicReturnAddress);
             }
 
-            Settings.SetDefault<Conventions>(conventionsBuilder.Conventions);
+            var conventions = conventionsBuilder.Conventions;
+            Settings.SetDefault<Conventions>(conventions);
+            var messageMetadataRegistry = new MessageMetadataRegistry(conventions);
+            messageMetadataRegistry.RegisterMessageTypesFoundIn(Settings.GetAvailableTypes());
+
+            Settings.SetDefault<MessageMetadataRegistry>(messageMetadataRegistry);
 
             return new InitializableEndpoint(Settings, container, registrations, Pipeline, pipelineCollection);
         }

--- a/src/NServiceBus.Core/Performance/MessageDurability/MessageDurabilityFeature.cs
+++ b/src/NServiceBus.Core/Performance/MessageDurability/MessageDurabilityFeature.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using DeliveryConstraints;
+    using Unicast.Messages;
 
     class MessageDurabilityFeature : Feature
     {
@@ -14,12 +15,6 @@
 
         protected internal override void Setup(FeatureConfigurationContext context)
         {
-            var conventions = context.Settings.Get<Conventions>();
-
-            var knownMessages = context.Settings.GetAvailableTypes()
-                .Where(conventions.IsMessageType)
-                .ToList();
-
             var defaultToDurableMessages = context.Settings.DurableMessagesEnabled();
 
             var nonDurableMessages = new HashSet<Type>();
@@ -31,15 +26,16 @@
                 durabilityConvention = t => t.GetCustomAttributes(typeof(ExpressAttribute), true).Any();
             }
 
-            foreach (var messageType in knownMessages)
+            var registry = context.Settings.Get<MessageMetadataRegistry>();
+            foreach (var messageMetadata in registry.GetAllMessages())
             {
                 if (!defaultToDurableMessages)
                 {
-                    nonDurableMessages.Add(messageType);
+                    nonDurableMessages.Add(messageMetadata.MessageType);
                 }
-                else if(durabilityConvention(messageType))
+                else if(durabilityConvention(messageMetadata.MessageType))
                 {
-                    nonDurableMessages.Add(messageType);
+                    nonDurableMessages.Add(messageMetadata.MessageType);
                 }
             }
 

--- a/src/NServiceBus.Core/Performance/TimeToBeReceived/TimeToBeReceived.cs
+++ b/src/NServiceBus.Core/Performance/TimeToBeReceived/TimeToBeReceived.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using DeliveryConstraints;
     using Performance.TimeToBeReceived;
+    using Unicast.Messages;
 
     class TimeToBeReceived : Feature
     {
@@ -26,11 +27,10 @@
             context.Container.ConfigureComponent(b => new ApplyTimeToBeReceivedBehavior(mappings), DependencyLifecycle.SingleInstance);
         }
 
-        TimeToBeReceivedMappings GetMappings(FeatureConfigurationContext context)
+        static TimeToBeReceivedMappings GetMappings(FeatureConfigurationContext context)
         {
-            var knownMessages = context.Settings.GetAvailableTypes()
-                .Where(context.Settings.Get<Conventions>().IsMessageType)
-                .ToList();
+            var registry = context.Settings.Get<MessageMetadataRegistry>();
+            var knownMessages = registry.GetAllMessages().Select(m => m.MessageType);
 
             var convention = TimeToBeReceivedMappings.DefaultConvention;
 

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -105,11 +105,8 @@
 
         static Type[] GetKnownMessageTypes(FeatureConfigurationContext context)
         {
-            var conventions = context.Settings.Get<Conventions>();
-            var knownMessageTypes = context.Settings.GetAvailableTypes()
-                .Where(conventions.IsMessageType)
-                .ToArray();
-            return knownMessageTypes;
+            var registry = context.Settings.Get<MessageMetadataRegistry>();
+            return registry.GetAllMessages().Select(m => m.MessageType).ToArray();
         }
 
         static void ImportMessageEndpointMappings(MessageEndpointMappingCollection legacyRoutingConfig, TransportInfrastructure transportInfrastructure, Publishers publishers, UnicastRoutingTable unicastRoutingTable, Type[] knownMessageTypes)

--- a/src/NServiceBus.Core/Serializers/XML/XmlSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlSerializer.cs
@@ -5,6 +5,7 @@
     using MessageInterfaces;
     using Serialization;
     using Settings;
+    using Unicast.Messages;
 
     /// <summary>
     /// Defines the capabilities of the XML serializer.
@@ -19,9 +20,6 @@
             return mapper =>
             {
                 var conventions = settings.Get<Conventions>();
-                var messageTypes = settings.GetAvailableTypes()
-                    .Where(conventions.IsMessageType).ToList();
-
                 var serializer = new XmlMessageSerializer(mapper, conventions);
 
                 string customNamespace;
@@ -41,6 +39,9 @@
                 {
                     serializer.SanitizeInput = sanitizeInput;
                 }
+
+                var registry = settings.Get<MessageMetadataRegistry>();
+                var messageTypes = registry.GetAllMessages().Select(m => m.MessageType);
 
                 serializer.Initialize(messageTypes);
                 return serializer;

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -69,7 +69,18 @@
             return new List<MessageMetadata>(messages.Values);
         }
 
-        internal MessageMetadata RegisterMessageType(Type messageType)
+        internal void RegisterMessageTypesFoundIn(IList<Type> availableTypes)
+        {
+            foreach (var type in availableTypes)
+            {
+                if (conventions.IsMessageType(type))
+                {
+                    RegisterMessageType(type);
+                }
+            }
+        }
+
+        MessageMetadata RegisterMessageType(Type messageType)
         {
             //get the parent types
             var parentMessages = GetParentTypes(messageType)


### PR DESCRIPTION
Closes #3938 