### PR TITLE
Incoming message body can only be updated from the core

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -3028,7 +3028,7 @@ namespace NServiceBus.Transport
     public class IncomingMessage
     {
         public IncomingMessage(string messageId, System.Collections.Generic.Dictionary<string, string> headers, System.IO.Stream bodyStream) { }
-        public byte[] Body { get; set; }
+        public byte[] Body { get; }
         public System.IO.Stream BodyStream { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public string MessageId { get; }

--- a/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
@@ -61,7 +61,7 @@
         {
             var originalMessageBody = Encoding.UTF8.GetBytes("message body");
             var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), new MemoryStream(originalMessageBody));
-            incomingMessage.Body = Encoding.UTF8.GetBytes("new body");
+            incomingMessage.UpdateBody(Encoding.UTF8.GetBytes("new body"));
 
             await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, new Exception(), new TransportTransaction());
 

--- a/src/NServiceBus.Core/Pipeline/Incoming/IncomingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IncomingPhysicalMessageContext.cs
@@ -15,7 +15,7 @@
 
         public void UpdateMessage(byte[] body)
         {
-            Message.Body = body;
+            Message.UpdateBody(body);
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -38,8 +38,8 @@ namespace NServiceBus.Transport
             Headers = headers;
             BodyStream = bodyStream;
 
-            body = new byte[bodyStream.Length];
-            bodyStream.Read(body, 0, body.Length);
+            Body = new byte[bodyStream.Length];
+            bodyStream.Read(Body, 0, Body.Length);
         }
 
         /// <summary>
@@ -60,25 +60,21 @@ namespace NServiceBus.Transport
         /// <summary>
         /// Gets/sets a byte array to the body content of the message.
         /// </summary>
-        public byte[] Body
-        {
-            get { return body; }
-            set { UpdateBody(value); }
-        }
+        public byte[] Body { get; private set; }
 
         /// <summary>
         /// Use this method to update the body if this message.
         /// </summary>
-        void UpdateBody(byte[] updatedBody)
+        internal void UpdateBody(byte[] updatedBody)
         {
             //preserve the original body if needed
-            if (body != null && originalBody == null)
+            if (Body != null && originalBody == null)
             {
-                originalBody = new byte[body.Length];
-                Buffer.BlockCopy(body, 0, originalBody, 0, body.Length);
+                originalBody = new byte[Body.Length];
+                Buffer.BlockCopy(Body, 0, originalBody, 0, Body.Length);
             }
 
-            body = updatedBody;
+            Body = updatedBody;
         }
 
         /// <summary>
@@ -88,11 +84,10 @@ namespace NServiceBus.Transport
         {
             if (originalBody != null)
             {
-                body = originalBody;
+                Body = originalBody;
             }
         }
 
-        byte[] body;
         byte[] originalBody;
     }
 }

--- a/src/NServiceBus.Testing.Fakes/TestableIncomingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableIncomingPhysicalMessageContext.cs
@@ -12,17 +12,22 @@ namespace NServiceBus.Testing
     /// </summary>
     public partial class TestableIncomingPhysicalMessageContext : TestableIncomingContext, IIncomingPhysicalMessageContext
     {
+        public TestableIncomingPhysicalMessageContext()
+        {
+            Message = new IncomingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), Stream.Null);
+        }
+
         /// <summary>
         /// Updates the message with the given body.
         /// </summary>
         public virtual void UpdateMessage(byte[] body)
         {
-            Message.Body = body;
+            Message = new IncomingMessage(Message.MessageId, Message.Headers, new MemoryStream(body));
         }
 
         /// <summary>
         /// The physical message being processed.
         /// </summary>
-        public IncomingMessage Message { get; set; } = new IncomingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), Stream.Null);
+        public IncomingMessage Message { get; set; }
     }
 }


### PR DESCRIPTION
Prevents that `IncomingMessage` body can be set by something from the outside. Only core infrastructure can update the body.

@tmasternak this would mean we could remove the `RevertMessageBody` from the `MoveToErrorExecutor`.