### PR TITLE
Switching from ElapsedTicks to Elapsed.Ticks on stopwatch

### DIFF
--- a/src/NServiceBus.Core/Performance/Statistics/ProcessingStatisticsBehavior.cs
+++ b/src/NServiceBus.Core/Performance/Statistics/ProcessingStatisticsBehavior.cs
@@ -29,7 +29,7 @@
             finally
             {
                 stopwatch.Stop();
-                state.ProcessingEnded = state.ProcessingStarted.AddTicks(stopwatch.ElapsedTicks);
+                state.ProcessingEnded = state.ProcessingStarted.AddTicks(stopwatch.Elapsed.Ticks);
             }
         }
 

--- a/src/NServiceBus.Core/Performance/Statistics/ProcessingStatisticsBehavior.cs
+++ b/src/NServiceBus.Core/Performance/Statistics/ProcessingStatisticsBehavior.cs
@@ -29,7 +29,7 @@
             finally
             {
                 stopwatch.Stop();
-                state.ProcessingEnded = state.ProcessingStarted.AddTicks(stopwatch.Elapsed.Ticks);
+                state.ProcessingEnded = state.ProcessingStarted + stopwatch.Elapsed;
             }
         }
 


### PR DESCRIPTION
Fixes #4249 

It is just awesome when you work with folks like @bording 

He pointed me to 

> Stopwatch ticks are different from DateTime.Ticks. Each tick in the DateTime.Ticks value represents one 100-nanosecond interval. Each tick in the ElapsedTicks value represents the time interval equal to 1 second divided by the Frequency.

https://msdn.microsoft.com/en-us/library/system.diagnostics.stopwatch.elapsedticks(v=vs.110).aspx

and the answer is to use `Elapsed.Ticks `instead of `ElapsedTicks`.