### PR TITLE
Change LogicalAddress to LocalAddress

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
@@ -34,14 +34,14 @@
 
         public override OutboundRoutingPolicy OutboundRoutingPolicy { get; } = new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Unicast, OutboundRoutingType.Unicast);
 
-        public override EndpointInstance BindToLocalEndpoint(EndpointInstance instance)
-        {
-            return instance;
-        }
-
         public override string ToTransportAddress(LogicalAddress logicalAddress)
         {
             return logicalAddress.ToString();
+        }
+
+        public override string ToTransportAddress(EndpointInstance endpointInstance)
+        {
+            return endpointInstance.ToString();
         }
 
         public override TransportReceiveInfrastructure ConfigureReceiveInfrastructure()

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
@@ -34,9 +34,9 @@
 
         public override OutboundRoutingPolicy OutboundRoutingPolicy { get; } = new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Unicast, OutboundRoutingType.Unicast);
 
-        public override string ToTransportAddress(LogicalAddress logicalAddress)
+        public override string ToTransportAddress(LocalAddress localAddress)
         {
-            return logicalAddress.ToString();
+            return localAddress.ToString();
         }
 
         public override string ToTransportAddress(EndpointInstance endpointInstance)

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -86,9 +86,9 @@
             public override TransportTransactionMode TransactionMode { get; } = TransportTransactionMode.None;
             public override OutboundRoutingPolicy OutboundRoutingPolicy { get; } = new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Unicast, OutboundRoutingType.Unicast);
 
-            public override string ToTransportAddress(LogicalAddress logicalAddress)
+            public override string ToTransportAddress(LocalAddress localAddress)
             {
-                return logicalAddress.ToString();
+                return localAddress.ToString();
             }
 
             public override string ToTransportAddress(EndpointInstance endpointInstance)

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -86,14 +86,14 @@
             public override TransportTransactionMode TransactionMode { get; } = TransportTransactionMode.None;
             public override OutboundRoutingPolicy OutboundRoutingPolicy { get; } = new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Unicast, OutboundRoutingType.Unicast);
 
-            public override EndpointInstance BindToLocalEndpoint(EndpointInstance instance)
-            {
-                return instance;
-            }
-
             public override string ToTransportAddress(LogicalAddress logicalAddress)
             {
                 return logicalAddress.ToString();
+            }
+
+            public override string ToTransportAddress(EndpointInstance endpointInstance)
+            {
+                return endpointInstance.ToString();
             }
 
             public override TransportReceiveInfrastructure ConfigureReceiveInfrastructure()

