### PR TITLE
Split LogicalAddress and EndpointInstance

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
@@ -34,14 +34,14 @@
 
         public override OutboundRoutingPolicy OutboundRoutingPolicy { get; } = new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Unicast, OutboundRoutingType.Unicast);
 
-        public override EndpointInstance BindToLocalEndpoint(EndpointInstance instance)
-        {
-            return instance;
-        }
-
         public override string ToTransportAddress(LogicalAddress logicalAddress)
         {
             return logicalAddress.ToString();
+        }
+
+        public override string ToTransportAddress(EndpointInstance endpointInstance)
+        {
+            return endpointInstance.ToString();
         }
 
         public override TransportReceiveInfrastructure ConfigureReceiveInfrastructure()

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
@@ -34,9 +34,9 @@
 
         public override OutboundRoutingPolicy OutboundRoutingPolicy { get; } = new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Unicast, OutboundRoutingType.Unicast);
 
-        public override string ToTransportAddress(LogicalAddress logicalAddress)
+        public override string ToTransportAddress(LocalAddress localAddress)
         {
-            return logicalAddress.ToString();
+            return localAddress.ToString();
         }
 
         public override string ToTransportAddress(EndpointInstance endpointInstance)

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -86,9 +86,9 @@
             public override TransportTransactionMode TransactionMode { get; } = TransportTransactionMode.None;
             public override OutboundRoutingPolicy OutboundRoutingPolicy { get; } = new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Unicast, OutboundRoutingType.Unicast);
 
-            public override string ToTransportAddress(LogicalAddress logicalAddress)
+            public override string ToTransportAddress(LocalAddress localAddress)
             {
-                return logicalAddress.ToString();
+                return localAddress.ToString();
             }
 
             public override string ToTransportAddress(EndpointInstance endpointInstance)

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -86,14 +86,14 @@
             public override TransportTransactionMode TransactionMode { get; } = TransportTransactionMode.None;
             public override OutboundRoutingPolicy OutboundRoutingPolicy { get; } = new OutboundRoutingPolicy(OutboundRoutingType.Unicast, OutboundRoutingType.Unicast, OutboundRoutingType.Unicast);
 
-            public override EndpointInstance BindToLocalEndpoint(EndpointInstance instance)
-            {
-                return instance;
-            }
-
             public override string ToTransportAddress(LogicalAddress logicalAddress)
             {
                 return logicalAddress.ToString();
+            }
+
+            public override string ToTransportAddress(EndpointInstance endpointInstance)
+            {
+                return endpointInstance.ToString();
             }
 
             public override TransportReceiveInfrastructure ConfigureReceiveInfrastructure()

