### PR TITLE
[WIP] Removed dynamic instance registration

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/When_subscribing_to_scaled_out_publisher_on_unicast_transport.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_subscribing_to_scaled_out_publisher_on_unicast_transport.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Routing
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using AcceptanceTesting;
@@ -56,7 +57,11 @@
                     // configure the scaled out publisher instances:
                     var publisherName = Conventions.EndpointNamingConvention(typeof(ScaledOutPublisher));
                     c.RegisterPublisher(typeof(MyEvent), publisherName);
-                    c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(publisherName, "1"), new EndpointInstance(publisherName, "2"));
+                    c.GetSettings().GetOrCreate<EndpointInstances>().AddOrReplaceInstances(Guid.NewGuid(),new List<EndpointInstance>
+                    {
+                        new EndpointInstance(publisherName, "1"),
+                        new EndpointInstance(publisherName, "2")
+                    });
                 });
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Routing/When_using_instance_ids.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_using_instance_ids.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.ScaleOut
 {
+    using System;
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
@@ -49,7 +51,10 @@
                 EndpointSetup<DefaultServer>((c, r) =>
                 {
                     c.UseTransport(r.GetTransportType()).Routing().RouteToEndpoint(typeof(MyMessage), ReceiverEndpoint);
-                    c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverEndpoint, "XYZ"));
+                    c.GetSettings().GetOrCreate<EndpointInstances>().AddOrReplaceInstances(Guid.NewGuid(), new List<EndpointInstance>
+                    {
+                        new EndpointInstance(ReceiverEndpoint, "XYZ")
+                    });
                 });
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Routing/when_replying_to_a_message_sent_to_specific_instance.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/when_replying_to_a_message_sent_to_specific_instance.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.ScaleOut
 {
+    using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
@@ -36,7 +38,10 @@
                 EndpointSetup<DefaultServer>((c, r) =>
                 {
                     c.UseTransport(r.GetTransportType()).Routing().RouteToEndpoint(typeof(MyRequest), ReceiverEndpoint);
-                    c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverEndpoint, "XYZ"));
+                    c.GetSettings().GetOrCreate<EndpointInstances>().AddOrReplaceInstances(Guid.NewGuid(), new List<EndpointInstance>
+                    {
+                        new EndpointInstance(ReceiverEndpoint, "XYZ")
+                    });
                 });
             }
 

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2585,15 +2585,12 @@ namespace NServiceBus.Routing
     public class EndpointInstances
     {
         public EndpointInstances() { }
-        public void Add(params NServiceBus.Routing.EndpointInstance[] instances) { }
-        public void Add(System.Collections.Generic.IEnumerable<NServiceBus.Routing.EndpointInstance> instances) { }
-        public void Add(NServiceBus.Routing.EndpointInstance instance) { }
-        public void AddDynamic(System.Func<string, System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.Routing.EndpointInstance>>> dynamicRule) { }
+        public void AddOrReplaceInstances(object sourceKey, System.Collections.Generic.IList<NServiceBus.Routing.EndpointInstance> endpointInstances) { }
     }
     public interface IMessageDrivenSubscriptionTransport { }
     public interface IUnicastRoute
     {
-        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget>> Resolve(System.Func<string, System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.Routing.EndpointInstance>>> instanceResolver);
+        System.Collections.Generic.IEnumerable<NServiceBus.UnicastRoutingTarget> Resolve(System.Func<string, System.Collections.Generic.IEnumerable<NServiceBus.Routing.EndpointInstance>> instanceResolver);
     }
     public class MulticastAddressTag : NServiceBus.Routing.AddressTag
     {

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
@@ -4,7 +4,6 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    using Extensibility;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
     using Unicast.Messages;
@@ -237,9 +236,9 @@
         {
             public IEnumerable<UnicastRoutingStrategy> FixedDestination { get; set; }
 
-            public Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, IDistributionPolicy distributionPolicy, ContextBag contextBag)
+            public IEnumerable<UnicastRoutingStrategy> Route(Type messageType, IDistributionPolicy distributionPolicy)
             {
-                return Task.FromResult(FixedDestination);
+                return FixedDestination;
             }
         }
 

