### PR TITLE
Default transport test timeouts to 30s

### DIFF
--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -168,7 +168,7 @@
         {
             testCancellationTokenSource = new CancellationTokenSource();
 
-            testCancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(10));
+            testCancellationTokenSource.CancelAfter(TimeSpan.FromSeconds(30));
             testCancellationTokenSource.Token.Register(onTimeoutAction);
         }
 


### PR DESCRIPTION
10s is to short for ASB. Just to get it going. We can consider making this configurable by the transport in the future if needed