### PR TITLE
Put transport transaction in the context for satellites

### DIFF
--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/DispatchTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/DispatchTimeoutBehavior.cs
@@ -31,8 +31,7 @@ namespace NServiceBus
 
             var outgoingMessage = new OutgoingMessage(context.MessageId, timeoutData.Headers, timeoutData.State);
             var transportOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(timeoutData.Destination), dispatchConsistency);
-            var transportTransaction = context.Context.GetOrCreate<TransportTransaction>();
-            await dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction, context.Context).ConfigureAwait(false);
+            await dispatcher.Dispatch(new TransportOperations(transportOperation), context.TransportTransaction, context.Context).ConfigureAwait(false);
 
             var timeoutRemoved = await persister.TryRemove(timeoutId, context.Context).ConfigureAwait(false);
             if (!timeoutRemoved)

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
@@ -65,8 +65,7 @@ namespace NServiceBus
                 {
                     var outgoingMessage = new OutgoingMessage(context.MessageId, data.Headers, data.State);
                     var transportOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(data.Destination));
-                    var transportTransaction = context.Context.GetOrCreate<TransportTransaction>();
-                    await dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction, context.Context).ConfigureAwait(false);
+                    await dispatcher.Dispatch(new TransportOperations(transportOperation), context.TransportTransaction, context.Context).ConfigureAwait(false);
                     return;
                 }
 

--- a/src/NServiceBus.Core/Pipeline/satellitePipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/satellitePipelineExecutor.cs
@@ -6,9 +6,6 @@
 
     class SatellitePipelineExecutor : IPipelineExecutor
     {
-        SatelliteDefinition satelliteDefinition;
-        IBuilder builder;
-
         public SatellitePipelineExecutor(IBuilder builder, SatelliteDefinition definition)
         {
             this.builder = builder;
@@ -17,7 +14,12 @@
 
         public Task Invoke(MessageContext messageContext)
         {
+            messageContext.Context.Set(messageContext.TransportTransaction);
+
             return satelliteDefinition.OnMessage(builder, messageContext);
         }
+
+        SatelliteDefinition satelliteDefinition;
+        IBuilder builder;
     }
 }


### PR DESCRIPTION
Satellites now also use explicit transport transaction from the message context when dispatching.

Fixes #4047 