### PR TITLE
Fix local autosubscribe

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Routing/AutomaticSubscriptions/When_handling_local_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/AutomaticSubscriptions/When_handling_local_event.cs
@@ -1,8 +1,9 @@
-﻿namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
+﻿namespace NServiceBus.AcceptanceTests.Core.Routing.AutomaticSubscriptions
 {
     using System;
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using AcceptanceTests.Routing;
     using EndpointTemplates;
     using NUnit.Framework;
 

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Recoverability\When_custom_policy_moves_to_overridden_error_queue.cs" />
     <Compile Include="Recoverability\When_message_is_moved_to_error_queue_with_header_customizations.cs" />
     <Compile Include="MessageDrivenPubSubRoutingExtensions.cs" />
+    <Compile Include="Routing\AutomaticSubscriptions\When_handling_local_event.cs" />
     <Compile Include="Routing\When_configure_routes_for_unobtrusive_messages.cs" />
     <Compile Include="Routing\When_extending_command_routing.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_extending_event_routing.cs" />

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -70,7 +70,7 @@
     <Compile Include="Recoverability\When_custom_policy_moves_to_overridden_error_queue.cs" />
     <Compile Include="Recoverability\When_message_is_moved_to_error_queue_with_header_customizations.cs" />
     <Compile Include="MessageDrivenPubSubRoutingExtensions.cs" />
-    <Compile Include="Routing\AutomaticSubscriptions\When_handling_local_event.cs" />
+    <Compile Include="Core\Routing\AutomaticSubscriptions\When_handling_local_event.cs" />
     <Compile Include="Routing\When_configure_routes_for_unobtrusive_messages.cs" />
     <Compile Include="Routing\When_extending_command_routing.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_extending_event_routing.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_handling_local_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_handling_local_event.cs
@@ -1,0 +1,79 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_handling_local_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_autosubscribe_to_event()
+        {
+            var ctx = await Scenario.Define<Context>(x => x.Id = Guid.NewGuid())
+                .WithEndpoint<PublisherAndSubscriber>(b => b
+                .When((session, context) =>
+                {
+                    if (context.HasNativePubSubSupport)
+                    {
+                        context.EventSubscribed = true;
+                    }
+                    return Task.FromResult(0);
+                })
+                .When(c => c.EventSubscribed || c.HasNativePubSubSupport, (session, context) => session.Publish(new Event { ContextId = context.Id })))
+                .Done(c => c.GotEvent)
+                .Run().ConfigureAwait(false);
+
+            Assert.True(ctx.GotEvent);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+            public bool GotEvent { get; set; }
+            public bool EventSubscribed { get; set; }
+        }
+
+        public class PublisherAndSubscriber : EndpointConfigurationBuilder
+        {
+            public PublisherAndSubscriber()
+            {
+                EndpointSetup<DefaultPublisher>(b =>
+                {
+                    // Make sure the subscription message isn't purged on startup
+                    b.PurgeOnStartup(true);
+                    b.OnEndpointSubscribed<Context>((s, context) =>
+                    {
+                        if (s.MessageType == typeof(Event).AssemblyQualifiedName)
+                        {
+                            context.EventSubscribed = true;
+                        }
+                    });
+                })
+                .AddMapping<Event>(typeof(PublisherAndSubscriber));
+            }
+
+            public class EventHandler : IHandleMessages<Event>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(Event @event, IMessageHandlerContext context)
+                {
+                    if (@event.ContextId != Context.Id)
+                    {
+                        return Task.FromResult(0);
+                    }
+                    Context.GotEvent = true;
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Event : IEvent
+        {
+            public Guid ContextId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Transports/TransportReceiver.cs
+++ b/src/NServiceBus.Core/Transports/TransportReceiver.cs
@@ -28,7 +28,12 @@ namespace NServiceBus
 
         public string Id { get; }
 
-        public async Task Start()
+        public Task Init()
+        {
+            return receiver.Init(c => pipelineExecutor.Invoke(c), c => recoverabilityExecutor.Invoke(c), criticalError, pushSettings);
+        }
+
+        public void Start()
         {
             if (isStarted)
             {
@@ -36,8 +41,6 @@ namespace NServiceBus
             }
 
             Logger.DebugFormat("Receiver {0} is starting, listening to queue {1}.", Id, pushSettings.InputQueue);
-
-            await receiver.Init(c => pipelineExecutor.Invoke(c), c => recoverabilityExecutor.Invoke(c), criticalError, pushSettings).ConfigureAwait(false);
 
             receiver.Start(pushRuntimeSettings);
 


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus/pull/3891 (stole the acceptance test from @ramonsmits ) by spliting initialization time from startup of the `TransportReceiver` allowing to purge queues before running FeatureStartupTasks.

@Particular/nservicebus-maintainers @ramonsmits please have a look. Although there were some conversations about ASB I think this is still the right approach in general (not only related to autosubscriptions, but to local sends in general).