### PR TITLE
In-memory persister does not throw concurrency exceptions

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Routing\MessageDrivenSubscriptions\When_subscribing_to_scaled_out_publisher.cs" />
     <Compile Include="Sagas\When_a_base_class_mapped_is_handled_by_a_saga.cs" />
     <Compile Include="Sagas\When_a_base_class_message_starts_a_saga.cs" />
+    <Compile Include="Sagas\When_saga_handles_messages_concurrently.cs" />
     <Compile Include="Serialization\When_configuring_custom_xml_namespace.cs" />
     <Compile Include="Serialization\When_registering_additional_deserializers.cs" />
     <Compile Include="Basic\When_no_content_type.cs" />

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -92,7 +92,7 @@
     <Compile Include="Routing\MessageDrivenSubscriptions\When_subscribing_to_scaled_out_publisher.cs" />
     <Compile Include="Sagas\When_a_base_class_mapped_is_handled_by_a_saga.cs" />
     <Compile Include="Sagas\When_a_base_class_message_starts_a_saga.cs" />
-    <Compile Include="Sagas\When_saga_handles_messages_concurrently.cs" />
+    <Compile Include="Sagas\When_saga_started_concurrently.cs" />
     <Compile Include="Serialization\When_configuring_custom_xml_namespace.cs" />
     <Compile Include="Serialization\When_registering_additional_deserializers.cs" />
     <Compile Include="Basic\When_no_content_type.cs" />

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_handles_messages_concurrently.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_handles_messages_concurrently.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_saga_handles_messages_concurrently
+    {
+        [Test]
+        public Task Should_complete_saga_eventually()
+        {
+            return Scenario.Define<Context>(c => { c.OrderId = Guid.NewGuid().ToString(); })
+                .WithEndpoint<ConcurrentHandlerEndpoint>(b =>
+                {
+                    b.When((session, context) =>
+                    {
+                        var t1 = session.SendLocal(new ConcurrentHandlerEndpoint.OrderPlaced { OrderId = context.OrderId });
+                        var t2 = session.SendLocal(new ConcurrentHandlerEndpoint.OrderBilled { OrderId = context.OrderId });
+                        return Task.WhenAll(t1, t2);
+                    });
+                })
+                .Done(c => c.PlacedSagaId != Guid.Empty && c.BilledSagaId != Guid.Empty)
+                .Repeat(r => r.For(Transports.Default))
+                .Should(c =>
+                {
+                    Assert.AreNotEqual(Guid.Empty, c.PlacedSagaId);
+                    Assert.AreNotEqual(Guid.Empty, c.BilledSagaId);
+                    Assert.AreEqual(c.PlacedSagaId, c.BilledSagaId, "Both messages should have been handled by the same saga, but SagaIds don't match.");
+                    Assert.True(c.SagaCompleted);
+                })
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public string OrderId { get; set; }
+            public Guid PlacedSagaId { get; set; }
+            public Guid BilledSagaId { get; set; }
+            public bool SagaCompleted { get; set; }
+        }
+
+        public class ConcurrentHandlerEndpoint : EndpointConfigurationBuilder
+        {
+            public ConcurrentHandlerEndpoint()
+            {
+                EndpointSetup<DefaultServer>(b =>
+                {
+                    b.LimitMessageProcessingConcurrencyTo(2);
+                    b.Recoverability().Immediate(immediate => immediate.NumberOfRetries(3));
+                });
+            }
+
+            public class OrderShippingPolicy : Saga<OrderBilledPolicyData>,
+                IAmStartedByMessages<OrderBilled>,
+                IAmStartedByMessages<OrderPlaced>
+            {
+                public Context Context { get; set; }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<OrderBilledPolicyData> mapper)
+                {
+                    mapper.ConfigureMapping<OrderPlaced>(msg => msg.OrderId).ToSaga(saga => saga.OrderId);
+                    mapper.ConfigureMapping<OrderBilled>(msg => msg.OrderId).ToSaga(saga => saga.OrderId);
+                }
+
+                public async Task Handle(OrderPlaced message, IMessageHandlerContext context)
+                {
+                    Data.Placed = true;
+                    await context.SendLocal(new SuccessfulProcessing
+                    {
+                        SagaId = Data.Id,
+                        Type = nameof(OrderPlaced)
+                    });
+                    await CheckForCompletion(context);
+                }
+
+                public async Task Handle(OrderBilled message, IMessageHandlerContext context)
+                {
+                    Data.Billed = true;
+                    await context.SendLocal(new SuccessfulProcessing
+                    {
+                        SagaId = Data.Id,
+                        Type = nameof(OrderBilled)
+                    });
+                    await CheckForCompletion(context);
+                }
+
+                Task CheckForCompletion(IMessageHandlerContext context)
+                {
+                    if (Data.Billed && Data.Placed)
+                    {
+                        this.MarkAsComplete();
+                        Context.SagaCompleted = true;
+                    }
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class OrderBilledPolicyData : ContainSagaData
+            {
+                public string OrderId { get; set; }
+                public bool Placed { get; set; }
+                public bool Billed { get; set; }
+            }
+
+            public class LogSuccessfulHandler : IHandleMessages<SuccessfulProcessing>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(SuccessfulProcessing message, IMessageHandlerContext context)
+                {
+                    if (message.Type == nameof(OrderPlaced))
+                    {
+                        Context.PlacedSagaId = message.SagaId;
+                    }
+                    else if (message.Type == nameof(OrderBilled))
+                    {
+                        Context.BilledSagaId = message.SagaId;
+                    }
+                    else
+                    {
+                        throw new Exception("Unknown type");
+                    }
+
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class OrderPlaced : ICommand
+            {
+                public string OrderId { get; set; }
+            }
+
+            public class OrderBilled : ICommand
+            {
+                public string OrderId { get; set; }
+            }
+
+            public class SuccessfulProcessing : ICommand
+            {
+                public string Type { get; set; }
+                public Guid SagaId { get; set; }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_started_concurrently.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_started_concurrently.cs
@@ -5,42 +5,37 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using NUnit.Framework;
-    using ScenarioDescriptors;
 
-    public class When_saga_handles_messages_concurrently : NServiceBusAcceptanceTest
+    public class When_saga_started_concurrently : NServiceBusAcceptanceTest
     {
         [Test]
-        public Task Should_complete_saga_eventually()
+        public async Task Should_start_single_saga()
         {
-            return Scenario.Define<Context>(c => { c.SomeId = Guid.NewGuid().ToString(); })
+            var context = await Scenario.Define<Context>(c => { c.SomeId = Guid.NewGuid().ToString(); })
                 .WithEndpoint<ConcurrentHandlerEndpoint>(b =>
                 {
-                    b.When((session, context) =>
+                    b.When((session, ctx) =>
                     {
                         var t1 = session.SendLocal(new StartMessageOne
                         {
-                            SomeId = context.SomeId
+                            SomeId = ctx.SomeId
                         });
                         var t2 = session.SendLocal(new StartMessageTwo
                         {
-                            SomeId = context.SomeId
+                            SomeId = ctx.SomeId
                         });
                         return Task.WhenAll(t1, t2);
                     });
                 })
                 .Done(c => c.PlacedSagaId != Guid.Empty && c.BilledSagaId != Guid.Empty)
-                .Repeat(r => r.For(Transports.Default))
-                .Should(c =>
-                {
-                    Assert.AreNotEqual(Guid.Empty, c.PlacedSagaId);
-                    Assert.AreNotEqual(Guid.Empty, c.BilledSagaId);
-                    Assert.AreEqual(c.PlacedSagaId, c.BilledSagaId, "Both messages should have been handled by the same saga, but SagaIds don't match.");
-                    Assert.True(c.SagaCompleted);
-                })
                 .Run();
+
+            Assert.AreNotEqual(Guid.Empty, context.PlacedSagaId);
+            Assert.AreNotEqual(Guid.Empty, context.BilledSagaId);
+            Assert.AreEqual(context.PlacedSagaId, context.BilledSagaId, "Both messages should have been handled by the same saga, but SagaIds don't match.");
         }
 
-        public class Context : ScenarioContext
+        class Context : ScenarioContext
         {
             public string SomeId { get; set; }
             public Guid PlacedSagaId { get; set; }
@@ -48,7 +43,7 @@
             public bool SagaCompleted { get; set; }
         }
 
-        public class ConcurrentHandlerEndpoint : EndpointConfigurationBuilder
+        class ConcurrentHandlerEndpoint : EndpointConfigurationBuilder
         {
             public ConcurrentHandlerEndpoint()
             {
@@ -59,7 +54,7 @@
                 });
             }
 
-            public class ConcurrentlyStartedSaga : Saga<ConcurrentlyStartedSagaData>,
+            class ConcurrentlyStartedSaga : Saga<ConcurrentlyStartedSagaData>,
                 IAmStartedByMessages<StartMessageTwo>,
                 IAmStartedByMessages<StartMessageOne>
             {
@@ -73,7 +68,7 @@
                         SagaId = Data.Id,
                         Type = nameof(StartMessageOne)
                     });
-                    await CheckForCompletion(context);
+                    CheckForCompletion(context);
                 }
 
                 public async Task Handle(StartMessageTwo message, IMessageHandlerContext context)
@@ -84,7 +79,7 @@
                         SagaId = Data.Id,
                         Type = nameof(StartMessageTwo)
                     });
-                    await CheckForCompletion(context);
+                    CheckForCompletion(context);
                 }
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ConcurrentlyStartedSagaData> mapper)
@@ -93,25 +88,26 @@
                     mapper.ConfigureMapping<StartMessageTwo>(msg => msg.SomeId).ToSaga(saga => saga.OrderId);
                 }
 
