### PR TITLE
Add EndpointInstances in fake message pump setup

### DIFF
--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -71,7 +71,9 @@
             queueBindings.BindReceiving(InputQueueName);
             queueBindings.BindSending(ErrorQueueName);
             transportSettings.Set<QueueBindings>(queueBindings);
-
+            
+            transportSettings.Set<EndpointInstances>(new EndpointInstances());
+            
             Configurer = CreateConfigurer();
 
             var configuration = Configurer.Configure(transportSettings, transactionMode);


### PR DESCRIPTION
This is needed as some of the transport e.g. SqlServer depend on `EndpointInstances` being always registered by the `Core` when transport gets initialized.

@Particular/nservicebus-maintainers 