--- a/src/NServiceBus.AcceptanceTests/Hosting/When_overriding_local_addresses.cs
+++ b/src/NServiceBus.AcceptanceTests/Hosting/When_overriding_local_addresses.cs
@@ -27,9 +27,9 @@ namespace NServiceBus.AcceptanceTests.Hosting
                 EndpointSetup<DefaultServer>((c, d) =>
                 {
                     c.EnableFeature<TimeoutManager>();
+                    c.OverrideLocalAddress("OverriddenLocalAddress");
                     c.UseTransport(d.GetTransportType())
-                        .Transactions(TransportTransactionMode.None)
-                        .AddAddressTranslationRule(address => "OverriddenLocalAddress" + address.Qualifier); //Overriding -> Overridden
+                        .Transactions(TransportTransactionMode.None);
                 });
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
+++ b/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
@@ -41,8 +41,8 @@
 
                 protected override void Setup(FeatureConfigurationContext context)
                 {
-                    var instanceName = context.Settings.EndpointInstanceName();
-                    var satelliteLogicalAddress = new LogicalAddress(instanceName, "MySatellite");
+                    var instanceName = context.Settings.LocalLogicalAddress();
+                    var satelliteLogicalAddress = new LogicalAddress(instanceName.Endpoint, "MySatellite");
                     var satelliteAddress = context.Settings.GetTransportAddress(satelliteLogicalAddress);
 
                     context.AddSatelliteReceiver("Test satellite", satelliteAddress, TransportTransactionMode.ReceiveOnly, PushRuntimeSettings.Default,

--- a/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
+++ b/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
@@ -41,8 +41,8 @@
 
                 protected override void Setup(FeatureConfigurationContext context)
                 {
-                    var instanceName = context.Settings.LocalLogicalAddress();
-                    var satelliteLogicalAddress = new LogicalAddress(instanceName.Endpoint, "MySatellite");
+                    var localAddress = context.Settings.LocalLogicalAddress();
+                    var satelliteLogicalAddress = new LocalAddress(localAddress.Endpoint, "MySatellite");
                     var satelliteAddress = context.Settings.GetTransportAddress(satelliteLogicalAddress);
 
                     context.AddSatelliteReceiver("Test satellite", satelliteAddress, TransportTransactionMode.ReceiveOnly, PushRuntimeSettings.Default,

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -747,19 +747,19 @@ namespace NServiceBus
     }
     [System.ObsoleteAttribute("Use `LoadMessageHandlersExtensions` instead. Will be removed in version 7.0.0.", true)]
     public class static LoadMessageHandlersExtentions { }
-    public class static LocalAddressOverrideExtensions
+    public sealed class LocalAddress
     {
-        public static void OverrideLocalAddress(this NServiceBus.EndpointConfiguration configuration, string addressOverride) { }
-    }
-    public sealed class LogicalAddress
-    {
-        public LogicalAddress(string endpoint, string qualifier = null, string discriminator = null) { }
+        public LocalAddress(string endpoint, string qualifier = null, string discriminator = null) { }
         public string Discriminator { get; }
         public string Endpoint { get; }
         public string Qualifier { get; }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
+    }
+    public class static LocalAddressOverrideExtensions
+    {
+        public static void OverrideLocalAddress(this NServiceBus.EndpointConfiguration configuration, string addressOverride) { }
     }
     public class MessageDeserializationException : System.Runtime.Serialization.SerializationException
     {
@@ -1117,7 +1117,7 @@ namespace NServiceBus
             where T :  class, new () { }
         public static string InstanceSpecificQueue(this NServiceBus.Settings.ReadOnlySettings settings) { }
         public static string LocalAddress(this NServiceBus.Settings.ReadOnlySettings settings) { }
-        public static NServiceBus.LogicalAddress LocalLogicalAddress(this NServiceBus.Settings.ReadOnlySettings settings) { }
+        public static NServiceBus.LocalAddress LocalLogicalAddress(this NServiceBus.Settings.ReadOnlySettings settings) { }
     }
     [System.ObsoleteAttribute("Use `SettingsExtensions` instead. Will be removed in version 7.0.0.", true)]
     public class static SettingsExtentions { }
@@ -3058,7 +3058,7 @@ namespace NServiceBus.Transport
     }
     public class static LogicalAddressExtensions
     {
-        public static string GetTransportAddress(this NServiceBus.Settings.ReadOnlySettings settings, NServiceBus.LogicalAddress logicalAddress) { }
+        public static string GetTransportAddress(this NServiceBus.Settings.ReadOnlySettings settings, NServiceBus.LocalAddress localAddress) { }
     }
     public class MessageContext
     {
@@ -3167,7 +3167,7 @@ namespace NServiceBus.Transport
         public virtual string MakeCanonicalForm(string transportAddress) { }
         public virtual System.Threading.Tasks.Task Start() { }
         public virtual System.Threading.Tasks.Task Stop() { }
-        public abstract string ToTransportAddress(NServiceBus.LogicalAddress logicalAddress);
+        public abstract string ToTransportAddress(NServiceBus.LocalAddress localAddress);
         public abstract string ToTransportAddress(NServiceBus.Routing.EndpointInstance endpointInstance);
     }
     public class TransportOperation

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -155,6 +155,7 @@ namespace NServiceBus
         public static void RijndaelEncryptionService(this NServiceBus.EndpointConfiguration config, string encryptionKeyIdentifier, byte[] encryptionKey, System.Collections.Generic.IList<byte[]> decryptionKeys = null) { }
         public static void RijndaelEncryptionService(this NServiceBus.EndpointConfiguration config, string encryptionKeyIdentifier, System.Collections.Generic.IDictionary<string, byte[]> keys, System.Collections.Generic.IList<byte[]> decryptionKeys = null) { }
     }
+    [System.ObsoleteAttribute("Not available any more. Will be removed in version 7.0.0.", true)]
     public class static ConfigureTransportConnectionString
     {
         [System.ObsoleteAttribute("Not available any more. The member currently throws a NotImplementedException. Wi" +
@@ -348,10 +349,6 @@ namespace NServiceBus
         public void EndpointName(string name) { }
         public void ExcludeAssemblies(params string[] assemblies) { }
         public void ExcludeTypes(params System.Type[] types) { }
-        [System.ObsoleteAttribute("Use `EndpointConfiguration.UseTransport<T>().AddAddressTranslationRule(Func<Logic" +
-            "alAddress, string> rule)` instead. The member currently throws a NotImplementedE" +
-            "xception. Will be removed in version 7.0.0.", true)]
-        public void OverrideLocalAddress(string queue) { }
         public void OverridePublicReturnAddress(string address) { }
         [System.ObsoleteAttribute("Use `EndpointConfiguration.OverridePublicReturnAddress(string address)` instead. " +
             "The member currently throws a NotImplementedException. Will be removed in versio" +
@@ -750,11 +747,15 @@ namespace NServiceBus
     }
     [System.ObsoleteAttribute("Use `LoadMessageHandlersExtensions` instead. Will be removed in version 7.0.0.", true)]
     public class static LoadMessageHandlersExtentions { }
+    public class static LocalAddressOverrideExtensions
+    {
+        public static void OverrideLocalAddress(this NServiceBus.EndpointConfiguration configuration, string addressOverride) { }
+    }
     public sealed class LogicalAddress
     {
-        public LogicalAddress(NServiceBus.Routing.EndpointInstance endpointInstance, [JetBrains.Annotations.NotNullAttribute()] string qualifier) { }
-        public LogicalAddress(NServiceBus.Routing.EndpointInstance endpointInstance) { }
-        public NServiceBus.Routing.EndpointInstance EndpointInstance { get; }
+        public LogicalAddress(string endpoint, string qualifier = null, string discriminator = null) { }
+        public string Discriminator { get; }
+        public string Endpoint { get; }
         public string Qualifier { get; }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
@@ -1110,13 +1111,13 @@ namespace NServiceBus
     }
     public class static SettingsExtensions
     {
-        public static NServiceBus.Routing.EndpointInstance EndpointInstanceName(this NServiceBus.Settings.ReadOnlySettings settings) { }
         public static string EndpointName(this NServiceBus.Settings.ReadOnlySettings settings) { }
         public static System.Collections.Generic.IList<System.Type> GetAvailableTypes(this NServiceBus.Settings.ReadOnlySettings settings) { }
         public static T GetConfigSection<T>(this NServiceBus.Settings.ReadOnlySettings settings)
             where T :  class, new () { }
         public static string InstanceSpecificQueue(this NServiceBus.Settings.ReadOnlySettings settings) { }
         public static string LocalAddress(this NServiceBus.Settings.ReadOnlySettings settings) { }
+        public static NServiceBus.LogicalAddress LocalLogicalAddress(this NServiceBus.Settings.ReadOnlySettings settings) { }
     }
     [System.ObsoleteAttribute("Use `SettingsExtensions` instead. Will be removed in version 7.0.0.", true)]
     public class static SettingsExtentions { }
@@ -1152,9 +1153,8 @@ namespace NServiceBus
     public class TransportExtensions : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
         public TransportExtensions(NServiceBus.Settings.SettingsHolder settings) { }
-        public NServiceBus.TransportExtensions AddAddressTranslationException(NServiceBus.LogicalAddress logicalAddress, string transportAddress) { }
         public NServiceBus.TransportExtensions AddAddressTranslationException(NServiceBus.Routing.EndpointInstance endpointInstance, string transportAddress) { }
-        public NServiceBus.TransportExtensions AddAddressTranslationRule(System.Func<NServiceBus.LogicalAddress, string> rule) { }
+        public NServiceBus.TransportExtensions AddAddressTranslationRule(System.Func<NServiceBus.Routing.EndpointInstance, string> rule) { }
         public NServiceBus.TransportExtensions ConnectionString(string connectionString) { }
         public NServiceBus.TransportExtensions ConnectionString(System.Func<string> connectionString) { }
         public NServiceBus.TransportExtensions ConnectionStringName(string name) { }
@@ -3128,9 +3128,8 @@ namespace NServiceBus.Transport
     }
     public class TransportAddresses
     {
-        public void AddRule(System.Func<NServiceBus.LogicalAddress, string> dynamicRule) { }
-        public void AddSpecialCase([JetBrains.Annotations.NotNullAttribute()] NServiceBus.LogicalAddress endpointInstance, string physicalAddress) { }
-        public void AddSpecialCase([JetBrains.Annotations.NotNullAttribute()] NServiceBus.Routing.EndpointInstance endpointInstance, string physicalAddress) { }
+        public void AddRule(System.Func<NServiceBus.Routing.EndpointInstance, string> dynamicRule) { }
+        public void AddSpecialCase(NServiceBus.Routing.EndpointInstance endpointInstance, string physicalAddress) { }
     }
     public abstract class TransportDefinition
     {
@@ -3162,7 +3161,6 @@ namespace NServiceBus.Transport
         public abstract NServiceBus.Transport.OutboundRoutingPolicy OutboundRoutingPolicy { get; }
         public bool RequireOutboxConsent { get; set; }
         public abstract NServiceBus.TransportTransactionMode TransactionMode { get; }
-        public abstract NServiceBus.Routing.EndpointInstance BindToLocalEndpoint(NServiceBus.Routing.EndpointInstance instance);
         public abstract NServiceBus.Transport.TransportReceiveInfrastructure ConfigureReceiveInfrastructure();
         public abstract NServiceBus.Transport.TransportSendInfrastructure ConfigureSendInfrastructure();
         public abstract NServiceBus.Transport.TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure();
@@ -3170,6 +3168,7 @@ namespace NServiceBus.Transport
         public virtual System.Threading.Tasks.Task Start() { }
         public virtual System.Threading.Tasks.Task Stop() { }
         public abstract string ToTransportAddress(NServiceBus.LogicalAddress logicalAddress);
+        public abstract string ToTransportAddress(NServiceBus.Routing.EndpointInstance endpointInstance);
     }
     public class TransportOperation
     {

--- a/src/NServiceBus.Core.Tests/DeliveryConstraintContextExtensions/DeliveryConstraintContextExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/DeliveryConstraintContextExtensions/DeliveryConstraintContextExtensionsTests.cs
@@ -54,7 +54,7 @@
 
         class FakeTransportInfrastructure : TransportInfrastructure
         {
-            public override string ToTransportAddress(LogicalAddress logicalAddress)
+            public override string ToTransportAddress(LocalAddress localAddress)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.Core.Tests/DeliveryConstraintContextExtensions/DeliveryConstraintContextExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/DeliveryConstraintContextExtensions/DeliveryConstraintContextExtensionsTests.cs
@@ -54,13 +54,12 @@
 
         class FakeTransportInfrastructure : TransportInfrastructure
         {
-
-            public override EndpointInstance BindToLocalEndpoint(EndpointInstance instance)
+            public override string ToTransportAddress(LogicalAddress logicalAddress)
             {
                 throw new NotImplementedException();
             }
 
-            public override string ToTransportAddress(LogicalAddress logicalAddress)
+            public override string ToTransportAddress(EndpointInstance endpointInstance)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
@@ -19,7 +19,7 @@
         {
             var publishers = new Publishers();
             publishers.AddByAddress(typeof(object), "publisher1");
-            router = new SubscriptionRouter(publishers, new EndpointInstances(), new TransportAddresses(address => null));
+            router = new SubscriptionRouter(publishers, new EndpointInstances(), new TransportAddresses(address => address.ToString(), address => address.ToString()));
             dispatcher = new FakeDispatcher();
             subscribeTerminator = new MessageDrivenSubscribeTerminator(router, "replyToAddress", "Endpoint", dispatcher);
         }

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
@@ -23,7 +23,7 @@
         {
             var publishers = new Publishers();
             publishers.AddByAddress(typeof(object), "publisher1");
-            router = new SubscriptionRouter(publishers, new EndpointInstances(), new TransportAddresses(address => null));
+            router = new SubscriptionRouter(publishers, new EndpointInstances(), new TransportAddresses(address => address.ToString(), address => address.ToString()));
             dispatcher = new FakeDispatcher();
             terminator = new MessageDrivenUnsubscribeTerminator(router, "replyToAddress", "Endpoint", dispatcher);
         }

--- a/src/NServiceBus.Core.Tests/Routing/SubscriptionRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SubscriptionRouterTests.cs
@@ -4,15 +4,15 @@ namespace NServiceBus.Core.Tests.Routing
     using System.Threading.Tasks;
     using NServiceBus.Routing;
     using NServiceBus.Routing.MessageDrivenSubscriptions;
-    using Transport;
     using NUnit.Framework;
+    using Transport;
 
     class SubscriptionRouterTests
     {
         [Test]
         public async Task Should_return_empty_list_for_events_with_no_routes()
         {
-            var router = new SubscriptionRouter(new Publishers(), new EndpointInstances(), new TransportAddresses(address => null));
+            var router = new SubscriptionRouter(new Publishers(), new EndpointInstances(), transportAddresses);
             Assert.IsEmpty(await router.GetAddressesForEventType(typeof(Message1)));
         }
 
@@ -31,9 +31,7 @@ namespace NServiceBus.Core.Tests.Routing
             publishers.Add(inheritedType, inheritedAddress);
             var endpointInstances = new EndpointInstances();
             endpointInstances.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(e))));
-            var physicalAddresses = new TransportAddresses(address => null);
-            physicalAddresses.AddRule(i => i.EndpointInstance.Endpoint);
-            var router = new SubscriptionRouter(publishers, endpointInstances, physicalAddresses);
+            var router = new SubscriptionRouter(publishers, endpointInstances, transportAddresses);
 
             Assert.Contains(baseAddress, (await router.GetAddressesForEventType(baseType)).ToList());
             Assert.Contains(inheritedAddress, (await router.GetAddressesForEventType(baseType)).ToList());
@@ -52,9 +50,7 @@ namespace NServiceBus.Core.Tests.Routing
             publishers.Add(inheritedType, "addressB");
             var knownEndpoints = new EndpointInstances();
             knownEndpoints.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(e, null, null))));
-            var physicalAddresses = new TransportAddresses(address => null);
-            physicalAddresses.AddRule(i => i.EndpointInstance.Endpoint);
-            var router = new SubscriptionRouter(publishers, knownEndpoints, physicalAddresses);
+            var router = new SubscriptionRouter(publishers, knownEndpoints, transportAddresses);
 
             Assert.AreEqual(2, (await router.GetAddressesForEventType(baseType)).Count());
         }
@@ -71,14 +67,14 @@ namespace NServiceBus.Core.Tests.Routing
 
             var knownEndpoints = new EndpointInstances();
             knownEndpoints.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(e, null, null))));
