### PR TITLE
Throwing when explicitly configured instance mapping file is missing

### DIFF
--- a/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
+++ b/src/NServiceBus.Core/Routing/FileBasedDynamicRouting/FileRoutingTableFeature.cs
@@ -11,22 +11,19 @@ namespace NServiceBus.Features
             Defaults(s =>
             {
                 s.SetDefault(CheckIntervalSettingsKey, TimeSpan.FromSeconds(30));
-                s.SetDefault(FilePathSettingsKey, "instance-mapping.xml");
+                s.SetDefault(FilePathSettingsKey, DefaultInstanceMappingFileName);
             });
+            Prerequisite(c => c.Settings.HasExplicitValue(FilePathSettingsKey) || File.Exists(GetRootedPath(DefaultInstanceMappingFileName)), "No explicit instance mapping file configuration and default file does not exist.");
             DependsOn<RoutingFeature>();
         }
 
         protected internal override void Setup(FeatureConfigurationContext context)
         {
-            var filePath = context.Settings.Get<string>(FilePathSettingsKey);
-            if (!Path.IsPathRooted(filePath))
-            {
-                filePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, filePath);
-            }
+            var filePath = GetRootedPath(context.Settings.Get<string>(FilePathSettingsKey));
 
             if (!File.Exists(filePath))
             {
-                return;
+                throw new Exception($"The specified instance mapping file '{filePath}' does not exist.");
             }
 
             var checkInterval = context.Settings.Get<TimeSpan>(CheckIntervalSettingsKey);
@@ -38,7 +35,15 @@ namespace NServiceBus.Features
             context.RegisterStartupTask(fileRoutingTable);
         }
 
+        static string GetRootedPath(string filePath)
+        {
+            return Path.IsPathRooted(filePath) 
+                ? filePath 
+                : Path.Combine(AppDomain.CurrentDomain.BaseDirectory, filePath);
+        }
+
         public const string CheckIntervalSettingsKey = "FileBasedRouting.CheckInterval";
         public const string FilePathSettingsKey = "FileBasedRouting.FilePath";
+        const string DefaultInstanceMappingFileName = "instance-mapping.xml";
     }
 }

--- a/src/NServiceBus.Msmq.AcceptanceTests/NServiceBus.Msmq.AcceptanceTests.csproj
+++ b/src/NServiceBus.Msmq.AcceptanceTests/NServiceBus.Msmq.AcceptanceTests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="When_replying_to_a_message_sent_via_a_distributor.cs" />
     <Compile Include="When_setting_label_generator.cs" />
     <Compile Include="When_starting_up_the_endpoint.cs" />
+    <Compile Include="When_starting_with_missing_instance_mapping_file.cs" />
     <Compile Include="When_starting_with_invalid_instance_mapping_file.cs" />
     <Compile Include="When_subscribing_with_address_containing_host_name.cs" />
     <Compile Include="When_subscribing_from_a_worker.cs" />

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_starting_with_missing_instance_mapping_file.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_starting_with_missing_instance_mapping_file.cs
@@ -1,0 +1,39 @@
+﻿namespace NServiceBus.AcceptanceTests
+{
+    using System;
+    using System.IO;
+    using AcceptanceTesting;
+    using NUnit.Framework;
+
+    public class When_starting_with_missing_instance_mapping_file : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_throw_at_startup()
+        {
+            var exception = Assert.ThrowsAsync<AggregateException>(() => Scenario.Define<ScenarioContext>()
+                .WithEndpoint<SenderWithMissingMappingFile>()
+                .Done(c => c.EndpointsStarted)
+                .Run());
+
+            Assert.That(exception.InnerException.InnerException.Message, Does.Contain($"The specified instance mapping file '{mappingFilePath}' does not exist."));
+        }
+
+        static string mappingFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, nameof(When_starting_with_missing_instance_mapping_file) + ".xml");
+
+        public class SenderWithMissingMappingFile : EndpointConfigurationBuilder
+        {
+            public SenderWithMissingMappingFile()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    var routingSettings = c.UseTransport<MsmqTransport>().Routing();
+                    routingSettings.InstanceMappingFile().FilePath(mappingFilePath);
+                });
+            }
+        }
+
+        public class Message : ICommand
+        {
+        }
+    }
+}


### PR DESCRIPTION
Connects to Particular/V6Launch#68

Resolves https://github.com/Particular/NServiceBus/issues/3998

### Todo

* [ ] Update documentation on file-based instance mapping