### PR TITLE
Distinct distribution strategies between sends and publishes

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/When_extending_command_routing.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_extending_command_routing.cs
@@ -65,19 +65,18 @@
                         new EndpointInstance(ReceiverEndpoint, "XYZ"),
                         new EndpointInstance(ReceiverEndpoint, "ABC")
                     });
-                    context.DistributionPolicy().SetDistributionStrategy(ReceiverEndpoint, new XyzDistributionStrategy());
+                    context.DistributionPolicy().SetDistributionStrategy(new XyzDistributionStrategy(ReceiverEndpoint));
                 }
 
                 class XyzDistributionStrategy : DistributionStrategy
                 {
-                    public override EndpointInstance SelectReceiver(EndpointInstance[] allInstances)
+                    public XyzDistributionStrategy(string endpoint) : base(endpoint, DistributionStrategyScope.Send)
                     {
-                        return allInstances.First(x => x.Discriminator.Contains("XYZ"));
                     }
 
-                    public override string SelectSubscriber(string[] subscriberAddresses)
+                    public override string SelectReceiver(string[] receiverAddresses)
                     {
-                        throw new System.NotImplementedException();
+                        return receiverAddresses.First(x => x.Contains("XYZ"));
                     }
                 }
             }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -295,7 +295,12 @@ namespace NServiceBus
     public class DistributionPolicy : NServiceBus.IDistributionPolicy
     {
         public DistributionPolicy() { }
-        public void SetDistributionStrategy(string endpointName, NServiceBus.Routing.DistributionStrategy distributionStrategy) { }
+        public void SetDistributionStrategy(NServiceBus.Routing.DistributionStrategy distributionStrategy) { }
+    }
+    public enum DistributionStrategyScope
+    {
+        Send = 0,
+        Publish = 1,
     }
     public class static DurableMessagesConfig
     {
@@ -800,7 +805,7 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> ApplyLabelToMessages(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> transportExtensions, System.Func<System.Collections.Generic.IReadOnlyDictionary<string, string>, string> labelGenerator) { }
         public static NServiceBus.InstanceMappingFileSettings InstanceMappingFile(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config) { }
         public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> OverrideAddressTranslation(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config, System.Func<NServiceBus.LogicalAddress, string> translationRule) { }
-        public static void SetMessageDistributionStrategy(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config, string endpointName, NServiceBus.Routing.DistributionStrategy distributionStrategy) { }
+        public static void SetMessageDistributionStrategy(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config, NServiceBus.Routing.DistributionStrategy distributionStrategy) { }
         public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> TransactionScopeOptions(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> transportExtensions, System.Nullable<System.TimeSpan> timeout = null, System.Nullable<System.Transactions.IsolationLevel> isolationLevel = null) { }
     }
     public class MsmqTransport : NServiceBus.Transport.TransportDefinition, NServiceBus.Routing.IMessageDrivenSubscriptionTransport
@@ -2558,9 +2563,10 @@ namespace NServiceBus.Routing
     }
     public abstract class DistributionStrategy
     {
-        protected DistributionStrategy() { }
-        public abstract NServiceBus.Routing.EndpointInstance SelectReceiver(NServiceBus.Routing.EndpointInstance[] allInstances);
-        public abstract string SelectSubscriber(string[] subscriberAddresses);
+        protected DistributionStrategy(string endpoint, NServiceBus.DistributionStrategyScope scope) { }
+        public string Endpoint { get; }
+        public NServiceBus.DistributionStrategyScope Scope { get; }
+        public abstract string SelectReceiver(string[] receiverAddresses);
     }
     public sealed class EndpointInstance
     {
@@ -2602,9 +2608,8 @@ namespace NServiceBus.Routing
     }
     public class SingleInstanceRoundRobinDistributionStrategy : NServiceBus.Routing.DistributionStrategy
     {
-        public SingleInstanceRoundRobinDistributionStrategy() { }
-        public override NServiceBus.Routing.EndpointInstance SelectReceiver(NServiceBus.Routing.EndpointInstance[] allInstances) { }
-        public override string SelectSubscriber(string[] subscriberAddresses) { }
+        public SingleInstanceRoundRobinDistributionStrategy(string endpoint, NServiceBus.DistributionStrategyScope scope) { }
+        public override string SelectReceiver(string[] receiverAddresses) { }
     }
     public class UnicastAddressTag : NServiceBus.Routing.AddressTag
     {

--- a/src/NServiceBus.Core.Tests/Routing/DistributionPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DistributionPolicyTests.cs
@@ -11,7 +11,7 @@
         {
             IDistributionPolicy policy = new DistributionPolicy();
 
-            var result = policy.GetDistributionStrategy("SomeEndpoint");
+            var result = policy.GetDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Send);
 
             Assert.That(result, Is.TypeOf<SingleInstanceRoundRobinDistributionStrategy>());
         }