-            var physicalAddresses = new TransportAddresses(a => null);
-            physicalAddresses.AddRule(i => i.EndpointInstance.Endpoint);
-            var router = new SubscriptionRouter(publishers, knownEndpoints, physicalAddresses);
+            var router = new SubscriptionRouter(publishers, knownEndpoints, transportAddresses);
 
             var result = await router.GetAddressesForEventType(typeof(BaseMessage));
 
             Assert.AreEqual(1, result.Count());
         }
+
+        TransportAddresses transportAddresses = new TransportAddresses(address => address.Endpoint, address => address.ToString());
 
         public class Message1
         {

--- a/src/NServiceBus.Core.Tests/Routing/TransportAddressesTest.cs
+++ b/src/NServiceBus.Core.Tests/Routing/TransportAddressesTest.cs
@@ -11,33 +11,33 @@
         [Test]
         public void Special_cases_should_override_rules()
         {
-            var addresses = new TransportAddresses(address => null);
+            var addresses = new TransportAddresses(address => null, address => null);
             addresses.AddRule(i => "Rule");
             addresses.AddSpecialCase(new EndpointInstance("Sales", null, null), "SpecialCase");
 
-            Assert.AreEqual("SpecialCase", addresses.GetTransportAddress(new LogicalAddress(new EndpointInstance("Sales"))));
-            Assert.AreEqual("Rule", addresses.GetTransportAddress(new LogicalAddress(new EndpointInstance("Billing"))));
+            Assert.AreEqual("SpecialCase", addresses.GetTransportAddress(new EndpointInstance("Sales")));
+            Assert.AreEqual("Rule", addresses.GetTransportAddress(new EndpointInstance("Billing")));
         }
 
         [Test]
         public void Rules_should_override_transport_defaults()
         {
-            var addresses = new TransportAddresses(address => "TransportDefault");
-            addresses.AddRule(i => i.EndpointInstance.Endpoint.StartsWith("S") ? "Rule" : null);
+            var addresses = new TransportAddresses(address => "TransportDefault", address => null);
+            addresses.AddRule(i => i.Endpoint.StartsWith("S") ? "Rule" : null);
 
 
-            Assert.AreEqual("Rule", addresses.GetTransportAddress(new LogicalAddress(new EndpointInstance("Sales"))));
-            Assert.AreEqual("TransportDefault", addresses.GetTransportAddress(new LogicalAddress(new EndpointInstance("Billing"))));
+            Assert.AreEqual("Rule", addresses.GetTransportAddress(new EndpointInstance("Sales")));
+            Assert.AreEqual("TransportDefault", addresses.GetTransportAddress(new EndpointInstance("Billing")));
         }
 
         [Test]
         public void It_should_throw_when_rules_are_ambiguous()
         {
-            var addresses = new TransportAddresses(address => null);
-            addresses.AddRule(i => i.EndpointInstance.Endpoint.StartsWith("S") ? "Rule1" : null);
-            addresses.AddRule(i => i.EndpointInstance.Endpoint.EndsWith("s") ? "Rule2" : null);
+            var addresses = new TransportAddresses(address => null, address => null);
+            addresses.AddRule(i => i.Endpoint.StartsWith("S") ? "Rule1" : null);
+            addresses.AddRule(i => i.Endpoint.EndsWith("s") ? "Rule2" : null);
 
-            TestDelegate action = () => addresses.GetTransportAddress(new LogicalAddress(new EndpointInstance("Sales")));
+            TestDelegate action = () => addresses.GetTransportAddress(new EndpointInstance("Sales"));
             Assert.Throws<Exception>(action);
         }
     }

