### PR TITLE
Provide pubsub metadata to acceptance tests

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
@@ -51,17 +51,15 @@
             return configuration;
         }
 
-        public EndpointConfigurationBuilder EndpointSetup<T>() where T : IEndpointSetupTemplate, new()
-        {
-            return EndpointSetup<T>(c => { });
-        }
-
-        public EndpointConfigurationBuilder EndpointSetup<T>(Action<EndpointConfiguration> configurationBuilderCustomization) where T : IEndpointSetupTemplate, new()
+        public EndpointConfigurationBuilder EndpointSetup<T>(Action<EndpointConfiguration> configurationBuilderCustomization = null,
+            Action<PublisherMetadata> publisherMetadataAction = null) where T : IEndpointSetupTemplate, new()
         {
             if (configurationBuilderCustomization == null)
             {
                 configurationBuilderCustomization = b => { };
             }
+
+            publisherMetadataAction?.Invoke(configuration.PublisherMetadata);
 
             return EndpointSetup<T>((bc, esc) =>
             {

--- a/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
@@ -52,14 +52,14 @@
         }
 
         public EndpointConfigurationBuilder EndpointSetup<T>(Action<EndpointConfiguration> configurationBuilderCustomization = null,
-            Action<PublisherMetadata> publisherMetadataAction = null) where T : IEndpointSetupTemplate, new()
+            Action<PublisherMetadata> publisherMetadata = null) where T : IEndpointSetupTemplate, new()
         {
             if (configurationBuilderCustomization == null)
             {
                 configurationBuilderCustomization = b => { };
             }
 
-            publisherMetadataAction?.Invoke(configuration.PublisherMetadata);
+            publisherMetadata?.Invoke(configuration.PublisherMetadata);
 
             return EndpointSetup<T>((bc, esc) =>
             {
@@ -67,12 +67,15 @@
             });
         }
 
-        public EndpointConfigurationBuilder EndpointSetup<T>(Action<EndpointConfiguration, RunDescriptor> configurationBuilderCustomization) where T : IEndpointSetupTemplate, new()
+        public EndpointConfigurationBuilder EndpointSetup<T>(Action<EndpointConfiguration, RunDescriptor> configurationBuilderCustomization, Action<PublisherMetadata> publisherMetadata = null) where T : IEndpointSetupTemplate, new()
         {
             if (configurationBuilderCustomization == null)
             {
                 configurationBuilderCustomization = (rd, b) => { };
             }
+
+            publisherMetadata?.Invoke(configuration.PublisherMetadata);
+
             configuration.GetConfiguration = async (runDescriptor, routingTable) =>
             {
                 var endpointSetupTemplate = new T();

--- a/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
+++ b/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Support\IScenarioWithEndpointBehavior.cs" />
     <Compile Include="Support\IWhenDefinition.cs" />
     <Compile Include="Support\MessagesFailedException.cs" />
+    <Compile Include="Support\PublisherMetadata.cs" />
     <Compile Include="Support\RunDescriptor.cs" />
     <Compile Include="Support\RunDescriptorsBuilder.cs" />
     <Compile Include="Scenario.cs" />

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointCustomizationConfiguration.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointCustomizationConfiguration.cs
@@ -11,6 +11,7 @@
             UserDefinedConfigSections = new Dictionary<Type, object>();
             TypesToExclude = new List<Type>();
             TypesToInclude = new List<Type>();
+            PublisherMetadata = new PublisherMetadata();
         }
 
         public IDictionary<Type, Type> EndpointMappings { get; set; }
@@ -20,6 +21,8 @@
         public IList<Type> TypesToInclude { get; set; }
 
         public Func<RunDescriptor, IDictionary<Type, string>, Task<EndpointConfiguration>> GetConfiguration { get; set; }
+
+        public PublisherMetadata PublisherMetadata { get; private set; }
 
         public string EndpointName
         {

--- a/src/NServiceBus.AcceptanceTesting/Support/IConfigureEndpointTestExecution.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/IConfigureEndpointTestExecution.cs
@@ -16,8 +16,9 @@
         /// <param name="settings">Settings from the RunDescriptor specifying Transport, Persistence,
         /// connection strings, Serializer, Builder, and other details. Transports must call configuration.UseTransport&lt;T&gt;().
         /// Persistence must call configuration.UsePersistence&lt;T&gt;(). </param>
+        /// <param name="publisherMetadata">Metadata about publishers and the events they own.</param>
         /// <returns>An async Task.</returns>
-        Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings);
+        Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings,PublisherMetadata publisherMetadata);
 
         /// <summary>
         /// Gives the transport/persistence a chance to clean up after the test is complete. Implementations of this class may store

--- a/src/NServiceBus.AcceptanceTesting/Support/IConfigureEndpointTestExecution.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/IConfigureEndpointTestExecution.cs
@@ -18,7 +18,7 @@
         /// Persistence must call configuration.UsePersistence&lt;T&gt;(). </param>
         /// <param name="publisherMetadata">Metadata about publishers and the events they own.</param>
         /// <returns>An async Task.</returns>
-        Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings,PublisherMetadata publisherMetadata);
+        Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings, PublisherMetadata publisherMetadata);
 
         /// <summary>
         /// Gives the transport/persistence a chance to clean up after the test is complete. Implementations of this class may store

--- a/src/NServiceBus.AcceptanceTesting/Support/PublisherMetadata.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/PublisherMetadata.cs
@@ -10,29 +10,6 @@ namespace NServiceBus.AcceptanceTesting.Support
     {
         public IEnumerable<PublisherDetails> Publishers => publisherDetails.Values;
 
-        public class PublisherDetails
-        {
-            public PublisherDetails(Type publisherTypeType)
-            {
-                PublisherType = publisherTypeType;
-            }
-            public void RegisterOwnedEvent<T>()
-            {
-                var eventType = typeof(T);
-
-                if (Events.Contains(eventType))
-                {
-                    return;
-                }
-
-                Events.Add(eventType);
-            }
-
-            public List<Type> Events { get; } = new List<Type>();
-
-            public Type PublisherType { get; set; }
-        }
-
         public void RegisterPublisherFor<T>(Type endpoint)
         {
             PublisherDetails publisher;
@@ -48,5 +25,29 @@ namespace NServiceBus.AcceptanceTesting.Support
         }
 
         Dictionary<Type, PublisherDetails> publisherDetails = new Dictionary<Type, PublisherDetails>();
+
+        public class PublisherDetails
+        {
+            public PublisherDetails(Type publisherTypeType)
+            {
+                PublisherType = publisherTypeType;
+            }
+
+            public List<Type> Events { get; } = new List<Type>();
+
+            public Type PublisherType { get; set; }
+
+            public void RegisterOwnedEvent<T>()
+            {
+                var eventType = typeof(T);
+
+                if (Events.Contains(eventType))
+                {
+                    return;
+                }
+
+                Events.Add(eventType);
+            }
+        }
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/Support/PublisherMetadata.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/PublisherMetadata.cs
@@ -1,0 +1,52 @@
+namespace NServiceBus.AcceptanceTesting.Support
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Metadata on events and their publishers.
+    /// </summary>
+    public class PublisherMetadata
+    {
+        public IEnumerable<PublisherDetails> Publishers => publisherDetails.Values;
+
+        public class PublisherDetails
+        {
+            public PublisherDetails(Type publisherTypeType)
+            {
+                PublisherType = publisherTypeType;
+            }
+            public void RegisterOwnedEvent<T>()
+            {
+                var eventType = typeof(T);
+
+                if (Events.Contains(eventType))
+                {
+                    return;
+                }
+
+                Events.Add(eventType);
+            }
+
+            public List<Type> Events { get; } = new List<Type>();
+
+            public Type PublisherType { get; set; }
+        }
+
+        public void RegisterPublisherFor<T>(Type endpoint)
+        {
+            PublisherDetails publisher;
+
+            if (!publisherDetails.TryGetValue(endpoint, out publisher))
+            {
+                publisher = new PublisherDetails(endpoint);
+
+                publisherDetails[endpoint] = publisher;
+            }
+
+            publisher.RegisterOwnedEvent<T>();
+        }
+
+        Dictionary<Type, PublisherDetails> publisherDetails = new Dictionary<Type, PublisherDetails>();
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_the_publish_api.cs
+++ b/src/NServiceBus.AcceptanceTests/ApiExtension/When_extending_the_publish_api.cs
@@ -92,8 +92,7 @@
         {
             public Subscriber1()
             {
-                EndpointSetup<DefaultServer>(builder => { builder.DisableFeature<AutoSubscribe>(); })
-                    .AddMapping<MyEvent>(typeof(Publisher));
+                EndpointSetup<DefaultServer>(builder => builder.DisableFeature<AutoSubscribe>(), metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>
@@ -108,7 +107,6 @@
             }
         }
 
-        
         public class MyEvent : IEvent
         {
         }

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled.cs
@@ -21,8 +21,8 @@
                 }))
                 .Done(c => c.EndpointsStarted)
                 // This test is only relevant for message driven transports since we need to use the mappings to
