### PR TITLE
Split the test into two classes.

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -73,10 +73,11 @@
     <Compile Include="Routing\When_configure_routes_for_unobtrusive_messages.cs" />
     <Compile Include="Routing\When_extending_command_routing.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_extending_event_routing.cs" />
+    <Compile Include="Routing\When_registering_publishers_unobtrusive_messages_config.cs" />
     <Compile Include="Routing\When_sending_non_message_with_routing_configured_by_type.cs" />
     <Compile Include="Routing\When_sending_non_message_with_routing_configured_by_assembly.cs" />
     <Compile Include="Routing\When_sending_non_message_with_routing_configured_via_mappings.cs" />
-    <Compile Include="Routing\When_registering_publishers_unobtrusive_messages.cs" />
+    <Compile Include="Routing\When_registering_publishers_unobtrusive_messages_code.cs" />
     <Compile Include="Routing\When_publishing_an_interface_with_unobtrusive.cs" />
     <Compile Include="Routing\When_replying_to_message_with_interface_and_unobtrusive.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_subscribing_to_a_base_event.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/When_registering_publishers_unobtrusive_messages_code.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_registering_publishers_unobtrusive_messages_code.cs
@@ -1,0 +1,80 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using AcceptanceTesting.Customization;
+    using ScenarioDescriptors;
+
+    public class When_registering_publishers_unobtrusive_messages_code : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public Task Should_deliver_event()
+        {
+            return Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(e => e
+                    .When(c => c.Subscribed, s => s.Publish(new SomeEvent())))
+                .WithEndpoint<Subscriber>()
+                .Done(c => c.ReceivedMessage)
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Should(context =>
+                {
+                    Assert.That(context.Subscribed, Is.True);
+                    Assert.That(context.ReceivedMessage, Is.True);
+                })
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscribed { get; set; }
+            public bool ReceivedMessage { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.OnEndpointSubscribed<Context>((e, ctx) => ctx.Subscribed = true);
+                    c.Conventions().DefiningEventsAs(t => t == typeof(SomeEvent));
+                }).ExcludeType<SomeEvent>();
+            }
+        }
+
+        public class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.Conventions().DefiningEventsAs(t => t == typeof(SomeEvent));
+
+                    c.MessageDrivenPubSubRouting().RegisterPublisher(typeof(SomeEvent).Assembly, Conventions.EndpointNamingConvention(typeof(Publisher)));
+                });
+            }
+
+            public class EventHandler : IHandleMessages<SomeEvent>
+            {
+                Context testContext;
+
+                public EventHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(SomeEvent message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedMessage = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class SomeEvent
+        {
+        }
+    }
+}


### PR DESCRIPTION
Because it breaks persistences which are not cleaned up between the test methods.