### PR TITLE
Verify correct transaction scope sharing

### DIFF
--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="When_on_message_throws.cs" />
     <Compile Include="When_requesting_immediate_retry.cs" />
     <Compile Include="When_sending_from_on_error.cs" />
+    <Compile Include="When_transaction_level_TransactionScope.cs" />
     <Compile Include="When_user_aborts_processing.cs" />
     <Compile Include="When_using_non_durable_delivery.cs" />
   </ItemGroup>

--- a/src/NServiceBus.TransportTests/When_transaction_level_TransactionScope.cs
+++ b/src/NServiceBus.TransportTests/When_transaction_level_TransactionScope.cs
@@ -30,7 +30,7 @@
 
             Assert.That(transactions.Item1, Is.Not.Null);
             Assert.That(transactions.Item2, Is.Not.Null);
-            Assert.AreEqual(transactions.Item1, transactions.Item2);
+            Assert.AreSame(transactions.Item1, transactions.Item2);
         }
     }
 }

--- a/src/NServiceBus.TransportTests/When_transaction_level_TransactionScope.cs
+++ b/src/NServiceBus.TransportTests/When_transaction_level_TransactionScope.cs
@@ -1,0 +1,36 @@
+﻿namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using System.Transactions;
+    using NUnit.Framework;
+    using Transport;
+
+    public class When_transaction_level_TransactionScope : NServiceBusTransportTest
+    {
+        [Test]
+        public async Task Should_have_active_transaction()
+        {
+            var messageHandled = new TaskCompletionSource<Tuple<Transaction, Transaction>>();
+
+            await StartPump(
+                context =>
+                {
+                    var currentTransaction = Transaction.Current;
+                    var contextTransaction = context.TransportTransaction.Get<Transaction>();
+                    messageHandled.SetResult(new Tuple<Transaction, Transaction>(currentTransaction, contextTransaction));
+
+                    return Task.FromResult(0);
+                },
+                errorContext => Task.FromResult(ErrorHandleResult.Handled),
+                TransportTransactionMode.TransactionScope);
+            await SendMessage(InputQueueName);
+
+            var transactions = await messageHandled.Task;
+
+            Assert.That(transactions.Item1, Is.Not.Null);
+            Assert.That(transactions.Item2, Is.Not.Null);
+            Assert.AreEqual(transactions.Item1, transactions.Item2);
+        }
+    }
+}


### PR DESCRIPTION
Adds a new transport test to verify correct behavior of `Transaction.Current` and `TransportTransactions.Get<Transaction>()` when using the TransactionScope transaction level.

@Particular/nservicebus-maintainers @Particular/sqlserver-transport-maintainers thoughts?