### PR TITLE
[SPIKE] Allow custom routing connectors with sample

### DIFF
--- a/src/Contracts/Commands/DemoCommand.cs
+++ b/src/Contracts/Commands/DemoCommand.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using NServiceBus;
+
+namespace Contracts.Commands
+{
+    public class DemoCommand : ICommand
+    {
+        public Guid CommandId { get; set; }
+    }
+}

--- a/src/Contracts/Contracts.csproj
+++ b/src/Contracts/Contracts.csproj
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{AE8AF7F5-26C7-4510-956A-D8A4401F4FDF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Contracts</RootNamespace>
+    <AssemblyName>Contracts</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Commands\DemoCommand.cs" />
+    <Compile Include="Events\DemoCommandReceived.cs" />
+    <Compile Include="Events\DemoEvent.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.Core\NServiceBus.Core.csproj">
+      <Project>{dd48b2d0-e996-412d-9157-821ed8b17a9d}</Project>
+      <Name>NServiceBus.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Contracts/Events/DemoCommandReceived.cs
+++ b/src/Contracts/Events/DemoCommandReceived.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using NServiceBus;
+
+namespace Contracts.Events
+{
+    public class DemoCommandReceived : IEvent
+    {
+        public Guid ReceivedCommandId { get; set; }
+    }
+}

--- a/src/Contracts/Events/DemoEvent.cs
+++ b/src/Contracts/Events/DemoEvent.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using NServiceBus;
+
+namespace Contracts.Events
+{
+    public class DemoEvent : IEvent
+    {
+        public Guid EventId { get; set; }
+    }
+}

--- a/src/Contracts/Properties/AssemblyInfo.cs
+++ b/src/Contracts/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Contracts")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Contracts")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("ae8af7f5-26c7-4510-956a-d8a4401f4fdf")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/EndpointA/App.config
+++ b/src/EndpointA/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    </startup>
+</configuration>

--- a/src/EndpointA/DemoCommandReceivedHandler.cs
+++ b/src/EndpointA/DemoCommandReceivedHandler.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading.Tasks;
+using Contracts.Events;
+using NServiceBus;
+
+namespace EndpointA
+{
+    public class DemoCommandReceivedHandler : IHandleMessages<DemoCommandReceived>
+    {
+        public Task Handle(DemoCommandReceived message, IMessageHandlerContext context)
+        {
+            Console.WriteLine($"Received {nameof(DemoCommandReceived)} for command {message.ReceivedCommandId}");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/EndpointA/EndpointA.csproj
+++ b/src/EndpointA/EndpointA.csproj
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2861AA2A-E1D6-4F66-AF32-A2F1C9656AF4}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EndpointA</RootNamespace>
+    <AssemblyName>EndpointA</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DemoCommandReceivedHandler.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Contracts\Contracts.csproj">
+      <Project>{ae8af7f5-26c7-4510-956a-d8a4401f4fdf}</Project>
+      <Name>Contracts</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\NServiceBus.CentralizedRouting\NServiceBus.CentralizedRouting.csproj">
+      <Project>{b9bd896f-2eb9-4a04-8713-70eb79fbfc3a}</Project>
+      <Name>NServiceBus.CentralizedRouting</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\NServiceBus.Core\NServiceBus.Core.csproj">
+      <Project>{dd48b2d0-e996-412d-9157-821ed8b17a9d}</Project>
+      <Name>NServiceBus.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="endpoints.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="instance-mapping.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/EndpointA/Program.cs
+++ b/src/EndpointA/Program.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Threading.Tasks;
+using Contracts.Commands;
+using Contracts.Events;
+using NServiceBus;
+using NServiceBus.Features;
+using NServiceBus.Persistence;
+
+namespace EndpointA
+{
+    using NServiceBus.CentralizedRouting;
+
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            AsyncMain().GetAwaiter().GetResult();
+        }
+
+        static async Task AsyncMain()
+        {
+            var endpointConfiguration = new EndpointConfiguration("endpointA");
+
+            endpointConfiguration.UsePersistence<InMemoryPersistence>();
+            endpointConfiguration.SendFailedMessagesTo("error");
+            endpointConfiguration.DisableFeature<AutoSubscribe>();
+
+            endpointConfiguration.EnableFeature<CentralizedRoutingFeature>();
+
+            var endpoint = await Endpoint.Start(endpointConfiguration);
+
+            Console.WriteLine("Press [c] to send a command. Press [e] to publish an event. Press [Esc] to quit.");
+
+            while (true)
+            {
+                var key = Console.ReadKey();
+                if (key.Key == ConsoleKey.Escape)
+                {
+                    break;
+                }
+
+                if (key.Key == ConsoleKey.C)
+                {
+                    var commandId = Guid.NewGuid();
+                    await endpoint.Send(new DemoCommand {CommandId = commandId});
+                    Console.WriteLine();
+                    Console.WriteLine("Sent command with id: " + commandId);
+                }
+
+                if (key.Key == ConsoleKey.E)
+                {
+                    var eventId = Guid.NewGuid();
+                    await endpoint.Publish(new DemoEvent() {EventId = eventId});
+                    Console.WriteLine();
+                    Console.WriteLine("Sent event with id: " + eventId);
+                }
+            }
+
+            await endpoint.Stop();
+        }
+    }
+}

--- a/src/EndpointA/Properties/AssemblyInfo.cs
+++ b/src/EndpointA/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("EndpointA")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("EndpointA")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2861aa2a-e1d6-4f66-af32-a2f1c9656af4")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/EndpointA/endpoints.xml
+++ b/src/EndpointA/endpoints.xml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<endpoints>
+  <endpoint name="endpointA">
+    <handles>
+      <event type="Contracts.Events.DemoCommandReceived, Contracts" />
+    </handles>
+  </endpoint>
+  <endpoint name="endpointB">
+    <handles>
+      <command type="Contracts.Commands.DemoCommand, Contracts" />
+      <event type="Contracts.Events.DemoEvent, Contracts" />
+    </handles>
+  </endpoint>
+</endpoints>

