### PR TITLE
Removing the stream from MessageContext and ErrorContext

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -3002,7 +3002,7 @@ namespace NServiceBus.Transport
     }
     public class ErrorContext
     {
-        public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, System.IO.Stream bodyStream, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures) { }
+        public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures) { }
         public int DelayedDeliveriesPerformed { get; }
         public System.Exception Exception { get; }
         public int ImmediateProcessingFailures { get; }
@@ -3033,9 +3033,8 @@ namespace NServiceBus.Transport
     }
     public class IncomingMessage
     {
-        public IncomingMessage(string messageId, System.Collections.Generic.Dictionary<string, string> headers, System.IO.Stream bodyStream) { }
+        public IncomingMessage(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body) { }
         public byte[] Body { get; }
-        public System.IO.Stream BodyStream { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public string MessageId { get; }
     }
@@ -3062,8 +3061,8 @@ namespace NServiceBus.Transport
     }
     public class MessageContext
     {
-        public MessageContext(string messageId, System.Collections.Generic.Dictionary<string, string> headers, System.IO.Stream bodyStream, NServiceBus.Transport.TransportTransaction transportTransaction, System.Threading.CancellationTokenSource receiveCancellationTokenSource, NServiceBus.Extensibility.ContextBag context) { }
-        public System.IO.Stream BodyStream { get; }
+        public MessageContext(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, System.Threading.CancellationTokenSource receiveCancellationTokenSource, NServiceBus.Extensibility.ContextBag context) { }
+        public byte[] Body { get; }
         public NServiceBus.Extensibility.ContextBag Context { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public string MessageId { get; }

--- a/src/NServiceBus.Core.Tests/Causation/AttachCausationHeadersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Causation/AttachCausationHeadersBehaviorTests.cs
@@ -2,12 +2,11 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Threading.Tasks;
     using NServiceBus.Pipeline;
-    using Transport;
     using NUnit.Framework;
     using Testing;
+    using Transport;
 
     [TestFixture]
     public class AttachCausationHeadersBehaviorTests
@@ -18,11 +17,11 @@
             var behavior = new AttachCausationHeadersBehavior();
             var context = InitializeContext();
 
-            await behavior.Invoke(context, ()=> TaskEx.CompletedTask);
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
 
             Assert.AreNotEqual(Guid.Empty.ToString(), context.Headers[Headers.ConversationId]);
         }
-        
+
         [Test]
         public async Task Should_set_the_conversation_id_to_conversation_id_of_incoming_message()
         {
@@ -31,7 +30,10 @@
             var behavior = new AttachCausationHeadersBehavior();
             var context = InitializeContext();
 
-            var transportMessage = new IncomingMessage("xyz", new Dictionary<string, string> { { Headers.ConversationId, incomingConversationId } }, Stream.Null);
+            var transportMessage = new IncomingMessage("xyz", new Dictionary<string, string>
+            {
+                {Headers.ConversationId, incomingConversationId}
+            }, new byte[0]);
             context.Extensions.Set(transportMessage);
 
             await behavior.Invoke(context, () => TaskEx.CompletedTask);
@@ -39,7 +41,7 @@
             Assert.AreEqual(incomingConversationId, context.Headers[Headers.ConversationId]);
         }
 
-        [Test,Ignore("Will be refactored to use a explicit override via options instead and not rely on the header being set")]
+        [Test, Ignore("Will be refactored to use a explicit override via options instead and not rely on the header being set")]
         public async Task Should_not_override_a_conversation_id_specified_by_the_user()
         {
             var userConversationId = Guid.NewGuid().ToString();
@@ -47,7 +49,7 @@
             var behavior = new AttachCausationHeadersBehavior();
             var context = InitializeContext();
 
-            
+
             await behavior.Invoke(context, () => TaskEx.CompletedTask);
 
             Assert.AreEqual(userConversationId, context.Headers[Headers.ConversationId]);
@@ -56,11 +58,10 @@
         [Test]
         public async Task Should_set_the_related_to_header_with_the_id_of_the_current_message()
         {
-            
             var behavior = new AttachCausationHeadersBehavior();
             var context = InitializeContext();
 
-            context.Extensions.Set(new IncomingMessage("the message id", new Dictionary<string, string>(), Stream.Null));
+            context.Extensions.Set(new IncomingMessage("the message id", new Dictionary<string, string>(), new byte[0]));
 
             await behavior.Invoke(context, () => TaskEx.CompletedTask);
 

--- a/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/DispatchTimeoutBehaviorTest.cs
+++ b/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/DispatchTimeoutBehaviorTest.cs
@@ -2,14 +2,13 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Extensibility;
     using NServiceBus.Timeout.Core;
-    using Transport;
     using NUnit.Framework;
+    using Transport;
 
     public class DispatchTimeoutBehaviorTest
     {
@@ -119,7 +118,7 @@
                 {"Timeout.Id", timeoutId}
             };
 
-            return new MessageContext(messageId, headers, Stream.Null, new TransportTransaction(), new CancellationTokenSource(), new ContextBag());
+            return new MessageContext(messageId, headers, new byte[0], new TransportTransaction(), new CancellationTokenSource(), new ContextBag());
         }
 
         class FakeMessageDispatcher : IDispatchMessages
@@ -135,11 +134,6 @@
 
         class FailingMessageDispatcher : IDispatchMessages
         {
-            public Task Dispatch(IEnumerable<TransportOperation> outgoingMessages, ContextBag context)
-            {
-                throw new Exception("simulated exception");
-            }
-
             public Task Dispatch(TransportOperations outgoingMessages, ContextBag context)
             {
                 throw new Exception("simulated exception");
@@ -148,6 +142,9 @@
 
         class FakeTimeoutStorage : IPersistTimeouts
         {
+            public Func<string, ContextBag, bool> OnTryRemove { get; set; } = (id, bag) => true;
+            public Func<string, ContextBag, TimeoutData> OnPeek { get; set; } = (id, bag) => null;
+
             public Task Add(TimeoutData timeout, ContextBag context)
             {
                 return TaskEx.CompletedTask;
@@ -167,9 +164,6 @@
             {
                 return TaskEx.CompletedTask;
             }
-
-            public Func<string, ContextBag, bool> OnTryRemove { get; set; } = (id, bag) => true;
-            public Func<string, ContextBag, TimeoutData> OnPeek { get; set; } = (id, bag) => null;
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateOutgoingMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateOutgoingMessageBehaviorTests.cs
@@ -1,13 +1,12 @@
 ﻿namespace NServiceBus.Core.Tests.Pipeline.MutateInstanceMessage
 {
     using System.Collections.Generic;
-    using System.IO;
     using System.Threading.Tasks;
     using MessageMutator;
     using NServiceBus.Pipeline;
-    using Transport;
     using NUnit.Framework;
     using Testing;
+    using Transport;
 
     [TestFixture]
     class MutateOutgoingMessageBehaviorTests
@@ -18,7 +17,7 @@
             var behavior = new MutateOutgoingMessageBehavior();
 
             var context = new TestableOutgoingLogicalMessageContext();
-            context.Extensions.Set(new IncomingMessage("messageId", new Dictionary<string, string>(), Stream.Null ));
+            context.Extensions.Set(new IncomingMessage("messageId", new Dictionary<string, string>(), new byte[0]));
             context.Extensions.Set(new LogicalMessage(null, null));
             context.Builder.Register<IMutateOutgoingMessages>(() => new MutateOutgoingMessagesReturnsNull());
 

--- a/src/NServiceBus.Core.Tests/Recoverability/DefaultRecoverabilityPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/DefaultRecoverabilityPolicyTests.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using NUnit.Framework;
     using Transport;
 
@@ -157,7 +156,7 @@
             return new ErrorContext(exception ?? new Exception(), retryNumber.HasValue ? new Dictionary<string, string>
             {
                 {Headers.Retries, retryNumber.ToString()}
-            } : headers ?? new Dictionary<string, string>(), "message-id", new MemoryStream(), new TransportTransaction(), numberOfDeliveryAttempts);
+            } : headers ?? new Dictionary<string, string>(), "message-id", new byte[0], new TransportTransaction(), numberOfDeliveryAttempts);
         }
 
         static Func<ErrorContext, RecoverabilityAction> CreatePolicy(int maxImmediateRetries = 2, int maxDelayedRetries = 2, TimeSpan? delayedRetryDelay = null)

--- a/src/NServiceBus.Core.Tests/Recoverability/DelayedRetryExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/DelayedRetryExecutorTests.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
     using DelayedDelivery;
@@ -111,7 +110,7 @@
 
         IncomingMessage CreateMessage(Dictionary<string, string> headers = null)
         {
-            return new IncomingMessage("messageId", headers ?? new Dictionary<string, string>(), Stream.Null);
+            return new IncomingMessage("messageId", headers ?? new Dictionary<string, string>(), new byte[0]);
         }
 
         DelayedRetryExecutor CreateExecutor(bool nativeDeferralsOn = true)

--- a/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Threading.Tasks;
     using Extensibility;
     using NUnit.Framework;
@@ -148,7 +147,7 @@
 
         static ErrorContext CreateErrorContext(Exception raisedException = null, string exceptionMessage = "default-message", string messageId = "default-id", int numberOfDeliveryAttempts = 1)
         {
-            return new ErrorContext(raisedException ?? new Exception(exceptionMessage), new Dictionary<string, string>(), messageId, Stream.Null, new TransportTransaction(), numberOfDeliveryAttempts);
+            return new ErrorContext(raisedException ?? new Exception(exceptionMessage), new Dictionary<string, string>(), messageId, new byte[0], new TransportTransaction(), numberOfDeliveryAttempts);
         }
 
         RecoverabilityExecutor CreateExecutor(Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> policy, bool delayedRetriesSupported = true, bool immediateRetriesSupported = true, bool raiseNotifications = true)

--- a/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageProcessingConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageProcessingConnectorTests.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
     using DelayedDelivery;
@@ -11,9 +10,9 @@
     using NServiceBus.Performance.TimeToBeReceived;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
-    using Transport;
     using NUnit.Framework;
     using Testing;
+    using Transport;
     using TransportOperation = Transport.TransportOperation;
 
     [TestFixture]
@@ -71,7 +70,7 @@
 
             options["Destination"] = "myEndpoint";
 
-            fakeOutbox.ExistingMessage = new OutboxMessage(messageId, new []
+            fakeOutbox.ExistingMessage = new OutboxMessage(messageId, new[]
             {
                 new NServiceBus.Outbox.TransportOperation("x", options, new byte[0], new Dictionary<string, string>())
             });
@@ -95,7 +94,7 @@
 
             options["EventType"] = typeof(MyEvent).AssemblyQualifiedName;
 
-            fakeOutbox.ExistingMessage = new OutboxMessage(messageId, new []
+            fakeOutbox.ExistingMessage = new OutboxMessage(messageId, new[]
             {
                 new NServiceBus.Outbox.TransportOperation("x", options, new byte[0], new Dictionary<string, string>())
             });
@@ -114,7 +113,7 @@
         {
             var context = new TestableTransportReceiveContext
             {
-                Message = new IncomingMessage(messageId, new Dictionary<string, string>(), Stream.Null)
+                Message = new IncomingMessage(messageId, new Dictionary<string, string>(), new byte[0])
             };
 
             context.Extensions.Set<IPipelineCache>(new FakePipelineCache(pipeline));

--- a/src/NServiceBus.Core.Tests/Routing/ApplyReplyToAddressBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/ApplyReplyToAddressBehaviorTests.cs
@@ -2,13 +2,12 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Threading.Tasks;
     using Extensibility;
     using NServiceBus.Pipeline;
-    using Transport;
     using NUnit.Framework;
     using Testing;
+    using Transport;
 
     [TestFixture]
     public class ApplyReplyToAddressBehaviorTests
@@ -27,8 +26,11 @@
 
         static IOutgoingLogicalMessageContext CreateContext(ExtendableOptions options)
         {
-            var context = new TestableOutgoingLogicalMessageContext { Extensions = options.Context };
-            
+            var context = new TestableOutgoingLogicalMessageContext
+            {
+                Extensions = options.Context
+            };
+
             return context;
         }
 
@@ -95,8 +97,8 @@
 
             context.Extensions.Set(new IncomingMessage("ID", new Dictionary<string, string>
             {
-                { LegacyDistributorHeaders.WorkerSessionId, "SessionID" }
-            }, new MemoryStream()));
+                {LegacyDistributorHeaders.WorkerSessionId, "SessionID"}
+            }, new byte[0]));
 
             var state = context.Extensions.GetOrCreate<ApplyReplyToAddressBehavior.State>();
             state.Option = ApplyReplyToAddressBehavior.RouteOption.RouteReplyToThisInstance;
@@ -146,10 +148,6 @@
             {
                 Assert.Pass();
             }
-        }
-
-        class MyMessage
-        {
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
@@ -2,14 +2,13 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
-    using Transport;
     using NUnit.Framework;
     using Testing;
+    using Transport;
 
     [TestFixture]
     public class DetermineRouteForReplyBehaviorTests
@@ -25,14 +24,14 @@
                 "id",
                 new Dictionary<string, string>
                 {
-                    { Headers.ReplyToAddress, "ReplyAddressOfIncomingMessage" }
+                    {Headers.ReplyToAddress, "ReplyAddressOfIncomingMessage"}
                 },
-                Stream.Null));
+                new byte[0]));
 
             UnicastAddressTag addressTag = null;
             await behavior.Invoke(context, c =>
             {
-                addressTag = (UnicastAddressTag)c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
+                addressTag = (UnicastAddressTag) c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
                 return TaskEx.CompletedTask;
             });
 
