### PR TITLE
Select transport for TransportTests based on available TransportDefinitions

### DIFF
--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -48,6 +48,7 @@
     <Compile Include="IConfigureTransportInfrastructure.cs" />
     <Compile Include="NServiceBusTransportTest.cs" />
     <Compile Include="TransportConfigurationResult.cs" />
+    <Compile Include="TypeScanner.cs" />
     <Compile Include="When_failure_happens_after_send.cs" />
     <Compile Include="When_on_error_throws.cs" />
     <Compile Include="When_on_message_throws_after_delayed_retry.cs" />

--- a/src/NServiceBus.TransportTests/TypeScanner.cs
+++ b/src/NServiceBus.TransportTests/TypeScanner.cs
@@ -1,0 +1,40 @@
+﻿namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Hosting.Helpers;
+
+    public class TypeScanner
+    {
+        static IEnumerable<Assembly> AvailableAssemblies
+        {
+            get
+            {
+                if (assemblies == null)
+                {
+                    var result = new AssemblyScanner().GetScannableAssemblies();
+
+                    assemblies = result.Assemblies.Where(a =>
+                    {
+                        var references = a.GetReferencedAssemblies();
+
+                        return references.All(an => an.Name != "nunit.framework");
+                    }).ToList();
+                }
+
+                return assemblies;
+            }
+        }
+
+        public static IEnumerable<Type> GetAllTypesAssignableTo<T>()
+        {
+            return AvailableAssemblies.SelectMany(a => a.GetTypes())
+                .Where(t => typeof(T).IsAssignableFrom(t) && t != typeof(T))
+                .ToList();
+        }
+
+        static List<Assembly> assemblies;
+    }
+}


### PR DESCRIPTION
This change makes the new transport tests project work more like the acceptance tests in how it chooses which transport to use to run the tests.

Instead of requiring the "Transport.UseSpecific" environment variable to be set to select something other than MSMQ, it now looks for types that implement `TransportDefinition` and picks the first non-MSMQ definition it finds, falling back to MSMQ if there aren't any. The environment variable can still be used to override the automatic selection if need be.

The `TypeScanner` class was copied from the AcceptanceTests project.

@tmasternak What do you think?

// cc @adamralph 