--- a/src/EndpointA/instance-mapping.xml
+++ b/src/EndpointA/instance-mapping.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<endpoints>
+  <endpoint name="endpointB">
+    <instance discriminator="1"/>
+    <instance discriminator="2"/>
+  </endpoint>
+</endpoints>

--- a/src/EndpointB/Configuration.cs
+++ b/src/EndpointB/Configuration.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Features;
+
+namespace EndpointB
+{
+    using NServiceBus.CentralizedRouting;
+
+    static class Configuration
+    {
+        public static async Task Start(string discriminator)
+        {
+            var endpointConfiguration = new EndpointConfiguration("endpointB");
+            endpointConfiguration.MakeInstanceUniquelyAddressable(discriminator);
+
+            endpointConfiguration.UsePersistence<InMemoryPersistence>();
+            endpointConfiguration.DisableFeature<AutoSubscribe>();
+            endpointConfiguration.SendFailedMessagesTo("error");
+
+            endpointConfiguration.EnableFeature<CentralizedRoutingFeature>();
+
+            var endpoint = await Endpoint.Start(endpointConfiguration);
+
+            Console.WriteLine("Press [Esc] to quit.");
+
+            while (true)
+            {
+                var key = Console.ReadKey();
+                if (key.Key == ConsoleKey.Escape)
+                {
+                    break;
+                }
+            }
+
+            await endpoint.Stop();
+        }
+    }
+}

--- a/src/EndpointB/DemoCommandHandler.cs
+++ b/src/EndpointB/DemoCommandHandler.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Contracts.Commands;
+using Contracts.Events;
+using NServiceBus;
+
+namespace EndpointB
+{
+    class DemoCommandHandler : IHandleMessages<DemoCommand>
+    {
+        public async Task Handle(DemoCommand message, IMessageHandlerContext context)
+        {
+            Console.WriteLine($"Received {nameof(DemoCommand)} {message.CommandId}");
+            await context.Publish(new DemoCommandReceived {ReceivedCommandId = message.CommandId});
+        }
+    }
+}

--- a/src/EndpointB/DemoEventHandler.cs
+++ b/src/EndpointB/DemoEventHandler.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading.Tasks;
+using Contracts.Events;
+using NServiceBus;
+
+namespace EndpointB
+{
+    class DemoEventHandler : IHandleMessages<DemoEvent>
+    {
+        public Task Handle(DemoEvent message, IMessageHandlerContext context)
+        {
+            Console.WriteLine($"Received {nameof(DemoEvent)} {message.EventId}");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/EndpointB/EndpointB.projitems
+++ b/src/EndpointB/EndpointB.projitems
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>fc8e81ca-93c8-40d6-936c-8c661950544c</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>EndpointB</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Configuration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DemoCommandHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DemoEventHandler.cs" />
+  </ItemGroup>
+</Project>

--- a/src/EndpointB/EndpointB.shproj
+++ b/src/EndpointB/EndpointB.shproj
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>fc8e81ca-93c8-40d6-936c-8c661950544c</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="EndpointB.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/src/EndpointB_1/App.config
+++ b/src/EndpointB_1/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    </startup>
+</configuration>

--- a/src/EndpointB_1/EndpointB_1.csproj
+++ b/src/EndpointB_1/EndpointB_1.csproj
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9D43421F-A590-4433-89EC-08322D5E4C5F}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EndpointB_1</RootNamespace>
+    <AssemblyName>EndpointB_1</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Contracts\Contracts.csproj">
+      <Project>{ae8af7f5-26c7-4510-956a-d8a4401f4fdf}</Project>
+      <Name>Contracts</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\NServiceBus.CentralizedRouting\NServiceBus.CentralizedRouting.csproj">
+      <Project>{b9bd896f-2eb9-4a04-8713-70eb79fbfc3a}</Project>
+      <Name>NServiceBus.CentralizedRouting</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\NServiceBus.Core\NServiceBus.Core.csproj">
+      <Project>{dd48b2d0-e996-412d-9157-821ed8b17a9d}</Project>
+      <Name>NServiceBus.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\EndpointA\endpoints.xml">
+      <Link>endpoints.xml</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\EndpointA\instance-mapping.xml">
+      <Link>instance-mapping.xml</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <Import Project="..\EndpointB\EndpointB.projitems" Label="Shared" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/EndpointB_1/Program.cs
+++ b/src/EndpointB_1/Program.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using EndpointB;
+
+namespace EndpointB_1
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Configuration.Start("1").GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/EndpointB_1/Properties/AssemblyInfo.cs
+++ b/src/EndpointB_1/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("EndpointB_1")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("EndpointB_1")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9d43421f-a590-4433-89ec-08322d5e4c5f")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/EndpointB_2/App.config
+++ b/src/EndpointB_2/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    </startup>
+</configuration>

--- a/src/EndpointB_2/EndpointB_2.csproj
+++ b/src/EndpointB_2/EndpointB_2.csproj
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5284CA88-05E9-406E-8EB0-11C822FAA262}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EndpointB_2</RootNamespace>
+    <AssemblyName>EndpointB_2</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Contracts\Contracts.csproj">
+      <Project>{ae8af7f5-26c7-4510-956a-d8a4401f4fdf}</Project>
+      <Name>Contracts</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\NServiceBus.CentralizedRouting\NServiceBus.CentralizedRouting.csproj">
+      <Project>{b9bd896f-2eb9-4a04-8713-70eb79fbfc3a}</Project>
+      <Name>NServiceBus.CentralizedRouting</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\NServiceBus.Core\NServiceBus.Core.csproj">
+      <Project>{dd48b2d0-e996-412d-9157-821ed8b17a9d}</Project>
+      <Name>NServiceBus.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\EndpointA\endpoints.xml">
+      <Link>endpoints.xml</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\EndpointA\instance-mapping.xml">
+      <Link>instance-mapping.xml</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <Import Project="..\EndpointB\EndpointB.projitems" Label="Shared" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/EndpointB_2/Program.cs
+++ b/src/EndpointB_2/Program.cs
@@ -1,0 +1,12 @@
+﻿using EndpointB;
+
+namespace EndpointB_2
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Configuration.Start("2").GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/EndpointB_2/Properties/AssemblyInfo.cs
+++ b/src/EndpointB_2/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("EndpointB_2")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("EndpointB_2")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5284ca88-05e9-406e-8eb0-11c822faa262")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NServiceBus.CentralizedRouting/CentralizedPubSubRoutingTable.cs
+++ b/src/NServiceBus.CentralizedRouting/CentralizedPubSubRoutingTable.cs
@@ -1,0 +1,55 @@
+﻿namespace NServiceBus.CentralizedRouting
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    class CentralizedPubSubRoutingTable
+    {
+        public IEnumerable<string> GetSubscribersFor(Type[] messageTypes)
+        {
+            //Use caching
+            return ComputeSubscribersFor(messageTypes).Distinct();
+        }
+
+        IEnumerable<string> ComputeSubscribersFor(Type[] messageTypes)
+        {
+            foreach (var type in messageTypes)
+            {
+                HashSet<string> subscribers;
+                if (routeTable.TryGetValue(type, out subscribers))
+                {
+                    foreach (var subscriber in subscribers)
+                    {
+                        yield return subscriber;
+                    }
+                }
+            }
+        }
+
+        public void ReplaceRoutes(IEnumerable<EndpointRoutingConfiguration> entries)
+        {
+            lock (updateLock)
+            {
+                var newRouteTable = new Dictionary<Type, HashSet<string>>();
+                foreach (var entry in entries.Select(e => Tuple.Create(e.LogicalEndpointName, e.Events)))
+                {
+                    foreach (var eventType in entry.Item2)
+                    {
+                        HashSet<string> routesForEvent;
+                        if (!newRouteTable.TryGetValue(eventType, out routesForEvent))
+                        {
+                            routesForEvent = new HashSet<string>();
+                            newRouteTable[eventType] = routesForEvent;
+                        }
+                        routesForEvent.Add(entry.Item1);
+                    }
+                }
+                routeTable = newRouteTable;
+            }
+        }
+
+        Dictionary<Type, HashSet<string>> routeTable = new Dictionary<Type, HashSet<string>>();
+        object updateLock = new object();
+    }
+}

