### PR TITLE
Add missing xml comment on TestableIncomingPhysicalMessageContext

### DIFF
--- a/src/NServiceBus.Testing.Fakes/TestableIncomingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableIncomingPhysicalMessageContext.cs
@@ -12,6 +12,9 @@ namespace NServiceBus.Testing
     /// </summary>
     public partial class TestableIncomingPhysicalMessageContext : TestableIncomingContext, IIncomingPhysicalMessageContext
     {
+        /// <summary>
+        /// Creates a new instance of <see cref="TestableIncomingPhysicalMessageContext"/>.
+        /// </summary>
         public TestableIncomingPhysicalMessageContext()
         {
             Message = new IncomingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), Stream.Null);


### PR DESCRIPTION
@danielmarbach this fails the build locally. Not sure why it doesn't do that on the build server. Please merge