--- a/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
+++ b/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
@@ -42,7 +42,7 @@
                 protected override void Setup(FeatureConfigurationContext context)
                 {
                     var instanceName = context.Settings.EndpointInstanceName();
-                    var satelliteLogicalAddress = new LogicalAddress(instanceName, "MySatellite");
+                    var satelliteLogicalAddress = new LocalAddress(instanceName, "MySatellite");
                     var satelliteAddress = context.Settings.GetTransportAddress(satelliteLogicalAddress);
 
                     context.AddSatelliteReceiver("Test satellite", satelliteAddress, TransportTransactionMode.ReceiveOnly, PushRuntimeSettings.Default,

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -745,14 +745,12 @@ namespace NServiceBus
     }
     [System.ObsoleteAttribute("Use `LoadMessageHandlersExtensions` instead. Will be removed in version 7.0.0.", true)]
     public class static LoadMessageHandlersExtentions { }
-    public struct LogicalAddress
+    public class LogicalAddress
     {
-        public LogicalAddress(NServiceBus.Routing.EndpointInstance endpointInstance, [JetBrains.Annotations.NotNullAttribute()] string qualifier) { }
-        public LogicalAddress(NServiceBus.Routing.EndpointInstance endpointInstance) { }
-        public NServiceBus.Routing.EndpointInstance EndpointInstance { get; }
+        public LogicalAddress(string instanceName, string qualifier = null, string discriminator = null) { }
+        public string Discriminator { get; }
+        public string InstanceName { get; }
         public string Qualifier { get; }
-        public override bool Equals(object obj) { }
-        public override int GetHashCode() { }
         public override string ToString() { }
     }
     public class MessageDeserializationException : System.Runtime.Serialization.SerializationException
@@ -797,7 +795,7 @@ namespace NServiceBus
     {
         public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> ApplyLabelToMessages(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> transportExtensions, System.Func<System.Collections.Generic.IReadOnlyDictionary<string, string>, string> labelGenerator) { }
         public static NServiceBus.FileRoutingTableSettings InstanceMappingFile(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config) { }
-        public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> OverrideAddressTranslation(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config, System.Func<NServiceBus.LogicalAddress, string> translationRule) { }
+        public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> OverrideAddressTranslation(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config, System.Func<NServiceBus.Routing.EndpointInstance, string> translationRule) { }
         public static void SetMessageDistributionStrategy(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config, string endpointName, NServiceBus.Routing.DistributionStrategy distributionStrategy) { }
         public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> TransactionScopeOptions(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> transportExtensions, System.Nullable<System.TimeSpan> timeout = null, System.Nullable<System.Transactions.IsolationLevel> isolationLevel = null) { }
     }
@@ -1115,7 +1113,7 @@ namespace NServiceBus
     }
     public class static SettingsExtensions
     {
-        public static NServiceBus.Routing.EndpointInstance EndpointInstanceName(this NServiceBus.Settings.ReadOnlySettings settings) { }
+        public static string EndpointInstanceName(this NServiceBus.Settings.ReadOnlySettings settings) { }
         public static string EndpointName(this NServiceBus.Settings.ReadOnlySettings settings) { }
         public static System.Collections.Generic.IList<System.Type> GetAvailableTypes(this NServiceBus.Settings.ReadOnlySettings settings) { }
         public static T GetConfigSection<T>(this NServiceBus.Settings.ReadOnlySettings settings)
@@ -3153,7 +3151,6 @@ namespace NServiceBus.Transport
         public abstract NServiceBus.Transport.OutboundRoutingPolicy OutboundRoutingPolicy { get; }
         public bool RequireOutboxConsent { get; set; }
         public abstract NServiceBus.TransportTransactionMode TransactionMode { get; }
-        public abstract NServiceBus.Routing.EndpointInstance BindToLocalEndpoint(NServiceBus.Routing.EndpointInstance instance);
         public abstract NServiceBus.Transport.TransportReceiveInfrastructure ConfigureReceiveInfrastructure();
         public abstract NServiceBus.Transport.TransportSendInfrastructure ConfigureSendInfrastructure();
         public abstract NServiceBus.Transport.TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure();
@@ -3161,6 +3158,7 @@ namespace NServiceBus.Transport
         public virtual System.Threading.Tasks.Task Start() { }
         public virtual System.Threading.Tasks.Task Stop() { }
         public abstract string ToTransportAddress(NServiceBus.LogicalAddress logicalAddress);
+        public abstract string ToTransportAddress(NServiceBus.Routing.EndpointInstance endpointInstance);
     }
     public class TransportOperation
     {

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -745,9 +745,9 @@ namespace NServiceBus
     }
     [System.ObsoleteAttribute("Use `LoadMessageHandlersExtensions` instead. Will be removed in version 7.0.0.", true)]
     public class static LoadMessageHandlersExtentions { }
-    public class LogicalAddress
+    public class LocalAddress
     {
-        public LogicalAddress(string instanceName, string qualifier = null, string discriminator = null) { }
+        public LocalAddress(string instanceName, string qualifier = null, string discriminator = null) { }
         public string Discriminator { get; }
         public string InstanceName { get; }
         public string Qualifier { get; }
@@ -3053,7 +3053,7 @@ namespace NServiceBus.Transport
     }
     public class static LogicalAddressExtensions
     {
-        public static string GetTransportAddress(this NServiceBus.Settings.ReadOnlySettings settings, NServiceBus.LogicalAddress logicalAddress) { }
+        public static string GetTransportAddress(this NServiceBus.Settings.ReadOnlySettings settings, NServiceBus.LocalAddress localAddress) { }
     }
     public class MessageContext
     {
@@ -3157,7 +3157,7 @@ namespace NServiceBus.Transport
         public virtual string MakeCanonicalForm(string transportAddress) { }
         public virtual System.Threading.Tasks.Task Start() { }
         public virtual System.Threading.Tasks.Task Stop() { }
-        public abstract string ToTransportAddress(NServiceBus.LogicalAddress logicalAddress);
+        public abstract string ToTransportAddress(NServiceBus.LocalAddress localAddress);
         public abstract string ToTransportAddress(NServiceBus.Routing.EndpointInstance endpointInstance);
     }
     public class TransportOperation

