### PR TITLE
Report first-time install metric to Particular when a user installs NServiceBus

### DIFF
--- a/packaging/nuget/tools/init.ps1
+++ b/packaging/nuget/tools/init.ps1
@@ -50,6 +50,6 @@ $jobScriptBlock = {
 $jobName = 'particular.analytics'
 $job = Get-Job -Name  $jobName -ErrorAction SilentlyContinue
 if (-not $job) {
-    Write-Output $notice
+    Write-Host $notice
     $job = Start-Job -ScriptBlock $jobScriptBlock -Name $jobName -ArgumentList $packageVersion 
 }

--- a/packaging/nuget/tools/init.ps1
+++ b/packaging/nuget/tools/init.ps1
@@ -12,8 +12,6 @@ if($package){
 }
 
 #Figure out if this is a first time user
-
-#Figure out if this is a first time user
 try {
 
 	#Check for existing NServiceBus installations
@@ -35,7 +33,7 @@ try {
 
 	Set-ItemProperty -Path $platformKeyPath -Name "NuGetUser" -Value "true" | Out-Null
 
-	Write-Host `Reporting first time install and version information to www.particular.net. This call does not collect any personal information. For more details, see the License Agreement and the Privacy Policy available here: http://particular.net/licenseagreement. Subsequent NuGet installs or updates will not invoke this call.`
+	Write-Verbose 'Reporting first time install and version information to www.particular.net. This call does not collect any personal information. For more details, see the License Agreement and the Privacy Policy available here: http://particular.net/licenseagreement. Subsequent NuGet installs or updates will not invoke this call.' -verbose
 	$url = 'https://particular.net/api/ReportFirstTimeUsage'
 	$postData  = New-Object System.Collections.Specialized.NameValueCollection
 	$postData.Add("version", $packageversion)
@@ -47,5 +45,7 @@ Catch [Exception] {
 	Write-Warning $error[0]
 }
 finally {
+	if ($wc){
 	$wc.Dispose()
+	}
 }

--- a/packaging/nuget/tools/init.ps1
+++ b/packaging/nuget/tools/init.ps1
@@ -65,6 +65,3 @@ Remove-Event -SourceIdentifier $noticeEvent -ErrorAction SilentlyContinue
 if ($event.MessageData -eq "newuser") {
     Write-Host $notice
 }
-
-
-

--- a/packaging/nuget/tools/init.ps1
+++ b/packaging/nuget/tools/init.ps1
@@ -51,6 +51,9 @@ $jobScriptBlock = {
 }
 
 $notice = @" 
+Reporting first time usage and version information to www.particular.net. 
+This call does not collect any personal information. For more details, 
+see the License Agreement and the Privacy Policy available here: http://particular.net/licenseagreement.
 "@
 
 # Run JobScript

--- a/packaging/nuget/tools/init.ps1
+++ b/packaging/nuget/tools/init.ps1
@@ -34,7 +34,7 @@ try {
 	Set-ItemProperty -Path $platformKeyPath -Name "NuGetUser" -Value "true" | Out-Null
 
 	Write-Verbose 'Reporting first time install and version information to www.particular.net. This call does not collect any personal information. For more details, see the License Agreement and the Privacy Policy available here: http://particular.net/licenseagreement. Subsequent NuGet installs or updates will not invoke this call.' -verbose
-	$url = 'https://particular.net/api/ReportFirstTimeUsage'
+	$url = 'https://particular.net/api/ReportFirstTimeInstall'
 	$postData  = New-Object System.Collections.Specialized.NameValueCollection
 	$postData.Add("version", $packageversion)
 	$wc = New-Object System.Net.WebClient

--- a/packaging/nuget/tools/init.ps1
+++ b/packaging/nuget/tools/init.ps1
@@ -43,7 +43,7 @@ $jobScriptBlock = {
             $wc.UseDefaultCredentials = $true
             $wc.UploadValues($url, "post", $postdata)
         } 
-        finally {$noticeEvent
+        finally {
             # Dispose
             Remove-Variable -Name wc 
         } 
@@ -53,7 +53,7 @@ $jobScriptBlock = {
 $notice = @" 
 Reporting first time usage and version information to www.particular.net. 
 This call does not collect any personal information. For more details, 
-see the License Agreement and the Privacy Policy available here: http://particular.net/licenseagreement.
+see the License Agreement and the Privacy Policy available here: https://particular.net/licenseagreement.
 "@
 
 # Run JobScript

--- a/packaging/nuget/tools/init.ps1
+++ b/packaging/nuget/tools/init.ps1
@@ -1,31 +1,35 @@
 param($installPath, $toolsPath, $package, $project)
 
 $packageVersion = 'Unknown'
+$noticeEvent = 'noticeEvent'
+$jobName = 'analytics'
 
-$notice = @"
-For first time users this script collects install and version information. 
-    
-This call does not collect any personal information. For more details, see the 
-License Agreement and the Privacy Policy available here: http://particular.net/licenseagreement.
-"@
-
+# cleanup previous runs
+Get-Job | ? { $_.Name  -eq $jobName } | Remove-Job -Force -ErrorAction SilentlyContinue    
+ 
 if ($package) {
     $packageVersion = $package.Version
 }
 
 # Define script to run in background job
 $jobScriptBlock = { 
-    param($packageVersion)
+    param($packageVersion, $noticeEvent)
 
-    # Set Tracing on with the Job
+    # Set Tracing on within the Job
     Set-PSDebug -Trace 2
 
+    # Setup event forwarding to foreground
+    Register-EngineEvent -SourceIdentifier $noticeEvent -Forward 
+    
     $nserviceBusKeyPath = 'HKCU:SOFTWARE\NServiceBus' 
     $platformKeyPath = 'HKCU:SOFTWARE\ParticularSoftware'
     
-    # Test for Existing reg keys and skip if either are found
-    if (-not ((Test-Path $nserviceBusKeyPath) -or (Test-Path $platformKeyPath))) {
-    
+    if ((Test-Path $nserviceBusKeyPath) -or (Test-Path $platformKeyPath)) {
+        New-Event -SourceIdentifier $noticeEvent -Sender "analytics" -MessageData "existing"
+    }
+    else {
+        New-Event -SourceIdentifier $noticeEvent -Sender "analytics" -MessageData "newuser"
+
         # Set Flag to bypass first time user feedback in Platform Installer
         New-Item -Path $platformKeyPath -Force | Out-Null
         Set-ItemProperty -Path $platformKeyPath -Name 'NuGetUser' -Value 'true' -Force
@@ -39,17 +43,25 @@ $jobScriptBlock = {
             $wc.UseDefaultCredentials = $true
             $wc.UploadValues($url, "post", $postdata)
         } 
-        finally {
+        finally {$noticeEvent
             # Dispose
             Remove-Variable -Name wc 
-        }
+        } 
     }
 }
 
-# If an existing instance of this job exists then we can skip running it, otherwise create and run 
-$jobName = 'particular.analytics'
-$job = Get-Job -Name  $jobName -ErrorAction SilentlyContinue
-if (-not $job) {
+$notice = @" 
+"@
+
+# Run JobScript
+$job = Start-Job -ScriptBlock $jobScriptBlock -Name $jobName -ArgumentList $packageVersion, $noticeEvent 
+
+# Wait for show notice event
+$event = Wait-Event -SourceIdentifier $noticeEvent -Timeout 5 
+Remove-Event -SourceIdentifier $noticeEvent -ErrorAction SilentlyContinue  
+if ($event.MessageData -eq "newuser") {
     Write-Host $notice
-    $job = Start-Job -ScriptBlock $jobScriptBlock -Name $jobName -ArgumentList $packageVersion 
 }
+
+
+

--- a/packaging/nuget/tools/init.ps1
+++ b/packaging/nuget/tools/init.ps1
@@ -12,6 +12,8 @@ if($package){
 }
 
 #Figure out if this is a first time user
+
+#Figure out if this is a first time user
 try {
 
 	#Check for existing NServiceBus installations
@@ -33,14 +35,17 @@ try {
 
 	Set-ItemProperty -Path $platformKeyPath -Name "NuGetUser" -Value "true" | Out-Null
 
-
-    $url = "http://particular.net/download-the-particular-service-platform?version=$packageVersion" 
-    $url = $url.ToLowerInvariant(); 
-
-    if($dte){
-	    $dte.ExecuteCommand("View.URL", $url)
-    }
+	Write-Host `Reporting first time install and version information to www.particular.net. This call does not collect any personal information. For more details, see the License Agreement and the Privacy Policy available here: http://particular.net/licenseagreement. Subsequent NuGet installs or updates will not invoke this call.`
+	$url = 'https://particular.net/api/ReportFirstTimeUsage'
+	$postData  = New-Object System.Collections.Specialized.NameValueCollection
+	$postData.Add("version", $packageversion)
+	$wc = New-Object System.Net.WebClient
+	$wc.UseDefaultCredentials = $true
+	$wc.UploadValuesAsync($url,"post", $postdata)
 } 
 Catch [Exception] { 
 	Write-Warning $error[0]
+}
+finally {
+	$wc.Dispose()
 }


### PR DESCRIPTION
Relates to: 
https://github.com/Particular/OptimizeTrialExtensions/issues/114
https://github.com/Particular/NServiceBus/pull/4262
https://github.com/Particular/Operations.Website.Backend/pull/237

Pros:
- Makes sure this metric report is only done inside a development environment.
- Can continue to use the pre-existing google analytics that tracks installs as opposed to first time execution

Cons:
- We are continuing to use and add more stuff to init.ps1 when we are actually trying to get rid of it.
- Creates more problems, see: https://github.com/Particular/NServiceBus/issues/4235 
- This approach is bad for the long term. The latest nuget has already deprecated install/uninstall scripts
- While the init script is technically still supported for now, the future remains unclear.
- When installing the nuget into a project.json-based project, the install/uninstall scripts will be ignored.


@gbiellem @andreasohlund - please have a look. 