### PR TITLE
Making the transport transaction an explicit concept on the dispatcher

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeDispatcher.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeDispatcher.cs
@@ -6,7 +6,7 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport
 
     class FakeDispatcher : IDispatchMessages
     {
-        public Task Dispatch(TransportOperations outgoingMessages, ContextBag context)
+        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, ContextBag context)
         {
             return Task.FromResult(0);
         }

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -62,7 +62,7 @@
 
         class FakeDispatcher : IDispatchMessages
         {
-            public Task Dispatch(TransportOperations outgoingMessages, ContextBag context)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, ContextBag context)
             {
                 return Task.FromResult(0);
             }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -3024,7 +3024,7 @@ namespace NServiceBus.Transport
     }
     public interface IDispatchMessages
     {
-        System.Threading.Tasks.Task Dispatch(NServiceBus.Transport.TransportOperations outgoingMessages, NServiceBus.Extensibility.ContextBag context);
+        System.Threading.Tasks.Task Dispatch(NServiceBus.Transport.TransportOperations outgoingMessages, NServiceBus.Transport.TransportTransaction transaction, NServiceBus.Extensibility.ContextBag context);
     }
     public interface IManageSubscriptions
     {
@@ -3199,7 +3199,7 @@ namespace NServiceBus.Transport
     {
         public TransportSubscriptionInfrastructure(System.Func<NServiceBus.Transport.IManageSubscriptions> subscriptionManagerFactory) { }
     }
-    public class TransportTransaction : NServiceBus.Extensibility.ContextBag
+    public sealed class TransportTransaction : NServiceBus.Extensibility.ContextBag
     {
         public TransportTransaction() { }
     }

--- a/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/DispatchTimeoutBehaviorTest.cs
+++ b/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/DispatchTimeoutBehaviorTest.cs
@@ -125,7 +125,7 @@
         {
             public TransportOperations OutgoingTransportOperations { get; private set; } = new TransportOperations();
 
-            public Task Dispatch(TransportOperations outgoingMessages, ContextBag context)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transportTransaction, ContextBag context)
             {
                 OutgoingTransportOperations = outgoingMessages;
                 return TaskEx.CompletedTask;
@@ -134,7 +134,7 @@
 
         class FailingMessageDispatcher : IDispatchMessages
         {
-            public Task Dispatch(TransportOperations outgoingMessages, ContextBag context)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transportTransaction, ContextBag context)
             {
                 throw new Exception("simulated exception");
             }

--- a/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/RecordingFakeDispatcher.cs
+++ b/src/NServiceBus.Core.Tests/DelayedDelivery/TimeoutManager/RecordingFakeDispatcher.cs
@@ -11,19 +11,21 @@
         {
             public TransportOperations Operations { get; }
             public ContextBag Context { get; }
+            public TransportTransaction Transaction { get; }
 
-            public DispatchedMessage(TransportOperations operations, ContextBag context)
+            public DispatchedMessage(TransportOperations operations, TransportTransaction transaction, ContextBag context)
             {
                 Operations = operations;
                 Context = context;
+                Transaction = transaction;
             }
         }
 
         public readonly List<DispatchedMessage> DispatchedMessages = new List<DispatchedMessage>();
 
-        public Task Dispatch(TransportOperations outgoingMessages, ContextBag context)
+        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, ContextBag context)
         {
-            DispatchedMessages.Add(new DispatchedMessage(outgoingMessages, context));
+            DispatchedMessages.Add(new DispatchedMessage(outgoingMessages, transaction, context));
             return TaskEx.CompletedTask;
         }
     }

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqMessageDispatcherTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqMessageDispatcherTests.cs
@@ -30,7 +30,7 @@
                 var headers = new Dictionary<string, string>();
                 var outgoingMessage = new OutgoingMessage("1", headers, bytes);
                 var transportOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(queueName), DispatchConsistency.Default);
