### PR TITLE
Subscription route inheritance

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga.cs
@@ -38,7 +38,7 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
             public Subscriber()
             {
                 EndpointSetup<DefaultServer>(c => c.Pipeline.Register("SubscriptionSpy", typeof(SubscriptionSpy), "Spies on subscriptions made"))
-                    .AddMapping<MyEventWithParent>(typeof(Subscriber)) //just map to our self for this test
+                    .AddMapping<MyEventBase>(typeof(Subscriber)) //just map to our self for this test
                     .AddMapping<MyEvent>(typeof(Subscriber)); //just map to our self for this test
             }
 
@@ -103,10 +103,6 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
         }
 
         public class MyEventWithParent : MyEventBase
-        {
-        }
-
-        public class MyMessage : IMessage
         {
         }
 

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -115,7 +115,7 @@
             {
                 m.Configure((type, endpointAddress) =>
                 {
-                    unicastRoutingTable.RouteTo(type, UnicastRoute.CreateFromPhysicalAddress(transportInfrastructure.MakeCanonicalForm(address));
+                    unicastRoutingTable.RouteTo(type, UnicastRoute.CreateFromPhysicalAddress(transportInfrastructure.MakeCanonicalForm(endpointAddress)));
                     publishers.AddByAddress(type, endpointAddress);
                 });
             }

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -44,7 +44,7 @@
             var unicastBusConfig = context.Settings.GetConfigSection<UnicastBusConfig>();
             if (unicastBusConfig != null)
             {
-                ImportMessageEndpointMappings(unicastBusConfig.MessageEndpointMappings, transportInfrastructure, publishers, unicastRoutingTable, knownMessageTypes);
+                ImportMessageEndpointMappings(unicastBusConfig.MessageEndpointMappings, transportInfrastructure, publishers, unicastRoutingTable);
             }
 
             foreach (var registration in configuredUnicastRoutes)
@@ -109,30 +109,16 @@
             return registry.GetAllMessages().Select(m => m.MessageType).ToArray();
         }
 
-        static void ImportMessageEndpointMappings(MessageEndpointMappingCollection legacyRoutingConfig, TransportInfrastructure transportInfrastructure, Publishers publishers, UnicastRoutingTable unicastRoutingTable, Type[] knownMessageTypes)
+        static void ImportMessageEndpointMappings(MessageEndpointMappingCollection legacyRoutingConfig, TransportInfrastructure transportInfrastructure, Publishers publishers, UnicastRoutingTable unicastRoutingTable)
         {
             foreach (MessageEndpointMapping m in legacyRoutingConfig)
             {
                 m.Configure((type, endpointAddress) =>
                 {
-                    ConfigureSendDestination(transportInfrastructure, unicastRoutingTable, type, endpointAddress);
-                    ConfigureSubscribeDestination(publishers, knownMessageTypes, type, endpointAddress);
+                    unicastRoutingTable.RouteTo(type, UnicastRoute.CreateFromPhysicalAddress(transportInfrastructure.MakeCanonicalForm(address));
+                    publishers.AddByAddress(type, endpointAddress);
                 });
             }
-        }
-
-        static void ConfigureSubscribeDestination(Publishers publishers, Type[] knownMessageTypes, Type type, string address)
-        {
-            var typesEnclosed = knownMessageTypes.Where(t => t.IsAssignableFrom(type));
-            foreach (var t in typesEnclosed)
-            {
-                publishers.AddByAddress(t, address);
-            }
-        }
-
-        static void ConfigureSendDestination(TransportInfrastructure transportInfrastructure, UnicastRoutingTable unicastRoutingTable, Type type, string address)
-        {
-            unicastRoutingTable.RouteTo(type, UnicastRoute.CreateFromPhysicalAddress(transportInfrastructure.MakeCanonicalForm(address)));
         }
     }
 


### PR DESCRIPTION
Removes the inheritance on subscription routes as suggested by #3911. This means that a route for a child event will not be applicable when trying to resolve a route for a base event. 

so the follow scenario will no longer work:

```
routingConfig.RegisterPublisher(typeof(Cat), "CatPublisher");

endpoint.Subscribe<Animal>(); // will no longer "inherit" the route from Cat
```