### PR TITLE
Provide a more helpful exception message

### DIFF
--- a/src/NServiceBus.Core/Routing/MessageEndpointMappingCollection.cs
+++ b/src/NServiceBus.Core/Routing/MessageEndpointMappingCollection.cs
@@ -120,7 +120,14 @@ namespace NServiceBus.Config
         /// </summary>
         protected override void BaseAdd(ConfigurationElement element)
         {
-            BaseAdd(element, true);
+            try
+            {
+                BaseAdd(element, true);
+            }
+            catch (ConfigurationErrorsException e)
+            {
+                throw new Exception($"An ambigious message endpoint mapping has been defined at line: {e.Line}. Check the 'MessageEndpointMappings' section in {e.Filename} for conflicting mappings.", e);
+            }
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Routing/MessageEndpointMappingCollection.cs
+++ b/src/NServiceBus.Core/Routing/MessageEndpointMappingCollection.cs
@@ -126,7 +126,7 @@ namespace NServiceBus.Config
             }
             catch (ConfigurationErrorsException e)
             {
-                throw new Exception($"An ambigious message endpoint mapping has been defined at line: {e.Line}. Check the 'MessageEndpointMappings' section in {e.Filename} for conflicting mappings.", e);
+                throw new Exception($"An ambiguous message endpoint mapping has been defined at line: {e.Line}. Check the 'MessageEndpointMappings' section in {e.Filename} for conflicting mappings.", e);
             }
         }
 


### PR DESCRIPTION
Relates to https://github.com/Particular/NServiceBus/issues/1939. An exception is raised when two entries with the same key (but different values) are configured to avoid accidental misconfiguration.  The raised exception is not very helpful because it doesn't give any information what this configuration issue is about and the given values are not understandable because we the entries key is an aggregate string of different properties, not helpful to users.

We can catch that exception though an provide a more helpful message. What do you think about the message @SimonCropp ? Sadly, I don't think there is a good way of giving more details about the conflicting key, but not sure this is absolutely necessary?