-                // configure the publisher. The code first API would blow up unless we turn of the checks for the entire endpoint.
-                // But if we do that turning of checks per message becomes pointless.
+                // configure the publisher. The code first API would blow up unless we turn off the checks for the entire endpoint.
+                // But if we do that turning off checks per message becomes pointless since they are already off.
                 // We would need a new api to turn off startup checks only for this to be testable across the board.
                 .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
                 .Should(c => Assert.True(c.EndpointsStarted))

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled.cs
@@ -4,13 +4,14 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using NUnit.Framework;
+    using ScenarioDescriptors;
 
     public class When_publishing_command_bestpractices_disabled : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_allow_publishing_commands()
+        public Task Should_allow_publishing_commands()
         {
-            var context = await Scenario.Define<ScenarioContext>()
+            return Scenario.Define<ScenarioContext>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) =>
                 {
                     var publishOptions = new PublishOptions();
@@ -19,16 +20,22 @@
                     return session.Publish(new MyCommand(), publishOptions);
                 }))
                 .Done(c => c.EndpointsStarted)
+                // This test is only relevant for message driven transports since we need to use the mappings to
+                // configure the publisher. The code first API would blow up unless we turn of the checks for the entire endpoint.
+                // But if we do that turning of checks per message becomes pointless.
+                // We would need a new api to turn off startup checks only for this to be testable across the board.
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Should(c => Assert.True(c.EndpointsStarted))
                 .Run();
 
-            Assert.True(context.EndpointsStarted);
         }
 
         public class Endpoint : EndpointConfigurationBuilder
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>(publisherMetadata: metadata => metadata.RegisterPublisherFor<MyCommand>(typeof(Endpoint)));
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<MyCommand>(typeof(Endpoint));
             }
 
             public class Handler : IHandleMessages<MyCommand>

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled.cs
@@ -28,18 +28,12 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>(publisherMetadata: metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Endpoint)))
-                    .AddMapping<MyCommand>(typeof(Endpoint));
+                EndpointSetup<DefaultServer>(publisherMetadata: metadata => metadata.RegisterPublisherFor<MyCommand>(typeof(Endpoint)));
             }
 
-            public class Handler : IHandleMessages<MyEvent>, IHandleMessages<MyCommand>
+            public class Handler : IHandleMessages<MyCommand>
             {
                 public Task Handle(MyCommand message, IMessageHandlerContext context)
-                {
-                    return Task.FromResult(0);
-                }
-
-                public Task Handle(MyEvent message, IMessageHandlerContext context)
                 {
                     return Task.FromResult(0);
                 }
@@ -47,10 +41,6 @@
         }
 
         public class MyCommand : ICommand
-        {
-        }
-
-        public class MyEvent : IEvent
         {
         }
     }

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled.cs
@@ -28,9 +28,8 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>()
-                    .AddMapping<MyCommand>(typeof(Endpoint))
-                    .AddMapping<MyEvent>(typeof(Endpoint));
+                EndpointSetup<DefaultServer>(publisherMetadata: metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Endpoint)))
+                    .AddMapping<MyCommand>(typeof(Endpoint));
             }
 
             public class Handler : IHandleMessages<MyEvent>, IHandleMessages<MyCommand>

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled_on_endpoint.cs
@@ -16,36 +16,22 @@
                 .Run();
         }
 
-        [Test]
-        public Task Should_allow_sending_events()
-        {
-            return Scenario.Define<ScenarioContext>()
-                .WithEndpoint<Endpoint>(b => b.When((session, c) => session.Send(new MyEvent())))
-                .Done(c => c.EndpointsStarted)
-                .Run();
-        }
 
         public class Endpoint : EndpointConfigurationBuilder
         {
             public Endpoint()
             {
                 EndpointSetup<DefaultServer>((c, r) =>
-                        {
-                            var routing = c.UseTransport(r.GetTransportType()).Routing();
-                            routing.DoNotEnforceBestPractices();
-                        },
-                        metadata => metadata.RegisterPublisherFor<MyCommand>(typeof(Endpoint)))
-                    .AddMapping<MyEvent>(typeof(Endpoint));
+                    {
+                        var routing = c.UseTransport(r.GetTransportType()).Routing();
+                        routing.DoNotEnforceBestPractices();
+                    },
+                    metadata => metadata.RegisterPublisherFor<MyCommand>(typeof(Endpoint)));
             }
 
-            public class Handler : IHandleMessages<MyEvent>, IHandleMessages<MyCommand>
+            public class Handler : IHandleMessages<MyCommand>
             {
                 public Task Handle(MyCommand message, IMessageHandlerContext context)
-                {
-                    return Task.FromResult(0);
-                }
-
-                public Task Handle(MyEvent message, IMessageHandlerContext context)
                 {
                     return Task.FromResult(0);
                 }
@@ -53,10 +39,6 @@
         }
 
         public class MyCommand : ICommand
