### PR TITLE
Verify databus still works with unobtrusive mode

### DIFF
--- a/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties_with_unobtrusive.cs
+++ b/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties_with_unobtrusive.cs
@@ -1,0 +1,84 @@
+﻿namespace NServiceBus.AcceptanceTests.DataBus
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_sending_databus_properties_with_unobtrusive : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_receive_messages_with_largepayload_correctly()
+        {
+            var payloadToSend = new byte[PayloadSize];
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(b => b.When(session => session.Send(new MyMessageWithLargePayload
+                {
+                    Payload = payloadToSend
+                })))
+                .WithEndpoint<Receiver>()
+                .Done(c => c.ReceivedPayload != null)
+                .Run();
+
+            Assert.AreEqual(payloadToSend, context.ReceivedPayload, "The large payload should be marshalled correctly using the databus");
+        }
+
+        const int PayloadSize = 100;
+
+        public class Context : ScenarioContext
+        {
+            public byte[] ReceivedPayload { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(builder =>
+                {
+                    builder.Conventions()
+                        .DefiningCommandsAs(t => t.Namespace != null && t.FullName == typeof(MyMessageWithLargePayload).FullName)
+                        .DefiningDataBusPropertiesAs(t => t.Name.Contains("Payload"));
+                    builder.UseDataBus<FileShareDataBus>().BasePath(@".\databus\sender");
+                    builder.UseSerialization<JsonSerializer>();
+                })
+                    .AddMapping<MyMessageWithLargePayload>(typeof(Receiver))
+                    .ExcludeType<MyMessageWithLargePayload>(); // remove that type from assembly scanning to simulate what would happen with true unobtrusive mode
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(builder =>
+                {
+                    builder.Conventions()
+                        .DefiningCommandsAs(t => t.Namespace != null && t.FullName == typeof(MyMessageWithLargePayload).FullName)
+                        .DefiningDataBusPropertiesAs(t => t.Name.Contains("Payload"));
+
+                    builder.UseDataBus<FileShareDataBus>().BasePath(@".\databus\sender");
+                    builder.UseSerialization<JsonSerializer>();
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessageWithLargePayload>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyMessageWithLargePayload messageWithLargePayload, IMessageHandlerContext context)
+                {
+                    Context.ReceivedPayload = messageWithLargePayload.Payload;
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MyMessageWithLargePayload
+        {
+            public byte[] Payload { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Basic\When_depending_on_untyped_feature.cs" />
     <Compile Include="Basic\When_extending_behavior_context.cs" />
     <Compile Include="Core\MessageDurability\When_sending_a_non_durable_message_with_conventions.cs" />
+    <Compile Include="DataBus\When_sending_databus_properties_with_unobtrusive.cs" />
     <Compile Include="Encryption\When_using_Rijndael_with_unobtrusive_mode.cs" />
     <Compile Include="Performance\TimeToBeReceived\When_TimeToBeReceived_used_with_unobtrusive_mode.cs" />
     <Compile Include="Recoverability\Retries\When_custom_policy_provided.cs" />


### PR DESCRIPTION
We had several issues around unobtrusive conventions. This verifies whether the data bus still works with unobtrusive and "optimized" assembly scanning with v6.

@Particular/nservicebus-maintainers please review and merge