### PR TITLE
Throw exception on ambiguous configuration providers

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Config/When_multiple_configuration_providers.cs
+++ b/src/NServiceBus.AcceptanceTests/Config/When_multiple_configuration_providers.cs
@@ -17,7 +17,7 @@
                 .Done(c => c.EndpointsStarted)
                 .Run());
 
-            Assert.That(exception?.InnerException?.InnerException?.Message, Does.Contain("Ambiguous configuration providers implementing IProvideConfiguration<CustomConfigSection> were found"));
+            Assert.That(exception?.InnerException?.InnerException?.Message, Does.Contain("2 configuration providers implementing IProvideConfiguration<CustomConfigSection> were found"));
         }
 
         class Endpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Config/When_multiple_configuration_providers.cs
+++ b/src/NServiceBus.AcceptanceTests/Config/When_multiple_configuration_providers.cs
@@ -1,0 +1,60 @@
+﻿namespace NServiceBus.AcceptanceTests.Config
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NServiceBus.Config.ConfigurationSource;
+    using NUnit.Framework;
+
+    public class When_multiple_configuration_providers : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_throw_at_startup()
+        {
+            var exception = Assert.ThrowsAsync<AggregateException>(() => Scenario.Define<ScenarioContext>()
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run());
+
+            Assert.That(exception?.InnerException?.InnerException?.Message, Does.Contain("Ambiguous configuration providers implementing IProvideConfiguration<CustomConfigSection> were found"));
+        }
+
+        class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(e => e
+                    .EnableFeature<CustomFeature>());
+            }
+        }
+
+        class CustomFeature : Feature
+        {
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.Settings.GetConfigSection<CustomConfigSection>();
+            }
+        }
+
+        public class ConfigProvider1 : IProvideConfiguration<CustomConfigSection>
+        {
+            public CustomConfigSection GetConfiguration()
+            {
+                return new CustomConfigSection();
+            }
+        }
+
+        public class ConfigProvider2 : IProvideConfiguration<CustomConfigSection>
+        {
+            public CustomConfigSection GetConfiguration()
+            {
+                return new CustomConfigSection();
+            }
+        }
+
+        public class CustomConfigSection
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Config/When_multiple_configuration_providers.cs
+++ b/src/NServiceBus.AcceptanceTests/Config/When_multiple_configuration_providers.cs
@@ -17,7 +17,7 @@
                 .Done(c => c.EndpointsStarted)
                 .Run());
 
-            Assert.That(exception?.InnerException?.InnerException?.Message, Does.Contain("2 configuration providers implementing IProvideConfiguration<CustomConfigSection> were found"));
+            Assert.That(exception?.InnerException?.InnerException?.Message, Does.Contain("Multiple configuration providers implementing IProvideConfiguration<CustomConfigSection> were found"));
         }
 
         class Endpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Basic\When_depending_on_untyped_feature.cs" />
     <Compile Include="Basic\When_extending_behavior_context.cs" />
     <Compile Include="Basic\When_receiving_unobtrusive_message_without_handler.cs" />
+    <Compile Include="Config\When_multiple_configuration_providers.cs" />
     <Compile Include="Core\Feature\When_feature_startup_task_fails.cs" />
     <Compile Include="Core\LegacyRetries\When_legacy_retries_left_in_retry_queue.cs" />
     <Compile Include="Core\MessageDurability\When_sending_a_non_durable_message_with_conventions.cs" />

--- a/src/NServiceBus.Core/SettingsExtensions.cs
+++ b/src/NServiceBus.Core/SettingsExtensions.cs
@@ -23,7 +23,7 @@ namespace NServiceBus
             var sectionOverrideTypes = typesToScan.Where(t => !t.IsAbstract && typeof(IProvideConfiguration<T>).IsAssignableFrom(t)).ToArray();
             if (sectionOverrideTypes.Length > 1)
             {
-                throw new Exception($"Ambiguous configuration providers implementing IProvideConfiguration<{typeof(T).Name}> were found. Ensure that only one configuration provider per configuration section is found to resolve this error.");
+                throw new Exception($"{sectionOverrideTypes.Length} configuration providers implementing IProvideConfiguration<{typeof(T).Name}> were found. Ensure that only one configuration provider per configuration section is found to resolve this error.");
             }
 
             if (sectionOverrideTypes.Length == 0)

--- a/src/NServiceBus.Core/SettingsExtensions.cs
+++ b/src/NServiceBus.Core/SettingsExtensions.cs
@@ -23,7 +23,7 @@ namespace NServiceBus
             var sectionOverrideTypes = typesToScan.Where(t => !t.IsAbstract && typeof(IProvideConfiguration<T>).IsAssignableFrom(t)).ToArray();
             if (sectionOverrideTypes.Length > 1)
             {
-                throw new Exception($"{sectionOverrideTypes.Length} configuration providers implementing IProvideConfiguration<{typeof(T).Name}> were found. Ensure that only one configuration provider per configuration section is found to resolve this error.");
+                throw new Exception($"Multiple configuration providers implementing IProvideConfiguration<{typeof(T).Name}> were found: {string.Join(", ", sectionOverrideTypes.Select(s => s.FullName))}. Ensure that only one configuration provider per configuration section is found to resolve this error.");
             }
 
             if (sectionOverrideTypes.Length == 0)


### PR DESCRIPTION
Fixes #4214 

throw an exception when we find more than one implementation of `IProvideConfiguration<X>`

ping @Particular/nservicebus-maintainers 