-        {
-        }
-
-        public class MyEvent : IEvent
         {
         }
     }

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled_on_endpoint.cs
@@ -30,12 +30,12 @@
             public Endpoint()
             {
                 EndpointSetup<DefaultServer>((c, r) =>
-                {
-                    var routing = c.UseTransport(r.GetTransportType()).Routing();
-                    routing.DoNotEnforceBestPractices();
-                })
-                .AddMapping<MyEvent>(typeof(Endpoint))
-                .AddMapping<MyCommand>(typeof(Endpoint));
+                        {
+                            var routing = c.UseTransport(r.GetTransportType()).Routing();
+                            routing.DoNotEnforceBestPractices();
+                        },
+                        metadata => metadata.RegisterPublisherFor<MyCommand>(typeof(Endpoint)))
+                    .AddMapping<MyEvent>(typeof(Endpoint));
             }
 
             public class Handler : IHandleMessages<MyEvent>, IHandleMessages<MyCommand>

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled_on_endpoint.cs
@@ -33,8 +33,9 @@
                 {
                     var routing = c.UseTransport(r.GetTransportType()).Routing();
                     routing.DoNotEnforceBestPractices();
-                }, metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Endpoint)))
-                    .AddMapping<MyCommand>(typeof(Endpoint));
+                })
+                .AddMapping<MyEvent>(typeof(Endpoint))
+                .AddMapping<MyCommand>(typeof(Endpoint));
             }
 
             public class Handler : IHandleMessages<MyEvent>, IHandleMessages<MyCommand>

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_publishing_command_bestpractices_disabled_on_endpoint.cs
@@ -33,9 +33,8 @@
                 {
                     var routing = c.UseTransport(r.GetTransportType()).Routing();
                     routing.DoNotEnforceBestPractices();
-                })
-                    .AddMapping<MyCommand>(typeof(Endpoint))
-                    .AddMapping<MyEvent>(typeof(Endpoint));
+                }, metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Endpoint)))
+                    .AddMapping<MyCommand>(typeof(Endpoint));
             }
 
             public class Handler : IHandleMessages<MyEvent>, IHandleMessages<MyCommand>

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled.cs
@@ -29,9 +29,8 @@ namespace NServiceBus.AcceptanceTests.BestPractices
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>()
-                    .AddMapping<MyCommand>(typeof(Endpoint))
-                    .AddMapping<MyEvent>(typeof(Endpoint));
+                EndpointSetup<DefaultServer>(publisherMetadata: metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Endpoint)))
+                    .AddMapping<MyCommand>(typeof(Endpoint));
             }
 
             public class Handler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled.cs
@@ -29,7 +29,8 @@ namespace NServiceBus.AcceptanceTests.BestPractices
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>(publisherMetadata: metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Endpoint)))
+                EndpointSetup<DefaultServer>()
+                    .AddMapping<MyEvent>(typeof(Endpoint))
                     .AddMapping<MyCommand>(typeof(Endpoint));
             }
 

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled_on_endpoint.cs
@@ -24,7 +24,8 @@
                     {
                         var routing = c.UseTransport(r.GetTransportType()).Routing();
                         routing.DoNotEnforceBestPractices();
-                    }, metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Endpoint)))
+                    })
+                    .AddMapping<MyEvent>(typeof(Endpoint))
                     .AddMapping<MyCommand>(typeof(Endpoint));
             }
 

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled_on_endpoint.cs
@@ -25,8 +25,7 @@
                         var routing = c.UseTransport(r.GetTransportType()).Routing();
                         routing.DoNotEnforceBestPractices();
                     })
-                    .AddMapping<MyEvent>(typeof(Endpoint))
-                    .AddMapping<MyCommand>(typeof(Endpoint));
+                    .AddMapping<MyEvent>(typeof(Endpoint));
             }
 
             public class Handler : IHandleMessages<MyEvent>
@@ -36,10 +35,6 @@
                     return Task.FromResult(0);
                 }
             }
-        }
-
-        public class MyCommand : ICommand
-        {
         }
 
         public class MyEvent : IEvent

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled_on_endpoint.cs
@@ -21,12 +21,11 @@
             public Endpoint()
             {
                 EndpointSetup<DefaultServer>((c, r) =>
-                {
-                    var routing = c.UseTransport(r.GetTransportType()).Routing();
-                    routing.DoNotEnforceBestPractices();
-                })
-                    .AddMapping<MyCommand>(typeof(Endpoint))
-                    .AddMapping<MyEvent>(typeof(Endpoint));
+                    {
+                        var routing = c.UseTransport(r.GetTransportType()).Routing();
+                        routing.DoNotEnforceBestPractices();
+                    }, metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Endpoint)))
+                    .AddMapping<MyCommand>(typeof(Endpoint));
             }
 
             public class Handler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command_bestpractices_disabled_on_endpoint.cs
@@ -42,9 +42,8 @@
                 {
                     var routing = c.UseTransport(r.GetTransportType()).Routing();
                     routing.DoNotEnforceBestPractices();
-                })
-                    .AddMapping<MyCommand>(typeof(Endpoint))
-                    .AddMapping<MyEvent>(typeof(Endpoint));
+                }, metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Endpoint)))
+                    .AddMapping<MyCommand>(typeof(Endpoint));
             }
 
             public class Handler : IHandleMessages<MyEvent>, IHandleMessages<MyCommand>

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command_bestpractices_disabled_on_endpoint.cs
@@ -42,9 +42,8 @@
                 {
                     var routing = c.UseTransport(r.GetTransportType()).Routing();
                     routing.DoNotEnforceBestPractices();
-                })
-                .AddMapping<MyEvent>(typeof(Endpoint))
-                .AddMapping<MyCommand>(typeof(Endpoint));
+                }, metadata => metadata.RegisterPublisherFor<MyCommand>(typeof(Endpoint)))
+                .AddMapping<MyEvent>(typeof(Endpoint));
             }
 
             public class Handler : IHandleMessages<MyEvent>, IHandleMessages<MyCommand>

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command_bestpractices_disabled_on_endpoint.cs
@@ -4,6 +4,7 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using NUnit.Framework;
+    using ScenarioDescriptors;
 
     public class When_subscribing_to_command_bestpractices_disabled_on_endpoint : NServiceBusAcceptanceTest
     {
@@ -13,24 +14,12 @@
             return Scenario.Define<ScenarioContext>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) => session.Subscribe<MyCommand>()))
                 .Done(c => c.EndpointsStarted)
-                .Run();
-        }
-
-        [Test]
-        public Task Should_allow_publishing_commands()
-        {
-            return Scenario.Define<ScenarioContext>()
-                .WithEndpoint<Endpoint>(b => b.When((session, c) => session.Publish(new MyCommand())))
-                .Done(c => c.EndpointsStarted)
-                .Run();
-        }
-
-        [Test]
-        public Task Should_allow_sending_events()
-        {
-            return Scenario.Define<ScenarioContext>()
-                .WithEndpoint<Endpoint>(b => b.When((session, c) => session.Send(new MyEvent())))
-                .Done(c => c.EndpointsStarted)
+                // This test is only relevant for message driven transports since we need to use the mappings to
+                // configure the publisher. The code first API would blow up unless we turn off the checks for the entire endpoint.
+                // But if we do that turning off checks per message becomes pointless since they are already off.
+                // We would need a new api to turn off startup checks only for this to be testable across the board.
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Should(c => Assert.True(c.EndpointsStarted))
                 .Run();
         }
 
@@ -39,32 +28,15 @@
             public Endpoint()
             {
                 EndpointSetup<DefaultServer>((c, r) =>
-                {
-                    var routing = c.UseTransport(r.GetTransportType()).Routing();
-                    routing.DoNotEnforceBestPractices();
-                }, metadata => metadata.RegisterPublisherFor<MyCommand>(typeof(Endpoint)))
-                .AddMapping<MyEvent>(typeof(Endpoint));
-            }
-
-            public class Handler : IHandleMessages<MyEvent>, IHandleMessages<MyCommand>
-            {
-                public Task Handle(MyCommand message, IMessageHandlerContext context)
-                {
-                    return Task.FromResult(0);
-                }
-
-                public Task Handle(MyEvent message, IMessageHandlerContext context)
-                {
-                    return Task.FromResult(0);
-                }
+                    {
+                        var routing = c.UseTransport(r.GetTransportType()).Routing();
+                        routing.DoNotEnforceBestPractices();
+                    })
+                    .AddMapping<MyCommand>(typeof(Endpoint));
             }
         }
 
         public class MyCommand : ICommand