-                messageSender.Dispatch(new TransportOperations(transportOperation), new ContextBag());
+                messageSender.Dispatch(new TransportOperations(transportOperation), new TransportTransaction(), new ContextBag());
                 var messageLabel = ReadMessageLabel(path);
                 Assert.AreEqual("mylabel", messageLabel);
 
@@ -58,7 +58,7 @@
                 var headers = new Dictionary<string, string>();
                 var outgoingMessage = new OutgoingMessage("1", headers, bytes);
                 var transportOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(queueName), DispatchConsistency.Default);
-                messageSender.Dispatch(new TransportOperations(transportOperation), new ContextBag());
+                messageSender.Dispatch(new TransportOperations(transportOperation), new TransportTransaction(), new ContextBag());
                 var messageLabel = ReadMessageLabel(path);
                 Assert.IsEmpty(messageLabel);
 

--- a/src/NServiceBus.Core.Tests/Recoverability/DelayedRetryExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/DelayedRetryExecutorTests.cs
@@ -27,7 +27,7 @@
 
             await delayedRetryExecutor.Retry(incomingMessage, TimeSpan.Zero, transportTransaction);
 
-            Assert.AreEqual(dispatcher.ContextBag.Get<TransportTransaction>(), transportTransaction);
+            Assert.AreEqual(dispatcher.Transaction, transportTransaction);
         }
 
         [Test]
@@ -131,10 +131,13 @@
 
             public ContextBag ContextBag { get; private set; }
 
-            public Task Dispatch(TransportOperations outgoingMessages, ContextBag context)
+            public TransportTransaction Transaction { get; private set; }
+
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, ContextBag context)
             {
                 TransportOperations = outgoingMessages;
                 ContextBag = context;
+                Transaction = transaction;
                 return Task.FromResult(0);
             }
         }

--- a/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
@@ -31,7 +31,7 @@
 
             Assert.That(dispatcher.TransportOperations.MulticastTransportOperations.Count(), Is.EqualTo(0));
             Assert.That(dispatcher.TransportOperations.UnicastTransportOperations.Count(), Is.EqualTo(1));
-            Assert.That(dispatcher.ContextBag.Get<TransportTransaction>(), Is.EqualTo(transportTransaction));
+            Assert.That(dispatcher.Transaction, Is.EqualTo(transportTransaction));
 
             var outgoingMessage = dispatcher.TransportOperations.UnicastTransportOperations.Single();
             Assert.That(outgoingMessage.Destination, Is.EqualTo(customErrorQueue));
@@ -140,14 +140,17 @@
 
         class FakeDispatcher : IDispatchMessages
         {
-            public TransportOperations TransportOperations { get; set; }
+            public TransportOperations TransportOperations { get; private set; }
 
-            public ContextBag ContextBag { get; set; }
+            public ContextBag ContextBag { get; private set; }
 
-            public Task Dispatch(TransportOperations outgoingMessages, ContextBag context)
+            public TransportTransaction Transaction { get; private set; }
+
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, ContextBag context)
             {
                 TransportOperations = outgoingMessages;
                 ContextBag = context;
+                Transaction = transaction;
                 return Task.FromResult(0);
             }
         }

