### PR TITLE
Queue override via endpoint instance property

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -313,6 +313,7 @@
     <Compile Include="ScenarioDescriptors\Transports.cs" />
     <Compile Include="Basic\When_sending_to_another_endpoint.cs" />
     <Compile Include="Versioning\When_multiple_versions_of_a_message_is_published.cs" />
+    <Compile Include="Routing\When_overriding_local_address.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\packaging\nuget\nservicebus.acceptancetests.nuspec">

--- a/src/NServiceBus.AcceptanceTests/Routing/When_overriding_local_address.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_overriding_local_address.cs
@@ -1,0 +1,76 @@
+﻿namespace ServiceBus.AcceptanceTests.Routing
+{
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
+
+    public class When_overriding_local_address : NServiceBusAcceptanceTest
+    {
+        public static string ReceiverEndpointName => Conventions.EndpointNamingConvention(typeof(Receiver));
+        public static string ReceiverQueueName => "q_" + ReceiverEndpointName;
+
+        [Test]
+        public async Task Should_use_the_provided_address_as_input_queue_name()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(e => e.When(c =>
+                {
+                    var options = new SendOptions();
+                    options.SetDestination(ReceiverQueueName);
+                    return c.Send(new Message(), options);
+                }))
+                .WithEndpoint<Receiver>()
+                .Done(c => c.ReceivedMessage)
+                .Run();
+
+            Assert.That(context.ReceivedMessage, Is.True);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool ReceivedMessage { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                });
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c => c.OverrideLocalAddress(ReceiverQueueName));
+            }
+
+            public class MessageHandler : IHandleMessages<Message>
+            {
+                Context testContext;
+
+                public MessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(Message message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedMessage = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Message : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
+++ b/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
@@ -47,8 +47,7 @@
 
                 protected override void Setup(FeatureConfigurationContext context)
                 {
-                    var instanceName = context.Settings.EndpointInstanceName();
-                    var satelliteLogicalAddress = new LogicalAddress(instanceName, "MySatellite");
+                    var satelliteLogicalAddress = context.Settings.LogicalAddress().CreateQualifiedAddress("MySatellite");
                     var satelliteAddress = context.Settings.GetTransportAddress(satelliteLogicalAddress);
 
                     context.AddSatelliteReceiver("Test satellite", satelliteAddress, TransportTransactionMode.ReceiveOnly, PushRuntimeSettings.Default,

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -754,10 +754,12 @@ namespace NServiceBus
     public class static LoadMessageHandlersExtentions { }
     public struct LogicalAddress
     {
-        public LogicalAddress(NServiceBus.Routing.EndpointInstance endpointInstance, [JetBrains.Annotations.NotNullAttribute()] string qualifier) { }
-        public LogicalAddress(NServiceBus.Routing.EndpointInstance endpointInstance) { }
         public NServiceBus.Routing.EndpointInstance EndpointInstance { get; }
         public string Qualifier { get; }
+        public NServiceBus.LogicalAddress CreateIndividualizedAddress(string discriminator) { }
+        public static NServiceBus.LogicalAddress CreateLocalAddress(string queueName, System.Collections.Generic.IReadOnlyDictionary<string, string> properties) { }
+        public NServiceBus.LogicalAddress CreateQualifiedAddress(string qualifier) { }
+        public static NServiceBus.LogicalAddress CreateRemoteAddress(NServiceBus.Routing.EndpointInstance endpointInstance) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
@@ -804,7 +806,6 @@ namespace NServiceBus
     {
         public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> ApplyLabelToMessages(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> transportExtensions, System.Func<System.Collections.Generic.IReadOnlyDictionary<string, string>, string> labelGenerator) { }
         public static NServiceBus.InstanceMappingFileSettings InstanceMappingFile(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config) { }
-        public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> OverrideAddressTranslation(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config, System.Func<NServiceBus.LogicalAddress, string> translationRule) { }
         public static void SetMessageDistributionStrategy(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config, NServiceBus.Routing.DistributionStrategy distributionStrategy) { }
         public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> TransactionScopeOptions(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> transportExtensions, System.Nullable<System.TimeSpan> timeout = null, System.Nullable<System.Transactions.IsolationLevel> isolationLevel = null) { }
     }
@@ -1126,13 +1127,13 @@ namespace NServiceBus
     }
     public class static SettingsExtensions
     {
-        public static NServiceBus.Routing.EndpointInstance EndpointInstanceName(this NServiceBus.Settings.ReadOnlySettings settings) { }
         public static string EndpointName(this NServiceBus.Settings.ReadOnlySettings settings) { }
         public static System.Collections.Generic.IList<System.Type> GetAvailableTypes(this NServiceBus.Settings.ReadOnlySettings settings) { }
         public static T GetConfigSection<T>(this NServiceBus.Settings.ReadOnlySettings settings)
             where T :  class, new () { }
         public static string InstanceSpecificQueue(this NServiceBus.Settings.ReadOnlySettings settings) { }
         public static string LocalAddress(this NServiceBus.Settings.ReadOnlySettings settings) { }
+        public static NServiceBus.LogicalAddress LogicalAddress(this NServiceBus.Settings.ReadOnlySettings settings) { }
     }
     [System.ObsoleteAttribute("Use `SettingsExtensions` instead. Will be removed in version 7.0.0.", true)]
     public class static SettingsExtentions { }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
@@ -63,8 +63,7 @@
 
         static string SetupDispatcherSatellite(FeatureConfigurationContext context, TransportTransactionMode requiredTransactionSupport)
         {
-            var instanceName = context.Settings.EndpointInstanceName();
-            var satelliteLogicalAddress = new LogicalAddress(instanceName, "TimeoutsDispatcher");
+            var satelliteLogicalAddress = context.Settings.LogicalAddress().CreateQualifiedAddress("TimeoutsDispatcher");
             var satelliteAddress = context.Settings.GetTransportAddress(satelliteLogicalAddress);
 
             context.AddSatelliteReceiver("Timeout Dispatcher Processor", satelliteAddress, requiredTransactionSupport, PushRuntimeSettings.Default, RecoverabilityPolicy,
@@ -83,8 +82,7 @@
 
         static void SetupStorageSatellite(FeatureConfigurationContext context, TransportTransactionMode requiredTransactionSupport)
         {
-            var instanceName = context.Settings.EndpointInstanceName();
-            var satelliteLogicalAddress = new LogicalAddress(instanceName, "Timeouts");
+            var satelliteLogicalAddress = context.Settings.LogicalAddress().CreateQualifiedAddress("Timeouts");
             var satelliteAddress = context.Settings.GetTransportAddress(satelliteLogicalAddress);
 
             context.AddSatelliteReceiver("Timeout Message Processor", satelliteAddress, requiredTransactionSupport, PushRuntimeSettings.Default, RecoverabilityPolicy,

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -45,8 +45,8 @@
             var outboundRoutingPolicy = transportInfrastructure.OutboundRoutingPolicy;
             context.Pipeline.Register(b =>
             {
-                var unicastSendRouter = new UnicastSendRouter(unicastRoutingTable, endpointInstances, i => transportInfrastructure.ToTransportAddress(new LogicalAddress(i)));
-                return new UnicastSendRouterConnector(context.Settings.LocalAddress(), context.Settings.InstanceSpecificQueue(), unicastSendRouter, distributionPolicy, i => transportInfrastructure.ToTransportAddress(new LogicalAddress(i)));
+                var unicastSendRouter = new UnicastSendRouter(unicastRoutingTable, endpointInstances, i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)));
+                return new UnicastSendRouterConnector(context.Settings.LocalAddress(), context.Settings.InstanceSpecificQueue(), unicastSendRouter, distributionPolicy, i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)));
             }, "Determines how the message being sent should be routed");
 
             context.Pipeline.Register(new UnicastReplyRouterConnector(), "Determines how replies should be routed");
@@ -72,7 +72,7 @@
                 if (outboundRoutingPolicy.Publishes == OutboundRoutingType.Unicast)
                 {
                     var subscriberAddress = distributorAddress ?? context.Settings.LocalAddress();
-                    var subscriptionRouter = new SubscriptionRouter(publishers, endpointInstances, i => transportInfrastructure.ToTransportAddress(new LogicalAddress(i)));
+                    var subscriptionRouter = new SubscriptionRouter(publishers, endpointInstances, i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)));
 
                     context.Pipeline.Register(b => new MessageDrivenSubscribeTerminator(subscriptionRouter, subscriberAddress, context.Settings.EndpointName(), b.Build<IDispatchMessages>()), "Sends subscription requests when message driven subscriptions is in use");
                     context.Pipeline.Register(b => new MessageDrivenUnsubscribeTerminator(subscriptionRouter, subscriberAddress, context.Settings.EndpointName(), b.Build<IDispatchMessages>()), "Sends requests to unsubscribe when message driven subscriptions is in use");

--- a/src/NServiceBus.Core/SettingsExtensions.cs
+++ b/src/NServiceBus.Core/SettingsExtensions.cs
@@ -4,7 +4,6 @@ namespace NServiceBus
     using System.Collections.Generic;
     using System.Linq;
     using Config.ConfigurationSource;
-    using Routing;
     using Settings;
 
     /// <summary>
@@ -64,12 +63,12 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Returns the name of this instance of the endpoint.
+        /// Returns the logical address of this endpoint.
         /// </summary>
-        public static EndpointInstance EndpointInstanceName(this ReadOnlySettings settings)
+        public static LogicalAddress LogicalAddress(this ReadOnlySettings settings)
         {
             Guard.AgainstNull(nameof(settings), settings);
-            return settings.Get<EndpointInstance>();
+            return settings.Get<LogicalAddress>();
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqConfigurationExtensions.cs
@@ -59,16 +59,5 @@ namespace NServiceBus
         {
             return new InstanceMappingFileSettings(config.Settings);
         }
-
-        /// <summary>
-        /// Overrides the default address translation rule "endpoint.quailfier-id@machine".
-        /// </summary>
-        /// <param name="config">Config object.</param>
-        /// <param name="translationRule">New translation rule.</param>
-        public static TransportExtensions<MsmqTransport> OverrideAddressTranslation(this TransportExtensions<MsmqTransport> config, Func<LogicalAddress, string> translationRule)
-        {
-            config.Settings.Set("NServiceBus.Transports.MSMQ.AddressTranslationRule", translationRule);
-            return config;
-        }
     }
 }

--- a/src/NServiceBus.Msmq.AcceptanceTests/NServiceBus.Msmq.AcceptanceTests.csproj
+++ b/src/NServiceBus.Msmq.AcceptanceTests/NServiceBus.Msmq.AcceptanceTests.csproj
@@ -62,7 +62,7 @@
     <Compile Include="When_customizing_scope_isolation_level.cs" />
     <Compile Include="When_distributing_an_event.cs" />
     <Compile Include="When_distributing_a_command.cs" />
-    <Compile Include="When_overriding_address_translation.cs" />
+    <Compile Include="When_overriding_local_address.cs" />
     <Compile Include="When_not_using_instance_mapping_file.cs" />
     <Compile Include="When_publishing.cs" />
     <Compile Include="When_publishing_with_authorizer.cs" />


### PR DESCRIPTION
Connects to Particular/V6Launch#68

Refactors the override local address code so that now it uses a `queue` property on the endpoint instance class. 
Removes the `OverrideAddressTranslation` API from MSMQ
Adds a `AddEndpointInstances` API to MSMQ which can be used in conjunction with `WithQueue` instance extension method to define routing to instances that have overridden queue name.

TODO:
 * [ ] Remove the translation rule hack from routing samples
