### PR TITLE
Make index threadsafe

### DIFF
--- a/src/NServiceBus.Core/Routing/SingleInstanceRoundRobinDistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/SingleInstanceRoundRobinDistributionStrategy.cs
@@ -17,11 +17,12 @@ namespace NServiceBus.Routing
             {
                 yield break;
             }
-            var result = currentAllInstances[(int)(index % currentAllInstances.Count)];
-            Interlocked.Increment(ref index);
+            var i = Interlocked.Increment(ref index);
+            var result = currentAllInstances[(int)(i % currentAllInstances.Count)];
             yield return result;
         }
 
-        long index;
+        // start with -1 so the index will be at 0 after the first increment.
+        long index = -1;
     }
 }


### PR DESCRIPTION
we should avoid race conditions by using the returned value from the increment operation instead of using the index variable directly.

addresses @danielmarbach comment here: https://github.com/Particular/NServiceBus/pull/4011#discussion_r73677488

@danielmarbach please review