### PR TITLE
Improve ToUtcDateTime performance

### DIFF
--- a/src/NServiceBus.Core.Tests/DateTimeExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/DateTimeExtensionsTests.cs
@@ -1,5 +1,4 @@
-﻿
-namespace NServiceBus.Core.Tests
+﻿namespace NServiceBus.Core.Tests
 {
     using System;
     using System.Globalization;
@@ -19,7 +18,7 @@ namespace NServiceBus.Core.Tests
         }
 
         [Test]
-        public void When_roundtripping_UtcNow_should_be_accurate_to_millisecond()
+        public void When_roundtripping_UtcNow_should_be_accurate_to_microseconds()
         {
             var date = DateTime.UtcNow;
             var dateString = DateTimeExtensions.ToWireFormattedString(date);
@@ -32,10 +31,11 @@ namespace NServiceBus.Core.Tests
             Assert.AreEqual(date.Minute, result.Minute);
             Assert.AreEqual(date.Second, result.Second);
             Assert.AreEqual(date.Millisecond, result.Millisecond);
+            Assert.AreEqual(date.Microseconds(), result.Microseconds());
         }
 
         [Test]
-        public void When_converting_string_should_be_accurate_to_millisecond()
+        public void When_converting_string_should_be_accurate_to_microseconds()
         {
             var dateString = "2016-08-16 10:06:20:123456 Z";
             var date = DateTime.ParseExact(dateString, "yyyy-MM-dd HH:mm:ss:ffffff Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
@@ -48,6 +48,7 @@ namespace NServiceBus.Core.Tests
             Assert.AreEqual(date.Minute, result.Minute);
             Assert.AreEqual(date.Second, result.Second);
             Assert.AreEqual(date.Millisecond, result.Millisecond);
+            Assert.AreEqual(date.Microseconds(), result.Microseconds());
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/DateTimeExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/DateTimeExtensionsTests.cs
@@ -1,0 +1,71 @@
+﻿
+namespace NServiceBus.Core.Tests
+{
+    using System;
+    using System.Globalization;
+    using NUnit.Framework;
+
+    [TestFixture]
+    class DateTimeExtensionsTests
+    {
+        [Test]
+        public void When_roundtripping_constructed_date_should_be_equal()
+        {
+            var date = new DateTime(2016, 8, 29, 16, 37, 25, 75, DateTimeKind.Utc);
+            var dateString = DateTimeExtensions.ToWireFormattedString(date);
+            var result = DateTimeExtensions.ToUtcDateTime(dateString);
+
+            Assert.AreEqual(date, result);
+        }
+
+        [Test]
+        public void When_roundtripping_UtcNow_should_be_accurate_to_millisecond()
+        {
+            var date = DateTime.UtcNow;
+            var dateString = DateTimeExtensions.ToWireFormattedString(date);
+            var result = DateTimeExtensions.ToUtcDateTime(dateString);
+
+            Assert.AreEqual(date.Year, result.Year);
+            Assert.AreEqual(date.Month, result.Month);
+            Assert.AreEqual(date.Day, result.Day);
+            Assert.AreEqual(date.Hour, result.Hour);
+            Assert.AreEqual(date.Minute, result.Minute);
+            Assert.AreEqual(date.Second, result.Second);
+            Assert.AreEqual(date.Millisecond, result.Millisecond);
+        }
+
+        [Test]
+        public void When_converting_string_should_be_accurate_to_millisecond()
+        {
+            var dateString = "2016-08-16 10:06:20:123456 Z";
+            var date = DateTime.ParseExact(dateString, "yyyy-MM-dd HH:mm:ss:ffffff Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
+            var result = DateTimeExtensions.ToUtcDateTime(dateString);
+
+            Assert.AreEqual(date.Year, result.Year);
+            Assert.AreEqual(date.Month, result.Month);
+            Assert.AreEqual(date.Day, result.Day);
+            Assert.AreEqual(date.Hour, result.Hour);
+            Assert.AreEqual(date.Minute, result.Minute);
+            Assert.AreEqual(date.Second, result.Second);
+            Assert.AreEqual(date.Millisecond, result.Millisecond);
+        }
+
+        [Test]
+        public void When_converting_string_that_is_too_short_should_throw()
+        {
+            var dateString = "201-08-16 10:06:20:123456 Z";
+
+            var exception = Assert.Throws<FormatException>(() => DateTimeExtensions.ToUtcDateTime(dateString));
+            Assert.AreEqual(exception.Message, "String was not recognized as a valid DateTime.");
+        }
+
+        [Test]
+        public void When_converting_string_with_invalid_characters_should_throw()
+        {
+            var dateString = "201j-08-16 10:06:20:123456 Z";
+
+            var exception = Assert.Throws<FormatException>(() => DateTimeExtensions.ToUtcDateTime(dateString));
+            Assert.AreEqual(exception.Message, "String was not recognized as a valid DateTime.");
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Config\When_using_initialization.cs" />
     <Compile Include="ContextBagTests.cs" />
     <Compile Include="Correlation\CorrelationContextExtensionsTests.cs" />
+    <Compile Include="DateTimeExtensionsTests.cs" />
     <Compile Include="DelayedDelivery\DelayedDeliveryOptionExtensionsTests.cs" />
     <Compile Include="DelayedDelivery\RouteDeferredMessageToTimeoutManagerBehaviorTests.cs" />
     <Compile Include="Encryption\When_decrypting_a_member_that_is_missing_encryption_data.cs" />

--- a/src/NServiceBus.Core/DateTimeExtensions.cs
+++ b/src/NServiceBus.Core/DateTimeExtensions.cs
@@ -24,6 +24,11 @@ namespace NServiceBus
         {
             Guard.AgainstNullAndEmpty(nameof(wireFormattedString), wireFormattedString);
 
+            if (wireFormattedString.Length != format.Length)
+            {
+                throw new FormatException(errorMessage);
+            }
+
             var year = 0;
             var month = 0;
             var day = 0;
@@ -39,30 +44,37 @@ namespace NServiceBus
                 switch (format[i])
                 {
                     case 'y':
+                        if (digit < '0' || digit > '9') throw new FormatException(errorMessage);
                         year = year * 10 + (digit - '0');
                         break;
 
                     case 'M':
+                        if (digit < '0' || digit > '9') throw new FormatException(errorMessage);
                         month = month * 10 + (digit - '0');
                         break;
 
                     case 'd':
+                        if (digit < '0' || digit > '9') throw new FormatException(errorMessage);
                         day = day * 10 + (digit - '0');
                         break;
 
                     case 'H':
+                        if (digit < '0' || digit > '9') throw new FormatException(errorMessage);
                         hour = hour * 10 + (digit - '0');
                         break;
 
                     case 'm':
+                        if (digit < '0' || digit > '9') throw new FormatException(errorMessage);
                         minute = minute * 10 + (digit - '0');
                         break;
 
                     case 's':
+                        if (digit < '0' || digit > '9') throw new FormatException(errorMessage);
                         second = second * 10 + (digit - '0');
                         break;
 
                     case 'f':
+                        if (digit < '0' || digit > '9') throw new FormatException(errorMessage);
                         microSecond = microSecond * 10 + (digit - '0');
                         break;
                 }
@@ -72,5 +84,6 @@ namespace NServiceBus
         }
 
         const string format = "yyyy-MM-dd HH:mm:ss:ffffff Z";
+        const string errorMessage = "String was not recognized as a valid DateTime.";
     }
 }

--- a/src/NServiceBus.Core/DateTimeExtensions.cs
+++ b/src/NServiceBus.Core/DateTimeExtensions.cs
@@ -13,7 +13,7 @@ namespace NServiceBus
         /// </summary>
         public static string ToWireFormattedString(DateTime dateTime)
         {
-            return dateTime.ToUniversalTime().ToString(Format, CultureInfo.InvariantCulture);
+            return dateTime.ToUniversalTime().ToString(format, CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -23,9 +23,54 @@ namespace NServiceBus
         public static DateTime ToUtcDateTime(string wireFormattedString)
         {
             Guard.AgainstNullAndEmpty(nameof(wireFormattedString), wireFormattedString);
-            return DateTime.ParseExact(wireFormattedString, Format, CultureInfo.InvariantCulture).ToUniversalTime();
+
+            var year = 0;
+            var month = 0;
+            var day = 0;
+            var hour = 0;
+            var minute = 0;
+            var second = 0;
+            var microSecond = 0;
+
+            for (var i = 0; i < format.Length; i++)
+            {
+                var digit = wireFormattedString[i];
+
+                switch (format[i])
+                {
+                    case 'y':
+                        year = year * 10 + (digit - '0');
+                        break;
+
+                    case 'M':
+                        month = month * 10 + (digit - '0');
+                        break;
+
+                    case 'd':
+                        day = day * 10 + (digit - '0');
+                        break;
+
+                    case 'H':
+                        hour = hour * 10 + (digit - '0');
+                        break;
+
+                    case 'm':
+                        minute = minute * 10 + (digit - '0');
+                        break;
+
+                    case 's':
+                        second = second * 10 + (digit - '0');
+                        break;
+
+                    case 'f':
+                        microSecond = microSecond * 10 + (digit - '0');
+                        break;
+                }
+            }
+
+            return new DateTime(year, month, day, hour, minute, second, microSecond / 1000, DateTimeKind.Utc);
         }
 
-        const string Format = "yyyy-MM-dd HH:mm:ss:ffffff Z";
+        const string format = "yyyy-MM-dd HH:mm:ss:ffffff Z";
     }
 }

--- a/src/NServiceBus.Core/DateTimeExtensions.cs
+++ b/src/NServiceBus.Core/DateTimeExtensions.cs
@@ -80,10 +80,21 @@ namespace NServiceBus
                 }
             }
 
-            return new DateTime(year, month, day, hour, minute, second, microSecond / 1000, DateTimeKind.Utc);
+            return new DateTime(year, month, day, hour, minute, second, DateTimeKind.Utc).AddMicroseconds(microSecond);
+        }
+
+        internal static int Microseconds(this DateTime self)
+        {
+            return (int)Math.Floor(self.Ticks % TimeSpan.TicksPerMillisecond / (double)ticksPerMicrosecond);
+        }
+
+        internal static DateTime AddMicroseconds(this DateTime self, int microseconds)
+        {
+            return self.AddTicks(microseconds * ticksPerMicrosecond);
         }
 
         const string format = "yyyy-MM-dd HH:mm:ss:ffffff Z";
         const string errorMessage = "String was not recognized as a valid DateTime.";
+        const int ticksPerMicrosecond = 10;
     }
 }


### PR DESCRIPTION
`DateTimeExtensions.ToUtcDateTime` is another method that's been showing up as very expensive in my profiling.

For my test case (seeding 200K messages, and then receiving all of them) this method was taking over 1,100 ms of total execution time.

With this change, it now takes 75 ms.

One difference in the output for this approach is that the "ffffff" part of the date format can't be used directly from any of the DateTime constructors, so I've had to round it down to milliseconds instead of microseconds. Given the [note](https://msdn.microsoft.com/en-us/library/8kb3ddd4(v=vs.110).aspx#Anchor_9) about this format string option, the microsends are likely a false level of precision anyway, so I didn't think losing this would be a big deal.



