### PR TITLE
Add test to verify unscubribe using scaled out publishers

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Recoverability\When_message_is_moved_to_error_queue_with_header_customizations.cs" />
     <Compile Include="MessageDrivenPubSubRoutingExtensions.cs" />
     <Compile Include="Core\Routing\AutomaticSubscriptions\When_handling_local_event.cs" />
+    <Compile Include="Routing\MessageDrivenSubscriptions\When_unsubscribing_to_scaled_out_publisher.cs" />
     <Compile Include="Routing\When_configure_routes_for_unobtrusive_messages.cs" />
     <Compile Include="Routing\When_extending_command_routing.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_extending_event_routing.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_unsubscribing_to_scaled_out_publisher.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_unsubscribing_to_scaled_out_publisher.cs
@@ -1,0 +1,71 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing.MessageDrivenSubscriptions
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using Configuration.AdvanceExtensibility;
+    using EndpointTemplates;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_unsubscribing_to_scaled_out_publisher : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public Task Should_send_unsubscription_message_to_each_instance()
+        {
+            return Scenario.Define<Context>()
+                .WithEndpoint<ScaledOutPublisher>(b => b.CustomConfig(c => c.MakeInstanceUniquelyAddressable("1")))
+                .WithEndpoint<ScaledOutPublisher>(b => b.CustomConfig(c => c.MakeInstanceUniquelyAddressable("2")))
+                .WithEndpoint<Unsubscriber>(b => b.When(s => s.Unsubscribe<MyEvent>()))
+                .Done(c => c.PublisherReceivedUnsubscription.Count >= 2)
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Should(c =>
+                {
+                    // each instance should receive an unsubscription message
+                    Assert.That(c.PublisherReceivedUnsubscription, Does.Contain("1"));
+                    Assert.That(c.PublisherReceivedUnsubscription, Does.Contain("2"));
+                    Assert.That(c.PublisherReceivedUnsubscription.Count, Is.EqualTo(2));
+                })
+                .Run();
+        }
+
+        class Context : ScenarioContext
+        {
+            public List<string> PublisherReceivedUnsubscription { get; } = new List<string>();
+        }
+
+        class ScaledOutPublisher : EndpointConfigurationBuilder
+        {
+            public ScaledOutPublisher()
+            {
+                // store the instance discriminator of each instance receiving a unsubscription message:
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.OnEndpointUnsubscribed<Context>((subscription, context) =>
+                            context.PublisherReceivedUnsubscription.Add(c.GetSettings().Get<string>("EndpointInstanceDiscriminator")));
+                });
+            }
+        }
+
+        class Unsubscriber : EndpointConfigurationBuilder
+        {
+            public Unsubscriber()
+            {
+                EndpointSetup<DefaultServer>((c, r) =>
+                {
+                    // configure the scaled out publisher instances:
+                    var publisherName = Conventions.EndpointNamingConvention(typeof(ScaledOutPublisher));
+                    var routing = c.UseTransport(r.GetTransportType()).Routing();
+                    c.MessageDrivenPubSubRouting().RegisterPublisher(typeof(MyEvent), publisherName);
+                    routing.RegisterEndpointInstances(new EndpointInstance(publisherName, "1"), new EndpointInstance(publisherName, "2"));
+                });
+            }
+        }
+
+        class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_unsubscribing_to_scaled_out_publisher.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_unsubscribing_to_scaled_out_publisher.cs
@@ -13,38 +13,38 @@
     public class When_unsubscribing_to_scaled_out_publisher : NServiceBusAcceptanceTest
     {
         [Test]
-        public Task Should_send_unsubscription_message_to_each_instance()
+        public Task Should_send_unsubscribe_message_to_each_instance()
         {
             return Scenario.Define<Context>()
                 .WithEndpoint<ScaledOutPublisher>(b => b.CustomConfig(c => c.MakeInstanceUniquelyAddressable("1")))
                 .WithEndpoint<ScaledOutPublisher>(b => b.CustomConfig(c => c.MakeInstanceUniquelyAddressable("2")))
                 .WithEndpoint<Unsubscriber>(b => b.When(s => s.Unsubscribe<MyEvent>()))
-                .Done(c => c.PublisherReceivedUnsubscription.Count >= 2)
+                .Done(c => c.PublisherReceivedUnsubscribeMessage.Count >= 2)
                 .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
                 .Should(c =>
                 {
-                    // each instance should receive an unsubscription message
-                    Assert.That(c.PublisherReceivedUnsubscription, Does.Contain("1"));
-                    Assert.That(c.PublisherReceivedUnsubscription, Does.Contain("2"));
-                    Assert.That(c.PublisherReceivedUnsubscription.Count, Is.EqualTo(2));
+                    // each instance should receive an unsubscribe message
+                    Assert.That(c.PublisherReceivedUnsubscribeMessage, Does.Contain("1"));
+                    Assert.That(c.PublisherReceivedUnsubscribeMessage, Does.Contain("2"));
+                    Assert.That(c.PublisherReceivedUnsubscribeMessage.Count, Is.EqualTo(2));
                 })
                 .Run();
         }
 
         class Context : ScenarioContext
         {
-            public List<string> PublisherReceivedUnsubscription { get; } = new List<string>();
+            public List<string> PublisherReceivedUnsubscribeMessage { get; } = new List<string>();
         }
 
         class ScaledOutPublisher : EndpointConfigurationBuilder
         {
             public ScaledOutPublisher()
             {
-                // store the instance discriminator of each instance receiving a unsubscription message:
+                // store the instance discriminator of each instance receiving a unsubscribe message:
                 EndpointSetup<DefaultServer>(c =>
                 {
                     c.OnEndpointUnsubscribed<Context>((subscription, context) =>
-                            context.PublisherReceivedUnsubscription.Add(c.GetSettings().Get<string>("EndpointInstanceDiscriminator")));
+                            context.PublisherReceivedUnsubscribeMessage.Add(c.GetSettings().Get<string>("EndpointInstanceDiscriminator")));
                 });
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehavior.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehavior.cs
@@ -1,18 +1,19 @@
 ﻿namespace NServiceBus.AcceptanceTests.Routing
 {
     using System;
-    using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using NServiceBus.Pipeline;
+    using ObjectBuilder;
     using Transport;
 
     class SubscriptionBehavior<TContext> : IBehavior<IIncomingPhysicalMessageContext, IIncomingPhysicalMessageContext> where TContext : ScenarioContext
     {
-        public SubscriptionBehavior(Action<SubscriptionEventArgs, TContext> action, TContext scenarioContext)
+        public SubscriptionBehavior(Action<SubscriptionEventArgs, TContext> action, TContext scenarioContext, MessageIntentEnum intentToHandle)
         {
             this.action = action;
             this.scenarioContext = scenarioContext;
+            this.intentToHandle = intentToHandle;
         }
 
         public async Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
@@ -26,6 +27,13 @@
                 {
                     context.Message.Headers.TryGetValue(Headers.ReplyToAddress, out returnAddress);
                 }
+
+                var intent = (MessageIntentEnum)Enum.Parse(typeof(MessageIntentEnum), context.Message.Headers[Headers.MessageIntent], true);
+                if (intent != intentToHandle)
+                {
+                    return;
+                }
+
                 action(new SubscriptionEventArgs
                 {
                     MessageType = subscriptionMessageType,
@@ -36,16 +44,18 @@
 
         static string GetSubscriptionMessageTypeFrom(IncomingMessage msg)
         {
-            return (from header in msg.Headers where header.Key == Headers.SubscriptionMessageType select header.Value).FirstOrDefault();
+            string headerValue;
+            return msg.Headers.TryGetValue(Headers.SubscriptionMessageType, out headerValue) ? headerValue : null;
         }
 
         Action<SubscriptionEventArgs, TContext> action;
         TContext scenarioContext;
+        MessageIntentEnum intentToHandle;
 
         internal class Registration : RegisterStep
         {
-            public Registration()
-                : base("SubscriptionBehavior", typeof(SubscriptionBehavior<TContext>), "So we can get subscription events")
+            public Registration(string id, Func<IBuilder, IBehavior> behaviorFactory)
+                : base(id, typeof(SubscriptionBehavior<TContext>), "notify subscription events", behaviorFactory)
             {
                 InsertBeforeIfExists("ProcessSubscriptionRequests");
             }

--- a/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehaviorExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehaviorExtensions.cs
@@ -5,15 +5,22 @@ namespace NServiceBus.AcceptanceTests.Routing
 
     static class SubscriptionBehaviorExtensions
     {
-        public static void OnEndpointSubscribed<TContext>(this EndpointConfiguration b, Action<SubscriptionEventArgs, TContext> action) where TContext : ScenarioContext
+        public static void OnEndpointSubscribed<TContext>(this EndpointConfiguration configuration, Action<SubscriptionEventArgs, TContext> action) where TContext : ScenarioContext
         {
-            b.Pipeline.Register<SubscriptionBehavior<TContext>.Registration>();
-
-            b.RegisterComponents(c => c.ConfigureComponent(builder =>
+            configuration.Pipeline.Register(new SubscriptionBehavior<TContext>.Registration("NotifySubscriptionBehavior", builder =>
             {
                 var context = builder.Build<TContext>();
-                return new SubscriptionBehavior<TContext>(action, context);
-            }, DependencyLifecycle.InstancePerCall));
+                return new SubscriptionBehavior<TContext>(action, context, MessageIntentEnum.Subscribe);
+            }));
+        }
+
+        public static void OnEndpointUnsubscribed<TContext>(this EndpointConfiguration configuration, Action<SubscriptionEventArgs, TContext> action) where TContext : ScenarioContext
+        {
+            configuration.Pipeline.Register(new SubscriptionBehavior<TContext>.Registration("NotifyUnsubscriptionBehavior", builder =>
+            {
+                var context = builder.Build<TContext>();
+                return new SubscriptionBehavior<TContext>(action, context, MessageIntentEnum.Unsubscribe);
+            }));
         }
     }
 }


### PR DESCRIPTION
noticed this missing test. Required to change the existing infrastructure to support notification on unsubscribe (actually, `OnEndpointSubscribed` also fired for unsubscribe).