@@ -20,11 +20,11 @@
         public void When_strategy_configured_for_endpoint_should_use_configured_strategy()
         {
             var p = new DistributionPolicy();
-            var configuredStrategy = new FakeDistributionStrategy();
-            p.SetDistributionStrategy("SomeEndpoint", configuredStrategy);
+            var configuredStrategy = new FakeDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Send);
+            p.SetDistributionStrategy(configuredStrategy);
 
             IDistributionPolicy policy = p;
-            var result = policy.GetDistributionStrategy("SomeEndpoint");
+            var result = policy.GetDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Send);
 
             Assert.That(result, Is.EqualTo(configuredStrategy));
         }
@@ -33,27 +33,26 @@
         public void When_multiple_strategies_configured_endpoint_should_use_last_configured_strategy()
         {
             var p = new DistributionPolicy();
-            var strategy = new FakeDistributionStrategy();
-            p.SetDistributionStrategy("SomeEndpoint", new FakeDistributionStrategy());
-            p.SetDistributionStrategy("SomeEndpoint", new FakeDistributionStrategy());
-            p.SetDistributionStrategy("SomeEndpoint", strategy);
+            var strategy1 = new FakeDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Send);
+            var strategy2 = new FakeDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Send);
+            p.SetDistributionStrategy(strategy1);
+            p.SetDistributionStrategy(strategy2);
 
             IDistributionPolicy policy = p;
-            var result = policy.GetDistributionStrategy("SomeEndpoint");
+            var result = policy.GetDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Send);
 
-            Assert.That(result, Is.EqualTo(strategy));
+            Assert.That(result, Is.EqualTo(strategy2));
         }
 
         class FakeDistributionStrategy : DistributionStrategy
         {
-            public override EndpointInstance SelectReceiver(EndpointInstance[] allInstances)
+            public FakeDistributionStrategy(string endpoint, DistributionStrategyScope scope) : base(endpoint, scope)
             {
-                return null;
             }
 
-            public override string SelectSubscriber(string[] subscriberAddresses)
+            public override string SelectReceiver(string[] receiverAddresses)
             {
-                throw new System.NotImplementedException();
+                return null;
             }
         }
     }

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
@@ -224,7 +224,7 @@
             var metadataRegistry = new MessageMetadataRegistry(new Conventions());
             metadataRegistry.RegisterMessageTypesFoundIn(new List<Type> { typeof(MyMessage), typeof(MessageWithoutRouting) });
 
-            return new UnicastSendRouterConnector(sharedQueue, instanceSpecificQueue, router ?? new FakeSendRouter(), new DistributionPolicy());
+            return new UnicastSendRouterConnector(sharedQueue, instanceSpecificQueue, router ?? new FakeSendRouter(), new DistributionPolicy(), e => e.ToString());
         }
 
         class FakeSendRouter : IUnicastSendRouter

