### PR TITLE
Single route for commands

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2599,8 +2599,8 @@ namespace NServiceBus.Routing
     public class UnicastRoutingTable
     {
         public UnicastRoutingTable() { }
-        public void AddDynamic(System.Func<System.Type, NServiceBus.Extensibility.ContextBag, System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.Routing.IUnicastRoute>>> dynamicRule) { }
-        public void AddDynamic(System.Func<System.Type, NServiceBus.Extensibility.ContextBag, System.Collections.Generic.IEnumerable<NServiceBus.Routing.IUnicastRoute>> dynamicRule) { }
+        public void AddDynamic(System.Func<System.Type, NServiceBus.Extensibility.ContextBag, System.Threading.Tasks.Task<NServiceBus.Routing.IUnicastRoute>> dynamicRule) { }
+        public void AddDynamic(System.Func<System.Type, NServiceBus.Extensibility.ContextBag, NServiceBus.Routing.IUnicastRoute> dynamicRule) { }
         public void RouteTo(System.Type messageType, NServiceBus.Routing.IUnicastRoute route) { }
         public void RouteTo(System.Type messageType, NServiceBus.Routing.IUnicastRoute route, bool overrideExistingRoute) { }
     }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2602,6 +2602,7 @@ namespace NServiceBus.Routing
         public void AddDynamic(System.Func<System.Type, NServiceBus.Extensibility.ContextBag, System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.Routing.IUnicastRoute>>> dynamicRule) { }
         public void AddDynamic(System.Func<System.Type, NServiceBus.Extensibility.ContextBag, System.Collections.Generic.IEnumerable<NServiceBus.Routing.IUnicastRoute>> dynamicRule) { }
         public void RouteTo(System.Type messageType, NServiceBus.Routing.IUnicastRoute route) { }
+        public void RouteTo(System.Type messageType, NServiceBus.Routing.IUnicastRoute route, bool overrideExistingRoute) { }
     }
 }
 namespace NServiceBus.Routing.Legacy

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2599,10 +2599,9 @@ namespace NServiceBus.Routing
     public class UnicastRoutingTable
     {
         public UnicastRoutingTable() { }
-        public void AddDynamic(System.Func<System.Type, NServiceBus.Extensibility.ContextBag, System.Threading.Tasks.Task<NServiceBus.Routing.IUnicastRoute>> dynamicRule) { }
-        public void AddDynamic(System.Func<System.Type, NServiceBus.Extensibility.ContextBag, NServiceBus.Routing.IUnicastRoute> dynamicRule) { }
         public void RouteTo(System.Type messageType, NServiceBus.Routing.IUnicastRoute route) { }
         public void RouteTo(System.Type messageType, NServiceBus.Routing.IUnicastRoute route, bool overrideExistingRoute) { }
+        public void SetFallbackRoute(System.Func<System.Type, NServiceBus.Extensibility.ContextBag, System.Threading.Tasks.Task<NServiceBus.Routing.IUnicastRoute>> fallbackRoute) { }
     }
 }
 namespace NServiceBus.Routing.Legacy

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Routing\SingleInstanceRoundRobinDistributionStrategyTests.cs" />
     <Compile Include="Routing\SubscriptionRouterTests.cs" />
     <Compile Include="Routing\UnicastPublisherRouterTests.cs" />
+    <Compile Include="Routing\UnicastRoutingTableTests.cs" />
     <Compile Include="Sagas\CustomFinderAdapterTests.cs" />
     <Compile Include="Sagas\InvokeSagaNotFoundBehaviorTests.cs" />
     <Compile Include="Sagas\When_saga_has_multiple_correlated_properties.cs" />

--- a/src/NServiceBus.Core.Tests/Routing/RoutingSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingSettingsTests.cs
@@ -53,10 +53,10 @@
             routingSettings.RouteToEndpoint(typeof(SomeMessageType), "destination");
 
             var routingTable = ApplyConfiguredRoutes(routingSettings);
