### PR TITLE
Hotfix-5.2.19

### DIFF
--- a/src/NServiceBus.Core/Transports/Msmq/MsmqUnitOfWork.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqUnitOfWork.cs
@@ -37,7 +37,12 @@ namespace NServiceBus.Transports.Msmq
         /// <returns><code>true</code> if a <see cref="MessageQueueTransaction"/> is currently in progress, otherwise <code>false</code>.</returns>
         public bool HasActiveTransaction()
         {
-            return currentTransaction.IsValueCreated;
+            if (!currentTransaction.IsValueCreated)
+            {
+                return false;
+            }
+
+            return currentTransaction.Value != null;
         }
 
         internal void ClearTransaction()


### PR DESCRIPTION
Closes #4215 

HasActiveTransaction of `MsmqUnitOfWork` needs to check the `currentTransaction.Value` for non-null
`currentTransaction.IsValueCreated` will always return true when a thread already assigned the slot although the value is null.

## What happens:

* When handling an incoming message, an MSMQ transaction is set on the `MsmqUnitOfWork`.
* After the processing, `ClearTransaction` is called which set the ThreadLocal variable value to null ( `currentTransaction.Value = null;`)
* When a message is sent on the bus outside the pipeline, it checks `MsmqUnitOfWork.HasActiveTransaction()` which uses the following implementation: `return currentTransaction.IsValueCreated;`

Sadly, `IsValueCreated` will remain true even after setting the current transaction to null. This makes the sender think it needs to enlist with a transaction although there is none.

Spec test to reproduce the issue:

    public class When_a_send_local : NServiceBusAcceptanceTest
    {
        [Test]
        public void Should_allow_send_local_with_reused_thread()
        {
            ThreadPool.SetMaxThreads(1, 1);

            IBus outerBus = null;
            Exception exception = null;
            var task = Task.Run(() =>
            {
                SpinWait.SpinUntil(() => outerBus != null);

                while (true)
                {
                    try
                    {
                        Task.Run(() => outerBus.SendLocal(new MyRequest())).GetAwaiter().GetResult();
                    }
                    catch (Exception ex)
                    {
                        exception = ex;
                        return;
                    }
                }
            });

            Scenario.Define<Context>()
                    .WithEndpoint<EndpointWithLocalCallback>(b => b.Given(
                    (bus, context) =>
                    {
                        outerBus = bus;
                        Task.Run(() => bus.SendLocal(new MyRequest())).GetAwaiter().GetResult();
                    }))
                    .Done(c => exception != null)
                    .Repeat(r => r.For(Transports.Default))
                    .Should(c =>
                    {
                        Assert.True(c.HandlerGotTheRequest);
                    })
                    .Run();

            task.GetAwaiter().GetResult();
        }

        public class Context : ScenarioContext
        {
            public bool HandlerGotTheRequest { get; set; }
        }

        public class EndpointWithLocalCallback : EndpointConfigurationBuilder
        {
            public EndpointWithLocalCallback()
            {
                EndpointSetup<DefaultServer>(c => c.Transactions().DisableDistributedTransactions());
            }

            public class MyRequestHandler : IHandleMessages<MyRequest>
            {
                public Context Context { get; set; }

                public void Handle(MyRequest request)
                {
                    Context.HandlerGotTheRequest = true;
                }
            }
        }

        [Serializable]
        public class MyRequest : IMessage { }
    }