### PR TITLE
Fix test to use correct class name for mappingFilePath

### DIFF
--- a/src/NServiceBus.Msmq.AcceptanceTests/When_using_instance_mapping_file.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_using_instance_mapping_file.cs
@@ -52,7 +52,7 @@
             Assert.That(context.MessagesForInstance2, Is.EqualTo(5));
         }
 
-        static string mappingFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, nameof(When_starting_with_invalid_instance_mapping_file) + ".xml");
+        static string mappingFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, nameof(When_using_instance_mapping_file) + ".xml");
         static string destination;
 
         public class Context : ScenarioContext


### PR DESCRIPTION
I happened to be looking at the MSMQ tests for the instance mapping xml file, and I noticed one of the tests was using the wrong class name for the mapping file path.