### PR TITLE
Fix unobtrusive assembly routing

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Recoverability\When_custom_policy_moves_to_overridden_error_queue.cs" />
     <Compile Include="Recoverability\When_message_is_moved_to_error_queue_with_header_customizations.cs" />
     <Compile Include="Routing\When_configure_routes_for_unobtrusive_messages.cs" />
+    <Compile Include="Routing\When_registering_publishers_unobtrusive_messages.cs" />
     <Compile Include="Routing\When_subscribing_to_scaled_out_publisher_on_unicast_transport.cs" />
     <Compile Include="Serialization\When_configuring_custom_xml_namespace.cs" />
     <Compile Include="Serialization\When_registering_additional_deserializers.cs" />

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Recoverability\Retries\When_custom_policy_provided.cs" />
     <Compile Include="Recoverability\When_custom_policy_moves_to_overridden_error_queue.cs" />
     <Compile Include="Recoverability\When_message_is_moved_to_error_queue_with_header_customizations.cs" />
+    <Compile Include="Routing\When_configure_routes_for_unobtrusive_messages.cs" />
     <Compile Include="Routing\When_subscribing_to_scaled_out_publisher_on_unicast_transport.cs" />
     <Compile Include="Serialization\When_configuring_custom_xml_namespace.cs" />
     <Compile Include="Serialization\When_registering_additional_deserializers.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/When_configure_routes_for_unobtrusive_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_configure_routes_for_unobtrusive_messages.cs
@@ -4,7 +4,7 @@
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using Configuration.AdvanceExtensibility;
-    using CustomMessageNamespace;
+    using CustomCommandMessageNamespace;
     using EndpointTemplates;
     using NUnit.Framework;
 
@@ -92,13 +92,11 @@
                 }
             }
         }
-
-
     }
 }
 
 // custom namespace is required to avoid automatically loading the type by the testing framework
-namespace CustomMessageNamespace
+namespace CustomCommandMessageNamespace
 {
     public class SomeCommand
     {

--- a/src/NServiceBus.AcceptanceTests/Routing/When_configure_routes_for_unobtrusive_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_configure_routes_for_unobtrusive_messages.cs
@@ -36,7 +36,7 @@
             Assert.That(context.ReceivedMessage, Is.True);
         }
 
-        class Context : ScenarioContext
+        public class Context : ScenarioContext
         {
             public bool ReceivedMessage { get; set; }
         }
@@ -72,10 +72,11 @@
             {
                 EndpointSetup<DefaultServer>(c => c
                     .Conventions()
-                    .DefiningCommandsAs(t => t == typeof(SomeCommand)));
+                    .DefiningCommandsAs(t => t == typeof(SomeCommand)))
+                    .IncludeType<SomeCommand>();
             }
 