-                Task CheckForCompletion(IMessageHandlerContext context)
+                void CheckForCompletion(IMessageHandlerContext context)
                 {
-                    if (Data.Billed && Data.Placed)
+                    if (!Data.Billed || !Data.Placed)
                     {
-                        MarkAsComplete();
-                        Context.SagaCompleted = true;
+                        return;
                     }
-                    return Task.FromResult(0);
+                    MarkAsComplete();
+                    Context.SagaCompleted = true;
                 }
             }
 
-            public class ConcurrentlyStartedSagaData : ContainSagaData
+            class ConcurrentlyStartedSagaData : ContainSagaData
             {
                 public virtual string OrderId { get; set; }
                 public virtual bool Placed { get; set; }
                 public virtual bool Billed { get; set; }
             }
 
-            public class LogSuccessfulHandler : IHandleMessages<SuccessfulProcessing>
+            // Intercepts the messages sent out by the saga
+            class LogSuccessfulHandler : IHandleMessages<SuccessfulProcessing>
             {
                 public Context Context { get; set; }
 
@@ -135,17 +131,17 @@
             }
         }
 
-        public class StartMessageOne : ICommand
+        class StartMessageOne : ICommand
         {
             public string SomeId { get; set; }
         }
 
-        public class StartMessageTwo : ICommand
+        class StartMessageTwo : ICommand
         {
             public string SomeId { get; set; }
         }
 
