### PR TITLE
ExtendableOptions sets the message id header.

### DIFF
--- a/src/NServiceBus.Core.Tests/Pipeline/HeaderOptionExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/HeaderOptionExtensionsTests.cs
@@ -14,19 +14,21 @@
 
             var result = options.GetHeaders();
 
-            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(3, result.Count);
             CollectionAssert.Contains(result.Values, "custom header value 1");
             CollectionAssert.Contains(result.Values, "custom header value 2");
+            CollectionAssert.Contains(result.Keys, Headers.MessageId);
         }
 
         [Test]
-        public void GetHeaders_Should_Return_Empty_Collection_When_No_Headers_Configured()
+        public void GetHeaders_Should_Return_Collection_With_MessageId_Header_Configured()
         {
             var options = new PublishOptions();
 
             var result = options.GetHeaders();
 
-            Assert.IsEmpty(result);
+            Assert.AreEqual(1, result.Count);
+            CollectionAssert.Contains(result.Keys, Headers.MessageId);
         }
     }
 }

--- a/src/NServiceBus.Core/Extensibility/ExtendableOptions.cs
+++ b/src/NServiceBus.Core/Extensibility/ExtendableOptions.cs
@@ -7,10 +7,24 @@ namespace NServiceBus.Extensibility
     /// </summary>
     public abstract class ExtendableOptions
     {
-        internal ContextBag Context = new ContextBag();
+        /// <summary>
+        /// Creates an instance of an extendable option.
+        /// </summary>
+        protected ExtendableOptions()
+        {
+            Context = new ContextBag();
+            OutgoingHeaders = new Dictionary<string, string>();
+            MessageId = CombGuid.Generate().ToString();
+        }
 
-        internal string MessageId = CombGuid.Generate().ToString();
+        internal ContextBag Context { get; }
 
-        internal Dictionary<string, string> OutgoingHeaders = new Dictionary<string, string>();
+        internal string MessageId
+        {
+            get { return OutgoingHeaders[Headers.MessageId]; }
+            set { OutgoingHeaders[Headers.MessageId] = value; }
+        }
+
+        internal Dictionary<string, string> OutgoingHeaders { get; }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPhysicalToRoutingConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPhysicalToRoutingConnector.cs
@@ -9,8 +9,6 @@
     {
         public override Task Invoke(IOutgoingPhysicalMessageContext context, Func<IRoutingContext, Task> stage)
         {
-            context.Headers[Headers.MessageId] = context.MessageId;
-
             var message = new OutgoingMessage(context.MessageId, context.Headers, context.Body);
 
             return stage(this.CreateRoutingContext(message, context.RoutingStrategies, context));


### PR DESCRIPTION
Connects to #3907 

This is a simple counter proposal to #3940 

In my point of view there is no real reason why the header needs to be set in the `OutgoingPhysicalToRoutingConnector`. The message id provided on the context cannot be changed. So the simplest possible solution which is backwards compatible is to early assign the header. If a user decides to override the message id header those changes will not be reflected on the pipeline contexts. We don't want to reflect those changes since it is an advanced use case when a user decides to fiddle with this header. We do not keep context properties in sync with other headers. So this approach is consistent.

It is the simpler solution because it is backwards compatible with the guidance we gave in the past (raised by @johnsimons  in https://github.com/Particular/NServiceBus/issues/3907#issuecomment-234428485) and doesn't require us to write complex infrastructure. 

I think to really pull off something like #3940 we would need to open a broader discussion like: Why can't the message id be changed? Does the same apply for the correlation id? and so forth.