--- a/src/NServiceBus.CentralizedRouting/CentralizedRoutingFeature.cs
+++ b/src/NServiceBus.CentralizedRouting/CentralizedRoutingFeature.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using NServiceBus.Features;
+using NServiceBus.Routing;
+using Timer = System.Threading.Timer;
+
+namespace NServiceBus.CentralizedRouting
+{
+    using Transport;
+    using Unicast.Messages;
+
+    public class CentralizedRoutingFeature : Feature
+    {
+        UnicastRoutingTable unicastRoutingTable;
+        RoutingTable routingTable = new RoutingTable();
+        CentralizedPubSubRoutingTable eventRoutingTable = new CentralizedPubSubRoutingTable();
+        Timer timer;
+
+        protected override void Setup(FeatureConfigurationContext context)
+        {
+            unicastRoutingTable = context.Settings.Get<UnicastRoutingTable>();
+
+            routingTable.routingDataUpdated += RoutingTableOnRoutingDataUpdated;
+            routingTable.Reload();
+
+            var distributionPolicy = context.Settings.Get<DistributionPolicy>();
+            var endpointInstances = context.Settings.Get<EndpointInstances>();
+            var transportInfrastructure = context.Settings.Get<TransportInfrastructure>();
+
+            context.Pipeline.Replace("UnicastPublishRouterConnector", b => new CentralizedRoutingPublishRouterConnector(b.Build<MessageMetadataRegistry>(), eventRoutingTable, distributionPolicy, endpointInstances, i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i))));
+
+
+            timer = new Timer(state => routingTable.Reload(), null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
+        }
+
+        void RoutingTableOnRoutingDataUpdated(object sender, EventArgs eventArgs)
+        {
+            UpdateRoutingTable(routingTable.Endpoints);
+        }
+
+        void UpdateRoutingTable(EndpointRoutingConfiguration[] endpoints)
+        {
+            var commandRoutes = new List<RouteTableEntry>();
+            foreach (var endpoint in endpoints)
+            {
+                foreach (var command in endpoint.Commands)
+                {
+                    commandRoutes.Add(new RouteTableEntry(command,
+                        UnicastRoute.CreateFromEndpointName(endpoint.LogicalEndpointName)));
+                }
+            }
+
+            eventRoutingTable.ReplaceRoutes(endpoints);
+            unicastRoutingTable.AddOrReplaceRoutes("FileBasedRouting", commandRoutes);
+        }
+    }
+}

