### PR TITLE
expose Definition on SerializationExtensions<T>

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2826,7 +2826,11 @@ namespace NServiceBus.Serialization
     public class SerializationExtensions<T> : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
         where T : NServiceBus.Serialization.SerializationDefinition
     {
+        [System.ObsoleteAttribute("Use `SerializationExtensions(SettingsHolder settings, T definition)` instead. Wil" +
+            "l be removed in version 7.0.0.", true)]
         public SerializationExtensions(NServiceBus.Settings.SettingsHolder settings) { }
+        public SerializationExtensions(NServiceBus.Settings.SettingsHolder settings, T definition) { }
+        public T Definition { get; }
     }
 }
 namespace NServiceBus.Serializers.Json

--- a/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/When_overriding_stream_encoding.cs
@@ -13,7 +13,7 @@ namespace NServiceBus.Serializers.Json.Tests
         public void Should_construct_serializer_that_uses_requested_encoding()
         {
             var settings = new SettingsHolder();
-            var extensions = new SerializationExtensions<JsonSerializer>(settings);
+            var extensions = new SerializationExtensions<JsonSerializer>(settings, new JsonSerializer());
             extensions.Encoding(Encoding.UTF7);
 
             var serializer = (NServiceBus.JsonMessageSerializer)new JsonSerializer().Configure(settings)(new MessageMapper());

--- a/src/NServiceBus.Core/Serialization/SerializationConfigExtensions.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationConfigExtensions.cs
@@ -36,7 +36,7 @@
 
             var settings = new SettingsHolder();
             config.Settings.SetMainSerializer(serializationDefinition, settings);
-            return CreateSerializationExtension<T>(settings);
+            return CreateSerializationExtension(settings, serializationDefinition);
         }
 
         /// <summary>
@@ -67,14 +67,14 @@
 
             var settings = new SettingsHolder();
             additionalSerializers.Add(Tuple.Create<SerializationDefinition, SettingsHolder>(serializationDefinition, settings));
-            return CreateSerializationExtension<T>(settings);
+            return CreateSerializationExtension(settings, serializationDefinition);
         }
 
-        static SerializationExtensions<T> CreateSerializationExtension<T>(SettingsHolder settings) where T : SerializationDefinition
+        static SerializationExtensions<T> CreateSerializationExtension<T>(SettingsHolder settings, T definition)
+            where T : SerializationDefinition
         {
             var type = typeof(SerializationExtensions<>).MakeGenericType(typeof(T));
-            var extension = (SerializationExtensions<T>) Activator.CreateInstance(type, settings);
-            return extension;
+            return (SerializationExtensions<T>) Activator.CreateInstance(type, settings);
         }
     }
 }

--- a/src/NServiceBus.Core/Serialization/SerializationExtensions.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationExtensions.cs
@@ -10,7 +10,7 @@
     public class SerializationExtensions<T> : ExposeSettings where T : SerializationDefinition
     {
         /// <summary>
-        /// The instance of <see cref="SerializationDefinition"/> that was created as part of <see cref="SerializationConfigExtensions.AddDeserializer{T}(EndpointConfiguration,T)"/>
+        /// The instance of <see cref="SerializationDefinition"/> that was created as part of <see cref="SerializationConfigExtensions.AddDeserializer{T}(EndpointConfiguration,T)"/>.
         /// </summary>
         public T Definition { get; }
 

--- a/src/NServiceBus.Core/Serialization/SerializationExtensions.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationExtensions.cs
@@ -10,10 +10,27 @@
     public class SerializationExtensions<T> : ExposeSettings where T : SerializationDefinition
     {
         /// <summary>
+        /// The instance of <see cref="SerializationDefinition"/> that was created as part of <see cref="SerializationConfigExtensions.AddDeserializer{T}(EndpointConfiguration,T)"/>
+        /// </summary>
+        public T Definition { get; }
+
+        /// <summary>
         /// Initializes a new instance of <see cref="SerializationExtensions{T}" />.
         /// </summary>
+        [ObsoleteEx(
+             RemoveInVersion = "7.0",
+             ReplacementTypeOrMember = "SerializationExtensions(SettingsHolder settings, T definition)")]
         public SerializationExtensions(SettingsHolder settings) : base(settings)
         {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="SerializationExtensions{T}" />.
+        /// </summary>
+        public SerializationExtensions(SettingsHolder settings, T definition) : base(settings)
+        {
+            Guard.AgainstNull(nameof(definition), definition);
+            Definition = definition;
         }
     }
 }


### PR DESCRIPTION
Required so that settings can be applied to a specific instance of a definition rather than globally for the type.

For example when transitioning between incompatible serializer settings then two versions of the same serializer settings will need to co exists. since all the serializer has access to is the global settings it has no way to determine which instance the settings were applied to.

There is a docs PR where this scenario is shown https://github.com/Particular/docs.particular.net/pull/2049/