### PR TITLE
[SPIKE] Pipe poison messages through recoverability

### DIFF
--- a/src/NServiceBus.Core.Tests/Msmq/MsmqMessagePumpTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqMessagePumpTests.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Core.Tests.Msmq
         public void ShouldThrowIfConfiguredToReceiveFromRemoteQueue()
         {
             var messagePump = new MessagePump(mode => null);
-            var pushSettings = new PushSettings("queue@remote", "error", false, TransportTransactionMode.None);
+            var pushSettings = new PushSettings("queue@remote", false, TransportTransactionMode.None);
 
             var exception = Assert.Throws<Exception>(() =>
             {

--- a/src/NServiceBus.Core/Recoverability/DefaultRecoverabilityPolicy.cs
+++ b/src/NServiceBus.Core/Recoverability/DefaultRecoverabilityPolicy.cs
@@ -18,6 +18,11 @@ namespace NServiceBus
         /// <returns>The recoverability action.</returns>
         public static RecoverabilityAction Invoke(RecoverabilityConfig config, ErrorContext errorContext)
         {
+            if (errorContext.Message.IsPoison)
+            {
+                return RecoverabilityAction.MoveToError(config.Failed.ErrorQueue);
+            }
+
             if (errorContext.Exception is MessageDeserializationException)
             {
                 return RecoverabilityAction.MoveToError(config.Failed.ErrorQueue);

--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -37,13 +37,13 @@
         /// <summary>
         /// Initializes the error context.
         /// </summary>
-        public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, Stream bodyStream, TransportTransaction transportTransaction, int immediateProcessingFailures)
+        public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, Stream bodyStream, TransportTransaction transportTransaction, int immediateProcessingFailures, bool isPoison = false)
         {
             Exception = exception;
             TransportTransaction = transportTransaction;
             ImmediateProcessingFailures = immediateProcessingFailures;
 
-            Message = new IncomingMessage(transportMessageId, headers, bodyStream);
+            Message = new IncomingMessage(transportMessageId, headers, bodyStream, isPoison);
 
             DelayedDeliveriesPerformed = Message.GetDelayedDeliveriesPerformed();
 

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -15,11 +15,14 @@ namespace NServiceBus.Transport
         /// <param name="messageId">Native message id.</param>
         /// <param name="headers">The message headers.</param>
         /// <param name="bodyStream">The message body stream.</param>
-        public IncomingMessage(string messageId, Dictionary<string, string> headers, Stream bodyStream)
+        /// <param name="isPoison"></param>
+        public IncomingMessage(string messageId, Dictionary<string, string> headers, Stream bodyStream, bool isPoison = false)
         {
             Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
             Guard.AgainstNull(nameof(bodyStream), bodyStream);
             Guard.AgainstNull(nameof(headers), headers);
+
+            IsPoison = isPoison;
 
             string originalMessageId;
 
@@ -38,9 +41,17 @@ namespace NServiceBus.Transport
             Headers = headers;
             BodyStream = bodyStream;
 
-            body = new byte[bodyStream.Length];
-            bodyStream.Read(body, 0, body.Length);
+            if (!isPoison)
+            {
+                body = new byte[bodyStream.Length];
+                bodyStream.Read(body, 0, body.Length);
+            }
         }
+
+        /// <summary>
+        ///
+        /// </summary>
+        public bool IsPoison { get; }
 
         /// <summary>
         /// The id of the message.

--- a/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
@@ -30,7 +30,6 @@ namespace NServiceBus
             receiveCircuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker("MsmqReceive", TimeSpan.FromSeconds(30), ex => criticalError.Raise("Failed to receive from " + settings.InputQueue, ex));
 
             var inputAddress = MsmqAddress.Parse(settings.InputQueue);
-            var errorAddress = MsmqAddress.Parse(settings.ErrorQueue);
 
             if (!string.Equals(inputAddress.Machine, RuntimeEnvironment.MachineName, StringComparison.OrdinalIgnoreCase))
             {
@@ -38,7 +37,6 @@ namespace NServiceBus
             }
 
             inputQueue = new MessageQueue(inputAddress.FullPath, false, true, QueueAccessMode.Receive);
-            errorQueue = new MessageQueue(errorAddress.FullPath, false, true, QueueAccessMode.Send);
 
             if (settings.RequiredTransactionMode != TransportTransactionMode.None && !QueueIsTransactional())
             {
@@ -54,7 +52,7 @@ namespace NServiceBus
 
             receiveStrategy = receiveStrategyFactory(settings.RequiredTransactionMode);
 
-            receiveStrategy.Init(inputQueue, errorQueue, onMessage, onError, criticalError);
+            receiveStrategy.Init(inputQueue, onMessage, onError, criticalError);
 
             return TaskEx.CompletedTask;
         }
@@ -93,7 +91,6 @@ namespace NServiceBus
             concurrencyLimiter.Dispose();
             runningReceiveTasks.Clear();
             inputQueue.Dispose();
-            errorQueue.Dispose();
         }
 
         [DebuggerNonUserCode]
@@ -207,7 +204,6 @@ namespace NServiceBus
         CancellationToken cancellationToken;
         CancellationTokenSource cancellationTokenSource;
         SemaphoreSlim concurrencyLimiter;
-        MessageQueue errorQueue;
         MessageQueue inputQueue;
 
         Task messagePumpTask;

--- a/src/NServiceBus.Core/Transports/PushSettings.cs
+++ b/src/NServiceBus.Core/Transports/PushSettings.cs
@@ -9,30 +9,22 @@
         /// Creates an instance of <see cref="PushSettings" />.
         /// </summary>
         /// <param name="inputQueue">Input queue name.</param>
-        /// <param name="errorQueue">Error queue name.</param>
         /// <param name="purgeOnStartup"><code>true</code> to purge <paramref name="inputQueue" /> at startup.</param>
         /// <param name="requiredTransactionMode">The transaction mode required for receive operations.</param>
-        public PushSettings(string inputQueue, string errorQueue, bool purgeOnStartup, TransportTransactionMode requiredTransactionMode)
+        public PushSettings(string inputQueue, bool purgeOnStartup, TransportTransactionMode requiredTransactionMode)
         {
             Guard.AgainstNullAndEmpty(nameof(inputQueue), inputQueue);
-            Guard.AgainstNullAndEmpty(nameof(errorQueue), errorQueue);
             Guard.AgainstNull(nameof(requiredTransactionMode), requiredTransactionMode);
 
             PurgeOnStartup = purgeOnStartup;
             RequiredTransactionMode = requiredTransactionMode;
             InputQueue = inputQueue;
-            ErrorQueue = errorQueue;
         }
 
         /// <summary>
         /// The native queue to consume messages from.
         /// </summary>
         public string InputQueue { get; private set; }
-
-        /// <summary>
-        /// The native queue where to send corrupted messages to.
-        /// </summary>
-        public string ErrorQueue { get; private set; }
 
         /// <summary>
         /// Instructs the message pump to purge the `InputQueue` before starting to push messages from it.

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -76,10 +76,8 @@
             MessagePump = ReceiveInfrastructure.MessagePumpFactory();
 
             var queueBindings = new QueueBindings();
-            ErrorQueueName = $"{InputQueueName}.error";
 
             queueBindings.BindReceiving(InputQueueName);
-            queueBindings.BindSending(ErrorQueueName);
 
             var queueCreator = ReceiveInfrastructure.QueueCreatorFactory();
 
@@ -87,7 +85,7 @@
 
             transportSettings.Set<QueueBindings>(queueBindings);
 
-            var pushSettings = new PushSettings(InputQueueName, ErrorQueueName, true, transactionMode);
+            var pushSettings = new PushSettings(InputQueueName, true, transactionMode);
 
             await MessagePump.Init(onMessage, onError, new FakeCriticalError(onCriticalError), pushSettings);
 
@@ -165,7 +163,6 @@
         }
 
         protected string InputQueueName;
-        protected string ErrorQueueName;
 
         SettingsHolder transportSettings;
         Lazy<IDispatchMessages> lazyDispatcher;


### PR DESCRIPTION
This is a quick and 30 attempt to verify if it would be possible to pipe poison messages through normal recoverability. The benefit of that is:

* Pump no longer has to deal with error queues
* Recoverability policy controls also poison messages
* Custom recoverability policy could essentially override the behavior if desired
* Poison messages go through the dispatcher as well

![image](https://cloud.githubusercontent.com/assets/174258/16991750/f6c9c998-4e9c-11e6-8b31-db1dd8dca405.png)

@Particular/nservicebus-maintainers @Particular/azure-service-bus-maintainers @Particular/azure-storage-queues-maintainers @Particular/rabbitmq-transport-maintainers @Particular/sqlserver-transport-maintainers  is that something we should tackle as part of the recoverability changes since it would affect the PushSettings?

