### PR TITLE
[SPIKE] Allows native routing for sends

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -160,6 +160,9 @@
     <Compile Include="Routing\MessageDrivenSubscriptions\NamespacePublisherSource.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\TypePublisherSource.cs" />
     <Compile Include="Routing\NativePublishSubscribeFeature.cs" />
+    <Compile Include="Routing\Routers\MulticastSendRouterBehavior.cs" />
+    <Compile Include="Routing\Routers\SendRouteOption.cs" />
+    <Compile Include="Routing\Routers\SendRouterConnectorArguments.cs" />
     <Compile Include="Routing\TypeRouteSource.cs" />
     <Compile Include="Routing\IDistributionPolicy.cs" />
     <Compile Include="Routing\IRouteSource.cs" />

--- a/src/NServiceBus.Core/Routing/Routers/MulticastSendRouterBehavior.cs
+++ b/src/NServiceBus.Core/Routing/Routers/MulticastSendRouterBehavior.cs
@@ -1,0 +1,55 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Threading.Tasks;
+    using Pipeline;
+    using Routing;
+
+    class MulticastSendRouterBehavior : StageConnector<IOutgoingSendContext, IOutgoingLogicalMessageContext>
+    {
+        string instanceSpecificQueue;
+        string sharedQueue;
+
+        public MulticastSendRouterBehavior(string sharedQueue, string instanceSpecificQueue)
+        {
+            this.sharedQueue = sharedQueue;
+            this.instanceSpecificQueue = instanceSpecificQueue;
+        }
+
+        public override Task Invoke(IOutgoingSendContext context, Func<IOutgoingLogicalMessageContext, Task> stage)
+        {
+            var state = context.Extensions.GetOrCreate<SendRouterConnectorArguments>();
+
+            if (state.Option == SendRouteOption.RouteToThisInstance && instanceSpecificQueue == null)
+            {
+                throw new InvalidOperationException("Cannot route to a specific instance because an endpoint instance discriminator was not configured for the destination endpoint. It can be specified via EndpointConfiguration.MakeInstanceUniquelyAddressable(string discriminator).");
+            }
+            var thisEndpoint = state.Option == SendRouteOption.RouteToAnyInstanceOfThisEndpoint ? sharedQueue : null;
+            var thisInstance = state.Option == SendRouteOption.RouteToThisInstance ? instanceSpecificQueue : null;
+            var explicitDestination = state.Option == SendRouteOption.ExplicitDestination ? state.ExplicitDestination : null;
+            var destination = explicitDestination ?? thisInstance ?? thisEndpoint;
+
+            RoutingStrategy routingStrategy;
+            if (string.IsNullOrEmpty(destination))
+            {
+                routingStrategy = new MulticastRoutingStrategy(context.Message.MessageType);
+            }
+            else
+            {
+                routingStrategy = new UnicastRoutingStrategy(destination);
+            }
+
+            context.Headers[Headers.MessageIntent] = MessageIntentEnum.Send.ToString();
+
+            var logicalMessageContext = this.CreateOutgoingLogicalMessageContext(
+                context.Message,
+                new[]
+                {
+                    routingStrategy
+                },
+                context);
+
+            return stage(logicalMessageContext);
+        }
+    }
+}

--- a/src/NServiceBus.Core/Routing/Routers/SendRouteOption.cs
+++ b/src/NServiceBus.Core/Routing/Routers/SendRouteOption.cs
@@ -1,0 +1,11 @@
+namespace NServiceBus
+{
+    enum SendRouteOption
+    {
+        None,
+        ExplicitDestination,
+        RouteToThisInstance,
+        RouteToAnyInstanceOfThisEndpoint,
+        RouteToSpecificInstance
+    }
+}

--- a/src/NServiceBus.Core/Routing/Routers/SendRouterConnectorArguments.cs
+++ b/src/NServiceBus.Core/Routing/Routers/SendRouterConnectorArguments.cs
@@ -1,0 +1,25 @@
+namespace NServiceBus
+{
+    using System;
+
+    class SendRouterConnectorArguments
+    {
+        public string ExplicitDestination { get; set; }
+        public string SpecificInstance { get; set; }
+
+        public SendRouteOption Option
+        {
+            get { return option; }
+            set
+            {
+                if (option != SendRouteOption.None)
+                {
+                    throw new Exception("Already specified routing option for this message: " + option);
+                }
+                option = value;
+            }
+        }
+
+        SendRouteOption option;
+    }
+}

--- a/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
+++ b/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
@@ -15,8 +15,8 @@
             Guard.AgainstNull(nameof(options), options);
             Guard.AgainstNullAndEmpty(nameof(destination), destination);
 
-            var state = options.Context.GetOrCreate<UnicastSendRouterConnector.State>();
-            state.Option = UnicastSendRouterConnector.RouteOption.ExplicitDestination;
+            var state = options.Context.GetOrCreate<SendRouterConnectorArguments>();
+            state.Option = SendRouteOption.ExplicitDestination;
             state.ExplicitDestination = destination;
         }
 
