### PR TITLE
[Spike] Expose feature components via properties

### DIFF
--- a/src/NServiceBus.Core/Features/SettingsExtensions.cs
+++ b/src/NServiceBus.Core/Features/SettingsExtensions.cs
@@ -8,6 +8,7 @@
     /// </summary>
     public static class SettingsExtensions
     {
+        const string FeatureStateKey = "FeatureState:";
         /// <summary>
         /// Marks the given feature as enabled by default.
         /// </summary>
@@ -25,7 +26,7 @@
         {
             Guard.AgainstNull(nameof(settings), settings);
             Guard.AgainstNull(nameof(featureType), featureType);
-            settings.SetDefault(featureType.FullName, FeatureState.Enabled);
+            settings.SetDefault(FeatureStateKey + featureType.FullName, FeatureState.Enabled);
             return settings;
         }
 
@@ -34,7 +35,7 @@
         /// </summary>
         public static bool IsFeatureActive(this ReadOnlySettings settings, Type featureType)
         {
-            return settings.GetOrDefault<FeatureState>(featureType.FullName) == FeatureState.Active;
+            return settings.GetFeatureState(featureType) == FeatureState.Active;
         }
 
         /// <summary>
@@ -42,27 +43,37 @@
         /// </summary>
         public static bool IsFeatureEnabled(this ReadOnlySettings settings, Type featureType)
         {
-            return settings.GetOrDefault<FeatureState>(featureType.FullName) == FeatureState.Enabled;
+            return settings.GetFeatureState(featureType) == FeatureState.Enabled;
         }
 
         internal static void EnableFeature(this SettingsHolder settings, Type featureType)
         {
-            settings.Set(featureType.FullName, FeatureState.Enabled);
+            settings.SetFeatureState(featureType, FeatureState.Enabled);
         }
 
         internal static void DisableFeature(this SettingsHolder settings, Type featureType)
         {
-            settings.Set(featureType.FullName, FeatureState.Disabled);
+            settings.SetFeatureState(featureType, FeatureState.Disabled);
         }
 
         internal static void MarkFeatureAsActive(this SettingsHolder settings, Type featureType)
         {
-            settings.Set(featureType.FullName, FeatureState.Active);
+            settings.SetFeatureState(featureType, FeatureState.Active);
         }
 
         internal static void MarkFeatureAsDeactivated(this SettingsHolder settings, Type featureType)
         {
-            settings.Set(featureType.FullName, FeatureState.Deactivated);
+            settings.SetFeatureState(featureType, FeatureState.Deactivated);
+        }
+
+        static void SetFeatureState(this SettingsHolder settings, Type featureType, FeatureState state)
+        {
+            settings.Set(FeatureStateKey + featureType.FullName, state);
+        }
+
+        static FeatureState GetFeatureState(this ReadOnlySettings settings, Type featureType)
+        {
+            return settings.GetOrDefault<FeatureState>(FeatureStateKey + featureType.FullName);
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -5,7 +5,6 @@
     using System.Linq;
     using System.Threading.Tasks;
     using Logging;
-    using Routing.MessageDrivenSubscriptions;
     using Transport;
     using Unicast;
 
@@ -17,6 +16,7 @@
         internal AutoSubscribe()
         {
             EnableByDefault();
+            DependsOn<RoutingFeature>();
             Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"), "Send only endpoints can't autosubscribe.");
         }
 
@@ -35,7 +35,7 @@
             var conventions = context.Settings.Get<Conventions>();
             var transportInfrastructure = context.Settings.Get<TransportInfrastructure>();
             var requireExplicitRouting = transportInfrastructure.OutboundRoutingPolicy.Publishes == OutboundRoutingType.Unicast;
-            var publishers = context.Settings.Get<Publishers>();
+            var publishers = context.Settings.Get<RoutingFeature>().Publishers;
 
             context.RegisterStartupTask(b =>
             {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -2,8 +2,6 @@ namespace NServiceBus.Features
 {
     using System;
     using Persistence;
-    using Routing;
-    using Routing.MessageDrivenSubscriptions;
     using Transport;
     using Unicast.Messages;
     using Unicast.Subscriptions.MessageDrivenSubscriptions;
@@ -40,9 +38,9 @@ namespace NServiceBus.Features
             var conventions = context.Settings.Get<Conventions>();
             var enforceBestPractices = context.Settings.Get<bool>(RoutingFeature.EnforceBestPracticesSettingsKey);
 
-            var distributionPolicy = context.Settings.Get<DistributionPolicy>();
-            var endpointInstances = context.Settings.Get<EndpointInstances>();
-            var publishers = context.Settings.Get<Publishers>();
+            var distributionPolicy = context.Settings.Get<RoutingFeature>().DistributionPolicy;
+            var endpointInstances = context.Settings.Get<RoutingFeature>().Instances;
+            var publishers = context.Settings.Get<RoutingFeature>().Publishers;
             var configuredPublishers = context.Settings.Get<ConfiguredPublishers>();
 
             configuredPublishers.Apply(publishers, conventions, enforceBestPractices);

--- a/src/NServiceBus.Core/Routing/RoutingFeature.cs
+++ b/src/NServiceBus.Core/Routing/RoutingFeature.cs
@@ -7,36 +7,36 @@
 
     class RoutingFeature : Feature
     {
-        public const string EnforceBestPracticesSettingsKey = "NServiceBus.Routing.EnforceBestPractices";
-
         public RoutingFeature()
         {
             EnableByDefault();
             Defaults(s =>
             {
-                s.SetDefault<UnicastRoutingTable>(new UnicastRoutingTable());
                 s.SetDefault<ConfiguredUnicastRoutes>(new ConfiguredUnicastRoutes());
-
-                s.SetDefault<EndpointInstances>(new EndpointInstances());
-                s.SetDefault<DistributionPolicy>(new DistributionPolicy());
-
                 s.SetDefault(EnforceBestPracticesSettingsKey, true);
-
-                s.SetDefault<Publishers>(new Publishers()); // required to initialize MessageEndpointMappings.
+                s.Set<RoutingFeature>(this);
             });
         }
 
+        // it's no longer possible to directly access UnicastRoutingTable/Publishers from the settings -> only via feature (with a dependency on routing)
+        // requires the RoutingFeature to be public to get access to these properties which were accessible via settings before
+        public UnicastRoutingTable RoutingTable { get; private set; }
+        public EndpointInstances Instances { get; private set; }
+        public DistributionPolicy DistributionPolicy { get; private set; }
+        public Publishers Publishers { get; private set; }
+
         protected internal override void Setup(FeatureConfigurationContext context)
         {
+            RoutingTable = new UnicastRoutingTable();
+            Instances = new EndpointInstances();
+            DistributionPolicy = context.Settings.GetOrDefault<DistributionPolicy>() ?? new DistributionPolicy();
+            Publishers = new Publishers();
+
             var canReceive = !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly");
             var transportInfrastructure = context.Settings.Get<TransportInfrastructure>();
             var conventions = context.Settings.Get<Conventions>();
             var unicastBusConfig = context.Settings.GetConfigSection<UnicastBusConfig>();
 
-            var unicastRoutingTable = context.Settings.Get<UnicastRoutingTable>();
-            var endpointInstances = context.Settings.Get<EndpointInstances>();
-            var publishers = context.Settings.Get<Publishers>();
-            var distributionPolicy = context.Settings.Get<DistributionPolicy>();
             var configuredUnicastRoutes = context.Settings.Get<ConfiguredUnicastRoutes>();
 
             if (context.Settings.Get<bool>(EnforceBestPracticesSettingsKey))
@@ -44,13 +44,13 @@
                 EnableBestPracticeEnforcement(context);
             }
 
-            unicastBusConfig?.MessageEndpointMappings.Apply(publishers, unicastRoutingTable, transportInfrastructure.MakeCanonicalForm, conventions);
-            configuredUnicastRoutes.Apply(unicastRoutingTable, conventions);
+            unicastBusConfig?.MessageEndpointMappings.Apply(Publishers, RoutingTable, transportInfrastructure.MakeCanonicalForm, conventions);
+            configuredUnicastRoutes.Apply(RoutingTable, conventions);
 
             context.Pipeline.Register(b =>
             {
-                var unicastSendRouter = new UnicastSendRouter(unicastRoutingTable, endpointInstances, i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)));
-                return new UnicastSendRouterConnector(context.Settings.LocalAddress(), context.Settings.InstanceSpecificQueue(), unicastSendRouter, distributionPolicy, i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)));
+                var unicastSendRouter = new UnicastSendRouter(RoutingTable, Instances, i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)));
+                return new UnicastSendRouterConnector(context.Settings.LocalAddress(), context.Settings.InstanceSpecificQueue(), unicastSendRouter, DistributionPolicy, i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)));
             }, "Determines how the message being sent should be routed");
 
             context.Pipeline.Register(new UnicastReplyRouterConnector(), "Determines how replies should be routed");