-        {
-        }
-
-        public class MyEvent : IEvent
         {
         }
     }

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_subscribing_to_command_bestpractices_disabled_on_endpoint.cs
@@ -42,8 +42,9 @@
                 {
                     var routing = c.UseTransport(r.GetTransportType()).Routing();
                     routing.DoNotEnforceBestPractices();
-                }, metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Endpoint)))
-                    .AddMapping<MyCommand>(typeof(Endpoint));
+                })
+                .AddMapping<MyEvent>(typeof(Endpoint))
+                .AddMapping<MyCommand>(typeof(Endpoint));
             }
 
             public class Handler : IHandleMessages<MyEvent>, IHandleMessages<MyCommand>

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command_bestpractices_disabled_on_endpoint.cs
@@ -4,6 +4,7 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using NUnit.Framework;
+    using ScenarioDescriptors;
 
     public class When_unsubscribing_to_command_bestpractices_disabled_on_endpoint : NServiceBusAcceptanceTest
     {
@@ -13,7 +14,12 @@
             return Scenario.Define<ScenarioContext>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) => session.Unsubscribe<MyCommand>()))
                 .Done(c => c.EndpointsStarted)
-                .Run();
+                // This test is only relevant for message driven transports since we need to use the mappings to
+                // configure the publisher. The code first API would blow up unless we turn off the checks for the entire endpoint.
+                // But if we do that turning off checks per message becomes pointless since they are already off.
+                // We would need a new api to turn off startup checks only for this to be testable across the board.
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Should(c => Assert.True(c.EndpointsStarted)).Run();
         }
 
         public class Endpoint : EndpointConfigurationBuilder
@@ -21,10 +27,11 @@
             public Endpoint()
             {
                 EndpointSetup<DefaultServer>((c, r) =>
-                {
-                    var routing = c.UseTransport(r.GetTransportType()).Routing();
-                    routing.DoNotEnforceBestPractices();
-                }, metadata => metadata.RegisterPublisherFor<MyCommand>(typeof(Endpoint)));
+                    {
+                        var routing = c.UseTransport(r.GetTransportType()).Routing();
+                        routing.DoNotEnforceBestPractices();
+                    })
+                    .AddMapping<MyCommand>(typeof(Endpoint));
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command_bestpractices_disabled_on_endpoint.cs
@@ -24,9 +24,8 @@
                 {
                     var routing = c.UseTransport(r.GetTransportType()).Routing();
                     routing.DoNotEnforceBestPractices();
-                })
-                    .AddMapping<MyCommand>(typeof(Endpoint))
-                    .AddMapping<MyEvent>(typeof(Endpoint));
+                }, metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Endpoint)))
+                    .AddMapping<MyCommand>(typeof(Endpoint));
             }
 
             public class Handler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_unsubscribing_to_command_bestpractices_disabled_on_endpoint.cs
@@ -24,24 +24,11 @@
                 {
                     var routing = c.UseTransport(r.GetTransportType()).Routing();
                     routing.DoNotEnforceBestPractices();
-                }, metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Endpoint)))
-                    .AddMapping<MyCommand>(typeof(Endpoint));
-            }
-
-            public class Handler : IHandleMessages<MyEvent>
-            {
-                public Task Handle(MyEvent message, IMessageHandlerContext context)
-                {
-                    return Task.FromResult(0);
-                }
+                }, metadata => metadata.RegisterPublisherFor<MyCommand>(typeof(Endpoint)));
             }
         }
 
         public class MyCommand : ICommand
-        {
-        }
-
-        public class MyEvent : IEvent
         {
         }
     }

--- a/src/NServiceBus.AcceptanceTests/ConfigureEndpointInMemoryPersistence.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureEndpointInMemoryPersistence.cs
@@ -4,7 +4,7 @@ using NServiceBus.AcceptanceTesting.Support;
 
 public class ConfigureEndpointInMemoryPersistence : IConfigureEndpointTestExecution
 {
-    public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings)
+    public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings, PublisherMetadata publisherMetadata)
     {
         configuration.UsePersistence<InMemoryPersistence>();
         return Task.FromResult(0);

--- a/src/NServiceBus.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
@@ -20,16 +20,14 @@ public class ConfigureScenariosForMsmqTransport : IConfigureSupportedScenariosFo
 
 public class ConfigureEndpointMsmqTransport : IConfigureEndpointTestExecution
 {
-    public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings)
+    public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings, PublisherMetadata publisherMetadata)
     {
         queueBindings = configuration.GetSettings().Get<QueueBindings>();
         var connectionString = settings.Get<string>("Transport.ConnectionString");
         var transportConfig = configuration.UseTransport<MsmqTransport>();
 
         transportConfig.ConnectionString(connectionString);
-
-        var publisherMetadata = configuration.GetSettings().Get<PublisherMetadata>();
-
+        
         foreach (var publisher in publisherMetadata.Publishers)
         {
             foreach (var eventType in publisher.Events)

--- a/src/NServiceBus.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
@@ -27,7 +27,7 @@ public class ConfigureEndpointMsmqTransport : IConfigureEndpointTestExecution
         var transportConfig = configuration.UseTransport<MsmqTransport>();
 
         transportConfig.ConnectionString(connectionString);
-        
+
         foreach (var publisher in publisherMetadata.Publishers)
         {
             foreach (var eventType in publisher.Events)

--- a/src/NServiceBus.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
@@ -28,13 +28,15 @@ public class ConfigureEndpointMsmqTransport : IConfigureEndpointTestExecution
 
         transportConfig.ConnectionString(connectionString);
 
+        var routingConfig = transportConfig.Routing();
+
         foreach (var publisher in publisherMetadata.Publishers)
         {
             foreach (var eventType in publisher.Events)
             {
                 var publisherName = Conventions.EndpointNamingConvention(publisher.PublisherType);
 
-                transportConfig.Routing().RegisterPublisher(eventType, publisherName);
+                routingConfig.RegisterPublisher(eventType, publisherName);
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/AutomaticSubscriptions/When_handling_local_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/AutomaticSubscriptions/When_handling_local_event.cs
@@ -51,8 +51,7 @@
                             context.EventSubscribed = true;
                         }
                     });
-                })
-                .AddMapping<Event>(typeof(PublisherAndSubscriber));
+                }, metadata => metadata.RegisterPublisherFor<Event>(typeof(PublisherAndSubscriber)));
             }
 
             public class EventHandler : IHandleMessages<Event>