--- a/src/NServiceBus.Core.Tests/Routing/RoutingSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingSettingsTests.cs
@@ -3,10 +3,8 @@
 namespace NServiceBus.Core.Tests.Routing
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
-    using System.Threading.Tasks;
     using MessageNamespaceA;
     using MessageNamespaceB;
     using NServiceBus.Features;
@@ -54,7 +52,7 @@ namespace NServiceBus.Core.Tests.Routing
         }
 
         [Test]
-        public async Task WhenRoutingMessageTypeToEndpoint_ShouldConfigureMessageTypeInRoutingTable()
+        public void WhenRoutingMessageTypeToEndpoint_ShouldConfigureMessageTypeInRoutingTable()
         {
             var settings = new SettingsHolder();
             settings.Set<Conventions>(new Conventions());
@@ -63,7 +61,10 @@ namespace NServiceBus.Core.Tests.Routing
 
             var routingTable = ApplyConfiguredRoutes(routingSettings);
             var route = routingTable.GetRouteFor(typeof(SomeMessageType));
-            var routingTargets = await RetrieveRoutingTargets(route);
+            var routingTargets = route.Resolve(e => new[]
+            {
+                new EndpointInstance(e)
+            });
 
             Assert.That(route, Is.Not.Null);
             Assert.That(routingTargets.Single().Endpoint, Is.EqualTo("destination"));
@@ -134,14 +135,6 @@ namespace NServiceBus.Core.Tests.Routing
             var configuredRoutes = routingSettings.Settings.GetOrDefault<ConfiguredUnicastRoutes>();
             configuredRoutes?.Apply(routingTable);
             return routingTable;
-        }
-
-        static Task<IEnumerable<UnicastRoutingTarget>> RetrieveRoutingTargets(IUnicastRoute result)
-        {
-            return result.Resolve(e => Task.FromResult<IEnumerable<EndpointInstance>>(new[]
-            {
-                new EndpointInstance(e)
-            }));
         }
 
         string expectedExceptionMessageForWrongEndpointName = "A logical endpoint name should not contain '@', but received 'EndpointName@MyHost'. To specify an endpoint's address, use the instance mapping file for the MSMQ transport, or refer to the routing documentation.";

--- a/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
@@ -71,8 +71,11 @@
         {
             var logicalEndpoint = "sales";
             subscriptionStorage.Subscribers.Add(new Subscriber("address", logicalEndpoint));
-            endpointInstances.Add(new EndpointInstance(logicalEndpoint, "1"));
-            endpointInstances.Add(new EndpointInstance(logicalEndpoint, "2"));
+            endpointInstances.AddOrReplaceInstances(Guid.NewGuid(), new List<EndpointInstance>
+            {
+                new EndpointInstance(logicalEndpoint, "1"),
+                new EndpointInstance(logicalEndpoint, "2")
+            });
 
             var routes = await router.Route(typeof(Event), new DistributionPolicy(), new ContextBag());
 

--- a/src/NServiceBus.Core.Tests/Transports/MSMQ/InstanceMapping/InstanceMappingTableTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/MSMQ/InstanceMapping/InstanceMappingTableTests.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Threading.Tasks;
     using System.Xml.Linq;
+    using NServiceBus.Routing;
     using NUnit.Framework;
 
     [TestFixture]
@@ -18,7 +19,7 @@
             {
                 throw fileAccessException;
             });
-            var table = new InstanceMappingTable(filePath, TimeSpan.Zero, timer, fileAccess);
+            var table = new InstanceMappingTable(filePath, TimeSpan.Zero, timer, fileAccess, new EndpointInstances());
 
             var exception = Assert.Throws<Exception>(() => table.ReloadData());
 