--- a/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Core.Tests.Routing
 {
     using System.Collections.Generic;
-    using NServiceBus.Routing;
     using NUnit.Framework;
 
     [TestFixture]
@@ -14,22 +13,22 @@ namespace NServiceBus.Core.Tests.Routing
             var policy = new DistributionPolicy();
             var endpointAInstances = new[]
             {
-                new EndpointInstance(endpointA, "1"),
-                new EndpointInstance(endpointA, "2")
+                endpointA + "1",
+                endpointA + "2"
             };
 
             var endpointB = "endpointB";
             var endpointBInstances = new[]
             {
-                new EndpointInstance(endpointB, "1"),
-                new EndpointInstance(endpointB, "2")
+                endpointB + "1",
+                endpointB + "2"
             };
 
-            var result = new List<EndpointInstance>();
-            result.Add(InvokeDistributionStrategy(policy, endpointAInstances));
-            result.Add(InvokeDistributionStrategy(policy, endpointBInstances));
-            result.Add(InvokeDistributionStrategy(policy, endpointAInstances));
-            result.Add(InvokeDistributionStrategy(policy, endpointBInstances));
+            var result = new List<string>();
+            result.Add(InvokeDistributionStrategy(policy, endpointA, endpointAInstances));
+            result.Add(InvokeDistributionStrategy(policy, endpointB, endpointBInstances));
+            result.Add(InvokeDistributionStrategy(policy, endpointA, endpointAInstances));
+            result.Add(InvokeDistributionStrategy(policy, endpointB, endpointBInstances));
 
             Assert.That(result.Count, Is.EqualTo(4));
             Assert.That(result, Has.Exactly(1).EqualTo(endpointAInstances[0]));
@@ -38,9 +37,9 @@ namespace NServiceBus.Core.Tests.Routing
             Assert.That(result, Has.Exactly(1).EqualTo(endpointBInstances[1]));
         }
 
