### PR TITLE
better obsolete for .scaleout()

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1039,11 +1039,13 @@ namespace NServiceBus
     {
         public NServiceBus.ToSagaExpression<TSagaData, TMessage> ConfigureMapping<TMessage>(System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty) { }
     }
-    [System.ObsoleteAttribute("Will be removed in version 7.0.0.", true)]
+    [System.ObsoleteAttribute("Use `ConfigureUniquelyAddressableInstanceExtensions` instead. Will be removed in " +
+        "version 7.0.0.", true)]
     public class static ScaleOutExtentions
     {
-        [System.ObsoleteAttribute("The member currently throws a NotImplementedException. Will be removed in version" +
-            " 7.0.0.", true)]
+        [System.ObsoleteAttribute("Use `ConfigureUniquelyAddressableInstanceExtensions.MakeInstanceUniquelyAddressab" +
+            "le` instead. The member currently throws a NotImplementedException. Will be remo" +
+            "ved in version 7.0.0.", true)]
         public static NServiceBus.Settings.ScaleOutSettings ScaleOut(this NServiceBus.EndpointConfiguration config) { }
     }
     [System.ObsoleteAttribute("Use extension methods provided on ISendOnlyBus. Will be removed in version 7.0.0." +

--- a/src/NServiceBus.Core/obsoletes.cs
+++ b/src/NServiceBus.Core/obsoletes.cs
@@ -392,13 +392,15 @@ namespace NServiceBus
     }
 
     [ObsoleteEx(
-        RemoveInVersion = "7.0",
-        TreatAsErrorFromVersion = "6.0")]
+         RemoveInVersion = "7.0",
+         TreatAsErrorFromVersion = "6.0",
+         ReplacementTypeOrMember = "ConfigureUniquelyAddressableInstanceExtensions")]
     public static class ScaleOutExtentions
     {
         [ObsoleteEx(
-            RemoveInVersion = "7.0",
-            TreatAsErrorFromVersion = "6.0")]
+             RemoveInVersion = "7.0",
+             TreatAsErrorFromVersion = "6.0",
+             ReplacementTypeOrMember = "ConfigureUniquelyAddressableInstanceExtensions.MakeInstanceUniquelyAddressable")]
         public static Settings.ScaleOutSettings ScaleOut(this EndpointConfiguration config)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
so this https://github.com/Particular/NServiceBus/commit/274c5f6913b97166cab0be410c68c935fc5f67d4

obsoleted .ScaleOut() with no replacement in the obsolete attribute

context https://github.com/Particular/docs.particular.net/issues/1649