### PR TITLE
[SPIKE] MSMQ use raw byte segments from the message without copying

### DIFF
--- a/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties.cs
+++ b/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties.cs
@@ -15,13 +15,13 @@
             var payloadToSend = new byte[PayloadSize];
 
             var context = await Scenario.Define<Context>()
-                .WithEndpoint<Sender>(b => b.When(session => session.Send(new MyMessageWithLargePayload
-                {
-                    Payload = new DataBusProperty<byte[]>(payloadToSend)
-                })))
-                .WithEndpoint<Receiver>()
-                .Done(c => c.ReceivedPayload != null)
-                .Run();
+                    .WithEndpoint<Sender>(b => b.When(session => session.Send(new MyMessageWithLargePayload
+                    {
+                        Payload = new DataBusProperty<byte[]>(payloadToSend)
+                    })))
+                    .WithEndpoint<Receiver>()
+                    .Done(c => c.ReceivedPayload != null)
+                    .Run();
 
             Assert.AreEqual(payloadToSend, context.ReceivedPayload, "The large payload should be marshalled correctly using the databus");
         }
@@ -83,7 +83,7 @@
             }
         }
 
-        
+
         public class MyMessageWithLargePayload : ICommand
         {
             public DataBusProperty<byte[]> Payload { get; set; }

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqUtilitiesTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqUtilitiesTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Messaging;
     using DeliveryConstraints;
     using NServiceBus.Performance.TimeToBeReceived;
@@ -85,6 +86,29 @@
 
             Assert.False(MsmqUtilities.Convert(new OutgoingMessage("message id", new Dictionary<string, string>(), new byte[0]), nonDurableDeliveryConstraint).Recoverable);
             Assert.True(MsmqUtilities.Convert(new OutgoingMessage("message id", new Dictionary<string, string>(), new byte[0]), durableDeliveryConstraint).Recoverable);
+        }
+
+        [Test]
+        public void Should_get_raw_array_segment_properly()
+        {
+            var bytes = new byte[]
+            {
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8,
+                9
+            };
+
+            const int testedLength = 8;
+            var stream = new MemoryStream(bytes, 0, testedLength);
+            var expected = new ArraySegment<byte>(bytes, 0, testedLength);
+
+            CollectionAssert.AreEqual(expected, MsmqUtilities.GetAsArraySegment(stream));
         }
     }
 }