-        static EndpointInstance InvokeDistributionStrategy(IDistributionPolicy policy, EndpointInstance[] instances)
+        static string InvokeDistributionStrategy(IDistributionPolicy policy, string endpointName, string[] instanceAddress)
         {
-            return policy.GetDistributionStrategy(instances[0].Endpoint).SelectReceiver(instances);
+            return policy.GetDistributionStrategy(endpointName, DistributionStrategyScope.Send).SelectReceiver(instanceAddress);
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
@@ -11,17 +11,16 @@
         [Test]
         public void ShouldRoundRobinOverAllProvidedInstances()
         {
-            var strategy = new SingleInstanceRoundRobinDistributionStrategy();
+            var strategy = new SingleInstanceRoundRobinDistributionStrategy("endpointA", DistributionStrategyScope.Send);
 
-            var endpointName = "endpointA";
             var instances = new[]
             {
-                new EndpointInstance(endpointName, "1"),
-                new EndpointInstance(endpointName, "2"),
-                new EndpointInstance(endpointName, "3")
+                "1",
+                "2",
+                "3"
             };
 
-            var result = new List<EndpointInstance>();
+            var result = new List<string>();
             result.Add(strategy.SelectReceiver(instances));
             result.Add(strategy.SelectReceiver(instances));
             result.Add(strategy.SelectReceiver(instances));
@@ -35,17 +34,16 @@
         [Test]
         public void ShouldRestartAtFirstInstance()
         {
-            var strategy = new SingleInstanceRoundRobinDistributionStrategy();
+            var strategy = new SingleInstanceRoundRobinDistributionStrategy("endpointA", DistributionStrategyScope.Send);
 
-            var endpointName = "endpointA";
             var instances = new[]
             {
-                new EndpointInstance(endpointName, "1"),
-                new EndpointInstance(endpointName, "2"),
-                new EndpointInstance(endpointName, "3")
+                "1",
+                "2",
+                "3"
             };
 
-            var result = new List<EndpointInstance>();
+            var result = new List<string>();
             result.Add(strategy.SelectReceiver(instances));
             result.Add(strategy.SelectReceiver(instances));
             result.Add(strategy.SelectReceiver(instances));
@@ -57,19 +55,18 @@
         [Test]
         public void WhenNewInstancesAdded_ShouldIncludeAllInstancesInDistribution()
         {
-            var endpointName = "endpointA";
-            var strategy = new SingleInstanceRoundRobinDistributionStrategy();
+            var strategy = new SingleInstanceRoundRobinDistributionStrategy("endpointA", DistributionStrategyScope.Send);
 
             var instances = new []
             {
-                new EndpointInstance(endpointName, "1"),
-                new EndpointInstance(endpointName, "2"),
+                "1",
+                "2",
             };
 
-            var result = new List<EndpointInstance>();
+            var result = new List<string>();
             result.Add(strategy.SelectReceiver(instances));
             result.Add(strategy.SelectReceiver(instances));
-            instances = instances.Concat(new [] { new EndpointInstance(endpointName, "3")}).ToArray(); // add new instance
+            instances = instances.Concat(new [] { "3" }).ToArray(); // add new instance
             result.Add(strategy.SelectReceiver(instances));
 
             Assert.That(result.Count, Is.EqualTo(3));
@@ -81,17 +78,16 @@
         [Test]
         public void WhenInstancesRemoved_ShouldOnlyDistributeAcrossRemainingInstances()
         {
-            var strategy = new SingleInstanceRoundRobinDistributionStrategy();
+            var strategy = new SingleInstanceRoundRobinDistributionStrategy("endpointA", DistributionStrategyScope.Send);
 
-            var endpointName = "endpointA";
             var instances = new []
             {
-                new EndpointInstance(endpointName, "1"),
-                new EndpointInstance(endpointName, "2"),
-                new EndpointInstance(endpointName, "3")
+                "1",
+                "2",
+                "3"
             };
 
-            var result = new List<EndpointInstance>();
+            var result = new List<string>();
             result.Add(strategy.SelectReceiver(instances));
             result.Add(strategy.SelectReceiver(instances));
             instances = instances.Take(2).ToArray(); // remove last instance.
@@ -100,34 +96,6 @@
             Assert.That(result.Count, Is.EqualTo(3));
             Assert.That(result, Has.Exactly(2).EqualTo(instances[0]));
             Assert.That(result, Has.Exactly(1).EqualTo(instances[1]));
-        }
-
-        [Test]
-        public void ShouldSeperateSubscriberFromInstanceDistribution()
-        {
-            var strategy = new SingleInstanceRoundRobinDistributionStrategy();
-
-            var instances = new[]
-            {
-                new EndpointInstance("A", "instance1"),
-                new EndpointInstance("A", "instance2"),
-            };
-
-            var subscribers = new[]
-            {
-                "subscriber1",
-                "subscriber2",
-            };
-
-            var instance1 = strategy.SelectReceiver(instances);
-            var subscriber1 = strategy.SelectSubscriber(subscribers);
-            var instance2 = strategy.SelectReceiver(instances);
-            var subscriber2 = strategy.SelectSubscriber(subscribers);
-
-            Assert.That(instance1.Discriminator, Is.EqualTo("instance1"));
-            Assert.That(instance2.Discriminator, Is.EqualTo("instance2"));
-            Assert.That(subscriber1, Is.EqualTo("subscriber1"));
-            Assert.That(subscriber2, Is.EqualTo("subscriber2"));
         }
     }
 }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Recoverability\DelayedRetryExecutor.cs" />
     <Compile Include="Recoverability\Settings\RecoverabilitySettings.cs" />
     <Compile Include="ReleaseDateAttribute.cs" />
+    <Compile Include="Routing\DistributionStrategyScope.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\AssemblyPublisherSource.cs" />
     <Compile Include="Routing\AssemblyRouteSource.cs" />
     <Compile Include="Routing\ConfiguredPublishers.cs" />

--- a/src/NServiceBus.Core/Routing/DistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionStrategy.cs
@@ -1,22 +1,36 @@
 namespace NServiceBus.Routing
 {
     /// <summary>
-    /// Governs to which instances of a given endpoint a message is to be sent.
+    /// Determines which instance of a given endpoint a message is to be sent.
     /// </summary>
     public abstract class DistributionStrategy
     {
         /// <summary>
-        /// Selects a destination instance for a command from all known instances of a logical endpoint.
+        /// Creates a new <see cref="DistributionStrategy"/>.
         /// </summary>
-        /// /// <param name="allInstances">All known endpoint instances belonging to the same logical endpoint.</param>
-        /// <returns>The endpoint instance to receive the message.</returns>
-        public abstract EndpointInstance SelectReceiver(EndpointInstance[] allInstances);
+        /// <param name="endpoint">The name of the endpoint this distribution strategy resolves instances for.</param>
+        /// <param name="scope">The scope for this strategy.</param>
+        protected DistributionStrategy(string endpoint, DistributionStrategyScope scope)
+        {
+            Guard.AgainstNullAndEmpty(nameof(endpoint), endpoint);
+
+            Endpoint = endpoint;
+            Scope = scope;
+        }
 
         /// <summary>
-        /// Selects a subscriber address to receive an event from all known subscriber addresses of a logical endpoint.
+        /// Selects a destination instance for a message from all known addresses of a logical endpoint.
         /// </summary>
-        /// <param name="subscriberAddresses">All known subscriber addresses belonging to the same logical endpoint.</param>
-        /// <returns>The subscriber address to receive the event.</returns>
-        public abstract string SelectSubscriber(string[] subscriberAddresses);
+        public abstract string SelectReceiver(string[] receiverAddresses);
+
+        /// <summary>
+        /// The name of the endpoint this distribution strategy resolves instances for.
+        /// </summary>
+        public string Endpoint { get; }
+
+        /// <summary>
+        /// The scope of this strategy.
+        /// </summary>
+        public DistributionStrategyScope Scope { get; }
     }
 }

--- a/src/NServiceBus.Core/Routing/DistributionStrategyScope.cs
+++ b/src/NServiceBus.Core/Routing/DistributionStrategyScope.cs
@@ -1,0 +1,21 @@
+namespace NServiceBus
+{
+    using Routing;
+
+    /// <summary>
+    /// Defines the usage scope of a <see cref="DistributionStrategy"/>.
+    /// </summary>
+    public enum DistributionStrategyScope
+    {
+
+        /// <summary>
+        /// All outgoing messages and commands, excluding events and subscription messages.
+        /// </summary>
+        Send,
+
+        /// <summary>
+        /// All published events.
+        /// </summary>
+        Publish
+    }
+}

--- a/src/NServiceBus.Core/Routing/IDistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/IDistributionPolicy.cs
@@ -4,6 +4,6 @@ namespace NServiceBus
 
     interface IDistributionPolicy
     {
-        DistributionStrategy GetDistributionStrategy(string endpointName);
+        DistributionStrategy GetDistributionStrategy(string endpointName, DistributionStrategyScope scope);
     }
 }

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -46,7 +46,7 @@
             context.Pipeline.Register(b =>
             {
                 var unicastSendRouter = new UnicastSendRouter(unicastRoutingTable, endpointInstances, i => transportInfrastructure.ToTransportAddress(new LogicalAddress(i)));
-                return new UnicastSendRouterConnector(context.Settings.LocalAddress(), context.Settings.InstanceSpecificQueue(), unicastSendRouter, distributionPolicy);
+                return new UnicastSendRouterConnector(context.Settings.LocalAddress(), context.Settings.InstanceSpecificQueue(), unicastSendRouter, distributionPolicy, i => transportInfrastructure.ToTransportAddress(new LogicalAddress(i)));
             }, "Determines how the message being sent should be routed");
 
             context.Pipeline.Register(new UnicastReplyRouterConnector(), "Determines how replies should be routed");

--- a/src/NServiceBus.Core/Routing/SingleInstanceRoundRobinDistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/SingleInstanceRoundRobinDistributionStrategy.cs
@@ -8,38 +8,30 @@ namespace NServiceBus.Routing
     public class SingleInstanceRoundRobinDistributionStrategy : DistributionStrategy
     {
         /// <summary>
-        /// Selects a destination instance for a command from all known instances of a logical endpoint.
+        /// Creates a new <see cref="SingleInstanceRoundRobinDistributionStrategy"/> instance.
         /// </summary>
-        /// /// <param name="allInstances">All known endpoint instances belonging to the same logical endpoint.</param>
-        /// <returns>The endpoint instance to receive the message.</returns>
-        public override EndpointInstance SelectReceiver(EndpointInstance[] allInstances)
+        /// <param name="endpoint">The name of the endpoint this distribution strategy resolves instances for.</param>
+        /// <param name="scope">The scope for this strategy.</param>
+        public SingleInstanceRoundRobinDistributionStrategy(string endpoint, DistributionStrategyScope scope)
+            : base(endpoint, scope)
         {
-            return SelectNextElement(allInstances, ref instanceIndex);
         }
 
         /// <summary>
-        /// Selects a subscriber address to receive an event from all known subscriber addresses of a logical endpoint.
+        /// Selects a destination instance for a message from all known addresses of a logical endpoint.
         /// </summary>
-        /// <param name="subscriberAddresses">All known subscriber addresses belonging to the same logical endpoint.</param>
-        /// <returns>The subscriber address to receive the event.</returns>
-        public override string SelectSubscriber(string[] subscriberAddresses)
+        public override string SelectReceiver(string[] receiverAddresses)
         {
-            return SelectNextElement(subscriberAddresses, ref subscriberIndex);
-        }
-
-        T SelectNextElement<T>(T[] collection, ref long index)
-        {
-            if (collection.Length == 0)
+            if (receiverAddresses.Length == 0)
             {
-                return default(T);
+                return default(string);
             }
             var i = Interlocked.Increment(ref index);
-            var result = collection[(int)(i % collection.Length)];
+            var result = receiverAddresses[(int)(i % receiverAddresses.Length)];
             return result;
         }
 
         // start with -1 so the index will be at 0 after the first increment.
-        long instanceIndex = -1;
-        long subscriberIndex = -1;
+        long index = -1;
     }
 }

