### PR TITLE
Move subscription behaviors to TransportReceive stage to avoid InsertBefore

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehavior.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehavior.cs
@@ -4,10 +4,9 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using NServiceBus.Pipeline;
-    using ObjectBuilder;
     using Transport;
 
-    class SubscriptionBehavior<TContext> : IBehavior<IIncomingPhysicalMessageContext, IIncomingPhysicalMessageContext> where TContext : ScenarioContext
+    class SubscriptionBehavior<TContext> : IBehavior<ITransportReceiveContext, ITransportReceiveContext> where TContext : ScenarioContext
     {
         public SubscriptionBehavior(Action<SubscriptionEventArgs, TContext> action, TContext scenarioContext, MessageIntentEnum intentToHandle)
         {
@@ -16,7 +15,7 @@
             this.intentToHandle = intentToHandle;
         }
 
-        public async Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
+        public async Task Invoke(ITransportReceiveContext context, Func<ITransportReceiveContext, Task> next)
         {
             await next(context).ConfigureAwait(false);
             var subscriptionMessageType = GetSubscriptionMessageTypeFrom(context.Message);
@@ -51,14 +50,5 @@
         Action<SubscriptionEventArgs, TContext> action;
         TContext scenarioContext;
         MessageIntentEnum intentToHandle;
-
-        internal class Registration : RegisterStep
-        {
-            public Registration(string id, Func<IBuilder, IBehavior> behaviorFactory)
-                : base(id, typeof(SubscriptionBehavior<TContext>), "notify subscription events", behaviorFactory)
-            {
-                InsertBeforeIfExists("ProcessSubscriptionRequests");
-            }
-        }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehaviorExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehaviorExtensions.cs
@@ -7,20 +7,20 @@ namespace NServiceBus.AcceptanceTests.Routing
     {
         public static void OnEndpointSubscribed<TContext>(this EndpointConfiguration configuration, Action<SubscriptionEventArgs, TContext> action) where TContext : ScenarioContext
         {
-            configuration.Pipeline.Register(new SubscriptionBehavior<TContext>.Registration("NotifySubscriptionBehavior", builder =>
+            configuration.Pipeline.Register("NotifySubscriptionBehavior", builder =>
             {
                 var context = builder.Build<TContext>();
                 return new SubscriptionBehavior<TContext>(action, context, MessageIntentEnum.Subscribe);
-            }));
+            }, "Provides notifications when endpoints subscribe");
         }
 
         public static void OnEndpointUnsubscribed<TContext>(this EndpointConfiguration configuration, Action<SubscriptionEventArgs, TContext> action) where TContext : ScenarioContext
         {
-            configuration.Pipeline.Register(new SubscriptionBehavior<TContext>.Registration("NotifyUnsubscriptionBehavior", builder =>
+            configuration.Pipeline.Register("NotifyUnsubscriptionBehavior", builder =>
             {
                 var context = builder.Build<TContext>();
                 return new SubscriptionBehavior<TContext>(action, context, MessageIntentEnum.Unsubscribe);
-            }));
+            }, "Provides notifications when endpoints unsubscribe");
         }
     }
 }

--- a/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionBehavior.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionBehavior.cs
@@ -7,7 +7,7 @@
     using Pipeline;
     using Transport;
 
-    class SubscriptionBehavior<TContext> : IBehavior<IIncomingPhysicalMessageContext, IIncomingPhysicalMessageContext> where TContext : ScenarioContext
+    class SubscriptionBehavior<TContext> : IBehavior<ITransportReceiveContext, ITransportReceiveContext> where TContext : ScenarioContext
     {
         Action<SubscriptionEventArgs, TContext> action;
         TContext scenarioContext;
@@ -18,7 +18,7 @@
             this.scenarioContext = scenarioContext;
         }
 
-        public async Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
+        public async Task Invoke(ITransportReceiveContext context, Func<ITransportReceiveContext, Task> next)
         {
             await next(context).ConfigureAwait(false);
             var subscriptionMessageType = GetSubscriptionMessageTypeFrom(context.Message);
@@ -40,15 +40,6 @@
         static string GetSubscriptionMessageTypeFrom(IncomingMessage msg)
         {
             return (from header in msg.Headers where header.Key == Headers.SubscriptionMessageType select header.Value).FirstOrDefault();
-        }
-
-        internal class Registration : RegisterStep
-        {
-            public Registration()
-                : base("SubscriptionBehavior", typeof(SubscriptionBehavior<TContext>), "So we can get subscription events")
-            {
-                InsertBeforeIfExists("ProcessSubscriptionRequests");
-            }
         }
     }
 }

--- a/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionBehaviorExtensions.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionBehaviorExtensions.cs
@@ -7,13 +7,11 @@ namespace NServiceBus.AcceptanceTests
     {
         public static void OnEndpointSubscribed<TContext>(this EndpointConfiguration b, Action<SubscriptionEventArgs, TContext> action) where TContext : ScenarioContext
         {
-            b.Pipeline.Register<SubscriptionBehavior<TContext>.Registration>();
-
-            b.RegisterComponents(c => c.ConfigureComponent(builder =>
+            b.Pipeline.Register(builder =>
             {
                 var context = builder.Build<TContext>();
                 return new SubscriptionBehavior<TContext>(action, context);
-            }, DependencyLifecycle.InstancePerCall));
+            }, "Provides notifications when endpoints subscribe");
         }
     }
 }


### PR DESCRIPTION
fixes #4199

Looks like there should be no issue by moving the subscription detection behavior on the transportreceive stage to avoid InsertBefore.

@Particular/nservicebus-maintainers please review