### PR TITLE
ATT for subscribing to multiple publishers

### DIFF
--- a/src/NServiceBus.AcceptanceTests/MessageDrivenPubSubRoutingExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/MessageDrivenPubSubRoutingExtensions.cs
@@ -1,0 +1,25 @@
+namespace NServiceBus.AcceptanceTests.Routing
+{
+    using Configuration.AdvanceExtensibility;
+    using NServiceBus.Routing;
+    using Settings;
+    using Transport;
+
+    public static class MessageDrivenPubSubRoutingExtensions
+    {
+        public static RoutingSettings<MessageDrivenPubSubTransportDefinition> MessageDrivenPubSubRouting(this EndpointConfiguration endpointConfiguration)
+        {
+            return new RoutingSettings<MessageDrivenPubSubTransportDefinition>(endpointConfiguration.GetSettings());
+        }
+
+        public class MessageDrivenPubSubTransportDefinition : TransportDefinition, IMessageDrivenSubscriptionTransport
+        {
+            public override string ExampleConnectionStringForErrorMessage { get; }
+
+            public override TransportInfrastructure Initialize(SettingsHolder settings, string connectionString)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -66,10 +66,12 @@
     <Compile Include="Recoverability\Retries\When_custom_policy_provided.cs" />
     <Compile Include="Recoverability\When_custom_policy_moves_to_overridden_error_queue.cs" />
     <Compile Include="Recoverability\When_message_is_moved_to_error_queue_with_header_customizations.cs" />
+    <Compile Include="MessageDrivenPubSubRoutingExtensions.cs" />
     <Compile Include="Routing\When_configure_routes_for_unobtrusive_messages.cs" />
     <Compile Include="Routing\When_registering_publishers_unobtrusive_messages.cs" />
     <Compile Include="Routing\When_publishing_an_interface_with_unobtrusive.cs" />
     <Compile Include="Routing\When_replying_to_message_with_interface.cs" />
+    <Compile Include="Routing\When_subscribing_to_multiple_publishers.cs" />
     <Compile Include="Routing\When_subscribing_to_scaled_out_publisher_on_unicast_transport.cs" />
     <Compile Include="Sagas\When_a_base_class_mapped_is_handled_by_a_saga.cs" />
     <Compile Include="Sagas\When_a_base_class_message_starts_a_saga.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/When_registering_publishers_unobtrusive_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_registering_publishers_unobtrusive_messages.cs
@@ -2,14 +2,10 @@
 {
     using System.Threading.Tasks;
     using AcceptanceTesting;
-    using Configuration.AdvanceExtensibility;
     using EndpointTemplates;
     using NUnit.Framework;
     using AcceptanceTesting.Customization;
-    using NServiceBus.Routing;
     using ScenarioDescriptors;
-    using Settings;
-    using Transport;
 
     public class When_registering_publishers_unobtrusive_messages : NServiceBusAcceptanceTest
     {
@@ -73,8 +69,7 @@
                 {
                     c.Conventions().DefiningEventsAs(t => t == typeof(SomeEvent));
 
-                    var routing = new RoutingSettings<MessageDrivenPubSubTransportDefinition>(c.GetSettings());
-                    routing.RegisterPublisher(typeof(SomeEvent).Assembly, Conventions.EndpointNamingConvention(typeof(Publisher)));
+                    c.MessageDrivenPubSubRouting().RegisterPublisher(typeof(SomeEvent).Assembly, Conventions.EndpointNamingConvention(typeof(Publisher)));
                 });
             }
 
@@ -118,16 +113,6 @@
                     testContext.ReceivedMessage = true;
                     return Task.FromResult(0);
                 }
-            }
-        }
-
-        class MessageDrivenPubSubTransportDefinition : TransportDefinition, IMessageDrivenSubscriptionTransport
-        {
-            public override string ExampleConnectionStringForErrorMessage { get; }
-
-            public override TransportInfrastructure Initialize(SettingsHolder settings, string connectionString)
-            {
-                throw new System.NotImplementedException();
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/When_subscribing_to_multiple_publishers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_subscribing_to_multiple_publishers.cs
@@ -1,0 +1,69 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_subscribing_to_multiple_publishers : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_subscribe_to_all_registered_publishers_of_same_type()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<Subscriber>(e => e
+                    .When(s => s.Subscribe<SomeEvent>()))
+                .WithEndpoint<Publisher>(e => e
+                    .CustomConfig(cfg =>
+                    {
+                        cfg.OverrideLocalAddress("Publisher1");
+                        cfg.OnEndpointSubscribed<Context>((args, ctx) => ctx.SubscribedToPublisher1 = true);
+                    }))
+                .WithEndpoint<Publisher>(e => e
+                    .CustomConfig(cfg =>
+                    {
+                        cfg.OverrideLocalAddress("Publisher2");
+                        cfg.OnEndpointSubscribed<Context>((args, ctx) => ctx.SubscribedToPublisher2 = true);
+                    }))
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Should(c =>
+                {
+                    Assert.That(c.SubscribedToPublisher1, Is.True);
+                    Assert.That(c.SubscribedToPublisher2, Is.True);
+                })
+                .Run();
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool SubscribedToPublisher1 { get; set; }
+            public bool SubscribedToPublisher2 { get; set; }
+        }
+
+        class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    var routing = c.MessageDrivenPubSubRouting();
+                    routing.RegisterPublisher(typeof(SomeEvent), "Publisher1");
+                    routing.RegisterPublisher(typeof(SomeEvent), "Publisher2");
+                });
+            }
+        }
+
+        class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        class SomeEvent : IEvent
+        {
+        }
+    }
+}


### PR DESCRIPTION
@SzymonPobiega noticed that we don't have an att to verify that we support registration of multiple publishers on the same message type for message driven pubsub transports (as brokered transports already support).

@Particular/nservicebus-maintainers please review
/cc @SzymonPobiega @DavidBoike 