--- a/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
@@ -102,7 +102,7 @@
             metadataRegistry = new MessageMetadataRegistry(new Conventions());
             endpointInstances = new EndpointInstances();
             subscriptionStorage = new FakeSubscriptionStorage();
-            transportAddresses = new TransportAddresses(address => address.ToString());
+            transportAddresses = new TransportAddresses(address => address.ToString(), address => address.ToString());
             router = new UnicastPublishRouter(
                 metadataRegistry,
                 subscriptionStorage,

--- a/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
@@ -83,7 +83,7 @@
             metadataRegistry = new MessageMetadataRegistry(new Conventions());
             routingTable = new UnicastRoutingTable();
             endpointInstances = new EndpointInstances();
-            transportAddresses = new TransportAddresses(address => address.ToString());
+            transportAddresses = new TransportAddresses(address => address.ToString(), address => address.ToString());
             router = new UnicastSendRouter(
                 metadataRegistry,
                 routingTable,

--- a/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
@@ -48,12 +48,12 @@
                 throw new NotImplementedException();
             }
 
-            public override EndpointInstance BindToLocalEndpoint(EndpointInstance instance)
+            public override string ToTransportAddress(LogicalAddress logicalAddress)
             {
                 throw new NotImplementedException();
             }
 
-            public override string ToTransportAddress(LogicalAddress logicalAddress)
+            public override string ToTransportAddress(EndpointInstance endpointInstance)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
@@ -48,7 +48,7 @@
                 throw new NotImplementedException();
             }
 
