### PR TITLE
Track already processed assemblies in Assembly Scanner

### DIFF
--- a/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.CodeDom.Compiler;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
     using System.Reflection;
@@ -58,14 +59,14 @@
         public void ReferencesNServiceBus_requires_binding_redirect()
         {
             var combine = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestDlls", "AssemblyWithRefToSN.dll");
-            Assert.IsTrue(AssemblyScanner.ReferencesNServiceBus(combine));
+            Assert.IsTrue(AssemblyScanner.ReferencesNServiceBus(combine, new Dictionary<string, bool>()));
         }
 
         [Test]
         public void ReferencesNServiceBus_returns_false_for_no_reference()
         {
             var combine = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestDlls", "dotNet.dll");
-            Assert.IsFalse(AssemblyScanner.ReferencesNServiceBus(combine));
+            Assert.IsFalse(AssemblyScanner.ReferencesNServiceBus(combine, new Dictionary<string, bool>()));
         }
 
         [Test, RunInApplicationDomain]


### PR DESCRIPTION
Based on top of #4257 

* Tracks already processed assemblies per scan and fast tracks if it can
* Removed the `IsRuntimeAssembly `check after[ !ReferencesNServiceBus](url) since `ReferencesNServiceBus` already checks whether the assembly is a runtime assembly and tracks / skips those. I was contemplating about letting the check there and just move it before `ReferencesNServiceBus`. But I think this would be the wrong tradeoff to make. The likelihood that you have a runtime assembly (we only know 4 types) deployed in the bin folder is quite small and then we would do the check and the additional name loading from the file multiple times.

## Small solutions

The new algo is slightly slower because of the tracking in the collection. This is suprising because I expected the reflection part to be much more expensive. Maybe this is also related to how fast the disk and the machine is. For larger solutions the optimizations starts to shine

### Before
<img width="943" alt="fewassembliesafter" src="https://cloud.githubusercontent.com/assets/174258/19925452/528b43ba-a0f0-11e6-8f9d-7019789144a1.PNG">

### After

<img width="925" alt="fewassembliesbefore" src="https://cloud.githubusercontent.com/assets/174258/19925458/5d399fe6-a0f0-11e6-9cb0-27355dab0dfb.PNG">

## Middle size solution (80 assemblies)

### Before

<img width="954" alt="eightyassembliesbefore" src="https://cloud.githubusercontent.com/assets/174258/19925485/6f3645f0-a0f0-11e6-9dad-508c8af35f42.PNG">

### After

<img width="945" alt="eightyassembliesafter" src="https://cloud.githubusercontent.com/assets/174258/19925491/773bac0e-a0f0-11e6-9c17-74f4aecd18b6.PNG">

## Large solution (200 assemblies)

### Before
<img width="945" alt="twohundredassembliesbefore" src="https://cloud.githubusercontent.com/assets/174258/19925502/84ba6352-a0f0-11e6-91b3-0db731e93afd.PNG">

### After

<img width="945" alt="twohundredassembliesafter" src="https://cloud.githubusercontent.com/assets/174258/19925510/8d9e20b2-a0f0-11e6-986e-06f52ef2fa6d.PNG">


## Test used to generate larger assemblies with references
```
 [Test, RunInApplicationDomain]
        public void Crazy()
        {
            var busAssembly = new DynamicAssembly("Fake.NServiceBus.Core");
            var assemblyC = new DynamicAssembly("C", new[]
            {
                busAssembly
            });
            var assemblyB = new DynamicAssembly("B", new[]
            {
                assemblyC
            });
            var assemblyA = new DynamicAssembly("A", new[]
            {
                assemblyB
            });
            var assemblyD = new DynamicAssembly("D", new[]
            {
                assemblyB
            });
            for (var i = 0; i < 50; i++)
            {
                new DynamicAssembly("F" + i.ToString(), new[]
                {
                    assemblyB
                });
            }

            for (var i = 50; i < 100; i++)
            {
                new DynamicAssembly("G" + i.ToString(), new[]
                {
                    busAssembly
                });
            }

            for (var i = 100; i < 150; i++)
            {
                new DynamicAssembly("H" + i.ToString(), new[]
                {
                    assemblyD
                });
            }
            for (var i = 151; i < 200; i++)
            {
                new DynamicAssembly("K" + i.ToString());
            }

            var scanner = new AssemblyScanner(DynamicAssembly.TestAssemblyDirectory);
            scanner.CoreAssemblyName = busAssembly.DynamicName;

            var result = scanner.GetScannableAssemblies();
        }
```