### PR TITLE
Added acceptance test for unobtrusive sending, publishing and replying with proxy

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Basic/When_sending_interface_message_with_conventions.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_sending_interface_message_with_conventions.cs
@@ -1,0 +1,76 @@
+﻿namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_sending_interface_message_with_conventions : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_receive_the_message()
+        {
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
+                .WithEndpoint<Sender>(b => b.When(async (session, c) =>
+                {
+                    await session.Send<IMyInterfaceMessage>(m => m.Id = c.Id);
+                }))
+                .WithEndpoint<Receiver>()
+                .Done(c => c.MessageInterfaceReceived)
+                .Run();
+
+            Assert.True(context.MessageInterfaceReceived);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool MessageInterfaceReceived { get; set; }
+            public Guid Id { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(b => b.Conventions().DefiningMessagesAs(type => type.Name.EndsWith("Message")))
+                    .AddMapping<IMyInterfaceMessage>(typeof(Receiver))
+                    .ExcludeType<IMyInterfaceMessage>(); // remove that type from assembly scanning to simulate what would happen with true unobtrusive mode
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(builder =>
+                {
+                    builder.Conventions()
+                        .DefiningMessagesAs(type => type.Name.EndsWith("Message"));
+                });
+            }
+
+            public class MyMessageInterfaceHandler : IHandleMessages<IMyInterfaceMessage>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(IMyInterfaceMessage interfaceMessage, IMessageHandlerContext context)
+                {
+                    if (Context.Id != interfaceMessage.Id)
+                    {
+                        return Task.FromResult(0);
+                    }
+
+                    Context.MessageInterfaceReceived = true;
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public interface IMyInterfaceMessage
+        {
+            Guid Id { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Basic\When_extending_behavior_context.cs" />
     <Compile Include="Core\MessageDurability\When_sending_a_non_durable_message_with_conventions.cs" />
     <Compile Include="DataBus\When_sending_databus_properties_with_unobtrusive.cs" />
+    <Compile Include="Basic\When_sending_interface_message_with_conventions.cs" />
     <Compile Include="Encryption\When_using_Rijndael_with_unobtrusive_mode.cs" />
     <Compile Include="Performance\TimeToBeReceived\When_TimeToBeReceived_used_with_unobtrusive_mode.cs" />
     <Compile Include="Recoverability\Retries\When_custom_policy_provided.cs" />
@@ -66,6 +67,8 @@
     <Compile Include="Recoverability\When_message_is_moved_to_error_queue_with_header_customizations.cs" />
     <Compile Include="Routing\When_configure_routes_for_unobtrusive_messages.cs" />
     <Compile Include="Routing\When_registering_publishers_unobtrusive_messages.cs" />
+    <Compile Include="Routing\When_publishing_an_interface_with_unobtrusive.cs" />
+    <Compile Include="Routing\When_replying_to_message_with_interface.cs" />
     <Compile Include="Routing\When_subscribing_to_scaled_out_publisher_on_unicast_transport.cs" />
     <Compile Include="Sagas\When_a_base_class_mapped_is_handled_by_a_saga.cs" />
     <Compile Include="Sagas\When_a_base_class_message_starts_a_saga.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface_with_unobtrusive.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface_with_unobtrusive.cs
@@ -1,0 +1,108 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_publishing_an_interface_with_unobtrusive : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_receive_event_for_non_xml()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(b =>
+                    b.When(c => c.Subscribed, (session, ctx) => session.Publish<MyEvent>()))
+                .WithEndpoint<Subscriber>(b => b.When(async (session, context) =>
+                {
+                    await session.Subscribe<MyEvent>();
+                    if (context.HasNativePubSubSupport)
+                    {
+                        context.Subscribed = true;
+                    }
+                }))
+                .Done(c => c.GotTheEvent)
+                .Repeat(r => r.For(Serializers.Json))
+                .Should(c =>
+                {
+                    Assert.True(c.GotTheEvent);
+                    Assert.AreEqual(typeof(MyEvent), c.EventTypePassedToRouting);
+                })
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotTheEvent { get; set; }
+            public bool Subscribed { get; set; }
+            public Type EventTypePassedToRouting { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(c =>
+                {
+                    c.Conventions().DefiningEventsAs(t => t.Namespace != null && t.Name.EndsWith("Event"));
+                    c.Pipeline.Register("EventTypeSpy", typeof(EventTypeSpy), "EventTypeSpy");
+                    c.OnEndpointSubscribed<Context>((s, context) =>
+                    {
+                        if (s.SubscriberReturnAddress.Contains("Subscriber"))
+                        {
+                            context.Subscribed = true;
+                        }
+                    });
+                }).ExcludeType<MyEvent>(); // remove that type from assembly scanning to simulate what would happen with true unobtrusive mode
+            }
+
+            class EventTypeSpy : Behavior<IOutgoingLogicalMessageContext>
+            {
+                public EventTypeSpy(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public override Task Invoke(IOutgoingLogicalMessageContext context, Func<Task> next)
+                {
+                    testContext.EventTypePassedToRouting = context.Message.MessageType;
+                    return next();
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.Conventions().DefiningEventsAs(t => t.Namespace != null && t.Name.EndsWith("Event"));
+                    c.DisableFeature<AutoSubscribe>();
+                })
+                    .AddMapping<MyEvent>(typeof(Publisher));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyEvent @event, IMessageHandlerContext context)
+                {
+                    Context.GotTheEvent = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public interface MyEvent
+        {
+        }
+    }
+}


### PR DESCRIPTION
I added these tests for verifying that sending, publishing and replying with proxy types works even though the assembly scanning didn't pick up the message type (it works because the message mapper gets initialized lazily)

@Particular/nservicebus-maintainers please review