### PR TITLE
Unicast router optimizations

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -3411,7 +3411,8 @@ namespace NServiceBus.Unicast.Messages
 {
     public class MessageMetadata
     {
-        public MessageMetadata(System.Type messageType, System.Collections.Generic.IEnumerable<System.Type> messageHierarchy = null) { }
+        public MessageMetadata(System.Type messageType) { }
+        public MessageMetadata(System.Type messageType, System.Type[] messageHierarchy) { }
         public System.Type[] MessageHierarchy { get; }
         public System.Type MessageType { get; }
         [System.ObsoleteAttribute("You can access Recoverable via the DeliveryConstraints collection on the outgoing" +

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -3412,7 +3412,7 @@ namespace NServiceBus.Unicast.Messages
     public class MessageMetadata
     {
         public MessageMetadata(System.Type messageType, System.Collections.Generic.IEnumerable<System.Type> messageHierarchy = null) { }
-        public System.Collections.Generic.IEnumerable<System.Type> MessageHierarchy { get; }
+        public System.Type[] MessageHierarchy { get; }
         public System.Type MessageType { get; }
         [System.ObsoleteAttribute("You can access Recoverable via the DeliveryConstraints collection on the outgoing" +
             " context, the new constraint is called NonDurableDelivery. The member currently " +

--- a/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehaviorTests.cs
@@ -21,9 +21,9 @@
             {
                 Message = logicalMessage
             };
-            
+
             context.Builder.Register<IMutateIncomingMessages>(() => new MutateIncomingMessagesReturnsNull());
-            
+
             Assert.That(async () => await behavior.Invoke(context, () => TaskEx.CompletedTask), Throws.Exception.With.Message.EqualTo("Return a Task or mark the method as async."));
         }
 

--- a/src/NServiceBus.Core/Routing/UnicastRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRouter.cs
@@ -28,10 +28,14 @@ namespace NServiceBus
                 .ToArray();
 
             var routes = await GetDestinations(contextBag, typesToRoute).ConfigureAwait(false);
-            var destinations = new List<UnicastRoutingTarget>();
+            var destinations = new HashSet<UnicastRoutingTarget>();
             foreach (var route in routes)
             {
-                destinations.AddRange(await route.Resolve(InstanceResolver).ConfigureAwait(false));
+                var routingTargets = await route.Resolve(InstanceResolver).ConfigureAwait(false);
+                foreach (var routingTarget in routingTargets)
+                {
+                    destinations.Add(routingTarget);
+                }
             }
 
             var selectedDestinations = SelectDestinationsForEachEndpoint(distributionPolicy, destinations);
@@ -49,7 +53,7 @@ namespace NServiceBus
             return endpointInstances.FindInstances(endpoint);
         }
 
-        static IEnumerable<UnicastRoutingTarget> SelectDestinationsForEachEndpoint(IDistributionPolicy distributionPolicy, List<UnicastRoutingTarget> destinations)
+        static IEnumerable<UnicastRoutingTarget> SelectDestinationsForEachEndpoint(IDistributionPolicy distributionPolicy, HashSet<UnicastRoutingTarget> destinations)
         {
             var destinationsByEndpoint = destinations
                 .GroupBy(d => d.Endpoint, d => d);

--- a/src/NServiceBus.Core/Routing/UnicastRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRouter.cs
@@ -22,10 +22,7 @@ namespace NServiceBus
 
         public async Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, IDistributionPolicy distributionPolicy, ContextBag contextBag)
         {
-            var typesToRoute = messageMetadataRegistry.GetMessageMetadata(messageType)
-                .MessageHierarchy
-                .Distinct()
-                .ToArray();
+            var typesToRoute = messageMetadataRegistry.GetMessageMetadata(messageType).MessageHierarchy;
 
             var routes = await GetDestinations(contextBag, typesToRoute).ConfigureAwait(false);
             var destinations = new HashSet<UnicastRoutingTarget>();

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadata.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadata.cs
@@ -2,12 +2,15 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Message metadata class.
     /// </summary>
     public partial class MessageMetadata
     {
+        static Type[] emptyHierarchy = new Type[0];
+
         /// <summary>
         /// Create a new instance of <see cref="MessageMetadata"/>.
         /// </summary>
@@ -16,7 +19,7 @@
         public MessageMetadata(Type messageType, IEnumerable<Type> messageHierarchy = null)
         {
             MessageType = messageType;
-            MessageHierarchy = (messageHierarchy == null ? new List<Type>() : new List<Type>(messageHierarchy)).AsReadOnly();
+            MessageHierarchy = messageHierarchy?.ToArray() ?? emptyHierarchy;
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadata.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadata.cs
@@ -31,6 +31,6 @@
         /// <summary>
         /// The message instance hierarchy.
         /// </summary>
-        public IEnumerable<Type> MessageHierarchy { get; private set; }
+        public Type[] MessageHierarchy { get; private set; }
     }
 }

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadata.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadata.cs
@@ -1,8 +1,6 @@
 ﻿namespace NServiceBus.Unicast.Messages
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
 
     /// <summary>
     /// Message metadata class.
@@ -15,11 +13,19 @@
         /// Create a new instance of <see cref="MessageMetadata"/>.
         /// </summary>
         /// <param name="messageType">The type of the message this metadata belongs to.</param>
+        public MessageMetadata(Type messageType) : this(messageType, null)
+        {
+        }
+
+        /// <summary>
+        /// Create a new instance of <see cref="MessageMetadata"/>.
+        /// </summary>
+        /// <param name="messageType">The type of the message this metadata belongs to.</param>
         /// <param name="messageHierarchy">the hierarchy of all message types implemented by the message this metadata belongs to.</param>
-        public MessageMetadata(Type messageType, IEnumerable<Type> messageHierarchy = null)
+        public MessageMetadata(Type messageType, Type[] messageHierarchy)
         {
             MessageType = messageType;
-            MessageHierarchy = messageHierarchy?.ToArray() ?? emptyHierarchy;
+            MessageHierarchy = messageHierarchy ?? emptyHierarchy;
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -74,13 +74,12 @@
             //get the parent types
             var parentMessages = GetParentTypes(messageType)
                 .Where(conventions.IsMessageType)
-                .OrderByDescending(PlaceInMessageHierarchy)
-                .ToList();
+                .OrderByDescending(PlaceInMessageHierarchy);
 
             var metadata = new MessageMetadata(messageType, new[]
             {
                 messageType
-            }.Concat(parentMessages));
+            }.Concat(parentMessages).ToArray());
 
             messages[messageType.TypeHandle] = metadata;
 


### PR DESCRIPTION
A few small optimizations to UnicastRouter

* MessageMetadata.Hierarchy is now an array which makes creating the hierachy and iterating it faster and cheaper.
* No longer use `Distinct` on the hierarchy. The hierachy shouldn't contain duplicates in the first place (not sure this can even occur)
* Use a HashSet when resolving the UnicastRoutes since they are comparable and deduplicating them avoids weird behavior on the distribution strategy. -> this change is questionable, the HashSet will come with much higher Add costs for cases where multiple routes for the same type are found. We could also stay with the faster list at the risk of the round-robin strategy behaving not entirely correct because the same destination may be passed multiple times to the distribution strategy (especially in cases with polymorphic messages)

@Particular/nservicebus-maintainers @Scooletz please review