-            public override string ToTransportAddress(LogicalAddress logicalAddress)
+            public override string ToTransportAddress(LocalAddress localAddress)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
@@ -63,8 +63,8 @@
 
         static string SetupDispatcherSatellite(FeatureConfigurationContext context, TransportTransactionMode requiredTransactionSupport)
         {
-            var instanceName = context.Settings.LocalLogicalAddress();
-            var satelliteLogicalAddress = new LogicalAddress(instanceName.Endpoint, "TimeoutsDispatcher");
+            var localAddress = context.Settings.LocalLogicalAddress();
+            var satelliteLogicalAddress = new LocalAddress(localAddress.Endpoint, "TimeoutsDispatcher");
             var satelliteAddress = context.Settings.GetTransportAddress(satelliteLogicalAddress);
 
             context.AddSatelliteReceiver("Timeout Dispatcher Processor", satelliteAddress, requiredTransactionSupport, PushRuntimeSettings.Default, RecoverabilityPolicy,
@@ -83,8 +83,8 @@
 
         static void SetupStorageSatellite(FeatureConfigurationContext context, TransportTransactionMode requiredTransactionSupport)
         {
-            var instanceName = context.Settings.LocalLogicalAddress();
-            var satelliteLogicalAddress = new LogicalAddress(instanceName.Endpoint, "Timeouts");
+            var localAddress = context.Settings.LocalLogicalAddress();
+            var satelliteLogicalAddress = new LocalAddress(localAddress.Endpoint, "Timeouts");
             var satelliteAddress = context.Settings.GetTransportAddress(satelliteLogicalAddress);
 
             context.AddSatelliteReceiver("Timeout Message Processor", satelliteAddress, requiredTransactionSupport, PushRuntimeSettings.Default, RecoverabilityPolicy,

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
@@ -63,8 +63,8 @@
 
         static string SetupDispatcherSatellite(FeatureConfigurationContext context, TransportTransactionMode requiredTransactionSupport)
         {
-            var instanceName = context.Settings.EndpointInstanceName();
-            var satelliteLogicalAddress = new LogicalAddress(instanceName, "TimeoutsDispatcher");
+            var instanceName = context.Settings.LocalLogicalAddress();
+            var satelliteLogicalAddress = new LogicalAddress(instanceName.Endpoint, "TimeoutsDispatcher");
             var satelliteAddress = context.Settings.GetTransportAddress(satelliteLogicalAddress);
 
             context.AddSatelliteReceiver("Timeout Dispatcher Processor", satelliteAddress, requiredTransactionSupport, PushRuntimeSettings.Default, RecoverabilityPolicy,
@@ -83,8 +83,8 @@
 
         static void SetupStorageSatellite(FeatureConfigurationContext context, TransportTransactionMode requiredTransactionSupport)
         {
-            var instanceName = context.Settings.EndpointInstanceName();
-            var satelliteLogicalAddress = new LogicalAddress(instanceName, "Timeouts");
+            var instanceName = context.Settings.LocalLogicalAddress();
+            var satelliteLogicalAddress = new LogicalAddress(instanceName.Endpoint, "Timeouts");
             var satelliteAddress = context.Settings.GetTransportAddress(satelliteLogicalAddress);
 
             context.AddSatelliteReceiver("Timeout Message Processor", satelliteAddress, requiredTransactionSupport, PushRuntimeSettings.Default, RecoverabilityPolicy,

--- a/src/NServiceBus.Core/LocalAddress.cs
+++ b/src/NServiceBus.Core/LocalAddress.cs
@@ -3,15 +3,15 @@
     /// <summary>
     /// Represents a logical address (independent of transport) of a local queue.
     /// </summary>
-    public sealed class LogicalAddress
+    public sealed class LocalAddress
     {
         /// <summary>
-        /// Creates new root logical address for the provided endpoint instance name.
+        /// Creates new local address for the provided endpoint instance name.
         /// </summary>
         /// <param name="endpoint">The logical name of the endpoint.</param>
         /// <param name="qualifier">The qualifier to apply to the given logical endpoint name.</param>
         /// <param name="discriminator">The discriminator to apply to the given logical endpoint name.</param>
-        public LogicalAddress(string endpoint, string qualifier = null, string discriminator = null)
+        public LocalAddress(string endpoint, string qualifier = null, string discriminator = null)
         {
             Endpoint = endpoint;
             Qualifier = qualifier;
@@ -19,13 +19,13 @@
         }
 
         /// <summary>
-        /// Returns the qualifier of the address.
+        /// Returns the qualifier of the local address.
         /// </summary>
         /// <returns>The configured qualifier or <code>null</code> when no qualifier is specified.</returns>
         public string Qualifier { get; }
 
         /// <summary>
-        /// Returns the discriminator of the address.
+        /// Returns the discriminator of the localaddress.
         /// </summary>
         /// <returns>The configured discriminator or <code>null</code> when no discriminator is specified.</returns>
         public string Discriminator { get; }
@@ -34,6 +34,7 @@
         /// Returns the logical endpoint name excluding qualifier and discriminator.
         /// </summary>
         public string Endpoint { get; }
+
         /// <summary>
         /// Returns a string that represents the current object.
         /// </summary>
@@ -54,7 +55,7 @@
             return name;
         }
 
-        bool Equals(LogicalAddress other)
+        bool Equals(LocalAddress other)
         {
             return string.Equals(Qualifier, other.Qualifier) && string.Equals(Discriminator, other.Discriminator) && string.Equals(Endpoint, other.Endpoint);
         }
@@ -66,7 +67,7 @@
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
-            return obj is LogicalAddress && Equals((LogicalAddress) obj);
+            return obj is LocalAddress && Equals((LocalAddress) obj);
         }
 
         /// <summary>Serves as the default hash function. </summary>
@@ -85,7 +86,7 @@
         /// <summary>
         /// Compares for equality.
         /// </summary>
-        public static bool operator ==(LogicalAddress left, LogicalAddress right)
+        public static bool operator ==(LocalAddress left, LocalAddress right)
         {
             return Equals(left, right);
         }
@@ -93,7 +94,7 @@
         /// <summary>
         /// Compares for inequality.
         /// </summary>
-        public static bool operator !=(LogicalAddress left, LogicalAddress right)
+        public static bool operator !=(LocalAddress left, LocalAddress right)
         {
             return !Equals(left, right);
         }

--- a/src/NServiceBus.Core/LogicalAddress.cs
+++ b/src/NServiceBus.Core/LogicalAddress.cs
@@ -1,105 +1,89 @@
 ﻿namespace NServiceBus
 {
-    using System;
-    using JetBrains.Annotations;
-    using Routing;
-
     /// <summary>
-    /// Represents a logical address (independent of transport).
+    /// Represents a logical address (independent of transport) of a local queue.
     /// </summary>
     public sealed class LogicalAddress
     {
         /// <summary>
-        /// Creates new qualified logical address for the provided endpoint instance name.
-        /// </summary>
-        /// <param name="endpointInstance">The name of the instance.</param>
-        /// <param name="qualifier">The qualifier of this address.</param>
-        public LogicalAddress(EndpointInstance endpointInstance, [NotNull] string qualifier)
-        {
-            if (qualifier == null)
-            {
-                throw new ArgumentNullException(nameof(qualifier));
-            }
-            EndpointInstance = endpointInstance;
-            Qualifier = qualifier;
-        }
-
-        /// <summary>
         /// Creates new root logical address for the provided endpoint instance name.
         /// </summary>
-        /// <param name="endpointInstance">The name of the instance.</param>
-        public LogicalAddress(EndpointInstance endpointInstance)
+        /// <param name="endpoint">The logical name of the endpoint.</param>
+        /// <param name="qualifier">The qualifier to apply to the given logical endpoint name.</param>
+        /// <param name="discriminator">The discriminator to apply to the given logical endpoint name.</param>
+        public LogicalAddress(string endpoint, string qualifier = null, string discriminator = null)
         {
-            EndpointInstance = endpointInstance;
+            Endpoint = endpoint;
+            Qualifier = qualifier;
+            Discriminator = discriminator;
         }
 
-
         /// <summary>
-        /// Returns the qualifier or null for the root logical address for a given instance name.
+        /// Returns the qualifier of the address.
         /// </summary>
+        /// <returns>The configured qualifier or <code>null</code> when no qualifier is specified.</returns>
         public string Qualifier { get; }
 
         /// <summary>
-        /// Returns the instance name.
+        /// Returns the discriminator of the address.
         /// </summary>
-        public EndpointInstance EndpointInstance { get; }
+        /// <returns>The configured discriminator or <code>null</code> when no discriminator is specified.</returns>
+        public string Discriminator { get; }
 
-        bool Equals(LogicalAddress other)
-        {
-            return string.Equals(Qualifier, other.Qualifier) && Equals(EndpointInstance, other.EndpointInstance);
-        }
-
+        /// <summary>
+        /// Returns the logical endpoint name excluding qualifier and discriminator.
+        /// </summary>
+        public string Endpoint { get; }
         /// <summary>
         /// Returns a string that represents the current object.
         /// </summary>
-        /// <returns>
-        /// A string that represents the current object.
-        /// </returns>
         public override string ToString()
         {
+            var name = Endpoint;
+
+            if (Discriminator != null)
+            {
+                name += $"-{Discriminator}";
+            }
+
             if (Qualifier != null)
             {
-                return EndpointInstance + "." + Qualifier;
+                name += $".{Qualifier}";
             }
-            return EndpointInstance.ToString();
+
+            return name;
         }
 
-        /// <summary>
-        /// Determines whether the specified object is equal to the current object.
-        /// </summary>
-        /// <returns>
-        /// true if the specified object  is equal to the current object; otherwise, false.
-        /// </returns>
+        bool Equals(LogicalAddress other)
+        {
+            return string.Equals(Qualifier, other.Qualifier) && string.Equals(Discriminator, other.Discriminator) && string.Equals(Endpoint, other.Endpoint);
+        }
+
+        /// <summary>Determines whether the specified object is equal to the current object.</summary>
+        /// <returns>true if the specified object  is equal to the current object; otherwise, false.</returns>
         /// <param name="obj">The object to compare with the current object. </param>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-            if (ReferenceEquals(this, obj))
-            {
-                return true;
-            }
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
             return obj is LogicalAddress && Equals((LogicalAddress) obj);
         }
 
-        /// <summary>
-        /// Serves as a hash function for a particular type.
-        /// </summary>
-        /// <returns>
-        /// A hash code for the current object.
-        /// </returns>
+        /// <summary>Serves as the default hash function. </summary>
+        /// <returns>A hash code for the current object.</returns>
         public override int GetHashCode()
         {
             unchecked
             {
-                return ((Qualifier?.GetHashCode() ?? 0)*397) ^ (EndpointInstance?.GetHashCode() ?? 0);
+                var hashCode = (Qualifier != null ? Qualifier.GetHashCode() : 0);
+                hashCode = (hashCode*397) ^ (Discriminator != null ? Discriminator.GetHashCode() : 0);
+                hashCode = (hashCode*397) ^ (Endpoint != null ? Endpoint.GetHashCode() : 0);
+                return hashCode;
             }
         }
 
         /// <summary>
-        /// Checks for equality.
+        /// Compares for equality.
         /// </summary>
         public static bool operator ==(LogicalAddress left, LogicalAddress right)
         {
@@ -107,7 +91,7 @@
         }
 
         /// <summary>
-        /// Checks for inequality.
+        /// Compares for inequality.
         /// </summary>
         public static bool operator !=(LogicalAddress left, LogicalAddress right)
         {

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Transports\ErrorContext.cs" />
     <Compile Include="Transports\ErrorHandleResult.cs" />
     <Compile Include="Transports\IOutgoingTransportOperation.cs" />
+    <Compile Include="Transports\LocalAddressOverrideExtensions.cs" />
     <Compile Include="Transports\LogicalAddressExtensions.cs" />
     <Compile Include="Transports\Msmq\MsmqScopeOptions.cs" />
     <Compile Include="Transports\Msmq\MsmqTransportInfrastructure.cs" />

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -409,7 +409,7 @@
     <Compile Include="Routing\MessagingBestPractices\BestPracticesOptionExtensions.cs" />
     <Compile Include="Pipeline\Outgoing\IOutgoingLogicalMessageContext.cs" />
     <Compile Include="Persistence\InMemory\Outbox\InMemoryOutboxSettingsExtensions.cs" />
-    <Compile Include="LogicalAddress.cs" />
+    <Compile Include="LocalAddress.cs" />
     <Compile Include="Pipeline\BehaviorInvoker.cs" />
     <Compile Include="Pipeline\Incoming\IIncomingContext.cs" />
     <Compile Include="Pipeline\Incoming\ITransportReceiveContext.cs" />

--- a/src/NServiceBus.Core/Routing/ConfigureUniquelyAddressableInstanceExtensions.cs
+++ b/src/NServiceBus.Core/Routing/ConfigureUniquelyAddressableInstanceExtensions.cs
@@ -15,7 +15,7 @@
             Guard.AgainstNull(nameof(config), config);
             Guard.AgainstNullAndEmpty(nameof(discriminator), discriminator);
 
-            config.Settings.Set("EndpointInstanceDiscriminator", discriminator);
+            config.Settings.Set(Receiving.EndpointInstanceDiscriminator, discriminator);
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionRouter.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionRouter.cs
@@ -24,7 +24,7 @@
             {
                 results.AddRange(await publisherAddress.Resolve(
                     ResolveInstances,
-                    i => physicalAddresses.GetTransportAddress(new LogicalAddress(i))).ConfigureAwait(false));
+                    i => physicalAddresses.GetTransportAddress(i)).ConfigureAwait(false));
             }
             return results.Distinct();
         }

--- a/src/NServiceBus.Core/Routing/UnicastRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRouter.cs
@@ -38,7 +38,7 @@ namespace NServiceBus
             var selectedDestinations = SelectDestinationsForEachEndpoint(distributionPolicy, destinations);
 
             return selectedDestinations
-                .Select(destination => destination.Resolve(x => physicalAddresses.GetTransportAddress(new LogicalAddress(x))))
+                .Select(destination => destination.Resolve(x => physicalAddresses.GetTransportAddress(x)))
                 .Distinct() //Make sure we are sending only one to each transport destination. Might happen when there are multiple routing information sources.
                 .Select(destination => new UnicastRoutingStrategy(destination));
         }

--- a/src/NServiceBus.Core/SettingsExtensions.cs
+++ b/src/NServiceBus.Core/SettingsExtensions.cs
@@ -74,9 +74,9 @@ namespace NServiceBus
         /// <summary>
         /// Returns the local logical address of this endpoint.
         /// </summary>
-        public static LogicalAddress LocalLogicalAddress(this ReadOnlySettings settings)
+        public static LocalAddress LocalLogicalAddress(this ReadOnlySettings settings)
         {
-            return settings.Get<LogicalAddress>(Receiving.SharedQueueLogicalAddressSettingsKey);
+            return settings.Get<LocalAddress>(Receiving.SharedQueueLogicalAddressSettingsKey);
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/SettingsExtensions.cs
+++ b/src/NServiceBus.Core/SettingsExtensions.cs
@@ -4,7 +4,6 @@ namespace NServiceBus
     using System.Collections.Generic;
     using System.Linq;
     using Config.ConfigurationSource;
-    using Routing;
     using Settings;
 
     /// <summary>
@@ -64,21 +63,20 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Returns the name of this instance of the endpoint.
-        /// </summary>
-        public static EndpointInstance EndpointInstanceName(this ReadOnlySettings settings)
-        {
-            Guard.AgainstNull(nameof(settings), settings);
-            return settings.Get<EndpointInstance>();
-        }
-
-        /// <summary>
         /// Returns the shared queue name of this endpoint.
         /// </summary>
         public static string LocalAddress(this ReadOnlySettings settings)
         {
             Guard.AgainstNull(nameof(settings), settings);
-            return settings.Get<string>("NServiceBus.SharedQueue");
+            return settings.Get<string>(Receiving.SharedQueueAddressSettingsKey);
+        }
+
+        /// <summary>
+        /// Returns the local logical address of this endpoint.
+        /// </summary>
+        public static LogicalAddress LocalLogicalAddress(this ReadOnlySettings settings)
+        {
+            return settings.Get<LogicalAddress>(Receiving.SharedQueueLogicalAddressSettingsKey);
         }
 
         /// <summary>
@@ -87,7 +85,7 @@ namespace NServiceBus
         public static string InstanceSpecificQueue(this ReadOnlySettings settings)
         {
             Guard.AgainstNull(nameof(settings), settings);
-            return settings.GetOrDefault<string>("NServiceBus.EndpointSpecificQueue");
+            return settings.GetOrDefault<string>(Receiving.UniqueEndpointAddressSettingsKey);
         }
 
         static bool HasConstructorThatAcceptsSettings(Type sectionOverrideType)

--- a/src/NServiceBus.Core/Transports/LocalAddressOverrideExtensions.cs
+++ b/src/NServiceBus.Core/Transports/LocalAddressOverrideExtensions.cs
@@ -1,0 +1,18 @@
+﻿namespace NServiceBus
+{
+    /// <summary>
+    /// Provides extension methods to configure the local input address.
+    /// </summary>
+    public static class LocalAddressOverrideExtensions
+    {
+        /// <summary>
+        /// Changes the name of the input address to the specified value instead of using the configured endpoint name.
+        /// </summary>
+        /// <param name="configuration">The endpoint configuration.</param>
+        /// <param name="addressOverride">The input address to use instead.</param>
+        public static void OverrideLocalAddress(this EndpointConfiguration configuration, string addressOverride)
+        {
+            configuration.Settings.Set(Receiving.SharedQueueAddressOverrideSettingsKey, addressOverride);
+        }
+    }
+}

--- a/src/NServiceBus.Core/Transports/LogicalAddressExtensions.cs
+++ b/src/NServiceBus.Core/Transports/LogicalAddressExtensions.cs
@@ -11,10 +11,10 @@ namespace NServiceBus.Transport
         /// Gets the native transport address for the given logical address.
         /// </summary>
         /// <returns>The native transport address.</returns>
-        public static string GetTransportAddress(this ReadOnlySettings settings, LogicalAddress logicalAddress)
+        public static string GetTransportAddress(this ReadOnlySettings settings, LocalAddress localAddress)
         {
             return settings.Get<TransportAddresses>()
-                .GetTransportAddress(logicalAddress);
+                .GetTransportAddress(localAddress);
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
@@ -63,16 +63,16 @@ namespace NServiceBus
             return queue + "@" + machine;
         }
 
-        public override string ToTransportAddress(LogicalAddress logicalAddress)
+        public override string ToTransportAddress(LocalAddress localAddress)
         {
-            var queue = new StringBuilder(logicalAddress.Endpoint);
-            if (logicalAddress.Discriminator != null)
+            var queue = new StringBuilder(localAddress.Endpoint);
+            if (localAddress.Discriminator != null)
             {
-                queue.Append("-" + logicalAddress.Discriminator);
+                queue.Append("-" + localAddress.Discriminator);
             }
-            if (logicalAddress.Qualifier != null)
+            if (localAddress.Qualifier != null)
             {
-                queue.Append("." + logicalAddress.Qualifier);
+                queue.Append("." + localAddress.Qualifier);
             }
             return queue + "@" + RuntimeEnvironment.MachineName;
         }

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
@@ -46,26 +46,35 @@ namespace NServiceBus
             return new ReceiveWithNativeTransaction(new MsmqFailureInfoStorage(1000));
         }
 
-        public override EndpointInstance BindToLocalEndpoint(EndpointInstance instance) => instance.AtMachine(RuntimeEnvironment.MachineName);
-
-        public override string ToTransportAddress(LogicalAddress logicalAddress)
+        public override string ToTransportAddress(EndpointInstance endpointInstance)
         {
             string machine;
-            if (!logicalAddress.EndpointInstance.Properties.TryGetValue("machine", out machine))
+            if (!endpointInstance.Properties.TryGetValue("machine", out machine))
             {
                 machine = RuntimeEnvironment.MachineName;
             }
 
-            var queue = new StringBuilder(logicalAddress.EndpointInstance.Endpoint);
-            if (logicalAddress.EndpointInstance.Discriminator != null)
+            var queue = new StringBuilder(endpointInstance.Endpoint);
+            if (endpointInstance.Discriminator != null)
             {
-                queue.Append("-" + logicalAddress.EndpointInstance.Discriminator);
+                queue.Append("-" + endpointInstance.Discriminator);
+            }
+
+            return queue + "@" + machine;
+        }
+
+        public override string ToTransportAddress(LogicalAddress logicalAddress)
+        {
+            var queue = new StringBuilder(logicalAddress.Endpoint);
+            if (logicalAddress.Discriminator != null)
+            {
+                queue.Append("-" + logicalAddress.Discriminator);
             }
             if (logicalAddress.Qualifier != null)
             {
                 queue.Append("." + logicalAddress.Qualifier);
             }
-            return queue + "@" + machine;
+            return queue + "@" + RuntimeEnvironment.MachineName;
         }
 
         public override string MakeCanonicalForm(string transportAddress)

--- a/src/NServiceBus.Core/Transports/Receiving.cs
+++ b/src/NServiceBus.Core/Transports/Receiving.cs
@@ -20,9 +20,9 @@ namespace NServiceBus
 
                 if (userDiscriminator != null)
                 {
-                    s.SetDefault(UniqueEndpointAddressSettingsKey, transportAddresses.GetTransportAddress(new LogicalAddress(receivingName, discriminator: userDiscriminator)));
+                    s.SetDefault(UniqueEndpointAddressSettingsKey, transportAddresses.GetTransportAddress(new LocalAddress(receivingName, discriminator: userDiscriminator)));
                 }
-                var address = new LogicalAddress(receivingName);
+                var address = new LocalAddress(receivingName);
                 s.SetDefault(SharedQueueAddressSettingsKey, transportAddresses.GetTransportAddress(address));
                 s.SetDefault(SharedQueueLogicalAddressSettingsKey, address);
             });

--- a/src/NServiceBus.Core/Transports/TransportAddresses.cs
+++ b/src/NServiceBus.Core/Transports/TransportAddresses.cs
@@ -3,7 +3,6 @@ namespace NServiceBus.Transport
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using JetBrains.Annotations;
     using Routing;
 
     /// <summary>
@@ -11,9 +10,10 @@ namespace NServiceBus.Transport
     /// </summary>
     public class TransportAddresses
     {
-        internal TransportAddresses(Func<LogicalAddress, string> transportDefault)
+        internal TransportAddresses(Func<EndpointInstance, string> instanceTransportDefault, Func<LogicalAddress, string> logicalTransportDefault)
         {
-            this.transportDefault = transportDefault;
+            this.instanceTransportDefault = instanceTransportDefault;
+            this.logicalTransportDefault = logicalTransportDefault;
         }
 
         /// <summary>
@@ -21,7 +21,7 @@ namespace NServiceBus.Transport
         /// </summary>
         /// <param name="endpointInstance">Logical address for which the exception is created.</param>
         /// <param name="physicalAddress">Physical address of that instance.</param>
-        public void AddSpecialCase([NotNull] LogicalAddress endpointInstance, string physicalAddress)
+        public void AddSpecialCase(EndpointInstance endpointInstance, string physicalAddress)
         {
             Guard.AgainstNull(nameof(endpointInstance), endpointInstance);
             Guard.AgainstNullAndEmpty(nameof(physicalAddress), physicalAddress);
@@ -30,26 +30,21 @@ namespace NServiceBus.Transport
         }
 
         /// <summary>
-        /// Adds an exception to the translation rules for a given endpoint instance.
-        /// </summary>
-        /// <param name="endpointInstance">Name of the instance for which the exception is created.</param>
-        /// <param name="physicalAddress">Physical address of that instance.</param>
-        public void AddSpecialCase([NotNull] EndpointInstance endpointInstance, string physicalAddress)
-        {
-            AddSpecialCase(new LogicalAddress(endpointInstance), physicalAddress);
-        }
-
-        /// <summary>
         /// Adds a rule for translating endpoint instance names to physical addresses in direct routing.
         /// </summary>
         /// <param name="dynamicRule">The rule.</param>
-        public void AddRule(Func<LogicalAddress, string> dynamicRule)
+        public void AddRule(Func<EndpointInstance, string> dynamicRule)
         {
             Guard.AgainstNull(nameof(dynamicRule), dynamicRule);
             rules.Add(dynamicRule);
         }
 
-        internal string GetTransportAddress(LogicalAddress endpointInstance)
+        internal string GetTransportAddress(LogicalAddress logicalAddress)
+        {
+            return logicalTransportDefault(logicalAddress);
+        }
+
+        internal string GetTransportAddress(EndpointInstance endpointInstance)
         {
             string exception;
             if (exceptions.TryGetValue(endpointInstance, out exception))
@@ -61,11 +56,12 @@ namespace NServiceBus.Transport
             {
                 throw new Exception("Translation of endpoint instance name " + endpointInstance + " to physical address using provided rules is ambiguous.");
             }
-            return overrides.FirstOrDefault() ?? transportDefault(endpointInstance);
+            return overrides.FirstOrDefault() ?? instanceTransportDefault(endpointInstance);
         }
 
-        Dictionary<LogicalAddress, string> exceptions = new Dictionary<LogicalAddress, string>();
-        List<Func<LogicalAddress, string>> rules = new List<Func<LogicalAddress, string>>();
-        Func<LogicalAddress, string> transportDefault;
+        Dictionary<EndpointInstance, string> exceptions = new Dictionary<EndpointInstance, string>();
+        List<Func<EndpointInstance, string>> rules = new List<Func<EndpointInstance, string>>();
+        Func<EndpointInstance, string> instanceTransportDefault;
+        Func<LogicalAddress, string> logicalTransportDefault;
     }
 }

--- a/src/NServiceBus.Core/Transports/TransportAddresses.cs
+++ b/src/NServiceBus.Core/Transports/TransportAddresses.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.Transport
     /// </summary>
     public class TransportAddresses
     {
-        internal TransportAddresses(Func<EndpointInstance, string> instanceTransportDefault, Func<LogicalAddress, string> logicalTransportDefault)
+        internal TransportAddresses(Func<EndpointInstance, string> instanceTransportDefault, Func<LocalAddress, string> logicalTransportDefault)
         {
             this.instanceTransportDefault = instanceTransportDefault;
             this.logicalTransportDefault = logicalTransportDefault;
@@ -39,9 +39,9 @@ namespace NServiceBus.Transport
             rules.Add(dynamicRule);
         }
 
-        internal string GetTransportAddress(LogicalAddress logicalAddress)
+        internal string GetTransportAddress(LocalAddress localAddress)
         {
-            return logicalTransportDefault(logicalAddress);
+            return logicalTransportDefault(localAddress);
         }
 
         internal string GetTransportAddress(EndpointInstance endpointInstance)
@@ -62,6 +62,6 @@ namespace NServiceBus.Transport
         Dictionary<EndpointInstance, string> exceptions = new Dictionary<EndpointInstance, string>();
         List<Func<EndpointInstance, string>> rules = new List<Func<EndpointInstance, string>>();
         Func<EndpointInstance, string> instanceTransportDefault;
-        Func<LogicalAddress, string> logicalTransportDefault;
+        Func<LocalAddress, string> logicalTransportDefault;
     }
 }

--- a/src/NServiceBus.Core/Transports/TransportAddressing.cs
+++ b/src/NServiceBus.Core/Transports/TransportAddressing.cs
@@ -11,7 +11,7 @@ namespace NServiceBus
             Defaults(s =>
             {
                 var transportInfrastructure = s.Get<TransportInfrastructure>();
-                s.SetDefault<TransportAddresses>(new TransportAddresses(transportInfrastructure.ToTransportAddress));
+                s.SetDefault<TransportAddresses>(new TransportAddresses(transportInfrastructure.ToTransportAddress, transportInfrastructure.ToTransportAddress));
             });
         }
 