--- a/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/When_a_subscription_message_arrives.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/When_a_subscription_message_arrives.cs
@@ -30,8 +30,8 @@
         {
             public UOWEndpoint()
             {
-                EndpointSetup<DefaultServer>(c => c.RegisterComponents(container => container.ConfigureComponent<MyUow>(DependencyLifecycle.InstancePerCall)))
-                    .AddMapping<MyMessage>(typeof(UOWEndpoint));
+                EndpointSetup<DefaultServer>(c => c.RegisterComponents(container => container.ConfigureComponent<MyUow>(DependencyLifecycle.InstancePerCall)),
+                    metadata => metadata.RegisterPublisherFor<MyMessage>(typeof(UOWEndpoint)));
             }
 
             class MyUow : IManageUnitsOfWork

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -3,12 +3,13 @@
     using System;
     using System.Threading.Tasks;
     using AcceptanceTesting.Support;
+    using Configuration.AdvanceExtensibility;
     using ObjectBuilder;
     using ScenarioDescriptors;
 
     public static class ConfigureExtensions
     {
-        public static Task DefineTransport(this EndpointConfiguration config, RunSettings settings, string endpointName)
+        public static Task DefineTransport(this EndpointConfiguration config, RunSettings settings, EndpointCustomizationConfiguration endpointCustomizationConfiguration)
         {
             Type transportType;
             if (!settings.TryGet("Transport", out transportType))
@@ -16,7 +17,10 @@
                 settings.Merge(Transports.Default.Settings);
             }
 
-            return ConfigureTestExecution(TestDependencyType.Transport, config, settings, endpointName);
+            //hack: for now
+            config.GetSettings().Set<PublisherMetadata>(endpointCustomizationConfiguration.PublisherMetadata);
+
+            return ConfigureTestExecution(TestDependencyType.Transport, config, settings, endpointCustomizationConfiguration.EndpointName);
         }
 
         public static Task DefinePersistence(this EndpointConfiguration config, RunSettings settings, string endpointName)

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
@@ -52,7 +52,7 @@
             {
                 configuration.UseSerialization((SerializationDefinition)Activator.CreateInstance(serializerType));
             }
-            await configuration.DefinePersistence(settings, endpointConfiguration.EndpointName).ConfigureAwait(false);
+            await configuration.DefinePersistence(settings, endpointConfiguration).ConfigureAwait(false);
 
             configuration.GetSettings().SetDefault("ScaleOut.UseSingleBrokerQueue", true);
             configurationBuilderCustomization(configuration);

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
@@ -42,7 +42,7 @@
             recoverability.Delayed(delayed => delayed.NumberOfRetries(0));
             recoverability.Immediate(immediate => immediate.NumberOfRetries(0));
 
-            await configuration.DefineTransport(settings, endpointConfiguration.EndpointName).ConfigureAwait(false);
+            await configuration.DefineTransport(settings, endpointConfiguration).ConfigureAwait(false);
 
             configuration.DefineBuilder(settings);
             configuration.RegisterComponentsAndInheritanceHierarchy(runDescriptor);

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ServerWithNoDefaultPersistenceDefinitions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ServerWithNoDefaultPersistenceDefinitions.cs
@@ -38,7 +38,7 @@
                 .Delayed(delayed => delayed.NumberOfRetries(0))
                 .Immediate(immediate => immediate.NumberOfRetries(0));
 
-            await builder.DefineTransport(settings, endpointConfiguration.EndpointName).ConfigureAwait(false);
+            await builder.DefineTransport(settings, endpointConfiguration).ConfigureAwait(false);
 
             builder.RegisterComponentsAndInheritanceHierarchy(runDescriptor);
 

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga.cs
@@ -37,9 +37,12 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
         {
             public Subscriber()
             {
-                EndpointSetup<DefaultServer>(c => c.Pipeline.Register("SubscriptionSpy", new SubscriptionSpy((Context)ScenarioContext), "Spies on subscriptions made"))
-                    .AddMapping<MyEventBase>(typeof(Subscriber)) //just map to our self for this test
-                    .AddMapping<MyEvent>(typeof(Subscriber)); //just map to our self for this test
+                EndpointSetup<DefaultServer>(c => c.Pipeline.Register("SubscriptionSpy", new SubscriptionSpy((Context) ScenarioContext), "Spies on subscriptions made"),
+                    metadata =>
+                    {
+                        metadata.RegisterPublisherFor<MyEventBase>(typeof(Subscriber));
+                        metadata.RegisterPublisherFor<MyEvent>(typeof(Subscriber));
+                    });
             }
 
             class SubscriptionSpy : IBehavior<ISubscribeContext, ISubscribeContext>

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs
@@ -37,9 +37,12 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
         {
             public Subscriber()
             {
-                EndpointSetup<DefaultServer>(c => c.Pipeline.Register("SubscriptionSpy", new SubscriptionSpy((Context)ScenarioContext), "Spies on subscriptions made"))
-                    .AddMapping<MyEventWithParent>(typeof(Subscriber)) //just map to our self for this test
-                    .AddMapping<MyEvent>(typeof(Subscriber)); //just map to our self for this test
+                EndpointSetup<DefaultServer>(c => c.Pipeline.Register("SubscriptionSpy", new SubscriptionSpy((Context) ScenarioContext), "Spies on subscriptions made"),
+                    metadata =>
+                    {
+                        metadata.RegisterPublisherFor<MyEventWithParent>(typeof(Subscriber));
+                        metadata.RegisterPublisherFor<MyEvent>(typeof(Subscriber));
+                    });
             }
 
             class SubscriptionSpy : IBehavior<ISubscribeContext, ISubscribeContext>

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_autoSubscribe.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_autoSubscribe.cs
@@ -41,11 +41,14 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
         {
             public Subscriber()
             {
-                EndpointSetup<DefaultServer>(c => c.Pipeline.Register("SubscriptionSpy", new SubscriptionSpy((Context)ScenarioContext), "Spies on subscriptions made"))
+                EndpointSetup<DefaultServer>(c => c.Pipeline.Register("SubscriptionSpy", new SubscriptionSpy((Context) ScenarioContext), "Spies on subscriptions made"),
+                        metadata =>
+                        {
+                            metadata.RegisterPublisherFor<MyEvent>(typeof(Subscriber));
+                            metadata.RegisterPublisherFor<MyEventWithNoHandler>(typeof(Subscriber));
+                        })
                     .AddMapping<MyMessage>(typeof(Subscriber)) //just map to our self for this test
-                    .AddMapping<MyCommand>(typeof(Subscriber)) //just map to our self for this test
-                    .AddMapping<MyEventWithNoHandler>(typeof(Subscriber)) //just map to our self for this test
-                    .AddMapping<MyEvent>(typeof(Subscriber)); //just map to our self for this test
+                    .AddMapping<MyCommand>(typeof(Subscriber)); //just map to our self for this test
             }
 
             class SubscriptionSpy : IBehavior<ISubscribeContext, ISubscribeContext>

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_multi_subscribing_to_a_polymorphic_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_multi_subscribing_to_a_polymorphic_event.cs
@@ -93,9 +93,12 @@
         {
             public Subscriber1()
             {
-                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
-                    .AddMapping<IMyEvent>(typeof(Publisher1))
-                    .AddMapping<MyEvent2>(typeof(Publisher2));
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(),
+                        metadata =>
+                        {
+                            metadata.RegisterPublisherFor<IMyEvent>(typeof(Publisher1));
+                            metadata.RegisterPublisherFor<MyEvent2>(typeof(Publisher2));
+                        });
             }
 
             public class MyEventHandler : IHandleMessages<IMyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_publishing_from_sendonly.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_publishing_from_sendonly.cs
@@ -49,8 +49,8 @@
         {
             public Subscriber()
             {
-                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
-                    .AddMapping<MyEvent>(typeof(SendOnlyPublisher));
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(),
+                   metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(SendOnlyPublisher)));
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_publishing_to_scaled_out_subscribers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_publishing_to_scaled_out_subscribers.cs
@@ -3,16 +3,13 @@
     using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
-    using AcceptanceTesting.Customization;
     using EndpointTemplates;
     using NUnit.Framework;
     using ScenarioDescriptors;
 
     public class When_publishing_to_scaled_out_subscribers : NServiceBusAcceptanceTest
     {
-        static string PublisherEndpoint => Conventions.EndpointNamingConvention(typeof(Publisher));
-
-        [Test]
+       [Test]
         public async Task Each_event_should_be_delivered_to_single_instance_of_each_subscriber()
         {
             await Scenario.Define<Context>()
@@ -71,10 +68,7 @@
         {
             public SubscriberA()
             {
-                EndpointSetup<DefaultServer>(c =>
-                {
-                    c.MessageDrivenPubSubRouting().RegisterPublisher(typeof(MyEvent), PublisherEndpoint);
-                });
+                EndpointSetup<DefaultServer>(publisherMetadata: metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>
@@ -93,10 +87,7 @@
         {
             public SubscriberB()
             {
-                EndpointSetup<DefaultServer>(c =>
-                {                    
-                    c.MessageDrivenPubSubRouting().RegisterPublisher(typeof(MyEvent), PublisherEndpoint);
-                });
+                EndpointSetup<DefaultServer>(publisherMetadata: metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_subscribing_to_a_base_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_subscribing_to_a_base_event.cs
@@ -54,8 +54,8 @@
                 EndpointSetup<DefaultServer>(c =>
                 {
                     c.DisableFeature<AutoSubscribe>();
-                })
-                    .AddMapping<IBaseEvent>(typeof(Publisher));
+                },
+                metadata => metadata.RegisterPublisherFor<IBaseEvent>(typeof(Publisher)));
             }
 
             public class MyEventHandler : IHandleMessages<IBaseEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_subscribing_to_a_derived_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_subscribing_to_a_derived_event.cs
@@ -54,8 +54,8 @@
                 {
                     c.DisableFeature<AutoSubscribe>();
                     c.LimitMessageProcessingConcurrencyTo(1); //To ensure Done is processed after the event.
-                })
-                    .AddMapping<SpecificEvent>(typeof(Publisher));
+                },
+                metadata => metadata.RegisterPublisherFor<SpecificEvent>(typeof(Publisher)));
             }
 
             public class MyEventHandler : IHandleMessages<SpecificEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_subscribing_to_multiple_publishers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_subscribing_to_multiple_publishers.cs
@@ -10,9 +10,9 @@
     public class When_subscribing_to_multiple_publishers : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_subscribe_to_all_registered_publishers_of_same_type()
+        public Task Should_subscribe_to_all_registered_publishers_of_same_type()
         {
-            await Scenario.Define<Context>()
+            return Scenario.Define<Context>()
                 .WithEndpoint<Subscriber>(e => e
                     .When(s => s.Subscribe<SomeEvent>()))
                 .WithEndpoint<Publisher>(e => e

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_using_legacy_routing_configuration.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_using_legacy_routing_configuration.cs
@@ -39,7 +39,6 @@
             public Publisher()
             {
                 EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) => { context.Subscribed = true; }))
-                    .AddMapping<MyEvent>(typeof(Subscriber))
                     .AddMapping<DoneCommand>(typeof(Subscriber));
             }
         }
@@ -52,8 +51,8 @@
                 {
                     c.DisableFeature<AutoSubscribe>();
                     c.LimitMessageProcessingConcurrencyTo(1);
-                })
-                    .AddMapping<MyEvent>(typeof(Publisher));
+                },
+                metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher))); 
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/When_base_event_from_2_publishers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_base_event_from_2_publishers.cs
@@ -79,9 +79,12 @@
         {
             public Subscriber1()
             {
-                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
-                    .AddMapping<DerivedEvent1>(typeof(Publisher1))
-                    .AddMapping<DerivedEvent2>(typeof(Publisher2));
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(),
+                    metadata =>
+                    {
+                        metadata.RegisterPublisherFor<DerivedEvent1>(typeof(Publisher1));
+                        metadata.RegisterPublisherFor<DerivedEvent2>(typeof(Publisher2));
+                    });
             }
 
             public class BaseEventHandler : IHandleMessages<BaseEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing.cs
