### PR TITLE
Reduce RouteTo overloads in UnicastRoutingTable

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2601,9 +2601,7 @@ namespace NServiceBus.Routing
         public UnicastRoutingTable() { }
         public void AddDynamic(System.Func<System.Type[], NServiceBus.Extensibility.ContextBag, System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.Routing.IUnicastRoute>>> dynamicRule) { }
         public void AddDynamic(System.Func<System.Type[], NServiceBus.Extensibility.ContextBag, System.Collections.Generic.IEnumerable<NServiceBus.Routing.IUnicastRoute>> dynamicRule) { }
-        public void RouteToAddress(System.Type messageType, string destinationAddress) { }
-        public void RouteToEndpoint(System.Type messageType, string destination) { }
-        public void RouteToInstance(System.Type messageType, NServiceBus.Routing.EndpointInstance instance) { }
+        public void RouteTo(System.Type messageType, NServiceBus.Routing.IUnicastRoute route) { }
     }
 }
 namespace NServiceBus.Routing.Legacy

--- a/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
@@ -22,7 +22,7 @@
         public async Task When_routing_command_to_logical_endpoint_without_configured_instances_should_route_to_a_single_destination()
         {
             var logicalEndpointName = "Sales";
-            routingTable.RouteToEndpoint(typeof(Command), logicalEndpointName);
+            routingTable.RouteTo(typeof(Command), UnicastRoute.CreateFromEndpointName(logicalEndpointName));
 
             var routes = await router.Route(typeof(Command), new DistributionPolicy(), new ContextBag());
 
@@ -35,8 +35,8 @@
         {
             var sales = "Sales";
             var shipping = "Shipping";
-            routingTable.RouteToEndpoint(typeof(Command), sales);
-            routingTable.RouteToEndpoint(typeof(Command), shipping);
+            routingTable.RouteTo(typeof(Command), UnicastRoute.CreateFromEndpointName(sales));
+            routingTable.RouteTo(typeof(Command), UnicastRoute.CreateFromEndpointName(shipping));
 
             endpointInstances.Add(new EndpointInstance(sales, "1"));
             endpointInstances.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(sales, "2"))));
@@ -53,9 +53,9 @@
         public async Task Should_not_route_multiple_copies_of_message_to_one_physical_destination()
         {
             var sales = "Sales";
-            routingTable.RouteToEndpoint(typeof(Command), sales);
+            routingTable.RouteTo(typeof(Command), UnicastRoute.CreateFromEndpointName(sales));
             endpointInstances.Add(new EndpointInstance(sales, "1"));
-            routingTable.RouteToAddress(typeof(Command), sales+"-1");
+            routingTable.RouteTo(typeof(Command), UnicastRoute.CreateFromPhysicalAddress(sales + "-1"));
 
             var routes = await router.Route(typeof(Command), new DistributionPolicy(), new ContextBag());
 

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -132,7 +132,7 @@
 
         static void ConfigureSendDestination(TransportInfrastructure transportInfrastructure, UnicastRoutingTable unicastRoutingTable, Type type, string address)
         {
-            unicastRoutingTable.RouteToAddress(type, transportInfrastructure.MakeCanonicalForm(address));
+            unicastRoutingTable.RouteTo(type, UnicastRoute.CreateFromPhysicalAddress(transportInfrastructure.MakeCanonicalForm(address)));
         }
     }
 

--- a/src/NServiceBus.Core/Routing/RoutingSettings.cs
+++ b/src/NServiceBus.Core/Routing/RoutingSettings.cs
@@ -4,6 +4,7 @@
     using System.Reflection;
     using Configuration.AdvanceExtensibility;
     using Features;
+    using Routing;
     using Settings;
     using Transport;
 
@@ -26,7 +27,7 @@
         {
             ThrowOnAddress(destination);
 
-            Settings.GetOrCreate<ConfiguredUnicastRoutes>().Add((routingTable, knownMessageTypes) => { routingTable.RouteToEndpoint(messageType, destination); });
+            Settings.GetOrCreate<ConfiguredUnicastRoutes>().Add((routingTable, knownMessageTypes) => { routingTable.RouteTo(messageType, UnicastRoute.CreateFromEndpointName(destination)); });
         }
 
         /// <summary>
