### PR TITLE
Changed DistributionPolicy to accept factory methods.

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/When_extending_command_routing.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_extending_command_routing.cs
@@ -65,19 +65,14 @@
                         new EndpointInstance(ReceiverEndpoint, "XYZ"),
                         new EndpointInstance(ReceiverEndpoint, "ABC")
                     });
-                    context.DistributionPolicy().SetDistributionStrategy(ReceiverEndpoint, new XyzDistributionStrategy());
+                    context.DistributionPolicy().SetDistributionStrategy(ReceiverEndpoint, _ => new XyzDistributionStrategy());
                 }
 
                 class XyzDistributionStrategy : DistributionStrategy
                 {
-                    public override EndpointInstance SelectReceiver(EndpointInstance[] allInstances)
+                    public override string SelectReceiver(string[] receiverAddresses)
                     {
-                        return allInstances.First(x => x.Discriminator.Contains("XYZ"));
-                    }
-
-                    public override string SelectSubscriber(string[] subscriberAddresses)
-                    {
-                        throw new System.NotImplementedException();
+                        return receiverAddresses.First(x => x.Contains("XYZ"));
                     }
                 }
             }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -294,8 +294,13 @@ namespace NServiceBus
     }
     public class DistributionPolicy : NServiceBus.IDistributionPolicy
     {
-        public DistributionPolicy() { }
-        public void SetDistributionStrategy(string endpointName, NServiceBus.Routing.DistributionStrategy distributionStrategy) { }
+        public DistributionPolicy(NServiceBus.Settings.ReadOnlySettings settings) { }
+        public void SetDistributionStrategy(string endpoint, System.Func<NServiceBus.Settings.ReadOnlySettings, NServiceBus.Routing.DistributionStrategy> distributionStrategyFactory) { }
+    }
+    public enum DistributionStrategyScope
+    {
+        Sends = 0,
+        Publishes = 1,
     }
     public class static DurableMessagesConfig
     {
@@ -800,7 +805,7 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> ApplyLabelToMessages(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> transportExtensions, System.Func<System.Collections.Generic.IReadOnlyDictionary<string, string>, string> labelGenerator) { }
         public static NServiceBus.InstanceMappingFileSettings InstanceMappingFile(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config) { }
         public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> OverrideAddressTranslation(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config, System.Func<NServiceBus.LogicalAddress, string> translationRule) { }
-        public static void SetMessageDistributionStrategy(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config, string endpointName, NServiceBus.Routing.DistributionStrategy distributionStrategy) { }
+        public static void SetMessageDistributionStrategy(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config, string endpoint, System.Func<NServiceBus.Settings.ReadOnlySettings, NServiceBus.Routing.DistributionStrategy> distributionStrategyFactory) { }
         public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> TransactionScopeOptions(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> transportExtensions, System.Nullable<System.TimeSpan> timeout = null, System.Nullable<System.Transactions.IsolationLevel> isolationLevel = null) { }
     }
     public class MsmqTransport : NServiceBus.Transport.TransportDefinition, NServiceBus.Routing.IMessageDrivenSubscriptionTransport
