### PR TITLE
CombGuid now using DateTime.UtcNow to resolve DST ordering issues

### DIFF
--- a/src/NServiceBus.Core/IdGeneration/CombGuid.cs
+++ b/src/NServiceBus.Core/IdGeneration/CombGuid.cs
@@ -2,8 +2,11 @@ namespace NServiceBus
 {
     using System;
 
-    // Generates a Guid using http://www.informit.com/articles/article.asp?p=25862
-    // The Comb algorithm is designed to make the use of Guids as Primary Keys, Foreign Keys, and Indexes nearly as efficient as ints.
+    /// <summary>
+    /// Generates a Guid using http://www.informit.com/articles/article.asp?p=25862
+    /// The Comb algorithm is designed to make the use of Guids as Primary Keys, Foreign Keys, and Indexes nearly as efficient as ints.
+    /// </summary>
+    /// <remarks>Source: https://github.com/nhibernate/nhibernate-core/blob/4.0.4.GA/src/NHibernate/Id/GuidCombGenerator.cs</remarks>
     static class CombGuid
     {
         /// <summary>
@@ -13,17 +16,16 @@ namespace NServiceBus
         {
             var guidArray = Guid.NewGuid().ToByteArray();
 
-            var baseDate = new DateTime(1900, 1, 1);
-            var now = DateTime.Now;
+            var now = DateTime.UtcNow;
 
             // Get the days and milliseconds which will be used to build the byte string 
-            var days = new TimeSpan(now.Ticks - baseDate.Ticks);
+            var days = new TimeSpan(now.Ticks - BaseDateTicks);
             var timeOfDay = now.TimeOfDay;
 
             // Convert to a byte array 
             // Note that SQL Server is accurate to 1/300th of a millisecond so we divide by 3.333333 
             var daysArray = BitConverter.GetBytes(days.Days);
-            var millisecondArray = BitConverter.GetBytes((long) (timeOfDay.TotalMilliseconds/3.333333));
+            var millisecondArray = BitConverter.GetBytes((long)(timeOfDay.TotalMilliseconds / 3.333333));
 
             // Reverse the bytes to match SQL Servers ordering 
             Array.Reverse(daysArray);
@@ -35,5 +37,7 @@ namespace NServiceBus
 
             return new Guid(guidArray);
         }
+
+        static readonly long BaseDateTicks = new DateTime(1900, 1, 1).Ticks;
     }
 }

--- a/src/NServiceBus.Core/IdGeneration/CombGuid.cs
+++ b/src/NServiceBus.Core/IdGeneration/CombGuid.cs
@@ -4,7 +4,8 @@ namespace NServiceBus
 
     /// <summary>
     /// Generates a Guid using http://www.informit.com/articles/article.asp?p=25862
-    /// The Comb algorithm is designed to make the use of Guids as Primary Keys, Foreign Keys, and Indexes nearly as efficient as ints.
+    /// The Comb algorithm is designed to make the use of Guids as Primary Keys, Foreign Keys, and Indexes nearly as efficient
+    /// as ints.
     /// </summary>
     /// <remarks>Source: https://github.com/nhibernate/nhibernate-core/blob/4.0.4.GA/src/NHibernate/Id/GuidCombGenerator.cs</remarks>
     static class CombGuid

--- a/src/NServiceBus.Core/IdGeneration/CombGuid.cs
+++ b/src/NServiceBus.Core/IdGeneration/CombGuid.cs
@@ -25,7 +25,7 @@ namespace NServiceBus
             // Convert to a byte array 
             // Note that SQL Server is accurate to 1/300th of a millisecond so we divide by 3.333333 
             var daysArray = BitConverter.GetBytes(days.Days);
-            var millisecondArray = BitConverter.GetBytes((long)(timeOfDay.TotalMilliseconds / 3.333333));
+            var millisecondArray = BitConverter.GetBytes((long) (timeOfDay.TotalMilliseconds/3.333333));
 
             // Reverse the bytes to match SQL Servers ordering 
             Array.Reverse(daysArray);


### PR DESCRIPTION
CombGuid was using `DateTime.Now` which is much slower due to timezone conversions but also causes sorting issues due to DST offsets.

Applied the same fix as I did for NHibernate (https://github.com/nhibernate/nhibernate-core/pull/440)