@@ -43,7 +44,7 @@
                 {
                     if (knownMessage.Assembly == assembly)
                     {
-                        routingTable.RouteToEndpoint(knownMessage, destination);
+                        routingTable.RouteTo(knownMessage, UnicastRoute.CreateFromEndpointName(destination));
                     }
                 }
             });
@@ -67,7 +68,7 @@
                 {
                     if (knownMessage.Assembly == assembly && knownMessage.Namespace == @namespace)
                     {
-                        routingTable.RouteToEndpoint(knownMessage, destination);
+                        routingTable.RouteTo(knownMessage, UnicastRoute.CreateFromEndpointName(destination));
                     }
                 }
             });

--- a/src/NServiceBus.Core/Routing/UnicastRoutingTable.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRoutingTable.cs
@@ -37,33 +37,22 @@ namespace NServiceBus.Routing
         }
 
         /// <summary>
-        /// Adds a static unicast route to a logical endpoint.
+        /// Adds a static unicast route for a given message type.
         /// </summary>
-        /// <param name="messageType">Message type.</param>
-        /// <param name="destination">Destination endpoint.</param>
-        public void RouteToEndpoint(Type messageType, string destination)
+        public void RouteTo(Type messageType, IUnicastRoute route)
         {
-            AddStaticRoute(messageType, UnicastRoute.CreateFromEndpointName(destination));
-        }
-
-        /// <summary>
-        /// Adds a static unicast route to a specific endpoint instance.
-        /// </summary>
-        /// <param name="messageType">Message type.</param>
-        /// <param name="instance">Destination endpoint instance.</param>
-        public void RouteToInstance(Type messageType, EndpointInstance instance)
-        {
-            AddStaticRoute(messageType, UnicastRoute.CreateFromEndpointInstance(instance));
-        }
-
-        /// <summary>
-        /// Adds a static unicast route to a specific transport address.
-        /// </summary>
-        /// <param name="messageType">Message type.</param>
-        /// <param name="destinationAddress">Destination endpoint instance address.</param>
-        public void RouteToAddress(Type messageType, string destinationAddress)
-        {
-            AddStaticRoute(messageType, UnicastRoute.CreateFromPhysicalAddress(destinationAddress));
+            List<IUnicastRoute> existingRoutes;
+            if (staticRoutes.TryGetValue(messageType, out existingRoutes))
+            {
+                existingRoutes.Add(route);
+            }
+            else
+            {
+                staticRoutes.Add(messageType, new List<IUnicastRoute>
+                {
+                    route
+                });
+            }
         }
 
         /// <summary>
@@ -84,22 +73,6 @@ namespace NServiceBus.Routing
         public void AddDynamic(Func<Type[], ContextBag, IEnumerable<IUnicastRoute>> dynamicRule)
         {
             dynamicRules.Add(dynamicRule);
-        }
-
-        void AddStaticRoute(Type messageType, IUnicastRoute route)
-        {
-            List<IUnicastRoute> existingRoutes;
-            if (staticRoutes.TryGetValue(messageType, out existingRoutes))
-            {
-                existingRoutes.Add(route);
-            }
-            else
-            {
-                staticRoutes.Add(messageType, new List<IUnicastRoute>
-                {
-                    route
-                });
-            }
         }
 
         async Task<IEnumerable<IUnicastRoute>> AddAsyncDynamicRules(Type[] messageTypes, ContextBag contextBag, List<IUnicastRoute> routes)


### PR DESCRIPTION
Connects to Particular/V6Launch#68

replaces the three RouteToAddress RouteToEndpoint and RouteToInstance overloads with RouteTo which just accepts a `IUnicastRoute`

RouteToXYZ already internally created a UnicastRoute and the methods were mapped 1:1 (for every unicastroute option there was a method on the routing table). Additionally, users were already able to provide a `IUnicastRoute` when using the dynamic overloads, so I think this aligns the API better.

This will also make testing of the routing table a lot more easier since it will be possible to compare references instead of having to resolve the routes which are created internally.

@Particular/nservicebus-maintainers @DavidBoike @SzymonPobiega please review