-            class CommandHandler : IHandleMessages<SomeCommand>
+            public class CommandHandler : IHandleMessages<SomeCommand>
             {
                 Context testContext;
 
@@ -99,7 +100,7 @@
 // custom namespace is required to avoid automatically loading the type by the testing framework
 namespace CustomMessageNamespace
 {
-    class SomeCommand
+    public class SomeCommand
     {
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Routing/When_configure_routes_for_unobtrusive_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_configure_routes_for_unobtrusive_messages.cs
@@ -1,0 +1,105 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using Configuration.AdvanceExtensibility;
+    using CustomMessageNamespace;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_configure_routes_for_unobtrusive_messages : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_use_configured_routes_from_routing_api()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SendingEndpointUsingRoutingApi>(e => e
+                    .When(async s => await s.Send(new SomeCommand())))
+                .WithEndpoint<ReceivingEndpoint>()
+                .Done(c => c.ReceivedMessage)
+                .Run();
+
+            Assert.That(context.ReceivedMessage, Is.True);
+        }
+
+        [Test]
+        public async Task Should_use_configured_routes_from_endpoint_mapping()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SendingEndpointUsingEndpointMapping>(e => e
+                    .When(async s => await s.Send(new SomeCommand())))
+                .WithEndpoint<ReceivingEndpoint>()
+                .Done(c => c.ReceivedMessage)
+                .Run();
+
+            Assert.That(context.ReceivedMessage, Is.True);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool ReceivedMessage { get; set; }
+        }
+
+        public class SendingEndpointUsingRoutingApi : EndpointConfigurationBuilder
+        {
+            public SendingEndpointUsingRoutingApi()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.Conventions().DefiningCommandsAs(t => t == typeof(SomeCommand));
+
+                    var routing = new RoutingSettings(c.GetSettings());
+                    routing.RouteToEndpoint(typeof(SomeCommand).Assembly, Conventions.EndpointNamingConvention(typeof(ReceivingEndpoint)));
+                });
+            }
+        }
+
+        public class SendingEndpointUsingEndpointMapping : EndpointConfigurationBuilder
+        {
+            public SendingEndpointUsingEndpointMapping()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.Conventions().DefiningCommandsAs(t => t == typeof(SomeCommand));
+                }).AddMapping<SomeCommand>(typeof(ReceivingEndpoint));
+            }
+        }
+
+        public class ReceivingEndpoint : EndpointConfigurationBuilder
+        {
+            public ReceivingEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c
+                    .Conventions()
+                    .DefiningCommandsAs(t => t == typeof(SomeCommand)));
+            }
+
+            class CommandHandler : IHandleMessages<SomeCommand>
+            {
+                Context testContext;
+
+                public CommandHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(SomeCommand message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedMessage = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+
+    }
+}
+
+// custom namespace is required to avoid automatically loading the type by the testing framework
+namespace CustomMessageNamespace
+{
+    class SomeCommand
+    {
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Routing/When_configure_routes_for_unobtrusive_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_configure_routes_for_unobtrusive_messages.cs
@@ -11,7 +11,7 @@
     public class When_configure_routes_for_unobtrusive_messages : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_use_configured_routes_from_routing_api()
+        public async Task Should_use_routes_from_routing_api()
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<SendingEndpointUsingRoutingApi>(e => e
@@ -24,7 +24,7 @@
         }
 
         [Test]
-        public async Task Should_use_configured_routes_from_endpoint_mapping()
+        public async Task Should_use_routes_from_endpoint_mapping()
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<SendingEndpointUsingEndpointMapping>(e => e

--- a/src/NServiceBus.AcceptanceTests/Routing/When_registering_publishers_unobtrusive_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_registering_publishers_unobtrusive_messages.cs
@@ -1,0 +1,144 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Configuration.AdvanceExtensibility;
+    using CustomEventMessageNamespace;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using AcceptanceTesting.Customization;
+    using NServiceBus.Routing;
+    using ScenarioDescriptors;
+    using Settings;
+    using Transport;
+
+    public class When_registering_publishers_unobtrusive_messages
+    {
+        [Test]
+        public Task Should_use_configured_routes_from_routing_api()
+        {
+            return Scenario.Define<Context>()
+                .WithEndpoint<PublishingEndpoint>(e => e
+                    .When(c => c.Subscribed, async s => await s.Publish(new SomeEvent())))
+                .WithEndpoint<SubscribingEndpointUsingRoutingApi>()
+                .Done(c => c.ReceivedMessage)
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Should(context =>
+                {
+                    Assert.That(context.Subscribed, Is.True);
+                    Assert.That(context.ReceivedMessage, Is.True);
+                })
+                .Run();
+        }
+
+        [Test]
+        public Task Should_use_configured_routes_from_endpoint_mapping()
+        {
+            return Scenario.Define<Context>()
+                .WithEndpoint<PublishingEndpoint>(e => e
+                    .When(c => c.Subscribed, async s => await s.Publish(new SomeEvent())))
+                .WithEndpoint<SubscribingEndpointUsingEndpointMappings>()
+                .Done(c => c.ReceivedMessage)
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Should(context =>
+                {
+                    Assert.That(context.Subscribed, Is.True);
+                    Assert.That(context.ReceivedMessage, Is.True);
+                })
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscribed { get; set; }
+            public bool ReceivedMessage { get; set; }
+        }
+
+        public class PublishingEndpoint : EndpointConfigurationBuilder
+        {
+            public PublishingEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.OnEndpointSubscribed<Context>((e, ctx) => ctx.Subscribed = true);
+                    c.Conventions().DefiningEventsAs(t => t == typeof(SomeEvent));
+                });
+            }
+        }
+
+        public class SubscribingEndpointUsingRoutingApi : EndpointConfigurationBuilder
+        {
+            public SubscribingEndpointUsingRoutingApi()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.Conventions().DefiningEventsAs(t => t == typeof(SomeEvent));
+
+                    var routing = new RoutingSettings<MessageDrivenPubSubTransportDefinition>(c.GetSettings());
+                    routing.RegisterPublisher(typeof(SomeEvent).Assembly, Conventions.EndpointNamingConvention(typeof(PublishingEndpoint)));
+                }).IncludeType<SomeEvent>();
+            }
+
+            public class EventHandler : IHandleMessages<SomeEvent>
+            {
+                Context testContext;
+
+                public EventHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(SomeEvent message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedMessage = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class SubscribingEndpointUsingEndpointMappings : EndpointConfigurationBuilder
+        {
+            public SubscribingEndpointUsingEndpointMappings()
+            {
+                EndpointSetup<DefaultServer>(c => c
+                .Conventions().DefiningEventsAs(t => t == typeof(SomeEvent)))
+                .AddMapping<SomeEvent>(typeof(PublishingEndpoint))
+                .IncludeType<SomeEvent>();
+            }
+
+            public class EventHandler : IHandleMessages<SomeEvent>
+            {
+                Context testContext;
+
+                public EventHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(SomeEvent message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedMessage = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        class MessageDrivenPubSubTransportDefinition : TransportDefinition, IMessageDrivenSubscriptionTransport
+        {
+            public override string ExampleConnectionStringForErrorMessage { get; }
+
+            public override TransportInfrastructure Initialize(SettingsHolder settings, string connectionString)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+    }
+}
+
+// custom namespace is required to avoid automatically loading the type by the testing framework
+namespace CustomEventMessageNamespace
+{
+    public class SomeEvent
+    {
+    }
+}

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -970,6 +970,7 @@ namespace NServiceBus
     }
     public class RoutingSettings : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {
+        public RoutingSettings(NServiceBus.Settings.SettingsHolder settings) { }
         public void RouteToEndpoint(System.Type messageType, string destination) { }
         public void RouteToEndpoint(System.Reflection.Assembly assembly, string destination) { }
         public void RouteToEndpoint(System.Reflection.Assembly assembly, string @namespace, string destination) { }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -976,7 +976,10 @@ namespace NServiceBus
         public void RouteToEndpoint(System.Reflection.Assembly assembly, string @namespace, string destination) { }
     }
     public class RoutingSettings<T> : NServiceBus.RoutingSettings
-        where T : NServiceBus.Transport.TransportDefinition { }
+        where T : NServiceBus.Transport.TransportDefinition
+    {
+        public RoutingSettings(NServiceBus.Settings.SettingsHolder settings) { }
+    }
     public class static RoutingSettingsExtensions
     {
         public static NServiceBus.RoutingSettings Routing(this NServiceBus.TransportExtensions config) { }

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensionsTests.cs
@@ -145,12 +145,13 @@
         static Publishers ApplyPublisherRegistrations(RoutingSettings<MessageDrivenTransportDefinition> routingSettings)
         {
             var publishers = new Publishers();
-            var messageTypes = Assembly.GetExecutingAssembly().GetTypes();
+            var conventions = new Conventions();
+            conventions.IsMessageTypeAction = type => true;
 
             var registrations = routingSettings.Settings.Get<ConfiguredPublishers>();
             foreach (var publisherRegistration in registrations)
             {
-                publisherRegistration(publishers, messageTypes);
+                publisherRegistration(publishers, conventions);
             }
 
             return publishers;

--- a/src/NServiceBus.Core.Tests/Routing/RoutingSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingSettingsTests.cs
@@ -116,9 +116,14 @@
         static UnicastRoutingTable ApplyConfiguredRoutes(RoutingSettings routingSettings)
         {
             var routingTable = new UnicastRoutingTable();
+            var conventions = new Conventions
+            {
+                IsMessageTypeAction = type => true
+            };
+
             foreach (var registration in routingSettings.Settings.Get<ConfiguredUnicastRoutes>())
             {
-                registration(routingTable, Assembly.GetExecutingAssembly().GetTypes());
+                registration(routingTable, conventions);
             }
             return routingTable;
         }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
@@ -49,7 +49,7 @@ namespace NServiceBus
             Guard.AgainstNullAndEmpty(nameof(publisherEndpoint), publisherEndpoint);
 
             ThrowOnAddress(publisherEndpoint);
-            routingSettings.Settings.GetOrCreate<ConfiguredPublishers>().Add((publishers, knownMessageTypes) => publishers.Add(eventType, publisherEndpoint));
+            routingSettings.Settings.GetOrCreate<ConfiguredPublishers>().Add((publishers, conventions) => publishers.Add(eventType, publisherEndpoint));
         }
 
         /// <summary>
@@ -65,13 +65,13 @@ namespace NServiceBus
 
             ThrowOnAddress(publisherEndpoint);
 
-            routingSettings.Settings.GetOrCreate<ConfiguredPublishers>().Add((publishers, knownMessageTypes) =>
+            routingSettings.Settings.GetOrCreate<ConfiguredPublishers>().Add((publishers, conventions) =>
             {
-                foreach (var knownMessageType in knownMessageTypes)
+                foreach (var type in assembly.GetTypes())
                 {
-                    if (knownMessageType.Assembly == assembly)
+                    if (conventions.IsMessageType(type))
                     {
-                        publishers.Add(knownMessageType, publisherEndpoint);
+                        publishers.Add(type, publisherEndpoint);
                     }
                 }
             });
@@ -96,14 +96,13 @@ namespace NServiceBus
 
             // empty namespace is null, not string.empty
             @namespace = @namespace == string.Empty ? null : @namespace;
-
-            routingSettings.Settings.GetOrCreate<ConfiguredPublishers>().Add((publishers, knownMessageTypes) =>
+            routingSettings.Settings.GetOrCreate<ConfiguredPublishers>().Add((publishers, conventions) =>
             {
-                foreach (var knownMessageType in knownMessageTypes)
+                foreach (var type in assembly.GetTypes())
                 {
-                    if (knownMessageType.Assembly == assembly && knownMessageType.Namespace == @namespace)
+                    if (type.Namespace == @namespace && conventions.IsMessageType(type))
                     {
-                        publishers.Add(knownMessageType, publisherEndpoint);
+                        publishers.Add(type, publisherEndpoint);
                     }
                 }
             });

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -37,6 +37,7 @@
             var distributionPolicy = context.Settings.Get<DistributionPolicy>();
             var configuredUnicastRoutes = context.Settings.Get<ConfiguredUnicastRoutes>();
             var configuredPublishers = context.Settings.Get<ConfiguredPublishers>();
+            var conventions = context.Settings.Get<Conventions>();
 
             var knownMessageTypes = GetKnownMessageTypes(context);
 
@@ -48,7 +49,7 @@
 
             foreach (var registration in configuredUnicastRoutes)
             {
-                registration(unicastRoutingTable, knownMessageTypes);
+                registration(unicastRoutingTable, conventions);
             }
 
             foreach (var registration in configuredPublishers)
@@ -121,7 +122,7 @@
         }
     }
 
-    class ConfiguredUnicastRoutes : List<Action<UnicastRoutingTable, Type[]>>
+    class ConfiguredUnicastRoutes : List<Action<UnicastRoutingTable, Conventions>>
     {
     }
 

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using Config;
     using Routing;
     using Routing.MessageDrivenSubscriptions;
@@ -39,8 +38,6 @@
             var configuredPublishers = context.Settings.Get<ConfiguredPublishers>();
             var conventions = context.Settings.Get<Conventions>();
 
-            var knownMessageTypes = GetKnownMessageTypes(context);
-
             var unicastBusConfig = context.Settings.GetConfigSection<UnicastBusConfig>();
             if (unicastBusConfig != null)
             {
@@ -54,7 +51,7 @@
 
             foreach (var registration in configuredPublishers)
             {
-                registration(publishers, knownMessageTypes);
+                registration(publishers, conventions);
             }
 
             var outboundRoutingPolicy = transportInfrastructure.OutboundRoutingPolicy;
@@ -103,12 +100,6 @@
             }
         }
 
-        static Type[] GetKnownMessageTypes(FeatureConfigurationContext context)
-        {
-            var registry = context.Settings.Get<MessageMetadataRegistry>();
-            return registry.GetAllMessages().Select(m => m.MessageType).ToArray();
-        }
-
         static void ImportMessageEndpointMappings(MessageEndpointMappingCollection legacyRoutingConfig, TransportInfrastructure transportInfrastructure, Publishers publishers, UnicastRoutingTable unicastRoutingTable)
         {
             foreach (MessageEndpointMapping m in legacyRoutingConfig)
@@ -126,7 +117,7 @@
     {
     }
 
-    class ConfiguredPublishers : List<Action<Publishers, Type[]>>
+    class ConfiguredPublishers : List<Action<Publishers, Conventions>>
     {
     }
 }

--- a/src/NServiceBus.Core/Routing/RoutingSettings.cs
+++ b/src/NServiceBus.Core/Routing/RoutingSettings.cs
@@ -92,7 +92,10 @@
     public class RoutingSettings<T> : RoutingSettings
         where T : TransportDefinition
     {
-        internal RoutingSettings(SettingsHolder settings)
+        /// <summary>
+        /// Creates a new instance of <see cref="RoutingSettings{T}"/>.
+        /// </summary>
+        public RoutingSettings(SettingsHolder settings)
             : base(settings)
         {
         }

--- a/src/NServiceBus.Core/Routing/RoutingSettings.cs
+++ b/src/NServiceBus.Core/Routing/RoutingSettings.cs
@@ -13,7 +13,11 @@
     /// </summary>
     public class RoutingSettings : ExposeSettings
     {
-        internal RoutingSettings(SettingsHolder settings)
+        /// <summary>
+        /// Creates a new instance of <see cref="RoutingSettings"/>.
+        /// </summary>
+        /// <param name="settings"></param>
+        public RoutingSettings(SettingsHolder settings)
             : base(settings)
         {
         }

--- a/src/NServiceBus.Core/Routing/RoutingSettings.cs
+++ b/src/NServiceBus.Core/Routing/RoutingSettings.cs
@@ -16,7 +16,6 @@
         /// <summary>
         /// Creates a new instance of <see cref="RoutingSettings"/>.
         /// </summary>
-        /// <param name="settings"></param>
         public RoutingSettings(SettingsHolder settings)
             : base(settings)
         {
@@ -31,7 +30,7 @@
         {
             ThrowOnAddress(destination);
 
-            Settings.GetOrCreate<ConfiguredUnicastRoutes>().Add((routingTable, knownMessageTypes) => { routingTable.RouteTo(messageType, UnicastRoute.CreateFromEndpointName(destination)); });
+            Settings.GetOrCreate<ConfiguredUnicastRoutes>().Add((routingTable, conventions) => { routingTable.RouteTo(messageType, UnicastRoute.CreateFromEndpointName(destination)); });
         }
 
         /// <summary>
@@ -42,13 +41,13 @@
         public void RouteToEndpoint(Assembly assembly, string destination)
         {
             ThrowOnAddress(destination);
-            Settings.GetOrCreate<ConfiguredUnicastRoutes>().Add((routingTable, knownMessageTypes) =>
+            Settings.GetOrCreate<ConfiguredUnicastRoutes>().Add((routingTable, conventions) =>
             {
-                foreach (var knownMessage in knownMessageTypes)
+                foreach (var type in assembly.GetTypes())
                 {
-                    if (knownMessage.Assembly == assembly)
+                    if (conventions.IsMessageType(type))
                     {
-                        routingTable.RouteTo(knownMessage, UnicastRoute.CreateFromEndpointName(destination));
+                        routingTable.RouteTo(type, UnicastRoute.CreateFromEndpointName(destination));
                     }
                 }
             });
@@ -66,13 +65,13 @@
 
             // empty namespace is null, not string.empty
             @namespace = @namespace == string.Empty ? null : @namespace;
-            Settings.GetOrCreate<ConfiguredUnicastRoutes>().Add((routingTable, knownMessageTypes) =>
+            Settings.GetOrCreate<ConfiguredUnicastRoutes>().Add((routingTable, conventions) =>
             {
-                foreach (var knownMessage in knownMessageTypes)
+                foreach (var type in assembly.GetTypes())
                 {
-                    if (knownMessage.Assembly == assembly && knownMessage.Namespace == @namespace)
+                    if (type.Namespace == @namespace && conventions.IsMessageType(type))
                     {
-                        routingTable.RouteTo(knownMessage, UnicastRoute.CreateFromEndpointName(destination));
+                        routingTable.RouteTo(type, UnicastRoute.CreateFromEndpointName(destination));
                     }
                 }
             });

--- a/src/NServiceBus.Core/Routing/RoutingSettings.cs
+++ b/src/NServiceBus.Core/Routing/RoutingSettings.cs
@@ -40,7 +40,11 @@
         /// <param name="destination">Destination endpoint.</param>
         public void RouteToEndpoint(Assembly assembly, string destination)
         {
+            Guard.AgainstNull(nameof(assembly), assembly);
+            Guard.AgainstNullAndEmpty(nameof(destination), destination);
+
             ThrowOnAddress(destination);
+
             Settings.GetOrCreate<ConfiguredUnicastRoutes>().Add((routingTable, conventions) =>
             {
                 foreach (var type in assembly.GetTypes())
@@ -61,6 +65,9 @@
         /// <param name="destination">Destination endpoint.</param>
         public void RouteToEndpoint(Assembly assembly, string @namespace, string destination)
         {
+            Guard.AgainstNull(nameof(assembly), assembly);
+            Guard.AgainstNullAndEmpty(nameof(destination), destination);
+
             ThrowOnAddress(destination);
 
             // empty namespace is null, not string.empty


### PR DESCRIPTION
Assembly based routing and publisher APIs no longer use known message types of the metadata registry since this will miss unobtrusive messages which aren't initially scanned and are added lazily during runtime. This requires the routing APIs which allow registration of routes for a whole assembly to scan the assemblies types itself at startup to configure the static routes.

Added specific tests for the expected behavior. Some of those already were green before (publisher registration API, because of the existing handlers which cause the unobtrusive messages to be included at startup), others were failing (Commands).

Also made the ctors of the routing API settings class public for the acceptance tests to have access to the routing API (which contains the assembly scanning logic), otherwise acceptance tests aren't possible. Not happy about this, but I also don't see a huge downside/risk on this. Open for better ideas though.

Connects to Particular/V6Launch#68