### PR TITLE
ReceiveStrategy.TryProcessMessage now uses the body stream and the messageId only

### DIFF
--- a/src/NServiceBus.Core/Transports/Msmq/NoTransactionStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/NoTransactionStrategy.cs
@@ -31,7 +31,7 @@ namespace NServiceBus
             {
                 try
                 {
-                    await TryProcessMessage(message, headers, bodyStream, transportTransaction).ConfigureAwait(false);
+                    await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction).ConfigureAwait(false);
                 }
                 catch (Exception exception)
                 {

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveOnlyNativeTransactionStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveOnlyNativeTransactionStrategy.cs
@@ -82,7 +82,7 @@
                 {
                     using (var bodyStream = message.BodyStream)
                     {
-                        var shouldAbortMessageProcessing = await TryProcessMessage(message, headers, bodyStream, transportTransaction).ConfigureAwait(false);
+                        var shouldAbortMessageProcessing = await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction).ConfigureAwait(false);
 
                         if (shouldAbortMessageProcessing)
                         {

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveStrategy.cs
@@ -99,12 +99,12 @@ namespace NServiceBus
             errorQueue.Send(message, transactionType);
         }
 
-        protected async Task<bool> TryProcessMessage(Message message, Dictionary<string, string> headers, Stream bodyStream, TransportTransaction transaction)
+        protected async Task<bool> TryProcessMessage(string messageId, Dictionary<string, string> headers, Stream bodyStream, TransportTransaction transaction)
         {
             using (var tokenSource = new CancellationTokenSource())
             {
-                var body = await ReadStream(message.BodyStream).ConfigureAwait(false);
-                var messageContext = new MessageContext(message.Id, headers, body, transaction, tokenSource, new ContextBag());
+                var body = await ReadStream(bodyStream).ConfigureAwait(false);
+                var messageContext = new MessageContext(messageId, headers, body, transaction, tokenSource, new ContextBag());
 
                 await onMessage(messageContext).ConfigureAwait(false);
 

--- a/src/NServiceBus.Core/Transports/Msmq/SendsAtomicWithReceiveNativeTransactionStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/SendsAtomicWithReceiveNativeTransactionStrategy.cs
@@ -86,7 +86,7 @@ namespace NServiceBus
                 {
                     using (var bodyStream = message.BodyStream)
                     {
-                        var shouldAbortMessageProcessing = await TryProcessMessage(message, headers, bodyStream, transportTransaction).ConfigureAwait(false);
+                        var shouldAbortMessageProcessing = await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction).ConfigureAwait(false);
 
                         if (shouldAbortMessageProcessing)
                         {

--- a/src/NServiceBus.Core/Transports/Msmq/TransactionScopeStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/TransactionScopeStrategy.cs
@@ -82,7 +82,7 @@ namespace NServiceBus
             {
                 using (var bodyStream = message.BodyStream)
                 {
-                    var shouldAbortMessageProcessing = await TryProcessMessage(message, headers, bodyStream, transportTransaction).ConfigureAwait(false);
+                    var shouldAbortMessageProcessing = await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction).ConfigureAwait(false);
 
                     if (shouldAbortMessageProcessing)
                     {


### PR DESCRIPTION
Small cleanup