### PR TITLE
Incoming and outgoing transport mutator contexts indiciate message has changed although there was no change

### DIFF
--- a/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehaviorTests.cs
@@ -27,6 +27,78 @@
             Assert.That(async () => await behavior.Invoke(context, () => TaskEx.CompletedTask), Throws.Exception.With.Message.EqualTo("Return a Task or mark the method as async."));
         }
 
+        [Test]
+        public async Task When_no_mutator_updates_the_body_should_not_update_the_body()
+        {
+            var behavior = new MutateIncomingMessageBehavior();
+
+            var context = new InterceptUpdateMessageIncomingLogicalMessageContext();
+
+            context.Builder.Register<IMutateIncomingMessages>(() => new MutatorWhichDoesNotMutateTheBody());
+
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
+
+            Assert.False(context.UpdateMessageCalled);
+        }
+
+        [Test]
+        public async Task When_no_mutator_available_should_not_update_the_body()
+        {
+            var behavior = new MutateIncomingMessageBehavior();
+
+            var context = new InterceptUpdateMessageIncomingLogicalMessageContext();
+
+            context.Builder.Register(() => new IMutateIncomingMessages[] { });
+
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
+
+            Assert.False(context.UpdateMessageCalled);
+        }
+
+        [Test]
+        public async Task When_mutator_modifies_the_body_should_update_the_body()
+        {
+            var behavior = new MutateIncomingMessageBehavior();
+
+            var context = new InterceptUpdateMessageIncomingLogicalMessageContext();
+
+            context.Builder.Register<IMutateIncomingMessages>(() => new MutatorWhichMutatesTheBody());
+
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
+
+            Assert.True(context.UpdateMessageCalled);
+        }
+
+        class InterceptUpdateMessageIncomingLogicalMessageContext : TestableIncomingLogicalMessageContext
+        {
+            public bool UpdateMessageCalled { get; private set; }
+
+            public override void UpdateMessageInstance(object newInstance)
+            {
+                base.UpdateMessageInstance(newInstance);
+
+                UpdateMessageCalled = true;
+            }
+        }
+
+        class MutatorWhichDoesNotMutateTheBody : IMutateIncomingMessages
+        {
+            public Task MutateIncoming(MutateIncomingMessageContext context)
+            {
+                return TaskEx.CompletedTask;
+            }
+        }
+
+        class MutatorWhichMutatesTheBody : IMutateIncomingMessages
+        {
+            public Task MutateIncoming(MutateIncomingMessageContext context)
+            {
+                context.Message = new object();
+
+                return TaskEx.CompletedTask;
+            }
+        }
+
         class MutateIncomingMessagesReturnsNull : IMutateIncomingMessages
         {
             public Task MutateIncoming(MutateIncomingMessageContext context)

--- a/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateOutgoingMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateOutgoingMessageBehaviorTests.cs
@@ -25,11 +25,83 @@
             Assert.That(async () => await behavior.Invoke(context, () => TaskEx.CompletedTask), Throws.Exception.With.Message.EqualTo("Return a Task or mark the method as async."));
         }
 
+        [Test]
+        public async Task When_no_mutator_updates_the_body_should_not_update_the_body()
+        {
+            var behavior = new MutateOutgoingMessageBehavior();
+
+            var context = new InterceptUpdateMessageOutgoingLogicalMessageContext();
+
+            context.Builder.Register<IMutateOutgoingMessages>(() => new MutatorWhichDoesNotMutateTheBody());
+
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
+
+            Assert.False(context.UpdateMessageCalled);
+        }
+
+        [Test]
+        public async Task When_no_mutator_available_should_not_update_the_body()
+        {
+            var behavior = new MutateOutgoingMessageBehavior();
+
+            var context = new InterceptUpdateMessageOutgoingLogicalMessageContext();
+
+            context.Builder.Register(() => new IMutateOutgoingMessages[] { });
+
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
+
+            Assert.False(context.UpdateMessageCalled);
+        }
+
+        [Test]
+        public async Task When_mutator_modifies_the_body_should_update_the_body()
+        {
+            var behavior = new MutateOutgoingMessageBehavior();
+
+            var context = new InterceptUpdateMessageOutgoingLogicalMessageContext();
+
+            context.Builder.Register<IMutateOutgoingMessages>(() => new MutatorWhichMutatesTheBody());
+
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
+
+            Assert.True(context.UpdateMessageCalled);
+        }
+
+        class InterceptUpdateMessageOutgoingLogicalMessageContext : TestableOutgoingLogicalMessageContext
+        {
+            public bool UpdateMessageCalled { get; private set; }
+
+            public override void UpdateMessage(object newInstance)
+            {
+                base.UpdateMessage(newInstance);
+
+                UpdateMessageCalled = true;
+            }
+        }
+
         class MutateOutgoingMessagesReturnsNull : IMutateOutgoingMessages
         {
             public Task MutateOutgoing(MutateOutgoingMessageContext context)
             {
                 return null;
+            }
+        }
+
+        class MutatorWhichDoesNotMutateTheBody : IMutateOutgoingMessages
+        {
+            public Task MutateOutgoing(MutateOutgoingMessageContext context)
+            {
+                return TaskEx.CompletedTask;
+            }
+        }
+
+        class MutatorWhichMutatesTheBody : IMutateOutgoingMessages
+        {
+            public Task MutateOutgoing(MutateOutgoingMessageContext context)
+            {
+                context.OutgoingMessage = new object();
+
+                return TaskEx.CompletedTask;
             }
         }
     }