--- a/src/NServiceBus.CentralizedRouting/CentralizedRoutingPublishRouterConnector.cs
+++ b/src/NServiceBus.CentralizedRouting/CentralizedRoutingPublishRouterConnector.cs
@@ -1,0 +1,70 @@
+﻿namespace NServiceBus.CentralizedRouting
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Pipeline;
+    using Routing;
+    using Unicast.Messages;
+    using Unicast.Queuing;
+
+    class CentralizedRoutingPublishRouterConnector : StageConnector<IOutgoingPublishContext, IOutgoingLogicalMessageContext>
+    {
+        MessageMetadataRegistry messageMetadataRegistry;
+        CentralizedPubSubRoutingTable routingTable;
+        DistributionPolicy distributionPolicy;
+        EndpointInstances endpointInstances;
+        Func<EndpointInstance, string> transportAddressTranslation;
+
+        public CentralizedRoutingPublishRouterConnector(MessageMetadataRegistry messageMetadataRegistry, CentralizedPubSubRoutingTable routingTable, DistributionPolicy distributionPolicy, EndpointInstances endpointInstances, Func<EndpointInstance, string> transportAddressTranslation)
+        {
+            this.messageMetadataRegistry = messageMetadataRegistry;
+            this.routingTable = routingTable;
+            this.distributionPolicy = distributionPolicy;
+            this.endpointInstances = endpointInstances;
+            this.transportAddressTranslation = transportAddressTranslation;
+        }
+
+        public override async Task Invoke(IOutgoingPublishContext context, Func<IOutgoingLogicalMessageContext, Task> stage)
+        {
+            var eventType = context.Message.MessageType;
+            var typesToRoute = messageMetadataRegistry.GetMessageMetadata(eventType).MessageHierarchy;
+
+            var subscribers = routingTable.GetSubscribersFor(typesToRoute);
+
+            var selectedDestinations = SelectDestinationsForEachEndpoint(subscribers);
+
+            var strategies = selectedDestinations.Select(destination => new UnicastRoutingStrategy(destination)).ToArray();
+
+            if (strategies.Length == 0)
+            {
+                //No subscribers for this message.
+                return;
+            }
+
+            context.Headers[Headers.MessageIntent] = MessageIntentEnum.Publish.ToString();
+
+            try
+            {
+                await stage(this.CreateOutgoingLogicalMessageContext(context.Message, strategies, context)).ConfigureAwait(false);
+            }
+            catch (QueueNotFoundException ex)
+            {
+                throw new Exception($"The destination queue '{ex.Queue}' could not be found. The destination may be misconfigured for this kind of message ({eventType}) in the MessageEndpointMappings of the UnicastBusConfig section in the configuration file. It may also be the case that the given queue hasn\'t been created yet, or has been deleted.", ex);
+            }
+        }
+
+        IEnumerable<string> SelectDestinationsForEachEndpoint(IEnumerable<string> subscribers)
+        {
+            return subscribers.Select(SelectDestinationForEndpoint);
+        }
+
+        string SelectDestinationForEndpoint(string endpoint)
+        {
+            var distributionStrategy = distributionPolicy.GetDistributionStrategy(endpoint, DistributionStrategyScope.Send);
+            var instances = endpointInstances.FindInstances(endpoint).Select(transportAddressTranslation).ToArray();
+            return distributionStrategy.SelectReceiver(instances);
+        }
+    }
+}

--- a/src/NServiceBus.CentralizedRouting/EndpointRoutingConfiguration.cs
+++ b/src/NServiceBus.CentralizedRouting/EndpointRoutingConfiguration.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace NServiceBus.CentralizedRouting
+{
+    class EndpointRoutingConfiguration
+    {
+        public string LogicalEndpointName { get; set; }
+
+        public Type[] Commands { get; set; }
+
+        public Type[] Events { get; set; }
+    }
+}