@@ -2559,8 +2564,7 @@ namespace NServiceBus.Routing
     public abstract class DistributionStrategy
     {
         protected DistributionStrategy() { }
-        public abstract NServiceBus.Routing.EndpointInstance SelectReceiver(NServiceBus.Routing.EndpointInstance[] allInstances);
-        public abstract string SelectSubscriber(string[] subscriberAddresses);
+        public abstract string SelectReceiver(string[] receiverAddresses);
     }
     public sealed class EndpointInstance
     {
@@ -2603,8 +2607,7 @@ namespace NServiceBus.Routing
     public class SingleInstanceRoundRobinDistributionStrategy : NServiceBus.Routing.DistributionStrategy
     {
         public SingleInstanceRoundRobinDistributionStrategy() { }
-        public override NServiceBus.Routing.EndpointInstance SelectReceiver(NServiceBus.Routing.EndpointInstance[] allInstances) { }
-        public override string SelectSubscriber(string[] subscriberAddresses) { }
+        public override string SelectReceiver(string[] receiverAddresses) { }
     }
     public class UnicastAddressTag : NServiceBus.Routing.AddressTag
     {

--- a/src/NServiceBus.Core.Tests/Routing/DistributionPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DistributionPolicyTests.cs
@@ -2,6 +2,7 @@
 {
     using NServiceBus.Routing;
     using NUnit.Framework;
+    using Settings;
 
     [TestFixture]
     public class DistributionPolicyTests
@@ -9,9 +10,9 @@
         [Test]
         public void When_no_strategy_configured_for_endpoint_should_use_round_robbin_strategy()
         {
-            IDistributionPolicy policy = new DistributionPolicy();
+            IDistributionPolicy policy = new DistributionPolicy(new SettingsHolder());
 
-            var result = policy.GetDistributionStrategy("SomeEndpoint");
+            var result = policy.GetDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Sends);
 
             Assert.That(result, Is.TypeOf<SingleInstanceRoundRobinDistributionStrategy>());
         }
@@ -19,41 +20,47 @@
         [Test]
         public void When_strategy_configured_for_endpoint_should_use_configured_strategy()
         {
-            var p = new DistributionPolicy();
+            var p = new DistributionPolicy(new SettingsHolder());
             var configuredStrategy = new FakeDistributionStrategy();
-            p.SetDistributionStrategy("SomeEndpoint", configuredStrategy);
+            p.SetDistributionStrategy("SomeEndpoint", _ => configuredStrategy);
 
             IDistributionPolicy policy = p;
-            var result = policy.GetDistributionStrategy("SomeEndpoint");
+            var result = policy.GetDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Sends);
 
             Assert.That(result, Is.EqualTo(configuredStrategy));
         }
 
         [Test]
-        public void When_multiple_strategies_configured_endpoint_should_use_last_configured_strategy()
+        public void When_requesting_a_strategy_should_always_return_the_same_instance()
         {
-            var p = new DistributionPolicy();
-            var strategy = new FakeDistributionStrategy();
-            p.SetDistributionStrategy("SomeEndpoint", new FakeDistributionStrategy());
-            p.SetDistributionStrategy("SomeEndpoint", new FakeDistributionStrategy());
-            p.SetDistributionStrategy("SomeEndpoint", strategy);
+            var p = new DistributionPolicy(new SettingsHolder());
+            p.SetDistributionStrategy("SomeEndpoint", _ => new FakeDistributionStrategy());
 
             IDistributionPolicy policy = p;
-            var result = policy.GetDistributionStrategy("SomeEndpoint");
+            var result1 = policy.GetDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Sends);
+            var result2 = policy.GetDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Sends);
 
-            Assert.That(result, Is.EqualTo(strategy));
+            Assert.AreSame(result1, result2);
+        }
+
+        [Test]
+        public void When_requesting_a_strategy_for_sends_and_publishes_should_return_different_instances()
+        {
+            var p = new DistributionPolicy(new SettingsHolder());
+            p.SetDistributionStrategy("SomeEndpoint", _ => new FakeDistributionStrategy());
+
+            IDistributionPolicy policy = p;
+            var result1 = policy.GetDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Sends);
+            var result2 = policy.GetDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Publishes);
+
+            Assert.AreNotSame(result1, result2);
         }
 
         class FakeDistributionStrategy : DistributionStrategy
         {
-            public override EndpointInstance SelectReceiver(EndpointInstance[] allInstances)
+            public override string SelectReceiver(string[] receiverAddresses)
             {
                 return null;
-            }
-
-            public override string SelectSubscriber(string[] subscriberAddresses)
-            {
-                throw new System.NotImplementedException();
             }
         }
     }

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastPublishRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastPublishRouterConnectorTests.cs
@@ -6,6 +6,7 @@
     using Extensibility;
     using NServiceBus.Routing;
     using NUnit.Framework;