@@ -45,7 +46,7 @@
                 return XDocument.Parse(@"<endpoints><endpoint name=""A""><instance/></endpoint></endpoints>");
             });
 
-            var table = new InstanceMappingTable("unused", TimeSpan.Zero, timer, fileAccess);
+            var table = new InstanceMappingTable("unused", TimeSpan.Zero, timer, fileAccess, new EndpointInstances());
             await table.PerformStartup(null);
 
             fail = true;

--- a/src/NServiceBus.Core/Routing/IUnicastRoute.cs
+++ b/src/NServiceBus.Core/Routing/IUnicastRoute.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.Routing
 {
     using System;
     using System.Collections.Generic;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// Represents destination of address routing.
@@ -13,6 +12,6 @@ namespace NServiceBus.Routing
         /// Resolves the destination, possibly resulting in multiple destination transport addresses.
         /// </summary>
         /// <param name="instanceResolver">A function that returns the collection of instances for a given endpoint.</param>
-        Task<IEnumerable<UnicastRoutingTarget>> Resolve(Func<string, Task<IEnumerable<EndpointInstance>>> instanceResolver);
+        IEnumerable<UnicastRoutingTarget> Resolve(Func<string, IEnumerable<EndpointInstance>> instanceResolver);
     }
 }

--- a/src/NServiceBus.Core/Routing/IUnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/IUnicastSendRouter.cs
@@ -2,12 +2,10 @@ namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
-    using System.Threading.Tasks;
-    using Extensibility;
     using Routing;
 
     interface IUnicastSendRouter
     {
-        Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, IDistributionPolicy distributionPolicy, ContextBag contextBag);
+        IEnumerable<UnicastRoutingStrategy> Route(Type messageType, IDistributionPolicy distributionPolicy);
     }
 }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -25,7 +25,7 @@
         {
             var eventType = context.EventType;
 
-            var publisherAddresses = (await subscriptionRouter.GetAddressesForEventType(eventType).ConfigureAwait(false))
+            var publisherAddresses = subscriptionRouter.GetAddressesForEventType(eventType)
                 .EnsureNonEmpty(() => $"No publisher address could be found for message type {eventType}. Ensure the configured publisher endpoint has at least one known instance.");
 
             var subscribeTasks = new List<Task>();

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -25,7 +25,7 @@
         {
             var eventType = context.EventType;
 
-            var publisherAddresses = (await subscriptionRouter.GetAddressesForEventType(eventType).ConfigureAwait(false))
+            var publisherAddresses = subscriptionRouter.GetAddressesForEventType(eventType)
                 .EnsureNonEmpty(() => $"No publisher address could be found for message type {eventType}. Ensure the configured publisher endpoint has at least one known instance.");
 
             var unsubscribeTasks = new List<Task>();

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/PublisherAddress.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/PublisherAddress.cs
@@ -3,7 +3,6 @@ namespace NServiceBus.Routing.MessageDrivenSubscriptions
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// Represents an address of a publisher.
@@ -49,7 +48,7 @@ namespace NServiceBus.Routing.MessageDrivenSubscriptions
         {
         }
 
-        internal async Task<IEnumerable<string>> Resolve(Func<string, Task<IEnumerable<EndpointInstance>>> instanceResolver, Func<EndpointInstance, string> addressResolver)
+        internal IEnumerable<string> Resolve(Func<string, IEnumerable<EndpointInstance>> instanceResolver, Func<EndpointInstance, string> addressResolver)
         {
             if (addresses != null)
             {
@@ -59,7 +58,7 @@ namespace NServiceBus.Routing.MessageDrivenSubscriptions
             {
                 return instances.Select(addressResolver);
             }
-            var result = await instanceResolver(endpoint).ConfigureAwait(false);
+            var result = instanceResolver(endpoint);
             return result.Select(addressResolver);
         }
 

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionRouter.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionRouter.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Threading.Tasks;
     using Routing;
     using Routing.MessageDrivenSubscriptions;
 
@@ -15,10 +14,10 @@
             this.transportAddressTranslation = transportAddressTranslation;
         }
 
-        public async Task<IEnumerable<string>> GetAddressesForEventType(Type messageType)
+        public IEnumerable<string> GetAddressesForEventType(Type messageType)
         {
             var publisher = publishers.GetPublisherFor(messageType);
-            var publisherTransportAddresses = await publisher.Resolve(e => endpointInstances.FindInstances(e), i => transportAddressTranslation(i)).ConfigureAwait(false);
+            var publisherTransportAddresses = publisher.Resolve(e => endpointInstances.FindInstances(e), i => transportAddressTranslation(i));
             return publisherTransportAddresses;
         }
 

--- a/src/NServiceBus.Core/Routing/Routers/UnicastSendRouterConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/UnicastSendRouterConnector.cs
@@ -49,7 +49,7 @@ namespace NServiceBus
             var distributionPolicy = state.Option == RouteOption.RouteToSpecificInstance ? new SpecificInstanceDistributionPolicy(state.SpecificInstance) : defaultDistributionPolicy;
 
             var routingStrategies = string.IsNullOrEmpty(destination)
-                ? await unicastSendRouter.Route(messageType, distributionPolicy, context.Extensions).ConfigureAwait(false)
+                ? unicastSendRouter.Route(messageType, distributionPolicy)
                 : RouteToDestination(destination);
 
             context.Headers[Headers.MessageIntent] = MessageIntentEnum.Send.ToString();

--- a/src/NServiceBus.Core/Routing/UnicastRoute.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRoute.cs
@@ -3,7 +3,6 @@ namespace NServiceBus.Routing
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading.Tasks;
 
     /// <summary>
     /// A destination of address routing.
@@ -47,7 +46,7 @@ namespace NServiceBus.Routing
         {
         }
 
-        async Task<IEnumerable<UnicastRoutingTarget>> IUnicastRoute.Resolve(Func<string, Task<IEnumerable<EndpointInstance>>> instanceResolver)
+        IEnumerable<UnicastRoutingTarget> IUnicastRoute.Resolve(Func<string, IEnumerable<EndpointInstance>> instanceResolver)
         {
             if (physicalAddress != null)
             {
@@ -57,7 +56,7 @@ namespace NServiceBus.Routing
             {
                 return EnumerableEx.Single(UnicastRoutingTarget.ToEndpointInstance(instance));
             }
-            var instances = await instanceResolver(endpoint).ConfigureAwait(false);
+            var instances = instanceResolver(endpoint);
             return instances.Select(UnicastRoutingTarget.ToEndpointInstance);
         }
 

--- a/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
@@ -3,8 +3,6 @@ namespace NServiceBus
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading.Tasks;
-    using Extensibility;
     using Routing;
 
     class UnicastSendRouter : IUnicastSendRouter
@@ -16,7 +14,7 @@ namespace NServiceBus
             this.transportAddressTranslation = transportAddressTranslation;
         }
 
-        public async Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, IDistributionPolicy distributionPolicy, ContextBag contextBag)
+        public IEnumerable<UnicastRoutingStrategy> Route(Type messageType, IDistributionPolicy distributionPolicy)
         {
             var route = unicastRoutingTable.GetRouteFor(messageType);
             if (route == null)
@@ -24,7 +22,7 @@ namespace NServiceBus
                 return emptyRoute;
             }
 
-            var routingTargets = await route.Resolve(endpoint => endpointInstances.FindInstances(endpoint)).ConfigureAwait(false);
+            var routingTargets = route.Resolve(endpoint => endpointInstances.FindInstances(endpoint));
 
             var selectedDestinations = SelectDestination(distributionPolicy, routingTargets);
 

--- a/src/NServiceBus.Core/Transports/Msmq/InstanceMapping/InstanceMappingFileFeature.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/InstanceMapping/InstanceMappingFileFeature.cs
@@ -29,9 +29,8 @@ namespace NServiceBus.Features
             var checkInterval = context.Settings.Get<TimeSpan>(CheckIntervalSettingsKey);
             var endpointInstances = context.Settings.Get<EndpointInstances>();
 
-            var instanceMappingTable = new InstanceMappingTable(filePath, checkInterval, new AsyncTimer(), new InstanceMappingFileAccess());
+            var instanceMappingTable = new InstanceMappingTable(filePath, checkInterval, new AsyncTimer(), new InstanceMappingFileAccess(), endpointInstances);
             instanceMappingTable.ReloadData();
-            endpointInstances.AddDynamic(instanceMappingTable.FindInstances);
             context.RegisterStartupTask(instanceMappingTable);
         }
 