-            var routes = await routingTable.GetDestinationsFor(typeof(SomeMessageType), new ContextBag());
-            var routingTargets = await RetrieveRoutingTargets(routes);
+            var route = await routingTable.GetRouteFor(typeof(SomeMessageType), new ContextBag());
+            var routingTargets = await RetrieveRoutingTargets(route);
 
-            Assert.That(routes.Count(), Is.EqualTo(1));
+            Assert.That(route, Is.Not.Null);
             Assert.That(routingTargets.Single().Endpoint, Is.EqualTo("destination"));
         }
 
@@ -68,13 +68,13 @@
 
             var routingTable = ApplyConfiguredRoutes(routingSettings);
 
-            var someMessageRoute = await routingTable.GetDestinationsFor(typeof(SomeMessageType), new ContextBag());
-            var otherMessageRoute = await routingTable.GetDestinationsFor(typeof(OtherMessageType), new ContextBag());
-            var messageWithoutNamespaceRoute = await routingTable.GetDestinationsFor(typeof(MessageWithoutNamespace), new ContextBag());
+            var someMessageRoute = await routingTable.GetRouteFor(typeof(SomeMessageType), new ContextBag());
+            var otherMessageRoute = await routingTable.GetRouteFor(typeof(OtherMessageType), new ContextBag());
+            var messageWithoutNamespaceRoute = await routingTable.GetRouteFor(typeof(MessageWithoutNamespace), new ContextBag());
 
-            Assert.That(someMessageRoute.Count(), Is.EqualTo(1));
-            Assert.That(otherMessageRoute.Count(), Is.EqualTo(1));
-            Assert.That(messageWithoutNamespaceRoute.Count(), Is.EqualTo(1));
+            Assert.That(someMessageRoute, Is.Not.Null);
+            Assert.That(otherMessageRoute, Is.Not.Null);
+            Assert.That(messageWithoutNamespaceRoute, Is.Not.Null);
         }
 
         [Test]
@@ -85,13 +85,13 @@
 
             var routingTable = ApplyConfiguredRoutes(routingSettings);
 
-            var someMessageRoute = await routingTable.GetDestinationsFor(typeof(SomeMessageType), new ContextBag());
-            var otherMessageRoute = await routingTable.GetDestinationsFor(typeof(OtherMessageType), new ContextBag());
-            var messageWithoutNamespaceRoute = await routingTable.GetDestinationsFor(typeof(MessageWithoutNamespace), new ContextBag());
+            var someMessageRoute = await routingTable.GetRouteFor(typeof(SomeMessageType), new ContextBag());
+            var otherMessageRoute = await routingTable.GetRouteFor(typeof(OtherMessageType), new ContextBag());
+            var messageWithoutNamespaceRoute = await routingTable.GetRouteFor(typeof(MessageWithoutNamespace), new ContextBag());
 
-            Assert.That(someMessageRoute, Has.Count.EqualTo(1), "because SomeMessageType is in the given namespace");
-            Assert.That(otherMessageRoute, Is.Empty, "because OtherMessageType is not in the given namespace");
-            Assert.That(messageWithoutNamespaceRoute, Is.Empty, "because MessageWithoutNamespace is not in the given namespace");
+            Assert.That(someMessageRoute, Is.Not.Null, "because SomeMessageType is in the given namespace");
+            Assert.That(otherMessageRoute, Is.Null, "because OtherMessageType is not in the given namespace");
+            Assert.That(messageWithoutNamespaceRoute, Is.Null, "because MessageWithoutNamespace is not in the given namespace");
         }
 
         [Theory]
@@ -104,13 +104,13 @@
 
             var routingTable = ApplyConfiguredRoutes(routingSettings);
 
-            var someMessageRoute = await routingTable.GetDestinationsFor(typeof(SomeMessageType), new ContextBag());
-            var otherMessageRoute = await routingTable.GetDestinationsFor(typeof(OtherMessageType), new ContextBag());
-            var messageWithoutNamespaceRoute = await routingTable.GetDestinationsFor(typeof(MessageWithoutNamespace), new ContextBag());
+            var someMessageRoute = await routingTable.GetRouteFor(typeof(SomeMessageType), new ContextBag());
+            var otherMessageRoute = await routingTable.GetRouteFor(typeof(OtherMessageType), new ContextBag());
+            var messageWithoutNamespaceRoute = await routingTable.GetRouteFor(typeof(MessageWithoutNamespace), new ContextBag());
 
