### PR TITLE
Making RecoverabilityConfig a class

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -268,8 +268,9 @@ namespace NServiceBus
     {
         public static NServiceBus.RecoverabilityAction Invoke(NServiceBus.RecoverabilityConfig config, NServiceBus.Transport.ErrorContext errorContext) { }
     }
-    public struct DelayedConfig
+    public class DelayedConfig
     {
+        public DelayedConfig(int maxNumberOfRetries, System.TimeSpan timeIncrease) { }
         public int MaxNumberOfRetries { get; }
         public System.TimeSpan TimeIncrease { get; }
     }
@@ -407,8 +408,9 @@ namespace NServiceBus
             "ly throws a NotImplementedException. Will be removed in version 7.0.0.", true)]
         public static void SetMessageHeader(this NServiceBus.IBus bus, object msg, string key, string value) { }
     }
-    public struct FailedConfig
+    public class FailedConfig
     {
+        public FailedConfig(string errorQueue) { }
         public string ErrorQueue { get; }
     }
     public class FileRoutingTableSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
@@ -655,8 +657,9 @@ namespace NServiceBus
         public static System.Threading.Tasks.Task Unsubscribe(this NServiceBus.IMessageSession session, System.Type messageType) { }
         public static System.Threading.Tasks.Task Unsubscribe<T>(this NServiceBus.IMessageSession session) { }
     }
-    public struct ImmediateConfig
+    public class ImmediateConfig
     {
+        public ImmediateConfig(int maxNumberOfRetries) { }
         public int MaxNumberOfRetries { get; }
     }
     public class static ImmediateDispatchOptionExtensions
@@ -903,8 +906,9 @@ namespace NServiceBus
         public static NServiceBus.ImmediateRetry ImmediateRetry() { }
         public static NServiceBus.MoveToError MoveToError(string errorQueue) { }
     }
-    public struct RecoverabilityConfig
+    public class RecoverabilityConfig
     {
+        public RecoverabilityConfig(NServiceBus.ImmediateConfig immediateConfig, NServiceBus.DelayedConfig delayedConfig, NServiceBus.FailedConfig failedConfig) { }
         public NServiceBus.DelayedConfig Delayed { get; }
         public NServiceBus.FailedConfig Failed { get; }
         public NServiceBus.ImmediateConfig Immediate { get; }

--- a/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
@@ -158,7 +158,7 @@
                 immediateRetriesSupported,
                 delayedRetriesSupported,
                 policy,
-                new RecoverabilityConfig(new ImmediateConfig(), new DelayedConfig(0, TimeSpan.MinValue), new FailedConfig(ErrorQueueAddress)),
+                new RecoverabilityConfig(new ImmediateConfig(0), new DelayedConfig(0, TimeSpan.Zero), new FailedConfig(ErrorQueueAddress)),
                 eventAggregator,
                 delayedRetriesSupported ? new DelayedRetryExecutor(InputQueueAddress, dispatcher) : null,
                 new MoveToErrorsExecutor(dispatcher, new Dictionary<string, string>(), headers => { }));

--- a/src/NServiceBus.Core/Recoverability/DelayedConfig.cs
+++ b/src/NServiceBus.Core/Recoverability/DelayedConfig.cs
@@ -5,10 +5,18 @@ namespace NServiceBus
     /// <summary>
     /// Provides information about the delayed retries configuration.
     /// </summary>