@@ -137,8 +137,8 @@
         {
             public Subscriber3()
             {
-                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
-                    .AddMapping<IFoo>(typeof(Publisher3));
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(),
+                    metadata => metadata.RegisterPublisherFor<IFoo>(typeof(Publisher3)));
             }
 
             public class MyEventHandler : IHandleMessages<IFoo>
@@ -157,8 +157,8 @@
         {
             public Subscriber1()
             {
-                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
-                    .AddMapping<MyEvent>(typeof(Publisher));
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(),
+                     metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>
@@ -178,8 +178,8 @@
         {
             public Subscriber2()
             {
-                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
-                    .AddMapping<MyEvent>(typeof(Publisher));
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(),
+                    metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>
@@ -198,7 +198,7 @@
         {
         }
 
-        
+
         public class MyEvent : IEvent
         {
         }

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
@@ -79,17 +79,20 @@
             public Subscriber()
             {
                 EndpointSetup<DefaultServer>(c =>
-                {
-                    c.Conventions().DefiningMessagesAs(t => t != typeof(CompositeEvent) && typeof(IMessage).IsAssignableFrom(t) &&
-                                                            typeof(IMessage) != t &&
-                                                            typeof(IEvent) != t &&
-                                                            typeof(ICommand) != t);
+                    {
+                        c.Conventions().DefiningMessagesAs(t => t != typeof(CompositeEvent) && typeof(IMessage).IsAssignableFrom(t) &&
+                                                                typeof(IMessage) != t &&
+                                                                typeof(IEvent) != t &&
+                                                                typeof(ICommand) != t);
 
-                    c.Conventions().DefiningEventsAs(t => t != typeof(CompositeEvent) && typeof(IEvent).IsAssignableFrom(t) && typeof(IEvent) != t);
-                    c.DisableFeature<AutoSubscribe>();
-                })
-                    .AddMapping<IEventA>(typeof(Publisher))
-                    .AddMapping<IEventB>(typeof(Publisher));
+                        c.Conventions().DefiningEventsAs(t => t != typeof(CompositeEvent) && typeof(IEvent).IsAssignableFrom(t) && typeof(IEvent) != t);
+                        c.DisableFeature<AutoSubscribe>();
+                    },
+                    metadata =>
+                    {
+                        metadata.RegisterPublisherFor<IEventA>(typeof(Publisher));
+                        metadata.RegisterPublisherFor<IEventB>(typeof(Publisher));
+                    });
             }
 
             public class EventAHandler : IHandleMessages<IEventA>

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface.cs
@@ -80,8 +80,8 @@
         {
             public Subscriber()
             {
-                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
-                    .AddMapping<MyEvent>(typeof(Publisher));
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(),
+                           metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface_with_unobtrusive.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface_with_unobtrusive.cs
@@ -85,8 +85,8 @@
                 {
                     c.Conventions().DefiningEventsAs(t => t.Namespace != null && t.Name.EndsWith("Event"));
                     c.DisableFeature<AutoSubscribe>();
-                })
-                    .AddMapping<MyEvent>(typeof(Publisher));
+                },
+                metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_using_root_type.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_using_root_type.cs
@@ -60,8 +60,7 @@
         {
             public Subscriber1()
             {
-                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
-                    .AddMapping<EventMessage>(typeof(Publisher));
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(), p => p.RegisterPublisherFor<EventMessage>(typeof(Publisher)));
             }
 
             public class MyEventHandler : IHandleMessages<EventMessage>
@@ -75,6 +74,7 @@
                 }
             }
         }
