### PR TITLE
Avoid allocating a complete copy of the message on every failure unless it is necessary

### DIFF
--- a/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
@@ -26,6 +26,9 @@ namespace NServiceBus.Faults
 
         internal void InvokeMessageHasBeenSentToErrorQueue(IncomingMessage message, Exception exception, string errorQueue)
         {
+            if (MessageSentToErrorQueue == null)
+                return;
+
             var failedMessage = new FailedMessage(
                 message.MessageId,
                 new Dictionary<string, string>(message.Headers),
@@ -35,6 +38,9 @@ namespace NServiceBus.Faults
 
         internal void InvokeMessageHasFailedAnImmediateRetryAttempt(int immediateRetryAttempt, IncomingMessage message, Exception exception)
         {
+            if (MessageHasFailedAnImmediateRetryAttempt == null)
+                return;
+
             var retry = new ImmediateRetryMessage(
                 message.MessageId,
                 new Dictionary<string, string>(message.Headers),
@@ -46,6 +52,9 @@ namespace NServiceBus.Faults
 
         internal void InvokeMessageHasBeenSentToDelayedRetries(int delayedRetryAttempt, IncomingMessage message, Exception exception)
         {
+            if (MessageHasBeenSentToDelayedRetries == null)
+                return;
+
             var retry = new DelayedRetryMessage(
                 new Dictionary<string, string>(message.Headers),
                 CopyOfBody(message.Body),

--- a/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
@@ -27,7 +27,9 @@ namespace NServiceBus.Faults
         internal void InvokeMessageHasBeenSentToErrorQueue(IncomingMessage message, Exception exception, string errorQueue)
         {
             if (MessageSentToErrorQueue == null)
+            {
                 return;
+            }
 
             var failedMessage = new FailedMessage(
                 message.MessageId,
@@ -39,7 +41,9 @@ namespace NServiceBus.Faults
         internal void InvokeMessageHasFailedAnImmediateRetryAttempt(int immediateRetryAttempt, IncomingMessage message, Exception exception)
         {
             if (MessageHasFailedAnImmediateRetryAttempt == null)
+            {
                 return;
+            }
 
             var retry = new ImmediateRetryMessage(
                 message.MessageId,
@@ -53,7 +57,9 @@ namespace NServiceBus.Faults
         internal void InvokeMessageHasBeenSentToDelayedRetries(int delayedRetryAttempt, IncomingMessage message, Exception exception)
         {
             if (MessageHasBeenSentToDelayedRetries == null)
+            {
                 return;
+            }
 
             var retry = new DelayedRetryMessage(
                 new Dictionary<string, string>(message.Headers),

--- a/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
@@ -26,48 +26,29 @@ namespace NServiceBus.Faults
 
         internal void InvokeMessageHasBeenSentToErrorQueue(IncomingMessage message, Exception exception, string errorQueue)
         {
-            if (MessageSentToErrorQueue == null)
-            {
-                return;
-            }
-
-            var failedMessage = new FailedMessage(
+            MessageSentToErrorQueue?.Invoke(this, new FailedMessage(
                 message.MessageId,
                 new Dictionary<string, string>(message.Headers),
-                CopyOfBody(message.Body), exception, errorQueue);
-            MessageSentToErrorQueue?.Invoke(this, failedMessage);
+                CopyOfBody(message.Body), exception, errorQueue));
         }
 
         internal void InvokeMessageHasFailedAnImmediateRetryAttempt(int immediateRetryAttempt, IncomingMessage message, Exception exception)
         {
-            if (MessageHasFailedAnImmediateRetryAttempt == null)
-            {
-                return;
-            }
-
-            var retry = new ImmediateRetryMessage(
+            MessageHasFailedAnImmediateRetryAttempt?.Invoke(this, new ImmediateRetryMessage(
                 message.MessageId,
                 new Dictionary<string, string>(message.Headers),
                 CopyOfBody(message.Body),
                 exception,
-                immediateRetryAttempt);
-            MessageHasFailedAnImmediateRetryAttempt?.Invoke(this, retry);
+                immediateRetryAttempt));
         }
 
         internal void InvokeMessageHasBeenSentToDelayedRetries(int delayedRetryAttempt, IncomingMessage message, Exception exception)
         {
-            if (MessageHasBeenSentToDelayedRetries == null)
-            {
-                return;
-            }
-
-            var retry = new DelayedRetryMessage(
+            MessageHasBeenSentToDelayedRetries?.Invoke(this, new DelayedRetryMessage(
                 new Dictionary<string, string>(message.Headers),
                 CopyOfBody(message.Body),
                 exception,
-                delayedRetryAttempt);
-
-            MessageHasBeenSentToDelayedRetries?.Invoke(this, retry);
+                delayedRetryAttempt));
         }
 
         static byte[] CopyOfBody(byte[] body)


### PR DESCRIPTION
Early return to avoid the full message copy with no eventhandlers registered.