### PR TITLE
Optimize MessageMetadataRegistry

### DIFF
--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -48,7 +48,7 @@
         {
             Guard.AgainstNullAndEmpty(nameof(messageTypeIdentifier), messageTypeIdentifier);
 
-            var messageType = Type.GetType(messageTypeIdentifier, false);
+            var messageType = GetType(messageTypeIdentifier);
 
             if (messageType == null)
             {
@@ -70,6 +70,24 @@
 
             Logger.WarnFormat("Message header '{0}' was mapped to type '{1}' but that type was not found in the message registry, ensure the same message registration conventions are used in all endpoints, especially if using unobtrusive mode. ", messageType, messageType.FullName);
             return null;
+        }
+
+        Type GetType(string messageTypeIdentifier)
+        {
+            for (int i = 0; i < cachedTypes.Count; i++)
+            {
+                var tuple = cachedTypes[0];
+
+                if (tuple.Item1 == messageTypeIdentifier)
+                {
+                    return tuple.Item2;
+                }
+            }
+
+            var type = Type.GetType(messageTypeIdentifier, false);
+            cachedTypes.Add(Tuple.Create(messageTypeIdentifier, type));
+
+            return type;
         }
 
         internal IEnumerable<MessageMetadata> GetAllMessages()
@@ -143,6 +161,7 @@
 
         Conventions conventions;
         Dictionary<RuntimeTypeHandle, MessageMetadata> messages = new Dictionary<RuntimeTypeHandle, MessageMetadata>();
+        List<Tuple<string, Type>> cachedTypes = new List<Tuple<string, Type>>();
 
         static ILog Logger = LogManager.GetLogger<MessageMetadataRegistry>();
     }

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -83,7 +83,7 @@
 
         Type GetType(string messageTypeIdentifier)
         {
-            for (int i = 0; i < cachedTypes.Count; i++)
+            for (var i = 0; i < cachedTypes.Count; i++)
             {
                 var tuple = cachedTypes[0];
 

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -53,7 +53,16 @@
             if (messageType == null)
             {
                 Logger.DebugFormat("Message type: '{0}' could not be determined by a 'Type.GetType', scanning known messages for a match", messageTypeIdentifier);
-                return messages.Values.FirstOrDefault(m => m.MessageType.FullName == messageTypeIdentifier);
+
+                foreach (var item in messages.Values)
+                {
+                    if (item.MessageType.FullName == messageTypeIdentifier)
+                    {
+                        return item;
+                    }
+                }
+
+                return null;
             }
 
             MessageMetadata metadata;

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Unicast.Messages
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
     using Logging;
@@ -83,18 +84,13 @@
 
         Type GetType(string messageTypeIdentifier)
         {
-            for (var i = 0; i < cachedTypes.Count; i++)
+            Type type;
+
+            if (!cachedTypes.TryGetValue(messageTypeIdentifier, out type))
             {
-                var tuple = cachedTypes[0];
-
-                if (tuple.Item1 == messageTypeIdentifier)
-                {
-                    return tuple.Item2;
-                }
+                type = Type.GetType(messageTypeIdentifier, false);
+                cachedTypes[messageTypeIdentifier] = type;
             }
-
-            var type = Type.GetType(messageTypeIdentifier, false);
-            cachedTypes.Add(Tuple.Create(messageTypeIdentifier, type));
 
             return type;
         }
@@ -170,7 +166,7 @@
 
         Conventions conventions;
         Dictionary<RuntimeTypeHandle, MessageMetadata> messages = new Dictionary<RuntimeTypeHandle, MessageMetadata>();
-        List<Tuple<string, Type>> cachedTypes = new List<Tuple<string, Type>>();
+        ConcurrentDictionary<string, Type> cachedTypes = new ConcurrentDictionary<string, Type>();
 
         static ILog Logger = LogManager.GetLogger<MessageMetadataRegistry>();
     }

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -165,7 +165,7 @@
         }
 
         Conventions conventions;
-        Dictionary<RuntimeTypeHandle, MessageMetadata> messages = new Dictionary<RuntimeTypeHandle, MessageMetadata>();
+        ConcurrentDictionary<RuntimeTypeHandle, MessageMetadata> messages = new ConcurrentDictionary<RuntimeTypeHandle, MessageMetadata>();
         ConcurrentDictionary<string, Type> cachedTypes = new ConcurrentDictionary<string, Type>();
 
         static ILog Logger = LogManager.GetLogger<MessageMetadataRegistry>();

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -59,6 +59,7 @@
                 {
                     if (item.MessageType.FullName == messageTypeIdentifier)
                     {
+                        cachedTypes[messageTypeIdentifier] = item.MessageType;
                         return item;
                     }
                 }


### PR DESCRIPTION
While doing some profiling, I noticed that the `MessageMetadataRegistry.GetMessageMetadata` method that takes a string was showing up as being very expensive.

This optimizes the method by caching the result of the `Type.GetType` call instead of calling it every time.

For the scenario I was profiling, (seeding 200K messages, and then running an endpoint to receive all of them) this reduces the total time spent in this method from around 2,000 ms to about 70ms.

I also went ahead and removed the LINQ usage from the method to prevent the capture allocation for each call. 

I'm not sure when we'd actually hit the scenario where `messageType` would be null. Is it possible that we don't need this test at all now?