### PR TITLE
Remove unnecessary collection

### DIFF
--- a/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
@@ -24,15 +24,9 @@ namespace NServiceBus
                 return emptyRoute;
             }
 
-            var destinations = new HashSet<UnicastRoutingTarget>();
-
             var routingTargets = await route.Resolve(endpoint => endpointInstances.FindInstances(endpoint)).ConfigureAwait(false);
-            foreach (var routingTarget in routingTargets)
-            {
-                destinations.Add(routingTarget);
-            }
 
-            var selectedDestinations = SelectDestinationsForEachEndpoint(distributionPolicy, destinations);
+            var selectedDestinations = SelectDestination(distributionPolicy, routingTargets);
 
             return selectedDestinations
                 .Select(destination => destination.Resolve(x => transportAddressTranslation(x)))
@@ -40,7 +34,7 @@ namespace NServiceBus
                 .Select(destination => new UnicastRoutingStrategy(destination));
         }
 
-        static IEnumerable<UnicastRoutingTarget> SelectDestinationsForEachEndpoint(IDistributionPolicy distributionPolicy, HashSet<UnicastRoutingTarget> destinations)
+        static IEnumerable<UnicastRoutingTarget> SelectDestination(IDistributionPolicy distributionPolicy, IEnumerable<UnicastRoutingTarget> destinations)
         {
             var destinationsByEndpoint = destinations
                 .GroupBy(d => d.Endpoint, d => d);


### PR DESCRIPTION
that HashSet was previously used for deduplication of equivalent routingtargets resolved by different routes. Since there is now only a single route, the routingTargets come from a single route and therefore shouldn't require filtering duplicate values.

Need to address some further refactorings before making more changes to UnicastSendRouter (I'm coming for you, GroupBy!)

@Particular/nservicebus-maintainers @SzymonPobiega please review

Connects to Particular/V6Launch#68