### PR TITLE
Rename OverrideInputQueueName back to OverrideLocalAddress

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Hosting/When_overriding_input_queue_name.cs
+++ b/src/NServiceBus.AcceptanceTests/Hosting/When_overriding_input_queue_name.cs
@@ -26,7 +26,7 @@ namespace NServiceBus.AcceptanceTests.Hosting
             {
                 EndpointSetup<DefaultServer>((c, d) =>
                 {
-                    c.OverrideInputQueueName("OverriddenInputQueue");
+                    c.OverrideLocalAddress("OverriddenInputQueue");
                     c.EnableFeature<TimeoutManager>();
                 });
             }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -344,10 +344,6 @@ namespace NServiceBus
         public void EndpointName(string name) { }
         public void ExcludeAssemblies(params string[] assemblies) { }
         public void ExcludeTypes(params System.Type[] types) { }
-        [System.ObsoleteAttribute("Use `EndpointConfiguration.OverrideInputQueueName(string baseQueueName)` instead." +
-            " The member currently throws a NotImplementedException. Will be removed in versi" +
-            "on 7.0.0.", true)]
-        public void OverrideLocalAddress(string transportAddress) { }
         [System.ObsoleteAttribute("Use `EndpointConfiguration.OverridePublicReturnAddress(string address)` instead. " +
             "The member currently throws a NotImplementedException. Will be removed in versio" +
             "n 7.0.0.", true)]
@@ -904,7 +900,7 @@ namespace NServiceBus
     public class static ReceiveSettingsExtensions
     {
         public static void MakeInstanceUniquelyAddressable(this NServiceBus.EndpointConfiguration config, string discriminator) { }
-        public static void OverrideInputQueueName(this NServiceBus.EndpointConfiguration config, string baseInputQueueName) { }
+        public static void OverrideLocalAddress(this NServiceBus.EndpointConfiguration config, string baseInputQueueName) { }
     }
     public abstract class RecoverabilityAction
     {

--- a/src/NServiceBus.Core/Transports/ReceiveSettingsExtensions.cs
+++ b/src/NServiceBus.Core/Transports/ReceiveSettingsExtensions.cs
@@ -23,7 +23,7 @@
         /// </summary>
         /// <param name="config">The <see cref="EndpointConfiguration" /> instance to apply the settings to.</param>
         /// <param name="baseInputQueueName">The base name of the input queue.</param>
-        public static void OverrideInputQueueName(this EndpointConfiguration config, string baseInputQueueName)
+        public static void OverrideLocalAddress(this EndpointConfiguration config, string baseInputQueueName)
         {
             Guard.AgainstNullAndEmpty(nameof(baseInputQueueName), baseInputQueueName);
             config.Settings.SetDefault("BaseInputQueueName", baseInputQueueName);

--- a/src/NServiceBus.Core/obsoletes.cs
+++ b/src/NServiceBus.Core/obsoletes.cs
@@ -221,15 +221,6 @@ namespace NServiceBus
         }
 
         [ObsoleteEx(
-            ReplacementTypeOrMember = "EndpointConfiguration.OverrideInputQueueName(string baseQueueName)",
-            RemoveInVersion = "7.0",
-            TreatAsErrorFromVersion = "6.0")]
-        public void OverrideLocalAddress(string transportAddress)
-        {
-            throw new NotImplementedException();
-        }
-
-        [ObsoleteEx(
             Message = "Endpoint name is now a mandatory constructor argument on EndpointConfiguration.",
             RemoveInVersion = "7.0",
             TreatAsErrorFromVersion = "6.0")]

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_an_event.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_distributing_an_event.cs
@@ -78,7 +78,7 @@
             {
                 EndpointSetup<DefaultServer>(c =>
                 {
-                    c.OverrideInputQueueName(SubscriberEndpoint + "-1");
+                    c.OverrideLocalAddress(SubscriberEndpoint + "-1");
                     var transport = c.UseTransport<MsmqTransport>();
                     transport.Routing().RegisterPublisher(typeof(MyEvent), PublisherEndpoint);
                 }).CustomEndpointName(SubscriberEndpoint);
@@ -102,7 +102,7 @@
             {
                 EndpointSetup<DefaultServer>(c =>
                 {
-                    c.OverrideInputQueueName(SubscriberEndpoint + "-2");
+                    c.OverrideLocalAddress(SubscriberEndpoint + "-2");
                     var transport = c.UseTransport<MsmqTransport>();
                     transport.Routing().RegisterPublisher(typeof(MyEvent), PublisherEndpoint);
                 }).CustomEndpointName(SubscriberEndpoint);

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_overriding_address_translation.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_overriding_address_translation.cs
@@ -48,7 +48,7 @@
         {
             public Receiver()
             {
-                EndpointSetup<DefaultServer>(c => c.OverrideInputQueueName("q_" + DefaultReceiverAddress));
+                EndpointSetup<DefaultServer>(c => c.OverrideLocalAddress("q_" + DefaultReceiverAddress));
             }
 
             public class MessageHandler : IHandleMessages<Message>


### PR DESCRIPTION


We talked about renaming `OverrideInputQueueName` back to it's v5 naming to make migrations easier at the cost of the slightly more accurate naming. There seems to be no difference in behavior between v5 and v6.

Connects to Particular/V6Launch#68

@Particular/nservicebus-maintainers @SzymonPobiega @DavidBoike ping