### PR TITLE
Distribution strategy refactoring

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2533,7 +2533,7 @@ namespace NServiceBus.Routing
     public abstract class DistributionStrategy
     {
         protected DistributionStrategy() { }
-        public abstract System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> SelectDestination(System.Collections.Generic.IList<NServiceBus.UnicastRoutingTarget> allInstances);
+        public abstract NServiceBus.UnicastRoutingTarget SelectDestination(NServiceBus.UnicastRoutingTarget[] allInstances);
     }
     public sealed class EndpointInstance
     {
@@ -2577,8 +2577,7 @@ namespace NServiceBus.Routing
     public class SingleInstanceRoundRobinDistributionStrategy : NServiceBus.Routing.DistributionStrategy
     {
         public SingleInstanceRoundRobinDistributionStrategy() { }
-        [System.Runtime.CompilerServices.IteratorStateMachineAttribute(typeof(NServiceBus.Routing.SingleInstanceRoundRobinDistributionStrategy.<SelectDestination>d__0))]
-        public override System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> SelectDestination(System.Collections.Generic.IList<NServiceBus.UnicastRoutingTarget> currentAllInstances) { }
+        public override NServiceBus.UnicastRoutingTarget SelectDestination(NServiceBus.UnicastRoutingTarget[] currentAllInstances) { }
     }
     public class UnicastAddressTag : NServiceBus.Routing.AddressTag
     {

--- a/src/NServiceBus.Core.Tests/Routing/DistributionPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DistributionPolicyTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Core.Tests.Routing
 {
-    using System.Collections.Generic;
     using NServiceBus.Routing;
     using NUnit.Framework;
 
@@ -47,7 +46,7 @@
 
         class FakeDistributionStrategy : DistributionStrategy
         {
-            public override IEnumerable<UnicastRoutingTarget> SelectDestination(IList<UnicastRoutingTarget> allInstances)
+            public override UnicastRoutingTarget SelectDestination(UnicastRoutingTarget[] allInstances)
             {
                 return null;
             }

--- a/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
@@ -26,10 +26,10 @@ namespace NServiceBus.Core.Tests.Routing
             };
 
             var result = new List<UnicastRoutingTarget>();
-            result.AddRange(InvokeDistributionStrategy(policy, endpointAInstances));
-            result.AddRange(InvokeDistributionStrategy(policy, endpointBInstances));
-            result.AddRange(InvokeDistributionStrategy(policy, endpointAInstances));
-            result.AddRange(InvokeDistributionStrategy(policy, endpointBInstances));
+            result.Add(InvokeDistributionStrategy(policy, endpointAInstances));
+            result.Add(InvokeDistributionStrategy(policy, endpointBInstances));
+            result.Add(InvokeDistributionStrategy(policy, endpointAInstances));
+            result.Add(InvokeDistributionStrategy(policy, endpointBInstances));
 
             Assert.That(result.Count, Is.EqualTo(4));
             Assert.That(result, Has.Exactly(1).EqualTo(endpointAInstances[0]));
@@ -38,7 +38,7 @@ namespace NServiceBus.Core.Tests.Routing
             Assert.That(result, Has.Exactly(1).EqualTo(endpointBInstances[1]));
         }
 
-        static IEnumerable<UnicastRoutingTarget> InvokeDistributionStrategy(IDistributionPolicy policy, UnicastRoutingTarget[] instances)
+        static UnicastRoutingTarget InvokeDistributionStrategy(IDistributionPolicy policy, UnicastRoutingTarget[] instances)
         {
             return policy.GetDistributionStrategy(instances[0].Endpoint).SelectDestination(instances);
         }

--- a/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
@@ -22,9 +22,9 @@
             };
 
             var result = new List<UnicastRoutingTarget>();
-            result.AddRange(strategy.SelectDestination(instances));
-            result.AddRange(strategy.SelectDestination(instances));
-            result.AddRange(strategy.SelectDestination(instances));
+            result.Add(strategy.SelectDestination(instances));
+            result.Add(strategy.SelectDestination(instances));
+            result.Add(strategy.SelectDestination(instances));
 
             Assert.That(result.Count, Is.EqualTo(3));
             Assert.That(result, Has.Exactly(1).EqualTo(instances[0]));
@@ -46,10 +46,10 @@
             };
 
             var result = new List<UnicastRoutingTarget>();
-            result.AddRange(strategy.SelectDestination(instances));
-            result.AddRange(strategy.SelectDestination(instances));
-            result.AddRange(strategy.SelectDestination(instances));
-            result.AddRange(strategy.SelectDestination(instances));
+            result.Add(strategy.SelectDestination(instances));
+            result.Add(strategy.SelectDestination(instances));
+            result.Add(strategy.SelectDestination(instances));
+            result.Add(strategy.SelectDestination(instances));
 
             Assert.That(result.Last(), Is.EqualTo(result.First()));
         }
@@ -60,17 +60,17 @@
             var endpointName = "endpointA";
             var strategy = new SingleInstanceRoundRobinDistributionStrategy();
 
-            var instances = new List<UnicastRoutingTarget>
+            var instances = new []
             {
                 UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "1")),
                 UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "2")),
             };
 
             var result = new List<UnicastRoutingTarget>();
-            result.AddRange(strategy.SelectDestination(instances));
-            result.AddRange(strategy.SelectDestination(instances));
-            instances.Add(UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "3"))); // add new instance
-            result.AddRange(strategy.SelectDestination(instances));
+            result.Add(strategy.SelectDestination(instances));
+            result.Add(strategy.SelectDestination(instances));
+            instances = instances.Concat(new [] { UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "3"))}).ToArray(); // add new instance
+            result.Add(strategy.SelectDestination(instances));
 
             Assert.That(result.Count, Is.EqualTo(3));
             Assert.That(result, Has.Exactly(1).EqualTo(instances[0]));
