### PR TITLE
Add obsolete warning for SetCorrelationId

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Correlation/When_using_a_custom_correlation_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Correlation/When_using_a_custom_correlation_id.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus.AcceptanceTests.Correlation
+﻿#pragma warning disable 618
+namespace NServiceBus.AcceptanceTests.Correlation
 {
     using System.Threading.Tasks;
     using AcceptanceTesting;

--- a/src/NServiceBus.AcceptanceTests/Correlation/When_using_a_custom_correlation_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Correlation/When_using_a_custom_correlation_id.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable 618
+﻿
 namespace NServiceBus.AcceptanceTests.Correlation
 {
     using System.Threading.Tasks;
@@ -16,7 +16,10 @@ namespace NServiceBus.AcceptanceTests.Correlation
                 {
                     var options = new SendOptions();
 
+#pragma warning disable 618
                     options.SetCorrelationId(CorrelationId);
+#pragma warning restore 618
+
                     options.RouteToThisEndpoint();
 
                     return session.Send(new MessageWithCustomCorrelationId(), options);

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -221,15 +221,21 @@ namespace NServiceBus
     }
     public class static CorrelationContextExtensions
     {
+        [System.ObsoleteAttribute("Using custom correlation IDs is discouraged and will be removed in the next major" +
+            " version. Will be treated as an error from version 7.0.0. Will be removed in ver" +
+            "sion 8.0.0.", false)]
         public static string GetCorrelationId(this NServiceBus.SendOptions options) { }
+        [System.ObsoleteAttribute("Using custom correlation IDs is discouraged and will be removed in the next major" +
+            " version. Will be treated as an error from version 7.0.0. Will be removed in ver" +
+            "sion 8.0.0.", false)]
         public static string GetCorrelationId(this NServiceBus.ReplyOptions options) { }
         [System.ObsoleteAttribute("Setting a custom correlation ID is discouraged and will be removed in the next ma" +
             "jor version. Will be treated as an error from version 7.0.0. Will be removed in " +
-            "version 7.0.0.", false)]
+            "version 8.0.0.", false)]
         public static void SetCorrelationId(this NServiceBus.SendOptions options, string correlationId) { }
         [System.ObsoleteAttribute("Setting a custom correlation ID is discouraged and will be removed in the next ma" +
             "jor version. Will be treated as an error from version 7.0.0. Will be removed in " +
-            "version 7.0.0.", false)]
+            "version 8.0.0.", false)]
         public static void SetCorrelationId(this NServiceBus.ReplyOptions options, string correlationId) { }
     }
     public class CriticalError

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -223,7 +223,13 @@ namespace NServiceBus
     {
         public static string GetCorrelationId(this NServiceBus.SendOptions options) { }
         public static string GetCorrelationId(this NServiceBus.ReplyOptions options) { }
+        [System.ObsoleteAttribute("Setting a custom correlation ID is discouraged and will be removed in the next ma" +
+            "jor version. Will be treated as an error from version 7.0.0. Will be removed in " +
+            "version 7.0.0.", false)]
         public static void SetCorrelationId(this NServiceBus.SendOptions options, string correlationId) { }
+        [System.ObsoleteAttribute("Setting a custom correlation ID is discouraged and will be removed in the next ma" +
+            "jor version. Will be treated as an error from version 7.0.0. Will be removed in " +
+            "version 7.0.0.", false)]
         public static void SetCorrelationId(this NServiceBus.ReplyOptions options, string correlationId) { }
     }
     public class CriticalError

--- a/src/NServiceBus.Core/Correlation/CorrelationContextExtensions.cs
+++ b/src/NServiceBus.Core/Correlation/CorrelationContextExtensions.cs
@@ -47,6 +47,10 @@
         /// </summary>
         /// <param name="options">Options being extended.</param>
         /// <returns>The configured correlation id or <c>null</c> when no correlation id was configured.</returns>
+        [ObsoleteEx(
+        Message = "Using custom correlation IDs is discouraged and will be removed in the next major version.",
+            RemoveInVersion = "8",
+            TreatAsErrorFromVersion = "7")]
         public static string GetCorrelationId(this SendOptions options)
         {
             Guard.AgainstNull(nameof(options), options);
@@ -63,6 +67,10 @@
         /// </summary>
         /// <param name="options">Options being extended.</param>
         /// <returns>The configured correlation id or <c>null</c> when no correlation id was configured.</returns>
+        [ObsoleteEx(
+        Message = "Using custom correlation IDs is discouraged and will be removed in the next major version.",
+            RemoveInVersion = "8",
+            TreatAsErrorFromVersion = "7")]
         public static string GetCorrelationId(this ReplyOptions options)
         {
             Guard.AgainstNull(nameof(options), options);

--- a/src/NServiceBus.Core/Correlation/CorrelationContextExtensions.cs
+++ b/src/NServiceBus.Core/Correlation/CorrelationContextExtensions.cs
@@ -10,6 +10,10 @@
         /// </summary>
         /// <param name="options">Options being extended.</param>
         /// <param name="correlationId">The custom correlation id.</param>
+        [ObsoleteEx(
+            Message = "Setting a custom correlation ID is discouraged and will be removed in the next major version.",
+            RemoveInVersion = "7",
+            TreatAsErrorFromVersion = "7")]
         public static void SetCorrelationId(this SendOptions options, string correlationId)
         {
             Guard.AgainstNull(nameof(options), options);
@@ -24,6 +28,10 @@
         /// </summary>
         /// <param name="options">Options being extended.</param>
         /// <param name="correlationId">The custom correlation id.</param>
+        [ObsoleteEx(
+            Message = "Setting a custom correlation ID is discouraged and will be removed in the next major version.",
+            RemoveInVersion = "7",
+            TreatAsErrorFromVersion = "7")]
         public static void SetCorrelationId(this ReplyOptions options, string correlationId)
         {
             Guard.AgainstNull(nameof(options), options);

--- a/src/NServiceBus.Core/Correlation/CorrelationContextExtensions.cs
+++ b/src/NServiceBus.Core/Correlation/CorrelationContextExtensions.cs
@@ -12,7 +12,7 @@
         /// <param name="correlationId">The custom correlation id.</param>
         [ObsoleteEx(
             Message = "Setting a custom correlation ID is discouraged and will be removed in the next major version.",
-            RemoveInVersion = "7",
+            RemoveInVersion = "8",
             TreatAsErrorFromVersion = "7")]
         public static void SetCorrelationId(this SendOptions options, string correlationId)
         {
@@ -30,7 +30,7 @@
         /// <param name="correlationId">The custom correlation id.</param>
         [ObsoleteEx(
             Message = "Setting a custom correlation ID is discouraged and will be removed in the next major version.",
-            RemoveInVersion = "7",
+            RemoveInVersion = "8",
             TreatAsErrorFromVersion = "7")]
         public static void SetCorrelationId(this ReplyOptions options, string correlationId)
         {


### PR DESCRIPTION
relates to https://github.com/Particular/NServiceBus/issues/4170

Should we also add a warning for the getter method? I left that one out since it doesn't really apply to the the "we want to avoid usage of that API" in the same way as the setter does.

ping @Particular/nservicebus-maintainers 