### PR TITLE
TimeToBeReceived does not work with unobtrusive mode

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Basic\When_depending_on_untyped_feature.cs" />
     <Compile Include="Basic\When_extending_behavior_context.cs" />
     <Compile Include="Encryption\When_using_Rijndael_with_unobtrusive_mode.cs" />
+    <Compile Include="Performance\TimeToBeReceived\When_TimeToBeReceived_used_with_unobtrusive_mode.cs" />
     <Compile Include="Recoverability\Retries\When_custom_policy_provided.cs" />
     <Compile Include="Recoverability\When_custom_policy_moves_to_overridden_error_queue.cs" />
     <Compile Include="Recoverability\When_message_is_moved_to_error_queue_with_header_customizations.cs" />

--- a/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_expired_convention.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_has_expired_convention.cs
@@ -57,7 +57,7 @@
                     {
                         if (messageType == typeof(MyMessage))
                         {
-                            return TimeSpan.Parse("00:00:02");
+                            return TimeSpan.FromSeconds(2);
                         }
                         return TimeSpan.MaxValue;
                     });

--- a/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_used_with_unobtrusive_mode.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/TimeToBeReceived/When_TimeToBeReceived_used_with_unobtrusive_mode.cs
@@ -1,0 +1,119 @@
+﻿namespace NServiceBus.AcceptanceTests.Performance.TimeToBeReceived
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_TimeToBeReceived_used_with_unobtrusive_mode : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Message_should_not_be_received()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>()
+                .WithEndpoint<Receiver>()
+                .Run(TimeSpan.FromSeconds(10));
+
+            Assert.IsFalse(context.WasCalled);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        class SendMessageWhileStarting : Feature
+        {
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.RegisterStartupTask(b => new SendMessageWhileStartingTask());
+            }
+        }
+
+        class SendMessageWhileStartingTask : FeatureStartupTask
+        {
+            protected override Task OnStart(IMessageSession session)
+            {
+                return session.Send(new MyCommand());
+            }
+
+            protected override Task OnStop(IMessageSession session)
+            {
+                return Task.FromResult(0);
+            }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.Conventions()
+                    .DefiningCommandsAs(t => t.Namespace != null && t.FullName == typeof(MyCommand).FullName)
+                    .DefiningTimeToBeReceivedAs(messageType =>
+                    {
+                        if (messageType == typeof(MyCommand))
+                        {
+                            return TimeSpan.FromSeconds(2);
+                        }
+                        return TimeSpan.MaxValue;
+                    });
+                    c.EnableFeature<SendMessageWhileStarting>();
+                }).AddMapping<MyCommand>(typeof(Receiver))
+                .ExcludeType<MyCommand>(); // remove that type from assembly scanning to simulate what would happen with true unobtrusive mode
+            }
+        }
+
+        class DelayReceiverFromStarting : Feature
+        {
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.RegisterStartupTask(b => new DelayReceiverFromStartingTask());
+            }
+        }
+
+        class DelayReceiverFromStartingTask : FeatureStartupTask
+        {
+            protected override Task OnStart(IMessageSession session)
+            {
+                return Task.Delay(TimeSpan.FromSeconds(5));
+            }
+
+            protected override Task OnStop(IMessageSession session)
+            {
+                return Task.FromResult(0);
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.Conventions().DefiningCommandsAs(t => t.Namespace != null && t.FullName == typeof(MyCommand).FullName);
+                    c.EnableFeature<DelayReceiverFromStarting>();
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyCommand>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyCommand message, IMessageHandlerContext context)
+                {
+                    Context.WasCalled = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MyCommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Performance/TimeToBeReceived/TimeToBeReceivedAttributeTests.cs
+++ b/src/NServiceBus.Core.Tests/Performance/TimeToBeReceived/TimeToBeReceivedAttributeTests.cs
@@ -6,25 +6,80 @@
     public class TimeToBeReceivedAttributeTests
     {
         [Test]
-        public void Should_use_TimeToBeReceived_from_bottom_of_tree()
+        public void Should_use_TimeToBeReceived_from_bottom_of_tree_when_initialized()
         {
-            var mappings = new TimeToBeReceivedMappings(new[]{typeof(InheritedClassWithAttribute)},TimeToBeReceivedMappings.DefaultConvention);
+            var mappings = new TimeToBeReceivedMappings(new[]
+            {
+                typeof(InheritedClassWithAttribute)
+            }, TimeToBeReceivedMappings.DefaultConvention, true);
 
             TimeSpan timeToBeReceived;
 
-            Assert.True(mappings.TryGetTimeToBeReceived(typeof(InheritedClassWithAttribute),out timeToBeReceived));
+            Assert.True(mappings.TryGetTimeToBeReceived(typeof(InheritedClassWithAttribute), out timeToBeReceived));
             Assert.AreEqual(TimeSpan.FromSeconds(2), timeToBeReceived);
         }
 
         [Test]
-        public void Should_use_inherited_TimeToBeReceived()
+        public void Should_use_inherited_TimeToBeReceived_when_initialized()
         {
-            var mappings = new TimeToBeReceivedMappings(new[] { typeof(InheritedClassWithNoAttribute) }, TimeToBeReceivedMappings.DefaultConvention);
+            var mappings = new TimeToBeReceivedMappings(new[]
+            {
+                typeof(InheritedClassWithNoAttribute)
+            }, TimeToBeReceivedMappings.DefaultConvention, true);
 
             TimeSpan timeToBeReceived;
 
             Assert.True(mappings.TryGetTimeToBeReceived(typeof(InheritedClassWithNoAttribute), out timeToBeReceived));
             Assert.AreEqual(TimeSpan.FromSeconds(1), timeToBeReceived);
+        }
+
+        [Test]
+        public void Should_throw_when_discard_before_received_not_supported_when_initialized()
+        {
+            Assert.That(() => new TimeToBeReceivedMappings(new[]
+            {
+                typeof(InheritedClassWithNoAttribute)
+            }, TimeToBeReceivedMappings.DefaultConvention, doesTransportSupportDiscardIfNotReceivedBefore: false), Throws.Exception.Message.StartWith("Messages with TimeToBeReceived found but the selected transport does not support this type of restriction"));
+        }
+
+        [Test]
+        public void Should_use_TimeToBeReceived_from_bottom_of_tree_when_tryget()
+        {
+            var mappings = new TimeToBeReceivedMappings(new Type[]
+            {
+            }, TimeToBeReceivedMappings.DefaultConvention, true);
+
+            TimeSpan timeToBeReceived;
+
+            Assert.True(mappings.TryGetTimeToBeReceived(typeof(InheritedClassWithAttribute), out timeToBeReceived));
+            Assert.AreEqual(TimeSpan.FromSeconds(2), timeToBeReceived);
+        }
+
+        [Test]
+        public void Should_use_inherited_TimeToBeReceived_when_tryget()
+        {
+            var mappings = new TimeToBeReceivedMappings(new Type[]
+            {
+            }, TimeToBeReceivedMappings.DefaultConvention, true);
+
+            TimeSpan timeToBeReceived;
+
+            Assert.True(mappings.TryGetTimeToBeReceived(typeof(InheritedClassWithNoAttribute), out timeToBeReceived));
+            Assert.AreEqual(TimeSpan.FromSeconds(1), timeToBeReceived);
+        }
+
+        [Test]
+        public void Should_throw_when_discard_before_received_not_supported_when_tryget()
+        {
+            var mappings = new TimeToBeReceivedMappings(new Type[]
+            {
+            }, TimeToBeReceivedMappings.DefaultConvention, doesTransportSupportDiscardIfNotReceivedBefore: false);
+
+            Assert.That(() =>
+            {
+                TimeSpan ttbr;
+                return mappings.TryGetTimeToBeReceived(typeof(InheritedClassWithNoAttribute), out ttbr);
+            }, Throws.Exception.Message.StartWith("Messages with TimeToBeReceived found but the selected transport does not support this type of restriction"));
         }
 
         [TimeToBeReceived("00:00:01")]
@@ -35,12 +90,10 @@
         [TimeToBeReceived("00:00:02")]
         class InheritedClassWithAttribute : BaseClass
         {
-
         }
 
         class InheritedClassWithNoAttribute : BaseClass
         {
-
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/Particular/NServiceBus/issues/3989

This fixes the time to be received for unobtrusive mode. The current design still tries to precache time to be received for known messages. If types are not known they will be added during runtime.

## Caching change of behavior

Previous version did only cache time to be received for messages when TTBR was less than `TimeSpan.Max`. This code changes it slightly to also cache TimeSpan.Max values. I think this is a reasonable trade off which allows us to use the more atomic `GetOrAdd` overloads of the concurrent dictionary instead of doing a `TryGet` and then a `TryAdd`.

And alternative approach could be to store Timespan? (Nullable) instead of `Timespan.Max` but I think this is unnecessary optimizations.