### PR TITLE
[SPIKE] Byte buffering for received messages for MSMQ

### DIFF
--- a/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
@@ -19,7 +19,15 @@
 
             context.Message.RevertToOriginalBodyIfNeeded();
 
-            var processedMessage = new OutgoingMessage(context.Message.MessageId, new Dictionary<string, string>(context.Message.Headers), context.Message.Body);
+            OutgoingMessage processedMessage;
+            if (context.Message.Body == null)
+            {
+                processedMessage = new OutgoingMessage(context.Message.MessageId, new Dictionary<string, string>(context.Message.Headers), context.Message.BodySegment);
+            }
+            else
+            {
+                processedMessage = new OutgoingMessage(context.Message.MessageId, new Dictionary<string, string>(context.Message.Headers), context.Message.Body);
+            }
 
             var auditContext = this.CreateAuditContext(processedMessage, auditAddress, context);
 

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
@@ -55,7 +55,7 @@ namespace NServiceBus
                 {
                     Destination = destination,
                     SagaId = sagaId,
-                    State = context.Body,
+                    State = context.Body ?? context.BodySegment.Array, // better way would now write 0 bytes as well, maybe ok???
                     Time = DateTimeExtensions.ToUtcDateTime(expire),
                     Headers = context.Headers,
                     OwningTimeoutManager = owningTimeoutManager

--- a/src/NServiceBus.Core/Forwarding/InvokeForwardingPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Forwarding/InvokeForwardingPipelineBehavior.cs
@@ -18,7 +18,15 @@
 
             context.Message.RevertToOriginalBodyIfNeeded();
 
-            var processedMessage = new OutgoingMessage(context.Message.MessageId, context.Message.Headers, context.Message.Body);
+            OutgoingMessage processedMessage;
+            if (context.Message.Body == null)
+            {
+                processedMessage = new OutgoingMessage(context.Message.MessageId, context.Message.Headers, context.Message.BodySegment);
+            }
+            else
+            {
+                processedMessage = new OutgoingMessage(context.Message.MessageId, context.Message.Headers, context.Message.Body);
+            }
 
             var forwardingContext = this.CreateForwardingContext(processedMessage, forwardingAddress, context);
 

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -31,6 +31,7 @@
     <DocumentationFile>..\..\binaries\NServiceBus.Core.xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -42,6 +43,7 @@
     <DocumentationFile>..\..\binaries\NServiceBus.Core.xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <None Include="FodyWeavers.xml">
@@ -173,6 +175,7 @@
     <Compile Include="Serialization\SerializationFeature.cs" />
     <Compile Include="Serialization\SerializationSettingsExtensions.cs" />
     <Compile Include="Serializers\XML\XmlSerialization.cs" />
+    <Compile Include="Transports\Msmq\System.Buffers.g.cs" />
     <Compile Include="Transports\ReceiveSettingsExtensions.cs" />
     <Compile Include="Transports\ErrorContext.cs" />
     <Compile Include="Transports\ErrorHandleResult.cs" />

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageProcessingConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageProcessingConnector.cs
@@ -64,7 +64,15 @@ namespace NServiceBus
         {
             foreach (var operation in deduplicationEntry.TransportOperations)
             {
-                var message = new OutgoingMessage(operation.MessageId, operation.Headers, operation.Body);
+                OutgoingMessage message;
+                if (operation.Body == null)
+                {
+                    message = new OutgoingMessage(operation.MessageId, operation.Headers, operation.BodySegment);
+                }
+                else
+                {
+                    message = new OutgoingMessage(operation.MessageId, operation.Headers, operation.Body);
+                }
 
                 pendingTransportOperations.Add(
                     new Transport.TransportOperation(
@@ -90,7 +98,17 @@ namespace NServiceBus
 
                 SerializeRoutingStrategy(operation.AddressTag, options);
 
-                transportOperations[index] = new TransportOperation(operation.Message.MessageId, options, operation.Message.Body, operation.Message.Headers);
+                TransportOperation transportOperation;
+                if (operation.Message.Body == null)
+                {
+                    transportOperation = new TransportOperation(operation.Message.MessageId, options, operation.Message.BodySegment, operation.Message.Headers);
+                }
+                else
+                {
+                    transportOperation = new TransportOperation(operation.Message.MessageId, options, operation.Message.Body, operation.Message.Headers);
+                }
+
+                transportOperations[index] = transportOperation;
                 index++;
             }
             return transportOperations;

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -24,7 +24,16 @@ namespace NServiceBus
             {
                 var rootContext = new RootContext(childBuilder, pipelineCache, eventAggregator);
 
-                var message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.Body);
+                IncomingMessage message;
+                if (messageContext.Body == null)
+                {
+                    message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.BodySegment);
+                }
+                else
+                {
+                    message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.Body);
+                }
+                
                 var context = new TransportReceiveContext(message, messageContext.TransportTransaction, messageContext.ReceiveCancellationTokenSource, rootContext);
 
                 context.Extensions.Merge(messageContext.Context);

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
@@ -11,7 +11,8 @@
         {
             var mutators = context.Builder.BuildAll<IMutateIncomingTransportMessages>();
             var transportMessage = context.Message;
-            var mutatorContext = new MutateIncomingTransportMessageContext(transportMessage.Body, transportMessage.Headers);
+            // Now mutator contains also the zero byte stuff, change?
+            var mutatorContext = new MutateIncomingTransportMessageContext(transportMessage.Body ?? transportMessage.BodySegment.Array, transportMessage.Headers);
             foreach (var mutator in mutators)
             {
                 await mutator.MutateIncoming(mutatorContext)

--- a/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
@@ -21,7 +21,15 @@
                 .Select(rs =>
                 {
                     var addressLabel = rs.Apply(context.Message.Headers);
-                    var message = new OutgoingMessage(context.Message.MessageId, context.Message.Headers, context.Message.Body);
+                    OutgoingMessage message;
+                    if (context.Message.Body == null)
+                    {
+                        message = new OutgoingMessage(context.Message.MessageId, context.Message.Headers, context.Message.BodySegment);
+                    }
+                    else
+                    {
+                        message = new OutgoingMessage(context.Message.MessageId, context.Message.Headers, context.Message.Body);
+                    }
                     return new TransportOperation(message, addressLabel, dispatchConsistency, context.Extensions.GetDeliveryConstraints());
                 }).ToArray();
 

--- a/src/NServiceBus.Core/Recoverability/DelayedRetryExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/DelayedRetryExecutor.cs
@@ -20,7 +20,15 @@
 
         public async Task<int> Retry(IncomingMessage message, TimeSpan delay, TransportTransaction transportTransaction)
         {
-            var outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body);
+            OutgoingMessage outgoingMessage;
+            if (message.Body == null)
+            {
+                outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.BodySegment);
+            }
+            else
+            {
+                outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body);
+            }
 
             var currentDelayedRetriesAttempt = message.GetDelayedDeliveriesPerformed() + 1;
 

--- a/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
@@ -20,7 +20,15 @@
         {
             message.RevertToOriginalBodyIfNeeded();
 
-            var outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body);
+            OutgoingMessage outgoingMessage;
+            if (message.Body == null)
+            {
+                outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.BodySegment);
+            }
+            else
+            {
+                outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body);
+            }
 
             var headers = outgoingMessage.Headers;
             headers.Remove(Headers.DelayedRetries);

