### PR TITLE
Make machine property key lowercase

### DIFF
--- a/src/NServiceBus.Core/Transports/Msmq/EndpointInstanceExtensions.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/EndpointInstanceExtensions.cs
@@ -14,7 +14,7 @@ namespace NServiceBus
         /// <param name="machineName">Machine name.</param>
         public static EndpointInstance AtMachine(this EndpointInstance instance, string machineName)
         {
-            return instance.SetProperty("Machine", machineName);
+            return instance.SetProperty("machine", machineName);
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
@@ -51,7 +51,7 @@ namespace NServiceBus
         public override string ToTransportAddress(LogicalAddress logicalAddress)
         {
             string machine;
-            if (!logicalAddress.EndpointInstance.Properties.TryGetValue("Machine", out machine))
+            if (!logicalAddress.EndpointInstance.Properties.TryGetValue("machine", out machine))
             {
                 machine = RuntimeEnvironment.MachineName;
             }


### PR DESCRIPTION
since we currently map they attributes 1:1 into dictionary key/value pairs, this changes the machine key to be lowercase to align with the rest of the instance mapping settings.

e.g. instead of 

```
<endpoints>
  <endpoint name="Routing.Receiver">
    <instance discriminator="1" Machine="machine1" />
  </endpoint>
</endpoints>
```

this becomes:

```
<endpoints>
  <endpoint name="Routing.Receiver">
    <instance discriminator="1" machine="machine1" />
  </endpoint>
</endpoints>
```

this does not address any of the ideas of changing the xsd to be more restrictive.

ping @Particular/nservicebus-maintainers @DavidBoike @SzymonPobiega 