--- a/src/NServiceBus.Core/Routing/SpecificInstanceDistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/SpecificInstanceDistributionPolicy.cs
@@ -6,42 +6,44 @@ namespace NServiceBus
 
     class SpecificInstanceDistributionPolicy : IDistributionPolicy
     {
-        readonly string specificInstance;
-
-        public SpecificInstanceDistributionPolicy(string specificInstance)
+        public SpecificInstanceDistributionPolicy(string discriminator, Func<EndpointInstance, string> transportAddressTranslation)
         {
-            this.specificInstance = specificInstance;
+            this.discriminator = discriminator;
+            this.transportAddressTranslation = transportAddressTranslation;
         }
 
-        public DistributionStrategy GetDistributionStrategy(string endpointName)
+        public DistributionStrategy GetDistributionStrategy(string endpointName, DistributionStrategyScope scope)
         {
-            return new SpecificInstanceDistributionStrategy(specificInstance);
+            return new SpecificInstanceDistributionStrategy(
+                new EndpointInstance(endpointName, discriminator),
+                transportAddressTranslation, scope);
         }
+
+        readonly Func<EndpointInstance, string> transportAddressTranslation;
+        string discriminator;
 
         class SpecificInstanceDistributionStrategy : DistributionStrategy
         {
-            public SpecificInstanceDistributionStrategy(string specificInstance)
+            public SpecificInstanceDistributionStrategy(EndpointInstance instance, Func<EndpointInstance, string> transportAddressTranslation, DistributionStrategyScope scope) : base(instance.Endpoint, scope)
             {
-                this.specificInstance = specificInstance;
+                this.instance = instance;
+                this.transportAddressTranslation = transportAddressTranslation;
             }
 
-            public override EndpointInstance SelectReceiver(EndpointInstance[] allInstances)
+            public override string SelectReceiver(string[] receiverAddresses)
             {
-                var target = allInstances.FirstOrDefault(t => t.Discriminator == specificInstance);
+                var instanceAddress = transportAddressTranslation(instance);
+                var target = receiverAddresses.FirstOrDefault(t => t == instanceAddress);
                 if (target == null)
                 {
-                    throw new Exception($"Specified instance {specificInstance} has not been configured in the routing tables.");
+                    throw new Exception($"Specified instance with discriminator {instance.Discriminator} has not been configured in the routing tables.");
                 }
                 return target;
             }
 
-            public override string SelectSubscriber(string[] subscriberAddresses)
-            {
-                // This strategy can't be used for publishes
-                throw new NotSupportedException();
-            }
+            readonly Func<EndpointInstance, string> transportAddressTranslation;
 
-            string specificInstance;
+            EndpointInstance instance;
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
@@ -48,7 +48,7 @@ namespace NServiceBus
                 }
                 else
                 {
-                    var subscriber = distributionPolicy.GetDistributionStrategy(group.First().Endpoint).SelectSubscriber(group.Select(s => s.TransportAddress).ToArray());
+                    var subscriber = distributionPolicy.GetDistributionStrategy(group.First().Endpoint, DistributionStrategyScope.Publish).SelectReceiver(group.Select(s => s.TransportAddress).ToArray());
                     addresses.Add(subscriber);
                 }
             }

