### PR TITLE
Url change for license expiration

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Serialization/When_configuring_custom_xml_namespace.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_configuring_custom_xml_namespace.cs
@@ -10,7 +10,7 @@
 
     public class When_configuring_custom_xml_namespace : NServiceBusAcceptanceTest
     {
-        const string CustomXmlNamespace = "http://particular.net";
+        const string CustomXmlNamespace = "https://particular.net";
 
         [Test]
         public async Task Should_use_as_root_namespace_in_messages()

--- a/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
@@ -84,7 +84,7 @@
 
         void PurchaseButton_Click(object sender, EventArgs e)
         {
-            Process.Start("http://particular.net/licensing");
+            Process.Start("https://particular.net/licensing");
         }
 
         void getTrialLicenseButton_Click(object sender, EventArgs e)
@@ -98,7 +98,7 @@
 
             if (CurrentLicense != null && CurrentLicense.IsTrialLicense)
             {   
-                var builder = new UriBuilder("http://particular.net/extend-nservicebus-trial")
+                var builder = new UriBuilder("https://particular.net/extend-nservicebus-trial")
                 {
                     Query = string.Join("&", parameterCollection.AllKeys.Select(key => $"{HttpUtility.UrlEncode(key)}={HttpUtility.UrlEncode(parameterCollection[key])}"))
                 };
@@ -110,7 +110,7 @@
             {
                 // We won't ever get here. If it's a extended license, then this dialog wont be invoked.
                 // See LicenseManager::InitializeLicense function for the why. Code is left here for cleanup later.
-                Process.Start("http://particular.net/extend-your-trial-45"); 
+                Process.Start("https://particular.net/extend-your-trial-45"); 
             }
         }
 

--- a/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
@@ -27,7 +27,7 @@
 
             warningText.Text = "The trial period is now over";
 
-            if (CurrentLicense != null && CurrentLicense.IsTrialLicense)
+            if (CurrentLicense != null && !CurrentLicense.IsExtendedTrial)
             {
                 Text = "NServiceBus - Initial Trial Expired";
                 instructionsText.Text = "To extend the free trial, click 'Extend trial' and register online. When the license file is received, save it to disk and then click the 'Browse' button below to select it.";
@@ -97,7 +97,7 @@
             };
 
             UriBuilder builder;
-            if (CurrentLicense != null && CurrentLicense.IsTrialLicense)
+            if (CurrentLicense != null && !CurrentLicense.IsExtendedTrial)
             {
                 // Original 14 day trial expired, give the user a chance to extend trial
                 builder = new UriBuilder("https://particular.net/extend-nservicebus-trial")

--- a/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
@@ -89,14 +89,15 @@
 
         void getTrialLicenseButton_Click(object sender, EventArgs e)
         {
-            if (CurrentLicense != null && CurrentLicense.IsTrialLicense)
+            var parameterCollection = new NameValueCollection
             {
-                var parameterCollection = new NameValueCollection
-                {
-                    {"NugetUser", IsNugetUser().ToString()},
-                    {"PlatformInstaller", HasUserInstalledPlatform().ToString()},
-                    {"TrialStartDate", TrialStartDateStore.GetTrialStartDate().ToString()}
-                };
+                {"NugetUser", IsNugetUser().ToString()},
+                {"PlatformInstaller", HasUserInstalledPlatform().ToString()},
+                {"TrialStartDate", TrialStartDateStore.GetTrialStartDate().ToString()}
+            };
+
+            if (CurrentLicense != null && CurrentLicense.IsTrialLicense)
+            {   
                 var builder = new UriBuilder("http://particular.net/extend-nservicebus-trial")
                 {
                     Query = string.Join("&", parameterCollection.AllKeys.Select(key => $"{HttpUtility.UrlEncode(key)}={HttpUtility.UrlEncode(parameterCollection[key])}"))
@@ -108,7 +109,6 @@
             else
             {
                 Process.Start("http://particular.net/extend-your-trial-45");
-                // the above url redirects to: http://particular.net/contact-us-to-extend-your-trial-period
                 //TODO: Check with Alex whether we need to provide the same parameters to the ContactUs url as well. 
             }
         }
@@ -127,8 +127,6 @@
 
         bool HasUserInstalledPlatform()
         {
-            //TODO: Should we check HKLM? Also there seems to be another key Software\Particular\PlatformInstaller
-            //TODO: is that an older version of Platform Installer? Should we check that as well?
             using (var regRoot = Registry.CurrentUser.OpenSubKey(@"Software\ParticularSoftware\PlatformInstaller"))
             {
                 if (regRoot != null)

--- a/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
@@ -108,8 +108,9 @@
             }
             else
             {
-                Process.Start("http://particular.net/extend-your-trial-45");
-                //TODO: Check with Alex whether we need to provide the same parameters to the ContactUs url as well. 
+                // We won't ever get here. If it's a extended license, then this dialog wont be invoked.
+                // See LicenseManager::InitializeLicense function for the why. Code is left here for cleanup later.
+                Process.Start("http://particular.net/extend-your-trial-45"); 
             }
         }
 

--- a/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
@@ -114,7 +114,7 @@
                 };
             }
 
-            // Create query string with all values
+            // Open the url with the querystrings
             Process.Start(builder.Uri.AbsoluteUri);
         }
 

--- a/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Diagnostics;
     using System.Globalization;
-    using System.Web;
     using System.Windows.Forms;
     using Janitor;
     using Logging;
@@ -101,7 +100,7 @@
                 baseUrl = "https://particular.net/extend-your-trial-45";
             }
 
