### PR TITLE
DelegateHolder should be a class

### DIFF
--- a/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
@@ -180,10 +180,10 @@
 
         readonly Conventions conventions;
         readonly Dictionary<Type, List<DelegateHolder>> handlerAndMessagesHandledByHandlerCache = new Dictionary<Type, List<DelegateHolder>>();
-        static List<MessageHandler> noMessageHandlers = new List<MessageHandler>();
+        static List<MessageHandler> noMessageHandlers = new List<MessageHandler>(0);
         static ILog Log = LogManager.GetLogger<MessageHandlerRegistry>();
 
-        struct DelegateHolder
+        class DelegateHolder
         {
             public Type MessageType;
             public Func<object, object, IMessageHandlerContext, Task> MethodDelegate;


### PR DESCRIPTION
The delegate holder is essentially a singleton per message handler. It is larger than 16 bytes and mutable. We are not gaining anything by making it a struct. See #3963 