-        public class SuccessfulProcessing : ICommand
+        class SuccessfulProcessing : ICommand
         {
             public string Type { get; set; }
             public Guid SagaId { get; set; }

--- a/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
@@ -70,7 +70,7 @@ namespace NServiceBus
             var inMemSession = (InMemorySynchronizedStorageSession) session;
             inMemSession.Enlist(() =>
             {
-                var lockenTokenKey = $"{sagaData.GetType().FullName}.{(correlationProperty == null ? "None" : correlationProperty.Name)}.{(correlationProperty == null ? "None" : correlationProperty.Value)}";
+                var lockenTokenKey = $"{sagaData.GetType().FullName}.{correlationProperty?.Name ?? "None"}.{correlationProperty?.Value ?? "None"}";
                 var lockToken = lockers.GetOrAdd(lockenTokenKey, key => new object());
                 lock (lockToken)
                 {
@@ -103,6 +103,7 @@ namespace NServiceBus
         {
             var sagaType = saga.GetType();
             var existingSagas = new List<VersionedSagaEntity>();
+            // ReSharper disable once LoopCanBeConvertedToQuery
             foreach (var s in data)
             {
                 if (s.Value.SagaData.GetType() == sagaType && (s.Key != saga.Id))
@@ -182,7 +183,7 @@ namespace NServiceBus
             }
 
             public IContainSagaData SagaData;
-            public readonly string LockTokenKey;
+            public string LockTokenKey;
 
             ConditionalWeakTable<IContainSagaData, SagaVersion> versionCache;
 


### PR DESCRIPTION
InMemoryPersistence will create saga duplicates under the following scenario:

## Who's affected

All users using InMemorySagaPersister 

## Symptoms

1. Persistence selected as InMemoryPersistence (obviously)
1. Usage of sagas which are started multiple message types with `IAmStartedByMessages`
1. Concurrency set to greater than one (default in v6)
1. Sending out two messages which can start the saga at the same time

Two saga instances are created which leads to incorrect business behavior.