--- a/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
@@ -229,7 +229,7 @@
         {
             public TransportOperations TransportOperations { get; private set; }
 
-            public Task Dispatch(TransportOperations outgoingMessages, ContextBag context)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, ContextBag context)
             {
                 TransportOperations = outgoingMessages;
                 return TaskEx.CompletedTask;

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
@@ -93,7 +93,7 @@
 
             public List<TransportOperations> DispatchedTransportOperations { get; } = new List<TransportOperations>();
 
-            public Task Dispatch(TransportOperations outgoingMessages, ContextBag context)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, ContextBag context)
             {
                 if (numberOfTimes.HasValue && FailedNumberOfTimes < numberOfTimes.Value)
                 {

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
@@ -89,7 +89,7 @@
                 numberOfTimes = times;
             }
 
-            public Task Dispatch(TransportOperations outgoingMessages, ContextBag context)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, ContextBag context)
             {
                 if (numberOfTimes.HasValue && FailedNumberOfTimes < numberOfTimes.Value)
                 {

--- a/src/NServiceBus.Core.Tests/Timeout/FakeMessageDispatcher.cs
+++ b/src/NServiceBus.Core.Tests/Timeout/FakeMessageDispatcher.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus.Core.Tests.Timeout
 {
-    using System.Linq;
     using System.Threading.Tasks;
     using Extensibility;
     using Transport;
@@ -13,9 +12,9 @@ namespace NServiceBus.Core.Tests.Timeout
             set { messagesSent = value; }
         }
 
-        public Task Dispatch(TransportOperations outgoingMessages, ContextBag context)
+        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transportTransaction, ContextBag context)
         {
-            MessagesSent += outgoingMessages.MulticastTransportOperations.Count() + outgoingMessages.UnicastTransportOperations.Count();
+            MessagesSent += outgoingMessages.MulticastTransportOperations.Count + outgoingMessages.UnicastTransportOperations.Count;
             return TaskEx.CompletedTask;
         }
 

--- a/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
@@ -16,13 +16,9 @@
             var context = new TestableIncomingLogicalMessageContext();
 
             context.Extensions.Set<OutboxTransaction>(new InMemoryOutboxTransaction());
-            context.Extensions.Set<TransportTransaction>(new FakeTransportTransaction());
+            context.Extensions.Set(new TransportTransaction());
 
             Assert.That(async () => await behavior.Invoke(context, c => TaskEx.CompletedTask), Throws.InvalidOperationException);
-        }
-
-        class FakeTransportTransaction : TransportTransaction
-        {
         }
     }
 }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/DispatchTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/DispatchTimeoutBehavior.cs
@@ -31,7 +31,8 @@ namespace NServiceBus
 
             var outgoingMessage = new OutgoingMessage(context.MessageId, timeoutData.Headers, timeoutData.State);
             var transportOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(timeoutData.Destination), dispatchConsistency);
-            await dispatcher.Dispatch(new TransportOperations(transportOperation), context.Context).ConfigureAwait(false);
+            var transportTransaction = context.Context.GetOrCreate<TransportTransaction>();
+            await dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction, context.Context).ConfigureAwait(false);
 
             var timeoutRemoved = await persister.TryRemove(timeoutId, context.Context).ConfigureAwait(false);
             if (!timeoutRemoved)

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ExpiredTimeoutsPoller.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ExpiredTimeoutsPoller.cs
@@ -109,7 +109,7 @@ namespace NServiceBus
                 dispatchRequest.Headers["Timeout.Id"] = timeoutData.Id;
 
                 var transportOperation = new TransportOperation(dispatchRequest, new UnicastAddressTag(dispatcherAddress));
-                await dispatcher.Dispatch(new TransportOperations(transportOperation), new ContextBag()).ConfigureAwait(false);
+                await dispatcher.Dispatch(new TransportOperations(transportOperation), new TransportTransaction(), new ContextBag()).ConfigureAwait(false);
             }
 
             lock (lockObject)

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
@@ -65,7 +65,8 @@ namespace NServiceBus
                 {
                     var outgoingMessage = new OutgoingMessage(context.MessageId, data.Headers, data.State);
                     var transportOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(data.Destination));
-                    await dispatcher.Dispatch(new TransportOperations(transportOperation), context.Context).ConfigureAwait(false);
+                    var transportTransaction = context.Context.GetOrCreate<TransportTransaction>();
+                    await dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction, context.Context).ConfigureAwait(false);
                     return;
                 }
 

