### PR TITLE
Property encryption does not work with unobtrusive mode

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Encryption/When_using_Rijndael_with_unobtrusive_mode.cs
+++ b/src/NServiceBus.AcceptanceTests/Encryption/When_using_Rijndael_with_unobtrusive_mode.cs
@@ -1,0 +1,139 @@
+namespace NServiceBus.AcceptanceTests.Encryption
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_using_Rijndael_with_unobtrusive_mode : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_receive_decrypted_message()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(b => b.When(session => session.Send(new MessageWithSecretData
+                {
+                    EncryptedSecret = "betcha can't guess my secret",
+                    SubProperty = new MySecretSubProperty
+                    {
+                        EncryptedSecret = "My sub secret"
+                    },
+                    CreditCards = new List<CreditCardDetails>
+                    {
+                        new CreditCardDetails
+                        {
+                            ValidTo = DateTime.UtcNow.AddYears(1),
+                            EncryptedNumber = "312312312312312"
+                        },
+                        new CreditCardDetails
+                        {
+                            ValidTo = DateTime.UtcNow.AddYears(2),
+                            EncryptedNumber = "543645546546456"
+                        }
+                    }
+                })))
+                .WithEndpoint<Receiver>()
+                .Done(c => c.GetTheMessage || c.FailedMessages.Any())
+                .Run();
+
+            Assert.AreEqual("betcha can't guess my secret", context.Secret);
+            Assert.AreEqual("My sub secret", context.SubPropertySecret);
+            CollectionAssert.AreEquivalent(new List<string>
+            {
+                "312312312312312",
+                "543645546546456"
+            }, context.CreditCards);
+        }
+
+        static Dictionary<string, byte[]> Keys = new Dictionary<string, byte[]>
+        {
+            {"1st", Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6")}
+        };
+
+        public class Context : ScenarioContext
+        {
+            public bool GetTheMessage { get; set; }
+
+            public string Secret { get; set; }
+
+            public string SubPropertySecret { get; set; }
+
+            public List<string> CreditCards { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.Conventions()
+                        .DefiningCommandsAs(t => t.Namespace != null && t.FullName == typeof(MessageWithSecretData).FullName)
+                        .DefiningEncryptedPropertiesAs(t => t.Name.StartsWith("Encrypted"));
+
+                    c.RijndaelEncryptionService("1st", Keys);
+                }).AddMapping<MessageWithSecretData>(typeof(Receiver))
+                    .ExcludeType<MessageWithSecretData>(); // remove that type from assembly scanning to simulate what would happen with true unobtrusive mode
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.Conventions()
+                        .DefiningCommandsAs(t => t.Namespace != null && t.FullName == typeof(MessageWithSecretData).FullName)
+                        .DefiningEncryptedPropertiesAs(t => t.Name.StartsWith("Encrypted"));
+
+                    c.RijndaelEncryptionService("1st", Keys);
+                });
+            }
+
+            public class Handler : IHandleMessages<MessageWithSecretData>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MessageWithSecretData message, IMessageHandlerContext context)
+                {
+                    Context.Secret = message.EncryptedSecret;
+
+                    Context.SubPropertySecret = message.SubProperty.EncryptedSecret;
+
+                    Context.CreditCards = new List<string>
+                    {
+                        message.CreditCards[0].EncryptedNumber,
+                        message.CreditCards[1].EncryptedNumber
+                    };
+
+                    Context.GetTheMessage = true;
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MessageWithSecretData
+        {
+            public string EncryptedSecret { get; set; }
+            public MySecretSubProperty SubProperty { get; set; }
+            public List<CreditCardDetails> CreditCards { get; set; }
+        }
+
+        public class CreditCardDetails
+        {
+            public DateTime ValidTo { get; set; }
+            public string EncryptedNumber { get; set; }
+        }
+
+        public class MySecretSubProperty
+        {
+            public string EncryptedSecret { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
     <Compile Include="Basic\When_depending_on_untyped_feature.cs" />
     <Compile Include="Basic\When_extending_behavior_context.cs" />
+    <Compile Include="Encryption\When_using_Rijndael_with_unobtrusive_mode.cs" />
     <Compile Include="Recoverability\Retries\When_custom_policy_provided.cs" />
     <Compile Include="Recoverability\When_custom_policy_moves_to_overridden_error_queue.cs" />
     <Compile Include="Recoverability\When_message_is_moved_to_error_queue_with_header_customizations.cs" />

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1685,9 +1685,12 @@ namespace NServiceBus.Features
     {
         protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
-    public class Encryptor : NServiceBus.Features.Feature
+    [System.ObsoleteAttribute("Encryption is no longer enabled by default. Encryption gets enabled by calling co" +
+        "nfiguration.RegisterEncryptionService or configuration.RijndaelEncryptionService" +
+        ". Will be removed in version 7.0.0.", true)]
+    public class Encryptor
     {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        public Encryptor() { }
     }
     public abstract class Feature
     {

--- a/src/NServiceBus.Core/Encryption/ConfigureRijndaelEncryptionService.cs
+++ b/src/NServiceBus.Core/Encryption/ConfigureRijndaelEncryptionService.cs
@@ -5,7 +5,6 @@ namespace NServiceBus
     using System.Linq;
     using System.Text;
     using Config;
-    using Features;
     using Logging;
     using Settings;
 

--- a/src/NServiceBus.Core/Encryption/ConfigureRijndaelEncryptionService.cs
+++ b/src/NServiceBus.Core/Encryption/ConfigureRijndaelEncryptionService.cs
@@ -5,6 +5,7 @@ namespace NServiceBus
     using System.Linq;
     using System.Text;
     using Config;
+    using Features;
     using Logging;
     using Settings;
 
@@ -169,12 +170,14 @@ namespace NServiceBus
         public static void RegisterEncryptionService(this EndpointConfiguration config, Func<IEncryptionService> func)
         {
             Guard.AgainstNull(nameof(config), config);
-            config.Settings.Set("EncryptionServiceConstructor", func);
+
+            config.EnableFeature<Encryptor>();
+            config.Settings.Set(EncryptedServiceContstructorKey, func);
         }
 
-        internal static bool GetEncryptionServiceConstructor(this ReadOnlySettings settings, out Func<IEncryptionService> func)
+        internal static Func<IEncryptionService> GetEncryptionServiceConstructor(this ReadOnlySettings settings)
         {
-            return settings.TryGet("EncryptionServiceConstructor", out func);
+            return settings.Get<Func<IEncryptionService>>(EncryptedServiceContstructorKey);
         }
 
         static byte[] ParseKey(string key, KeyFormat keyFormat)
@@ -211,6 +214,8 @@ namespace NServiceBus
                 result.Add(item.KeyIdentifier, key);
             }
         }
+
+        const string EncryptedServiceContstructorKey = "EncryptionServiceConstructor";
 
         static readonly ILog Log = LogManager.GetLogger(typeof(ConfigureRijndaelEncryptionService));
     }

--- a/src/NServiceBus.Core/Encryption/ConfigureRijndaelEncryptionService.cs
+++ b/src/NServiceBus.Core/Encryption/ConfigureRijndaelEncryptionService.cs
@@ -170,7 +170,6 @@ namespace NServiceBus
         {
             Guard.AgainstNull(nameof(config), config);
 
-            config.EnableFeature<Encryptor>();
             config.Settings.Set(EncryptedServiceContstructorKey, func);
         }
 
@@ -214,7 +213,7 @@ namespace NServiceBus
             }
         }
 
