### PR TITLE
Remove false tests and incorrect comments about spring

### DIFF
--- a/src/NServiceBus.ContainerTests/When_building_components.cs
+++ b/src/NServiceBus.ContainerTests/When_building_components.cs
@@ -85,41 +85,6 @@ namespace NServiceBus.ContainerTests
             }
         }
 
-        [Test]
-        public void Should_be_able_to_build_components_registered_after_first_build()
-        {
-            using (var builder = TestContainerBuilder.ConstructBuilder())
-            {
-                InitializeBuilder(builder);
-                builder.Build(typeof(SingletonComponent));
-                builder.Configure(typeof(UnregisteredComponent), DependencyLifecycle.SingleInstance);
-
-                var unregisteredComponent = builder.Build(typeof(UnregisteredComponent)) as UnregisteredComponent;
-                Assert.NotNull(unregisteredComponent);
-                Assert.NotNull(unregisteredComponent.SingletonComponent);
-            }
-            //Not supported by,typeof(SpringObjectBuilder));
-        }
-
-        [Test]
-        public void Should_support_mixed_dependency_styles()
-        {
-            using (var builder = TestContainerBuilder.ConstructBuilder())
-            {
-                InitializeBuilder(builder);
-                builder.Configure(typeof(ComponentWithBothConstructorAndSetterInjection), DependencyLifecycle.InstancePerCall);
-                builder.Configure(typeof(ConstructorDependency), DependencyLifecycle.InstancePerCall);
-                builder.Configure(typeof(SetterDependency), DependencyLifecycle.InstancePerCall);
-
-                var component = (ComponentWithBothConstructorAndSetterInjection) builder.Build(typeof(ComponentWithBothConstructorAndSetterInjection));
-                Assert.NotNull(component.ConstructorDependency);
-                Assert.NotNull(component.SetterDependency);
-            }
-
-            //Not supported by, typeof(SpringObjectBuilder));
-        }
-
-
         void InitializeBuilder(IContainer container)
         {
             container.Configure(typeof(SingletonComponent), DependencyLifecycle.SingleInstance);

--- a/src/NServiceBus.ContainerTests/When_registering_components.cs
+++ b/src/NServiceBus.ContainerTests/When_registering_components.cs
@@ -44,8 +44,6 @@ namespace NServiceBus.ContainerTests
 
                 Assert.IsInstanceOf<AnotherSingletonComponent>(builder.Build(typeof(ISingletonComponent)));
             }
-
-            //Not supported by, typeof(SpringObjectBuilder));
         }
 
         [Test]
@@ -80,8 +78,6 @@ namespace NServiceBus.ContainerTests
                 Assert.AreEqual(builder.Build(typeof(ISingleton1)), singleton);
                 Assert.AreEqual(builder.Build(typeof(ISingleton2)), singleton);
             }
-
-            //Not supported by,typeof(SpringObjectBuilder));
         }
 
         [Test]
@@ -175,7 +171,6 @@ namespace NServiceBus.ContainerTests
                     Assert.AreEqual(2, childBuilder.BuildAll(typeof(ISomeInterface)).Count());
                 }
             }
-            //Not supported by,typeof(WindsorObjectBuilder));
         }
 
         [Test]

--- a/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
+++ b/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
@@ -154,8 +154,6 @@ namespace NServiceBus.ContainerTests
                 Assert.False(AnotherDisposableComponent.DisposeCalled, "Dispose should not be called on AnotherSingletonComponent because it belongs to main container");
                 Assert.True(DisposableComponent.DisposeCalled, "Dispose should be called on DisposableComponent");
             }
-
-            //Not supported by, typeof(SpringObjectBuilder));
         }
 
         public interface IInstanceToReplaceInNested


### PR DESCRIPTION
Based on the discussion [here](https://github.com/Particular/NServiceBus/issues/4075), there is no value in keeping these tests around - and in fact it makes it harder for community ports to other containers. This PR will remove these non-tests as well as update the list of comments that are making incorrect assumptions about Spring and Castle Windsor support.

Ping @Particular/nservicebus-maintainers and @Particular/container-maintainers 