--- a/src/NServiceBus.Core/Recoverability/Recoverability.cs
+++ b/src/NServiceBus.Core/Recoverability/Recoverability.cs
@@ -202,7 +202,16 @@
                     //HINT: this header is added by v3 when doing SLR
                     outgoingHeaders.Remove("NServiceBus.OriginalId");
 
-                    var outgoingMessage = new OutgoingMessage(messageContext.MessageId, outgoingHeaders, messageContext.Body);
+                    OutgoingMessage outgoingMessage;
+                    if (messageContext.Body == null)
+                    {
+                        outgoingMessage = new OutgoingMessage(messageContext.MessageId, outgoingHeaders, messageContext.BodySegment);
+                    }
+                    else
+                    {
+                        outgoingMessage = new OutgoingMessage(messageContext.MessageId, outgoingHeaders, messageContext.Body);
+                    }
+
                     var outgoingOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(mainQueueTransportAddress));
 
                     return messageDispatcher.Dispatch(new TransportOperations(outgoingOperation), messageContext.TransportTransaction, messageContext.Context);

--- a/src/NServiceBus.Core/Reliability/Outbox/TransportOperation.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/TransportOperation.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Outbox
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -26,6 +27,24 @@
         }
 
         /// <summary>
+        /// Creates a new instance of a <see cref="TransportOperation" />.
+        /// </summary>
+        /// <param name="messageId">The identifier of the outgoing message.</param>
+        /// <param name="options">The sending options.</param>
+        /// <param name="body">The message body.</param>
+        /// <param name="headers">The message headers.</param>
+        /// .
+        public TransportOperation(string messageId, Dictionary<string, string> options, ArraySegment<byte> body, Dictionary<string, string> headers)
+        {
+            Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
+
+            MessageId = messageId;
+            Options = options;
+            BodySegment = body;
+            Headers = headers;
+        }
+
+        /// <summary>
         /// Gets the identifier of the outgoing message.
         /// </summary>
         public string MessageId { get; private set; }
@@ -39,6 +58,11 @@
         /// Gets a byte array to the body content of the outgoing message.
         /// </summary>
         public byte[] Body { get; private set; }
+
+        /// <summary>
+        /// Gets a byte array to the body content of the outgoing message.
+        /// </summary>
+        public ArraySegment<byte> BodySegment { get; private set; }
 
         /// <summary>
         /// Gets outgoing message headers.

