### PR TITLE
[WIP] Message mapper needs to lazy initialize message types not found during scanning

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -191,6 +191,7 @@
     <Compile Include="Sagas\When_saga_handles_unmapped_message.cs" />
     <Compile Include="Satellites\When_a_message_is_available.cs" />
     <Compile Include="Serialization\When_registering_deserializers_with_settings.cs" />
+    <Compile Include="Serialization\When_receiving_interface_message_where_child_is_excluded.cs" />
     <Compile Include="Serialization\When_sanitizing_xml_messages.cs" />
     <Compile Include="Serialization\When_skip_wrapping_xml.cs" />
     <Compile Include="Serialization\When_wrapping_is_not_skipped.cs" />

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_receiving_interface_message_where_child_is_excluded.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_receiving_interface_message_where_child_is_excluded.cs
@@ -1,0 +1,78 @@
+﻿namespace NServiceBus.AcceptanceTests.Serialization
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_receiving_interface_message_where_child_is_excluded : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_process_base_message()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(e => e.When(session => session.Send<ISomeMessage>(m => { })))
+                .WithEndpoint<Receiver>()
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            Assert.True(context.MessageReceived);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool MessageReceived { get; set; }
+        }
+
+        class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseSerialization<JsonSerializer>();
+                }//only reproduces on json
+                )
+                .AddMapping<ISomeMessage>(typeof(Receiver));
+            }
+        }
+
+
+        class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseSerialization<JsonSerializer>(); //only reproduces on json
+                })
+                .ExcludeType<ISomeMessage>();
+            }
+
+            class MessageHandler : IHandleMessages<ISomeBaseMessage>
+            {
+                public MessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(ISomeBaseMessage message, IMessageHandlerContext context)
+                {
+                    testContext.MessageReceived = true;
+
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public interface ISomeMessage : ISomeBaseMessage
+        {
+        }
+
+        public interface ISomeBaseMessage : IMessage
+        {
+        }
+    }
+}


### PR DESCRIPTION
Added a test that shows the use case. In a real prod scenario you would have to have:

* Interface messages
* Inheritance chain
* Child message received and available in appdomain
* Child message not included in scanning

