### PR TITLE
[WIP] Change settings key from  "TypesToScan" to "AvailableTypes".

### DIFF
--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_directory_with_nested_directories.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_directory_with_nested_directories.cs
@@ -1,7 +1,5 @@
 namespace NServiceBus.Core.Tests.AssemblyScanner
 {
-    using System;
-    using System.Collections.Generic;
     using System.Linq;
     using Config;
     using NUnit.Framework;
@@ -16,8 +14,8 @@ namespace NServiceBus.Core.Tests.AssemblyScanner
             endpointConfiguration.ExcludeTypes(typeof(When_using_initialization_with_non_default_ctor.FeatureWithInitialization));
             endpointConfiguration.Build();
 
-            var scanedTypes = endpointConfiguration.Settings.Get<IList<Type>>("TypesToScan");
-            var foundTypeFromNestedAssembly = scanedTypes.Any(x => x.Name == "NestedClass");
+            var availableTypes = endpointConfiguration.Settings.GetAvailableTypes();
+            var foundTypeFromNestedAssembly = availableTypes.Any(x => x.Name == "NestedClass");
             Assert.False(foundTypeFromNestedAssembly, "Was expected not to scan nested assemblies, but nested assembly was scanned.");
         }
 
@@ -30,8 +28,8 @@ namespace NServiceBus.Core.Tests.AssemblyScanner
             endpointConfiguration.ExcludeTypes(typeof(When_using_initialization_with_non_default_ctor.FeatureWithInitialization));
             endpointConfiguration.Build();
 
-            var scanedTypes = endpointConfiguration.Settings.Get<IList<Type>>("TypesToScan");
-            var foundTypeFromNestedAssembly = scanedTypes.Any(x => x.Name == "NestedClass");
+            var availableTypes = endpointConfiguration.Settings.GetAvailableTypes();
+            var foundTypeFromNestedAssembly = availableTypes.Any(x => x.Name == "NestedClass");
             Assert.True(foundTypeFromNestedAssembly, "Was expected to scan nested assemblies, but nested assembly were not scanned.");
         }
     }

--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -195,7 +195,7 @@ namespace NServiceBus
                 scannedTypes = scannedTypes.Union(GetAllowedCoreTypes()).ToList();
             }
 
-            Settings.SetDefault("TypesToScan", scannedTypes);
+            Settings.SetDefault("AvailableTypes", scannedTypes);
             ActivateAndInvoke<INeedInitialization>(scannedTypes, t => t.Customize(this));
 
             UseTransportExtensions.EnsureTransportConfigured(this);

--- a/src/NServiceBus.Core/SettingsExtensions.cs
+++ b/src/NServiceBus.Core/SettingsExtensions.cs
@@ -50,7 +50,7 @@ namespace NServiceBus
         public static IList<Type> GetAvailableTypes(this ReadOnlySettings settings)
         {
             Guard.AgainstNull(nameof(settings), settings);
-            return settings.Get<IList<Type>>("TypesToScan");
+            return settings.Get<IList<Type>>("AvailableTypes");
         }
 
         /// <summary>


### PR DESCRIPTION
The key name of "TypesToScan" is just incorrect. The value stored on this key is the types that have been picked up by the assembly scanner when the endpoint started. They are already scanned, so they are not TO BE SCANNED at all. I changed it to "AvailableTypes", since we are already using that term in the public API that exposes the setting.