--- a/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
@@ -1,10 +1,8 @@
 ﻿namespace NServiceBus
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Pipeline;
-    using Transport;
 
     class InvokeAuditPipelineBehavior : IForkConnector<IIncomingPhysicalMessageContext, IIncomingPhysicalMessageContext, IAuditContext>
     {
@@ -19,8 +17,8 @@
 
             context.Message.RevertToOriginalBodyIfNeeded();
 
-            var processedMessage = new OutgoingMessage(context.Message.MessageId, new Dictionary<string, string>(context.Message.Headers), context.Message.Body);
-
+            var processedMessage = context.Message.ToOutgoingMessage();
+            
             var auditContext = this.CreateAuditContext(processedMessage, auditAddress, context);
 
             await this.Fork(auditContext).ConfigureAwait(false);

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
@@ -55,7 +55,7 @@ namespace NServiceBus
                 {
                     Destination = destination,
                     SagaId = sagaId,
-                    State = context.Body,
+                    State = context.Body ?? context.BodySegment.Array, // better way would now write 0 bytes as well, maybe ok???
                     Time = DateTimeExtensions.ToUtcDateTime(expire),
                     Headers = context.Headers,
                     OwningTimeoutManager = owningTimeoutManager

--- a/src/NServiceBus.Core/Forwarding/InvokeForwardingPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Forwarding/InvokeForwardingPipelineBehavior.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Threading.Tasks;
     using Pipeline;
-    using Transport;
 
     class InvokeForwardingPipelineBehavior : IForkConnector<IIncomingPhysicalMessageContext, IIncomingPhysicalMessageContext, IForwardingContext>
     {
@@ -18,8 +17,8 @@
 
             context.Message.RevertToOriginalBodyIfNeeded();
 
-            var processedMessage = new OutgoingMessage(context.Message.MessageId, context.Message.Headers, context.Message.Body);
-
+            var processedMessage = context.Message.ToOutgoingMessage();
+            
             var forwardingContext = this.CreateForwardingContext(processedMessage, forwardingAddress, context);
 
             await this.Fork(forwardingContext).ConfigureAwait(false);

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -31,6 +31,7 @@
     <DocumentationFile>..\..\binaries\NServiceBus.Core.xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -42,6 +43,7 @@
     <DocumentationFile>..\..\binaries\NServiceBus.Core.xml</DocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <None Include="FodyWeavers.xml">

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageProcessingConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageProcessingConnector.cs
@@ -64,7 +64,15 @@ namespace NServiceBus
         {
             foreach (var operation in deduplicationEntry.TransportOperations)
             {
-                var message = new OutgoingMessage(operation.MessageId, operation.Headers, operation.Body);
+                OutgoingMessage message;
+                if (operation.Body == null)
+                {
+                    message = new OutgoingMessage(operation.MessageId, operation.Headers, operation.BodySegment);
+                }
+                else
+                {
+                    message = new OutgoingMessage(operation.MessageId, operation.Headers, operation.Body);
+                }
 
                 pendingTransportOperations.Add(
                     new Transport.TransportOperation(
@@ -90,7 +98,17 @@ namespace NServiceBus
 
                 SerializeRoutingStrategy(operation.AddressTag, options);
 
-                transportOperations[index] = new TransportOperation(operation.Message.MessageId, options, operation.Message.Body, operation.Message.Headers);
+                TransportOperation transportOperation;
+                if (operation.Message.Body == null)
+                {
+                    transportOperation = new TransportOperation(operation.Message.MessageId, options, operation.Message.BodySegment, operation.Message.Headers);
+                }
+                else
+                {
+                    transportOperation = new TransportOperation(operation.Message.MessageId, options, operation.Message.Body, operation.Message.Headers);
+                }
+
+                transportOperations[index] = transportOperation;
                 index++;
             }
             return transportOperations;

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -24,7 +24,16 @@ namespace NServiceBus
             {
                 var rootContext = new RootContext(childBuilder, pipelineCache, eventAggregator);
 
-                var message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.Body);
+                IncomingMessage message;
+                if (messageContext.Body == null)
+                {
+                    message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.BodySegment);
+                }
+                else
+                {
+                    message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.Body);
+                }
+                
                 var context = new TransportReceiveContext(message, messageContext.TransportTransaction, messageContext.ReceiveCancellationTokenSource, rootContext);
 
                 context.Extensions.Merge(messageContext.Context);

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
@@ -26,7 +26,8 @@
         {
             var mutators = context.Builder.BuildAll<IMutateIncomingTransportMessages>();
             var transportMessage = context.Message;
-            var mutatorContext = new MutateIncomingTransportMessageContext(transportMessage.Body, transportMessage.Headers);
+            // Now mutator contains also the zero byte stuff, change?
+            var mutatorContext = new MutateIncomingTransportMessageContext(transportMessage.Body ?? transportMessage.BodySegment.Array, transportMessage.Headers);
             foreach (var mutator in mutators)
             {
                 await mutator.MutateIncoming(mutatorContext)

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
@@ -27,7 +27,17 @@
             var mutators = context.Builder.BuildAll<IMutateIncomingTransportMessages>();
             var transportMessage = context.Message;
             // Now mutator contains also the zero byte stuff, change?
-            var mutatorContext = new MutateIncomingTransportMessageContext(transportMessage.Body ?? transportMessage.BodySegment.Array, transportMessage.Headers);
+            MutateIncomingTransportMessageContext mutatorContext;
+
+            if (transportMessage.Body != null)
+            {
+                mutatorContext = new MutateIncomingTransportMessageContext(transportMessage.Body, transportMessage.Headers);
+            }
+            else
+            {
+                mutatorContext = new MutateIncomingTransportMessageContext(transportMessage.BodySegment, transportMessage.Headers);    
+            }
+            
             foreach (var mutator in mutators)
             {
                 await mutator.MutateIncoming(mutatorContext)

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageContext.cs
@@ -1,6 +1,8 @@
 namespace NServiceBus.MessageMutator
 {
+    using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Context class for <see cref="IMutateIncomingTransportMessages" />.
@@ -21,11 +23,36 @@ namespace NServiceBus.MessageMutator
         }
 
         /// <summary>
+        /// Initializes a new instance of <see cref="MutateOutgoingTransportMessageContext" />.
+        /// </summary>
+        public MutateIncomingTransportMessageContext(ArraySegment<byte> bodySegment, Dictionary<string, string> headers)
+        {
+            Guard.AgainstNull(nameof(headers), headers);
+            Headers = headers;
+
+            // Intentionally assign to field to not set the MessageBodyChanged flag.
+            this.bodySegment = bodySegment;
+        }
+
+        /// <summary>
         /// The body of the message.
         /// </summary>
         public byte[] Body
         {
-            get { return body; }
+            get
+            {
+                if (body != null)
+                {
+                    return body;
+                }
+
+                if (bodySegment.Array != null)
+                {
+                    body = bodySegment.ToArray();
+                }
+
+                return body;
+            }
             set
             {
                 Guard.AgainstNull(nameof(value), value);
@@ -40,6 +67,7 @@ namespace NServiceBus.MessageMutator
         public Dictionary<string, string> Headers { get; private set; }
 
         byte[] body;
+        ArraySegment<byte> bodySegment;
 
         internal bool MessageBodyChanged;
     }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
@@ -21,7 +21,7 @@
                 .Select(rs =>
                 {
                     var addressLabel = rs.Apply(context.Message.Headers);
-                    var message = new OutgoingMessage(context.Message.MessageId, context.Message.Headers, context.Message.Body);
+                    var message = context.Message.Clone();
                     return new TransportOperation(message, addressLabel, dispatchConsistency, context.Extensions.GetDeliveryConstraints());
                 }).ToArray();
 

--- a/src/NServiceBus.Core/Recoverability/DelayedRetryExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/DelayedRetryExecutor.cs
@@ -20,8 +20,7 @@
 
         public async Task<int> Retry(IncomingMessage message, TimeSpan delay, TransportTransaction transportTransaction)
         {
-            var outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body);
-
+            var outgoingMessage = message.ToOutgoingMessage();
             var currentDelayedRetriesAttempt = message.GetDelayedDeliveriesPerformed() + 1;
 
             outgoingMessage.SetCurrentDelayedDeliveries(currentDelayedRetriesAttempt);

--- a/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
@@ -20,7 +20,7 @@
         {
             message.RevertToOriginalBodyIfNeeded();
 
-            var outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body);
+            var outgoingMessage = message.ToOutgoingMessage();
 
             var headers = outgoingMessage.Headers;
             headers.Remove(Headers.DelayedRetries);

--- a/src/NServiceBus.Core/Recoverability/Recoverability.cs
+++ b/src/NServiceBus.Core/Recoverability/Recoverability.cs
@@ -202,7 +202,16 @@
                     //HINT: this header is added by v3 when doing SLR
                     outgoingHeaders.Remove("NServiceBus.OriginalId");
 
-                    var outgoingMessage = new OutgoingMessage(messageContext.MessageId, outgoingHeaders, messageContext.Body);
+                    OutgoingMessage outgoingMessage;
+                    if (messageContext.Body == null)
+                    {
+                        outgoingMessage = new OutgoingMessage(messageContext.MessageId, outgoingHeaders, messageContext.BodySegment);
+                    }
+                    else
+                    {
+                        outgoingMessage = new OutgoingMessage(messageContext.MessageId, outgoingHeaders, messageContext.Body);
+                    }
+
                     var outgoingOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(mainQueueTransportAddress));
 
                     return messageDispatcher.Dispatch(new TransportOperations(outgoingOperation), messageContext.TransportTransaction, messageContext.Context);

--- a/src/NServiceBus.Core/Reliability/Outbox/TransportOperation.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/TransportOperation.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Outbox
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -26,6 +27,24 @@
         }
 
         /// <summary>
+        /// Creates a new instance of a <see cref="TransportOperation" />.
+        /// </summary>
+        /// <param name="messageId">The identifier of the outgoing message.</param>
+        /// <param name="options">The sending options.</param>
+        /// <param name="body">The message body.</param>
+        /// <param name="headers">The message headers.</param>
+        /// .
+        public TransportOperation(string messageId, Dictionary<string, string> options, ArraySegment<byte> body, Dictionary<string, string> headers)
+        {
+            Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
+
+            MessageId = messageId;
+            Options = options;
+            BodySegment = body;
+            Headers = headers;
+        }
+
+        /// <summary>
         /// Gets the identifier of the outgoing message.
         /// </summary>
         public string MessageId { get; private set; }
@@ -39,6 +58,11 @@
         /// Gets a byte array to the body content of the outgoing message.
         /// </summary>
         public byte[] Body { get; private set; }
+
+        /// <summary>
+        /// Gets a byte array to the body content of the outgoing message.
+        /// </summary>
+        public ArraySegment<byte> BodySegment { get; private set; }
 
         /// <summary>
         /// Gets outgoing message headers.

--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -23,6 +23,20 @@
         }
 
         /// <summary>
+        /// Initializes the error context.
+        /// </summary>
+        public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, ArraySegment<byte> body, TransportTransaction transportTransaction, int immediateProcessingFailures)
+        {
+            Exception = exception;
+            TransportTransaction = transportTransaction;
+            ImmediateProcessingFailures = immediateProcessingFailures;
+
+            Message = new IncomingMessage(transportMessageId, headers, body);
+
+            DelayedDeliveriesPerformed = Message.GetDelayedDeliveriesPerformed();
+        }
+
+        /// <summary>
         /// Exception that caused the message processing to fail.
         /// </summary>
         public Exception Exception { get; }

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -95,16 +95,24 @@ namespace NServiceBus.Transport
         /// </summary>
         internal void UpdateBody(byte[] updatedBody)
         {
-            throw new NotSupportedException("Currently not supported to Update the body");
-            // Fix this???
             //preserve the original body if needed
-            //if (Body != null && originalBody == null)
-            //{
-            //    originalBody = new byte[Body.Length];
-            //    Buffer.BlockCopy(Body, 0, originalBody, 0, Body.Length);
-            //}
+            if (originalBody == null)
+            {
+                if (Body != null)
+                {
+                    originalBody = new byte[Body.Length];
+                    Buffer.BlockCopy(Body, 0, originalBody, 0, Body.Length);
+                }
 
-            //Body = updatedBody;
+                if (BodySegment.Array != null)
+                {
+                    originalBody = new byte[BodySegment.Count];
+                    Buffer.BlockCopy(BodySegment.Array, BodySegment.Offset, originalBody, 0, BodySegment.Count);
+                }
+            }
+
+            Body = updatedBody;
+            BodySegment = default(ArraySegment<byte>);
         }
 
         /// <summary>
@@ -112,13 +120,13 @@ namespace NServiceBus.Transport
         /// </summary>
         internal void RevertToOriginalBodyIfNeeded()
         {
-            //if (originalBody != null)
-            //{
-            //    Body = originalBody;
-            //}
+            if (originalBody != null)
+            {
+                Body = originalBody;
+            }
         }
 
-        //byte[] originalBody;
+        byte[] originalBody;
 
         internal OutgoingMessage ToOutgoingMessage()
         {

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -40,6 +40,37 @@ namespace NServiceBus.Transport
         }
 
         /// <summary>
+        /// Creates a new message.
+        /// </summary>
+        /// <param name="messageId">Native message id.</param>
+        /// <param name="headers">The message headers.</param>
+        /// <param name="segment">The message body.</param>
+        public IncomingMessage(string messageId, Dictionary<string, string> headers, ArraySegment<byte> segment)
+        {
+            Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
+            Guard.AgainstNull(nameof(segment), segment);
+            Guard.AgainstNull(nameof(headers), headers);
+
+            string originalMessageId;
+
+            if (headers.TryGetValue(NServiceBus.Headers.MessageId, out originalMessageId) && !string.IsNullOrEmpty(originalMessageId))
+            {
+                MessageId = originalMessageId;
+            }
+            else
+            {
+                MessageId = messageId;
+
+                headers[NServiceBus.Headers.MessageId] = messageId;
+            }
+
+
+            Headers = headers;
+
+            BodySegment = segment;
+        }
+
+        /// <summary>
         /// The id of the message.
         /// </summary>
         public string MessageId { get; private set; }
@@ -55,18 +86,25 @@ namespace NServiceBus.Transport
         public byte[] Body { get; private set; }
 
         /// <summary>
+        /// Gets/sets a byte array segment to the body content of the message.
+        /// </summary>
+        public ArraySegment<byte> BodySegment { get; private set; }
+
+        /// <summary>
         /// Use this method to update the body if this message.
         /// </summary>
         internal void UpdateBody(byte[] updatedBody)
         {
+            throw new NotSupportedException("Currently not supported to Update the body");
+            // Fix this???
             //preserve the original body if needed
-            if (Body != null && originalBody == null)
-            {
-                originalBody = new byte[Body.Length];
-                Buffer.BlockCopy(Body, 0, originalBody, 0, Body.Length);
-            }
+            //if (Body != null && originalBody == null)
+            //{
+            //    originalBody = new byte[Body.Length];
+            //    Buffer.BlockCopy(Body, 0, originalBody, 0, Body.Length);
+            //}
 
-            Body = updatedBody;
+            //Body = updatedBody;
         }
 
         /// <summary>
@@ -74,12 +112,17 @@ namespace NServiceBus.Transport
         /// </summary>
         internal void RevertToOriginalBodyIfNeeded()
         {
-            if (originalBody != null)
-            {
-                Body = originalBody;
-            }
+            //if (originalBody != null)
+            //{
+            //    Body = originalBody;
+            //}
         }
 
-        byte[] originalBody;
+        //byte[] originalBody;
+
+        internal OutgoingMessage ToOutgoingMessage()
+        {
+            return Body == null ? new OutgoingMessage(MessageId, new Dictionary<string, string>(Headers), BodySegment) : new OutgoingMessage(MessageId, new Dictionary<string, string>(Headers), Body);
+        }
     }
 }

--- a/src/NServiceBus.Core/Transports/MessageContext.cs
+++ b/src/NServiceBus.Core/Transports/MessageContext.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Transport
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading;
     using Extensibility;
@@ -40,6 +41,36 @@
         }
 
         /// <summary>
+        /// Initializes the context.
+        /// </summary>
+        /// <param name="messageId">Native message id.</param>
+        /// <param name="headers">The message headers.</param>
+        /// <param name="body">The message body.</param>
+        /// <param name="transportTransaction">Transaction (along with connection if applicable) used to receive the message.</param>
+        /// <param name="receiveCancellationTokenSource">
+        /// Allows the pipeline to flag that it has been aborted and the receive operation should be rolled back.
+        /// It also allows the transport to communicate to the pipeline to abort if possible. Transports should check if the token
+        /// has been aborted after invoking the pipeline and roll back the message accordingly.
+        /// </param>
+        /// <param name="context">Any context that the transport wants to be available on the pipeline.</param>
+        public MessageContext(string messageId, Dictionary<string, string> headers, ArraySegment<byte> body, TransportTransaction transportTransaction, CancellationTokenSource receiveCancellationTokenSource, ContextBag context)
+        {
+            Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
+            Guard.AgainstNull(nameof(body), body);
+            Guard.AgainstNull(nameof(headers), headers);
+            Guard.AgainstNull(nameof(transportTransaction), transportTransaction);
+            Guard.AgainstNull(nameof(receiveCancellationTokenSource), receiveCancellationTokenSource);
+            Guard.AgainstNull(nameof(context), context);
+
+            Headers = headers;
+            BodySegment = body;
+            MessageId = messageId;
+            Context = context;
+            TransportTransaction = transportTransaction;
+            ReceiveCancellationTokenSource = receiveCancellationTokenSource;
+        }
+
+        /// <summary>
         /// The native id of the message.
         /// </summary>
         public string MessageId { get; }
@@ -53,6 +84,11 @@
         /// The message body.
         /// </summary>
         public byte[] Body { get; }
+
+        /// <summary>
+        /// The message body segment.
+        /// </summary>
+        public ArraySegment<byte> BodySegment { get; }
 
         /// <summary>
         /// Transaction (along with connection if applicable) used to receive the message.

--- a/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
@@ -66,6 +66,7 @@ namespace NServiceBus
             runningReceiveTasks = new ConcurrentDictionary<Task, Task>();
             concurrencyLimiter = new SemaphoreSlim(limitations.MaxConcurrency);
             cancellationTokenSource = new CancellationTokenSource();
+            receiveStrategy.MaxConcurrency = limitations.MaxConcurrency; // maybe there is a better way?
 
             cancellationToken = cancellationTokenSource.Token;
             // ReSharper disable once ConvertClosureToMethodGroup

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqUtilities.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqUtilities.cs
@@ -5,6 +5,8 @@ namespace NServiceBus
     using System.IO;
     using System.Linq;
     using System.Messaging;
+    using System.Reflection;
+    using System.Reflection.Emit;
     using System.Text;
     using System.Xml;
     using DeliveryConstraints;
@@ -15,6 +17,29 @@ namespace NServiceBus
 
     class MsmqUtilities
     {
+        static MsmqUtilities()
+        {
+            var getRawBytesSegment = new DynamicMethod(nameof(GetAsArraySegment), typeof(ArraySegment<byte>), new[]{typeof(MemoryStream)}, true);
+
+            var il = getRawBytesSegment.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, typeof(MemoryStream).GetField("_buffer", BindingFlags.NonPublic|BindingFlags.Instance));
+            il.Emit(OpCodes.Ldc_I4_0);
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, typeof(MemoryStream).GetField("_length", BindingFlags.NonPublic | BindingFlags.Instance));
+            il.Emit(OpCodes.Newobj, typeof(ArraySegment<byte>).GetConstructor(new [] { typeof(byte[]), typeof(int), typeof(int)}));
+            il.Emit(OpCodes.Ret);
+
+            GetAsArraySegment = (Func<MemoryStream, ArraySegment<byte>>) getRawBytesSegment.CreateDelegate(typeof(Func<MemoryStream, ArraySegment<byte>>));
+        }
+
+        public static readonly Func<MemoryStream, ArraySegment<byte>> GetAsArraySegment;
+
+        public static ArraySegment<byte> GetBodyAsArraySegment(Message m)
+        {
+            return GetAsArraySegment((MemoryStream) m.BodyStream);
+        }
+
         static MsmqAddress GetIndependentAddressForQueue(MessageQueue q)
         {
             var arr = q.FormatName.Split('\\');
@@ -101,7 +126,7 @@ namespace NServiceBus
             {
                 using (var reader = XmlReader.Create(stream, new XmlReaderSettings
                 {
-                    CheckCharacters = false
+                    CheckCharacters = false,
                 }))
                 {
                     o = headerSerializer.Deserialize(reader);
@@ -123,11 +148,16 @@ namespace NServiceBus
         {
             var result = new Message();
 
+            // not event necessary here
             if (message.Body != null)
             {
                 result.BodyStream = new MemoryStream(message.Body);
             }
-
+            else
+            {
+                var segment = message.BodySegment;
+                result.BodyStream = new MemoryStream(segment.Array, segment.Offset, segment.Count);
+            }
 
             AssignMsmqNativeCorrelationId(message, result);
             result.Recoverable = !deliveryConstraints.Any(c => c is NonDurableDelivery);

--- a/src/NServiceBus.Core/Transports/Msmq/NoTransactionStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/NoTransactionStrategy.cs
@@ -31,7 +31,7 @@ namespace NServiceBus
             {
                 try
                 {
-                    await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction).ConfigureAwait(false);
+                    await TryProcessMessage(message, headers, bodyStream, transportTransaction).ConfigureAwait(false);
                 }
                 catch (Exception exception)
                 {

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveOnlyNativeTransactionStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveOnlyNativeTransactionStrategy.cs
@@ -82,7 +82,7 @@
                 {
                     using (var bodyStream = message.BodyStream)
                     {
-                        var shouldAbortMessageProcessing = await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction).ConfigureAwait(false);
+                        var shouldAbortMessageProcessing = await TryProcessMessage(message, headers, bodyStream, transportTransaction).ConfigureAwait(false);
 
                         if (shouldAbortMessageProcessing)
                         {

--- a/src/NServiceBus.Core/Transports/Msmq/SendsAtomicWithReceiveNativeTransactionStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/SendsAtomicWithReceiveNativeTransactionStrategy.cs
@@ -86,7 +86,7 @@ namespace NServiceBus
                 {
                     using (var bodyStream = message.BodyStream)
                     {
-                        var shouldAbortMessageProcessing = await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction).ConfigureAwait(false);
+                        var shouldAbortMessageProcessing = await TryProcessMessage(message, headers, bodyStream, transportTransaction).ConfigureAwait(false);
 
                         if (shouldAbortMessageProcessing)
                         {

--- a/src/NServiceBus.Core/Transports/Msmq/TransactionScopeStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/TransactionScopeStrategy.cs
@@ -82,7 +82,7 @@ namespace NServiceBus
             {
                 using (var bodyStream = message.BodyStream)
                 {
-                    var shouldAbortMessageProcessing = await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction).ConfigureAwait(false);
+                    var shouldAbortMessageProcessing = await TryProcessMessage(message, headers, bodyStream, transportTransaction).ConfigureAwait(false);
 
                     if (shouldAbortMessageProcessing)
                     {

--- a/src/NServiceBus.Core/Transports/OutgoingMessage.cs
+++ b/src/NServiceBus.Core/Transports/OutgoingMessage.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Transport
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -21,10 +22,27 @@ namespace NServiceBus.Transport
         }
 
         /// <summary>
+        /// Initializes a new instance of <see cref="OutgoingMessage" />.
+        /// </summary>
+        /// <param name="messageId">The message id to use.</param>
+        /// <param name="headers">The headers associated with this message.</param>
+        /// <param name="body">The body of the message.</param>
+        public OutgoingMessage(string messageId, Dictionary<string, string> headers, ArraySegment<byte> body)
+        {
+            MessageId = messageId;
+            Headers = headers;
+            BodySegment = body;
+        }
+
+        /// <summary>
         /// The body to be sent.
         /// </summary>
         public byte[] Body { get; }
 
+        /// <summary>
+        /// The body to be sent.
+        /// </summary>
+        public ArraySegment<byte> BodySegment { get; }
 
         /// <summary>
         /// The id of the message.
@@ -35,5 +53,10 @@ namespace NServiceBus.Transport
         /// The headers for the message.
         /// </summary>
         public Dictionary<string, string> Headers { get; }
+
+        internal OutgoingMessage Clone()
+        {
+            return Body == null ? new OutgoingMessage(MessageId, Headers, BodySegment) : new OutgoingMessage(MessageId, Headers, Body);
+        }
     }
 }

--- a/src/NServiceBus.Core/Unicast/IncomingMessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/IncomingMessageOperations.cs
@@ -14,10 +14,7 @@ namespace NServiceBus
             var cache = context.Extensions.Get<IPipelineCache>();
             var pipeline = cache.Pipeline<IRoutingContext>();
 
-            var outgoingMessage = new OutgoingMessage(
-                messageBeingProcessed.MessageId,
-                messageBeingProcessed.Headers,
-                messageBeingProcessed.Body);
+            var outgoingMessage = messageBeingProcessed.ToOutgoingMessage();
 
             var routingContext = new RoutingContext(outgoingMessage, new UnicastRoutingStrategy(destination), context);
 

--- a/src/NServiceBus.Core/Unicast/MessageOperationsInvokeHandlerContext.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperationsInvokeHandlerContext.cs
@@ -21,10 +21,21 @@ namespace NServiceBus
             var cache = context.Extensions.Get<IPipelineCache>();
             var pipeline = cache.Pipeline<IRoutingContext>();
 
-            var outgoingMessage = new OutgoingMessage(
-                messageBeingProcessed.MessageId,
-                messageBeingProcessed.Headers,
-                messageBeingProcessed.Body);
+            OutgoingMessage outgoingMessage;
+            if (messageBeingProcessed.Body != null)
+            {
+                outgoingMessage = new OutgoingMessage(
+                    messageBeingProcessed.MessageId,
+                    messageBeingProcessed.Headers,
+                    messageBeingProcessed.Body);
+            }
+            else
+            {
+                outgoingMessage = new OutgoingMessage(
+                    messageBeingProcessed.MessageId,
+                    messageBeingProcessed.Headers,
+                    messageBeingProcessed.BodySegment);
+            }
 
             var routingContext = new RoutingContext(outgoingMessage, new UnicastRoutingStrategy(settings.LocalAddress()), context);
 


### PR DESCRIPTION
@danielmarbach  and I where discussing the buffering PR #4227 and decided that it is actually unnecessary to introduce buffering and all the cruft that comes with it since MSMQ will always allocate a byte array per message anyway. With this PR we want to explore the pros and cons of bypassing the public API of memory stream and directly access the byte array which is held internally. Our main argument was that `MemoryStream` and Msmq is unlikely to change that behavior (we also checked memory stream imp in .NET core). Since MSMQ will remain a full framework thing only we can assume to always have reflection EMIT as well as the stable behavior of MSMQ and the memory stream.