--- a/src/NServiceBus.Core.Tests/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehaviorTests.cs
@@ -12,7 +12,7 @@
         public void Should_throw_friendly_exception_when_IMutateIncomingTransportMessages_MutateIncoming_returns_null()
         {
             var behavior = new MutateIncomingTransportMessageBehavior();
-            
+
             var context = new TestableIncomingPhysicalMessageContext();
 
             context.Builder.Register<IMutateIncomingTransportMessages>(() => new MutateIncomingTransportMessagesReturnsNull());
@@ -20,11 +20,83 @@
             Assert.That(async () => await behavior.Invoke(context, () => TaskEx.CompletedTask), Throws.Exception.With.Message.EqualTo("Return a Task or mark the method as async."));
         }
 
+        [Test]
+        public async Task When_no_mutator_updates_the_body_should_not_update_the_body()
+        {
+            var behavior = new MutateIncomingTransportMessageBehavior();
+
+            var context = new InterceptUpdateMessageIncomingPhysicalMessageContext();
+
+            context.Builder.Register<IMutateIncomingTransportMessages>(() => new MutatorWhichDoesNotMutateTheBody());
+
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
+
+            Assert.False(context.UpdateMessageBodyCalled);
+        }
+
+        [Test]
+        public async Task When_no_mutator_available_should_not_update_the_body()
+        {
+            var behavior = new MutateIncomingTransportMessageBehavior();
+
+            var context = new InterceptUpdateMessageIncomingPhysicalMessageContext();
+
+            context.Builder.Register(() => new IMutateIncomingTransportMessages[]{ });
+
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
+
+            Assert.False(context.UpdateMessageBodyCalled);
+        }
+
+        [Test]
+        public async Task When_mutator_modifies_the_body_should_update_the_body()
+        {
+            var behavior = new MutateIncomingTransportMessageBehavior();
+
+            var context = new InterceptUpdateMessageIncomingPhysicalMessageContext();
+
+            context.Builder.Register<IMutateIncomingTransportMessages>(() => new MutatorWhichMutatesTheBody());
+
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
+
+            Assert.True(context.UpdateMessageBodyCalled);
+        }
+
+        class InterceptUpdateMessageIncomingPhysicalMessageContext : TestableIncomingPhysicalMessageContext
+        {
+            public bool UpdateMessageBodyCalled { get; private set; }
+
+            public override void UpdateMessage(byte[] body)
+            {
+                base.UpdateMessage(body);
+
+                UpdateMessageBodyCalled = true;
+            }
+        }
+
         class MutateIncomingTransportMessagesReturnsNull : IMutateIncomingTransportMessages
         {
             public Task MutateIncoming(MutateIncomingTransportMessageContext context)
             {
                 return null;
+            }
+        }
+
+        class MutatorWhichDoesNotMutateTheBody : IMutateIncomingTransportMessages
+        {
+            public Task MutateIncoming(MutateIncomingTransportMessageContext context)
+            {
+                return TaskEx.CompletedTask;
+            }
+        }
+
+        class MutatorWhichMutatesTheBody : IMutateIncomingTransportMessages
+        {
+            public Task MutateIncoming(MutateIncomingTransportMessageContext context)
+            {
+                context.Body = new byte[0];
+
+                return TaskEx.CompletedTask;
             }
         }
     }