@@ -58,7 +58,7 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            UnicastSendRouterConnector.State state;
+            SendRouterConnectorArguments state;
             options.Context.TryGet(out state);
             return state?.ExplicitDestination;
         }
@@ -71,8 +71,8 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            options.Context.GetOrCreate<UnicastSendRouterConnector.State>()
-                .Option = UnicastSendRouterConnector.RouteOption.RouteToAnyInstanceOfThisEndpoint;
+            options.Context.GetOrCreate<SendRouterConnectorArguments>()
+                .Option = SendRouteOption.RouteToAnyInstanceOfThisEndpoint;
         }
 
         /// <summary>
@@ -84,10 +84,10 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            UnicastSendRouterConnector.State state;
+            SendRouterConnectorArguments state;
             if (options.Context.TryGet(out state))
             {
-                return state.Option == UnicastSendRouterConnector.RouteOption.RouteToAnyInstanceOfThisEndpoint;
+                return state.Option == SendRouteOption.RouteToAnyInstanceOfThisEndpoint;
             }
 
             return false;
@@ -101,8 +101,8 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            options.Context.GetOrCreate<UnicastSendRouterConnector.State>()
-                .Option = UnicastSendRouterConnector.RouteOption.RouteToThisInstance;
+            options.Context.GetOrCreate<SendRouterConnectorArguments>()
+                .Option = SendRouteOption.RouteToThisInstance;
         }
 
         /// <summary>
@@ -114,10 +114,10 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            UnicastSendRouterConnector.State state;
+            SendRouterConnectorArguments state;
             if (options.Context.TryGet(out state))
             {
-                return state.Option == UnicastSendRouterConnector.RouteOption.RouteToThisInstance;
+                return state.Option == SendRouteOption.RouteToThisInstance;
             }
 
             return false;
@@ -133,8 +133,8 @@
             Guard.AgainstNull(nameof(options), options);
             Guard.AgainstNull(nameof(instanceId), instanceId);
 
-            var state = options.Context.GetOrCreate<UnicastSendRouterConnector.State>();
-            state.Option = UnicastSendRouterConnector.RouteOption.RouteToSpecificInstance;
+            var state = options.Context.GetOrCreate<SendRouterConnectorArguments>();
+            state.Option = SendRouteOption.RouteToSpecificInstance;
             state.SpecificInstance = instanceId;
         }
 
@@ -147,8 +147,8 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            UnicastSendRouterConnector.State state;
-            if (options.Context.TryGet(out state) && state.Option == UnicastSendRouterConnector.RouteOption.RouteToSpecificInstance)
+            SendRouterConnectorArguments state;
+            if (options.Context.TryGet(out state) && state.Option == SendRouteOption.RouteToSpecificInstance)
             {
                 return state.SpecificInstance;
             }


### PR DESCRIPTION
Relates to https://github.com/Particular/PlatformDevelopment/issues/980

The aim of this pull is to explore the simplest way to allow for natively routed (a.k.a. multicast) sending of commands. 

## Why native/multicast commands?

Native command routing allows underlying transport to fully control the routing of messages. It is a natural complement of native event routing (which is possible with the current version of the core). When combined (event + command routing) they allow for zero-configuration topologies if the transport is sufficiently advanced

### Example

In RabbitMQ we can have a convention where commands are published to exchanges the same way as events are. There are mechanisms to ensure there is at most one endpoint bound to such an exchange preventing sending commands to multiple endpoints. 

EventStore transport uses similar exchange topology mechanism (but it evaluates it on the client, not on the broker) so it could also benefit from native command routing.

## Changes in this PR

### Added missing `MulticastSendRouterBehavior`

It complements the other router behaviors. Currently even if transport returns `Multicast` as type of command routing, the core ignores this value and wires up `UnicastSendRouterBehavior`.

#### Why in the core and not in the transport?

An equivalent of `MulticastSendRouterBehavior` can be registered by the transport but then it would not have access to the `state` object set up by `SendOptions` extension methods that allow to customize the send behavior.

### Allowed deferring of natively routed messages

Currently the TimeoutManager can't defer the natively routed messages. This decision was based on the assumption that only events can be natively routed and events can't be deferred. This PR extends the TM (hopefully in a backwards-compatible way) to allow for deferring natively routed messages.

#### Why do we need this?

We need this because transports that allow native command routing might not be able to provide native timeout support. In such a scenario we would not be able to use delayed delivery. Alternatively we could say that native delivery is limited to sending to the same endpoint (which is the most common scenario anyway for the delayed delivery)

## Unsolved problems

Should we allow `SendLocal` and `SetDestination` when the transport offers native send routing? I think that native support by the transport should be an extension in the sense that the transport that report native support for send routing **must** also support non-native routing (via `UnicastAddressTag`).

If so then `SendLocal` and `SetDestination` can be implemented. If we agree that limiting delayed delivery to local endpoint in case of a transport supporting native routing but no native delays is acceptable then we can also remove the whole part related to TimeoutManager from the PR.