--- a/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
@@ -46,16 +46,18 @@ namespace NServiceBus.Transport
         public abstract TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure();
 
         /// <summary>
-        /// Returns the discriminator for this endpoint instance.
-        /// </summary>
-        public abstract EndpointInstance BindToLocalEndpoint(EndpointInstance instance);
-
-        /// <summary>
-        /// Converts a given logical address to the transport address.
+        /// Converts a given <see cref="LogicalAddress"/> to the transport address.
         /// </summary>
         /// <param name="logicalAddress">The logical address.</param>
         /// <returns>The transport address.</returns>
         public abstract string ToTransportAddress(LogicalAddress logicalAddress);
+
+        /// <summary>
+        /// Converts a given <see cref="EndpointInstance"/> to the the transport address.
+        /// </summary>
+        /// <param name="endpointInstance">The endpoint instance.</param>
+        /// <returns>The transport address.</returns>
+        public abstract string ToTransportAddress(EndpointInstance endpointInstance);
 
         /// <summary>
         /// Returns the canonical for of the given transport address so various transport addresses can be effectively compared and

--- a/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
@@ -46,11 +46,11 @@ namespace NServiceBus.Transport
         public abstract TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure();
 
         /// <summary>
-        /// Converts a given <see cref="LogicalAddress"/> to the transport address.
+        /// Converts a given <see cref="LocalAddress"/> to the transport address.
         /// </summary>