--- a/src/NServiceBus.Core.Tests/DeliveryConstraintContextExtensions/DeliveryConstraintContextExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/DeliveryConstraintContextExtensions/DeliveryConstraintContextExtensionsTests.cs
@@ -54,7 +54,7 @@
 
         class FakeTransportInfrastructure : TransportInfrastructure
         {
-            public override string ToTransportAddress(LogicalAddress logicalAddress)
+            public override string ToTransportAddress(LocalAddress localAddress)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.Core.Tests/DeliveryConstraintContextExtensions/DeliveryConstraintContextExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/DeliveryConstraintContextExtensions/DeliveryConstraintContextExtensionsTests.cs
@@ -54,13 +54,12 @@
 
         class FakeTransportInfrastructure : TransportInfrastructure
         {
-
-            public override EndpointInstance BindToLocalEndpoint(EndpointInstance instance)
+            public override string ToTransportAddress(LogicalAddress logicalAddress)
             {
                 throw new NotImplementedException();
             }
 
-            public override string ToTransportAddress(LogicalAddress logicalAddress)
+            public override string ToTransportAddress(EndpointInstance endpointInstance)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
@@ -48,12 +48,12 @@
                 throw new NotImplementedException();
             }
 
-            public override EndpointInstance BindToLocalEndpoint(EndpointInstance instance)
+            public override string ToTransportAddress(LogicalAddress logicalAddress)
             {
                 throw new NotImplementedException();
             }
 
-            public override string ToTransportAddress(LogicalAddress logicalAddress)
+            public override string ToTransportAddress(EndpointInstance endpointInstance)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
@@ -48,7 +48,7 @@
                 throw new NotImplementedException();
             }
 
