### PR TITLE
Log changes to instance mapping file

### DIFF
--- a/src/NServiceBus.Core.Tests/Routing/FileRoutingTableParserTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/FileRoutingTableParserTests.cs
@@ -62,7 +62,7 @@
         }
 
         [Test]
-        public void It_allows_endpoint_to_not_have_an_instance()
+        public void It_requires_endpoint_to_have_an_instance()
         {
             const string xml = @"
 <endpoints>
@@ -72,7 +72,8 @@
             var doc = XDocument.Parse(xml);
             var parser = new FileRoutingTableParser();
 
-            Assert.DoesNotThrow(() => parser.Parse(doc));
+            var exception = Assert.Throws<XmlSchemaValidationException>(() => parser.Parse(doc));
+            Assert.That(exception.Message, Does.Contain("The element 'endpoint' has incomplete content. List of possible elements expected: 'instance'."));
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTable.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTable.cs
@@ -3,6 +3,7 @@ namespace NServiceBus
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text;
     using System.Threading.Tasks;
     using Features;
     using Logging;
@@ -36,8 +37,10 @@ namespace NServiceBus
                 var instances = parser.Parse(doc);
 
                 var newInstanceMap = instances
-                .GroupBy(i => i.Endpoint)
-                .ToDictionary(g => g.Key, g => new HashSet<EndpointInstance>(g));
+                    .GroupBy(i => i.Endpoint)
+                    .ToDictionary(g => g.Key, g => new HashSet<EndpointInstance>(g));
+
+                LogChanges(instanceMap, newInstanceMap);
 
                 instanceMap = newInstanceMap;
             }
@@ -45,6 +48,50 @@ namespace NServiceBus
             {
                 throw new Exception($"An error occurred while reading the endpoint instance mapping file at {filePath}. See the inner exception for more details.", ex);
             }
+        }
+
+        void LogChanges(Dictionary<string, HashSet<EndpointInstance>> oldInstanceMap, Dictionary<string, HashSet<EndpointInstance>> newInstanceMap)
+        {
+            var output = new StringBuilder();
+            var hasChanges = false;
+            output.AppendLine($"Updating instance mapping table from '{filePath}':");
+
+            foreach (var endpoint in newInstanceMap)
+            {
+                HashSet<EndpointInstance> existingInstances;
+                if (oldInstanceMap.TryGetValue(endpoint.Key, out existingInstances))
+                {
+                    var newInstances = endpoint.Value.Except(existingInstances).Count();
+                    var removedInstances = existingInstances.Except(endpoint.Value).Count();
+
+                    if (newInstances > 0 || removedInstances > 0)
+                    {
+                        output.AppendLine($"Updated endpoint '{endpoint.Key}': +{Instances(newInstances)}, -{Instances(removedInstances)}");
+                        hasChanges = true;
+                    }
+                }
+                else
+                {
+                    output.AppendLine($"Added endpoint '{endpoint.Key}' with {Instances(endpoint.Value.Count)}");
+                    hasChanges = true;
+                }
+            }
+
+            foreach (var removedEndpoint in oldInstanceMap.Keys.Except(newInstanceMap.Keys))
+            {
+                output.AppendLine($"Removed all instances of endpoint '{removedEndpoint}'");
+                hasChanges = true;
+            }
+
+            if (hasChanges)
+            {
+                log.Info(output.ToString());
+            }
+        }
+
+        static string Instances(int count)
+        {
+            return count > 1 ? $"{count} instances" : $"{count} instance";
         }
 
         public Task<IEnumerable<EndpointInstance>> FindInstances(string endpoint)
@@ -63,7 +110,7 @@ namespace NServiceBus
         IRoutingFileAccess fileAccess;
         string filePath;
 
-        Dictionary<string, HashSet<EndpointInstance>> instanceMap;
+        Dictionary<string, HashSet<EndpointInstance>> instanceMap = new Dictionary<string, HashSet<EndpointInstance>>(0);
         FileRoutingTableParser parser = new FileRoutingTableParser();
         IAsyncTimer timer;
         Task<IEnumerable<EndpointInstance>> noInstances = Task.FromResult(Enumerable.Empty<EndpointInstance>());

--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/endpoints.xsd
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/endpoints.xsd
@@ -5,7 +5,7 @@
         <xs:element minOccurs="0" maxOccurs="unbounded" name="endpoint">
           <xs:complexType>
             <xs:sequence>
-              <xs:element minOccurs="0" maxOccurs="unbounded" name="instance">
+              <xs:element minOccurs="1" maxOccurs="unbounded" name="instance">
                 <xs:complexType>
                   <xs:attribute name="discriminator" type="xs:string" use="optional" />
                   <xs:anyAttribute processContents="lax" />

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_using_empty_instance_mapping_file.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_using_empty_instance_mapping_file.cs
@@ -18,11 +18,7 @@
             logicalEndpointName = Conventions.EndpointNamingConvention(typeof(ScaledOutReceiver));
 
             // e.g. spelling error in endpoint:
-            File.WriteAllText(mappingFilePath,
-                $@"<endpoints>
-    <endpoint name=""{logicalEndpointName}"">
-    </endpoint>
-</endpoints>");
+            File.WriteAllText(mappingFilePath, "<endpoints></endpoints>");
         }
 
         [TearDown]


### PR DESCRIPTION
Connects to Particular/V6Launch#68

Adds logging of added/removed instances on the instance-mapping file as suggested by @DavidBoike 

Example log outputs:
* Changing an instance value (e.g. changing the discriminator or machine attribute): `Updated endpoint 'test': +1 instance, -1 instance`
* Adding a new endpoint with instance: `Added endpoint 'test2' with 1 instance`
* Removing an endpoint: `Removed endpoint 'test2' with all instances`

all entries are a single log-entry (with line breaks)

Not handled:
* Adding a logical endpoint without instances will not show up in the logging because we don't have an EndpointInstance. I think it's probably not worth to change the code to handle that, but I don't have a strong opinion on this and happy to discuss this on this PR.

I went with LINQ statements for simplicity, since this is executed on the background and is not on the hot path, this should be acceptable.

@DavidBoike @Scooletz @Particular/nservicebus-maintainers please review