--- a/src/NServiceBus.Core/Pipeline/Outgoing/ImmediateDispatchTerminator.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/ImmediateDispatchTerminator.cs
@@ -14,7 +14,8 @@
 
         protected override Task Terminate(IDispatchContext context)
         {
-            return dispatcher.Dispatch(new TransportOperations(context.Operations.ToArray()), context.Extensions);
+            var transaction = context.Extensions.GetOrCreate<TransportTransaction>();
+            return dispatcher.Dispatch(new TransportOperations(context.Operations.ToArray()), transaction, context.Extensions);
         }
 
         IDispatchMessages dispatcher;

--- a/src/NServiceBus.Core/Recoverability/DelayedRetryExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/DelayedRetryExecutor.cs
@@ -48,10 +48,7 @@
 
             var transportOperations = new TransportOperations(new TransportOperation(outgoingMessage, messageDestination, deliveryConstraints: deliveryConstraints));
 
-            var dispatchContext = new ContextBag();
-            dispatchContext.Set(transportTransaction);
-
-            await dispatcher.Dispatch(transportOperations, dispatchContext).ConfigureAwait(false);
+            await dispatcher.Dispatch(transportOperations, transportTransaction, new ContextBag()).ConfigureAwait(false);
 
             return currentDelayedRetriesAttempt;
         }

--- a/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
@@ -36,10 +36,7 @@
 
             var transportOperations = new TransportOperations(new TransportOperation(outgoingMessage, new UnicastAddressTag(errorQueueAddress)));
 
-            var dispatchContext = new ContextBag();
-            dispatchContext.Set(transportTransaction);
-
-            return dispatcher.Dispatch(transportOperations, dispatchContext);
+            return dispatcher.Dispatch(transportOperations, transportTransaction, new ContextBag());
         }
 
         IDispatchMessages dispatcher;

--- a/src/NServiceBus.Core/Routing/Legacy/ReadyMessageSender.cs
+++ b/src/NServiceBus.Core/Routing/Legacy/ReadyMessageSender.cs
@@ -47,7 +47,7 @@
             }
 
             var transportOperation = new TransportOperation(readyMessage, new UnicastAddressTag(distributorControlAddress));
-            return dispatcher.Dispatch(new TransportOperations(transportOperation), new ContextBag());
+            return dispatcher.Dispatch(new TransportOperations(transportOperation), new TransportTransaction(), new ContextBag());
         }
 
         public Task MessageProcessed(Dictionary<string, string> headers)

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -53,7 +53,8 @@
             try
             {
                 var transportOperation = new TransportOperation(subscriptionMessage, new UnicastAddressTag(destination));
-                await dispatcher.Dispatch(new TransportOperations(transportOperation), context).ConfigureAwait(false);
+                var transportTransaction = context.GetOrCreate<TransportTransaction>();
+                await dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction, context).ConfigureAwait(false);
             }
             catch (QueueNotFoundException ex)
             {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -53,7 +53,8 @@
             try
             {
                 var transportOperation = new TransportOperation(unsubscribeMessage, new UnicastAddressTag(destination));
-                await dispatcher.Dispatch(new TransportOperations(transportOperation), context).ConfigureAwait(false);
+                var transportTransaction = context.GetOrCreate<TransportTransaction>();
+                await dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction, context).ConfigureAwait(false);
             }
             catch (QueueNotFoundException ex)
             {

--- a/src/NServiceBus.Core/Transports/IDispatchMessages.cs
+++ b/src/NServiceBus.Core/Transports/IDispatchMessages.cs
@@ -11,6 +11,6 @@ namespace NServiceBus.Transport
         /// <summary>
         /// Dispatches the given operations to the transport.
         /// </summary>
-        Task Dispatch(TransportOperations outgoingMessages, ContextBag context);
+        Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, ContextBag context);
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveWithTransactionScope.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveWithTransactionScope.cs
@@ -62,7 +62,8 @@ namespace NServiceBus
 
         async Task<bool> ProcessMessage(Message message, Dictionary<string, string> headers)
         {
-            var transportTransaction = new ScopeTransportTransaction(Transaction.Current);
+            var transportTransaction = new TransportTransaction();
+            transportTransaction.Set(Transaction.Current);
 
             MsmqFailureInfoStorage.ProcessingFailureInfo failureInfo;
 
@@ -101,13 +102,5 @@ namespace NServiceBus
 
         TransactionOptions transactionOptions;
         MsmqFailureInfoStorage failureInfoStorage;
-
-        class ScopeTransportTransaction : TransportTransaction
-        {
-            public ScopeTransportTransaction(Transaction current)
-            {
-                Set(current);
-            }
-        }
     }
 }

