### PR TITLE
Pass satellite runtime settings to satellite receiver

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
     using EndpointTemplates;
     using Extensibility;
     using NServiceBus.Routing;
@@ -36,14 +37,21 @@
 
         class FakeReceiver : IPushMessages
         {
+            PushSettings pushSettings;
+
             public Task Init(Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, CriticalError criticalError, PushSettings settings)
             {
+                pushSettings = settings;
                 return Task.FromResult(0);
             }
 
             public void Start(PushRuntimeSettings limitations)
             {
-                Assert.AreEqual(10, limitations.MaxConcurrency);
+                if (pushSettings.InputQueue == Conventions.EndpointNamingConvention(typeof(ThrottledEndpoint)))
+                {
+                    // The LimitMessageProcessingConcurrencyTo setting only applies to the input queue
+                    Assert.AreEqual(10, limitations.MaxConcurrency);
+                }
             }
 
             public Task Stop()

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -47,9 +47,9 @@
 
             public void Start(PushRuntimeSettings limitations)
             {
+                // The LimitMessageProcessingConcurrencyTo setting only applies to the input queue
                 if (pushSettings.InputQueue == Conventions.EndpointNamingConvention(typeof(ThrottledEndpoint)))
-                {
-                    // The LimitMessageProcessingConcurrencyTo setting only applies to the input queue
+                {   
                     Assert.AreEqual(10, limitations.MaxConcurrency);
                 }
             }

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -123,7 +123,7 @@ namespace NServiceBus
             var recoverabilityExecutor = recoverabilityExecutorFactory.CreateDefault(eventAggregator, localAddress);
             var pushSettings = new PushSettings(settings.LocalAddress(), errorQueue, purgeOnStartup, requiredTransactionSupport);
             var mainPipelineExecutor = new MainPipelineExecutor(builder, eventAggregator, pipelineCache, mainPipeline);
-            var dequeueLimitations = GeDequeueLimitationsForReceivePipeline();
+            var dequeueLimitations = GetDequeueLimitationsForReceivePipeline();
 
             var receivers = new List<TransportReceiver>();
 
@@ -143,7 +143,7 @@ namespace NServiceBus
 
         //note: this should be handled in a feature but we don't have a good
         // extension point to plugin atm
-        PushRuntimeSettings GeDequeueLimitationsForReceivePipeline()
+        PushRuntimeSettings GetDequeueLimitationsForReceivePipeline()
         {
             var transportConfig = settings.GetConfigSection<TransportConfig>();
 

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -101,29 +101,29 @@ namespace NServiceBus
 
             var purgeOnStartup = settings.GetOrDefault<bool>("Transport.PurgeOnStartup");
             var errorQueue = settings.ErrorQueueAddress();
-            var dequeueLimitations = GeDequeueLimitationsForReceivePipeline();
             var requiredTransactionSupport = settings.GetRequiredTransactionModeForReceives();
             var recoverabilityExecutorFactory = builder.Build<RecoverabilityExecutorFactory>();
 
-            var receivers = BuildMainReceivers(errorQueue, purgeOnStartup, requiredTransactionSupport, dequeueLimitations, recoverabilityExecutorFactory, mainPipeline);
+            var receivers = BuildMainReceivers(errorQueue, purgeOnStartup, requiredTransactionSupport, recoverabilityExecutorFactory, mainPipeline);
 
             foreach (var satellitePipeline in settings.Get<SatelliteDefinitions>().Definitions)
             {
                 var satelliteRecoverabilityExecutor = recoverabilityExecutorFactory.Create(satellitePipeline.RecoverabilityPolicy, eventAggregator, satellitePipeline.ReceiveAddress);
                 var satellitePushSettings = new PushSettings(satellitePipeline.ReceiveAddress, errorQueue, purgeOnStartup, satellitePipeline.RequiredTransportTransactionMode);
 
-                receivers.Add(new TransportReceiver(satellitePipeline.Name, builder.Build<IPushMessages>(), satellitePushSettings, dequeueLimitations, new SatellitePipelineExecutor(builder, satellitePipeline), satelliteRecoverabilityExecutor, criticalError));
+                receivers.Add(new TransportReceiver(satellitePipeline.Name, builder.Build<IPushMessages>(), satellitePushSettings, satellitePipeline.RuntimeSettings, new SatellitePipelineExecutor(builder, satellitePipeline), satelliteRecoverabilityExecutor, criticalError));
             }
 
             return receivers;
         }
 
-        List<TransportReceiver> BuildMainReceivers(string errorQueue, bool purgeOnStartup, TransportTransactionMode requiredTransactionSupport, PushRuntimeSettings dequeueLimitations, RecoverabilityExecutorFactory recoverabilityExecutorFactory, IPipeline<ITransportReceiveContext> mainPipeline)
+        List<TransportReceiver> BuildMainReceivers(string errorQueue, bool purgeOnStartup, TransportTransactionMode requiredTransactionSupport, RecoverabilityExecutorFactory recoverabilityExecutorFactory, IPipeline<ITransportReceiveContext> mainPipeline)
         {
             var localAddress = settings.LocalAddress();
             var recoverabilityExecutor = recoverabilityExecutorFactory.CreateDefault(eventAggregator, localAddress);
             var pushSettings = new PushSettings(settings.LocalAddress(), errorQueue, purgeOnStartup, requiredTransactionSupport);
             var mainPipelineExecutor = new MainPipelineExecutor(builder, eventAggregator, pipelineCache, mainPipeline);
+            var dequeueLimitations = GeDequeueLimitationsForReceivePipeline();
 
             var receivers = new List<TransportReceiver>();
 


### PR DESCRIPTION
Fixes #4213 

as mentioned in that issue, this will change the behavior of our satellite pipelines:

> fixing this also means that core satellites (timeout manager) ignores configured concurrency settings and always will use the default concurrency as of now. Since this code is under own control, I'd say that's no issue but not sure whether I'm missing something?

comment by @andreasohlund 

> That was the plan, to decouple that setting from the user one.
> 
> If the the default (max(2,virtualcores) is suitable for the TM satellites can be discussed though

should we make this discussion part of this PR?
First thoughts:
- the timeout receiver receiver can be concurrent without issues
- dispatcher may reduce duplicates by using a concurrency of 1 (but also limiting the TMs throughput of course)

ping @Particular/nservicebus-maintainers @mikeminutillo 
