### PR TITLE
Set the transport transaction scope as top-level

### DIFF
--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
@@ -20,7 +20,7 @@ namespace NServiceBus
 
             this.settings = settings;
             this.connectionString = connectionString;
-            this.addressTranslationRule = settings.GetOrDefault<Func<LogicalAddress, string>>("NServiceBus.Transports.MSMQ.AddressTranslationRule") ?? DefaultAddressTranslationRule;
+            addressTranslationRule = settings.GetOrDefault<Func<LogicalAddress, string>>("NServiceBus.Transports.MSMQ.AddressTranslationRule") ?? DefaultAddressTranslationRule;
         }
 
         public override IEnumerable<Type> DeliveryConstraints { get; } = new[]

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveWithTransactionScope.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveWithTransactionScope.cs
@@ -20,7 +20,7 @@ namespace NServiceBus
             Message message = null;
             try
             {
-                using (var scope = new TransactionScope(TransactionScopeOption.Required, transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
+                using (var scope = new TransactionScope(TransactionScopeOption.RequiresNew, transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
                 {
                     if (!TryReceive(MessageQueueTransactionType.Automatic, out message))
                     {


### PR DESCRIPTION
This change should not change code behavior in any way but should express the intent of starting the top level transaction scope more clearly. A similar change has already been implemented in the SQL Server transport.