-            public override string ToTransportAddress(LogicalAddress logicalAddress)
+            public override string ToTransportAddress(LocalAddress localAddress)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
@@ -64,7 +64,7 @@
         static string SetupDispatcherSatellite(FeatureConfigurationContext context, TransportTransactionMode requiredTransactionSupport)
         {
             var instanceName = context.Settings.EndpointInstanceName();
-            var satelliteLogicalAddress = new LogicalAddress(instanceName, "TimeoutsDispatcher");
+            var satelliteLogicalAddress = new LocalAddress(instanceName, "TimeoutsDispatcher");
             var satelliteAddress = context.Settings.GetTransportAddress(satelliteLogicalAddress);
 
             context.AddSatelliteReceiver("Timeout Dispatcher Processor", satelliteAddress, requiredTransactionSupport, PushRuntimeSettings.Default, RecoverabilityPolicy,
@@ -84,7 +84,7 @@
         static void SetupStorageSatellite(FeatureConfigurationContext context, TransportTransactionMode requiredTransactionSupport)
         {
             var instanceName = context.Settings.EndpointInstanceName();
-            var satelliteLogicalAddress = new LogicalAddress(instanceName, "Timeouts");
+            var satelliteLogicalAddress = new LocalAddress(instanceName, "Timeouts");
             var satelliteAddress = context.Settings.GetTransportAddress(satelliteLogicalAddress);
 
             context.AddSatelliteReceiver("Timeout Message Processor", satelliteAddress, requiredTransactionSupport, PushRuntimeSettings.Default, RecoverabilityPolicy,

--- a/src/NServiceBus.Core/LocalAddress.cs
+++ b/src/NServiceBus.Core/LocalAddress.cs
@@ -3,15 +3,15 @@
     /// <summary>
     /// Represents a logical address (independent of transport).
     /// </summary>
-    public class LogicalAddress
+    public class LocalAddress
     {
         /// <summary>
-        /// Creates new qualified logical address for the provided endpoint instance name.
+        /// Creates new qualified local address for the provided endpoint instance name.
         /// </summary>
         /// <param name="instanceName">The name of the instance.</param>
         /// <param name="qualifier">The qualifier of this address.</param>
         /// <param name="discriminator">The discriminator of this address.</param>
-        public LogicalAddress(string instanceName, string qualifier = null, string discriminator = null)
+        public LocalAddress(string instanceName, string qualifier = null, string discriminator = null)
         {
             Guard.AgainstNullAndEmpty(nameof(instanceName), instanceName);
 
@@ -21,12 +21,12 @@
         }
 
         /// <summary>
-        /// Returns the qualifier or null for the logical endpoint.
+        /// Returns the qualifier or null for the local endpoint.
         /// </summary>
         public string Qualifier { get; }
 
         /// <summary>
-        /// Returns the discriminator or null for the logical endpoint.
+        /// Returns the discriminator or null for the local endpoint.
         /// </summary>
         public string Discriminator { get; }
 

--- a/src/NServiceBus.Core/LogicalAddress.cs
+++ b/src/NServiceBus.Core/LogicalAddress.cs
@@ -1,53 +1,39 @@
 ﻿namespace NServiceBus
 {
-    using System;
-    using JetBrains.Annotations;
-    using Routing;
-
     /// <summary>
     /// Represents a logical address (independent of transport).
     /// </summary>
-    public struct LogicalAddress
+    public class LogicalAddress
     {
         /// <summary>
         /// Creates new qualified logical address for the provided endpoint instance name.
         /// </summary>
-        /// <param name="endpointInstance">The name of the instance.</param>
+        /// <param name="instanceName">The name of the instance.</param>
         /// <param name="qualifier">The qualifier of this address.</param>
-        public LogicalAddress(EndpointInstance endpointInstance, [NotNull] string qualifier)
+        /// <param name="discriminator">The discriminator of this address.</param>
+        public LogicalAddress(string instanceName, string qualifier = null, string discriminator = null)
         {
-            if (qualifier == null)
-            {
-                throw new ArgumentNullException(nameof(qualifier));
-            }
-            EndpointInstance = endpointInstance;
+            Guard.AgainstNullAndEmpty(nameof(instanceName), instanceName);
+
+            InstanceName = instanceName;
             Qualifier = qualifier;
+            Discriminator = discriminator;
         }
 
         /// <summary>
-        /// Creates new root logical address for the provided endpoint instance name.
-        /// </summary>
-        /// <param name="endpointInstance">The name of the instance.</param>
-        public LogicalAddress(EndpointInstance endpointInstance)
-        {
-            EndpointInstance = endpointInstance;
-            Qualifier = null;
-        }
-
-        /// <summary>
-        /// Returns the qualifier or null for the root logical address for a given instance name.
+        /// Returns the qualifier or null for the logical endpoint.
         /// </summary>
         public string Qualifier { get; }
 
         /// <summary>
+        /// Returns the discriminator or null for the logical endpoint.
+        /// </summary>
+        public string Discriminator { get; }
+
+        /// <summary>
         /// Returns the instance name.
         /// </summary>
-        public EndpointInstance EndpointInstance { get; }
-
-        bool Equals(LogicalAddress other)
-        {
-            return string.Equals(Qualifier, other.Qualifier) && Equals(EndpointInstance, other.EndpointInstance);
-        }
+        public string InstanceName { get; }
 
         /// <summary>
         /// Returns a string that represents the current object.
@@ -57,61 +43,16 @@
         /// </returns>
         public override string ToString()
         {
+            var value = InstanceName;
+            if (Discriminator != null)
+            {
+                value += "-" + Discriminator;
+            }
             if (Qualifier != null)
             {
-                return EndpointInstance + "." + Qualifier;
+                value += "." + Qualifier;
             }
-            return EndpointInstance.ToString();
-        }
-
-        /// <summary>
-        /// Determines whether the specified object is equal to the current object.
-        /// </summary>
-        /// <returns>
-        /// true if the specified object  is equal to the current object; otherwise, false.
-        /// </returns>
-        /// <param name="obj">The object to compare with the current object. </param>
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-            if (ReferenceEquals(this, obj))
-            {
-                return true;
-            }
-            return obj is LogicalAddress && Equals((LogicalAddress) obj);
-        }
-
-        /// <summary>
-        /// Serves as a hash function for a particular type.
-        /// </summary>
-        /// <returns>
-        /// A hash code for the current object.
-        /// </returns>
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return ((Qualifier?.GetHashCode() ?? 0)*397) ^ (EndpointInstance?.GetHashCode() ?? 0);
-            }
-        }
-
-        /// <summary>
-        /// Checks for equality.
-        /// </summary>
-        public static bool operator ==(LogicalAddress left, LogicalAddress right)
-        {
-            return Equals(left, right);
-        }
-
-        /// <summary>
-        /// Checks for inequality.
-        /// </summary>
-        public static bool operator !=(LogicalAddress left, LogicalAddress right)
-        {
-            return !Equals(left, right);
+            return value;
         }
     }
 }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -406,7 +406,7 @@
     <Compile Include="Routing\MessagingBestPractices\BestPracticesOptionExtensions.cs" />
     <Compile Include="Pipeline\Outgoing\IOutgoingLogicalMessageContext.cs" />
     <Compile Include="Persistence\InMemory\Outbox\InMemoryOutboxSettingsExtensions.cs" />
-    <Compile Include="LogicalAddress.cs" />
+    <Compile Include="LocalAddress.cs" />
     <Compile Include="Pipeline\BehaviorInvoker.cs" />
     <Compile Include="Pipeline\Incoming\IIncomingContext.cs" />
     <Compile Include="Pipeline\Incoming\ITransportReceiveContext.cs" />

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -59,7 +59,7 @@
             var outboundRoutingPolicy = transportInfrastructure.OutboundRoutingPolicy;
             context.Pipeline.Register(b =>
             {
-                var unicastSendRouter = new UnicastSendRouter(unicastRoutingTable, endpointInstances, i => transportInfrastructure.ToTransportAddress(new LogicalAddress(i)));
+                var unicastSendRouter = new UnicastSendRouter(unicastRoutingTable, endpointInstances, i => transportInfrastructure.ToTransportAddress(i));
                 return new UnicastSendRouterConnector(context.Settings.LocalAddress(), context.Settings.InstanceSpecificQueue(), unicastSendRouter, distributionPolicy);
             }, "Determines how the message being sent should be routed");
 
@@ -68,7 +68,7 @@
             {
                 context.Pipeline.Register(b =>
                 {
-                    var unicastPublishRouter = new UnicastPublishRouter(b.Build<MessageMetadataRegistry>(), b.Build<ISubscriptionStorage>(), endpointInstances, i => transportInfrastructure.ToTransportAddress(new LogicalAddress(i)));
+                    var unicastPublishRouter = new UnicastPublishRouter(b.Build<MessageMetadataRegistry>(), b.Build<ISubscriptionStorage>(), endpointInstances, i => transportInfrastructure.ToTransportAddress(i));
                     return new UnicastPublishRouterConnector(unicastPublishRouter, distributionPolicy);
                 }, "Determines how the published messages should be routed");
             }
@@ -86,7 +86,7 @@
                 if (outboundRoutingPolicy.Publishes == OutboundRoutingType.Unicast)
                 {
                     var subscriberAddress = distributorAddress ?? context.Settings.LocalAddress();
-                    var subscriptionRouter = new SubscriptionRouter(publishers, endpointInstances, i => transportInfrastructure.ToTransportAddress(new LogicalAddress(i)));
+                    var subscriptionRouter = new SubscriptionRouter(publishers, endpointInstances, i => transportInfrastructure.ToTransportAddress(i));
 
                     context.Pipeline.Register(b => new MessageDrivenSubscribeTerminator(subscriptionRouter, subscriberAddress, context.Settings.EndpointName(), b.Build<IDispatchMessages>()), "Sends subscription requests when message driven subscriptions is in use");
                     context.Pipeline.Register(b => new MessageDrivenUnsubscribeTerminator(subscriptionRouter, subscriberAddress, context.Settings.EndpointName(), b.Build<IDispatchMessages>()), "Sends requests to unsubscribe when message driven subscriptions is in use");

--- a/src/NServiceBus.Core/SettingsExtensions.cs
+++ b/src/NServiceBus.Core/SettingsExtensions.cs
@@ -68,7 +68,7 @@ namespace NServiceBus
         public static string EndpointInstanceName(this ReadOnlySettings settings)
         {
             Guard.AgainstNull(nameof(settings), settings);
-            return settings.Get<LogicalAddress>().InstanceName;
+            return settings.Get<LocalAddress>().InstanceName;
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/SettingsExtensions.cs
+++ b/src/NServiceBus.Core/SettingsExtensions.cs
@@ -4,7 +4,6 @@ namespace NServiceBus
     using System.Collections.Generic;
     using System.Linq;
     using Config.ConfigurationSource;
-    using Routing;
     using Settings;
 
     /// <summary>
@@ -66,10 +65,10 @@ namespace NServiceBus
         /// <summary>
         /// Returns the name of this instance of the endpoint.
         /// </summary>
-        public static EndpointInstance EndpointInstanceName(this ReadOnlySettings settings)
+        public static string EndpointInstanceName(this ReadOnlySettings settings)
         {
             Guard.AgainstNull(nameof(settings), settings);
-            return settings.Get<EndpointInstance>();
+            return settings.Get<LogicalAddress>().InstanceName;
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Transports/LogicalAddressExtensions.cs
+++ b/src/NServiceBus.Core/Transports/LogicalAddressExtensions.cs
@@ -8,12 +8,12 @@ namespace NServiceBus.Transport
     public static class LogicalAddressExtensions
     {
         /// <summary>
-        /// Gets the native transport address for the given logical address.
+        /// Gets the native transport address for the given local address.
         /// </summary>
         /// <returns>The native transport address.</returns>
-        public static string GetTransportAddress(this ReadOnlySettings settings, LogicalAddress logicalAddress)
+        public static string GetTransportAddress(this ReadOnlySettings settings, LocalAddress localAddress)
         {
-            return settings.Get<TransportInfrastructure>().ToTransportAddress(logicalAddress);
+            return settings.Get<TransportInfrastructure>().ToTransportAddress(localAddress);
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqConfigurationExtensions.cs
@@ -62,11 +62,11 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Overrides the default address translation rule "endpoint.quailfier-id@machine".
+        /// Overrides the default address translation rule "endpoint-identifier@machine".
         /// </summary>
         /// <param name="config">Config object.</param>
         /// <param name="translationRule">New translation rule.</param>
-        public static TransportExtensions<MsmqTransport> OverrideAddressTranslation(this TransportExtensions<MsmqTransport> config, Func<LogicalAddress, string> translationRule)
+        public static TransportExtensions<MsmqTransport> OverrideAddressTranslation(this TransportExtensions<MsmqTransport> config, Func<EndpointInstance, string> translationRule)
         {
             config.Settings.Set("NServiceBus.Transports.MSMQ.AddressTranslationRule", translationRule);
             return config;

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
@@ -20,7 +20,7 @@ namespace NServiceBus
 
             this.settings = settings;
             this.connectionString = connectionString;
-            this.addressTranslationRule = settings.GetOrDefault<Func<LogicalAddress, string>>("NServiceBus.Transports.MSMQ.AddressTranslationRule") ?? DefaultAddressTranslationRule;
+            this.addressTranslationRule = settings.GetOrDefault<Func<EndpointInstance, string>>("NServiceBus.Transports.MSMQ.AddressTranslationRule") ?? DefaultAddressTranslationRule;
         }
 
         public override IEnumerable<Type> DeliveryConstraints { get; } = new[]
@@ -47,31 +47,45 @@ namespace NServiceBus
             return new ReceiveWithNativeTransaction(new MsmqFailureInfoStorage(1000));
         }
 
-        public override EndpointInstance BindToLocalEndpoint(EndpointInstance instance) => instance.AtMachine(RuntimeEnvironment.MachineName);
-
         public override string ToTransportAddress(LogicalAddress logicalAddress)
         {
-            return addressTranslationRule(logicalAddress);
-        }
+            var address = new StringBuilder(logicalAddress.InstanceName);
 
-        static string DefaultAddressTranslationRule(LogicalAddress logicalAddress)
-        {
-            string machine;
-            if (!logicalAddress.EndpointInstance.Properties.TryGetValue("machine", out machine))
+            if (logicalAddress.Discriminator != null)
             {
-                machine = RuntimeEnvironment.MachineName;
+                address.Append("-" + logicalAddress.Discriminator);
             }
 
-            var queue = new StringBuilder(logicalAddress.EndpointInstance.Endpoint);
-            if (logicalAddress.EndpointInstance.Discriminator != null)
-            {
-                queue.Append("-" + logicalAddress.EndpointInstance.Discriminator);
-            }
             if (logicalAddress.Qualifier != null)
             {
-                queue.Append("." + logicalAddress.Qualifier);
+                address.Append("." + logicalAddress.Qualifier);
             }
-            return queue + "@" + machine;
+
+            return address + "@" + RuntimeEnvironment.MachineName;
+        }
+
+        public override string ToTransportAddress(EndpointInstance endpointInstance)
+        {
+            return addressTranslationRule(endpointInstance);
+        }
+
+        static string DefaultAddressTranslationRule(EndpointInstance endpointInstance)
+        {
+            var address = new StringBuilder(endpointInstance.Endpoint);
+
+            if (endpointInstance.Discriminator != null)
+            {
+                address.Append("-" + endpointInstance.Discriminator);
+            }
+
+            string machineName;
+            if (!endpointInstance.Properties.TryGetValue("machine", out machineName))
+            {
+                machineName = RuntimeEnvironment.MachineName;
+            }
+
+            address.Append("@").Append(machineName);
+            return address.ToString();
         }
 
         public override string MakeCanonicalForm(string transportAddress)
@@ -147,6 +161,6 @@ namespace NServiceBus
 
         string connectionString;
         ReadOnlySettings settings;
-        Func<LogicalAddress, string> addressTranslationRule;
+        Func<EndpointInstance, string> addressTranslationRule;
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
@@ -47,18 +47,18 @@ namespace NServiceBus
             return new ReceiveWithNativeTransaction(new MsmqFailureInfoStorage(1000));
         }
 
-        public override string ToTransportAddress(LogicalAddress logicalAddress)
+        public override string ToTransportAddress(LocalAddress localAddress)
         {
-            var address = new StringBuilder(logicalAddress.InstanceName);
+            var address = new StringBuilder(localAddress.InstanceName);
 
-            if (logicalAddress.Discriminator != null)
+            if (localAddress.Discriminator != null)
             {
-                address.Append("-" + logicalAddress.Discriminator);
+                address.Append("-" + localAddress.Discriminator);
             }
 
-            if (logicalAddress.Qualifier != null)
+            if (localAddress.Qualifier != null)
             {
-                address.Append("." + logicalAddress.Qualifier);
+                address.Append("." + localAddress.Qualifier);
             }
 
             return address + "@" + RuntimeEnvironment.MachineName;

--- a/src/NServiceBus.Core/Transports/Receiving.cs
+++ b/src/NServiceBus.Core/Transports/Receiving.cs
@@ -18,12 +18,12 @@ namespace NServiceBus
                 var baseQueueName = s.GetOrDefault<string>("BaseInputQueueName") ?? s.EndpointName();
                 if (userDiscriminator != null)
                 {
-                    s.SetDefault("NServiceBus.EndpointSpecificQueue", transportInfrastructure.ToTransportAddress(new LogicalAddress(baseQueueName, discriminator:userDiscriminator)));
+                    s.SetDefault("NServiceBus.EndpointSpecificQueue", transportInfrastructure.ToTransportAddress(new LocalAddress(baseQueueName, discriminator:userDiscriminator)));
                 }
-                var logicalAddress = new LogicalAddress(baseQueueName);
+                var logicalAddress = new LocalAddress(baseQueueName);
                 s.SetDefault("NServiceBus.SharedQueue", transportInfrastructure.ToTransportAddress(logicalAddress));
 
-                s.SetDefault<LogicalAddress>(logicalAddress);
+                s.SetDefault<LocalAddress>(logicalAddress);
             });
         }
 

--- a/src/NServiceBus.Core/Transports/Receiving.cs
+++ b/src/NServiceBus.Core/Transports/Receiving.cs
@@ -3,7 +3,6 @@ namespace NServiceBus
     using System;
     using System.Threading.Tasks;
     using Features;
-    using Routing;
     using Transport;
 
     class Receiving : Feature
@@ -19,13 +18,12 @@ namespace NServiceBus
                 var baseQueueName = s.GetOrDefault<string>("BaseInputQueueName") ?? s.EndpointName();
                 if (userDiscriminator != null)
                 {
-                    var p = s.Get<TransportInfrastructure>().BindToLocalEndpoint(new EndpointInstance(baseQueueName, userDiscriminator));
-                    s.SetDefault("NServiceBus.EndpointSpecificQueue", transportInfrastructure.ToTransportAddress(new LogicalAddress(p)));
+                    s.SetDefault("NServiceBus.EndpointSpecificQueue", transportInfrastructure.ToTransportAddress(new LogicalAddress(baseQueueName, discriminator:userDiscriminator)));
                 }
-                var instanceProperties = s.Get<TransportInfrastructure>().BindToLocalEndpoint(new EndpointInstance(baseQueueName));
-                s.SetDefault("NServiceBus.SharedQueue", transportInfrastructure.ToTransportAddress(new LogicalAddress(instanceProperties)));
+                var logicalAddress = new LogicalAddress(baseQueueName);
+                s.SetDefault("NServiceBus.SharedQueue", transportInfrastructure.ToTransportAddress(logicalAddress));
 
-                s.SetDefault<EndpointInstance>(instanceProperties);
+                s.SetDefault<LogicalAddress>(logicalAddress);
             });
         }
 

