### PR TITLE
[WIP] Changes LogicalAddress to class again.

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -751,7 +751,7 @@ namespace NServiceBus
     }
     [System.ObsoleteAttribute("Use `LoadMessageHandlersExtensions` instead. Will be removed in version 7.0.0.", true)]
     public class static LoadMessageHandlersExtentions { }
-    public struct LogicalAddress
+    public class LogicalAddress
     {
         public NServiceBus.Routing.EndpointInstance EndpointInstance { get; }
         public string Qualifier { get; }

--- a/src/NServiceBus.Core.Tests/StructConventionsTests.ApproveStructsWhichDontFollowStructGuidelines.approved.txt
+++ b/src/NServiceBus.Core.Tests/StructConventionsTests.ApproveStructsWhichDontFollowStructGuidelines.approved.txt
@@ -10,10 +10,6 @@ AVOID defining a struct unless the type has all of the following characteristics
 In all other cases, you should define your types as classes.
 -------------------------------------------------- REMEMBER --------------------------------------------------
 
-NServiceBus.LogicalAddress violates the following rules:
-   - The following fields are reference types, which are potentially mutable:
-      - Field <EndpointInstance>k__BackingField of type NServiceBus.Routing.EndpointInstance is a reference type.
-
 NServiceBus.MessageQueueExtensions+ACE_HEADER violates the following rules:
    - The following fields are public, so the type is not immutable:
       - Field AceType of type System.Byte is public.

--- a/src/NServiceBus.Core/LogicalAddress.cs
+++ b/src/NServiceBus.Core/LogicalAddress.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// Represents a logical address (independent of transport).
     /// </summary>
-    public struct LogicalAddress
+    public class LogicalAddress
     {
         LogicalAddress(EndpointInstance endpointInstance, string qualifier)
         {

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Routing\MessageDrivenSubscriptions\IPublisherSource.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\NamespacePublisherSource.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\TypePublisherSource.cs" />
+    <Compile Include="Routing\TransportAddressTranslator.cs" />
     <Compile Include="Routing\TypeRouteSource.cs" />
     <Compile Include="Routing\IDistributionPolicy.cs" />
     <Compile Include="Routing\IRouteSource.cs" />

--- a/src/NServiceBus.Core/Routing/EndpointInstance.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstance.cs
@@ -8,6 +8,8 @@
     /// </summary>
     public sealed class EndpointInstance
     {
+        int hashCode; //Instances are not mutable and hashcode is accessed frequently.
+
         /// <summary>
         /// Creates a new endpoint name for a given discriminator.
         /// </summary>
@@ -21,6 +23,7 @@
             Properties = properties ?? new Dictionary<string, string>();
             Endpoint = endpoint;
             Discriminator = discriminator;
+            hashCode = CalculateHashCode();
         }
 
         /// <summary>
@@ -126,6 +129,11 @@
         /// A hash code for the current object.
         /// </returns>
         public override int GetHashCode()
+        {
+            return hashCode;
+        }
+
+        int CalculateHashCode()
         {
             unchecked
             {

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -40,6 +40,7 @@
             var configuredPublishers = context.Settings.Get<ConfiguredPublishers>();
             var conventions = context.Settings.Get<Conventions>();
             var unicastBusConfig = context.Settings.GetConfigSection<UnicastBusConfig>();
+            var translator = new TransportAddressTranslator(transportInfrastructure);
 
             var enforceBestPractices = context.Settings.Get<bool>(EnforceBestPracticesSettingsKey);
             if (enforceBestPractices)
@@ -54,8 +55,8 @@
             var outboundRoutingPolicy = transportInfrastructure.OutboundRoutingPolicy;
             context.Pipeline.Register(b =>
             {
-                var unicastSendRouter = new UnicastSendRouter(unicastRoutingTable, endpointInstances, i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)));
-                return new UnicastSendRouterConnector(context.Settings.LocalAddress(), context.Settings.InstanceSpecificQueue(), unicastSendRouter, distributionPolicy, i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)));
+                var unicastSendRouter = new UnicastSendRouter(unicastRoutingTable, endpointInstances, i => translator.ToTransportAddress(i));
+                return new UnicastSendRouterConnector(context.Settings.LocalAddress(), context.Settings.InstanceSpecificQueue(), unicastSendRouter, distributionPolicy, i => translator.ToTransportAddress(i));
             }, "Determines how the message being sent should be routed");
 
             context.Pipeline.Register(new UnicastReplyRouterConnector(), "Determines how replies should be routed");
@@ -81,7 +82,7 @@
                 if (outboundRoutingPolicy.Publishes == OutboundRoutingType.Unicast)
                 {
                     var subscriberAddress = distributorAddress ?? context.Settings.LocalAddress();
-                    var subscriptionRouter = new SubscriptionRouter(publishers, endpointInstances, i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)));
+                    var subscriptionRouter = new SubscriptionRouter(publishers, endpointInstances, i => translator.ToTransportAddress(i));
 
                     context.Pipeline.Register(b => new MessageDrivenSubscribeTerminator(subscriptionRouter, subscriberAddress, context.Settings.EndpointName(), b.Build<IDispatchMessages>()), "Sends subscription requests when message driven subscriptions is in use");
                     context.Pipeline.Register(b => new MessageDrivenUnsubscribeTerminator(subscriptionRouter, subscriberAddress, context.Settings.EndpointName(), b.Build<IDispatchMessages>()), "Sends requests to unsubscribe when message driven subscriptions is in use");

--- a/src/NServiceBus.Core/Routing/TransportAddressTranslator.cs
+++ b/src/NServiceBus.Core/Routing/TransportAddressTranslator.cs
@@ -1,0 +1,27 @@
+namespace NServiceBus.Features
+{
+    using System.Collections.Concurrent;
+    using Routing;
+    using Transport;
+
+    class TransportAddressTranslator
+    {
+        public TransportAddressTranslator(TransportInfrastructure transportInfrastructure)
+        {
+            this.transportInfrastructure = transportInfrastructure;
+        }
+
+        public string ToTransportAddress(EndpointInstance remoteEndpointInstance)
+        {
+            return cache.GetOrAdd(remoteEndpointInstance, Translate);
+        }
+
+        string Translate(EndpointInstance endpointInstance)
+        {
+            return transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(endpointInstance));
+        }
+
+        ConcurrentDictionary<EndpointInstance, string> cache = new ConcurrentDictionary<EndpointInstance, string>();
+        TransportInfrastructure transportInfrastructure;
+    }
+}


### PR DESCRIPTION
Makes it a class again.
Introduces a cache that holds translated addresses. This way we can save on allocating the new transport address string each time we send (cost is `ConcurrentDictionary` lookup)