### PR TITLE
Split timeout dispatcher test based on tx level

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_TimeoutManager_is_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_TimeoutManager_is_disabled.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.DelayedDelivery
+﻿namespace NServiceBus.AcceptanceTests.Core.DelayedDelivery.TimeoutManager
 {
     using System;
     using System.Threading.Tasks;

--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.DelayedDelivery
+﻿namespace NServiceBus.AcceptanceTests.Core.DelayedDelivery.TimeoutManager
 {
     using System;
     using System.Threading.Tasks;
@@ -7,9 +7,9 @@
     using Extensibility;
     using Features;
     using NServiceBus;
+    using NServiceBus.Persistence;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
-    using Persistence;
     using ScenarioDescriptors;
     using Timeout.Core;
     using Conventions = AcceptanceTesting.Customization.Conventions;

--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails_on_timeout_removal_using_dtc.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails_on_timeout_removal_using_dtc.cs
@@ -1,0 +1,172 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.DelayedDelivery.TimeoutManager
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Extensibility;
+    using Features;
+    using NServiceBus;
+    using NServiceBus.Persistence;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+    using Timeout.Core;
+    using Conventions = AcceptanceTesting.Customization.Conventions;
+
+    public class When_timeout_dispatch_fails_on_timeout_removal_using_dtc : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_move_control_message_to_errors_and_not_dispatch_original_message_to_handler()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b
+                    .DoNotFailOnErrorMessages()
+                    .CustomConfig(c => c
+                        .UseTransport<MsmqTransport>()
+                        .Transactions(TransportTransactionMode.TransactionScope))
+                    .When((bus, c) =>
+                    {
+                        var options = new SendOptions();
+                        options.DelayDeliveryWith(TimeSpan.FromMinutes(1));
+                        options.RouteToThisEndpoint();
+                        options.SetMessageId(c.TestRunId.ToString());
+
+                        return bus.Send(new MyMessage
+                        {
+                            Id = c.TestRunId
+                        }, options);
+                    }))
+                .Done(c => c.FailedTimeoutMovedToError)
+                .Run();
+
+            Assert.IsFalse(context.DelayedMessageDeliveredToHandler);
+            Assert.IsTrue(context.FailedTimeoutMovedToError);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool FailedTimeoutMovedToError { get; set; }
+            public bool DelayedMessageDeliveredToHandler { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.EnableFeature<TimeoutManager>();
+                    config.UsePersistence<FakeTimeoutPersistence>();
+                    config.SendFailedMessagesTo(Conventions.EndpointNamingConvention(typeof(Endpoint)));
+                    config.RegisterComponents(c => c.ConfigureComponent<FakeTimeoutStorage>(DependencyLifecycle.SingleInstance));
+                    config.Pipeline.Register<BehaviorThatLogsControlMessageDelivery.Registration>();
+                    config.LimitMessageProcessingConcurrencyTo(1);
+                });
+            }
+
+            class Handler : IHandleMessages<MyMessage>
+            {
+                public Context TestContext { get; set; }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    if (message.Id == TestContext.TestRunId)
+                    {
+                        TestContext.DelayedMessageDeliveredToHandler = true;
+                    }
+
+                    return Task.FromResult(0);
+                }
+            }
+
+            class FakeTimeoutPersistence : PersistenceDefinition
+            {
+                public FakeTimeoutPersistence()
+                {
+                    Supports<StorageType.Timeouts>(s => { });
+                }
+            }
+
+            class FakeTimeoutStorage : IQueryTimeouts, IPersistTimeouts
+            {
+                public Context TestContext { get; set; }
+
+                public Task Add(TimeoutData timeout, ContextBag context)
+                {
+                    if (TestContext.TestRunId.ToString() == timeout.Headers[Headers.MessageId])
+                    {
+                        timeout.Id = TestContext.TestRunId.ToString();
+                        timeout.Time = DateTime.UtcNow;
+
+                        timeoutData = timeout;
+                    }
+
+                    return Task.FromResult(0);
+                }
+
+                public Task<bool> TryRemove(string timeoutId, ContextBag context)
+                {
+                    throw new Exception("Simulated exception on removing timeout data.");
+                }
+
+                public Task<TimeoutData> Peek(string timeoutId, ContextBag context)
+                {
+                    if (timeoutId == TestContext.TestRunId.ToString() && timeoutData != null)
+                    {
+                        return Task.FromResult(timeoutData);
+                    }
+
+                    return Task.FromResult((TimeoutData) null);
+                }
+
+                public Task RemoveTimeoutBy(Guid sagaId, ContextBag context)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public Task<TimeoutsChunk> GetNextChunk(DateTime startSlice)
+                {
+                    var timeouts = timeoutData != null
+                        ? new[]
+                        {
+                            new TimeoutsChunk.Timeout(timeoutData.Id, timeoutData.Time)
+                        }
+                        : new TimeoutsChunk.Timeout[0];
+
+                    return Task.FromResult(new TimeoutsChunk(timeouts, DateTime.UtcNow + TimeSpan.FromSeconds(10)));
+                }
+
+                TimeoutData timeoutData;
+            }
+
+            class BehaviorThatLogsControlMessageDelivery : IBehavior<ITransportReceiveContext, ITransportReceiveContext>
+            {
+                public Context TestContext { get; set; }
+
+                public Task Invoke(ITransportReceiveContext context, Func<ITransportReceiveContext, Task> next)
+                {
+                    if (context.Message.Headers.ContainsKey(Headers.ControlMessageHeader) &&
+                        context.Message.Headers["Timeout.Id"] == TestContext.TestRunId.ToString())
+                    {
+                        TestContext.FailedTimeoutMovedToError = true;
+                        return Task.FromResult(0);
+                    }
+
+                    return next(context);
+                }
+
+                public class Registration : RegisterStep
+                {
+                    public Registration() : base("BehaviorThatLogsControlMessageDelivery", typeof(BehaviorThatLogsControlMessageDelivery), "BehaviorThatLogsControlMessageDelivery")
+                    {
+                    }
+                }
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+            public Guid Id { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails_on_timeout_removal_using_dtc.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails_on_timeout_removal_using_dtc.cs
@@ -21,9 +21,6 @@
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b
                     .DoNotFailOnErrorMessages()
-                    .CustomConfig(c => c
-                        .UseTransport<MsmqTransport>()
-                        .Transactions(TransportTransactionMode.TransactionScope))
                     .When((bus, c) =>
                     {
                         var options = new SendOptions();
@@ -53,7 +50,7 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>(config =>
+                EndpointSetup<DefaultServer>((config, runDescriptor) =>
                 {
                     config.EnableFeature<TimeoutManager>();
                     config.UsePersistence<FakeTimeoutPersistence>();
@@ -61,6 +58,7 @@
                     config.RegisterComponents(c => c.ConfigureComponent<FakeTimeoutStorage>(DependencyLifecycle.SingleInstance));
                     config.Pipeline.Register<BehaviorThatLogsControlMessageDelivery.Registration>();
                     config.LimitMessageProcessingConcurrencyTo(1);
+                    config.UseTransport(runDescriptor.GetTransportType()).Transactions(TransportTransactionMode.TransactionScope);
                 });
             }
 

--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails_on_timeout_removal_using_sendsatomicwithreceive.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails_on_timeout_removal_using_sendsatomicwithreceive.cs
@@ -19,9 +19,6 @@
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b
                     .DoNotFailOnErrorMessages()
-                    .CustomConfig(c => c
-                        .UseTransport<MsmqTransport>()
-                        .Transactions(TransportTransactionMode.SendsAtomicWithReceive))
                     .When((bus, c) =>
                     {
                         var options = new SendOptions();
@@ -51,7 +48,7 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>(config =>
+                EndpointSetup<DefaultServer>((config, runDescriptor) =>
                 {
                     config.EnableFeature<TimeoutManager>();
                     config.UsePersistence<FakeTimeoutPersistence>();
@@ -59,6 +56,7 @@
                     config.RegisterComponents(c => c.ConfigureComponent<FakeTimeoutStorage>(DependencyLifecycle.SingleInstance));
                     config.Pipeline.Register<BehaviorThatLogsControlMessageDelivery.Registration>();
                     config.LimitMessageProcessingConcurrencyTo(1);
+                    config.UseTransport(runDescriptor.GetTransportType()).Transactions(TransportTransactionMode.SendsAtomicWithReceive);
                 });
             }
 

--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_timeout_storage_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_timeout_storage_fails.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.DelayedDelivery
+﻿namespace NServiceBus.AcceptanceTests.Core.DelayedDelivery.TimeoutManager
 {
     using System;
     using System.Threading.Tasks;
@@ -7,8 +7,8 @@
     using Extensibility;
     using Features;
     using NServiceBus;
+    using NServiceBus.Persistence;
     using NUnit.Framework;
-    using Persistence;
     using ScenarioDescriptors;
     using Timeout.Core;
 

--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_using_external_timeout_manager.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_using_external_timeout_manager.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.DelayedDelivery
+﻿namespace NServiceBus.AcceptanceTests.Core.DelayedDelivery.TimeoutManager
 {
     using System;
     using System.Threading.Tasks;

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -59,12 +59,13 @@
     <Compile Include="Basic\When_extending_behavior_context.cs" />
     <Compile Include="Basic\When_receiving_unobtrusive_message_without_handler.cs" />
     <Compile Include="Config\When_multiple_configuration_providers.cs" />
+    <Compile Include="Core\DelayedDelivery\TimeoutManager\When_timeout_dispatch_fails_on_timeout_removal_using_sendsAtomicWithReceive.cs" />
     <Compile Include="Core\Feature\When_feature_startup_task_fails.cs" />
     <Compile Include="Core\LegacyRetries\When_legacy_retries_left_in_retry_queue.cs" />
     <Compile Include="Core\MessageDurability\When_sending_a_non_durable_message_with_conventions.cs" />
     <Compile Include="DataBus\When_sending_databus_properties_with_unobtrusive.cs" />
     <Compile Include="Basic\When_sending_interface_message_with_conventions.cs" />
-    <Compile Include="DelayedDelivery\TimeoutManager\When_using_external_timeout_manager.cs" />
+    <Compile Include="Core\DelayedDelivery\TimeoutManager\When_using_external_timeout_manager.cs" />
     <Compile Include="Encryption\When_using_Rijndael_with_unobtrusive_mode.cs" />
     <Compile Include="Forwarding\When_requesting_message_to_be_forwarded.cs" />
     <Compile Include="Performance\TimeToBeReceived\When_TimeToBeReceived_used_with_unobtrusive_mode.cs" />
@@ -105,9 +106,9 @@
     <Compile Include="ConventionEnforcementTests.cs" />
     <Compile Include="Correlation\When_replying_to_received_message_without_correlationid.cs" />
     <Compile Include="DelayedDelivery\When_deferring_a_message_to_the_past.cs" />
-    <Compile Include="DelayedDelivery\TimeoutManager\When_timeout_dispatch_fails.cs" />
-    <Compile Include="DelayedDelivery\TimeoutManager\When_timeout_dispatch_fails_on_timeout_data_removal.cs" />
-    <Compile Include="DelayedDelivery\TimeoutManager\When_timeout_storage_fails.cs" />
+    <Compile Include="Core\DelayedDelivery\TimeoutManager\When_timeout_dispatch_fails.cs" />
+    <Compile Include="Core\DelayedDelivery\TimeoutManager\When_timeout_dispatch_fails_on_timeout_removal_using_dtc.cs" />
+    <Compile Include="Core\DelayedDelivery\TimeoutManager\When_timeout_storage_fails.cs" />
     <Compile Include="EndpointTemplates\EndpointCustomizationConfigurationExtensions.cs" />
     <Compile Include="EndpointTemplates\ServerWithNoDefaultPersistenceDefinitions.cs" />
     <Compile Include="Core\FakeTransport\CriticalError\When_registering_custom_critical_error_handler.cs" />
@@ -125,7 +126,7 @@
     <Compile Include="MessageId\When_message_has_no_id_header.cs" />
     <Compile Include="CriticalError\When_raising_critical_error.cs" />
     <Compile Include="Basic\When_deferring_to_non_local.cs" />
-    <Compile Include="DelayedDelivery\TimeoutManager\When_TimeoutManager_is_disabled.cs" />
+    <Compile Include="Core\DelayedDelivery\TimeoutManager\When_TimeoutManager_is_disabled.cs" />
     <Compile Include="Mutators\When_incoming_mutator_changes_message_type.cs" />
     <Compile Include="Mutators\When_mutating.cs" />
     <Compile Include="BestPractices\When_publishing_command_bestpractices_disabled_on_endpoint.cs" />

--- a/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllTransports.cs
+++ b/src/NServiceBus.AcceptanceTests/ScenarioDescriptors/AllTransports.cs
@@ -60,14 +60,6 @@
         }
     }
 
-    public class AllTransportsWithoutNativeDeferralAndWithAtomicSendAndReceive : AllTransports
-    {
-        public AllTransportsWithoutNativeDeferralAndWithAtomicSendAndReceive()
-        {
-            ScenarioFilter.Run(this, Remove);
-        }
-    }
-
     public class TypeScanner
     {
         static IEnumerable<Assembly> AvailableAssemblies

--- a/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_native_multi_queue_transaction.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_native_multi_queue_transaction.cs
@@ -75,12 +75,12 @@
             }
         }
 
-        
+
         public class MyMessage : ICommand
         {
         }
 
-        
+
         public class MessageHandledEvent : IMessage
         {
             public bool HasFailed { get; set; }


### PR DESCRIPTION
fixes #4244 
- Split test based on tx level
- Move tests to core folder which excludes them from moving to downstreams