@@ -49,7 +48,7 @@
             context.Extensions.Set(new IncomingMessage(
                 "id",
                 new Dictionary<string, string>(),
-                Stream.Null));
+                new byte[0]));
 
             Assert.That(async () => await behavior.Invoke(context, _ => TaskEx.CompletedTask), Throws.InstanceOf<Exception>().And.Message.Contains(typeof(MyReply).FullName));
         }
@@ -68,7 +67,7 @@
             UnicastAddressTag addressTag = null;
             await behavior.Invoke(context, c =>
             {
-                addressTag = (UnicastAddressTag)c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
+                addressTag = (UnicastAddressTag) c.RoutingStrategies.Single().Apply(new Dictionary<string, string>());
                 return TaskEx.CompletedTask;
             });
 

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
@@ -50,15 +50,12 @@ namespace NServiceBus
                 {
                     destination = routeExpiredTimeoutTo;
                 }
-                var body = new byte[context.BodyStream.Length];
-
-                await context.BodyStream.ReadAsync(body, 0, body.Length).ConfigureAwait(false);
 
                 var data = new TimeoutData
                 {
                     Destination = destination,
                     SagaId = sagaId,
-                    State = body,
+                    State = context.Body,
                     Time = DateTimeExtensions.ToUtcDateTime(expire),
                     Headers = context.Headers,
                     OwningTimeoutManager = owningTimeoutManager

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -24,7 +24,7 @@ namespace NServiceBus
             {
                 var rootContext = new RootContext(childBuilder, pipelineCache, eventAggregator);
 
-                var message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.BodyStream);
+                var message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.Body);
                 var context = new TransportReceiveContext(message, messageContext.TransportTransaction, messageContext.ReceiveCancellationTokenSource, rootContext);
 
                 context.Extensions.Merge(messageContext.Context);

