### PR TITLE
Reduce contention on UnfinishedFailedMessages dictionary

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -301,14 +301,17 @@
         static async Task StopEndpoints(IEnumerable<EndpointRunner> endpoints, ScenarioContext scenarioContext)
         {
             var failBecauseUnhandledFailedMessage = false;
-            var startTime = DateTime.Now;
+            var startTime = DateTime.UtcNow;
+            var maxTime = TimeSpan.FromSeconds(30);
             while (scenarioContext.UnfinishedFailedMessages.Values.Any(x => x))
             {
-                if (DateTime.Now - startTime >= TimeSpan.FromSeconds(30))
+                if (DateTime.UtcNow - startTime > maxTime)
                 {
                     failBecauseUnhandledFailedMessage = true;
                     break;
                 }
+
+                await Task.Delay(1).ConfigureAwait(false);
             }
 
             var tasks = endpoints.Select(async endpoint =>


### PR DESCRIPTION
 and align check logic with when done condition check

@MarcinHoppe and I found a bug with contentions on the UnfinishedFailedMessages dictionary. When a test shuts down quicker than the CatchExceptionBehavior added by the acceptance test framework then the tight while loop on the dictionary will prevent the AddOrUpdate method call from succeeding. Therefore the tests will fail with an indication that there were unfinished failed messages (which is a obviously false).