-        /// <param name="logicalAddress">The logical address.</param>
+        /// <param name="localAddress">The logical address.</param>
         /// <returns>The transport address.</returns>
-        public abstract string ToTransportAddress(LogicalAddress logicalAddress);
+        public abstract string ToTransportAddress(LocalAddress localAddress);
 
         /// <summary>
         /// Converts a given <see cref="EndpointInstance"/> to the the transport address.

--- a/src/NServiceBus.Core/Unicast/Transport/Config/TransportExtensions.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/Config/TransportExtensions.cs
@@ -115,20 +115,9 @@ namespace NServiceBus
         /// Adds a rule for translating endpoint instance names to physical addresses in direct routing.
         /// </summary>
         /// <param name="rule">The rule.</param>
-        public TransportExtensions AddAddressTranslationRule(Func<LogicalAddress, string> rule)
+        public TransportExtensions AddAddressTranslationRule(Func<EndpointInstance, string> rule)
         {
             GetOrCreateTransportAddresses().AddRule(rule);
-            return this;
-        }
-
-        /// <summary>
-        /// Adds an exception to the translation rules for a given endpoint instance.
-        /// </summary>
-        /// <param name="logicalAddress">Logical address for which the exception is created.</param>
-        /// <param name="transportAddress">Transport address of that instance.</param>
-        public TransportExtensions AddAddressTranslationException(LogicalAddress logicalAddress, string transportAddress)
-        {
-            GetOrCreateTransportAddresses().AddSpecialCase(logicalAddress, transportAddress);
             return this;
         }
 
