### PR TITLE
Add subscription behavior acceptance test

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Recoverability\Retries\When_custom_policy_provided.cs" />
     <Compile Include="Recoverability\When_custom_policy_moves_to_overridden_error_queue.cs" />
     <Compile Include="Recoverability\When_message_is_moved_to_error_queue_with_header_customizations.cs" />
+    <Compile Include="Routing\When_subscribing_to_scaled_out_publisher_on_unicast_transport.cs" />
     <Compile Include="Serialization\When_configuring_custom_xml_namespace.cs" />
     <Compile Include="Serialization\When_registering_additional_deserializers.cs" />
     <Compile Include="Basic\When_no_content_type.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/When_subscribing_to_scaled_out_publisher_on_unicast_transport.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_subscribing_to_scaled_out_publisher_on_unicast_transport.cs
@@ -1,0 +1,69 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using Configuration.AdvanceExtensibility;
+    using EndpointTemplates;
+    using NServiceBus.Routing;
+    using NServiceBus.Routing.MessageDrivenSubscriptions;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_subscribing_to_scaled_out_publisher_on_unicast_transport : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public Task Should_send_subscription_message_to_each_instance()
+        {
+            return Scenario.Define<Context>()
+                .WithEndpoint<ScaledOutPublisher>(b => b.CustomConfig(c => c.MakeInstanceUniquelyAddressable("1")))
+                .WithEndpoint<ScaledOutPublisher>(b => b.CustomConfig(c => c.MakeInstanceUniquelyAddressable("2")))
+                .WithEndpoint<Subscriber>(b => b.When(s => s.Subscribe<MyEvent>()))
+                .Done(c => c.PublisherReceivedSubscription.Count >= 2)
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Should(c =>
+                {
+                    // each instance should receive a subscription message
+                    Assert.That(c.PublisherReceivedSubscription, Does.Contain("1"));
+                    Assert.That(c.PublisherReceivedSubscription, Does.Contain("2"));
+                    Assert.That(c.PublisherReceivedSubscription.Count, Is.EqualTo(2));
+                })
+                .Run();
+        }
+
+        class Context : ScenarioContext
+        {
+            public List<string> PublisherReceivedSubscription { get; } = new List<string>();
+        }
+
+        class ScaledOutPublisher : EndpointConfigurationBuilder
+        {
+            public ScaledOutPublisher()
+            {
+                // store the instance discriminator of each instance receiving a subscription message:
+                EndpointSetup<DefaultServer>(c => c
+                    .OnEndpointSubscribed<Context>((subscription, context) =>
+                        context.PublisherReceivedSubscription.Add(c.GetSettings().Get<string>("EndpointInstanceDiscriminator"))));
+            }
+        }
+
+        class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    // configure the scaled out publisher instances:
+                    var publisherName = Conventions.EndpointNamingConvention(typeof(ScaledOutPublisher));
+                    c.GetSettings().GetOrCreate<Publishers>().Add(typeof(MyEvent), publisherName);
+                    c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(publisherName, "1"), new EndpointInstance(publisherName, "2"));
+                });
+            }
+        }
+
+        class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Routing/When_using_assembly_level_message_mapping_for_pub_sub.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_using_assembly_level_message_mapping_for_pub_sub.cs
@@ -102,14 +102,14 @@
                 }
             }
         }
-        
+
         public class MyEvent : IEvent
         {
         }
-        
+
         public class DoneCommand : ICommand
         {
-            
+
         }
     }
 }


### PR DESCRIPTION
Connects to Particular/V6Launch#68

Tests that we send a subscription message to each instance of a logical endpoint and that we do not use a distribution strategy.

@Particular/nservicebus-maintainers @SzymonPobiega @DavidBoike please review