--- a/src/NServiceBus.Core/Transports/TransportTransaction.cs
+++ b/src/NServiceBus.Core/Transports/TransportTransaction.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Transport
     /// <summary>
     /// Represents a transaction used to receive the message from the queueing infrastructure.
     /// </summary>
-    public class TransportTransaction : ContextBag
+    public sealed class TransportTransaction : ContextBag
     {
         /// <summary>
         /// Create an instance of <see cref="TransportTransaction" />.

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_receiving_control_message_with_body.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_receiving_control_message_with_body.cs
@@ -65,7 +65,7 @@
                     }, body);
 
                     var endpoint = Conventions.EndpointNamingConvention(typeof(TestingEndpoint));
-                    return dispatcher.Dispatch(new TransportOperations(new TransportOperation(outgoingMessage, new UnicastAddressTag(endpoint))), new ContextBag());
+                    return dispatcher.Dispatch(new TransportOperations(new TransportOperation(outgoingMessage, new UnicastAddressTag(endpoint))), new TransportTransaction(), new ContextBag());
                 }
 
                 protected override Task OnStop(IMessageSession session)

--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -74,6 +74,9 @@
     </None>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\GitVersionTask.3.4.1\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.4.1\build\dotnet\GitVersionTask.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -139,15 +139,12 @@
 
             var dispatcher = lazyDispatcher.Value;
 
-            var context = new ContextBag();
-
-            //until we fix the seam we have to do this
-            if (transportTransaction != null)
+            if (transportTransaction == null)
             {
-                context.Set(transportTransaction);
+                transportTransaction = new TransportTransaction();
             }
 
-            return dispatcher.Dispatch(new TransportOperations(new TransportOperation(message, new UnicastAddressTag(address))), context);
+            return dispatcher.Dispatch(new TransportOperations(new TransportOperation(message, new UnicastAddressTag(address))), transportTransaction, new ContextBag());
         }
 
         protected void OnTestTimeout(Action onTimeoutAction)


### PR DESCRIPTION
Quick recap

* The dispatcher gets a context bag which will contain everything that is available in the pipeline that was explicitly added to the contexts. This is our back door for extensibility.
* The transport transaction is an explicit concept which allows floating transaction relevant state into the dispatcher. 

In the current design, an implementor of a dispatcher needed to know that a transport transaction might be added to the context bag and do a try get on the context bag. After discussions with @yvesgoeleven from @Particular/azure-service-bus-maintainers we came to the conclusion that this is not really intention revealing.

This PR changes that and makes the transport transaction an explicit concept. In order to do that, I needed to seal the type (inheritance was anyway not necessary since the transaction is a context bag as well. With this approach, we can always do a `GetOrCreate` if we have a floating context bag available. For all other cases, we can just create a transport transaction object (for example sends outside the handler). 

The benefit for implementors is that there will always be a transaction object (MessageContext and ErrorContext guard against null anyway) and implementors who use it will save one TryGet.

Currently, the following transports use the transport transaction:

* MSMQ
* SqlServer
* Azure Service Bus

@Particular/nservicebus-maintainers @Particular/azure-service-bus-maintainers @Particular/azure-storage-queues-maintainers @Particular/sqlserver-transport-maintainers @Particular/rabbitmq-transport-maintainers are you OK with that change?

