### PR TITLE
Fix assembly scanner tests

### DIFF
--- a/src/NServiceBus.Core.Tests/App.config
+++ b/src/NServiceBus.Core.Tests/App.config
@@ -1,38 +1,42 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-    <section name="TestConfigurationSection" type="NServiceBus.Core.Tests.Config.TestConfigurationSection, NServiceBus.Core.Tests"/>
-    <section name="UnicastBus_with_empty_ttr" type="NServiceBus.Config.UnicastBusConfig, NServiceBus.Core"/>
-    <section name="UnicastBus_with_ttr_set" type="NServiceBus.Config.UnicastBusConfig, NServiceBus.Core"/>
-    <section name="GatewayConfig" type="NServiceBus.Config.GatewayConfig, NServiceBus.Core"/>
+    <section name="TestConfigurationSection" type="NServiceBus.Core.Tests.Config.TestConfigurationSection, NServiceBus.Core.Tests" />
+    <section name="UnicastBus_with_empty_ttr" type="NServiceBus.Config.UnicastBusConfig, NServiceBus.Core" />
+    <section name="UnicastBus_with_ttr_set" type="NServiceBus.Config.UnicastBusConfig, NServiceBus.Core" />
+    <section name="GatewayConfig" type="NServiceBus.Config.GatewayConfig, NServiceBus.Core" />
   </configSections>
-  <TestConfigurationSection TestSetting="test"/>
+  <TestConfigurationSection TestSetting="test" />
 
-  <UnicastBus_with_empty_ttr/>
+  <UnicastBus_with_empty_ttr />
 
-  <UnicastBus_with_ttr_set TimeToBeReceivedOnForwardedMessages="00:30:00"/>
+  <UnicastBus_with_ttr_set TimeToBeReceivedOnForwardedMessages="00:30:00" />
 
   <appSettings>
-    <add key="ListenUrl" value="http://localhost:8090/Gateway/"/>
-    <add key="RemoteUrl" value="http://localhost:8092/Gateway/"/>
+    <add key="ListenUrl" value="http://localhost:8090/Gateway/" />
+    <add key="RemoteUrl" value="http://localhost:8092/Gateway/" />
   </appSettings>
 
   <GatewayConfig>
     <Sites>
-      <Site Key="SiteA" Address="http://sitea.com" ChannelType="Http"/>
+      <Site Key="SiteA" Address="http://sitea.com" ChannelType="Http" />
     </Sites>
     <Channels>
-      <Channel Address="http://localhost/headquarter" ChannelType="Http"/>
-      <Channel Address="ftp://localhost:21" ChannelType="ftp"/>
-      <Channel Address="https://localhost/headquarter" ChannelType="Http" NumberOfWorkerThreads="3"/>
+      <Channel Address="http://localhost/headquarter" ChannelType="Http" />
+      <Channel Address="ftp://localhost:21" ChannelType="ftp" />
+      <Channel Address="https://localhost/headquarter" ChannelType="Http" NumberOfWorkerThreads="3" />
     </Channels>
   </GatewayConfig>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <probing privatePath="bin;TestDlls;assemblyscannerfiles"/>
+      <probing privatePath="bin;TestDlls;assemblyscannerfiles" />
       <dependentAssembly>
         <assemblyIdentity name="AssemblyWithSN" publicKeyToken="e60a6e0900d08672" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="nunit.framework" publicKeyToken="2638cd05610744eb" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.2.1.0" newVersion="3.2.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
@@ -117,7 +117,7 @@
         }
 
         [Test, RunInApplicationDomain]
-        [Explicit]
+        //[Explicit]
         public void Assemblies_which_reference_older_nsb_version_are_included()
         {
             var busAssemblyV1 = new DynamicAssembly("Fake.NServiceBus.Core", version: new Version(1, 0, 0), fakeIdentity: true);

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
@@ -227,7 +227,7 @@
 
                 var result = provider.CompileAssemblyFromSource(param, builder.ToString());
                 ThrowIfCompilationWasNotSuccessful(result);
-                Assembly = result.CompiledAssembly;
+
                 provider.Dispose();
 
                 if (fakeIdentity)
@@ -237,6 +237,8 @@
                     reader.MainModule.Name = nameWithoutExtension;
                     reader.Write(FilePath);
                 }
+
+                Assembly = result.CompiledAssembly;
             }
 
             public string Namespace { get; }

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
@@ -33,7 +33,19 @@
         [SetUp]
         public void SetUp()
         {
-            Directory.Delete(DynamicAssembly.TestAssemblyDirectory, true);
+            if (!AppDomainRunner.IsInTestAppDomain)
+            {
+                Directory.Delete(DynamicAssembly.TestAssemblyDirectory, true);
+            }
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (!AppDomainRunner.IsInTestAppDomain)
+            {
+                Directory.Delete(DynamicAssembly.TestAssemblyDirectory, true);
+            }
         }
 
         [Test]
@@ -65,7 +77,7 @@
             Assert.IsFalse(AssemblyScanner.ReferencesNServiceBus(combine));
         }
 