--- a/src/NServiceBus.Core/Transports/Msmq/InstanceMapping/InstanceMappingTable.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/InstanceMapping/InstanceMappingTable.cs
@@ -1,9 +1,7 @@
 namespace NServiceBus
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
-    using System.Text;
     using System.Threading.Tasks;
     using Features;
     using Logging;
@@ -11,12 +9,13 @@ namespace NServiceBus
 
     class InstanceMappingTable : FeatureStartupTask
     {
-        public InstanceMappingTable(string filePath, TimeSpan checkInterval, IAsyncTimer timer, IInstanceMappingFileAccess fileAccess)
+        public InstanceMappingTable(string filePath, TimeSpan checkInterval, IAsyncTimer timer, IInstanceMappingFileAccess fileAccess, EndpointInstances endpointInstances)
         {
             this.filePath = filePath;
             this.checkInterval = checkInterval;
             this.timer = timer;
             this.fileAccess = fileAccess;
+            this.endpointInstances = endpointInstances;
         }
 
         protected override Task OnStart(IMessageSession session)
@@ -35,14 +34,7 @@ namespace NServiceBus
             {
                 var doc = fileAccess.Load(filePath);
                 var instances = parser.Parse(doc);
-
-                var newInstanceMap = instances
-                    .GroupBy(i => i.Endpoint)
-                    .ToDictionary(g => g.Key, g => new HashSet<EndpointInstance>(g));
-
-                LogChanges(instanceMap, newInstanceMap);
-
-                instanceMap = newInstanceMap;
+                endpointInstances.AddOrReplaceInstances("FileRoutingTable", instances.ToList());
             }
             catch (Exception ex)
             {
@@ -50,70 +42,14 @@ namespace NServiceBus
             }
         }
 
