### PR TITLE
Set invariant culture in core tests

### DIFF
--- a/src/NServiceBus.Core.Tests/GlobalTestSetup.cs
+++ b/src/NServiceBus.Core.Tests/GlobalTestSetup.cs
@@ -1,0 +1,16 @@
+﻿namespace NServiceBus.Core.Tests
+{
+    using System.Globalization;
+    using System.Threading;
+    using NUnit.Framework;
+
+    [SetUpFixture]
+    public class GlobalTestSetup
+    {
+        [OneTimeSetUp]
+        public void Initialize()
+        {
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Fakes\TestableMessageHandlerContextTests.cs" />
     <Compile Include="Fakes\TestableMessageSessionTests.cs" />
     <Compile Include="Features\FeatureDifferingOnlyByNamespaceTests.cs" />
+    <Compile Include="GlobalTestSetup.cs" />
     <Compile Include="Handlers\MessageHandlerRegistryTests.cs" />
     <Compile Include="MessageMapper\MessageMapperTests.cs" />
     <Compile Include="Msmq\MsmqMessagePumpTests.cs" />

--- a/src/NServiceBus.Core.Tests/RedirectHelper.cs
+++ b/src/NServiceBus.Core.Tests/RedirectHelper.cs
@@ -7,7 +7,6 @@ using NUnit.Framework;
 [SetUpFixture]
 public class RedirectHelper
 {
-
     [OneTimeSetUp]
     public void Initialize()
     {


### PR DESCRIPTION
### What is the problem?

Some unit tests make assertions on exception messages. When these test are executed on operating systems using a culture that is different than one of the English variants, they fail because the exception messages are localized.

### What to do about it?

The easiest solution to this problem that I found is to run all the tests with invariant culture (English without any other culture specific modifications).