### PR TITLE
Default concurrency to max(2,LogicalProcessorCount)

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -3132,7 +3132,8 @@ namespace NServiceBus.Transport
     }
     public class PushRuntimeSettings
     {
-        public PushRuntimeSettings(int maxConcurrency = 0) { }
+        public PushRuntimeSettings() { }
+        public PushRuntimeSettings(int maxConcurrency) { }
         public static NServiceBus.Transport.PushRuntimeSettings Default { get; }
         public int MaxConcurrency { get; }
     }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -3132,7 +3132,7 @@ namespace NServiceBus.Transport
     }
     public class PushRuntimeSettings
     {
-        public PushRuntimeSettings(int maxConcurrency = 100) { }
+        public PushRuntimeSettings(int maxConcurrency = 0) { }
         public static NServiceBus.Transport.PushRuntimeSettings Default { get; }
         public int MaxConcurrency { get; }
     }

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -300,6 +300,7 @@
     <Compile Include="Timeout\FakeMessageDispatcher.cs" />
     <Compile Include="Timeout\InMemoryTimeoutPersisterTests.cs" />
     <Compile Include="Timeout\When_fetching_timeouts_from_storage.cs" />
+    <Compile Include="Transports\PushRuntimeSettingsTests.cs" />
     <Compile Include="Transports\TransportOperationsTests.cs" />
     <Compile Include="Unicast\ConfigurationSettings.cs" />
     <Compile Include="Unicast\ConfiguringMessageEndpointMapping.cs" />

--- a/src/NServiceBus.Core.Tests/Transports/PushRuntimeSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/PushRuntimeSettingsTests.cs
@@ -1,0 +1,16 @@
+﻿namespace NServiceBus.Core.Tests.Transports
+{
+    using System;
+    using NUnit.Framework;
+    using Transport;
+
+    [TestFixture]
+    public class PushRuntimeSettingsTests
+    {
+        [Test]
+        public void Should_default_concurrency_to_num_processors()
+        {
+            Assert.AreEqual(Environment.ProcessorCount, new PushRuntimeSettings().MaxConcurrency);
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Transports/PushRuntimeSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/PushRuntimeSettingsTests.cs
@@ -10,7 +10,7 @@
         [Test]
         public void Should_default_concurrency_to_num_processors()
         {
-            Assert.AreEqual(Environment.ProcessorCount, new PushRuntimeSettings().MaxConcurrency);
+            Assert.AreEqual(Math.Max(2, Environment.ProcessorCount), new PushRuntimeSettings().MaxConcurrency);
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Transports/PushRuntimeSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/PushRuntimeSettingsTests.cs
@@ -12,5 +12,11 @@
         {
             Assert.AreEqual(Math.Max(2, Environment.ProcessorCount), new PushRuntimeSettings().MaxConcurrency);
         }
+
+        [Test]
+        public void Should_honor_explicit_concurrency_settings()
+        {
+            Assert.AreEqual(10, new PushRuntimeSettings(10).MaxConcurrency);
+        }
     }
 }

--- a/src/NServiceBus.Core/Transports/PushRuntimeSettings.cs
+++ b/src/NServiceBus.Core/Transports/PushRuntimeSettings.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.Transport
         /// <summary>
         /// Constructs the settings.
         /// </summary>
-        /// <param name="maxConcurrency">The maximum concurrency to allow. 0 allows NServiceBus to pick the a suitable default.</param>
+        /// <param name="maxConcurrency">The maximum concurrency to allow. Zero allows NServiceBus to pick a suitable default.</param>
         public PushRuntimeSettings(int maxConcurrency = 0)
         {
             Guard.AgainstNegative(nameof(maxConcurrency), maxConcurrency);

--- a/src/NServiceBus.Core/Transports/PushRuntimeSettings.cs
+++ b/src/NServiceBus.Core/Transports/PushRuntimeSettings.cs
@@ -8,17 +8,20 @@ namespace NServiceBus.Transport
     public class PushRuntimeSettings
     {
         /// <summary>
+        /// Constructs the settings. NServiceBus will pick a suitable default for `MaxConcurrency`.
+        /// </summary>
+        public PushRuntimeSettings()
+        {
+            MaxConcurrency = Math.Max(2, Environment.ProcessorCount);
+        }
+
+        /// <summary>
         /// Constructs the settings.
         /// </summary>
-        /// <param name="maxConcurrency">The maximum concurrency to allow. Zero allows NServiceBus to pick a suitable default.</param>
-        public PushRuntimeSettings(int maxConcurrency = 0)
+        /// <param name="maxConcurrency">The maximum concurrency to allow.</param>
+        public PushRuntimeSettings(int maxConcurrency)
         {
-            Guard.AgainstNegative(nameof(maxConcurrency), maxConcurrency);
-
-            if (maxConcurrency == 0)
-            {
-                maxConcurrency = Math.Max(2, Environment.ProcessorCount);
-            }
+            Guard.AgainstNegativeAndZero(nameof(maxConcurrency), maxConcurrency);
 
             MaxConcurrency = maxConcurrency;
         }
@@ -27,7 +30,6 @@ namespace NServiceBus.Transport
         /// The maximum number of messages that should be in flight at any given time.
         /// </summary>
         public int MaxConcurrency { get; private set; }
-
 
         /// <summary>
         /// Use default settings.

--- a/src/NServiceBus.Core/Transports/PushRuntimeSettings.cs
+++ b/src/NServiceBus.Core/Transports/PushRuntimeSettings.cs
@@ -1,16 +1,25 @@
 namespace NServiceBus.Transport
 {
+    using System;
+
     /// <summary>
-    /// Contains the limits for how messages should be dequeued.
+    /// Controls how the message pump should behave.
     /// </summary>
     public class PushRuntimeSettings
     {
         /// <summary>
-        /// Restricts the concurrency.
+        /// Constructs the settings.
         /// </summary>
-        /// <param name="maxConcurrency">The max value to enforce.</param>
-        public PushRuntimeSettings(int maxConcurrency = 100)
+        /// <param name="maxConcurrency">The maximum concurrency to allow. 0 allows NServiceBus to pick the a suitable default.</param>
+        public PushRuntimeSettings(int maxConcurrency = 0)
         {
+            Guard.AgainstNegative(nameof(maxConcurrency), maxConcurrency);
+
+            if (maxConcurrency == 0)
+            {
+                maxConcurrency = Math.Max(2, Environment.ProcessorCount);
+            }
+
             MaxConcurrency = maxConcurrency;
         }
 


### PR DESCRIPTION
I went with logical processor count since that seems to be close enough and much easier to get at

http://stackoverflow.com/questions/1542213/how-to-find-the-number-of-cpu-cores-via-net-c

Doco PR - https://github.com/Particular/docs.particular.net/pull/1814

Closes #4089 