--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -2,13 +2,26 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
 
     /// <summary>
     /// The context for messages that has failed processing.
     /// </summary>
     public class ErrorContext
     {
+        /// <summary>
+        /// Initializes the error context.
+        /// </summary>
+        public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, byte[] body, TransportTransaction transportTransaction, int immediateProcessingFailures)
+        {
+            Exception = exception;
+            TransportTransaction = transportTransaction;
+            ImmediateProcessingFailures = immediateProcessingFailures;
+
+            Message = new IncomingMessage(transportMessageId, headers, body);
+
+            DelayedDeliveriesPerformed = Message.GetDelayedDeliveriesPerformed();
+        }
+
         /// <summary>
         /// Exception that caused the message processing to fail.
         /// </summary>
@@ -33,22 +46,5 @@
         /// Failed incoming message.
         /// </summary>
         public IncomingMessage Message { get; }
-
-        /// <summary>
-        /// Initializes the error context.
-        /// </summary>
-        public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, Stream bodyStream, TransportTransaction transportTransaction, int immediateProcessingFailures)
-        {
-            Exception = exception;
-            TransportTransaction = transportTransaction;
-            ImmediateProcessingFailures = immediateProcessingFailures;
-
-            Message = new IncomingMessage(transportMessageId, headers, bodyStream);
-
-            DelayedDeliveriesPerformed = Message.GetDelayedDeliveriesPerformed();
-
-            //Incoming message reads the body stream so we need to rewind it
-            Message.BodyStream.Position = 0;
-        }
     }
 }

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.Transport
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
 
     /// <summary>
     /// The raw message coming from the transport.
