### PR TITLE
Set serializer to XML explictly to support multi inherited interface

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
+++ b/src/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
@@ -57,18 +57,22 @@
         {
             public V2Publisher()
             {
-                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
+                EndpointSetup<DefaultPublisher>(b =>
                 {
-                    if (s.SubscriberReturnAddress.Contains("V1Subscriber"))
+                    b.UseSerialization<XmlSerializer>();
+                    b.OnEndpointSubscribed<Context>((s, context) =>
                     {
-                        context.V1Subscribed = true;
-                    }
+                        if (s.SubscriberReturnAddress.Contains("V1Subscriber"))
+                        {
+                            context.V1Subscribed = true;
+                        }
 
-                    if (s.SubscriberReturnAddress.Contains("V2Subscriber"))
-                    {
-                        context.V2Subscribed = true;
-                    }
-                }));
+                        if (s.SubscriberReturnAddress.Contains("V2Subscriber"))
+                        {
+                            context.V2Subscribed = true;
+                        }
+                    });
+                });
             }
         }
 
@@ -76,7 +80,11 @@
         {
             public V1Subscriber()
             {
-                EndpointSetup<DefaultServer>(b => b.DisableFeature<AutoSubscribe>())
+                EndpointSetup<DefaultServer>(b =>
+                {
+                    b.UseSerialization<XmlSerializer>();
+                    b.DisableFeature<AutoSubscribe>();
+                })
                     .ExcludeType<V2Event>()
                     .AddMapping<V1Event>(typeof(V2Publisher));
             }
@@ -97,7 +105,11 @@
         {
             public V2Subscriber()
             {
-                EndpointSetup<DefaultServer>(b => b.DisableFeature<AutoSubscribe>())
+                EndpointSetup<DefaultServer>(b =>
+                {
+                    b.UseSerialization<XmlSerializer>();
+                    b.DisableFeature<AutoSubscribe>();
+                })
                     .AddMapping<V2Event>(typeof(V2Publisher));
             }
 


### PR DESCRIPTION
This sets the serializer explicitly to XML for the multi inheritance interface message test since transports defaulting to serializers with no interface support would blow up