-        [Test]
+        [Test, RunInApplicationDomain]
         public void Assemblies_with_direct_reference_are_included()
         {
             var busAssembly = new DynamicAssembly("Fake.NServiceBus.Core.dll");
@@ -74,20 +86,17 @@
                 busAssembly
             });
 
-            using (var dynamicDirectory = new DynamicAssemblyDirectory(busAssembly, assemblyWithReference))
-            {
-                var scanner = new AssemblyScanner(dynamicDirectory);
-                scanner.CoreAssemblyName = busAssembly.DynamicName;
+            var scanner = new AssemblyScanner(DynamicAssembly.TestAssemblyDirectory);
+            scanner.CoreAssemblyName = busAssembly.DynamicName;
 
-                var result = scanner.GetScannableAssemblies();
+            var result = scanner.GetScannableAssemblies();
 
-                Assert.AreEqual(2, result.Assemblies.Count);
-                Assert.IsTrue(result.Assemblies.Contains(assemblyWithReference));
-                Assert.IsTrue(result.Assemblies.Contains(busAssembly));
-            }
+            Assert.AreEqual(2, result.Assemblies.Count);
+            Assert.IsTrue(result.Assemblies.Contains(assemblyWithReference));
+            Assert.IsTrue(result.Assemblies.Contains(busAssembly));
         }
 
-        [Test]
+        [Test, RunInApplicationDomain]
         public void Assemblies_with_no_reference_are_excluded()
         {
             var busAssembly = new DynamicAssembly("Fake.NServiceBus.Core");
@@ -97,21 +106,18 @@
             });
             var assemblyWithoutReference = new DynamicAssembly("AssemblyWithoutReference");
 
-            using (var dynamicDirectory = new DynamicAssemblyDirectory(busAssembly, assemblyWithReference, assemblyWithoutReference))
-            {
-                var scanner = new AssemblyScanner(dynamicDirectory);
-                scanner.CoreAssemblyName = busAssembly.DynamicName;
+            var scanner = new AssemblyScanner(DynamicAssembly.TestAssemblyDirectory);
+            scanner.CoreAssemblyName = busAssembly.DynamicName;
 
-                var result = scanner.GetScannableAssemblies();
+            var result = scanner.GetScannableAssemblies();
 
-                Assert.AreEqual(2, result.Assemblies.Count);
-                Assert.IsTrue(result.Assemblies.Contains(assemblyWithReference));
-                Assert.IsTrue(result.Assemblies.Contains(busAssembly));
-                Assert.IsFalse(result.Assemblies.Contains(assemblyWithoutReference));
-            }
+            Assert.AreEqual(2, result.Assemblies.Count);
+            Assert.IsTrue(result.Assemblies.Contains(assemblyWithReference));
+            Assert.IsTrue(result.Assemblies.Contains(busAssembly));
+            Assert.IsFalse(result.Assemblies.Contains(assemblyWithoutReference));
         }
 
-        [Test]
+        [Test, RunInApplicationDomain]
         [Explicit]
         public void Assemblies_which_reference_older_nsb_version_are_included()
         {
@@ -126,21 +132,18 @@
                 busAssemblyV2
             });
 
-            using (var dynamicDirectory = new DynamicAssemblyDirectory(busAssemblyV1, busAssemblyV2, assemblyReferencesV1, assemblyReferencesV2))
-            {
-                var scanner = new AssemblyScanner(dynamicDirectory);
-                scanner.ThrowExceptions = false;
-                scanner.CoreAssemblyName = busAssemblyV2.Name;
+            var scanner = new AssemblyScanner(DynamicAssembly.TestAssemblyDirectory);
+            scanner.ThrowExceptions = false;
+            scanner.CoreAssemblyName = busAssemblyV2.Name;
 
-                var result = scanner.GetScannableAssemblies();
+            var result = scanner.GetScannableAssemblies();
 
-                Assert.AreEqual(4, result.Assemblies.Count);
-                Assert.IsTrue(result.Assemblies.Contains(assemblyReferencesV1));
-                Assert.IsTrue(result.Assemblies.Contains(assemblyReferencesV2));
-            }
+            Assert.AreEqual(4, result.Assemblies.Count);
+            Assert.IsTrue(result.Assemblies.Contains(assemblyReferencesV1));
+            Assert.IsTrue(result.Assemblies.Contains(assemblyReferencesV2));
         }
 
-        [Test]
+        [Test, RunInApplicationDomain]
         public void Assemblies_with_transitive_reference_are_include()
         {
             var busAssembly = new DynamicAssembly("Fake.NServiceBus.Core");
@@ -161,49 +164,20 @@
                 assemblyB
             });
 