@@ -14,11 +13,11 @@ namespace NServiceBus.Transport
         /// </summary>
         /// <param name="messageId">Native message id.</param>
         /// <param name="headers">The message headers.</param>
-        /// <param name="bodyStream">The message body stream.</param>
-        public IncomingMessage(string messageId, Dictionary<string, string> headers, Stream bodyStream)
+        /// <param name="body">The message body.</param>
+        public IncomingMessage(string messageId, Dictionary<string, string> headers, byte[] body)
         {
             Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
-            Guard.AgainstNull(nameof(bodyStream), bodyStream);
+            Guard.AgainstNull(nameof(body), body);
             Guard.AgainstNull(nameof(headers), headers);
 
             string originalMessageId;
@@ -36,10 +35,8 @@ namespace NServiceBus.Transport
 
 
             Headers = headers;
-            BodyStream = bodyStream;
 
-            Body = new byte[bodyStream.Length];
-            bodyStream.Read(Body, 0, Body.Length);
+            Body = body;
         }
 
         /// <summary>
@@ -51,11 +48,6 @@ namespace NServiceBus.Transport
         /// The message headers.
         /// </summary>
         public Dictionary<string, string> Headers { get; private set; }
-
-        /// <summary>
-        /// The message body.
-        /// </summary>
-        public Stream BodyStream { get; private set; }
 
         /// <summary>
         /// Gets/sets a byte array to the body content of the message.