--- a/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
@@ -46,11 +46,11 @@ namespace NServiceBus.Transport
         public abstract TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure();
 
         /// <summary>
-        /// Converts a given logical address to the transport address.
+        /// Converts a given local address to the transport address.
         /// </summary>
-        /// <param name="logicalAddress">The logical address.</param>
+        /// <param name="localAddress">The local address.</param>
         /// <returns>The transport address.</returns>
-        public abstract string ToTransportAddress(LogicalAddress logicalAddress);
+        public abstract string ToTransportAddress(LocalAddress localAddress);
 
         /// <summary>
         /// Converts a given endpoint instance to the transport address.

--- a/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
@@ -46,16 +46,18 @@ namespace NServiceBus.Transport
         public abstract TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure();
 
         /// <summary>
-        /// Returns the discriminator for this endpoint instance.
-        /// </summary>
-        public abstract EndpointInstance BindToLocalEndpoint(EndpointInstance instance);
-
-        /// <summary>
         /// Converts a given logical address to the transport address.
         /// </summary>
         /// <param name="logicalAddress">The logical address.</param>
         /// <returns>The transport address.</returns>
         public abstract string ToTransportAddress(LogicalAddress logicalAddress);
+
+        /// <summary>
+        /// Converts a given endpoint instance to the transport address.
+        /// </summary>
+        /// <param name="endpointInstance">The endpoint instance.</param>
+        /// <returns>The transport address.</returns>
+        public abstract string ToTransportAddress(EndpointInstance endpointInstance);
 
         /// <summary>
         /// Returns the canonical for of the given transport address so various transport addresses can be effectively compared and

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_overriding_address_translation.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_overriding_address_translation.cs
@@ -7,7 +7,7 @@
 
     public class When_overriding_address_translation : NServiceBusAcceptanceTest
     {
-        public static string DefaultReceiverAddress => Conventions.EndpointNamingConvention(typeof(Receiver));
+        static string DefaultReceiverAddress => Conventions.EndpointNamingConvention(typeof(Receiver));
 
         [Test]
         public async Task Should_use_the_overridden_rule()
@@ -39,7 +39,7 @@
                     routing.RouteToEndpoint(typeof(Message), DefaultReceiverAddress);
 
                     // add translation rule
-                    transport.OverrideAddressTranslation(a => "q_" + a.EndpointInstance.Endpoint);
+                    transport.OverrideAddressTranslation(a => "q_" + a.Endpoint);
                 });
             }
         }


### PR DESCRIPTION
Connects to Particular/V6Launch#68

`LogicalAddress` is only used to define local input queues with qualifiers and/or discriminators. It contained an `EndpointInstance` from where it read the discriminator and transport specific properties (set by `BindToLocalEndpoint`) while it used the Qualifier property on LogicalAddress directly.

This PR renames `LogicalAddress` to `LocalAddress`. It adds a new abstract method on the transport seam where the transport has to define how the physical address is created. In exchange, `BindToLocalEndpoint` for `EndpointInstance` has been removed from the transport seam. This separates different concerns of routing and configuring local input queues.