### PR TITLE
Optimize behaviors that call BuildAll by skipping logic if nothing is registered

### DIFF
--- a/src/NServiceBus.Core.Tests/UnitOfWork/UnitOfWorkBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/UnitOfWork/UnitOfWorkBehaviorTests.cs
@@ -11,6 +11,21 @@
     public class UnitOfWorkBehaviorTests
     {
         [Test]
+        public async Task Should_not_call_Begin_or_End_when_hasUnitsOfWork_is_false()
+        {
+            var builder = new FakeBuilder();
+
+            var unitOfWork = new UnitOfWork();
+
+            builder.Register<IManageUnitsOfWork>(unitOfWork);
+
+            await InvokeBehavior(builder, hasUnitsOfWork: false);
+
+            Assert.IsFalse(unitOfWork.BeginCalled);
+            Assert.IsFalse(unitOfWork.EndCalled);
+        }
+
+        [Test]
         public void When_first_throw_second_is_cleaned_up()
         {
             var builder = new FakeBuilder();
@@ -144,9 +159,9 @@
                 Throws.Exception.With.Message.EqualTo("Return a Task or mark the method as async."));
         }
 
-        static Task InvokeBehavior(FakeBuilder builder, Exception toThrow = null)
+        static Task InvokeBehavior(FakeBuilder builder, Exception toThrow = null, bool hasUnitsOfWork = true)
         {
-            var runner = new UnitOfWorkBehavior();
+            var runner = new UnitOfWorkBehavior(hasUnitsOfWork);
 
             var context = new TestableIncomingPhysicalMessageContext();
             context.Builder = builder;

--- a/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
@@ -3,6 +3,7 @@
     using System.Threading.Tasks;
     using Extensibility;
     using Janitor;
+    using MessageMutator;
     using NServiceBus.Outbox;
     using Persistence;
     using Transport;
@@ -24,7 +25,9 @@
             var hasUnitsOfWork = context.Container.HasComponent<IManageUnitsOfWork>();
             context.Pipeline.Register("ExecuteUnitOfWork", new UnitOfWorkBehavior(hasUnitsOfWork), "Executes the UoW");
 
-            context.Pipeline.Register("MutateIncomingTransportMessage", new MutateIncomingTransportMessageBehavior(), "Executes IMutateIncomingTransportMessages");
+            var hasIncomingTransportMessageMutators = context.Container.HasComponent<IMutateIncomingTransportMessages>();
+            context.Pipeline.Register("MutateIncomingTransportMessage", new MutateIncomingTransportMessageBehavior(hasIncomingTransportMessageMutators), "Executes IMutateIncomingTransportMessages");
+
             context.Pipeline.Register("MutateIncomingMessages", new MutateIncomingMessageBehavior(), "Executes IMutateIncomingMessages");
             context.Pipeline.Register("InvokeHandlers", new InvokeHandlerTerminator(), "Calls the IHandleMessages<T>.Handle(T)");
 

--- a/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
@@ -7,6 +7,7 @@
     using Persistence;
     using Transport;
     using Unicast;
+    using UnitOfWork;
 
     class ReceiveFeature : Feature
     {
@@ -20,7 +21,9 @@
             context.Pipeline.Register("TransportReceiveToPhysicalMessageProcessingConnector", b => b.Build<TransportReceiveToPhysicalMessageProcessingConnector>(), "Allows to abort processing the message");
             context.Pipeline.Register("LoadHandlersConnector", b => b.Build<LoadHandlersConnector>(), "Gets all the handlers to invoke from the MessageHandler registry based on the message type.");
 
-            context.Pipeline.Register("ExecuteUnitOfWork", new UnitOfWorkBehavior(), "Executes the UoW");
+            var hasUnitsOfWork = context.Container.HasComponent<IManageUnitsOfWork>();
+            context.Pipeline.Register("ExecuteUnitOfWork", new UnitOfWorkBehavior(hasUnitsOfWork), "Executes the UoW");
+
             context.Pipeline.Register("MutateIncomingTransportMessage", new MutateIncomingTransportMessageBehavior(), "Executes IMutateIncomingTransportMessages");
             context.Pipeline.Register("MutateIncomingMessages", new MutateIncomingMessageBehavior(), "Executes IMutateIncomingMessages");
             context.Pipeline.Register("InvokeHandlers", new InvokeHandlerTerminator(), "Calls the IHandleMessages<T>.Handle(T)");

--- a/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
@@ -28,7 +28,9 @@
             var hasIncomingTransportMessageMutators = context.Container.HasComponent<IMutateIncomingTransportMessages>();
             context.Pipeline.Register("MutateIncomingTransportMessage", new MutateIncomingTransportMessageBehavior(hasIncomingTransportMessageMutators), "Executes IMutateIncomingTransportMessages");
 
-            context.Pipeline.Register("MutateIncomingMessages", new MutateIncomingMessageBehavior(), "Executes IMutateIncomingMessages");
+            var hasIncomingMessageMutators = context.Container.HasComponent<IMutateIncomingMessages>();
+            context.Pipeline.Register("MutateIncomingMessages", new MutateIncomingMessageBehavior(hasIncomingMessageMutators), "Executes IMutateIncomingMessages");
+
             context.Pipeline.Register("InvokeHandlers", new InvokeHandlerTerminator(), "Calls the IHandleMessages<T>.Handle(T)");
 
             context.Container.ConfigureComponent(b =>

--- a/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehavior.cs
@@ -7,7 +7,22 @@
 
     class MutateIncomingMessageBehavior : IBehavior<IIncomingLogicalMessageContext, IIncomingLogicalMessageContext>
     {
-        public async Task Invoke(IIncomingLogicalMessageContext context, Func<IIncomingLogicalMessageContext, Task> next)
+        public MutateIncomingMessageBehavior(bool hasIncomingMessageMutators)
+        {
+            this.hasIncomingMessageMutators = hasIncomingMessageMutators;
+        }
+
+        public Task Invoke(IIncomingLogicalMessageContext context, Func<IIncomingLogicalMessageContext, Task> next)
+        {
+            if (hasIncomingMessageMutators)
+            {
+                return InvokeIncomingMessageMutators(context, next);
+            }
+
+            return next(context);
+        }
+
+        async Task InvokeIncomingMessageMutators(IIncomingLogicalMessageContext context, Func<IIncomingLogicalMessageContext, Task> next)
         {
             var logicalMessage = context.Message;
             var current = logicalMessage.Instance;
@@ -27,5 +42,7 @@
 
             await next(context).ConfigureAwait(false);
         }
+
+        bool hasIncomingMessageMutators;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateOutgoingMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateInstanceMessage/MutateOutgoingMessageBehavior.cs
@@ -8,7 +8,22 @@
 
     class MutateOutgoingMessageBehavior : IBehavior<IOutgoingLogicalMessageContext, IOutgoingLogicalMessageContext>
     {
-        public async Task Invoke(IOutgoingLogicalMessageContext context, Func<IOutgoingLogicalMessageContext, Task> next)
+        public MutateOutgoingMessageBehavior(bool hasOutgoingMessageMutators)
+        {
+            this.hasOutgoingMessageMutators = hasOutgoingMessageMutators;
+        }
+
+        public Task Invoke(IOutgoingLogicalMessageContext context, Func<IOutgoingLogicalMessageContext, Task> next)
+        {
+            if (hasOutgoingMessageMutators)
+            {
+                return InvokeOutgoingMessageMutators(context, next);
+            }
+
+            return next(context);
+        }
+
+        async Task InvokeOutgoingMessageMutators(IOutgoingLogicalMessageContext context, Func<IOutgoingLogicalMessageContext, Task> next)
         {
             LogicalMessage incomingLogicalMessage;
             context.Extensions.TryGet(out incomingLogicalMessage);
@@ -36,5 +51,7 @@
 
             await next(context).ConfigureAwait(false);
         }
+
+        bool hasOutgoingMessageMutators;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
@@ -7,7 +7,22 @@
 
     class MutateIncomingTransportMessageBehavior : IBehavior<IIncomingPhysicalMessageContext, IIncomingPhysicalMessageContext>
     {
-        public async Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
+        public MutateIncomingTransportMessageBehavior(bool hasIncomingTransportMessageMutators)
+        {
+            this.hasIncomingTransportMessageMutators = hasIncomingTransportMessageMutators;
+        }
+
+        public Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
+        {
+            if (hasIncomingTransportMessageMutators)
+            {
+                return InvokeIncomingTransportMessagesMutators(context, next);
+            }
+
+            return next(context);
+        }
+
+        async Task InvokeIncomingTransportMessagesMutators(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
         {
             var mutators = context.Builder.BuildAll<IMutateIncomingTransportMessages>();
             var transportMessage = context.Message;
@@ -26,5 +41,7 @@
 
             await next(context).ConfigureAwait(false);
         }
+
+        bool hasIncomingTransportMessageMutators;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageBehavior.cs
@@ -8,7 +8,22 @@
 
     class MutateOutgoingTransportMessageBehavior : IBehavior<IOutgoingPhysicalMessageContext, IOutgoingPhysicalMessageContext>
     {
-        public async Task Invoke(IOutgoingPhysicalMessageContext context, Func<IOutgoingPhysicalMessageContext, Task> next)
+        public MutateOutgoingTransportMessageBehavior(bool hasOutgoingTransportMessageMutators)
+        {
+            this.hasOutgoingTransportMessageMutators = hasOutgoingTransportMessageMutators;
+        }
+
+        public Task Invoke(IOutgoingPhysicalMessageContext context, Func<IOutgoingPhysicalMessageContext, Task> next)
+        {
+            if (hasOutgoingTransportMessageMutators)
+            {
+                return InvokeOutgoingTransportMessageMutators(context, next);
+            }
+
+            return next(context);
+        }
+
+        async Task InvokeOutgoingTransportMessageMutators(IOutgoingPhysicalMessageContext context, Func<IOutgoingPhysicalMessageContext, Task> next)
         {
             var outgoingMessage = context.Extensions.Get<OutgoingLogicalMessage>();
 
@@ -39,5 +54,7 @@
 
             await next(context).ConfigureAwait(false);
         }
+
+        bool hasOutgoingTransportMessageMutators;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPipelineFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPipelineFeature.cs
@@ -15,7 +15,8 @@
             var hasOutgoingMessageMutators = context.Container.HasComponent<IMutateOutgoingMessages>();
             context.Pipeline.Register("MutateOutgoingMessages", new MutateOutgoingMessageBehavior(hasOutgoingMessageMutators), "Executes IMutateOutgoingMessages");
 
-            context.Pipeline.Register("MutateOutgoingTransportMessage", new MutateOutgoingTransportMessageBehavior(), "Executes IMutateOutgoingTransportMessages");
+            var hasOutgoingTransportMessageMutators = context.Container.HasComponent<IMutateOutgoingTransportMessages>();
+            context.Pipeline.Register("MutateOutgoingTransportMessage", new MutateOutgoingTransportMessageBehavior(hasOutgoingTransportMessageMutators), "Executes IMutateOutgoingTransportMessages");
 
             context.Pipeline.Register(new AttachSenderRelatedInfoOnMessageBehavior(), "Makes sure that outgoing messages contains relevant info on the sending endpoint.");
 

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPipelineFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPipelineFeature.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Features
 {
+    using MessageMutator;
     using Transport;
 
     class OutgoingPipelineFeature : Feature
@@ -11,7 +12,9 @@
 
         protected internal override void Setup(FeatureConfigurationContext context)
         {
-            context.Pipeline.Register("MutateOutgoingMessages", new MutateOutgoingMessageBehavior(), "Executes IMutateOutgoingMessages");
+            var hasOutgoingMessageMutators = context.Container.HasComponent<IMutateOutgoingMessages>();
+            context.Pipeline.Register("MutateOutgoingMessages", new MutateOutgoingMessageBehavior(hasOutgoingMessageMutators), "Executes IMutateOutgoingMessages");
+
             context.Pipeline.Register("MutateOutgoingTransportMessage", new MutateOutgoingTransportMessageBehavior(), "Executes IMutateOutgoingTransportMessages");
 
             context.Pipeline.Register(new AttachSenderRelatedInfoOnMessageBehavior(), "Makes sure that outgoing messages contains relevant info on the sending endpoint.");

--- a/src/NServiceBus.Core/UnitOfWork/UnitOfWorkBehavior.cs
+++ b/src/NServiceBus.Core/UnitOfWork/UnitOfWorkBehavior.cs
@@ -9,7 +9,22 @@
 
     class UnitOfWorkBehavior : IBehavior<IIncomingPhysicalMessageContext, IIncomingPhysicalMessageContext>
     {
-        public async Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
+        public UnitOfWorkBehavior(bool hasUnitsOfWork)
+        {
+            this.hasUnitsOfWork = hasUnitsOfWork;
+        }
+
+        public Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
+        {
+            if (hasUnitsOfWork)
+            {
+                return InvokeUnitsOfWork(context, next);
+            }
+
+            return next(context);
+        }
+
+        async Task InvokeUnitsOfWork(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
         {
             var unitsOfWork = new Stack<IManageUnitsOfWork>();
 
@@ -68,5 +83,7 @@
             }
             return exceptionsToThrow;
         }
+
+        bool hasUnitsOfWork;
     }
 }


### PR DESCRIPTION
After doing some profiling, I saw that calling `BuildAll` is expensive, and we are doing it three times per message on the incoming pipeline and two times out the outgoing pipeline.

This updates the following behaviors to bypass `BuildAll` if nothing has been registered for them to do:

- UnitOfWorkBehavior
- MutateIncomingTransportMessageBehavior
- MutateIncomingMessageBehavior
- MutateOutgoingMessageBehavior
- MutateOutgoingTransportMessageBehavior

The reason I chose to bypass the logic instead of skipping registration of the behaviors altogether is that when talking with the other @Particular/nservicebus-maintainers, we decided that it would be safer to always have them registered. This way any sort of InsertBefore/After calls would not be impacted.

Should I add tests that register a mutator/unitofwork and then pass `false` into the behavior to verify that they aren't called?