### PR TITLE
Licensing wording for better clarity

### DIFF
--- a/src/NServiceBus.Core/Licensing/LicenseExpiredForm.Designer.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseExpiredForm.Designer.cs
@@ -114,7 +114,7 @@
             this.instructionsText.Name = "instructionsText";
             this.instructionsText.ReadOnly = true;
             this.instructionsText.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
-            this.instructionsText.Size = new System.Drawing.Size(520, 77);
+            this.instructionsText.Size = new System.Drawing.Size(520, 112);
             this.instructionsText.TabIndex = 18;
             this.instructionsText.Text = "Instructions....";
             // 

--- a/src/NServiceBus.Core/Licensing/LicenseExpiredForm.Designer.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseExpiredForm.Designer.cs
@@ -31,7 +31,6 @@
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(LicenseExpiredForm));
             this.headerPanel = new System.Windows.Forms.Panel();
             this.logoPictureBox = new System.Windows.Forms.PictureBox();
-            this.thanksLabel = new System.Windows.Forms.Label();
             this.browseButton = new System.Windows.Forms.Button();
             this.purchaseButton = new System.Windows.Forms.Button();
             this.warningText = new System.Windows.Forms.RichTextBox();
@@ -62,18 +61,6 @@
             this.logoPictureBox.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
             this.logoPictureBox.TabIndex = 0;
             this.logoPictureBox.TabStop = false;
-            // 
-            // thanksLabel
-            // 
-            this.thanksLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.thanksLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.thanksLabel.ForeColor = System.Drawing.Color.Black;
-            this.thanksLabel.Location = new System.Drawing.Point(39, 105);
-            this.thanksLabel.Name = "thanksLabel";
-            this.thanksLabel.Size = new System.Drawing.Size(562, 48);
-            this.thanksLabel.TabIndex = 2;
-            this.thanksLabel.Text = "Thank you for using NServiceBus in Particular";
             // 
             // browseButton
             // 