+    using Settings;
     using Testing;
 
     [TestFixture]
@@ -14,7 +15,7 @@
         [Test]
         public async Task Should_set_messageintent_to_publish()
         {
-            var router = new UnicastPublishRouterConnector(new FakePublishRouter(), new DistributionPolicy());
+            var router = new UnicastPublishRouterConnector(new FakePublishRouter(), new DistributionPolicy(new SettingsHolder()));
             var context = new TestableOutgoingPublishContext();
 
             await router.Invoke(context, ctx => TaskEx.CompletedTask);

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
@@ -8,6 +8,7 @@
     using NServiceBus.Routing;
     using Unicast.Messages;
     using NUnit.Framework;
+    using Settings;
     using Testing;
 
     [TestFixture]
@@ -224,7 +225,7 @@
             var metadataRegistry = new MessageMetadataRegistry(new Conventions());
             metadataRegistry.RegisterMessageTypesFoundIn(new List<Type> { typeof(MyMessage), typeof(MessageWithoutRouting) });
 
-            return new UnicastSendRouterConnector(sharedQueue, instanceSpecificQueue, router ?? new FakeSendRouter(), new DistributionPolicy());
+            return new UnicastSendRouterConnector(sharedQueue, instanceSpecificQueue, router ?? new FakeSendRouter(), new DistributionPolicy(new SettingsHolder()), e => e.ToString());
         }
 
         class FakeSendRouter : IUnicastSendRouter