--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -23,6 +23,20 @@
         }
 
         /// <summary>
+        /// Initializes the error context.
+        /// </summary>
+        public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, ArraySegment<byte> body, TransportTransaction transportTransaction, int immediateProcessingFailures)
+        {
+            Exception = exception;
+            TransportTransaction = transportTransaction;
+            ImmediateProcessingFailures = immediateProcessingFailures;
+
+            Message = new IncomingMessage(transportMessageId, headers, body);
+
+            DelayedDeliveriesPerformed = Message.GetDelayedDeliveriesPerformed();
+        }
+
+        /// <summary>
         /// Exception that caused the message processing to fail.
         /// </summary>
         public Exception Exception { get; }

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -40,6 +40,37 @@ namespace NServiceBus.Transport
         }
 
         /// <summary>
+        /// Creates a new message.
+        /// </summary>
+        /// <param name="messageId">Native message id.</param>
+        /// <param name="headers">The message headers.</param>
+        /// <param name="segment">The message body.</param>
+        public IncomingMessage(string messageId, Dictionary<string, string> headers, ArraySegment<byte> segment)
+        {
+            Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
+            Guard.AgainstNull(nameof(segment), segment);
+            Guard.AgainstNull(nameof(headers), headers);
+
+            string originalMessageId;
+
+            if (headers.TryGetValue(NServiceBus.Headers.MessageId, out originalMessageId) && !string.IsNullOrEmpty(originalMessageId))
+            {
+                MessageId = originalMessageId;
+            }
+            else
+            {
+                MessageId = messageId;
+
+                headers[NServiceBus.Headers.MessageId] = messageId;
+            }
+
+
+            Headers = headers;
+
+            BodySegment = segment;
+        }
+
+        /// <summary>
         /// The id of the message.
         /// </summary>
         public string MessageId { get; private set; }
@@ -55,18 +86,25 @@ namespace NServiceBus.Transport
         public byte[] Body { get; private set; }
 
         /// <summary>
+        /// Gets/sets a byte array segment to the body content of the message.
+        /// </summary>
+        public ArraySegment<byte> BodySegment { get; private set; }
+
+        /// <summary>
         /// Use this method to update the body if this message.
         /// </summary>
         internal void UpdateBody(byte[] updatedBody)
         {
+            throw new NotSupportedException("Currently not supported to Update the body");
+            // Fix this???
             //preserve the original body if needed
-            if (Body != null && originalBody == null)
-            {
-                originalBody = new byte[Body.Length];
-                Buffer.BlockCopy(Body, 0, originalBody, 0, Body.Length);
-            }
+            //if (Body != null && originalBody == null)
+            //{
+            //    originalBody = new byte[Body.Length];
+            //    Buffer.BlockCopy(Body, 0, originalBody, 0, Body.Length);
+            //}
 
-            Body = updatedBody;
+            //Body = updatedBody;
         }
 
         /// <summary>
@@ -74,12 +112,12 @@ namespace NServiceBus.Transport
         /// </summary>
         internal void RevertToOriginalBodyIfNeeded()
         {
-            if (originalBody != null)
-            {
-                Body = originalBody;
-            }
+            //if (originalBody != null)
+            //{
+            //    Body = originalBody;
+            //}
         }
 
-        byte[] originalBody;
+        //byte[] originalBody;
     }
 }

--- a/src/NServiceBus.Core/Transports/MessageContext.cs
+++ b/src/NServiceBus.Core/Transports/MessageContext.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Transport
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using Extensibility;
@@ -40,6 +41,36 @@
         }
 
         /// <summary>
+        /// Initializes the context.
+        /// </summary>
+        /// <param name="messageId">Native message id.</param>
+        /// <param name="headers">The message headers.</param>
+        /// <param name="body">The message body.</param>
+        /// <param name="transportTransaction">Transaction (along with connection if applicable) used to receive the message.</param>
+        /// <param name="receiveCancellationTokenSource">
+        /// Allows the pipeline to flag that it has been aborted and the receive operation should be rolled back.
+        /// It also allows the transport to communicate to the pipeline to abort if possible. Transports should check if the token
+        /// has been aborted after invoking the pipeline and roll back the message accordingly.
+        /// </param>
+        /// <param name="context">Any context that the transport wants to be available on the pipeline.</param>
+        public MessageContext(string messageId, Dictionary<string, string> headers, ArraySegment<byte> body, TransportTransaction transportTransaction, CancellationTokenSource receiveCancellationTokenSource, ContextBag context)
+        {
+            Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
+            Guard.AgainstNull(nameof(body), body);
+            Guard.AgainstNull(nameof(headers), headers);
+            Guard.AgainstNull(nameof(transportTransaction), transportTransaction);
+            Guard.AgainstNull(nameof(receiveCancellationTokenSource), receiveCancellationTokenSource);
+            Guard.AgainstNull(nameof(context), context);
+
+            Headers = headers;
+            BodySegment = body;
+            MessageId = messageId;
+            Context = context;
+            TransportTransaction = transportTransaction;
+            ReceiveCancellationTokenSource = receiveCancellationTokenSource;
+        }
+
+        /// <summary>
         /// The native id of the message.
         /// </summary>
         public string MessageId { get; }