@@ -108,14 +95,14 @@
             this.warningText.BackColor = System.Drawing.Color.White;
             this.warningText.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.warningText.Font = new System.Drawing.Font("Microsoft Sans Serif", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.warningText.ForeColor = System.Drawing.Color.Red;
-            this.warningText.Location = new System.Drawing.Point(43, 138);
+            this.warningText.ForeColor = System.Drawing.Color.Black;
+            this.warningText.Location = new System.Drawing.Point(43, 105);
             this.warningText.Name = "warningText";
             this.warningText.ReadOnly = true;
             this.warningText.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
             this.warningText.Size = new System.Drawing.Size(520, 28);
             this.warningText.TabIndex = 17;
-            this.warningText.Text = "The Trial period is now over";
+            this.warningText.Text = "It\'s time to extend your trial.";
             // 
             // instructionsText
             // 
@@ -123,7 +110,7 @@
             this.instructionsText.BorderStyle = System.Windows.Forms.BorderStyle.None;
             this.instructionsText.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.instructionsText.ForeColor = System.Drawing.Color.Black;
-            this.instructionsText.Location = new System.Drawing.Point(43, 185);
+            this.instructionsText.Location = new System.Drawing.Point(43, 138);
             this.instructionsText.Name = "instructionsText";
             this.instructionsText.ReadOnly = true;
             this.instructionsText.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.None;
@@ -156,7 +143,6 @@
             this.Controls.Add(this.warningText);
             this.Controls.Add(this.purchaseButton);
             this.Controls.Add(this.browseButton);
-            this.Controls.Add(this.thanksLabel);
             this.Controls.Add(this.headerPanel);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
@@ -176,7 +162,6 @@
 
         private System.Windows.Forms.Panel headerPanel;
         private System.Windows.Forms.PictureBox logoPictureBox;
-        private System.Windows.Forms.Label thanksLabel;
         private System.Windows.Forms.Button browseButton;
         private System.Windows.Forms.Button purchaseButton;
         private System.Windows.Forms.RichTextBox warningText;

--- a/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Diagnostics;
     using System.Globalization;
-    using System.Reflection;
     using System.Windows.Forms;
     using Janitor;
     using Logging;
@@ -24,7 +23,7 @@
         {
             base.OnLoad(e);
 
-            var version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion;
+            var version = GitFlowVersion.MajorMinorPatch;
 
             if (CurrentLicense != null && !CurrentLicense.IsExtendedTrial)
             {

--- a/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
@@ -24,11 +24,11 @@
         {
             base.OnLoad(e);
 
-            var version = Assembly.GetExecutingAssembly().GetName().Version;
+            var version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion;
 
             if (CurrentLicense != null && !CurrentLicense.IsExtendedTrial)
             {
-                Text = $"NServiceBus License (v{version.ToString(3)})";
+                Text = $"NServiceBus License (v{version})";
                 warningText.Text = "It's time to extend your trial.";
                 instructionsText.Text = @"Your 14-day trial is up, but you can instantly extend your trial for FREE. NServiceBus will remain fully functional although continued use is in violation of our EULA.
 
@@ -39,7 +39,7 @@ When you receive your new license file, save it to disk and click the 'Browse' b
             }
             else
             {
-                Text = $"NServiceBus License (v{version.ToString(3)})";
+                Text = $"NServiceBus License (v{version})";
                 warningText.Text = "It's time to buy a license.";
                 instructionsText.Text = @"Your extended trial is up, but we don't want to stop you in your tracks. If you need to extend your trial further, please contact us and we'll work something out. NServiceBus will remain fully functional although continued use is in violation of our EULA.
 

--- a/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
@@ -30,7 +30,7 @@
             {
                 Text = $"NServiceBus License (v{version.ToString(3)})";
                 warningText.Text = "It's time to extend your trial.";
-                instructionsText.Text = @"Your 14-day trial is up, but you can instantly extend your trial for 30 days.
+                instructionsText.Text = @"Your 14-day trial is up, but you can instantly extend your trial for FREE. NServiceBus will remain fully functional although continued use is in violation of our EULA.
 
 When you receive your new license file, save it to disk and click the 'Browse' button to select it.";
                 getTrialLicenseButton.Text = "Extend Trial";
@@ -41,7 +41,7 @@ When you receive your new license file, save it to disk and click the 'Browse' b
             {
                 Text = $"NServiceBus License (v{version.ToString(3)})";
                 warningText.Text = "It's time to buy a license.";
-                instructionsText.Text = @"Your 45-day trial is up, but we don't want to stop you in your tracks. If you need to extend your trial, please contact us and we'll work something out.
+                instructionsText.Text = @"Your extended trial is up, but we don't want to stop you in your tracks. If you need to extend your trial further, please contact us and we'll work something out. NServiceBus will remain fully functional although continued use is in violation of our EULA.
 
 When you receive your new license file, save it to disk and click the 'Browse' button to select it.";
                 getTrialLicenseButton.Text = "Contact Us";

--- a/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseExpiredForm.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Diagnostics;
     using System.Globalization;
+    using System.Reflection;
     using System.Windows.Forms;
     using Janitor;
     using Logging;
@@ -23,21 +24,27 @@
         {
             base.OnLoad(e);
 
-            warningText.Text = "The trial period is now over";
+            var version = Assembly.GetExecutingAssembly().GetName().Version;
 
             if (CurrentLicense != null && !CurrentLicense.IsExtendedTrial)
             {
-                Text = "NServiceBus - Initial Trial Expired";
-                instructionsText.Text = "To extend the free trial, click 'Extend trial' and register online. When the license file is received, save it to disk and then click the 'Browse' button below to select it.";
+                Text = $"NServiceBus License (v{version.ToString(3)})";
+                warningText.Text = "It's time to extend your trial.";
+                instructionsText.Text = @"Your 14-day trial is up, but you can instantly extend your trial for 30 days.
+
+When you receive your new license file, save it to disk and click the 'Browse' button to select it.";
                 getTrialLicenseButton.Text = "Extend Trial";
                 purchaseButton.Visible = false;
                 getTrialLicenseButton.Left = purchaseButton.Left;
             }
             else
             {
-                Text = "NServiceBus - Extended Trial Expired";
-                instructionsText.Text = "Click 'Contact Sales' to request an extension to the free trial, or click 'Buy Now' to purchase a license online. When the license file is received, save it to disk and then click the 'Browse' button below to select it.";
-                getTrialLicenseButton.Text = "Contact Sales";
+                Text = $"NServiceBus License (v{version.ToString(3)})";
+                warningText.Text = "It's time to buy a license.";
+                instructionsText.Text = @"Your 45-day trial is up, but we don't want to stop you in your tracks. If you need to extend your trial, please contact us and we'll work something out.
+
+When you receive your new license file, save it to disk and click the 'Browse' button to select it.";
+                getTrialLicenseButton.Text = "Contact Us";
             }
 
             Visible = true;
@@ -87,7 +94,6 @@
 
         void getTrialLicenseButton_Click(object sender, EventArgs e)
         {
-
             string baseUrl;
             if (CurrentLicense != null && !CurrentLicense.IsExtendedTrial)
             {
@@ -102,9 +108,9 @@
 
             var trialStart = TrialStartDateStore.GetTrialStartDate().ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
             var url = $"{baseUrl}?NugetUser={IsNugetUser()}&PlatformInstaller={HasUserInstalledPlatform()}&TrialStartDate={trialStart}";
-            
+
             // Open the url with the querystrings
-            Process.Start(url); 
+            Process.Start(url);
         }
 
         static string IsNugetUser()
@@ -113,7 +119,7 @@
             {
                 if (regRoot != null)
                 {
-                    return (string)regRoot.GetValue("NuGetUser", "false");
+                    return (string) regRoot.GetValue("NuGetUser", "false");
                 }
             }
             return bool.FalseString;

--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -71,7 +71,7 @@ namespace NServiceBus
             }
             else
             {
-                var message = $"Trial for Particular Service Platform is still active, trial expires on {trialLicense.ExpirationDate.Value.ToLocalTime().ToShortDateString()}.";
+                var message = $"Trial for the Particular Service Platform has been active since {trialStartDate.ToLocalTime().ToShortDateString()}.";
                 Logger.Info(message);
             }
 


### PR DESCRIPTION
Related to https://github.com/Particular/OptimizeTrialExtensions/issues/10 with wordings suggested by task force consisting of @DavidBoike @adamralph @alxrz @ryansteinparticular.

## Objective

Make all the wording related to licensing more clear so that customers aren't put off thinking that the trial period is _only_ 14 days and that they have options. Also, seek to remove clutter and only use the minimum words necessary, since people commonly don't fully read dialogs.

The purpose of this PR is to start with the suggested wording from the Task Force, engage @Particular/nservicebus-maintainers first, and then RFC the changes company-wide.

## LicenseManager Logging

Every time an endpoint in the initial trial would run, you would see:

> INFO Trial for Particular Service Platform is still active, trial expires on {expirationDate}.

Likely reaction: "What? I can't finish this POC by then!" and then move on. This PR changes that to:

> INFO Trial for the Particular Service Platform has been active since {trialStartDate}.

This doesn't give the impression of impending doom.

## License Manager Dialog

* Don't want to scare away users with red error text.
* The "thanks for using" is redundant and unnecessary, so remove it.
* Dialog title is not usually read, can maybe provide a little more utility there (add the version) and remove any use of the word "Expired"

### Initial 14-day Trial Expired, Before/After

![image](https://cloud.githubusercontent.com/assets/427110/18686889/436c38ae-7f43-11e6-89cb-92b61221e57e.png)

![image](https://cloud.githubusercontent.com/assets/427110/18793001/7601bbd0-817e-11e6-9f15-a0e223414183.png)

### Extended Trial Expired, Before/After

![image](https://cloud.githubusercontent.com/assets/427110/18686911/61d34512-7f43-11e6-8f91-c44228297b1f.png)

![image](https://cloud.githubusercontent.com/assets/427110/18793041/a7000f5c-817e-11e6-98c4-46e252360a23.png)