--- a/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
@@ -31,9 +31,10 @@ namespace NServiceBus
                 return new UnicastRoutingStrategy(transportAddressTranslation(route.Instance));
             }
 
-            var instances = endpointInstances.FindInstances(route.Endpoint).ToArray();
-            var selectedInstance = distributionPolicy.GetDistributionStrategy(route.Endpoint).SelectReceiver(instances);
-            return new UnicastRoutingStrategy(transportAddressTranslation(selectedInstance));
+
+            var instances = endpointInstances.FindInstances(route.Endpoint).Select(e => transportAddressTranslation(e)).ToArray();
+            var selectedInstanceAddress = distributionPolicy.GetDistributionStrategy(route.Endpoint, DistributionStrategyScope.Send).SelectReceiver(instances);
+            return new UnicastRoutingStrategy(selectedInstanceAddress);
         }
 
         EndpointInstances endpointInstances;

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqConfigurationExtensions.cs
@@ -46,11 +46,10 @@ namespace NServiceBus
         /// Sets a distribution strategy for a given endpoint.
         /// </summary>
         /// <param name="config">Config object.</param>
-        /// <param name="endpointName">The name of the logical endpoint the given strategy should apply to.</param>
         /// <param name="distributionStrategy">The instance of a distribution strategy.</param>
