### PR TITLE
Assert on exception messages using invariant culture

### DIFF
--- a/src/NServiceBus.Core.Tests/EndpointConfigurationTests.cs
+++ b/src/NServiceBus.Core.Tests/EndpointConfigurationTests.cs
@@ -3,7 +3,7 @@
     using System;
     using NUnit.Framework;
 
-    [TestFixture]
+    [TestFixture, TestWithInvariantCulture]
     public class EndpointConfigurationTests
     {
         [Theory]

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -163,6 +163,7 @@
     <Compile Include="Routing\DetermineRouteForPublishBehaviorTests.cs" />
     <Compile Include="Routing\DistributionPolicyTests.cs" />
     <Compile Include="Routing\MessageEndpointMappingTests.cs" />
+    <Compile Include="TestWithInvariantCultureAttribute.cs" />
     <Compile Include="Transports\MSMQ\InstanceMapping\InstanceMappingFileFeatureTests.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\MessageDrivenSubscriptionsConfigExtensionsTests.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\PublishersTests.cs" />

--- a/src/NServiceBus.Core.Tests/TestWithInvariantCultureAttribute.cs
+++ b/src/NServiceBus.Core.Tests/TestWithInvariantCultureAttribute.cs
@@ -1,0 +1,27 @@
+namespace NServiceBus.Core.Tests
+{
+    using System;
+    using System.Globalization;
+    using System.Threading;
+    using NUnit.Framework;
+    using NUnit.Framework.Interfaces;
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    class TestWithInvariantCultureAttribute : Attribute, ITestAction
+    {
+        public void BeforeTest(ITest test)
+        {
+            currentCulture = Thread.CurrentThread.CurrentUICulture;
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
+        }
+
+        public void AfterTest(ITest test)
+        {
+            Thread.CurrentThread.CurrentUICulture = currentCulture;
+        }
+
+        public ActionTargets Targets { get; } = ActionTargets.Default;
+
+        CultureInfo currentCulture;
+    }
+}

--- a/src/NServiceBus.Core.Tests/Transports/MSMQ/InstanceMapping/InstanceMappingFileParserTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/MSMQ/InstanceMapping/InstanceMappingFileParserTests.cs
@@ -46,7 +46,7 @@
             Assert.DoesNotThrow(() => parser.Parse(doc));
         }
 
-        [Test]
+        [Test, TestWithInvariantCulture]
         public void It_requires_endpoint_name()
         {
             const string xml = @"
@@ -61,7 +61,7 @@
             Assert.That(exception.Message, Does.Contain("The required attribute 'name' is missing."));
         }
 
-        [Test]
+        [Test, TestWithInvariantCulture]
         public void It_requires_endpoint_to_have_an_instance()
         {
             const string xml = @"


### PR DESCRIPTION
### What is the problem?

Some unit tests make assertions on exception messages. When these test are executed on operating systems using a culture that is different than one of the English variants, they fail because the exception messages are localized.

### What to do about it?

The easiest solution to this problem that I found is to run the test with invariant culture (English without any other culture specific modifications). To make usage easier, I wrapped this into an NUnit test action.