### PR TITLE
Hotfix-5.2.18

### DIFF
--- a/src/NServiceBus.Core/Impersonation/Windows/WindowsIdentityEnricher.cs
+++ b/src/NServiceBus.Core/Impersonation/Windows/WindowsIdentityEnricher.cs
@@ -2,15 +2,14 @@ namespace NServiceBus.Impersonation.Windows
 {
     using System.Security.Principal;
     using System.Threading;
-    using MessageMutator;
-    using Unicast.Messages;
+    using NServiceBus.MessageMutator;
+    using NServiceBus.Unicast.Messages;
 
     /// <summary>
-    /// Stamps outgoing messages with the current windows identity
+    ///     Stamps outgoing messages with the current windows identity
     /// </summary>
     class WindowsIdentityEnricher : IMutateOutgoingTransportMessages
     {
-
         public void MutateOutgoing(LogicalMessage logicalMessage, TransportMessage transportMessage)
         {
             if (Thread.CurrentPrincipal != null && Thread.CurrentPrincipal.Identity != null && !string.IsNullOrEmpty(Thread.CurrentPrincipal.Identity.Name))
@@ -19,11 +18,7 @@ namespace NServiceBus.Impersonation.Windows
                 return;
             }
             var windowsIdentity = WindowsIdentity.GetCurrent();
-            if (windowsIdentity != null)
-            {
-                transportMessage.Headers[Headers.WindowsIdentityName] = windowsIdentity.Name;
-            }
-
+            transportMessage.Headers[Headers.WindowsIdentityName] = windowsIdentity.Name;
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqDequeueStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqDequeueStrategy.cs
@@ -375,9 +375,7 @@ namespace NServiceBus.Transports.Msmq
         static string GetUserName()
         {
             var windowsIdentity = WindowsIdentity.GetCurrent();
-            return windowsIdentity != null
-                ? windowsIdentity.Name
-                : "Unknown User";
+            return windowsIdentity.Name;
         }
 
         CircuitBreaker circuitBreaker = new CircuitBreaker(100, TimeSpan.FromSeconds(30));

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqDequeueStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqDequeueStrategy.cs
@@ -173,8 +173,7 @@ namespace NServiceBus.Transports.Msmq
 
             throttlingSemaphore.Wait();
 
-            Task.Factory
-                .StartNew(() => Action(transactionSettings, transactionOptions, unitOfWork, receiveQueue, errorQueue, circuitBreaker, criticalError, peekResetEvent, receiveTimeout, throttlingSemaphore, tryProcessMessage, endProcessMessage), CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default)
+            Task.Run(() => Action(transactionSettings, transactionOptions, unitOfWork, receiveQueue, errorQueue, circuitBreaker, criticalError, peekResetEvent, receiveTimeout, throttlingSemaphore, tryProcessMessage, endProcessMessage))
                 .ContinueWith(task => task.Exception.Handle(ex =>
                 {
                     Logger.Error("Error processing message.", ex);

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqDequeueStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqDequeueStrategy.cs
@@ -188,8 +188,7 @@ namespace NServiceBus.Transports.Msmq
             stopResetEvent.Set();
         }
 
-        static void Action(TransactionSettings transactionSettings, TransactionOptions transactionOptions, MsmqUnitOfWork unitOfWork, MessageQueue receiveQueue, MessageQueue errorQueue, CircuitBreaker circuitBreaker, CriticalError criticalError, AutoResetEvent peekResetEvent, TimeSpan receiveTimeout, SemaphoreSlim throttlingSemaphore, Func<TransportMessage, bool> tryProcessMessage,
-            Action<TransportMessage, Exception> endProcessMessage)
+        static void Action(TransactionSettings transactionSettings, TransactionOptions transactionOptions, MsmqUnitOfWork unitOfWork, MessageQueue receiveQueue, MessageQueue errorQueue, CircuitBreaker circuitBreaker, CriticalError criticalError, AutoResetEvent peekResetEvent, TimeSpan receiveTimeout, SemaphoreSlim throttlingSemaphore, Func<TransportMessage, bool> tryProcessMessage, Action<TransportMessage, Exception> endProcessMessage)
         {
             TransportMessage transportMessage = null;
             try

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqDequeueStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqDequeueStrategy.cs
@@ -197,14 +197,15 @@ namespace NServiceBus.Transports.Msmq
                     if (transactionSettings.SuppressDistributedTransactions)
                     {
                         using (var msmqTransaction = new MessageQueueTransaction())
-                        {
-                            msmqTransaction.Begin();
-                            
+                        {                           
                             Message message;
 
-                            if (!TryReceiveMessage(() => queue.Receive(receiveTimeout, msmqTransaction),out message))
+                            if (!TryReceiveMessage(() =>
                             {
-                                msmqTransaction.Commit();
+                                msmqTransaction.Begin();
+                                return queue.Receive(receiveTimeout, msmqTransaction);
+                            }, out message))
+                            {
                                 return;
                             }
 
@@ -245,7 +246,7 @@ namespace NServiceBus.Transports.Msmq
                         {
                             Message message;
 
-                            if (!TryReceiveMessage(() => queue.Receive(receiveTimeout, MessageQueueTransactionType.Automatic),out message))
+                            if (!TryReceiveMessage(() => queue.Receive(receiveTimeout, MessageQueueTransactionType.Automatic), out message))
                             {
                                 scope.Complete();
                                 return;
@@ -274,7 +275,7 @@ namespace NServiceBus.Transports.Msmq
                 {
                     Message message;
 
-                    if (!TryReceiveMessage(() => queue.Receive(receiveTimeout, MessageQueueTransactionType.None),out message))
+                    if (!TryReceiveMessage(() => queue.Receive(receiveTimeout, MessageQueueTransactionType.None), out message))
                     {
                         return;
                     }

--- a/src/NServiceBus.Core/Unicast/Queuing/QueueNotFoundException.cs
+++ b/src/NServiceBus.Core/Unicast/Queuing/QueueNotFoundException.cs
@@ -40,8 +40,7 @@ namespace NServiceBus.Unicast.Queuing
             System.Runtime.Serialization.SerializationInfo info, 
             System.Runtime.Serialization.StreamingContext context) : base(info, context)
         {
-            if (info != null)
-                Queue = Address.Parse(info.GetString("Queue"));
+            Queue = Address.Parse(info.GetString("Queue"));
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Utils/ElevateChecker.cs
+++ b/src/NServiceBus.Core/Utils/ElevateChecker.cs
@@ -4,15 +4,10 @@ namespace NServiceBus.Installation
 
     static class ElevateChecker
     {
-
         public static bool IsCurrentUserElevated()
         {
             using (var windowsIdentity = WindowsIdentity.GetCurrent())
             {
-                if (windowsIdentity == null)
-                {
-                    return false;
-                }
                 var windowsPrincipal = new WindowsPrincipal(windowsIdentity);
                 return windowsPrincipal.IsInRole(WindowsBuiltInRole.Administrator);
             }


### PR DESCRIPTION
Rebased after v6 merge to master. Made some relevant comments here https://github.com/Particular/NServiceBus/pull/4189

* Fixes deadlock when MSMQ service restarts with native transaction, closes #4188 
* Reduces allocations on hot path for the dequeue strategy
* Removes the long running flag and replaces Task.Factory.StartNew with Task.Run, fixes #3251