### PR TITLE
Use endpoints logical address to generate performance counters

### DIFF
--- a/src/NServiceBus.Core/Performance/ReceiveStatisticsFeature.cs
+++ b/src/NServiceBus.Core/Performance/ReceiveStatisticsFeature.cs
@@ -12,7 +12,8 @@
 
         protected internal override void Setup(FeatureConfigurationContext context)
         {
-            var performanceDiagnosticsBehavior = new ReceivePerformanceDiagnosticsBehavior(context.Settings.LocalAddress());
+            var logicalAddress = context.Settings.LogicalAddress();
+            var performanceDiagnosticsBehavior = new ReceivePerformanceDiagnosticsBehavior(logicalAddress.EndpointInstance.Endpoint);
 
             context.Pipeline.Register(performanceDiagnosticsBehavior, "Provides various performance counters for receive statistics");
             context.Pipeline.Register("ProcessingStatistics", new ProcessingStatisticsBehavior(), "Collects timing for ProcessingStarted and adds the state to determine ProcessingEnded");

--- a/src/NServiceBus.Core/Performance/Statistics/ReceivePerformanceDiagnosticsBehavior.cs
+++ b/src/NServiceBus.Core/Performance/Statistics/ReceivePerformanceDiagnosticsBehavior.cs
@@ -8,22 +8,22 @@ namespace NServiceBus
     [SkipWeaving]
     class ReceivePerformanceDiagnosticsBehavior : IBehavior<IIncomingPhysicalMessageContext, IIncomingPhysicalMessageContext>
     {
-        public ReceivePerformanceDiagnosticsBehavior(string transportAddress)
+        public ReceivePerformanceDiagnosticsBehavior(string queueName)
         {
-            this.transportAddress = transportAddress;
+            this.queueName = queueName;
         }
 
         public void Warmup()
         {
             messagesPulledFromQueueCounter = PerformanceCounterHelper.TryToInstantiatePerformanceCounter(
                 "# of msgs pulled from the input queue /sec",
-                transportAddress);
+                queueName);
             successRateCounter = PerformanceCounterHelper.TryToInstantiatePerformanceCounter(
                 "# of msgs successfully processed / sec",
-                transportAddress);
+                queueName);
             failureRateCounter = PerformanceCounterHelper.TryToInstantiatePerformanceCounter(
                 "# of msgs failures / sec",
-                transportAddress);
+                queueName);
         }
 
         public async Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
@@ -54,6 +54,6 @@ namespace NServiceBus
         IPerformanceCounterInstance messagesPulledFromQueueCounter;
         IPerformanceCounterInstance successRateCounter;
 
-        string transportAddress;
+        string queueName;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus/issues/4165

This approach also works when configuring an input queue different from the endpoints logical name, using `OverrideLocalAddress` (then performance counters have the overridden name).

ping @Particular/nservicebus-maintainers 