-            var trialStart = HttpUtility.UrlEncode(TrialStartDateStore.GetTrialStartDate().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+            var trialStart = TrialStartDateStore.GetTrialStartDate().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
             var url = $"{baseUrl}?NugetUser={IsNugetUser()}&PlatformInstaller={HasUserInstalledPlatform()}&TrialStartDate={trialStart}";
             
             // Open the url with the querystrings

--- a/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
@@ -96,22 +96,26 @@
                 {"TrialStartDate", TrialStartDateStore.GetTrialStartDate().ToString()}
             };
 
+            UriBuilder builder;
             if (CurrentLicense != null && CurrentLicense.IsTrialLicense)
-            {   
-                var builder = new UriBuilder("https://particular.net/extend-nservicebus-trial")
+            {
+                // Original 14 day trial expired, give the user a chance to extend trial
+                builder = new UriBuilder("https://particular.net/extend-nservicebus-trial")
                 {
                     Query = string.Join("&", parameterCollection.AllKeys.Select(key => $"{HttpUtility.UrlEncode(key)}={HttpUtility.UrlEncode(parameterCollection[key])}"))
                 };
-
-                // Create query string with all values
-                Process.Start(builder.Uri.AbsoluteUri);
             }
             else
             {
-                // We won't ever get here. If it's a extended license, then this dialog wont be invoked.
-                // See LicenseManager::InitializeLicense function for the why. Code is left here for cleanup later.
-                Process.Start("https://particular.net/extend-your-trial-45"); 
+                // Extended trial license expired, ask the user to Contact Sales
+                builder = new UriBuilder("https://particular.net/extend-your-trial-45")
+                {
+                    Query = string.Join("&", parameterCollection.AllKeys.Select(key => $"{HttpUtility.UrlEncode(key)}={HttpUtility.UrlEncode(parameterCollection[key])}"))
+                };
             }
+
+            // Create query string with all values
+            Process.Start(builder.Uri.AbsoluteUri);
         }
 
         bool IsNugetUser()

--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -35,6 +35,13 @@ namespace NServiceBus
 
             if (LicenseExpirationChecker.HasLicenseExpired(foundLicense))
             {
+                // foundLicense could be a trial license.  The extended trail licenses are installed like a commercial license
+                // Checking both the IsTrailLicense and the IsExtendedTrial properties due to a fault with the extended trial license generation 
+                if (foundLicense.IsTrialLicense || foundLicense.IsExtendedTrial)
+                {
+                    PromptUserForLicenseIfTrialHasExpired();
+                    return;
+                }
                 Logger.Fatal("Your license has expired! You can renew it at https://particular.net/licensing.");
                 return;
             }

--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -35,7 +35,7 @@ namespace NServiceBus
 
             if (LicenseExpirationChecker.HasLicenseExpired(foundLicense))
             {
-                Logger.Fatal("Your license has expired! You can renew it at http://particular.net/licensing.");
+                Logger.Fatal("Your license has expired! You can renew it at https://particular.net/licensing.");
                 return;
             }
 

--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -35,10 +35,11 @@ namespace NServiceBus
 
             if (LicenseExpirationChecker.HasLicenseExpired(foundLicense))
             {
-                // foundLicense could be a trial license.  The extended trail licenses are installed like a commercial license
-                // Checking both the IsTrailLicense and the IsExtendedTrial properties due to a fault with the extended trial license generation 
-                if (foundLicense.IsTrialLicense || foundLicense.IsExtendedTrial)
+                // If the found license is a trial license then it is actually a extended trial license not a locally generated trial.
+                // Set the property to indicate that it is an extended license as it's not set by the license generation 
+                if (foundLicense.IsTrialLicense)
                 {
+                    foundLicense.IsExtendedTrial = true;
                     PromptUserForLicenseIfTrialHasExpired();
                     return;
                 }


### PR DESCRIPTION
Relates to https://github.com/Particular/V6Launch/issues/119
URL now includes trial date info.

Things to do:
- [x] Verify and change code if additional parameters also needs to be passed to the Contact Us Url when the extended trial expires
- [x] Check the registry key for the Platform Installer. See the TODOs in the code
- [x] Fix https://github.com/Particular/V6Launch/issues/134