--- a/src/NServiceBus.Core.Tests/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageBehaviorTests.cs
@@ -13,12 +13,95 @@
         public void Should_throw_friendly_exception_when_IMutateOutgoingTransportMessages_MutateOutgoing_returns_null()
         {
             var behavior = new MutateOutgoingTransportMessageBehavior();
-            
+
             var physicalContext = new TestableOutgoingPhysicalMessageContext();
             physicalContext.Extensions.Set(new OutgoingLogicalMessage(typeof(FakeMessage), new FakeMessage()));
             physicalContext.Builder.Register<IMutateOutgoingTransportMessages>(() => new MutateOutgoingTransportMessagesReturnsNull());
-            
+
             Assert.That(async () => await behavior.Invoke(physicalContext, () => TaskEx.CompletedTask), Throws.Exception.With.Message.EqualTo("Return a Task or mark the method as async."));
+        }
+
+        [Test]
+        public async Task When_no_mutator_updates_the_body_should_not_update_the_body()
+        {
+            var behavior = new MutateOutgoingTransportMessageBehavior();
+
+            var context = new InterceptUpdateMessageOutgoingPhysicalMessageContext();
+            context.Extensions.Set(new OutgoingLogicalMessage(typeof(FakeMessage), new FakeMessage()));
+
+            context.Builder.Register<IMutateOutgoingTransportMessages>(() => new MutatorWhichDoesNotMutateTheBody());
+
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
+
+            Assert.False(context.UpdateMessageCalled);
+        }
+
+        [Test]
+        public async Task When_no_mutator_available_should_not_update_the_body()
+        {
+            var behavior = new MutateOutgoingTransportMessageBehavior();
+
+            var context = new InterceptUpdateMessageOutgoingPhysicalMessageContext();
+            context.Extensions.Set(new OutgoingLogicalMessage(typeof(FakeMessage), new FakeMessage()));
+
+            context.Builder.Register(() => new IMutateOutgoingTransportMessages[] { });
+
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
+
+            Assert.False(context.UpdateMessageCalled);
+        }
+
+        [Test]
+        public async Task When_mutator_modifies_the_body_should_update_the_body()
+        {
+            var behavior = new MutateOutgoingTransportMessageBehavior();
+
+            var context = new InterceptUpdateMessageOutgoingPhysicalMessageContext();
+            context.Extensions.Set(new OutgoingLogicalMessage(typeof(FakeMessage), new FakeMessage()));
+
+            context.Builder.Register<IMutateOutgoingTransportMessages>(() => new MutatorWhichMutatesTheBody());
+
+            await behavior.Invoke(context, () => TaskEx.CompletedTask);
+
+            Assert.True(context.UpdateMessageCalled);
+        }
+
+        class InterceptUpdateMessageOutgoingPhysicalMessageContext : TestableOutgoingPhysicalMessageContext
+        {
+            public bool UpdateMessageCalled { get; private set; }
+
+            public override void UpdateMessage(byte[] body)
+            {
+                base.UpdateMessage(body);
+
+                UpdateMessageCalled = true;
+            }
+        }
+
+        class MutateOutgoingMessagesReturnsNull : IMutateOutgoingTransportMessages
+        {
+            public Task MutateOutgoing(MutateOutgoingTransportMessageContext context)
+            {
+                return null;
+            }
+        }
+
+        class MutatorWhichDoesNotMutateTheBody : IMutateOutgoingTransportMessages
+        {
+            public Task MutateOutgoing(MutateOutgoingTransportMessageContext context)
+            {
+                return TaskEx.CompletedTask;
+            }
+        }
+
+        class MutatorWhichMutatesTheBody : IMutateOutgoingTransportMessages
+        {
+            public Task MutateOutgoing(MutateOutgoingTransportMessageContext context)
+            {
+                context.OutgoingBody = new byte[0];
+
+                return TaskEx.CompletedTask;
+            }
         }
 
         class MutateOutgoingTransportMessagesReturnsNull : IMutateOutgoingTransportMessages
@@ -29,6 +112,8 @@
             }
         }
 
-        class FakeMessage : IMessage { }
+        class FakeMessage : IMessage
+        {
+        }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateOutgoingMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateOutgoingMessageBehavior.cs
@@ -21,7 +21,7 @@
                 context.Headers,
                 incomingLogicalMessage?.Instance,
                 incomingPhysicalMessage?.Headers);
-            
+
             foreach (var mutator in context.Builder.BuildAll<IMutateOutgoingMessages>())
             {
                 await mutator.MutateOutgoing(mutatorContext)

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageContext.cs
@@ -15,7 +15,9 @@ namespace NServiceBus.MessageMutator
             Guard.AgainstNull(nameof(headers), headers);
             Guard.AgainstNull(nameof(body), body);
             Headers = headers;
-            Body = body;
+
+            // Intentionally assign to field to not set the MessageBodyChanged flag.
+            this.body = body;
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageContext.cs
@@ -15,8 +15,10 @@ namespace NServiceBus.MessageMutator
             Guard.AgainstNull(nameof(outgoingHeaders), outgoingHeaders);
             Guard.AgainstNull(nameof(outgoingBody), outgoingBody);
             Guard.AgainstNull(nameof(outgoingMessage), outgoingMessage);
+
             OutgoingHeaders = outgoingHeaders;
-            OutgoingBody = outgoingBody;
+            // Intentionally assign to field to not set the MessageBodyChanged flag.
+            this.outgoingBody = outgoingBody;
             OutgoingMessage = outgoingMessage;
             this.incomingHeaders = incomingHeaders;
             this.incomingMessage = incomingMessage;
@@ -25,7 +27,7 @@ namespace NServiceBus.MessageMutator
         /// <summary>
         /// The current outgoing message.
         /// </summary>
-        public object OutgoingMessage { get; private set; }
+        public object OutgoingMessage { get; }
 
         /// <summary>
         /// The body of the message.
@@ -44,7 +46,7 @@ namespace NServiceBus.MessageMutator
         /// <summary>
         /// The current outgoing headers.
         /// </summary>
-        public Dictionary<string, string> OutgoingHeaders { get; private set; }
+        public Dictionary<string, string> OutgoingHeaders { get; }
 
         /// <summary>
         /// Gets the incoming message that initiated the current send if it exists.


### PR DESCRIPTION
For #3956 I was debugging acceptance tests and found out that we always update the message body although not mutator has changed anything. This PR fixes it and adds more test coverage to the mutator behaviors.

@Particular/nservicebus-maintainers please review 

// cc @SimonCropp 