### PR TITLE
MessageMetadataRegistry GetMessageMetadata with strings registers type if it matches the message conventions

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Basic/When_receiving_unobtrusive_message_without_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_receiving_unobtrusive_message_without_handler.cs
@@ -1,0 +1,65 @@
+namespace NServiceBus.AcceptanceTests.Basic
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Logging;
+    using NUnit.Framework;
+
+    public class When_receiving_unobtrusive_message_without_handler : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Message_should_be_moved_to_error_cause_handler_not_found()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(c => c.When(s => s.Send(new MyCommand())))
+                .WithEndpoint<Receiver>(c => c.DoNotFailOnErrorMessages())
+                .Done(c => c.FailedMessages.Any())
+                .Run();
+
+            Assert.True(context.Logs.Any(l => l.Level == LogLevel.Error && l.Message.Contains($"No handlers could be found for message type: { typeof(MyCommand).FullName}")), "No handlers could be found was not logged.");
+            Assert.False(context.Logs.Any(l => l.Level == LogLevel.Warn && l.Message.Contains($"Message header '{ typeof(MyCommand).FullName }' was mapped to type '{ typeof(MyCommand).FullName }' but that type was not found in the message registry, ensure the same message registration conventions are used in all endpoints, especially if using unobtrusive mode.")), "Message type could not be mapped.");
+            Assert.False(context.Logs.Any(l => l.Level == LogLevel.Warn && l.Message.Contains($"Could not determine message type from message header '{ typeof(MyCommand).FullName}'")), "Message type could not be mapped.");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.Conventions()
+                        .DefiningCommandsAs(t => t.Namespace != null && t.FullName == typeof(MyCommand).FullName);
+
+                    c.UseSerialization<JsonSerializer>();
+                }).AddMapping<MyCommand>(typeof(Receiver))
+                    .ExcludeType<MyCommand>(); // remove that type from assembly scanning to simulate what would happen with true unobtrusive mode
+            }
+        }
+
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.Conventions().DefiningCommandsAs(t => t.Namespace != null && t.FullName == typeof(MyCommand).FullName);
+
+                    c.UseSerialization<JsonSerializer>();
+                })
+                    .ExcludeType<MyCommand>(); // remove that type from assembly scanning to simulate what would happen with true unobtrusive mode
+            }
+        }
+
+        public class MyCommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -57,6 +57,7 @@
   <ItemGroup>
     <Compile Include="Basic\When_depending_on_untyped_feature.cs" />
     <Compile Include="Basic\When_extending_behavior_context.cs" />
+    <Compile Include="Basic\When_receiving_unobtrusive_message_without_handler.cs" />
     <Compile Include="Core\MessageDurability\When_sending_a_non_durable_message_with_conventions.cs" />
     <Compile Include="DataBus\When_sending_databus_properties_with_unobtrusive.cs" />
     <Compile Include="Encryption\When_using_Rijndael_with_unobtrusive_mode.cs" />


### PR DESCRIPTION
With unobtrusive and assembly scanning which excludes assemblies that don't reference NServiceBus we can no longer rely on messages being registered during bootstrapping. This PR aligns the string overload of `GetMessageMetadata` to runtime register the type when it could be loaded in the current app domain.

I had a hard time to come up with ATTs. So this change comes in without tests. If someone is willing to help out I would appreciate your help. Maybe there is a simple way to test it. If not I'll propose to pull it in as is.