### PR TITLE
Make LogicalAddress a struct

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -751,7 +751,7 @@ namespace NServiceBus
     }
     [System.ObsoleteAttribute("Use `LoadMessageHandlersExtensions` instead. Will be removed in version 7.0.0.", true)]
     public class static LoadMessageHandlersExtentions { }
-    public sealed class LogicalAddress
+    public struct LogicalAddress
     {
         public LogicalAddress(NServiceBus.Routing.EndpointInstance endpointInstance, [JetBrains.Annotations.NotNullAttribute()] string qualifier) { }
         public LogicalAddress(NServiceBus.Routing.EndpointInstance endpointInstance) { }

--- a/src/NServiceBus.Core/LogicalAddress.cs
+++ b/src/NServiceBus.Core/LogicalAddress.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// Represents a logical address (independent of transport).
     /// </summary>
-    public sealed class LogicalAddress
+    public struct LogicalAddress
     {
         /// <summary>
         /// Creates new qualified logical address for the provided endpoint instance name.
@@ -31,8 +31,8 @@
         public LogicalAddress(EndpointInstance endpointInstance)
         {
             EndpointInstance = endpointInstance;
+            Qualifier = null;
         }
-
 
         /// <summary>
         /// Returns the qualifier or null for the root logical address for a given instance name.


### PR DESCRIPTION
Small improvement without big impact on usages. Since we have to wrap an EndpointInstance in a LogicalAddress every time we want to resolve it's transport address this should improve allocations a bit.

@Particular/nservicebus-maintainers @SzymonPobiega @Scooletz please review