@@ -84,7 +84,7 @@
             var strategy = new SingleInstanceRoundRobinDistributionStrategy();
 
             var endpointName = "endpointA";
-            var instances = new List<UnicastRoutingTarget>
+            var instances = new []
             {
                 UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "1")),
                 UnicastRoutingTarget.ToEndpointInstance(new EndpointInstance(endpointName, "2")),
@@ -92,10 +92,10 @@
             };
 
             var result = new List<UnicastRoutingTarget>();
-            result.AddRange(strategy.SelectDestination(instances));
-            result.AddRange(strategy.SelectDestination(instances));
-            instances.RemoveAt(2); // remove last instance.
-            result.AddRange(strategy.SelectDestination(instances));
+            result.Add(strategy.SelectDestination(instances));
+            result.Add(strategy.SelectDestination(instances));
+            instances = instances.Take(2).ToArray(); // remove last instance.
+            result.Add(strategy.SelectDestination(instances));
 
             Assert.That(result.Count, Is.EqualTo(3));
             Assert.That(result, Has.Exactly(2).EqualTo(instances[0]));

--- a/src/NServiceBus.Core/Routing/DistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionStrategy.cs
@@ -1,7 +1,5 @@
 namespace NServiceBus.Routing
 {
-    using System.Collections.Generic;
-
     /// <summary>
     /// Governs to how many and which instances of a given endpoint a message is to be sent.
     /// </summary>
@@ -10,6 +8,6 @@ namespace NServiceBus.Routing
         /// <summary>
         /// Selects destination instances from all known instances of a given endpoint.
         /// </summary>
-        public abstract IEnumerable<UnicastRoutingTarget> SelectDestination(IList<UnicastRoutingTarget> allInstances);
+        public abstract UnicastRoutingTarget SelectDestination(UnicastRoutingTarget[] allInstances);
     }
 }

--- a/src/NServiceBus.Core/Routing/SingleInstanceRoundRobinDistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/SingleInstanceRoundRobinDistributionStrategy.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus.Routing
 {
-    using System.Collections.Generic;
     using System.Threading;
 
     /// <summary>
@@ -11,15 +10,15 @@ namespace NServiceBus.Routing
         /// <summary>
         /// Selects destination instances from all known instances of a given endpoint.
         /// </summary>
-        public override IEnumerable<UnicastRoutingTarget> SelectDestination(IList<UnicastRoutingTarget> currentAllInstances)
+        public override UnicastRoutingTarget SelectDestination(UnicastRoutingTarget[] currentAllInstances)
         {
-            if (currentAllInstances.Count == 0)
+            if (currentAllInstances.Length == 0)
             {
-                yield break;
+                return null;
             }
             var i = Interlocked.Increment(ref index);
-            var result = currentAllInstances[(int)(i % currentAllInstances.Count)];
-            yield return result;
+            var result = currentAllInstances[(int)(i % currentAllInstances.Length)];
+            return result;
         }
 
         // start with -1 so the index will be at 0 after the first increment.

--- a/src/NServiceBus.Core/Routing/SpecificInstanceDistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/SpecificInstanceDistributionPolicy.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using Routing;
 
@@ -26,14 +25,14 @@ namespace NServiceBus
                 this.specificInstance = specificInstance;
             }
 
-            public override IEnumerable<UnicastRoutingTarget> SelectDestination(IList<UnicastRoutingTarget> allInstances)
+            public override UnicastRoutingTarget SelectDestination(UnicastRoutingTarget[] allInstances)
             {
                 var target = allInstances.FirstOrDefault(t => t.Instance != null && t.Instance.Discriminator == specificInstance);
                 if (target == null)
                 {
                     throw new Exception($"Specified instance {specificInstance} has not been configured in the routing tables.");
                 }
-                yield return target;
+                return target;
             }
 
             string specificInstance;

--- a/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
@@ -51,9 +51,10 @@ namespace NServiceBus
                 else
                 {
                     //Use the distribution strategy to select subset of instances of a given endpoint
-                    foreach (var destination in distributionPolicy.GetDistributionStrategy(group.Key).SelectDestination(group.ToArray()))
+                    var destinationForEndpoint = distributionPolicy.GetDistributionStrategy(@group.Key).SelectDestination(@group.ToArray());
+                    if (destinationForEndpoint != null)
                     {
-                        yield return destination;
+                        yield return destinationForEndpoint;
                     }
                 }
             }

--- a/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
@@ -52,9 +52,10 @@ namespace NServiceBus
                 else
                 {
                     //Use the distribution strategy to select subset of instances of a given endpoint
-                    foreach (var destination in distributionPolicy.GetDistributionStrategy(group.Key).SelectDestination(group.ToArray()))
+                    var destinationForEndpoint = distributionPolicy.GetDistributionStrategy(@group.Key).SelectDestination(@group.ToArray());
+                    if (destinationForEndpoint != null)
                     {
-                        yield return destination;
+                        yield return destinationForEndpoint;
                     }
                 }
             }


### PR DESCRIPTION
DistributionStrategies can now only return a single result instead of multiple. Since we allow commands only to be sent to a single receiver, it would be invalid for a distributionstrategy to return multiple instances. For events there is currently also no realistic scenario to publish the same event to multiple instances of the same logical endpoint.

@Particular/nservicebus-maintainers @SzymonPobiega please review

Connects to Particular/V6Launch#68