### PR TITLE
Do not swallow timeout exceptions in Acceptance Tests

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/FailTestOnErrorMessageFeature.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/FailTestOnErrorMessageFeature.cs
@@ -6,6 +6,7 @@
     using System.Threading.Tasks;
     using Faults;
     using Features;
+    using Logging;
     using Pipeline;
 
     public class FailTestOnErrorMessageFeature : Feature
@@ -53,13 +54,17 @@
             public async Task Invoke(ITransportReceiveContext context, Func<ITransportReceiveContext, Task> next)
             {
                 failedMessages.AddOrUpdate(context.Message.MessageId, id => true, (id, value) => true);
+                log.Debug($"Procesing message {context.Message.MessageId}");
 
                 await next(context).ConfigureAwait(false);
 
                 failedMessages.AddOrUpdate(context.Message.MessageId, id => false, (id, value) => false);
+                log.Debug($"Finished message {context.Message.MessageId}");
             }
 
             ConcurrentDictionary<string, bool> failedMessages;
+
+            static ILog log = LogManager.GetLogger<FailTestOnErrorMessageFeature>();
         }
     }
 }


### PR DESCRIPTION
@Scooletz and I noted that the ATT may swallow the exception which is thrown in case the test doesn't complete in the given time. The scenario works as follows:

* Test doesn't complete in the specified time because messages are still processed. An exception is thrown.
* A finally block will shut down the endpoints
* In the shutdown procedure we wait for messages which are marked for retries to complete
* After 30 seconds, there are still messages (possibly new messages) scheduled for retries. A new exception is thrown from the finally block.
* The new exception hides the first exception and hides some valuable information that the done condition was not hit within the specified time.

I think we can solve this by moving this check before actually shutting down the endpoints in the finally block, as it will keep the expected behavior:
* It can delay shut down
* even if it fails, it will shut down nevertheless

but now it no longer checks for message to be retried in case the test already exceeded the test timeout.

@Particular/nservicebus-maintainers please review
/cc @Scooletz 

(also added some logging to `FailTestOnErrorMessageFeature` we used during our investigations)