-            Assert.That(someMessageRoute, Is.Empty);
-            Assert.That(otherMessageRoute, Is.Empty);
-            Assert.That(messageWithoutNamespaceRoute, Has.Count.EqualTo(1));
+            Assert.That(someMessageRoute, Is.Null);
+            Assert.That(otherMessageRoute, Is.Null);
+            Assert.That(messageWithoutNamespaceRoute, Is.Not.Null);
         }
 
         static UnicastRoutingTable ApplyConfiguredRoutes(RoutingSettings routingSettings)
@@ -123,12 +123,12 @@
             return routingTable;
         }
 
-        static async Task<IEnumerable<UnicastRoutingTarget>> RetrieveRoutingTargets(IEnumerable<IUnicastRoute> result)
+        static Task<IEnumerable<UnicastRoutingTarget>> RetrieveRoutingTargets(IUnicastRoute result)
         {
-            return (await Task.WhenAll(result.Select(x => x.Resolve(e => Task.FromResult<IEnumerable<EndpointInstance>>(new[]
+            return result.Resolve(e => Task.FromResult<IEnumerable<EndpointInstance>>(new[]
             {
                 new EndpointInstance(e)
-            }))))).SelectMany(x => x);
+            }));
         }
 
         string expectedExceptionMessageForWrongEndpointName = "A logical endpoint name should not contain '@', but received 'EndpointName@MyHost'. To specify an endpoint's address, use the instance mapping file for the MSMQ transport, or refer to the routing documentation.";

--- a/src/NServiceBus.Core.Tests/Routing/UnicastRoutingTableTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastRoutingTableTests.cs
@@ -1,0 +1,73 @@
+﻿namespace NServiceBus.Core.Tests.Routing
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+
+    [TestFixture]
+    class UnicastRoutingTableTests
+    {
+        [Test]
+        public async Task When_registering_multiple_static_routes_for_same_type_should_only_use_last_route()
+        {
+            var routingTable = new UnicastRoutingTable();
+            var expectedRoute = UnicastRoute.CreateFromEndpointName("sales");
+            routingTable.RouteTo(typeof(Command), UnicastRoute.CreateFromPhysicalAddress("address@somewhere"));
+            routingTable.RouteTo(typeof(Command), UnicastRoute.CreateFromEndpointInstance(new EndpointInstance("billing")));
+            routingTable.RouteTo(typeof(Command), expectedRoute);
+
+            var routes = await routingTable.GetDestinationsFor(typeof(Command), new ContextBag());
+
+            Assert.That(routes, Has.Count.EqualTo(1));
+            Assert.That(routes.Single(), Is.EqualTo(expectedRoute));
+        }
+
+        [Test]
+        public async Task When_returning_multiple_dynamic_routes_for_same_type_should_return_all_routes()
+        {
+            var routingTable = new UnicastRoutingTable();
+            routingTable.AddDynamic((t, c) => new[]
+            {
+                UnicastRoute.CreateFromPhysicalAddress("a")
+            });
+            routingTable.AddDynamic((t, c) => new[]
+            {
+                UnicastRoute.CreateFromPhysicalAddress("b")
+            });
+            routingTable.AddDynamic((t, c) => Task.FromResult<IEnumerable<IUnicastRoute>>(new[]
+            {
+                UnicastRoute.CreateFromPhysicalAddress("c")
+            }));
+
+            var routes = await routingTable.GetDestinationsFor(typeof(Command), new ContextBag());
+
+            Assert.That(routes, Has.Count.EqualTo(3));
+        }
+
+        [Test]
+        public async Task When_static_and_dynamic_routes_found_for_same_type_should_return_static_and_dynamic_routes()
+        {
+            var routingTable = new UnicastRoutingTable();
+            routingTable.RouteTo(typeof(Command), UnicastRoute.CreateFromEndpointName("a"));
+            routingTable.AddDynamic((t, c) => new[]
+            {
+                UnicastRoute.CreateFromPhysicalAddress("b")
+            });
+            routingTable.AddDynamic((t, c) => Task.FromResult<IEnumerable<IUnicastRoute>>(new[]
+            {
+                UnicastRoute.CreateFromPhysicalAddress("c")
+            }));
+
+            var routes = await routingTable.GetDestinationsFor(typeof(Command), new ContextBag());
+
+            Assert.That(routes, Has.Count.EqualTo(3));
+        }
+
+        class Command
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Routing/UnicastRoutingTableTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastRoutingTableTests.cs
@@ -22,7 +22,7 @@
         }
 
         [Test]
