### PR TITLE
ATT Publisher that are required to be accessible by ASB

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface.cs
@@ -42,7 +42,7 @@
             public Type EventTypePassedToRouting { get; set; }
         }
 
-        class Publisher : EndpointConfigurationBuilder
+        internal class Publisher : EndpointConfigurationBuilder
         {
             public Publisher()
             {

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface.cs
@@ -35,14 +35,14 @@
                 .Run();
         }
 
-        class Context : ScenarioContext
+        public class Context : ScenarioContext
         {
             public bool GotTheEvent { get; set; }
             public bool Subscribed { get; set; }
             public Type EventTypePassedToRouting { get; set; }
         }
 
-        internal class Publisher : EndpointConfigurationBuilder
+        public class Publisher : EndpointConfigurationBuilder
         {
             public Publisher()
             {
@@ -76,7 +76,7 @@
             }
         }
 
-        class Subscriber : EndpointConfigurationBuilder
+        public class Subscriber : EndpointConfigurationBuilder
         {
             public Subscriber()
             {

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface_with_unobtrusive.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface_with_unobtrusive.cs
@@ -35,14 +35,14 @@
                 .Run();
         }
 
-        class Context : ScenarioContext
+        public class Context : ScenarioContext
         {
             public bool GotTheEvent { get; set; }
             public bool Subscribed { get; set; }
             public Type EventTypePassedToRouting { get; set; }
         }
 
-        internal class Publisher : EndpointConfigurationBuilder
+        public class Publisher : EndpointConfigurationBuilder
         {
             public Publisher()
             {
@@ -77,7 +77,7 @@
             }
         }
 
-        class Subscriber : EndpointConfigurationBuilder
+        public class Subscriber : EndpointConfigurationBuilder
         {
             public Subscriber()
             {

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface_with_unobtrusive.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface_with_unobtrusive.cs
@@ -42,7 +42,7 @@
             public Type EventTypePassedToRouting { get; set; }
         }
 
-        class Publisher : EndpointConfigurationBuilder
+        internal class Publisher : EndpointConfigurationBuilder
         {
             public Publisher()
             {

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_using_root_type.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_using_root_type.cs
@@ -76,7 +76,6 @@
             }
         }
 
-        
         public class EventMessage : IMyEvent
         {
             public Guid EventId { get; set; }


### PR DESCRIPTION
Publisher classes that are required to be accessible by downstream ATTs for testing pub/sub for ASB

Here's an [example](https://github.com/Particular/NServiceBus.AzureServiceBus/blob/master/src/AcceptanceTests/ConfigureEndpointAzureServiceBusTransport.cs#L54) where ASB transport needs to wire the publishers for one of the topologies and requires the class to be internally visible.