### PR TITLE
Avoid exceptions when FileName not set on FileLoadException

### DIFF
--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -209,7 +209,7 @@ namespace NServiceBus.Hosting.Helpers
             {
                 var loadException = ex as FileLoadException;
 
-                if (loadException != null)
+                if (loadException?.FileName != null)
                 {
                     var assemblyName = new AssemblyName(loadException.FileName);
                     var assemblyPublicKeyToken = BitConverter.ToString(assemblyName.GetPublicKeyToken()).Replace("-", "").ToLowerInvariant();


### PR DESCRIPTION
backports fixes related to https://github.com/Particular/NServiceBus/issues/2722 to latest v5.

This hasn't been tested yet.