-        public async Task When_overriding_static_routes_with_same_type_should_only_use_last_route()
+        public async Task When_overriding_static_routes_should_use_route_which_overrides_previous_routes()
         {
             var routingTable = new UnicastRoutingTable();
             var expectedRoute = UnicastRoute.CreateFromEndpointName("sales");

--- a/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
@@ -27,12 +27,12 @@
         }
 
         [Test]
-        public async Task When_multiple_instances_for_logical_endpoints_should_route_message_to_a_single_instance_of_each_logical_endpoint()
+        public async Task When_multiple_dynamic_instances_for_logical_endpoints_should_route_message_to_a_single_instance_of_each_logical_endpoint()
         {
             var sales = "Sales";
             var shipping = "Shipping";
-            routingTable.RouteTo(typeof(Command), UnicastRoute.CreateFromEndpointName(sales));
-            routingTable.RouteTo(typeof(Command), UnicastRoute.CreateFromEndpointName(shipping));
+            routingTable.AddDynamic((t, c) => new[] { UnicastRoute.CreateFromEndpointName(sales) });
+            routingTable.AddDynamic((t, c) => new[] { UnicastRoute.CreateFromEndpointName(shipping) });
 
             endpointInstances.Add(new EndpointInstance(sales, "1"));
             endpointInstances.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(sales, "2"))));

--- a/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
@@ -30,7 +30,7 @@
         public async Task When_multiple_dynamic_instances_for_logical_endpoints_should_route_message_to_a_single_instance()
         {
             var sales = "Sales";
-            routingTable.AddDynamic((t, c) => new[] { UnicastRoute.CreateFromEndpointName(sales) });
+            routingTable.AddDynamic((t, c) => UnicastRoute.CreateFromEndpointName(sales));
 
             endpointInstances.Add(new EndpointInstance(sales, "1"));
             endpointInstances.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(sales, "2"))));

--- a/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
@@ -27,35 +27,18 @@
         }
 
         [Test]
-        public async Task When_multiple_dynamic_instances_for_logical_endpoints_should_route_message_to_a_single_instance_of_each_logical_endpoint()
+        public async Task When_multiple_dynamic_instances_for_logical_endpoints_should_route_message_to_a_single_instance()
         {
             var sales = "Sales";
-            var shipping = "Shipping";
             routingTable.AddDynamic((t, c) => new[] { UnicastRoute.CreateFromEndpointName(sales) });
-            routingTable.AddDynamic((t, c) => new[] { UnicastRoute.CreateFromEndpointName(shipping) });
 
             endpointInstances.Add(new EndpointInstance(sales, "1"));
             endpointInstances.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(sales, "2"))));
-            endpointInstances.Add(new EndpointInstance(shipping, "1", null), new EndpointInstance(shipping, "2"));
 
             var routes = (await router.Route(typeof(Command), new DistributionPolicy(), new ContextBag())).ToArray();
 
-            Assert.AreEqual(2, routes.Length);
+            Assert.AreEqual(1, routes.Length);
             Assert.AreEqual("Sales-1", ExtractDestination(routes[0]));