--- a/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
@@ -1,8 +1,8 @@
 namespace NServiceBus.Core.Tests.Routing
 {
     using System.Collections.Generic;
-    using NServiceBus.Routing;
     using NUnit.Framework;
+    using Settings;
 
     [TestFixture]
     public class RoutingPolicyTests
@@ -11,25 +11,25 @@ namespace NServiceBus.Core.Tests.Routing
         public void ShouldScopeDistributionToEndpointName()
         {
             var endpointA = "endpointA";
-            var policy = new DistributionPolicy();
+            var policy = new DistributionPolicy(new SettingsHolder());
             var endpointAInstances = new[]
             {
-                new EndpointInstance(endpointA, "1"),
-                new EndpointInstance(endpointA, "2")
+                endpointA + "1",
+                endpointA + "2"
             };
 
             var endpointB = "endpointB";
             var endpointBInstances = new[]
             {
-                new EndpointInstance(endpointB, "1"),
-                new EndpointInstance(endpointB, "2")
+                endpointB + "1",
+                endpointB + "2"
             };
 
-            var result = new List<EndpointInstance>();
-            result.Add(InvokeDistributionStrategy(policy, endpointAInstances));
-            result.Add(InvokeDistributionStrategy(policy, endpointBInstances));
-            result.Add(InvokeDistributionStrategy(policy, endpointAInstances));
-            result.Add(InvokeDistributionStrategy(policy, endpointBInstances));
+            var result = new List<string>();
+            result.Add(InvokeDistributionStrategy(policy, endpointA, endpointAInstances));
+            result.Add(InvokeDistributionStrategy(policy, endpointB, endpointBInstances));
+            result.Add(InvokeDistributionStrategy(policy, endpointA, endpointAInstances));
+            result.Add(InvokeDistributionStrategy(policy, endpointB, endpointBInstances));
 
             Assert.That(result.Count, Is.EqualTo(4));
             Assert.That(result, Has.Exactly(1).EqualTo(endpointAInstances[0]));
@@ -38,9 +38,9 @@ namespace NServiceBus.Core.Tests.Routing
             Assert.That(result, Has.Exactly(1).EqualTo(endpointBInstances[1]));
         }
 
-        static EndpointInstance InvokeDistributionStrategy(IDistributionPolicy policy, EndpointInstance[] instances)
+        static string InvokeDistributionStrategy(IDistributionPolicy policy, string endpointName, string[] instanceAddress)
         {
-            return policy.GetDistributionStrategy(instances[0].Endpoint).SelectReceiver(instances);
+            return policy.GetDistributionStrategy(endpointName, DistributionStrategyScope.Sends).SelectReceiver(instanceAddress);
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
@@ -13,15 +13,14 @@
         {
             var strategy = new SingleInstanceRoundRobinDistributionStrategy();
 
-            var endpointName = "endpointA";
             var instances = new[]
             {
-                new EndpointInstance(endpointName, "1"),
-                new EndpointInstance(endpointName, "2"),
-                new EndpointInstance(endpointName, "3")
+                "1",
+                "2",
+                "3"
             };
 
-            var result = new List<EndpointInstance>();
+            var result = new List<string>();
             result.Add(strategy.SelectReceiver(instances));
             result.Add(strategy.SelectReceiver(instances));
             result.Add(strategy.SelectReceiver(instances));
@@ -37,15 +36,14 @@
         {
             var strategy = new SingleInstanceRoundRobinDistributionStrategy();
 
-            var endpointName = "endpointA";
             var instances = new[]
             {
-                new EndpointInstance(endpointName, "1"),
-                new EndpointInstance(endpointName, "2"),
-                new EndpointInstance(endpointName, "3")
+                "1",
+                "2",
+                "3"
             };
 
-            var result = new List<EndpointInstance>();
+            var result = new List<string>();
             result.Add(strategy.SelectReceiver(instances));
             result.Add(strategy.SelectReceiver(instances));
             result.Add(strategy.SelectReceiver(instances));
@@ -57,19 +55,18 @@
         [Test]
         public void WhenNewInstancesAdded_ShouldIncludeAllInstancesInDistribution()
         {
-            var endpointName = "endpointA";
             var strategy = new SingleInstanceRoundRobinDistributionStrategy();
 
             var instances = new []
             {
-                new EndpointInstance(endpointName, "1"),
-                new EndpointInstance(endpointName, "2"),
+                "1",
+                "2",
             };
 
-            var result = new List<EndpointInstance>();
+            var result = new List<string>();
             result.Add(strategy.SelectReceiver(instances));
             result.Add(strategy.SelectReceiver(instances));
-            instances = instances.Concat(new [] { new EndpointInstance(endpointName, "3")}).ToArray(); // add new instance
+            instances = instances.Concat(new [] { "3" }).ToArray(); // add new instance
             result.Add(strategy.SelectReceiver(instances));
 
             Assert.That(result.Count, Is.EqualTo(3));
@@ -83,15 +80,14 @@
         {
             var strategy = new SingleInstanceRoundRobinDistributionStrategy();
 
-            var endpointName = "endpointA";
             var instances = new []
             {
-                new EndpointInstance(endpointName, "1"),
-                new EndpointInstance(endpointName, "2"),
-                new EndpointInstance(endpointName, "3")
+                "1",
+                "2",
+                "3"
             };
 
-            var result = new List<EndpointInstance>();
+            var result = new List<string>();
             result.Add(strategy.SelectReceiver(instances));
             result.Add(strategy.SelectReceiver(instances));
             instances = instances.Take(2).ToArray(); // remove last instance.
@@ -100,34 +96,6 @@
             Assert.That(result.Count, Is.EqualTo(3));
             Assert.That(result, Has.Exactly(2).EqualTo(instances[0]));
             Assert.That(result, Has.Exactly(1).EqualTo(instances[1]));
-        }
-
-        [Test]
-        public void ShouldSeperateSubscriberFromInstanceDistribution()
-        {
-            var strategy = new SingleInstanceRoundRobinDistributionStrategy();
-
-            var instances = new[]
-            {
-                new EndpointInstance("A", "instance1"),
-                new EndpointInstance("A", "instance2"),
-            };
-
-            var subscribers = new[]
-            {
-                "subscriber1",
-                "subscriber2",
-            };
-
-            var instance1 = strategy.SelectReceiver(instances);
-            var subscriber1 = strategy.SelectSubscriber(subscribers);
-            var instance2 = strategy.SelectReceiver(instances);
-            var subscriber2 = strategy.SelectSubscriber(subscribers);
-
-            Assert.That(instance1.Discriminator, Is.EqualTo("instance1"));
-            Assert.That(instance2.Discriminator, Is.EqualTo("instance2"));
-            Assert.That(subscriber1, Is.EqualTo("subscriber1"));
-            Assert.That(subscriber2, Is.EqualTo("subscriber2"));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
@@ -7,6 +7,7 @@
     using Extensibility;
     using NServiceBus.Routing;
     using NUnit.Framework;
+    using Settings;
     using Unicast.Messages;
     using Unicast.Subscriptions;
     using Unicast.Subscriptions.MessageDrivenSubscriptions;
@@ -25,7 +26,7 @@
             subscriptionStorage.Subscribers.Add(new Subscriber("address1", null));
             subscriptionStorage.Subscribers.Add(new Subscriber("address2", null));
 
-            var routes = await router.Route(typeof(Event), new DistributionPolicy(), new ContextBag());
+            var routes = await router.Route(typeof(Event), new DistributionPolicy(new SettingsHolder()), new ContextBag());
 
             var destinations = routes.Select(ExtractDestination).ToList();
             Assert.AreEqual(2, destinations.Count);
@@ -43,7 +44,7 @@
             subscriptionStorage.Subscribers.Add(new Subscriber("shipping1", shipping));
             subscriptionStorage.Subscribers.Add(new Subscriber("shipping2", shipping));
 
-            var routes = (await router.Route(typeof(Event), new DistributionPolicy(), new ContextBag())).ToArray();
+            var routes = (await router.Route(typeof(Event), new DistributionPolicy(new SettingsHolder()), new ContextBag())).ToArray();
 
             var destinations = routes.Select(ExtractDestination).ToList();
             Assert.AreEqual(2, destinations.Count);
@@ -60,7 +61,7 @@
             subscriptionStorage.Subscribers.Add(new Subscriber("address", "sales"));
             subscriptionStorage.Subscribers.Add(new Subscriber("address", "shipping"));
 
-            var routes = await router.Route(typeof(Event), new DistributionPolicy(), new ContextBag());
+            var routes = await router.Route(typeof(Event), new DistributionPolicy(new SettingsHolder()), new ContextBag());
 
             Assert.AreEqual(1, routes.Count());
             Assert.AreEqual("address", ExtractDestination(routes.Single()));
@@ -77,7 +78,7 @@
                 new EndpointInstance(logicalEndpoint, "2")
             });
 
-            var routes = await router.Route(typeof(Event), new DistributionPolicy(), new ContextBag());
+            var routes = await router.Route(typeof(Event), new DistributionPolicy(new SettingsHolder()), new ContextBag());
 
             Assert.AreEqual(1, routes.Count());
             Assert.AreEqual("address", ExtractDestination(routes.First()));
@@ -86,7 +87,7 @@
         [Test]
         public async Task Should_return_empty_list_when_no_routes_found()
         {
-            var routes = await router.Route(typeof(Event), new DistributionPolicy(), new ContextBag());
+            var routes = await router.Route(typeof(Event), new DistributionPolicy(new SettingsHolder()), new ContextBag());
 
             Assert.IsEmpty(routes);
         }

--- a/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using NServiceBus.Routing;
     using NUnit.Framework;
+    using Settings;
 
     [TestFixture]
     public class UnicastSendRouterTests
@@ -17,7 +18,7 @@
             var logicalEndpointName = "Sales";
             routingTable.AddOrReplaceRoutes("A", new List<RouteTableEntry> {new RouteTableEntry(typeof(Command), UnicastRoute.CreateFromEndpointName(logicalEndpointName)) });
 
-            var route = router.Route(typeof(Command), new DistributionPolicy());
+            var route = router.Route(typeof(Command), new DistributionPolicy(new SettingsHolder()));
 
             Assert.AreEqual(logicalEndpointName, ExtractDestination(route));
         }
@@ -34,7 +35,7 @@
                 new EndpointInstance(sales, "2"),
             });
 
-            var route = router.Route(typeof(Command), new DistributionPolicy());
+            var route = router.Route(typeof(Command), new DistributionPolicy(new SettingsHolder()));
 
             Assert.AreEqual("Sales-1", ExtractDestination(route));
         }