--- a/src/NServiceBus.CentralizedRouting/NServiceBus.CentralizedRouting.csproj
+++ b/src/NServiceBus.CentralizedRouting/NServiceBus.CentralizedRouting.csproj
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B9BD896F-2EB9-4A04-8713-70EB79FBFC3A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NServiceBus.CentralizedRouting</RootNamespace>
+    <AssemblyName>NServiceBus.CentralizedRouting</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CentralizedPubSubRoutingTable.cs" />
+    <Compile Include="CentralizedRoutingPublishRouterConnector.cs" />
+    <Compile Include="EndpointRoutingConfiguration.cs" />
+    <Compile Include="CentralizedRoutingFeature.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RoutingFile.cs" />
+    <Compile Include="RoutingTable.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.Core\NServiceBus.Core.csproj">
+      <Project>{dd48b2d0-e996-412d-9157-821ed8b17a9d}</Project>
+      <Name>NServiceBus.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/NServiceBus.CentralizedRouting/Properties/AssemblyInfo.cs
+++ b/src/NServiceBus.CentralizedRouting/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NServiceBus.CentralizedRouting")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("NServiceBus.CentralizedRouting")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b9bd896f-2eb9-4a04-8713-70eb79fbfc3a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NServiceBus.CentralizedRouting/RoutingFile.cs
+++ b/src/NServiceBus.CentralizedRouting/RoutingFile.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace NServiceBus.CentralizedRouting
+{
+    class RoutingFile
+    {
+        public IEnumerable<EndpointRoutingConfiguration> Read()
+        {
+            using (var fileStream = File.OpenRead("endpoints.xml"))
+            {
+                var document = XDocument.Load(fileStream);
+                var endpointElements = document.Root.Descendants("endpoint");
+
+                var configs = new List<EndpointRoutingConfiguration>();
+                foreach (var endpointElement in endpointElements)
+                {
+                    var config = new EndpointRoutingConfiguration();
+                    config.LogicalEndpointName = endpointElement.Attribute("name").Value;
+
+                    config.Commands = endpointElement.Element("handles")
+                        ?.Elements("command")
+                        .Select(e => Type.GetType(e.Attribute("type").Value, true))
+                        .ToArray() ?? new Type[0];
+
+                    config.Events = endpointElement.Element("handles")
+                        ?.Elements("event")
+                        .Select(e => Type.GetType(e.Attribute("type").Value, true))
+                        .ToArray() ?? new Type[0];
+
+                    configs.Add(config);
+                }
+
+                return configs;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.CentralizedRouting/RoutingTable.cs
+++ b/src/NServiceBus.CentralizedRouting/RoutingTable.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NServiceBus.Routing;
+
+namespace NServiceBus.CentralizedRouting
+{
+    class RoutingTable
+    {
+        readonly RoutingFile routingFileAccess = new RoutingFile();
+
+        public event EventHandler routingDataUpdated;
+
+        public void Reload()
+        {
+            Endpoints = routingFileAccess.Read().ToArray();
+            routingDataUpdated?.Invoke(this, EventArgs.Empty);
+        }
+
+        public EndpointRoutingConfiguration[] Endpoints { get; private set; }
+
+        public List<EndpointInstance> EndpointInstances { get; private set; }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Routing/DistributionPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DistributionPolicyTests.cs
@@ -9,7 +9,7 @@
         [Test]
         public void When_no_strategy_configured_for_endpoint_should_use_round_robbin_strategy()
         {
-            IDistributionPolicy policy = new DistributionPolicy();
+            var policy = new DistributionPolicy();
 
             var result = policy.GetDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Send);
 
@@ -19,11 +19,10 @@
         [Test]
         public void When_strategy_configured_for_endpoint_should_use_configured_strategy()
         {
-            var p = new DistributionPolicy();
+            var policy = new DistributionPolicy();
             var configuredStrategy = new FakeDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Send);
-            p.SetDistributionStrategy(configuredStrategy);
+            policy.SetDistributionStrategy(configuredStrategy);
 
-            IDistributionPolicy policy = p;
             var result = policy.GetDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Send);
 
             Assert.That(result, Is.EqualTo(configuredStrategy));
@@ -32,13 +31,12 @@
         [Test]
         public void When_multiple_strategies_configured_endpoint_should_use_last_configured_strategy()
         {
-            var p = new DistributionPolicy();
+            var policy = new DistributionPolicy();
             var strategy1 = new FakeDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Send);
             var strategy2 = new FakeDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Send);
-            p.SetDistributionStrategy(strategy1);
-            p.SetDistributionStrategy(strategy2);
+            policy.SetDistributionStrategy(strategy1);
+            policy.SetDistributionStrategy(strategy2);
 
-            IDistributionPolicy policy = p;
             var result = policy.GetDistributionStrategy("SomeEndpoint", DistributionStrategyScope.Send);
 
             Assert.That(result, Is.EqualTo(strategy2));

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastPublishRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastPublishRouterConnectorTests.cs
@@ -25,7 +25,7 @@
 
         class FakePublishRouter : IUnicastPublishRouter
         {
-            public Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, IDistributionPolicy distributionPolicy, ContextBag contextBag)
+            public Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, DistributionPolicy distributionPolicy, ContextBag contextBag)
             {
                 IEnumerable<UnicastRoutingStrategy> unicastRoutingStrategies = new List<UnicastRoutingStrategy>
                 {

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
@@ -231,7 +231,7 @@
         {
             public UnicastRoutingStrategy FixedDestination { get; set; }
 
-            public UnicastRoutingStrategy Route(Type messageType, IDistributionPolicy distributionPolicy)
+            public UnicastRoutingStrategy Route(Type messageType, Func<string, DistributionStrategyScope, DistributionStrategy> distributionPolicy)
             {
                 return FixedDestination;
             }

--- a/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
@@ -37,7 +37,7 @@ namespace NServiceBus.Core.Tests.Routing
             Assert.That(result, Has.Exactly(1).EqualTo(endpointBInstances[1]));
         }
 
-        static string InvokeDistributionStrategy(IDistributionPolicy policy, string endpointName, string[] instanceAddress)
+        static string InvokeDistributionStrategy(DistributionPolicy policy, string endpointName, string[] instanceAddress)
         {
             return policy.GetDistributionStrategy(endpointName, DistributionStrategyScope.Send).SelectReceiver(instanceAddress);
         }

--- a/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
@@ -17,7 +17,7 @@
             var logicalEndpointName = "Sales";
             routingTable.AddOrReplaceRoutes("A", new List<RouteTableEntry> {new RouteTableEntry(typeof(Command), UnicastRoute.CreateFromEndpointName(logicalEndpointName)) });
 
-            var route = router.Route(typeof(Command), new DistributionPolicy());
+            var route = router.Route(typeof(Command), new DistributionPolicy().GetDistributionStrategy);
 
             Assert.AreEqual(logicalEndpointName, ExtractDestination(route));
         }
@@ -34,7 +34,7 @@
                 new EndpointInstance(sales, "2"),
             });
 
-            var route = router.Route(typeof(Command), new DistributionPolicy());
+            var route = router.Route(typeof(Command), new DistributionPolicy().GetDistributionStrategy);
 
             Assert.AreEqual("Sales-1", ExtractDestination(route));
         }
@@ -42,7 +42,7 @@
         [Test]
         public void Should_return_empty_list_when_no_routes_found()
         {
-            var route = router.Route(typeof(Command), new DistributionPolicy());
+            var route = router.Route(typeof(Command), new DistributionPolicy().GetDistributionStrategy);
 
             Assert.IsNull(route);
         }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -158,7 +158,6 @@
     <Compile Include="Routing\MessageDrivenSubscriptions\NamespacePublisherSource.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\TypePublisherSource.cs" />
     <Compile Include="Routing\TypeRouteSource.cs" />
-    <Compile Include="Routing\IDistributionPolicy.cs" />
     <Compile Include="Routing\IRouteSource.cs" />
     <Compile Include="Routing\IUnicastSendRouter.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\IMessageDrivenSubscriptionTransport.cs" />

--- a/src/NServiceBus.Core/Routing/DistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionPolicy.cs
@@ -7,7 +7,7 @@ namespace NServiceBus
     /// <summary>
     /// Configures distribution strategies.
     /// </summary>
-    public class DistributionPolicy : IDistributionPolicy
+    public class DistributionPolicy
     {
         /// <summary>
         /// Sets the distribution strategy for a given endpoint.
@@ -20,7 +20,12 @@ namespace NServiceBus
             configuredStrategies[Tuple.Create(distributionStrategy.Endpoint, distributionStrategy.Scope)] = distributionStrategy;
         }
 
-        DistributionStrategy IDistributionPolicy.GetDistributionStrategy(string endpointName, DistributionStrategyScope scope)
+        /// <summary>
+        /// Returns a distribution strategy for a given endpoint and scope.
+        /// </summary>
+        /// <param name="endpointName">Name of destination endpoint.</param>
+        /// <param name="scope">Scope of operation.</param>
+        public DistributionStrategy GetDistributionStrategy(string endpointName, DistributionStrategyScope scope)
         {
             return configuredStrategies.GetOrAdd(Tuple.Create(endpointName, scope), key => new SingleInstanceRoundRobinDistributionStrategy(key.Item1, key.Item2));
         }

--- a/src/NServiceBus.Core/Routing/EndpointInstances.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstances.cs
@@ -8,7 +8,10 @@ namespace NServiceBus.Routing
     /// </summary>
     public class EndpointInstances
     {
-        internal IEnumerable<EndpointInstance> FindInstances(string endpoint)
+        /// <summary>
+        /// Returns a collection of instances for a given endpoint. Returns a default instance if no specific instances are found.
+        /// </summary>
+        public IEnumerable<EndpointInstance> FindInstances(string endpoint)
         {
             HashSet<EndpointInstance> registeredInstances;
             return allInstances.TryGetValue(endpoint, out registeredInstances)

--- a/src/NServiceBus.Core/Routing/IDistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/IDistributionPolicy.cs
@@ -1,9 +1,0 @@
-namespace NServiceBus
-{
-    using Routing;
-
-    interface IDistributionPolicy
-    {
-        DistributionStrategy GetDistributionStrategy(string endpointName, DistributionStrategyScope scope);
-    }
-}

--- a/src/NServiceBus.Core/Routing/IUnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/IUnicastPublishRouter.cs
@@ -8,6 +8,6 @@ namespace NServiceBus
 
     interface IUnicastPublishRouter
     {
-        Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, IDistributionPolicy distributionPolicy, ContextBag contextBag);
+        Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, DistributionPolicy distributionPolicy, ContextBag contextBag);
     }
 }