-        const string EncryptedServiceContstructorKey = "EncryptionServiceConstructor";
+        internal const string EncryptedServiceContstructorKey = "EncryptionServiceConstructor";
 
         static readonly ILog Log = LogManager.GetLogger(typeof(ConfigureRijndaelEncryptionService));
     }

--- a/src/NServiceBus.Core/Encryption/Encryption.cs
+++ b/src/NServiceBus.Core/Encryption/Encryption.cs
@@ -1,9 +1,14 @@
-﻿namespace NServiceBus
+﻿namespace NServiceBus.Features
 {
-    using Features;
-
-    class Encryptor : Feature
+    class Encryption : Feature
     {
+        public Encryption()
+        {
+            Prerequisite(c => c.Settings.HasSetting(ConfigureRijndaelEncryptionService.EncryptedServiceContstructorKey), "Encryption service not defined.");
+
+            EnableByDefault();
+        }
+
         protected internal override void Setup(FeatureConfigurationContext context)
         {
             var serviceConstructor = context.Settings.GetEncryptionServiceConstructor();

--- a/src/NServiceBus.Core/Encryption/Encryptor.cs
+++ b/src/NServiceBus.Core/Encryption/Encryptor.cs
@@ -1,77 +1,17 @@
-﻿namespace NServiceBus.Features
+﻿namespace NServiceBus
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
-    using System.Text;
-    using Logging;
-    using Unicast.Messages;
+    using Features;
 
-    /// <summary>
-    /// Used to configure encryption.
-    /// </summary>
-    public class Encryptor : Feature
+    class Encryptor : Feature
     {
-        internal Encryptor()
-        {
-            EnableByDefault();
-            Prerequisite(VerifyPrerequisite, "No encryption properties was found in available messages");
-        }
-
-        bool VerifyPrerequisite(FeatureConfigurationContext context)
-        {
-            var encryptedProperties = GetEncryptedProperties(context);
-            var encryptionServiceConstructorDefined = context.Settings.GetEncryptionServiceConstructor(out serviceConstructor);
-            var encryptionPropertiesFound = encryptedProperties.Any();
-            if (encryptionPropertiesFound)
-            {
-                if (!encryptionServiceConstructorDefined)
-                {
-                    var stringBuilder = new StringBuilder("Encrypted properties were found but no encryption service has been defined. Call endpointConfiguration.RijndaelEncryptionService or endpointConfiguration.RegisterEncryptionService. Encrypted properties: ");
-                    foreach (var encryptedProperty in encryptedProperties)
-                    {
-                        stringBuilder.AppendFormat("{0}.{1}\r\n", encryptedProperty.DeclaringType, encryptedProperty.Name);
-                    }
-                    throw new Exception(stringBuilder.ToString());
-                }
-            }
-            else
-            {
-                if (encryptionServiceConstructorDefined)
-                {
-                    var message =
-                        @"Encryption service has been configured via either endpointConfiguration.RijndaelEncryptionService or endpointConfiguration.RegisterEncryptionService however no properties were found on type that require encryption.
-Ensure that either encryption message conventions are defined or to define message properties using as WireEncryptedString.";
-                    log.Warn(message);
-                }
-            }
-            return encryptionPropertiesFound;
-        }
-
-        static List<PropertyInfo> GetEncryptedProperties(FeatureConfigurationContext context)
-        {
-            var conventions = context.Settings.Get<Conventions>();
-            var registry = context.Settings.Get<MessageMetadataRegistry>();
-            return registry.GetAllMessages()
-                .SelectMany(metadata => metadata.MessageType.GetProperties(BindingFlags.Instance | BindingFlags.Public))
-                .Where(conventions.IsEncryptedProperty)
-                .ToList();
-        }
-
-        /// <summary>
-        /// <see cref="Feature.Setup" />.
-        /// </summary>
         protected internal override void Setup(FeatureConfigurationContext context)
         {
+            var serviceConstructor = context.Settings.GetEncryptionServiceConstructor();
             var service = serviceConstructor();
             var inspector = new EncryptionInspector(context.Settings.Get<Conventions>());
 
             context.Pipeline.Register(new EncryptBehavior.EncryptRegistration(inspector, service));
             context.Pipeline.Register(new DecryptBehavior.DecryptRegistration(inspector, service));
         }
-
-        Func<IEncryptionService> serviceConstructor;
-        static ILog log = LogManager.GetLogger<Encryptor>();
     }
 }

--- a/src/NServiceBus.Core/Encryption/StringConversions.cs
+++ b/src/NServiceBus.Core/Encryption/StringConversions.cs
@@ -19,10 +19,7 @@ namespace NServiceBus
 
         public static void DecryptValue(this IEncryptionService encryptionService, ref string stringToDecrypt, IIncomingLogicalMessageContext context)
         {
-            var parts = stringToDecrypt.Split(new[]
-            {
-                '@'
-            }, StringSplitOptions.None);
+            var parts = stringToDecrypt.Split(splitChars, StringSplitOptions.None);
 
             stringToDecrypt = encryptionService.Decrypt(
                 new EncryptedValue
@@ -33,5 +30,7 @@ namespace NServiceBus
                 context
                 );
         }
+
+        static char[] splitChars = { '@' };
     }
 }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -338,7 +338,7 @@
     <Compile Include="Encryption\DecryptBehavior.cs" />
     <Compile Include="Encryption\EncryptBehavior.cs" />
     <Compile Include="Encryption\EncryptedValue.cs" />
