### PR TITLE
Remove subscription versioning for MSMQ and InMemory subscriptions

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -128,6 +128,8 @@
     <Compile Include="Msmq\ConnectionStringParserTests.cs" />
     <Compile Include="ObservableTests.cs" />
     <Compile Include="Persistence\InMemory\InMemorySagaPersistenceFixture.cs" />
+    <Compile Include="Persistence\InMemory\InMemorySubscriptionStorageTests.cs" />
+    <Compile Include="Persistence\Msmq\MsmqSubscriptionStorageTests.cs" />
     <Compile Include="Persistence\PersistenceExtentionsTests.cs" />
     <Compile Include="Persistence\PersistenceStorageMergerTests.cs" />
     <Compile Include="Sagas\SagaModelTests.cs" />

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/InMemorySubscriptionStorageTests.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/InMemorySubscriptionStorageTests.cs
@@ -1,0 +1,30 @@
+namespace NServiceBus.Persistence.InMemory.Tests
+{
+    using System.Linq;
+    using NServiceBus.InMemory.SubscriptionStorage;
+    using NServiceBus.Unicast.Subscriptions;
+    using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
+    using NUnit.Framework;
+
+    [TestFixture]
+    class InMemorySubscriptionStorageTests
+    {
+        [Test]
+        public void Should_ignore_message_version_on_subscriptions()
+        {
+            ISubscriptionStorage storage = new InMemorySubscriptionStorage();
+
+            storage.Subscribe(new Address("subscriberA", "subscriberA"), new[]
+            {
+                new MessageType("SomeMessage", "1.0.0")
+            });
+
+            var subscribers = storage.GetSubscriberAddressesForMessage(new[]
+            {
+                new MessageType("SomeMessage", "2.0.0")
+            });
+
+            Assert.AreEqual("subscriberA", subscribers.Single().Queue);
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Persistence/Msmq/MsmqSubscriptionStorageTests.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/Msmq/MsmqSubscriptionStorageTests.cs
@@ -1,0 +1,46 @@
+﻿namespace NServiceBus.Core.Tests.Persistence.Msmq
+{
+    using System;
+    using System.Linq;
+    using System.Messaging;
+    using NServiceBus.Persistence.SubscriptionStorage;
+    using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
+    using NUnit.Framework;
+    using MessageType = NServiceBus.Unicast.Subscriptions.MessageType;
+
+    public class MsmqSubscriptionStorageTests
+    {
+        [Test]
+        public void Should_ignore_message_version_on_subscriptions()
+        {
+            var testQueueName = "ShouldIgnoreMessageVersionOnSubscriptions";
+            var testQueueNativeAddress = Environment.MachineName + MsmqUtilities.PRIVATE + testQueueName;
+
+            if (MessageQueue.Exists(testQueueNativeAddress))
+            {
+                new MessageQueue(testQueueNativeAddress).Purge();
+            }
+            else
+            {
+                MessageQueue.Create(testQueueNativeAddress);
+            }
+
+            ISubscriptionStorage subscriptionStorage = new MsmqSubscriptionStorage
+            {
+                Queue = Address.Parse(testQueueName)
+            };
+
+            subscriptionStorage.Init();
+
+            subscriptionStorage.Subscribe(new Address("subscriberA", "server1"), new[] { new MessageType("SomeMessage", "1.0.0") });
+
+
+            var subscribers = subscriptionStorage.GetSubscriberAddressesForMessage(new[]
+            {
+                new MessageType("SomeMessage", "2.0.0")
+            });
+
+            Assert.AreEqual("subscriberA", subscribers.Single().Queue);
+        }
+    }
+}

--- a/src/NServiceBus.Core/Unicast/Subscriptions/MessageDrivenSubscriptions/MessageType.cs
+++ b/src/NServiceBus.Core/Unicast/Subscriptions/MessageDrivenSubscriptions/MessageType.cs
@@ -18,19 +18,19 @@ namespace NServiceBus.Unicast.Subscriptions
         }
 
         /// <summary>
-        /// Initializes the message type from the given string. 
+        /// Initializes the message type from the given string.
         /// </summary>
         public MessageType(string messageTypeString)
         {
             var parts = messageTypeString.Split(',');
 
-         
-            Version = ParseVersion(messageTypeString); 
+
+            Version = ParseVersion(messageTypeString);
             TypeName = parts.First();
         }
 
         /// <summary>
-        /// Initializes the message type from the given string. 
+        /// Initializes the message type from the given string.
         /// </summary>
         public MessageType(string typeName, string versionString)
         {
@@ -39,20 +39,20 @@ namespace NServiceBus.Unicast.Subscriptions
         }
 
         /// <summary>
-        /// Initializes the message type from the given string. 
+        /// Initializes the message type from the given string.
         /// </summary>
-        public MessageType(string typeName,Version version)
+        public MessageType(string typeName, Version version)
         {
             Version = version;
             TypeName = typeName;
         }
-    
+
         Version ParseVersion(string versionString)
         {
             const string version = "Version=";
             var index = versionString.IndexOf(version);
-           
-            if(index >= 0)
+
+            if (index >= 0)
                 versionString = versionString.Substring(index + version.Length)
                     .Split(',').First();
             return Version.Parse(versionString);
@@ -62,7 +62,7 @@ namespace NServiceBus.Unicast.Subscriptions
         /// <summary>
         /// TypeName of the message
         /// </summary>
-        public string TypeName { get;private  set; }
+        public string TypeName { get; private set; }
 
         /// <summary>
         /// Version of the message
@@ -84,7 +84,7 @@ namespace NServiceBus.Unicast.Subscriptions
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
-            return Equals(other.TypeName, TypeName) && other.Version.Major == Version.Major;
+            return Equals(other.TypeName, TypeName);
         }
 
         /// <summary>
@@ -94,8 +94,8 @@ namespace NServiceBus.Unicast.Subscriptions
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != typeof (MessageType)) return false;
-            return Equals((MessageType) obj);
+            if (obj.GetType() != typeof(MessageType)) return false;
+            return Equals((MessageType)obj);
         }
 
         /// <summary>
@@ -103,10 +103,7 @@ namespace NServiceBus.Unicast.Subscriptions
         /// </summary>
         public override int GetHashCode()
         {
-            unchecked
-            {
-                return (TypeName.GetHashCode()*397) ^ Version.GetHashCode();
-            }
+            return TypeName.GetHashCode();
         }
 
         /// <summary>

--- a/src/NServiceBus.sln.DotSettings
+++ b/src/NServiceBus.sln.DotSettings
@@ -581,6 +581,7 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsWrapperSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	
 	
 	


### PR DESCRIPTION
### Symptoms

Subscribers no longer receive events published if the publisher changes the `Major` assembly version part on the contract assembly without subscribers being updated at the same time.

### Who's affected

All users on a transport using [message driven pub/sub](https://docs.particular.net/nservicebus/messaging/publish-subscribe/#mechanics-persistence-based-message-driven) that have a message contract versioning strategy that increases the `Major` assembly version part for changes that are not to be considered breaking for subscribers.


Related to  https://github.com/Particular/NServiceBus/issues/1394