-            Assert.AreEqual("Shipping-1", ExtractDestination(routes[1]));
-        }
-
-        [Test]
-        public async Task Should_not_route_multiple_copies_of_message_to_one_physical_destination()
-        {
-            var sales = "Sales";
-            routingTable.RouteTo(typeof(Command), UnicastRoute.CreateFromEndpointName(sales));
-            endpointInstances.Add(new EndpointInstance(sales, "1"));
-            routingTable.RouteTo(typeof(Command), UnicastRoute.CreateFromPhysicalAddress(sales + "-1"));
-
-            var routes = await router.Route(typeof(Command), new DistributionPolicy(), new ContextBag());
-
-            Assert.AreEqual(1, routes.Count());
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
@@ -30,7 +30,7 @@
         public async Task When_multiple_dynamic_instances_for_logical_endpoints_should_route_message_to_a_single_instance()
         {
             var sales = "Sales";
-            routingTable.AddDynamic((t, c) => UnicastRoute.CreateFromEndpointName(sales));
+            routingTable.RouteTo(typeof(Command), UnicastRoute.CreateFromEndpointName(sales));
 
             endpointInstances.Add(new EndpointInstance(sales, "1"));
             endpointInstances.AddDynamic(e => Task.FromResult(EnumerableEx.Single(new EndpointInstance(sales, "2"))));

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -114,7 +114,7 @@
             {
                 m.Configure((type, endpointAddress) =>
                 {
-                    unicastRoutingTable.RouteTo(type, UnicastRoute.CreateFromPhysicalAddress(transportInfrastructure.MakeCanonicalForm(endpointAddress)), true);
+                    unicastRoutingTable.RouteTo(type, UnicastRoute.CreateFromPhysicalAddress(transportInfrastructure.MakeCanonicalForm(endpointAddress)), overrideExistingRoute: true);
                     publishers.AddByAddress(type, endpointAddress);
                 });
             }

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -114,7 +114,7 @@
             {
                 m.Configure((type, endpointAddress) =>
                 {
-                    unicastRoutingTable.RouteTo(type, UnicastRoute.CreateFromPhysicalAddress(transportInfrastructure.MakeCanonicalForm(endpointAddress)));
+                    unicastRoutingTable.RouteTo(type, UnicastRoute.CreateFromPhysicalAddress(transportInfrastructure.MakeCanonicalForm(endpointAddress)), true);
                     publishers.AddByAddress(type, endpointAddress);
                 });
             }

--- a/src/NServiceBus.Core/Routing/UnicastRoutingTable.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRoutingTable.cs
@@ -10,38 +10,36 @@ namespace NServiceBus.Routing
     /// </summary>
     public class UnicastRoutingTable
     {
-        internal Task<IEnumerable<IUnicastRoute>> GetDestinationsFor(Type messageType, ContextBag contextBag)
+        internal Task<IUnicastRoute> GetRouteFor(Type messageType, ContextBag contextBag)
         {
-            var routes = new List<IUnicastRoute>();
-
-            IUnicastRoute messageRoutes;
-            if (staticRoutes.TryGetValue(messageType, out messageRoutes))
+            IUnicastRoute unicastRoute;
+            if (staticRoutes.TryGetValue(messageType, out unicastRoute))
             {
-                routes.Add(messageRoutes);
+                return Task.FromResult(unicastRoute);
             }
 
             foreach (var rule in dynamicRules)
             {
-                routes.AddRange(rule.Invoke(messageType, contextBag));
+                var route = rule(messageType, contextBag);
+                if (route != null)
+                {
+                    return Task.FromResult(route);
+                }
             }
 
             if (asyncDynamicRules.Count > 0)
             {
-                return AddAsyncDynamicRules(messageType, contextBag, routes);
+                return ExecuteDynamicRules(messageType, contextBag);
             }
 
-            if (routes.Count > 1)
-            {
-                throw new Exception($"Found ambiguous routes for message '{messageType.Name}'. Check your dynamic and static routes and avoid multiple routes for the same message type.");
-            }
-
-            return Task.FromResult<IEnumerable<IUnicastRoute>>(routes);
+            return noRoute;
         }
 
         /// <summary>
         /// Adds a static unicast route for a given message type.
         /// </summary>
-        /// /// <param name="messageType">The message type to use the route for.</param>
+        /// ///
+        /// <param name="messageType">The message type to use the route for.</param>
         /// <param name="route">The route to use for the given message type.</param>
         /// <exception cref="Exception">Throws an exception when an ambiguous route exists.</exception>
         public void RouteTo(Type messageType, IUnicastRoute route)
@@ -54,8 +52,14 @@ namespace NServiceBus.Routing
         /// </summary>
         /// <param name="messageType">The message type to use the route for.</param>
         /// <param name="route">The route to use for the given message type.</param>
-        /// <param name="overrideExistingRoute">Will override an existing route for the message type without throwing an exception when set to <code>true</code>.</param>
-        /// <exception cref="Exception">Throws an exception when an ambiguous route exists and <paramref name="overrideExistingRoute"/> is not set to <code>true</code>.</exception>
+        /// <param name="overrideExistingRoute">
+        /// Will override an existing route for the message type without throwing an exception
+        /// when set to <code>true</code>.
+        /// </param>
+        /// <exception cref="Exception">
+        /// Throws an exception when an ambiguous route exists and
+        /// <paramref name="overrideExistingRoute" /> is not set to <code>true</code>.
+        /// </exception>
         public void RouteTo(Type messageType, IUnicastRoute route, bool overrideExistingRoute)
         {
             if (!overrideExistingRoute && staticRoutes.ContainsKey(messageType))
@@ -69,9 +73,12 @@ namespace NServiceBus.Routing
         /// <summary>
         /// Adds an external provider of routes.
         /// </summary>
-        /// <remarks>For dynamic routes that do not require async use <see cref="AddDynamic(System.Func{Type,NServiceBus.Extensibility.ContextBag,System.Collections.Generic.IEnumerable{NServiceBus.Routing.IUnicastRoute}})" />.</remarks>
+        /// <remarks>
+        /// For dynamic routes that do not require async use
+        /// <see cref="AddDynamic(System.Func{Type,NServiceBus.Extensibility.ContextBag,NServiceBus.Routing.IUnicastRoute})" />.
+        /// </remarks>
         /// <param name="dynamicRule">The rule.</param>
-        public void AddDynamic(Func<Type, ContextBag, Task<IEnumerable<IUnicastRoute>>> dynamicRule)
+        public void AddDynamic(Func<Type, ContextBag, Task<IUnicastRoute>> dynamicRule)
         {
             asyncDynamicRules.Add(dynamicRule);
         }
@@ -79,30 +86,35 @@ namespace NServiceBus.Routing
         /// <summary>
         /// Adds an external provider of routes.
         /// </summary>
-        /// <remarks>For dynamic routes that require async use <see cref="AddDynamic(System.Func{Type,NServiceBus.Extensibility.ContextBag,System.Threading.Tasks.Task{System.Collections.Generic.IEnumerable{NServiceBus.Routing.IUnicastRoute}}})" />.</remarks>
+        /// <remarks>
+        /// For dynamic routes that require async use
+        /// <see
+        ///     cref="AddDynamic(System.Func{Type,NServiceBus.Extensibility.ContextBag,System.Threading.Tasks.Task{NServiceBus.Routing.IUnicastRoute}})" />
+        /// .
+        /// </remarks>
         /// <param name="dynamicRule">The rule.</param>
-        public void AddDynamic(Func<Type, ContextBag, IEnumerable<IUnicastRoute>> dynamicRule)
+        public void AddDynamic(Func<Type, ContextBag, IUnicastRoute> dynamicRule)
         {
             dynamicRules.Add(dynamicRule);
         }
 
-        async Task<IEnumerable<IUnicastRoute>> AddAsyncDynamicRules(Type messageType, ContextBag contextBag, List<IUnicastRoute> routes)
+        async Task<IUnicastRoute> ExecuteDynamicRules(Type messageType, ContextBag contextBag)
         {
             foreach (var rule in asyncDynamicRules)
             {
-                routes.AddRange(await rule.Invoke(messageType, contextBag).ConfigureAwait(false));
+                var route = await rule(messageType, contextBag).ConfigureAwait(false);
+                if (route != null)
+                {
+                    return route;
+                }
             }
 
-            if (routes.Count > 1)
-            {
-                throw new Exception($"Found ambiguous routes for message '{messageType.Name}'. Check your dynamic and static routes and avoid multiple routes for the same message type.");
-            }
-
-            return routes;
+            return null;
         }
 
-        List<Func<Type, ContextBag, Task<IEnumerable<IUnicastRoute>>>> asyncDynamicRules = new List<Func<Type, ContextBag, Task<IEnumerable<IUnicastRoute>>>>();
-        List<Func<Type, ContextBag, IEnumerable<IUnicastRoute>>> dynamicRules = new List<Func<Type, ContextBag, IEnumerable<IUnicastRoute>>>();
+        List<Func<Type, ContextBag, Task<IUnicastRoute>>> asyncDynamicRules = new List<Func<Type, ContextBag, Task<IUnicastRoute>>>();
+        List<Func<Type, ContextBag, IUnicastRoute>> dynamicRules = new List<Func<Type, ContextBag, IUnicastRoute>>();
         Dictionary<Type, IUnicastRoute> staticRoutes = new Dictionary<Type, IUnicastRoute>();
+        static Task<IUnicastRoute> noRoute = Task.FromResult<IUnicastRoute>(null);
     }
 }

--- a/src/NServiceBus.Core/Routing/UnicastRoutingTable.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRoutingTable.cs
@@ -14,10 +14,10 @@ namespace NServiceBus.Routing
         {
             var routes = new List<IUnicastRoute>();
 
-            List<IUnicastRoute> messageRoutes;
+            IUnicastRoute messageRoutes;
             if (staticRoutes.TryGetValue(messageType, out messageRoutes))
             {
-                routes.AddRange(messageRoutes);
+                routes.Add(messageRoutes);
             }
 
             foreach (var rule in dynamicRules)
@@ -38,18 +38,7 @@ namespace NServiceBus.Routing
         /// </summary>
         public void RouteTo(Type messageType, IUnicastRoute route)
         {
-            List<IUnicastRoute> existingRoutes;
-            if (staticRoutes.TryGetValue(messageType, out existingRoutes))
-            {
-                existingRoutes.Add(route);
-            }
-            else
-            {
-                staticRoutes.Add(messageType, new List<IUnicastRoute>
-                {
-                    route
-                });
-            }
+            staticRoutes[messageType] = route;
         }
 
         /// <summary>
@@ -84,6 +73,6 @@ namespace NServiceBus.Routing
 
         List<Func<Type, ContextBag, Task<IEnumerable<IUnicastRoute>>>> asyncDynamicRules = new List<Func<Type, ContextBag, Task<IEnumerable<IUnicastRoute>>>>();
         List<Func<Type, ContextBag, IEnumerable<IUnicastRoute>>> dynamicRules = new List<Func<Type, ContextBag, IEnumerable<IUnicastRoute>>>();
-        Dictionary<Type, List<IUnicastRoute>> staticRoutes = new Dictionary<Type, List<IUnicastRoute>>();
+        Dictionary<Type, IUnicastRoute> staticRoutes = new Dictionary<Type, IUnicastRoute>();
     }
 }


### PR DESCRIPTION
No longer allow multiple static route for a message type. This PR addresses https://github.com/Particular/NServiceBus/issues/3909 

A command can no longer have multiple routes registered and therefore no longer be sent to multiple receivers when registering multiple routes for the same message type.

Changes:
* when registering multiple routes  using the (legacy) message endpoint mapping config, the last route for a specific type overrides the current route. This should align with the v5 behavior.
* when registering multiple static routes for the same type, it will throw an exception
* the advanced routing table API provides an overload where you can define whether you want to allow a static route or not.
* You can no longer add multiple dynamic routes. There is a single (async) "fallback" callback that you can register which is executed in case no static route was found when resolving a type.