-    public struct DelayedConfig
+    public class DelayedConfig
     {
-        internal DelayedConfig(int maxNumberOfRetries, TimeSpan timeIncrease)
+        /// <summary>
+        /// Creates a new delayed retries configuration.
+        /// </summary>
+        /// <param name="maxNumberOfRetries">The maximum number of delayed retries.</param>
+        /// <param name="timeIncrease">The time of increase for individual delayed retries.</param>
+        public DelayedConfig(int maxNumberOfRetries, TimeSpan timeIncrease)
         {
+            Guard.AgainstNegative(nameof(maxNumberOfRetries), maxNumberOfRetries);
+            Guard.AgainstNegative(nameof(timeIncrease), timeIncrease);
+
             MaxNumberOfRetries = maxNumberOfRetries;
             TimeIncrease = timeIncrease;
         }

--- a/src/NServiceBus.Core/Recoverability/FailedConfig.cs
+++ b/src/NServiceBus.Core/Recoverability/FailedConfig.cs
@@ -3,10 +3,16 @@ namespace NServiceBus
     /// <summary>
     /// Provides information about the fault configuration.
     /// </summary>
-    public struct FailedConfig
+    public class FailedConfig
     {
-        internal FailedConfig(string errorQueue)
+        /// <summary>
+        /// Creates a new fault configuration.
+        /// </summary>
+        /// <param name="errorQueue">The address of the error queue.</param>
+        public FailedConfig(string errorQueue)
         {
+            Guard.AgainstNullAndEmpty(nameof(errorQueue), errorQueue);
+
             ErrorQueue = errorQueue;
         }
 

--- a/src/NServiceBus.Core/Recoverability/ImmediateConfig.cs
+++ b/src/NServiceBus.Core/Recoverability/ImmediateConfig.cs
@@ -3,10 +3,16 @@ namespace NServiceBus
     /// <summary>
     /// Provides information about the immediate retries configuration.
     /// </summary>
-    public struct ImmediateConfig
+    public class ImmediateConfig
     {
-        internal ImmediateConfig(int maxNumberOfRetries)
+        /// <summary>
+        /// Creates a new immediate retries configuration.
+        /// </summary>
+        /// <param name="maxNumberOfRetries">The maximum number of immediate retries.</param>
+        public ImmediateConfig(int maxNumberOfRetries)
         {
+            Guard.AgainstNegative(nameof(maxNumberOfRetries), maxNumberOfRetries);
+
             MaxNumberOfRetries = maxNumberOfRetries;
         }
 

--- a/src/NServiceBus.Core/Recoverability/Recoverability.cs
+++ b/src/NServiceBus.Core/Recoverability/Recoverability.cs
@@ -120,7 +120,7 @@
             {
                 Logger.Warn("Delayed Retries will be disabled. Delayed retries are not supported when running with TransportTransactionMode.None. Failed messages will be moved to the error queue instead.");
                 //Transactions must be enabled since SLR requires the transport to be able to rollback
-                return new DelayedConfig(0, TimeSpan.MinValue);
+                return new DelayedConfig(0, TimeSpan.Zero);
             }
 
             var numberOfRetries = settings.Get<int>(SlrNumberOfRetries);

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityConfig.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityConfig.cs
@@ -3,10 +3,20 @@ namespace NServiceBus
     /// <summary>
     /// Provides information about the recoverability configuration.
     /// </summary>
-    public struct RecoverabilityConfig
+    public class RecoverabilityConfig
     {
-        internal RecoverabilityConfig(ImmediateConfig immediateConfig, DelayedConfig delayedConfig, FailedConfig failedConfig)
+        /// <summary>
+        /// Creates a new recoverability configuration.
+        /// </summary>
+        /// <param name="immediateConfig">The immediate retries configuration.</param>
+        /// <param name="delayedConfig">The delayed retries configuration.</param>
+        /// <param name="failedConfig">The failed retries configuration.</param>
+        public RecoverabilityConfig(ImmediateConfig immediateConfig, DelayedConfig delayedConfig, FailedConfig failedConfig)
         {
+            Guard.AgainstNull(nameof(immediateConfig), immediateConfig);
+            Guard.AgainstNull(nameof(delayedConfig), delayedConfig);
+            Guard.AgainstNull(nameof(failedConfig), failedConfig);
+
             Immediate = immediateConfig;
             Delayed = delayedConfig;
             Failed = failedConfig;


### PR DESCRIPTION
Connects to https://github.com/Particular/V6Launch/issues/69

* RecoverabilityConfig should not be a struct because it is larger than 16 bytes (currently 32 bytes) see #3963 
* Making ctors public for better testability of custom recoverability policies

@Particular/nservicebus-maintainers please review and merge

// @tmasternak 