### PR TITLE
[WIP] Refactored logical address to not depend so much on EndpointInstance

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -753,8 +753,9 @@ namespace NServiceBus
     public class static LoadMessageHandlersExtentions { }
     public struct LogicalAddress
     {
-        public NServiceBus.Routing.EndpointInstance EndpointInstance { get; }
+        public string Discriminator { get; }
         public string Qualifier { get; }
+        public string QueueName { get; }
         public NServiceBus.LogicalAddress CreateIndividualizedAddress(string discriminator) { }
         public static NServiceBus.LogicalAddress CreateLocalAddress(string queueName, System.Collections.Generic.IReadOnlyDictionary<string, string> properties) { }
         public NServiceBus.LogicalAddress CreateQualifiedAddress(string qualifier) { }
@@ -762,6 +763,7 @@ namespace NServiceBus
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
         public override string ToString() { }
+        public bool TryGetProperty(string propertyName, out string value) { }
     }
     public class MessageDeserializationException : System.Runtime.Serialization.SerializationException
     {

--- a/src/NServiceBus.Core.Tests/StructConventionsTests.ApproveStructsWhichDontFollowStructGuidelines.approved.txt
+++ b/src/NServiceBus.Core.Tests/StructConventionsTests.ApproveStructsWhichDontFollowStructGuidelines.approved.txt
@@ -11,8 +11,9 @@ In all other cases, you should define your types as classes.
 -------------------------------------------------- REMEMBER --------------------------------------------------
 
 NServiceBus.LogicalAddress violates the following rules:
+   - The size cannot be determined. This type likely violates all struct rules.
    - The following fields are reference types, which are potentially mutable:
-      - Field <EndpointInstance>k__BackingField of type NServiceBus.Routing.EndpointInstance is a reference type.
+      - Field properties of type System.Collections.Generic.IReadOnlyDictionary`2[System.String,System.String] is a reference type.
 
 NServiceBus.MessageQueueExtensions+ACE_HEADER violates the following rules:
    - The following fields are public, so the type is not immutable:

--- a/src/NServiceBus.Core/LogicalAddress.cs
+++ b/src/NServiceBus.Core/LogicalAddress.cs
@@ -2,16 +2,23 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
     using Routing;
+    using static System.String;
 
     /// <summary>
     /// Represents a logical address (independent of transport).
     /// </summary>
     public struct LogicalAddress
     {
-        LogicalAddress(EndpointInstance endpointInstance, string qualifier)
+        IReadOnlyDictionary<string, string> properties;
+
+        LogicalAddress(string queueName, string discriminator, string qualifier, IReadOnlyDictionary<string, string> properties)
         {
-            EndpointInstance = endpointInstance;
+            this.properties = properties;
+            QueueName = queueName;
+            Discriminator = discriminator;
             Qualifier = qualifier;
         }
 
@@ -21,7 +28,8 @@
         /// <param name="endpointInstance">The endpoint instance that describes the remote endpoint.</param>
         public static LogicalAddress CreateRemoteAddress(EndpointInstance endpointInstance)
         {
-            return new LogicalAddress(endpointInstance, null);
+            Guard.AgainstNull(nameof(endpointInstance), endpointInstance);
+            return new LogicalAddress(endpointInstance.Endpoint, endpointInstance.Discriminator, null, endpointInstance.Properties);
         }
 
         /// <summary>
@@ -31,7 +39,9 @@
         /// <param name="properties">The additional transport-specific properties.</param>
         public static LogicalAddress CreateLocalAddress(string queueName, IReadOnlyDictionary<string, string> properties)
         {
-            return new LogicalAddress(new EndpointInstance(queueName, null, properties), null);
+            Guard.AgainstNullAndEmpty(nameof(queueName), queueName);
+            Guard.AgainstNull(nameof(properties), properties);
+            return new LogicalAddress(queueName, null, null, properties);
         }
 
         /// <summary>
@@ -45,11 +55,11 @@
             {
                 throw new Exception("Cannot add a qualifier to an already qualified address.");
             }
-            if (EndpointInstance.Discriminator != null)
+            if (Discriminator != null)
             {
                 throw new Exception("Cannot add a qualifier to an individualized address.");
             }
-            return new LogicalAddress(EndpointInstance, qualifier);
+            return new LogicalAddress(QueueName, null, qualifier, properties);
         }
 
 
@@ -60,7 +70,7 @@
         public LogicalAddress CreateIndividualizedAddress(string discriminator)
         {
             Guard.AgainstNullAndEmpty(nameof(discriminator), discriminator);
-            if (EndpointInstance.Discriminator != null)
+            if (Discriminator != null)
             {
                 throw new Exception("Cannot add a discriminator to an already individualized address.");
             }
@@ -68,7 +78,7 @@
             {
                 throw new Exception("Cannot add a discriminator to a qualified address.");
             }
-            return new LogicalAddress(new EndpointInstance(EndpointInstance.Endpoint, discriminator, EndpointInstance.Properties), null);
+            return new LogicalAddress(QueueName, discriminator, null, properties);
         }
 
         /// <summary>
@@ -79,11 +89,22 @@
         /// <summary>
         /// Returns the endpoint instance.
         /// </summary>
-        public EndpointInstance EndpointInstance { get; }
+        public string QueueName { get; }
 
-        bool Equals(LogicalAddress other)
+        /// <summary>
+        /// Returns the discriminator for the queue.
+        /// </summary>
+        public string Discriminator { get; }
+
+        /// <summary>
+        /// Gets a property value.
+        /// </summary>
+        /// <param name="propertyName">Name of the property.</param>
+        /// <param name="value">Value of the property.</param>
+        public bool TryGetProperty(string propertyName, out string value)
         {
-            return string.Equals(Qualifier, other.Qualifier) && Equals(EndpointInstance, other.EndpointInstance);
+            Guard.AgainstNull(nameof(propertyName), propertyName);
+            return properties.TryGetValue(propertyName, out value);
         }
 
         /// <summary>
@@ -94,45 +115,87 @@
         /// </returns>
         public override string ToString()
         {
+            var propsFormatted = properties.Select(kvp => $"{kvp.Key}:{kvp.Value}");
+            var queueNameBuilder = new StringBuilder(QueueName);
+            if (Discriminator != null)
+            {
+                queueNameBuilder.Append("-" + Discriminator);
+            }
             if (Qualifier != null)
             {
-                return EndpointInstance + "." + Qualifier;
+                queueNameBuilder.Append("." + Qualifier);
             }
-            return EndpointInstance.ToString();
+            var parts = new[]
+            {
+                queueNameBuilder.ToString()
+            }.Concat(propsFormatted);
+            return Join(";", parts);
         }
 
-        /// <summary>
-        /// Determines whether the specified object is equal to the current object.
-        /// </summary>
+        bool Equals(LogicalAddress other)
+        {
+            return PropertiesEqual(properties, other.properties)
+                   && string.Equals(Qualifier, other.Qualifier, StringComparison.Ordinal)
+                   && string.Equals(QueueName, other.QueueName, StringComparison.Ordinal)
+                   && string.Equals(Discriminator, other.Discriminator, StringComparison.Ordinal);
+        }
+
+        /// <summary>Indicates whether this instance and a specified object are equal.</summary>
         /// <returns>
-        /// true if the specified object  is equal to the current object; otherwise, false.
+        /// true if <paramref name="obj" /> and this instance are the same type and represent the same value; otherwise,
+        /// false.
         /// </returns>
-        /// <param name="obj">The object to compare with the current object. </param>
+        /// <param name="obj">The object to compare with the current instance. </param>
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
-            if (ReferenceEquals(this, obj))
-            {
-                return true;
-            }
+            if (ReferenceEquals(null, obj)) return false;
             return obj is LogicalAddress && Equals((LogicalAddress) obj);
         }
 
-        /// <summary>
-        /// Serves as a hash function for a particular type.
-        /// </summary>
-        /// <returns>
-        /// A hash code for the current object.
-        /// </returns>
+        /// <summary>Returns the hash code for this instance.</summary>
+        /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
         public override int GetHashCode()
         {
             unchecked
             {
-                return ((Qualifier?.GetHashCode() ?? 0)*397) ^ (EndpointInstance?.GetHashCode() ?? 0);
+                var hashCode = PropertiesHashcode(properties);
+                hashCode = (hashCode*397) ^ QueueName.GetHashCode();
+                hashCode = (hashCode*397) ^ (Qualifier?.GetHashCode() ?? 0);
+                hashCode = (hashCode*397) ^ (Discriminator?.GetHashCode() ?? 0);
+                return hashCode;
             }
+        }
+
+        static int PropertiesHashcode(IReadOnlyDictionary<string, string> props)
+        {
+            var hashCode = 0;
+            foreach (var kvp in props.OrderBy(kvp => kvp.Key))
+            {
+                hashCode = (hashCode*397) ^ kvp.Key.GetHashCode();
+                hashCode = (hashCode*397) ^ (kvp.Value?.GetHashCode() ?? 0);
+            }
+            return hashCode;
+        }
+
+        static bool PropertiesEqual(IReadOnlyDictionary<string, string> left, IReadOnlyDictionary<string, string> right)
+        {
+            if (left.Count != right.Count)
+            {
+                return false;
+            }
+            foreach (var p in left)
+            {
+                string equivalent;
+                if (!right.TryGetValue(p.Key, out equivalent))
+                {
+                    return false;
+                }
+                if (!string.Equals(p.Value, equivalent, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+            return true;
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Routing/EndpointInstance.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstance.cs
@@ -18,7 +18,7 @@
         {
             Guard.AgainstNull(nameof(endpoint), endpoint);
 
-            Properties = properties ?? new Dictionary<string, string>();
+            Properties = properties ?? emptyDictionary;
             Endpoint = endpoint;
             Discriminator = discriminator;
         }
@@ -152,6 +152,7 @@
         }
 
         static readonly IEqualityComparer<KeyValuePair<string, string>> propertyComparer = new PropertyComparer();
+        static Dictionary<string, string> emptyDictionary = new Dictionary<string, string>();
 
         class PropertyComparer : IEqualityComparer<KeyValuePair<string, string>>
         {

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
@@ -51,19 +51,19 @@ namespace NServiceBus
         public override string ToTransportAddress(LogicalAddress logicalAddress)
         {
             string machine;
-            if (!logicalAddress.EndpointInstance.Properties.TryGetValue("machine", out machine))
+            if (!logicalAddress.TryGetProperty("machine", out machine))
             {
                 machine = RuntimeEnvironment.MachineName;
             }
             string queueName;
-            if (!logicalAddress.EndpointInstance.Properties.TryGetValue("queue", out queueName))
+            if (!logicalAddress.TryGetProperty("queue", out queueName))
             {
-                queueName = logicalAddress.EndpointInstance.Endpoint;
+                queueName = logicalAddress.QueueName;
             }
             var queue = new StringBuilder(queueName);
-            if (logicalAddress.EndpointInstance.Discriminator != null)
+            if (logicalAddress.Discriminator != null)
             {
-                queue.Append("-" + logicalAddress.EndpointInstance.Discriminator);
+                queue.Append("-" + logicalAddress.Discriminator);
             }
             if (logicalAddress.Qualifier != null)
             {

--- a/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
@@ -49,7 +49,7 @@ namespace NServiceBus.Transport
         /// Returns the discriminator for this endpoint instance.
         /// </summary>
         public abstract EndpointInstance BindToLocalEndpoint(EndpointInstance instance);
-
+        
         /// <summary>
         /// Converts a given logical address to the transport address.
         /// </summary>


### PR DESCRIPTION
Removes the dependency on `EndpointInstance` (save for one of factory methods) and makes the concepts more explicit. The impact on downstreams is pretty small. Although the struct conventions are complaining I am sure it actually is better than before because we have less exposure to change (IReadOnlyDictionary instead of EndpointInstance)

### Downstream PRs:
 * SQL - https://github.com/Particular/NServiceBus.SqlServer/pull/295
 * RabbitMQ - https://github.com/Particular/NServiceBus.RabbitMQ/pull/197
 * ASQ - https://github.com/Particular/NServiceBus.AzureStorageQueues/pull/149
 * ASB - https://github.com/Particular/NServiceBus.AzureServiceBus/pull/316