@@ -42,7 +43,7 @@
         [Test]
         public void Should_return_empty_list_when_no_routes_found()
         {
-            var route = router.Route(typeof(Command), new DistributionPolicy());
+            var route = router.Route(typeof(Command), new DistributionPolicy(new SettingsHolder()));
 
             Assert.IsNull(route);
         }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Recoverability\DelayedRetryExecutor.cs" />
     <Compile Include="Recoverability\Settings\RecoverabilitySettings.cs" />
     <Compile Include="ReleaseDateAttribute.cs" />
+    <Compile Include="Routing\DistributionStrategyScope.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\AssemblyPublisherSource.cs" />
     <Compile Include="Routing\AssemblyRouteSource.cs" />
     <Compile Include="Routing\ConfiguredPublishers.cs" />

--- a/src/NServiceBus.Core/Routing/DistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionPolicy.cs
@@ -1,28 +1,54 @@
 namespace NServiceBus
 {
+    using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using Routing;
+    using Settings;
 
     /// <summary>
     /// Allows to configure distribution strategies.
     /// </summary>
     public class DistributionPolicy : IDistributionPolicy
     {
+        ReadOnlySettings settings;
+
+        /// <summary>
+        /// Creates new instance of the policy.
+        /// </summary>
+        public DistributionPolicy(ReadOnlySettings settings)
+        {
+            this.settings = settings;
+        }
+
         /// <summary>
         /// Sets the distribution strategy for a given endpoint.
         /// </summary>
-        /// <param name="endpointName">Endpoint name.</param>
-        /// <param name="distributionStrategy">Distribution strategy to be used.</param>
-        public void SetDistributionStrategy(string endpointName, DistributionStrategy distributionStrategy)
+        /// <param name="endpoint">Endpoint for which configure the strategy.</param>
+        /// <param name="distributionStrategyFactory">Distribution strategy to be used.</param>
+        public void SetDistributionStrategy(string endpoint, Func<ReadOnlySettings, DistributionStrategy> distributionStrategyFactory)
         {
-            Guard.AgainstNullAndEmpty(nameof(endpointName), endpointName);
-            Guard.AgainstNull(nameof(distributionStrategy), distributionStrategy);
+            Guard.AgainstNull(nameof(distributionStrategyFactory), distributionStrategyFactory);
 
-            configuredStrategies[endpointName] = distributionStrategy;
+            configuredStrategyFactories[endpoint] = distributionStrategyFactory;
         }
 
-        DistributionStrategy IDistributionPolicy.GetDistributionStrategy(string endpointName) => configuredStrategies.GetOrAdd(endpointName, key => new SingleInstanceRoundRobinDistributionStrategy());
+        DistributionStrategy IDistributionPolicy.GetDistributionStrategy(string endpointName, DistributionStrategyScope scope)
+        {
+            return configuredStrategies.GetOrAdd(Tuple.Create(endpointName, scope), k => CreateStrategy(k.Item1));
+        }
 
-        ConcurrentDictionary<string, DistributionStrategy> configuredStrategies = new ConcurrentDictionary<string, DistributionStrategy>();
+        DistributionStrategy CreateStrategy(string key)
+        {
+            Func<ReadOnlySettings, DistributionStrategy> factory;
+            if (configuredStrategyFactories.TryGetValue(key, out factory))
+            {
+                return factory(settings);
+            }
+            return new SingleInstanceRoundRobinDistributionStrategy();
+        }
+
+        Dictionary<string, Func<ReadOnlySettings, DistributionStrategy>> configuredStrategyFactories = new Dictionary<string, Func<ReadOnlySettings, DistributionStrategy>>();
+        ConcurrentDictionary<Tuple<string, DistributionStrategyScope>, DistributionStrategy> configuredStrategies = new ConcurrentDictionary<Tuple<string, DistributionStrategyScope>, DistributionStrategy>();
     }
 }