+
 
         public class EventMessage : IMyEvent
         {

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_with_only_local_messagehandlers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_with_only_local_messagehandlers.cs
@@ -46,8 +46,8 @@
         {
             public MessageDrivenPublisher()
             {
-                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) => { context.LocalEndpointSubscribed = true; }))
-                    .AddMapping<EventHandledByLocalEndpoint>(typeof(MessageDrivenPublisher)); //an explicit mapping is needed
+                EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) => { context.LocalEndpointSubscribed = true; }),
+                    metadata => metadata.RegisterPublisherFor<EventHandledByLocalEndpoint>(typeof(MessageDrivenPublisher)));
             }
 
             class CatchAllHandler : IHandleMessages<IEvent> //not enough for auto subscribe to work
@@ -75,8 +75,7 @@
         {
             public CentralizedStoragePublisher()
             {
-                EndpointSetup<DefaultServer>()
-                    .AddMapping<EventHandledByLocalEndpoint>(typeof(CentralizedStoragePublisher)); //an explicit mapping may be needed, depends on the technology underneath;
+                EndpointSetup<DefaultServer>(publisherMetadata: metadata => metadata.RegisterPublisherFor<EventHandledByLocalEndpoint>(typeof(CentralizedStoragePublisher)));
             }
 
             class CatchAllHandler : IHandleMessages<IEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_with_overridden_local_address.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_with_overridden_local_address.cs
@@ -58,9 +58,8 @@
                 EndpointSetup<DefaultServer>(builder =>
                 {
                     builder.DisableFeature<AutoSubscribe>();
-                    //builder.OverrideLocalAddress("myInputQueue"); Fix in 133
-                })
-                    .AddMapping<MyEvent>(typeof(Publisher));
+                },
+                metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/When_registering_publishers_unobtrusive_messages_config.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_registering_publishers_unobtrusive_messages_config.cs
@@ -47,9 +47,8 @@
         {
             public Subscriber()
             {
-                EndpointSetup<DefaultServer>(c => c
-                .Conventions().DefiningEventsAs(t => t == typeof(SomeEvent)))
-                .AddMapping<SomeEvent>(typeof(Publisher));
+                EndpointSetup<DefaultServer>(c => c.Conventions().DefiningEventsAs(t => t == typeof(SomeEvent)),
+                metadata => metadata.RegisterPublisherFor<SomeEvent>(typeof(Publisher)));
             }
 
             public class EventHandler : IHandleMessages<SomeEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/When_replying_to_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_replying_to_message.cs
@@ -49,7 +49,7 @@
         {
             public SendingEndpoint()
             {
-                EndpointSetup<DefaultPublisher>().AddMapping<MyMessage>(typeof(ReplyingEndpoint));
+                EndpointSetup<DefaultServer>().AddMapping<MyMessage>(typeof(ReplyingEndpoint));
             }
 
             public class ResponseHandler : IHandleMessages<MyReply>

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_replies_to_message_published_by_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_replies_to_message_published_by_a_saga.cs
@@ -45,11 +45,7 @@
         {
             public ReplyEndpoint()
             {
-                EndpointSetup<DefaultServer>(b =>
-                    {
-                        b.DisableFeature<AutoSubscribe>();
-                    })
-                    .AddMapping<DidSomething>(typeof(SagaEndpoint));
+                EndpointSetup<DefaultServer>(b => b.DisableFeature<AutoSubscribe>(), metadata => metadata.RegisterPublisherFor<DidSomething>(typeof(SagaEndpoint)));
             }
 
             class DidSomethingHandler : IHandleMessages<DidSomething>

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_base_event_from_other_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_base_event_from_other_saga.cs
@@ -62,8 +62,8 @@
                 {
                     c.EnableFeature<TimeoutManager>();
                     c.DisableFeature<AutoSubscribe>();
-                })
-                    .AddMapping<BaseEvent>(typeof(Publisher));
+                },
+                metdata => metdata.RegisterPublisherFor<BaseEvent>(typeof(Publisher)));
             }
 
             public class SagaStartedByBaseEvent : Saga<SagaStartedByBaseEvent.SagaStartedByBaseEventSagaData>, IAmStartedByMessages<BaseEvent>
@@ -90,7 +90,7 @@
             }
         }
 
-        
+
         public class StartSaga : ICommand
         {
             public Guid DataId { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_event_from_another_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_event_from_another_saga.cs
@@ -105,8 +105,8 @@
                 {
                     c.EnableFeature<TimeoutManager>();
                     c.DisableFeature<AutoSubscribe>();
-                })
-                    .AddMapping<SomethingHappenedEvent>(typeof(SagaThatPublishesAnEvent));
+                },
+                metadata => metadata.RegisterPublisherFor<SomethingHappenedEvent>(typeof(SagaThatPublishesAnEvent)));
             }
 
             public class EventFromOtherSaga2 : Saga<EventFromOtherSaga2.EventFromOtherSaga2Data>,
@@ -145,7 +145,7 @@
             }
         }
 