@@ -152,28 +141,14 @@ namespace NServiceBus
                 {
                     var transportInfrastructure = Settings.Get<TransportInfrastructure>();
                     return transportInfrastructure.ToTransportAddress(a);
+                }, a =>
+                {
+                    var transportInfrastructure = Settings.Get<TransportInfrastructure>();
+                    return transportInfrastructure.ToTransportAddress(a);
                 });
                 Settings.Set<TransportAddresses>(value);
             }
             return value;
-        }
-    }
-
-    /// <summary>
-    /// Allows you to read which transport connectionstring has been set.
-    /// </summary>
-    public static class ConfigureTransportConnectionString
-    {
-        /// <summary>
-        /// Gets the transport connectionstring.
-        /// </summary>
-        [ObsoleteEx(
-            TreatAsErrorFromVersion = "6",
-            RemoveInVersion = "7",
-            Message = "Not available any more.")]
-        public static string TransportConnectionString(this Configure config)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/NServiceBus.Core/obsoletes.cs
+++ b/src/NServiceBus.Core/obsoletes.cs
@@ -186,16 +186,6 @@ namespace NServiceBus
         }
 
         [ObsoleteEx(
-            ReplacementTypeOrMember = "EndpointConfiguration.UseTransport<T>().AddAddressTranslationRule(Func<LogicalAddress, string> rule)",
-            RemoveInVersion = "7.0",
-            TreatAsErrorFromVersion = "6.0")]
-        public void OverrideLocalAddress(string queue)
-        {
-            throw new NotImplementedException();
-        }
-
-
-        [ObsoleteEx(
             Message = "Endpoint name is now a mandatory constructor argument on EndpointConfiguration.",
             RemoveInVersion = "7.0",
             TreatAsErrorFromVersion = "6.0")]
@@ -470,6 +460,22 @@ namespace NServiceBus
         TreatAsErrorFromVersion = "6.0",
         ReplacementTypeOrMember = "SanitizeInput(this SerializationExtensions<XmlSerializer> config)")]
         public static SerializationExtentions<XmlSerializer> SanitizeInput(this SerializationExtentions<XmlSerializer> config)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    [ObsoleteEx(
+        TreatAsErrorFromVersion = "6",
+        RemoveInVersion = "7",
+        Message = "Not available any more.")]
+    public static class ConfigureTransportConnectionString
+    {
+        [ObsoleteEx(
+            TreatAsErrorFromVersion = "6",
+            RemoveInVersion = "7",
+            Message = "Not available any more.")]
+        public static string TransportConnectionString(this Configure config)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
`LogicalAddress` is only used to define local input queues with qualifiers and/or discriminators. It contained an `EndpointInstance` from where it read the discriminator property while it used the Qualifier property on `LogicalAddress` directly. To change the local input queue, you had to define a address translation exception with an `Routing.EndpointInstance` matching the local endpoint.

This PR
* Renames `LogicalAddress` to `LocalAddress`. It adds a new abstract method on the transport seam where the transport has to define how the physical address is created. In exchange, `BindToLocalEndpoint` for `EndpointInstance` has been removed from the transport seam.
* AddressTranslationRules/Exception can no longer be used to interfere with local queues. to change the local input queues, `OverrideLocalAddress` has been reintroduced again.

This essentially replaces https://github.com/Particular/NServiceBus/pull/3962

@Particular/nservicebus-maintainers @DavidBoike @SzymonPobiega @Scooletz please review