--- a/src/NServiceBus.Core/Routing/DistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionStrategy.cs
@@ -6,17 +6,8 @@ namespace NServiceBus.Routing
     public abstract class DistributionStrategy
     {
         /// <summary>
-        /// Selects a destination instance for a command from all known instances of a logical endpoint.
+        /// Selects a destination instance for a message from all known addresses of a logical endpoint.
         /// </summary>
-        /// /// <param name="allInstances">All known endpoint instances belonging to the same logical endpoint.</param>
-        /// <returns>The endpoint instance to receive the message.</returns>
-        public abstract EndpointInstance SelectReceiver(EndpointInstance[] allInstances);
-
-        /// <summary>
-        /// Selects a subscriber address to receive an event from all known subscriber addresses of a logical endpoint.
-        /// </summary>
-        /// <param name="subscriberAddresses">All known subscriber addresses belonging to the same logical endpoint.</param>
-        /// <returns>The subscriber address to receive the event.</returns>
-        public abstract string SelectSubscriber(string[] subscriberAddresses);
+        public abstract string SelectReceiver(string[] receiverAddresses);
     }
 }

--- a/src/NServiceBus.Core/Routing/DistributionStrategyScope.cs
+++ b/src/NServiceBus.Core/Routing/DistributionStrategyScope.cs
@@ -1,0 +1,21 @@
+namespace NServiceBus
+{
+    using Routing;
+
+    /// <summary>
+    /// Defines the scope of a <see cref="DistributionStrategy"/>.
+    /// </summary>
+    public enum DistributionStrategyScope
+    {
+
+        /// <summary>
+        /// All outgoing messages and commands excluding events and subscription messages.
+        /// </summary>
+        Sends,
+
+        /// <summary>
+        /// All published messages.
+        /// </summary>
+        Publishes
+    }
+}

