### PR TITLE
[WIP] Changes allowing wiring dispatcher directly to pump

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -242,6 +242,7 @@ namespace NServiceBus
     {
         public CriticalError(System.Func<NServiceBus.ICriticalErrorContext, System.Threading.Tasks.Task> onCriticalErrorAction) { }
         public virtual void Raise(string errorMessage, System.Exception exception) { }
+        public void SetStopCallback(System.Func<System.Threading.Tasks.Task> callback) { }
     }
     public class CriticalErrorContext : NServiceBus.ICriticalErrorContext
     {
@@ -1178,6 +1179,11 @@ namespace NServiceBus
     {
         public ToSagaExpression(NServiceBus.IConfigureHowToFindSagaWithMessage sagaMessageFindingConfiguration, System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty) { }
         public void ToSaga(System.Linq.Expressions.Expression<System.Func<TSagaData, object>> sagaEntityProperty) { }
+    }
+    public sealed class TransportConnectionString
+    {
+        public TransportConnectionString(System.Func<string> func) { }
+        public bool TryGetValue(out string connectionString) { }
     }
     public class TransportExtensions : NServiceBus.Configuration.AdvanceExtensibility.ExposeSettings
     {

--- a/src/NServiceBus.Core/CriticalError/CriticalError.cs
+++ b/src/NServiceBus.Core/CriticalError/CriticalError.cs
@@ -48,7 +48,7 @@ namespace NServiceBus
 
             lock (endpointCriticalLock)
             {
-                if (endpoint == null)
+                if (stopCallback == null)
                 {
                     criticalErrors.Add(new LatentCritical
                     {
@@ -67,16 +67,19 @@ namespace NServiceBus
         {
             Task.Run(() =>
             {
-                var context = new CriticalErrorContext(endpoint.Stop, errorMessage, exception);
+                var context = new CriticalErrorContext(stopCallback, errorMessage, exception);
                 return criticalErrorAction(context);
             });
         }
 
-        internal void SetEndpoint(IEndpointInstance endpointInstance)
+        /// <summary>
+        /// Sets the callback that is executed when hendling critical action.
+        /// </summary>
+        public void SetStopCallback(Func<Task> callback)
         {
             lock (endpointCriticalLock)
             {
-                endpoint = endpointInstance;
+                stopCallback = callback;
                 foreach (var latentCritical in criticalErrors)
                 {
                     RaiseForEndpoint(latentCritical.Message, latentCritical.Exception);
@@ -88,7 +91,7 @@ namespace NServiceBus
         Func<CriticalErrorContext, Task> criticalErrorAction;
 
         List<LatentCritical> criticalErrors = new List<LatentCritical>();
-        IEndpointInstance endpoint;
+        Func<Task> stopCallback;
         object endpointCriticalLock = new object();
 
         class LatentCritical

--- a/src/NServiceBus.Core/CriticalError/CriticalError.cs
+++ b/src/NServiceBus.Core/CriticalError/CriticalError.cs
@@ -73,7 +73,7 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Sets the callback that is executed when hendling critical action.
+        /// Sets the callback that is executed when handling critical action.
         /// </summary>
         public void SetStopCallback(Func<Task> callback)
         {

--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -43,7 +43,11 @@ namespace NServiceBus
             ConfigRunBeforeIsFinalized(concreteTypes);
 
             var transportDefinition = settings.Get<TransportDefinition>();
-            var connectionString = settings.Get<TransportConnectionString>().GetConnectionStringOrRaiseError(transportDefinition);
+            string connectionString;
+            if (!settings.Get<TransportConnectionString>().TryGetValue(out connectionString) && transportDefinition.RequiresConnectionString)
+            {
+                throw new InvalidOperationException(string.Format(ConnectionStringMissingMessage, transportDefinition.GetType().Name, transportDefinition.ExampleConnectionStringForErrorMessage));
+            }
             var transportInfrastructure = transportDefinition.Initialize(settings, connectionString);
             settings.Set<TransportInfrastructure>(transportInfrastructure);
 
@@ -184,5 +188,20 @@ namespace NServiceBus
         PipelineSettings pipelineSettings;
         SettingsHolder settings;
         CriticalError criticalError;
+
+        const string ConnectionStringMissingMessage =
+            @"Transport connection string has not been explicitly configured via ConnectionString method and no default connection has been was found in the app.config or web.config file for the {0} Transport.
+
+To run NServiceBus with {0} Transport you need to specify the database connectionstring.
+Here are examples of what is required:
+  
+  <connectionStrings>
+    <add name=""NServiceBus/Transport"" connectionString=""{1}"" />
+  </connectionStrings>
+
+or
+
+  busConfig.UseTransport<{0}>().ConnectionString(""{1}"");
+";
     }
 }

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -45,8 +45,8 @@ namespace NServiceBus
             var featureRunner = await StartFeatures(messageSession).ConfigureAwait(false);
 
             var runningInstance = new RunningEndpointInstance(settings, builder, receivers, featureRunner, messageSession, transportInfrastructure);
-            // set the started endpoint on CriticalError to pass the endpoint to the critical error action
-            criticalError.SetEndpoint(runningInstance);
+            // pass the endpoint Stop method to the critical error action
+            criticalError.SetStopCallback(runningInstance.Stop);
 
             StartReceivers(receivers);
 

--- a/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
@@ -2,35 +2,40 @@
 {
     using System;
     using System.Configuration;
-    using Transport;
 
-    sealed class TransportConnectionString
+    /// <summary>
+    /// Allows to get the configured transport connection string.
+    /// </summary>
+    public sealed class TransportConnectionString
     {
         TransportConnectionString()
         {
         }
 
+        /// <summary>
+        /// Creates new connection string configuration that returns value provided by a callback.
+        /// </summary>
+        /// <param name="func">Callback providing connection string value.</param>
         public TransportConnectionString(Func<string> func)
         {
             GetValue = func;
         }
 
-
-        public TransportConnectionString(string name)
+        internal TransportConnectionString(string name)
         {
             GetValue = () => ReadConnectionString(name);
         }
 
-        public static TransportConnectionString Default => new TransportConnectionString();
+        internal static TransportConnectionString Default => new TransportConnectionString();
 
-        public string GetConnectionStringOrRaiseError(TransportDefinition transportDefinition)
+        /// <summary>
+        /// Returns the configured transport connection string.
+        /// </summary>
+        /// <returns></returns>
+        public bool TryGetValue(out string connectionString)
         {
-            var connectionString = GetValue();
-            if (connectionString == null && transportDefinition.RequiresConnectionString)
-            {
-                throw new InvalidOperationException(string.Format(Message, transportDefinition.GetType().Name, transportDefinition.ExampleConnectionStringForErrorMessage));
-            }
-            return connectionString;
+            connectionString = GetValue();
+            return connectionString != null;
         }
 
         static string ReadConnectionString(string connectionStringName)
@@ -42,20 +47,7 @@
 
         Func<string> GetValue = () => ReadConnectionString(DefaultConnectionStringName);
 
-        const string Message =
-            @"Transport connection string has not been explicitly configured via ConnectionString method and no default connection has been was found in the app.config or web.config file for the {0} Transport.
-
-To run NServiceBus with {0} Transport you need to specify the database connectionstring.
-Here are examples of what is required:
-  
-  <connectionStrings>
-    <add name=""NServiceBus/Transport"" connectionString=""{1}"" />
-  </connectionStrings>
-
-or
-
-  busConfig.UseTransport<{0}>().ConnectionString(""{1}"");
-";
+        
 
         const string DefaultConnectionStringName = "NServiceBus/Transport";
     }


### PR DESCRIPTION
Allows wiring pump and dispatcher directly to allow for raw message processing

 * CriticalError does not retquire IEndpointInstance. This also makes it easier for downstreams to test
 * TransportConnectionString is public to allow reading connection string

This is meant to solve https://github.com/Particular/NServiceBus/issues/3389 and is related to https://github.com/Particular/NServiceBus/issues/4221#issuecomment-258182646

### Why?

Here's a couple of reasons why I think this is useful:
 * Allows to build integration tooling where spinning up a whole endpoint would be an overkill
 * Allows to build transport bridges (including the one proposed by me for ServiceControl)
 * Makes testing the transport infrastructure in isolation easier (less reflection hackery)
 * Allows to build performance-optimized endpoints which use raw transport