-        
+
         public class StartSaga : ICommand
         {
             public Guid DataId { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_two_sagas_subscribe_to_the_same_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_two_sagas_subscribe_to_the_same_event.cs
@@ -72,9 +72,9 @@
         {
             public SagaEndpoint()
             {
-                EndpointSetup<DefaultServer>(c => c.EnableFeature<TimeoutManager>())
-                    .AddMapping<OpenGroupCommand>(typeof(Publisher))
-                    .AddMapping<GroupPendingEvent>(typeof(Publisher));
+                EndpointSetup<DefaultServer>(c => c.EnableFeature<TimeoutManager>(),
+                    metadata => metadata.RegisterPublisherFor<GroupPendingEvent>(typeof(Publisher)))
+                    .AddMapping<OpenGroupCommand>(typeof(Publisher));
             }
 
             public class Saga1 : Saga<Saga1.MySaga1Data>,
@@ -150,7 +150,7 @@
             }
         }
 
-        
+
         public class GroupPendingEvent : IEvent
         {
             public Guid DataId { get; set; }
@@ -161,7 +161,7 @@
             public Guid DataId { get; set; }
         }
 
-        
+
         public class StartSaga2 : ICommand
         {
             public Guid DataId { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
+++ b/src/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
@@ -79,9 +79,9 @@
         {
             public V1Subscriber()
             {
-                EndpointSetup<DefaultServer>(b => b.DisableFeature<AutoSubscribe>())
-                    .ExcludeType<V2Event>()
-                    .AddMapping<V1Event>(typeof(V2Publisher));
+                EndpointSetup<DefaultServer>(b => b.DisableFeature<AutoSubscribe>(),
+                    metadata => metadata.RegisterPublisherFor<V1Event>(typeof(V2Publisher)))
+                    .ExcludeType<V2Event>();
             }
 
             class V1Handler : IHandleMessages<V1Event>
@@ -100,8 +100,8 @@
         {
             public V2Subscriber()
             {
-                EndpointSetup<DefaultServer>(b => b.DisableFeature<AutoSubscribe>())
-                    .AddMapping<V2Event>(typeof(V2Publisher));
+                EndpointSetup<DefaultServer>(b => b.DisableFeature<AutoSubscribe>(),
+                     metadata => metadata.RegisterPublisherFor<V2Event>(typeof(V2Publisher)));
             }
 
             class V2Handler : IHandleMessages<V2Event>

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/TypePublisherSourceTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/TypePublisherSourceTests.cs
@@ -28,6 +28,13 @@ namespace NServiceBus.Core.Tests.Routing
             Assert.That(() => source.GenerateWithoutBestPracticeEnforcement(new Conventions()).ToArray(), Throws.Exception.Message.Contains("it is not considered a message"));
         }
 
+        [Test]
+        public void Without_best_practice_enforcement_it_throws_if_specified_type_is_a_command()
+        {
+            var source = new TypePublisherSource(typeof(Command), PublisherAddress.CreateFromEndpointName("Destination"));
+            Assert.That(() => source.GenerateWithoutBestPracticeEnforcement(new Conventions()).ToArray(), Throws.Exception.Message.Contains("because it is a command"));
+        }
+
         class NonMessage
         {
         }

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/TypePublisherSourceTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/TypePublisherSourceTests.cs
@@ -28,13 +28,6 @@ namespace NServiceBus.Core.Tests.Routing
             Assert.That(() => source.GenerateWithoutBestPracticeEnforcement(new Conventions()).ToArray(), Throws.Exception.Message.Contains("it is not considered a message"));
         }
 
-        [Test]
-        public void Without_best_practice_enforcement_it_throws_if_specified_type_is_a_command()
-        {
-            var source = new TypePublisherSource(typeof(Command), PublisherAddress.CreateFromEndpointName("Destination"));
-            Assert.That(() => source.GenerateWithoutBestPracticeEnforcement(new Conventions()).ToArray(), Throws.Exception.Message.Contains("because it is a command"));
-        }
-
         class NonMessage
         {
         }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/TypePublisherSource.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/TypePublisherSource.cs
@@ -34,10 +34,7 @@ namespace NServiceBus
             {
                 throw new Exception($"Cannot configure publisher for type '{messageType.FullName}' because it is not considered a message. Message types have to either implement NServiceBus.IMessage interface or match a defined message convention.");
             }
-            if (conventions.IsCommandType(messageType))
-            {
-                throw new Exception($"Cannot configure publisher for type '{messageType.FullName}' because it is a command.");
-            }
+
             yield return new PublisherTableEntry(messageType, address);
         }
 

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/TypePublisherSource.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/TypePublisherSource.cs
@@ -34,7 +34,10 @@ namespace NServiceBus
             {
                 throw new Exception($"Cannot configure publisher for type '{messageType.FullName}' because it is not considered a message. Message types have to either implement NServiceBus.IMessage interface or match a defined message convention.");
             }
-
+            if (conventions.IsCommandType(messageType))
+            {
+                throw new Exception($"Cannot configure publisher for type '{messageType.FullName}' because it is a command.");
+            }
             yield return new PublisherTableEntry(messageType, address);
         }
 

--- a/src/NServiceBus.Msmq.AcceptanceTests/ConfigureMsmqTransport.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/ConfigureMsmqTransport.cs
@@ -20,13 +20,15 @@ public class ConfigureEndpointMsmqTransport : IConfigureEndpointTestExecution
 
         transportConfig.ConnectionString(connectionString);
 
+        var routingConfig = transportConfig.Routing();
+
         foreach (var publisher in publisherMetadata.Publishers)
         {
             foreach (var eventType in publisher.Events)
             {
                 var publisherName = Conventions.EndpointNamingConvention(publisher.PublisherType);
 
-                transportConfig.Routing().RegisterPublisher(eventType, publisherName);
+                routingConfig.RegisterPublisher(eventType, publisherName);
             }
         }
 

--- a/src/NServiceBus.Msmq.AcceptanceTests/ConfigureMsmqTransport.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/ConfigureMsmqTransport.cs
@@ -11,7 +11,7 @@ using Conventions = NServiceBus.AcceptanceTesting.Customization.Conventions;
 
 public class ConfigureEndpointMsmqTransport : IConfigureEndpointTestExecution
 {
-    public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings)
+    public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings, PublisherMetadata publisherMetadata)
     {
         queueBindings = configuration.GetSettings().Get<QueueBindings>();
         var connectionString = settings.Get<string>("Transport.ConnectionString");
@@ -19,8 +19,6 @@ public class ConfigureEndpointMsmqTransport : IConfigureEndpointTestExecution
         var transportConfig = configuration.UseTransport<MsmqTransport>();
 
         transportConfig.ConnectionString(connectionString);
-
-        var publisherMetadata = configuration.GetSettings().Get<PublisherMetadata>();
 
         foreach (var publisher in publisherMetadata.Publishers)
         {

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_publishing.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_publishing.cs
@@ -66,8 +66,13 @@
         {
             public Subscriber()
             {
-                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
-                    .AddMapping<MyEvent>(typeof(Publisher));
+                EndpointSetup<DefaultServer>(c =>
+                    {
+                        c.DisableFeature<AutoSubscribe>();
+                        c.UseTransport<MsmqTransport>()
+                            .Routing().RegisterPublisher(typeof(MyEvent), AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(Publisher)));
+                    }
+                );
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_publishing_with_authorizer.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_publishing_with_authorizer.cs
@@ -84,8 +84,13 @@
         {
             public Subscriber1()
             {
-                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
-                    .AddMapping<MyEvent>(typeof(Publisher));
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.DisableFeature<AutoSubscribe>();
+                    c.UseTransport<MsmqTransport>()
+                        .Routing().RegisterPublisher(typeof(MyEvent), AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(Publisher)));
+
+                });
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>
@@ -109,8 +114,13 @@
         {
             public Subscriber2()
             {
-                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
-                    .AddMapping<MyEvent>(typeof(Publisher));
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.DisableFeature<AutoSubscribe>();
+                    c.UseTransport<MsmqTransport>()
+                        .Routing().RegisterPublisher(typeof(MyEvent), AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(Publisher)));
+
+                });
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_subscribing_from_a_worker.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_subscribing_from_a_worker.cs
@@ -67,8 +67,13 @@
         {
             public Worker()
             {
-                EndpointSetup<DefaultServer>(c => { c.EnlistWithLegacyMSMQDistributor(DistributorEndpoint, DistributorEndpoint, 1); })
-                    .AddMapping<MyEvent>(typeof(Publisher));
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.EnlistWithLegacyMSMQDistributor(DistributorEndpoint, DistributorEndpoint, 1);
+                    c.UseTransport<MsmqTransport>()
+                        .Routing().RegisterPublisher(typeof(MyEvent), Conventions.EndpointNamingConvention(typeof(Publisher)));
+
+                });
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_unsubscribing_with_authorizer.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_unsubscribing_with_authorizer.cs
@@ -72,8 +72,13 @@
         {
             public Subscriber()
             {
-                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>())
-                    .AddMapping<MyEvent>(typeof(Publisher));
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.DisableFeature<AutoSubscribe>();
+                    c.UseTransport<MsmqTransport>()
+                        .Routing().RegisterPublisher(typeof(MyEvent), AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(Publisher)));
+
+                });
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>


### PR DESCRIPTION
Early days but this aims to decouple the ATT's from having to know about message driven pub sub

More elegant solution to https://github.com/Particular/NServiceBus/pull/4239

### WIP
- [x] Need to figure out how to pass this to the transport, perhaps introduce a  `IConfigureEndpointTestExecution2` instead of changing the existing one
- [x] Need to convert all the pubsub tests to this new way
- [x] Decide and implement https://github.com/Particular/NServiceBus/issues/4259
- [x] Verify that this solves the ASB issue (WIP PR)
- [x] Remove `MessageDrivenPubSubRoutingExtensions` 