--- a/src/NServiceBus.Core/Routing/IDistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/IDistributionPolicy.cs
@@ -4,6 +4,6 @@ namespace NServiceBus
 
     interface IDistributionPolicy
     {
-        DistributionStrategy GetDistributionStrategy(string endpointName);
+        DistributionStrategy GetDistributionStrategy(string endpointName, DistributionStrategyScope scope);
     }
 }

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -17,7 +17,7 @@
                 s.SetDefault<UnicastRoutingTable>(new UnicastRoutingTable());
                 s.SetDefault<EndpointInstances>(new EndpointInstances());
                 s.SetDefault<Publishers>(new Publishers());
-                s.SetDefault<DistributionPolicy>(new DistributionPolicy());
+                s.SetDefault<DistributionPolicy>(new DistributionPolicy(s));
                 s.SetDefault<ConfiguredUnicastRoutes>(new ConfiguredUnicastRoutes());
                 s.SetDefault<ConfiguredPublishers>(new ConfiguredPublishers());
             });
@@ -46,7 +46,7 @@
             context.Pipeline.Register(b =>
             {
                 var unicastSendRouter = new UnicastSendRouter(unicastRoutingTable, endpointInstances, i => transportInfrastructure.ToTransportAddress(new LogicalAddress(i)));
-                return new UnicastSendRouterConnector(context.Settings.LocalAddress(), context.Settings.InstanceSpecificQueue(), unicastSendRouter, distributionPolicy);
+                return new UnicastSendRouterConnector(context.Settings.LocalAddress(), context.Settings.InstanceSpecificQueue(), unicastSendRouter, distributionPolicy, i => transportInfrastructure.ToTransportAddress(new LogicalAddress(i)));
             }, "Determines how the message being sent should be routed");
 
             context.Pipeline.Register(new UnicastReplyRouterConnector(), "Determines how replies should be routed");