--- a/src/NServiceBus.Core/Routing/IUnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/IUnicastSendRouter.cs
@@ -5,6 +5,6 @@ namespace NServiceBus
 
     interface IUnicastSendRouter
     {
-        UnicastRoutingStrategy Route(Type messageType, IDistributionPolicy distributionPolicy);
+        UnicastRoutingStrategy Route(Type messageType, Func<string, DistributionStrategyScope, DistributionStrategy> distributionPolicy);
     }
 }

--- a/src/NServiceBus.Core/Routing/Routers/UnicastSendRouterConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/UnicastSendRouterConnector.cs
@@ -46,7 +46,15 @@ namespace NServiceBus
             var explicitDestination = state.Option == RouteOption.ExplicitDestination ? state.ExplicitDestination : null;
             var destination = explicitDestination ?? thisInstance ?? thisEndpoint;
 
-            var distributionPolicy = state.Option == RouteOption.RouteToSpecificInstance ? new SpecificInstanceDistributionPolicy(state.SpecificInstance, transportAddressTranslation) : defaultDistributionPolicy;
+            Func<string, DistributionStrategyScope, DistributionStrategy> distributionPolicy;
+            if (state.Option == RouteOption.RouteToSpecificInstance)
+            {
+                distributionPolicy = new SpecificInstanceDistributionPolicy(state.SpecificInstance, transportAddressTranslation).GetDistributionStrategy;
+            }
+            else
+            {
+                distributionPolicy = defaultDistributionPolicy.GetDistributionStrategy;
+            }
 
             var routingStrategy = string.IsNullOrEmpty(destination)
                 ? unicastSendRouter.Route(messageType, distributionPolicy)
@@ -82,7 +90,7 @@ namespace NServiceBus
             return new UnicastRoutingStrategy(physicalAddress);
         }
 
-        IDistributionPolicy defaultDistributionPolicy;
+        DistributionPolicy defaultDistributionPolicy;
         Func<EndpointInstance, string> transportAddressTranslation;
         string instanceSpecificQueue;
         string sharedQueue;

--- a/src/NServiceBus.Core/Routing/SpecificInstanceDistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/SpecificInstanceDistributionPolicy.cs
@@ -4,7 +4,7 @@ namespace NServiceBus
     using System.Linq;
     using Routing;
 
-    class SpecificInstanceDistributionPolicy : IDistributionPolicy
+    class SpecificInstanceDistributionPolicy
     {
         public SpecificInstanceDistributionPolicy(string discriminator, Func<EndpointInstance, string> transportAddressTranslation)
         {

--- a/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
@@ -18,7 +18,7 @@ namespace NServiceBus
             this.subscriptionStorage = subscriptionStorage;
         }
 
-        public async Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, IDistributionPolicy distributionPolicy, ContextBag contextBag)
+        public async Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, DistributionPolicy distributionPolicy, ContextBag contextBag)
         {
             var typesToRoute = messageMetadataRegistry.GetMessageMetadata(messageType).MessageHierarchy;
 
@@ -29,7 +29,7 @@ namespace NServiceBus
             return selectedDestinations.Select(destination => new UnicastRoutingStrategy(destination));
         }
 