-    <Compile Include="Encryption\Encryptor.cs" />
+    <Compile Include="Encryption\Encryption.cs" />
     <Compile Include="Encryption\KeyFormat.cs" />
     <Compile Include="Encryption\RijndaelEncryptionServiceConfigValidations.cs" />
     <Compile Include="Encryption\RijndaelExpiredKey.cs" />

--- a/src/NServiceBus.Core/obsoletes.cs
+++ b/src/NServiceBus.Core/obsoletes.cs
@@ -899,6 +899,12 @@ namespace NServiceBus.Features
     public class ConfigureTransport
     {
     }
+
+    [ObsoleteEx(
+        RemoveInVersion = "7.0",
+        TreatAsErrorFromVersion = "6.0",
+        Message = "Encryption is no longer enabled by default. Encryption gets enabled by calling configuration.RegisterEncryptionService or configuration.RijndaelEncryptionService.")]
+    public class Encryptor { }
 }
 
 namespace NServiceBus.Transports


### PR DESCRIPTION
Closes #3990 

## Breaking change

The encryption feature will no longer be enabled by default and silently disable itself when there is nothing to decrypt. The feature is now opt-in by using the following approach:

When you call `RegisterEncryptionService` or `RijndaelEncryptionService` the feature will get enabled. 

If I understood the logic flow correctly it was always required to call `RegisterEncryptionService` or `RijndaelEncryptionService` anyway. The previous feature would throw configuration exceptions if you didn't.

See https://github.com/Particular/NServiceBus/pull/3991/files#diff-095bc316e056d2a288aa5e4839fd9a06L31

> Property encryption is enabled via the configuration API.

http://docs.particular.net/nservicebus/security/encryption

Since we cannot properly rely on message types being included in the scan if they are not handled the check whether you called  `RegisterEncryptionService` or `RijndaelEncryptionService` but you don't have messages defined with properties that require encryption can no longer be done.

https://github.com/Particular/NServiceBus/pull/3991/files#diff-095bc316e056d2a288aa5e4839fd9a06L44

I think that is a small price to pay.

## Doco PR

https://github.com/Particular/docs.particular.net/pull/1737

Smoke tested with #3986 