--- a/src/NServiceBus.Core/Routing/SingleInstanceRoundRobinDistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/SingleInstanceRoundRobinDistributionStrategy.cs
@@ -8,38 +8,20 @@ namespace NServiceBus.Routing
     public class SingleInstanceRoundRobinDistributionStrategy : DistributionStrategy
     {
         /// <summary>
-        /// Selects a destination instance for a command from all known instances of a logical endpoint.
+        /// Selects a destination instance for a message from all known addresses of a logical endpoint.
         /// </summary>
-        /// /// <param name="allInstances">All known endpoint instances belonging to the same logical endpoint.</param>
-        /// <returns>The endpoint instance to receive the message.</returns>
-        public override EndpointInstance SelectReceiver(EndpointInstance[] allInstances)
+        public override string SelectReceiver(string[] receiverAddresses)
         {
-            return SelectNextElement(allInstances, ref instanceIndex);
-        }
-
-        /// <summary>
-        /// Selects a subscriber address to receive an event from all known subscriber addresses of a logical endpoint.
-        /// </summary>
-        /// <param name="subscriberAddresses">All known subscriber addresses belonging to the same logical endpoint.</param>
-        /// <returns>The subscriber address to receive the event.</returns>
-        public override string SelectSubscriber(string[] subscriberAddresses)
-        {
-            return SelectNextElement(subscriberAddresses, ref subscriberIndex);
-        }
-
-        T SelectNextElement<T>(T[] collection, ref long index)
-        {
-            if (collection.Length == 0)
+            if (receiverAddresses.Length == 0)
             {
-                return default(T);
+                return default(string);
             }
             var i = Interlocked.Increment(ref index);
-            var result = collection[(int)(i % collection.Length)];
+            var result = receiverAddresses[(int)(i % receiverAddresses.Length)];
             return result;
         }
 
         // start with -1 so the index will be at 0 after the first increment.
-        long instanceIndex = -1;
-        long subscriberIndex = -1;
+        long index = -1;
     }
 }

--- a/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
@@ -48,7 +48,7 @@ namespace NServiceBus
                 }
                 else
                 {
-                    var subscriber = distributionPolicy.GetDistributionStrategy(group.First().Endpoint).SelectSubscriber(group.Select(s => s.TransportAddress).ToArray());
+                    var subscriber = distributionPolicy.GetDistributionStrategy(group.First().Endpoint, DistributionStrategyScope.Publishes).SelectReceiver(group.Select(s => s.TransportAddress).ToArray());
                     addresses.Add(subscriber);
                 }
             }

--- a/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
@@ -31,9 +31,10 @@ namespace NServiceBus
                 return new UnicastRoutingStrategy(transportAddressTranslation(route.Instance));
             }
 
-            var instances = endpointInstances.FindInstances(route.Endpoint).ToArray();
-            var selectedInstance = distributionPolicy.GetDistributionStrategy(route.Endpoint).SelectReceiver(instances);
-            return new UnicastRoutingStrategy(transportAddressTranslation(selectedInstance));
+
+            var instances = endpointInstances.FindInstances(route.Endpoint).Select(e => transportAddressTranslation(e)).ToArray();
+            var selectedInstanceAddress = distributionPolicy.GetDistributionStrategy(route.Endpoint, DistributionStrategyScope.Sends).SelectReceiver(instances);
+            return new UnicastRoutingStrategy(selectedInstanceAddress);
         }
 
         EndpointInstances endpointInstances;


### PR DESCRIPTION
This is an alternative to https://github.com/Particular/NServiceBus/pull/4069

Instead requiring user to specify the scope, we manage the scope internally. The user provides a factory for creating distribution strategies.

An advantage of this over #4069 and the previous APIs is that it is harder to pass the same instance by accident to multiple endpoints. 