-        HashSet<string> SelectDestinationsForEachEndpoint(IDistributionPolicy distributionPolicy, IEnumerable<Subscriber> subscribers)
+        HashSet<string> SelectDestinationsForEachEndpoint(DistributionPolicy distributionPolicy, IEnumerable<Subscriber> subscribers)
         {
             //Make sure we are sending only one to each transport destination. Might happen when there are multiple routing information sources.
             var addresses = new HashSet<string>();

--- a/src/NServiceBus.Core/Routing/UnicastRoutingTable.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRoutingTable.cs
@@ -9,7 +9,10 @@ namespace NServiceBus.Routing
     /// </summary>
     public class UnicastRoutingTable
     {
-        internal UnicastRoute GetRouteFor(Type messageType)
+        /// <summary>
+        /// Returns a route for a given message type.
+        /// </summary>
+        public UnicastRoute GetRouteFor(Type messageType)
         {
             UnicastRoute unicastRoute;
             return routeTable.TryGetValue(messageType, out unicastRoute)

--- a/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
@@ -13,7 +13,7 @@ namespace NServiceBus
             this.transportAddressTranslation = transportAddressTranslation;
         }
 
-        public UnicastRoutingStrategy Route(Type messageType, IDistributionPolicy distributionPolicy)
+        public UnicastRoutingStrategy Route(Type messageType, Func<string, DistributionStrategyScope, DistributionStrategy> distributionPolicy)
         {
             var route = unicastRoutingTable.GetRouteFor(messageType);
             if (route == null)
@@ -33,7 +33,7 @@ namespace NServiceBus
 
 
             var instances = endpointInstances.FindInstances(route.Endpoint).Select(e => transportAddressTranslation(e)).ToArray();
-            var selectedInstanceAddress = distributionPolicy.GetDistributionStrategy(route.Endpoint, DistributionStrategyScope.Send).SelectReceiver(instances);
+            var selectedInstanceAddress = distributionPolicy(route.Endpoint, DistributionStrategyScope.Send).SelectReceiver(instances);
             return new UnicastRoutingStrategy(selectedInstanceAddress);
         }
 

--- a/src/NServiceBus.sln
+++ b/src/NServiceBus.sln
@@ -27,7 +27,26 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Testing.Fakes",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.TransportTests", "NServiceBus.TransportTests\NServiceBus.TransportTests.csproj", "{7EF57153-179F-449A-9C81-BD049B1B5613}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.CentralizedRouting", "NServiceBus.CentralizedRouting\NServiceBus.CentralizedRouting.csproj", "{B9BD896F-2EB9-4A04-8713-70EB79FBFC3A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Demo", "Demo", "{3195099F-DB77-47A1-B295-565E6183ACF9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Contracts", "Contracts\Contracts.csproj", "{AE8AF7F5-26C7-4510-956A-D8A4401F4FDF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EndpointA", "EndpointA\EndpointA.csproj", "{2861AA2A-E1D6-4F66-AF32-A2F1C9656AF4}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "EndpointB", "EndpointB\EndpointB.shproj", "{FC8E81CA-93C8-40D6-936C-8C661950544C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EndpointB_1", "EndpointB_1\EndpointB_1.csproj", "{9D43421F-A590-4433-89EC-08322D5E4C5F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EndpointB_2", "EndpointB_2\EndpointB_2.csproj", "{5284CA88-05E9-406E-8EB0-11C822FAA262}"
+EndProject
 Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		EndpointB\EndpointB.projitems*{fc8e81ca-93c8-40d6-936c-8c661950544c}*SharedItemsImports = 13
+		EndpointB\EndpointB.projitems*{9d43421f-a590-4433-89ec-08322d5e4c5f}*SharedItemsImports = 4
+		EndpointB\EndpointB.projitems*{5284ca88-05e9-406e-8eb0-11c822faa262}*SharedItemsImports = 4
+	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug|Mixed Platforms = Debug|Mixed Platforms
@@ -135,6 +154,66 @@ Global
 		{7EF57153-179F-449A-9C81-BD049B1B5613}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{7EF57153-179F-449A-9C81-BD049B1B5613}.Release|x86.ActiveCfg = Release|Any CPU
 		{7EF57153-179F-449A-9C81-BD049B1B5613}.Release|x86.Build.0 = Release|Any CPU
+		{B9BD896F-2EB9-4A04-8713-70EB79FBFC3A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B9BD896F-2EB9-4A04-8713-70EB79FBFC3A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B9BD896F-2EB9-4A04-8713-70EB79FBFC3A}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{B9BD896F-2EB9-4A04-8713-70EB79FBFC3A}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{B9BD896F-2EB9-4A04-8713-70EB79FBFC3A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B9BD896F-2EB9-4A04-8713-70EB79FBFC3A}.Debug|x86.Build.0 = Debug|Any CPU
+		{B9BD896F-2EB9-4A04-8713-70EB79FBFC3A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B9BD896F-2EB9-4A04-8713-70EB79FBFC3A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B9BD896F-2EB9-4A04-8713-70EB79FBFC3A}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{B9BD896F-2EB9-4A04-8713-70EB79FBFC3A}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{B9BD896F-2EB9-4A04-8713-70EB79FBFC3A}.Release|x86.ActiveCfg = Release|Any CPU
+		{B9BD896F-2EB9-4A04-8713-70EB79FBFC3A}.Release|x86.Build.0 = Release|Any CPU
+		{AE8AF7F5-26C7-4510-956A-D8A4401F4FDF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE8AF7F5-26C7-4510-956A-D8A4401F4FDF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE8AF7F5-26C7-4510-956A-D8A4401F4FDF}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{AE8AF7F5-26C7-4510-956A-D8A4401F4FDF}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{AE8AF7F5-26C7-4510-956A-D8A4401F4FDF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AE8AF7F5-26C7-4510-956A-D8A4401F4FDF}.Debug|x86.Build.0 = Debug|Any CPU
+		{AE8AF7F5-26C7-4510-956A-D8A4401F4FDF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE8AF7F5-26C7-4510-956A-D8A4401F4FDF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE8AF7F5-26C7-4510-956A-D8A4401F4FDF}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{AE8AF7F5-26C7-4510-956A-D8A4401F4FDF}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{AE8AF7F5-26C7-4510-956A-D8A4401F4FDF}.Release|x86.ActiveCfg = Release|Any CPU
+		{AE8AF7F5-26C7-4510-956A-D8A4401F4FDF}.Release|x86.Build.0 = Release|Any CPU
+		{2861AA2A-E1D6-4F66-AF32-A2F1C9656AF4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2861AA2A-E1D6-4F66-AF32-A2F1C9656AF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2861AA2A-E1D6-4F66-AF32-A2F1C9656AF4}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{2861AA2A-E1D6-4F66-AF32-A2F1C9656AF4}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{2861AA2A-E1D6-4F66-AF32-A2F1C9656AF4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2861AA2A-E1D6-4F66-AF32-A2F1C9656AF4}.Debug|x86.Build.0 = Debug|Any CPU
+		{2861AA2A-E1D6-4F66-AF32-A2F1C9656AF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2861AA2A-E1D6-4F66-AF32-A2F1C9656AF4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2861AA2A-E1D6-4F66-AF32-A2F1C9656AF4}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{2861AA2A-E1D6-4F66-AF32-A2F1C9656AF4}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{2861AA2A-E1D6-4F66-AF32-A2F1C9656AF4}.Release|x86.ActiveCfg = Release|Any CPU
+		{2861AA2A-E1D6-4F66-AF32-A2F1C9656AF4}.Release|x86.Build.0 = Release|Any CPU
+		{9D43421F-A590-4433-89EC-08322D5E4C5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D43421F-A590-4433-89EC-08322D5E4C5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D43421F-A590-4433-89EC-08322D5E4C5F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{9D43421F-A590-4433-89EC-08322D5E4C5F}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{9D43421F-A590-4433-89EC-08322D5E4C5F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9D43421F-A590-4433-89EC-08322D5E4C5F}.Debug|x86.Build.0 = Debug|Any CPU
+		{9D43421F-A590-4433-89EC-08322D5E4C5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D43421F-A590-4433-89EC-08322D5E4C5F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D43421F-A590-4433-89EC-08322D5E4C5F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{9D43421F-A590-4433-89EC-08322D5E4C5F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{9D43421F-A590-4433-89EC-08322D5E4C5F}.Release|x86.ActiveCfg = Release|Any CPU
+		{9D43421F-A590-4433-89EC-08322D5E4C5F}.Release|x86.Build.0 = Release|Any CPU
+		{5284CA88-05E9-406E-8EB0-11C822FAA262}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5284CA88-05E9-406E-8EB0-11C822FAA262}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5284CA88-05E9-406E-8EB0-11C822FAA262}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{5284CA88-05E9-406E-8EB0-11C822FAA262}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{5284CA88-05E9-406E-8EB0-11C822FAA262}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5284CA88-05E9-406E-8EB0-11C822FAA262}.Debug|x86.Build.0 = Debug|Any CPU
+		{5284CA88-05E9-406E-8EB0-11C822FAA262}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5284CA88-05E9-406E-8EB0-11C822FAA262}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5284CA88-05E9-406E-8EB0-11C822FAA262}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{5284CA88-05E9-406E-8EB0-11C822FAA262}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{5284CA88-05E9-406E-8EB0-11C822FAA262}.Release|x86.ActiveCfg = Release|Any CPU
+		{5284CA88-05E9-406E-8EB0-11C822FAA262}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -144,5 +223,10 @@ Global
 		{758357F6-CD31-4337-80C4-BA377FC257AF} = {2904B75F-8F07-4C07-BABC-BC42533B3E75}
 		{80105366-8EF9-494D-A296-E100E82224CF} = {2904B75F-8F07-4C07-BABC-BC42533B3E75}
 		{7EF57153-179F-449A-9C81-BD049B1B5613} = {2904B75F-8F07-4C07-BABC-BC42533B3E75}
+		{AE8AF7F5-26C7-4510-956A-D8A4401F4FDF} = {3195099F-DB77-47A1-B295-565E6183ACF9}
+		{2861AA2A-E1D6-4F66-AF32-A2F1C9656AF4} = {3195099F-DB77-47A1-B295-565E6183ACF9}
+		{FC8E81CA-93C8-40D6-936C-8C661950544C} = {3195099F-DB77-47A1-B295-565E6183ACF9}
+		{9D43421F-A590-4433-89EC-08322D5E4C5F} = {3195099F-DB77-47A1-B295-565E6183ACF9}
+		{5284CA88-05E9-406E-8EB0-11C822FAA262} = {3195099F-DB77-47A1-B295-565E6183ACF9}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Publishes a bunch of routing extensibility APIs:
 * FindInstances
 * GetRouteFor
 * GetDistributionStrategy

in order to allow replacing of routing connectors to provide completely custom routing