-        void LogChanges(Dictionary<string, HashSet<EndpointInstance>> oldInstanceMap, Dictionary<string, HashSet<EndpointInstance>> newInstanceMap)
-        {
-            var output = new StringBuilder();
-            var hasChanges = false;
-            output.AppendLine($"Updating instance mapping table from '{filePath}':");
-
-            foreach (var endpoint in newInstanceMap)
-            {
-                HashSet<EndpointInstance> existingInstances;
-                if (oldInstanceMap.TryGetValue(endpoint.Key, out existingInstances))
-                {
-                    var newInstances = endpoint.Value.Except(existingInstances).Count();
-                    var removedInstances = existingInstances.Except(endpoint.Value).Count();
-
-                    if (newInstances > 0 || removedInstances > 0)
-                    {
-                        output.AppendLine($"Updated endpoint '{endpoint.Key}': +{Instances(newInstances)}, -{Instances(removedInstances)}");
-                        hasChanges = true;
-                    }
-                }
-                else
-                {
-                    output.AppendLine($"Added endpoint '{endpoint.Key}' with {Instances(endpoint.Value.Count)}");
-                    hasChanges = true;
-                }
-            }
-
-            foreach (var removedEndpoint in oldInstanceMap.Keys.Except(newInstanceMap.Keys))
-            {
-                output.AppendLine($"Removed all instances of endpoint '{removedEndpoint}'");
-                hasChanges = true;
-            }
-
-            if (hasChanges)
-            {
-                log.Info(output.ToString());
-            }
-        }
-
-        static string Instances(int count)
-        {
-            return count > 1 ? $"{count} instances" : $"{count} instance";
-        }
-
-        public Task<IEnumerable<EndpointInstance>> FindInstances(string endpoint)
-        {
-            HashSet<EndpointInstance> result;
-
-            // ReSharper disable once PossibleNullReferenceException
-            return instanceMap.TryGetValue(endpoint, out result)
-                ? Task.FromResult<IEnumerable<EndpointInstance>>(result)
-                : noInstances;
-        }
-
         protected override Task OnStop(IMessageSession session) => timer.Stop();
 
         TimeSpan checkInterval;
         IInstanceMappingFileAccess fileAccess;
         string filePath;