--- a/src/NServiceBus.Core/Transports/MessageContext.cs
+++ b/src/NServiceBus.Core/Transports/MessageContext.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Transport
 {
     using System.Collections.Generic;
-    using System.IO;
     using System.Threading;
     using Extensibility;
 
@@ -15,7 +14,7 @@
         /// </summary>
         /// <param name="messageId">Native message id.</param>
         /// <param name="headers">The message headers.</param>
-        /// <param name="bodyStream">The message body stream.</param>
+        /// <param name="body">The message body.</param>
         /// <param name="transportTransaction">Transaction (along with connection if applicable) used to receive the message.</param>
         /// <param name="receiveCancellationTokenSource">
         /// Allows the pipeline to flag that it has been aborted and the receive operation should be rolled back.
@@ -23,17 +22,17 @@
         /// has been aborted after invoking the pipeline and roll back the message accordingly.
         /// </param>
         /// <param name="context">Any context that the transport wants to be available on the pipeline.</param>
-        public MessageContext(string messageId, Dictionary<string, string> headers, Stream bodyStream, TransportTransaction transportTransaction, CancellationTokenSource receiveCancellationTokenSource, ContextBag context)
+        public MessageContext(string messageId, Dictionary<string, string> headers, byte[] body, TransportTransaction transportTransaction, CancellationTokenSource receiveCancellationTokenSource, ContextBag context)
         {
             Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
-            Guard.AgainstNull(nameof(bodyStream), bodyStream);
+            Guard.AgainstNull(nameof(body), body);
             Guard.AgainstNull(nameof(headers), headers);
             Guard.AgainstNull(nameof(transportTransaction), transportTransaction);
             Guard.AgainstNull(nameof(receiveCancellationTokenSource), receiveCancellationTokenSource);
             Guard.AgainstNull(nameof(context), context);
 
             Headers = headers;
-            BodyStream = bodyStream;
+            Body = body;
             MessageId = messageId;
             Context = context;
             TransportTransaction = transportTransaction;
@@ -53,7 +52,7 @@
         /// <summary>
         /// The message body.
         /// </summary>
-        public Stream BodyStream { get; }
+        public byte[] Body { get; }
 
         /// <summary>
         /// Transaction (along with connection if applicable) used to receive the message.

--- a/src/NServiceBus.Testing.Fakes/TestableIncomingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableIncomingPhysicalMessageContext.cs
@@ -1,9 +1,9 @@
 ﻿// ReSharper disable PartialTypeWithSinglePart
+
 namespace NServiceBus.Testing
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using Pipeline;
     using Transport;
 
@@ -17,7 +17,7 @@ namespace NServiceBus.Testing
         /// </summary>
         public TestableIncomingPhysicalMessageContext()
         {
-            Message = new IncomingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), Stream.Null);
+            Message = new IncomingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[] { });
         }
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace NServiceBus.Testing
         /// </summary>
         public virtual void UpdateMessage(byte[] body)
         {
-            Message = new IncomingMessage(Message.MessageId, Message.Headers, new MemoryStream(body));
+            Message = new IncomingMessage(Message.MessageId, Message.Headers, body);
         }
 
         /// <summary>