@@ -92,5 +92,7 @@
                 new EnforceUnsubscribeBestPracticesBehavior(validations),
                 "Enforces unsubscribe messaging best practices");
         }
+
+        public const string EnforceBestPracticesSettingsKey = "NServiceBus.Routing.EnforceBestPractices";
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/InstanceMapping/InstanceMappingFileFeature.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/InstanceMapping/InstanceMappingFileFeature.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.Features
 {
     using System;
     using System.IO;
-    using Routing;
 
     class InstanceMappingFileFeature : Feature
     {
@@ -27,7 +26,7 @@ namespace NServiceBus.Features
             }
 
             var checkInterval = context.Settings.Get<TimeSpan>(CheckIntervalSettingsKey);
-            var endpointInstances = context.Settings.Get<EndpointInstances>();
+            var endpointInstances = context.Settings.Get<RoutingFeature>().Instances;
 
             var instanceMappingTable = new InstanceMappingFileMonitor(filePath, checkInterval, new AsyncTimer(), new InstanceMappingFileAccess(), endpointInstances);
             instanceMappingTable.ReloadData();


### PR DESCRIPTION
Instead of exposing components setup by a feature via the context bag, features could expose these as properties which makes the dependencies more explicit and reduces the usage of the context bag.

When using a component from a feature, it's easy to identify this as a dependency and add the required `DependsOn` on the feature to ensure proper setup sequence.

Downsides:
requires all features which expose publicly available components (e.g. `Publishers` `RoutingTable` etc.) to be public in order to retrieve them and to define the dependency. The risk is, that those feature can also be passed to `DisableFeature`. But also, this seems to be something we could detect (e.g. by having a `CoreFeature` base class which can't be disabled by the user).
components currently exposed and accessible via settings ("advanced routing api") is only configurable via a feature. I don't really see this as a downside as we haven't been able to come up with a proper "advanced API". Requiring a feature doesn't seem to be that bad in this case as it again, it requires an explicit statement of dependencies.

@Particular/nservicebus-maintainers thoughts?