### PR TITLE
Add configuration for TimeoutManager concurrency settings

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1163,6 +1163,15 @@ namespace NServiceBus
     {
         public SubscribeOptions() { }
     }
+    public class TimeoutManagerConfiguration
+    {
+        public TimeoutManagerConfiguration(NServiceBus.Settings.SettingsHolder settings) { }
+    }
+    public class static TimeoutManagerConfigurationExtensions
+    {
+        public static void LimitMessageProcessingConcurrencyTo(this NServiceBus.TimeoutManagerConfiguration timeoutManagerConfiguration, int maxConcurrency) { }
+        public static NServiceBus.TimeoutManagerConfiguration TimeoutManager(this NServiceBus.EndpointConfiguration endpointConfiguration) { }
+    }
     [System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Interface | System.AttributeTargets.All)]
     public sealed class TimeToBeReceivedAttribute : System.Attribute
     {

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManagerConfiguration.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManagerConfiguration.cs
@@ -12,7 +12,6 @@ namespace NServiceBus
         /// <summary>
         /// Creates a new instance of <see cref="TimeoutManagerConfiguration"/>.
         /// </summary>
-        /// <param name="settings"></param>
         public TimeoutManagerConfiguration(SettingsHolder settings)
         {
             this.settings = settings;

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManagerConfiguration.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManagerConfiguration.cs
@@ -1,0 +1,21 @@
+namespace NServiceBus
+{
+    using Settings;
+
+    /// <summary>
+    /// Allows configuration of the timeout manager.
+    /// </summary>
+    public class TimeoutManagerConfiguration
+    {
+        internal SettingsHolder settings;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="TimeoutManagerConfiguration"/>.
+        /// </summary>
+        /// <param name="settings"></param>
+        public TimeoutManagerConfiguration(SettingsHolder settings)
+        {
+            this.settings = settings;
+        }
+    }
+}

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManagerConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManagerConfigurationExtensions.cs
@@ -1,0 +1,36 @@
+﻿namespace NServiceBus
+{
+    using Settings;
+    using Transport;
+
+    /// <summary>
+    /// Extensions to configure the timeout manager via <see cref="TimeoutManagerConfiguration"/>.
+    /// </summary>
+    public static class TimeoutManagerConfigurationExtensions
+    {
+        const string TimeoutManagerMaxConcurrencySettingsKey = "NServiceBus.TimeoutManager.MaxConcurrency";
+
+        /// <summary>
+        /// Configures the timeout manager.
+        /// </summary>
+        public static TimeoutManagerConfiguration TimeoutManager(this EndpointConfiguration endpointConfiguration)
+        {
+            return new TimeoutManagerConfiguration(endpointConfiguration.Settings);
+        }
+
+        /// <summary>
+        /// Configures the allowed number of concurrent messages for the timeout manager's satellite queues. The default value is specified in <see cref="PushRuntimeSettings.Default"/>.
+        /// </summary>
+        /// <param name="timeoutManagerConfiguration">The settings to extend.</param>
+        /// <param name="maxConcurrency">The maximum number of processed messages per satellite queue.</param>
+        public static void LimitMessageProcessingConcurrencyTo(this TimeoutManagerConfiguration timeoutManagerConfiguration, int maxConcurrency)
+        {
+            timeoutManagerConfiguration.settings.Set(TimeoutManagerMaxConcurrencySettingsKey, new PushRuntimeSettings(maxConcurrency));
+        }
+
+        internal static PushRuntimeSettings GetTimeoutManagerMaxConcurrency(this ReadOnlySettings settings)
+        {
+            return settings.GetOrDefault<PushRuntimeSettings>(TimeoutManagerMaxConcurrencySettingsKey) ?? PushRuntimeSettings.Default;
+        }
+    }
+}

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -100,6 +100,8 @@
     <Compile Include="Audit\AuditToDispatchConnector.cs" />
     <Compile Include="Audit\InvokeAuditPipelineBehavior.cs" />
     <Compile Include="DelayedDelivery\TimeoutManagerRoutingStrategy.cs" />
+    <Compile Include="DelayedDelivery\TimeoutManager\TimeoutManagerConfiguration.cs" />
+    <Compile Include="DelayedDelivery\TimeoutManager\TimeoutManagerConfigurationExtensions.cs" />
     <Compile Include="Features\SatelliteDefinitions.cs" />
     <Compile Include="Notifications.cs" />
     <Compile Include="Notifications\EventAggregator.cs" />


### PR DESCRIPTION
addresses https://github.com/Particular/NServiceBus/issues/4264

Adds a configuration API for the timeout manager's satellite queues concurrency settings, to override the default concurrency settings.

usage:

`endpointConfiguration.TimeoutManager().LimitMessageProcessingConcurrencyTo(5);`

@Particular/nservicebus-maintainers the above API is just a suggestion based on the current API design. Tbh I don't think it's very good but I'm lacking better ideas. The only alternative I see would be similar to the recoverability APIs, e.g:

`endpointConfiguration.TimeoutManager(tm => tm.LimitMessageProcessingConcurrencyTo(5));`

thoughts?

Also, I tried to write some tests for it, but this becomes ridiculously complicated as unit tests are nearly impossible and acceptance tests require a full fake transport allowing to identify the satellite queues and their settings. I'll investigate a bit on how to improve the situation, but at that point I'm not yet able to come up with a reasonable test. 