--- a/src/NServiceBus.Testing.Fakes/TestableSatelliteProcessingContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableSatelliteProcessingContext.cs
@@ -3,19 +3,18 @@ namespace NServiceBus.Testing
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using Pipeline;
     using Transport;
 
     /// <summary>
     /// A testable implementation of <see cref="ISatelliteProcessingContext" />.
     /// </summary>
-    
+
     public partial class TestableSatelliteProcessingContext : TestableBehaviorContext, ISatelliteProcessingContext
     {
         /// <summary>
         /// The physical message being processed.
         /// </summary>
-        public IncomingMessage Message { get; set; } = new IncomingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), Stream.Null);
+        public IncomingMessage Message { get; set; } = new IncomingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]);
     }
 }

--- a/src/NServiceBus.Testing.Fakes/TestableTransportReceiveContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableTransportReceiveContext.cs
@@ -1,9 +1,9 @@
 ﻿// ReSharper disable PartialTypeWithSinglePart
+
 namespace NServiceBus.Testing
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using Pipeline;
     using Transport;
 
@@ -28,6 +28,6 @@ namespace NServiceBus.Testing
         /// <summary>
         /// The physical message being processed.
         /// </summary>
-        public IncomingMessage Message { get; set; } = new IncomingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), Stream.Null);
+        public IncomingMessage Message { get; set; } = new IncomingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]);
     }
 }

--- a/src/NServiceBus.TransportTests/When_message_is_available.cs
+++ b/src/NServiceBus.TransportTests/When_message_is_available.cs
@@ -1,7 +1,7 @@
 namespace NServiceBus.TransportTests
 {
     using System.Collections.Generic;
-    using System.IO;
+    using System.Text;
     using System.Threading.Tasks;
     using NUnit.Framework;
     using Transport;
@@ -18,17 +18,21 @@ namespace NServiceBus.TransportTests
 
             OnTestTimeout(() => onMessageCalled.SetCanceled());
 
-            await StartPump(async context =>
+            await StartPump(context =>
             {
-                var body = await new StreamReader(context.BodyStream).ReadToEndAsync();
+                var body = Encoding.UTF8.GetString(context.Body);
 
                 Assert.AreEqual("", body, "Should pass the body");
 
                 onMessageCalled.SetResult(context);
+                return Task.FromResult(0);
             },
                 context => Task.FromResult(ErrorHandleResult.Handled), transactionMode);
 
-            await SendMessage(InputQueueName, new Dictionary<string, string> { { "MyHeader", "MyValue" } });
+            await SendMessage(InputQueueName, new Dictionary<string, string>
+            {
+                {"MyHeader", "MyValue"}
+            });
 
             var messageContext = await onMessageCalled.Task;
 

--- a/src/NServiceBus.TransportTests/When_on_message_throws.cs
+++ b/src/NServiceBus.TransportTests/When_on_message_throws.cs
@@ -20,7 +20,6 @@ namespace NServiceBus.TransportTests
 
             await StartPump(context =>
             {
-                context.BodyStream.Position = 1;
                 throw new Exception("Simulated exception");
             },
                 context =>
@@ -36,7 +35,6 @@ namespace NServiceBus.TransportTests
 
             Assert.AreEqual(errorContext.Exception.Message, "Simulated exception", "Should preserve the exception");
             Assert.AreEqual(1, errorContext.ImmediateProcessingFailures, "Should track the number of delivery attempts");
-            Assert.AreEqual(0, errorContext.Message.BodyStream.Position, "Should rewind the stream");
             Assert.AreEqual("MyValue", errorContext.Message.Headers["MyHeader"], "Should pass the message headers");
         }
     }


### PR DESCRIPTION
@bording brought up a good point that for some transports the transport gets a byte array, turns that into a memory stream to pass it into the core just so that incoming message turns that again into a byte array. That doesn't make sense. Let's face it, core is not ready to properly handle streams. This PR backtracks that. WIP PRs all submitted to transports to show the influence.

* Azure Service Bus influence https://github.com/Particular/NServiceBus.AzureServiceBus/pull/285
* Azure Storage Queue influence https://github.com/Particular/NServiceBus.AzureStorageQueues/pull/137
* Sql Server influence https://github.com/Particular/NServiceBus.SqlServer/pull/282
* RabbitMQ influence https://github.com/Particular/NServiceBus.RabbitMQ/pull/186