### PR TITLE
Use a consistent lifecyle for testing

### DIFF
--- a/src/NServiceBus.ContainerTests/When_registering_components.cs
+++ b/src/NServiceBus.ContainerTests/When_registering_components.cs
@@ -85,7 +85,7 @@ namespace NServiceBus.ContainerTests
         {
             using (var builder = TestContainerBuilder.ConstructBuilder())
             {
-                builder.Configure(typeof(SomeClass), DependencyLifecycle.InstancePerCall);
+                builder.Configure(typeof(SomeClass), DependencyLifecycle.SingleInstance);
                 builder.Configure(typeof(ClassWithSetterDependencies), DependencyLifecycle.SingleInstance);
 
                 var component = (ClassWithSetterDependencies)builder.Build(typeof(IWithSetterDependencies));
@@ -101,7 +101,7 @@ namespace NServiceBus.ContainerTests
         {
             using (var builder = TestContainerBuilder.ConstructBuilder())
             {
-                builder.Configure(typeof(SomeClass), DependencyLifecycle.InstancePerCall);
+                builder.Configure(typeof(SomeClass), DependencyLifecycle.SingleInstance);
                 builder.Configure(typeof(ClassWithSetterDependencies), DependencyLifecycle.SingleInstance);
 
                 var component = (ClassWithSetterDependencies)builder.Build(typeof(ClassWithSetterDependencies));


### PR DESCRIPTION
## Problem

The `Setter_injection_should_be_enabled_by_default` and `Setter_dependencies_should_be_supported_when_resolving_interfaces` tests are testing a valid core assumption, but they are doing so by using different lifecycles for the properties.

The tests are intended to check that the instance of `ClassWithSetterDependencies` has it's properties set correctly by asserting that the instances of the `SomeClass` property is populated by the container.

The inconsistency is that `ClassWithSetterDependencies` is declared as a single instance type, while `SomeClass` is currently declared as an `InstancePerCall` type. There can never be a scenario in these tests where the instance of `SomeClass` can be a different lifecycle when compared to the instance of `ClassWithSetterDependencies`.

This problem manifests when stricter containers enforce consistency between dependent registrations (e.g. SimpleInjector)

## Proposed solution

Making the lifecycle of the classes the same would make the test more reliable in all container types.

Ping @Particular/nservicebus-maintainers and @Particular/container-maintainers 