-        public static void SetMessageDistributionStrategy(this RoutingSettings<MsmqTransport> config, string endpointName, DistributionStrategy distributionStrategy)
+        public static void SetMessageDistributionStrategy(this RoutingSettings<MsmqTransport> config, DistributionStrategy distributionStrategy)
         {
-            config.Settings.GetOrCreate<DistributionPolicy>().SetDistributionStrategy(endpointName, distributionStrategy);
+            config.Settings.GetOrCreate<DistributionPolicy>().SetDistributionStrategy(distributionStrategy);
         }
 
         /// <summary>


### PR DESCRIPTION
based on top of #4065 

Please do not merge. Let's merge #4065 first and then change the base of this PR.

Changes the distribution strategy according to @SzymonPobiega proposal to always accept resolved addresses instead of `EndpointInstance` to have the same API for publishes and sends.

We still need to differentiate publishes and sends because of the received parameters in the resolved strategies. Therefore adding/resolving strategies requires a scope parameter, which defines whether that strategy is used for publishes or sends.

ping @SzymonPobiega @DavidBoike @bording 

Todo:
* [ ] Add tests for subscription related distribution strategies
* [x] Fix `RouteToSpecificEndpoint`
* [x] Raise doco issue https://github.com/Particular/docs.particular.net/issues/1802