@@ -53,6 +84,11 @@
         /// The message body.
         /// </summary>
         public byte[] Body { get; }
+
+        /// <summary>
+        /// The message body segment.
+        /// </summary>
+        public ArraySegment<byte> BodySegment { get; }
 
         /// <summary>
         /// Transaction (along with connection if applicable) used to receive the message.

--- a/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
@@ -66,6 +66,7 @@ namespace NServiceBus
             runningReceiveTasks = new ConcurrentDictionary<Task, Task>();
             concurrencyLimiter = new SemaphoreSlim(limitations.MaxConcurrency);
             cancellationTokenSource = new CancellationTokenSource();
+            receiveStrategy.MaxConcurrency = limitations.MaxConcurrency; // maybe there is a better way?
 
             cancellationToken = cancellationTokenSource.Token;
             // ReSharper disable once ConvertClosureToMethodGroup

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqUtilities.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqUtilities.cs
@@ -101,7 +101,7 @@ namespace NServiceBus
             {
                 using (var reader = XmlReader.Create(stream, new XmlReaderSettings
                 {
-                    CheckCharacters = false
+                    CheckCharacters = false,
                 }))
                 {
                     o = headerSerializer.Deserialize(reader);
@@ -123,11 +123,16 @@ namespace NServiceBus
         {
             var result = new Message();
 
+            // not event necessary here
             if (message.Body != null)
             {
                 result.BodyStream = new MemoryStream(message.Body);
             }
-
+            else
+            {
+                var segment = message.BodySegment;
+                result.BodyStream = new MemoryStream(segment.Array, segment.Offset, segment.Count);
+            }
 
             AssignMsmqNativeCorrelationId(message, result);
             result.Recoverable = !deliveryConstraints.Any(c => c is NonDurableDelivery);

--- a/src/NServiceBus.Core/Transports/Msmq/System.Buffers.g.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/System.Buffers.g.cs
@@ -1,0 +1,513 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace System.Buffers
+{
+    /// <summary>
+    /// Provides a resource pool that enables reusing instances of type <see cref="T:T[]"/>. 
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Renting and returning buffers with an <see cref="ArrayPool{T}"/> can increase performance
+    /// in situations where arrays are created and destroyed frequently, resulting in significant
+    /// memory pressure on the garbage collector.
+    /// </para>
+    /// <para>
+    /// This class is thread-safe.  All members may be used by multiple threads concurrently.
+    /// </para>
+    /// </remarks>
+    internal abstract class ArrayPool<T>
+    {
+        /// <summary>The lazily-initialized shared pool instance.</summary>
+        private static ArrayPool<T> s_sharedInstance = null;
+
+        /// <summary>
+        /// Retrieves a shared <see cref="ArrayPool{T}"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// The shared pool provides a default implementation of <see cref="ArrayPool{T}"/>
+        /// that's intended for general applicability.  It maintains arrays of multiple sizes, and 
+        /// may hand back a larger array than was actually requested, but will never hand back a smaller 
+        /// array than was requested. Renting a buffer from it with <see cref="Rent"/> will result in an 
+        /// existing buffer being taken from the pool if an appropriate buffer is available or in a new 
+        /// buffer being allocated if one is not available.
+        /// </remarks>
+        public static ArrayPool<T> Shared
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return Volatile.Read(ref s_sharedInstance) ?? EnsureSharedCreated(); }
+        }
+
+        /// <summary>Ensures that <see cref="s_sharedInstance"/> has been initialized to a pool and returns it.</summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ArrayPool<T> EnsureSharedCreated()
+        {
+            Interlocked.CompareExchange(ref s_sharedInstance, Create(), null);
+            return s_sharedInstance;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ArrayPool{T}"/> instance using default configuration options.
+        /// </summary>
+        /// <returns>A new <see cref="ArrayPool{T}"/> instance.</returns>
+        public static ArrayPool<T> Create()
+        {
+            return new DefaultArrayPool<T>();
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ArrayPool{T}"/> instance using custom configuration options.
+        /// </summary>
+        /// <param name="maxArrayLength">The maximum length of array instances that may be stored in the pool.</param>
+        /// <param name="maxArraysPerBucket">
+        /// The maximum number of array instances that may be stored in each bucket in the pool.  The pool
+        /// groups arrays of similar lengths into buckets for faster access.
+        /// </param>
+        /// <returns>A new <see cref="ArrayPool{T}"/> instance with the specified configuration options.</returns>
+        /// <remarks>
+        /// The created pool will group arrays into buckets, with no more than <paramref name="maxArraysPerBucket"/>
+        /// in each bucket and with those arrays not exceeding <paramref name="maxArrayLength"/> in length.
+        /// </remarks>
+        public static ArrayPool<T> Create(int maxArrayLength, int maxArraysPerBucket)
+        {
+            return new DefaultArrayPool<T>(maxArrayLength, maxArraysPerBucket);
+        }
+
+        /// <summary>
+        /// Retrieves a buffer that is at least the requested length.
+        /// </summary>
+        /// <param name="minimumLength">The minimum length of the array needed.</param>
+        /// <returns>
+        /// An <see cref="T:T[]"/> that is at least <paramref name="minimumLength"/> in length.
+        /// </returns>
+        /// <remarks>
+        /// This buffer is loaned to the caller and should be returned to the same pool via 
+        /// <see cref="Return"/> so that it may be reused in subsequent usage of <see cref="Rent"/>.  
+        /// It is not a fatal error to not return a rented buffer, but failure to do so may lead to 
+        /// decreased application performance, as the pool may need to create a new buffer to replace
+        /// the one lost.
+        /// </remarks>
+        public abstract T[] Rent(int minimumLength);
+
+        /// <summary>
+        /// Returns to the pool an array that was previously obtained via <see cref="Rent"/> on the same 
+        /// <see cref="ArrayPool{T}"/> instance.
+        /// </summary>
+        /// <param name="array">
+        /// The buffer previously obtained from <see cref="Rent"/> to return to the pool.
+        /// </param>
+        /// <param name="clearArray">
+        /// If <c>true</c> and if the pool will store the buffer to enable subsequent reuse, <see cref="Return"/>
+        /// will clear <paramref name="array"/> of its contents so that a subsequent consumer via <see cref="Rent"/> 
+        /// will not see the previous consumer's content.  If <c>false</c> or if the pool will release the buffer,
+        /// the array's contents are left unchanged.
+        /// </param>
+        /// <remarks>
+        /// Once a buffer has been returned to the pool, the caller gives up all ownership of the buffer 
+        /// and must not use it. The reference returned from a given call to <see cref="Rent"/> must only be
+        /// returned via <see cref="Return"/> once.  The default <see cref="ArrayPool{T}"/>
+        /// may hold onto the returned buffer in order to rent it again, or it may release the returned buffer
+        /// if it's determined that the pool already has enough buffers stored.
+        /// </remarks>
+        public abstract void Return(T[] array, bool clearArray = false);
+    }
+}
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Buffers
+{
+    internal sealed partial class DefaultArrayPool<T> : ArrayPool<T>
+    {
+        /// <summary>The default maximum length of each array in the pool (2^20).</summary>
+        private const int DefaultMaxArrayLength = 1024 * 1024;
+        /// <summary>The default maximum number of arrays per bucket that are available for rent.</summary>
+        private const int DefaultMaxNumberOfArraysPerBucket = 50;
+        /// <summary>Lazily-allocated empty array used when arrays of length 0 are requested.</summary>
+        private static T[] s_emptyArray; // we support contracts earlier than those with Array.Empty<T>()
+
+        private readonly Bucket[] _buckets;
+
+        internal DefaultArrayPool() : this(DefaultMaxArrayLength, DefaultMaxNumberOfArraysPerBucket)
+        {
+        }
+
+        internal DefaultArrayPool(int maxArrayLength, int maxArraysPerBucket)
+        {
+            if (maxArrayLength <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxArrayLength));
+            }
+            if (maxArraysPerBucket <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxArraysPerBucket));
+            }
+
+            // Our bucketing algorithm has a min length of 2^4 and a max length of 2^30.
+            // Constrain the actual max used to those values.
+            const int MinimumArrayLength = 0x10, MaximumArrayLength = 0x40000000;
+            if (maxArrayLength > MaximumArrayLength)
+            {
+                maxArrayLength = MaximumArrayLength;
+            }
+            else if (maxArrayLength < MinimumArrayLength)
+            {
+                maxArrayLength = MinimumArrayLength;
+            }
+
+            // Create the buckets.
+            int poolId = Id;
+            int maxBuckets = Utilities.SelectBucketIndex(maxArrayLength);
+            var buckets = new Bucket[maxBuckets + 1];
+            for (int i = 0; i < buckets.Length; i++)
+            {
+                buckets[i] = new Bucket(Utilities.GetMaxSizeForBucket(i), maxArraysPerBucket, poolId);
+            }
+            _buckets = buckets;
+        }
+
+        /// <summary>Gets an ID for the pool to use with events.</summary>
+        private int Id => GetHashCode();
+
+        public override T[] Rent(int minimumLength)
+        {
+            // Arrays can't be smaller than zero.  We allow requesting zero-length arrays (even though
+            // pooling such an array isn't valuable) as it's a valid length array, and we want the pool
+            // to be usable in general instead of using `new`, even for computed lengths.
+            if (minimumLength < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minimumLength));
+            }
+            else if (minimumLength == 0)
+            {
+                // No need for events with the empty array.  Our pool is effectively infinite
+                // and we'll never allocate for rents and never store for returns.
+                return s_emptyArray ?? (s_emptyArray = new T[0]);
+            }
+
+            var log = ArrayPoolEventSource.Log;
+            T[] buffer = null;
+
+            int index = Utilities.SelectBucketIndex(minimumLength);
+            if (index < _buckets.Length)
+            {
+                // Search for an array starting at the 'index' bucket. If the bucket is empty, bump up to the
+                // next higher bucket and try that one, but only try at most a few buckets.
+                const int MaxBucketsToTry = 2;
+                int i = index;
+                do
+                {
+                    // Attempt to rent from the bucket.  If we get a buffer from it, return it.
+                    buffer = _buckets[i].Rent();
+                    if (buffer != null)
+                    {
+                        if (log.IsEnabled())
+                        {
+                            log.BufferRented(buffer.GetHashCode(), buffer.Length, Id, _buckets[i].Id);
+                        }
+                        return buffer;
+                    }
+                }
+                while (++i < _buckets.Length && i != index + MaxBucketsToTry);
+
+                // The pool was exhausted for this buffer size.  Allocate a new buffer with a size corresponding
+                // to the appropriate bucket.
+                buffer = new T[_buckets[index]._bufferLength];
+            }
+            else
+            {
+                // The request was for a size too large for the pool.  Allocate an array of exactly the requested length.
+                // When it's returned to the pool, we'll simply throw it away.
+                buffer = new T[minimumLength];
+            }
+
+            if (log.IsEnabled())
+            {
+                int bufferId = buffer.GetHashCode(), bucketId = -1; // no bucket for an on-demand allocated buffer
+                log.BufferRented(bufferId, buffer.Length, Id, bucketId);
+                log.BufferAllocated(bufferId, buffer.Length, Id, bucketId, index >= _buckets.Length ?
+                    ArrayPoolEventSource.BufferAllocatedReason.OverMaximumSize : ArrayPoolEventSource.BufferAllocatedReason.PoolExhausted);
+            }
+
+            return buffer;
+        }
+
+        public override void Return(T[] array, bool clearArray = false)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException(nameof(array));
+            }
+            else if (array.Length == 0)
+            {
+                // Ignore empty arrays.  When a zero-length array is rented, we return a singleton
+                // rather than actually taking a buffer out of the lowest bucket.
+                return;
+            }
+
+            // Determine with what bucket this array length is associated
+            int bucket = Utilities.SelectBucketIndex(array.Length);
+
+            // If we can tell that the buffer was allocated, drop it. Otherwise, check if we have space in the pool
+            if (bucket < _buckets.Length)
+            {
+                // Clear the array if the user requests
+                if (clearArray)
+                {
+                    Array.Clear(array, 0, array.Length);
+                }
+
+                // Return the buffer to its bucket.  In the future, we might consider having Return return false
+                // instead of dropping a bucket, in which case we could try to return to a lower-sized bucket,
+                // just as how in Rent we allow renting from a higher-sized bucket.
+                _buckets[bucket].Return(array);
+            }
+
+            // Log that the buffer was returned
+            var log = ArrayPoolEventSource.Log;
+            if (log.IsEnabled())
+            {
+                log.BufferReturned(array.GetHashCode(), array.Length, Id);
+            }
+        }
+    }
+}
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Buffers
+{
+    using Diagnostics;
+
+    internal sealed partial class DefaultArrayPool<T> : ArrayPool<T>
+    {
+        /// <summary>Provides a thread-safe bucket containing buffers that can be Rent'd and Return'd.</summary>
+        private sealed class Bucket
+        {
+            internal readonly int _bufferLength;
+            private readonly T[][] _buffers;
+            private readonly int _poolId;
+
+            private SpinLock _lock; // do not make this readonly; it's a mutable struct
+            private int _index;
+
+            /// <summary>
+            /// Creates the pool with numberOfBuffers arrays where each buffer is of bufferLength length.
+            /// </summary>
+            internal Bucket(int bufferLength, int numberOfBuffers, int poolId)
+            {
+                _lock = new SpinLock(Debugger.IsAttached); // only enable thread tracking if debugger is attached; it adds non-trivial overheads to Enter/Exit
+                _buffers = new T[numberOfBuffers][];
+                _bufferLength = bufferLength;
+                _poolId = poolId;
+            }
+
+            /// <summary>Gets an ID for the bucket to use with events.</summary>
+            internal int Id => GetHashCode();
+
+            /// <summary>Takes an array from the bucket.  If the bucket is empty, returns null.</summary>
+            internal T[] Rent()
+            {
+                T[][] buffers = _buffers;
+                T[] buffer = null;
+
+                // While holding the lock, grab whatever is at the next available index and
+                // update the index.  We do as little work as possible while holding the spin
+                // lock to minimize contention with other threads.  The try/finally is
+                // necessary to properly handle thread aborts on platforms which have them.
+                bool lockTaken = false, allocateBuffer = false;
+                try
+                {
+                    _lock.Enter(ref lockTaken);
+
+                    if (_index < buffers.Length)
+                    {
+                        buffer = buffers[_index];
+                        buffers[_index++] = null;
+                        allocateBuffer = buffer == null;
+                    }
+                }
+                finally
+                {
+                    if (lockTaken) _lock.Exit(false);
+                }
+
+                // While we were holding the lock, we grabbed whatever was at the next available index, if
+                // there was one.  If we tried and if we got back null, that means we hadn't yet allocated
+                // for that slot, in which case we should do so now.
+                if (allocateBuffer)
+                {
+                    buffer = new T[_bufferLength];
+
+                    var log = ArrayPoolEventSource.Log;
+                    if (log.IsEnabled())
+                    {
+                        log.BufferAllocated(buffer.GetHashCode(), _bufferLength, _poolId, Id,
+                            ArrayPoolEventSource.BufferAllocatedReason.Pooled);
+                    }
+                }
+
+                return buffer;
+            }
+
+            /// <summary>
+            /// Attempts to return the buffer to the bucket.  If successful, the buffer will be stored
+            /// in the bucket and true will be returned; otherwise, the buffer won't be stored, and false
+            /// will be returned.
+            /// </summary>
+            internal void Return(T[] array)
+            {
+                // Check to see if the buffer is the correct size for this bucket
+                if (array.Length != _bufferLength)
+                {
+                    throw new ArgumentException("Buffer was not rented from pool", nameof(array));
+                }
+
+                // While holding the spin lock, if there's room available in the bucket,
+                // put the buffer into the next available slot.  Otherwise, we just drop it.
+                // The try/finally is necessary to properly handle thread aborts on platforms
+                // which have them.
+                bool lockTaken = false;
+                try
+                {
+                    _lock.Enter(ref lockTaken);
+
+                    if (_index != 0)
+                    {
+                        _buffers[--_index] = array;
+                    }
+                }
+                finally
+                {
+                    if (lockTaken) _lock.Exit(false);
+                }
+            }
+        }
+    }
+}
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+
+namespace System.Buffers
+{
+    using Diagnostics.Tracing;
+
+    [EventSource(Name = "System.Buffers.ArrayPoolEventSource")]
+    internal sealed class ArrayPoolEventSource : EventSource
+    {
+        internal readonly static ArrayPoolEventSource Log = new ArrayPoolEventSource();
+
+        /// <summary>The reason for a BufferAllocated event.</summary>
+        internal enum BufferAllocatedReason : int
+        {
+            /// <summary>The pool is allocating a buffer to be pooled in a bucket.</summary>
+            Pooled,
+            /// <summary>The requested buffer size was too large to be pooled.</summary>
+            OverMaximumSize,
+            /// <summary>The pool has already allocated for pooling as many buffers of a particular size as it's allowed.</summary>
+            PoolExhausted
+        }
+
+        /// <summary>
+        /// Event for when a buffer is rented.  This is invoked once for every successful call to Rent,
+        /// regardless of whether a buffer is allocated or a buffer is taken from the pool.  In a
+        /// perfect situation where all rented buffers are returned, we expect to see the number
+        /// of BufferRented events exactly match the number of BuferReturned events, with the number
+        /// of BufferAllocated events being less than or equal to those numbers (ideally significantly
+        /// less than).
+        /// </summary>
+        [Event(1, Level = EventLevel.Verbose)]
+        internal unsafe void BufferRented(int bufferId, int bufferSize, int poolId, int bucketId)
+        {
+            EventData* payload = stackalloc EventData[4];
+            payload[0].Size = sizeof(int);
+            payload[0].DataPointer = ((IntPtr)(&bufferId));
+            payload[1].Size = sizeof(int);
+            payload[1].DataPointer = ((IntPtr)(&bufferSize));
+            payload[2].Size = sizeof(int);
+            payload[2].DataPointer = ((IntPtr)(&poolId));
+            payload[3].Size = sizeof(int);
+            payload[3].DataPointer = ((IntPtr)(&bucketId));
+            WriteEventCore(1, 4, payload);
+        }
+
+        /// <summary>
+        /// Event for when a buffer is allocated by the pool.  In an ideal situation, the number
+        /// of BufferAllocated events is significantly smaller than the number of BufferRented and
+        /// BufferReturned events.
+        /// </summary>
+        [Event(2, Level = EventLevel.Informational)]
+        internal unsafe void BufferAllocated(int bufferId, int bufferSize, int poolId, int bucketId, BufferAllocatedReason reason)
+        {
+            EventData* payload = stackalloc EventData[5];
+            payload[0].Size = sizeof(int);
+            payload[0].DataPointer = ((IntPtr)(&bufferId));
+            payload[1].Size = sizeof(int);
+            payload[1].DataPointer = ((IntPtr)(&bufferSize));
+            payload[2].Size = sizeof(int);
+            payload[2].DataPointer = ((IntPtr)(&poolId));
+            payload[3].Size = sizeof(int);
+            payload[3].DataPointer = ((IntPtr)(&bucketId));
+            payload[4].Size = sizeof(BufferAllocatedReason);
+            payload[4].DataPointer = ((IntPtr)(&reason));
+            WriteEventCore(2, 5, payload);
+        }
+
+        /// <summary>
+        /// Event raised when a buffer is returned to the pool.  This event is raised regardless of whether
+        /// the returned buffer is stored or dropped.  In an ideal situation, the number of BufferReturned
+        /// events exactly matches the number of BufferRented events.
+        /// </summary>
+        [Event(3, Level = EventLevel.Verbose)]
+        internal void BufferReturned(int bufferId, int bufferSize, int poolId) => WriteEvent(3, bufferId, bufferSize, poolId);
+    }
+}
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Buffers
+{
+    using Diagnostics;
+
+    internal static class Utilities
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int SelectBucketIndex(int bufferSize)
+        {
+            Debug.Assert(bufferSize > 0);
+
+            uint bitsRemaining = ((uint)bufferSize - 1) >> 4;
+
+            int poolIndex = 0;
+            if (bitsRemaining > 0xFFFF) { bitsRemaining >>= 16; poolIndex = 16; }
+            if (bitsRemaining > 0xFF) { bitsRemaining >>= 8; poolIndex += 8; }
+            if (bitsRemaining > 0xF) { bitsRemaining >>= 4; poolIndex += 4; }
+            if (bitsRemaining > 0x3) { bitsRemaining >>= 2; poolIndex += 2; }
+            if (bitsRemaining > 0x1) { bitsRemaining >>= 1; poolIndex += 1; }
+
+            return poolIndex + (int)bitsRemaining;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int GetMaxSizeForBucket(int binIndex)
+        {
+            int maxSize = 16 << binIndex;
+            Debug.Assert(maxSize >= 0);
+            return maxSize;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Transports/OutgoingMessage.cs
+++ b/src/NServiceBus.Core/Transports/OutgoingMessage.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Transport
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -21,10 +22,27 @@ namespace NServiceBus.Transport
         }
 
         /// <summary>
+        /// Initializes a new instance of <see cref="OutgoingMessage" />.
+        /// </summary>
+        /// <param name="messageId">The message id to use.</param>
+        /// <param name="headers">The headers associated with this message.</param>
+        /// <param name="body">The body of the message.</param>
+        public OutgoingMessage(string messageId, Dictionary<string, string> headers, ArraySegment<byte> body)
+        {
+            MessageId = messageId;
+            Headers = headers;
+            BodySegment = body;
+        }
+
+        /// <summary>
         /// The body to be sent.
         /// </summary>
         public byte[] Body { get; }
 
+        /// <summary>
+        /// The body to be sent.
+        /// </summary>
+        public ArraySegment<byte> BodySegment { get; }
 
         /// <summary>
         /// The id of the message.


### PR DESCRIPTION
This is a quick spike to explore what would be necessary to enable byte payload buffering with MSMQ. This PR shows that it would be possible to enable byte buffering per transport without requiring a major version update. The following would be required:
- `MessageContext`, `ErrorContext`, `IncomingMessage`and `OutgoingMessage`would need to be extended with a constructor which allows passing in an `ArraySegment`
- Core would need to support both `byte[]` body and `ArraySegment` body in a minor version
- Transports which want to make use of byte buffering can implement their own byte buffer pools (I copy pasted for the spike the .NET Core System.Buffers)
- Transports which don't need byte buffering yet would still be compliant with the core since they would call the previous constructor of the previously mentioned `*Context` and `*Message` classes

In the next major version we could deprecate the support for the byte array and only support ArraySegment.

In my profiling sessions I used 35 KB large messages with a concurrency of 64 and consumed 50K messages. I could see overall a memory reduction of 20-30 megabyte of byte array allocations which increased the overall throughput slightly. I expect the faster the message processing is and the larger the messages the more we would see the impact.

Extract of one memory profiling session

> Cross workspace snapshots comparison
> (A) Snapshot #4 from current workspace taken 16.10.2016 13:24:05
> (B) Snapshot #5 from Facility.Producer taken 16.10.2016 13:35:34
> 
> Type: System.Byte[]
> Objects (A): 1'401
> Objects (B): 795
> Bytes (A): 31'874'236
> Bytes (B): 9'917'670
> Objects delta: -606
> Bytes delta: -21'956'566

This spike doesn't address pooling for outgoing messages that are not connected to the incoming message (audit, forwarding, delayed delivery and move to error works though)