-            using (var dynamicDirectory = new DynamicAssemblyDirectory(assemblyA, assemblyB, assemblyC, assemblyD, busAssembly))
-            {
-                var scanner = new AssemblyScanner(dynamicDirectory);
-                scanner.CoreAssemblyName = busAssembly.DynamicName;
+            var scanner = new AssemblyScanner(DynamicAssembly.TestAssemblyDirectory);
+            scanner.CoreAssemblyName = busAssembly.DynamicName;
 
-                var result = scanner.GetScannableAssemblies();
+            var result = scanner.GetScannableAssemblies();
 
-                Assert.AreEqual(5, result.Assemblies.Count);
-                Assert.IsTrue(result.Assemblies.Contains(assemblyA));
-                Assert.IsTrue(result.Assemblies.Contains(assemblyB));
-                Assert.IsTrue(result.Assemblies.Contains(assemblyC));
-                Assert.IsTrue(result.Assemblies.Contains(assemblyD));
-            }
-        }
-
-        class DynamicAssemblyDirectory : IDisposable
-        {
-            public DynamicAssemblyDirectory(params DynamicAssembly[] assemblies)
-            {
-                dynamicAssemblies = assemblies;
-                Directory = assemblies.Select(a => Path.GetDirectoryName(a.FilePath)).Distinct().Single();
-            }
-
-            public string Directory { get; }
-
-            public void Dispose()
-            {
-                foreach (var dynamicAssembly in dynamicAssemblies)
-                {
-                    dynamicAssembly.Dispose();
-                }
-            }
-
-            public static implicit operator string(DynamicAssemblyDirectory directory)
-            {
-                return directory.Directory;
-            }
-
-            DynamicAssembly[] dynamicAssemblies;
+            Assert.AreEqual(5, result.Assemblies.Count);
+            Assert.IsTrue(result.Assemblies.Contains(assemblyA));
+            Assert.IsTrue(result.Assemblies.Contains(assemblyB));
+            Assert.IsTrue(result.Assemblies.Contains(assemblyC));
+            Assert.IsTrue(result.Assemblies.Contains(assemblyD));
         }
 
         [DebuggerDisplay("Name = {Name}, DynamicName = {DynamicName}, Namespace = {Namespace}, FileName = {FileName}")]
-        class DynamicAssembly : IDisposable
+        class DynamicAssembly
         {
             public DynamicAssembly(string nameWithoutExtension, DynamicAssembly[] references = null, Version version = null, bool fakeIdentity = false)
             {
@@ -275,18 +249,6 @@
             public string FilePath { get; }
 
             public Assembly Assembly { get; }
-
-            public void Dispose()
-            {
-                try
-                {
-                    File.Delete(FilePath);
-                }
-                catch (Exception ex)
-                {
-                    Trace.Write(ex.Message);
-                }
-            }
 
             public static string TestAssemblyDirectory => GetTestAssemblyDirectory();
 

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
@@ -4,7 +4,6 @@
     using System.CodeDom.Compiler;
     using System.Diagnostics;
     using System.IO;
-    using System.Linq;
     using System.Reflection;
     using System.Text;
     using System.Threading;

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
@@ -246,6 +246,7 @@
             public string DynamicName { get; }
 
             public string FileName { get; }
+
             public string FilePath { get; }
 
             public Assembly Assembly { get; }
@@ -285,10 +286,7 @@
                 }
             }
 
-            public static implicit operator Assembly(DynamicAssembly dynamicAssembly)
-            {
-                return dynamicAssembly.Assembly;
-            }
+            public static implicit operator Assembly(DynamicAssembly dynamicAssembly) => dynamicAssembly.Assembly;
 
             static long dynamicAssemblyId;
         }

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -76,6 +76,10 @@
     <Reference Include="NuDoq">
       <HintPath>..\packages\NuDoq.1.2.5\lib\net35\NuDoq.dll</HintPath>
     </Reference>
+    <Reference Include="NUnit.ApplicationDomain, Version=10.0.0.0, Culture=neutral, PublicKeyToken=afbd8211e0c40e2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.ApplicationDomain.10.0.00\lib\net40\NUnit.ApplicationDomain.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>

--- a/src/NServiceBus.Core.Tests/packages.config
+++ b/src/NServiceBus.Core.Tests/packages.config
@@ -6,4 +6,5 @@
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net452" />
   <package id="NuDoq" version="1.2.5" targetFramework="net45" />
   <package id="NUnit" version="3.2.1" targetFramework="net452" />
+  <package id="NUnit.ApplicationDomain" version="10.0.00" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
@danielmarbach This gets almost everything working. I brought in https://bitbucket.org/zastrowm/nunit.applicationdomain/ which make it easy to run each test in its own AppDomain. This along with the Setup and Teardown makes it easy to clean up the scannerassemblies folder without problems. The issues around removing the files previously was because the assemblies were loaded in the AppDomain and still in use when trying to delete them

Accessing the result.CompiledAssembly property causes the assembly to be loaded, so I moved that to after the `fakeIdentity` assembly rewrite, which avoids the exception that was happening there.

At this point the `Assemblies_which_reference_older_nsb_version_are_included` is still failing, but now it's just a failing assert, and not throwing an exception.

However, the failing Assert reveals another problem with this test. Even though we are creating two different fake core assemblies, only one of them can be loaded at once, because they are not strong named. They have to be strong named if you want to be able to load both at the same time.