-
-        Dictionary<string, HashSet<EndpointInstance>> instanceMap = new Dictionary<string, HashSet<EndpointInstance>>(0);
+        EndpointInstances endpointInstances;
         InstanceMappingFileParser parser = new InstanceMappingFileParser();
         IAsyncTimer timer;
-        Task<IEnumerable<EndpointInstance>> noInstances = Task.FromResult(Enumerable.Empty<EndpointInstance>());
 
         static readonly ILog log = LogManager.GetLogger(typeof(InstanceMappingTable));
     }

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_a_command.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_a_command.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests
 {
+    using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using AcceptanceTesting.Customization;
     using AcceptanceTesting;
@@ -63,8 +65,13 @@
                     routing.RouteToEndpoint(typeof(RequestA), ReceiverAEndpoint);
                     routing.RouteToEndpoint(typeof(RequestB), ReceiverBEndpoint);
 
-                    routing.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverAEndpoint, "1"), new EndpointInstance(ReceiverAEndpoint, "2"));
-                    routing.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverBEndpoint, "1"), new EndpointInstance(ReceiverBEndpoint, "2"));
+                    routing.GetSettings().GetOrCreate<EndpointInstances>().AddOrReplaceInstances(Guid.NewGuid(), new List<EndpointInstance>
+                    {
+                        new EndpointInstance(ReceiverAEndpoint, "1"), 
+                        new EndpointInstance(ReceiverAEndpoint, "2"),
+                        new EndpointInstance(ReceiverBEndpoint, "1"),
+                        new EndpointInstance(ReceiverBEndpoint, "2")
+                    });
                 });
             }
 

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_replying_to_a_message_sent_via_a_distributor.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_replying_to_a_message_sent_via_a_distributor.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.ScaleOut
 {
+    using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
@@ -37,7 +39,10 @@
                 {
                     var routing = c.UseTransport<MsmqTransport>().Routing();
                     routing.RouteToEndpoint(typeof(MyRequest), ReceiverEndpoint);
-                    c.GetSettings().GetOrCreate<EndpointInstances>().Add(new EndpointInstance(ReceiverEndpoint, "XYZ"));
+                    c.GetSettings().GetOrCreate<EndpointInstances>().AddOrReplaceInstances(Guid.NewGuid(), new List<EndpointInstance>
+                    {
+                        new EndpointInstance(ReceiverEndpoint, "XYZ")
+                    });
                     c.AddHeaderToAllOutgoingMessages("NServiceBus.Distributor.WorkerSessionId", "SomeID");
                 });
             }


### PR DESCRIPTION
Connects to Particular/V6Launch#68

This is the last PR from the series (#4019, #4020). It removes `async` from the routing path (with an exception of publishes which still need to access the subscription store in an `async` way).

To be rebased and merged after #4020