### PR TITLE
Allow MEM entries to overwrite each other

### DIFF
--- a/src/NServiceBus.Core/Routing/MessageEndpointMappingCollection.cs
+++ b/src/NServiceBus.Core/Routing/MessageEndpointMappingCollection.cs
@@ -120,7 +120,7 @@ namespace NServiceBus.Config
         /// </summary>
         protected override void BaseAdd(ConfigurationElement element)
         {
-            BaseAdd(element, true);
+            BaseAdd(element, false);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus/issues/1939 by allowing duplicate entries. Last one wins.

As mentioned in the linked issue, I think behavior is acceptable since different mappings may overwrite each other already. E.g. a mapping for a type overwrites mappings from namespace mappings which overwrites full assembly mappings.

Thoughts? /cc @SimonCropp 