### PR TITLE
Adding acceptance tests for unsubscribe

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -74,7 +74,9 @@
     <Compile Include="Recoverability\When_message_is_moved_to_error_queue_with_header_customizations.cs" />
     <Compile Include="MessageDrivenPubSubRoutingExtensions.cs" />
     <Compile Include="Core\Routing\AutomaticSubscriptions\When_handling_local_event.cs" />
+    <Compile Include="Routing\MessageDrivenSubscriptions\When_unsubscribing_from_event.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_unsubscribing_to_scaled_out_publisher.cs" />
+    <Compile Include="Routing\NativePublishSubscribe\When_unsubscribing_from_event.cs" />
     <Compile Include="Routing\When_configure_routes_for_unobtrusive_messages.cs" />
     <Compile Include="Routing\When_extending_command_routing.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_extending_event_routing.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_unsubscribing_from_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_unsubscribing_from_event.cs
@@ -1,0 +1,146 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing.MessageDrivenSubscriptions
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_unsubscribing_from_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task ShouldNoLongerReceiveEvent()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(c => c
+                    .When(
+                        ctx => ctx.Subscriber1Subscribed && ctx.Subscriber2Subscribed,
+                        s => s.Publish(new Event()))
+                    .When(
+                        ctx => ctx.Subscriber2Unsubscribed,
+                        async s =>
+                        {
+                            await s.Publish(new Event());
+                            await s.Publish(new Event());
+                            await s.Publish(new Event());
+
+                        }))
+                .WithEndpoint<Subscriber1>(c => c
+                    .When(s => s.Subscribe<Event>()))
+                .WithEndpoint<Subscriber2>(c => c
+                    .When(s => s.Subscribe<Event>())
+                    .When(
+                        ctx => ctx.Subscriber2ReceivedMessages >= 1,
+                        s => s.Unsubscribe<Event>()))
+                .Done(c => c.Subscriber1ReceivedMessages >= 4)
+                .Repeat(r => r.For<AllTransportsWithMessageDrivenPubSub>())
+                .Should(c =>
+                {
+                    Assert.AreEqual(4, c.Subscriber1ReceivedMessages);
+                    Assert.AreEqual(1, c.Subscriber2ReceivedMessages);
+                    Assert.IsTrue(c.Subscriber2Unsubscribed);
+                })
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscriber1Subscribed { get; set; }
+            public bool Subscriber2Subscribed { get; set; }
+            public bool Subscriber2Unsubscribed { get; set; }
+            public int Subscriber1ReceivedMessages { get; set; }
+            public int Subscriber2ReceivedMessages { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.OnEndpointSubscribed<Context>((args, ctx) =>
+                    {
+                        if (args.SubscriberReturnAddress.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber1))))
+                        {
+                            ctx.Subscriber1Subscribed = true;
+                        }
+
+                        if (args.SubscriberReturnAddress.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber2))))
+                        {
+                            ctx.Subscriber2Subscribed = true;
+                        }
+                    });
+                    c.OnEndpointUnsubscribed<Context>((args, ctx) =>
+                    {
+                        if (args.SubscriberReturnAddress.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber2))))
+                        {
+                            ctx.Subscriber2Unsubscribed = true;
+                        }
+                    });
+                });
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.DisableFeature<AutoSubscribe>();
+                    c.MessageDrivenPubSubRouting().RegisterPublisher(typeof(Event), Conventions.EndpointNamingConvention(typeof(Publisher)));
+                });
+            }
+
+            public class EventHandler : IHandleMessages<Event>
+            {
+                Context testContext;
+
+                public EventHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(Event message, IMessageHandlerContext context)
+                {
+                    testContext.Subscriber1ReceivedMessages++;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Subscriber2 : EndpointConfigurationBuilder
+        {
+            public Subscriber2()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.DisableFeature<AutoSubscribe>();
+                    c.MessageDrivenPubSubRouting().RegisterPublisher(typeof(Event), Conventions.EndpointNamingConvention(typeof(Publisher)));
+                });
+            }
+
+            public class EventHandler : IHandleMessages<Event>
+            {
+                Context testContext;
+
+                public EventHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(Event message, IMessageHandlerContext context)
+                {
+                    testContext.Subscriber2ReceivedMessages++;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Event : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_unsubscribing_from_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_unsubscribing_from_event.cs
@@ -11,9 +11,9 @@
     public class When_unsubscribing_from_event : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task ShouldNoLongerReceiveEvent()
+        public Task ShouldNoLongerReceiveEvent()
         {
-            await Scenario.Define<Context>()
+            return Scenario.Define<Context>()
                 .WithEndpoint<Publisher>(c => c
                     .When(
                         ctx => ctx.Subscriber1Subscribed && ctx.Subscriber2Subscribed,
@@ -25,7 +25,6 @@
                             await s.Publish(new Event());
                             await s.Publish(new Event());
                             await s.Publish(new Event());
-
                         }))
                 .WithEndpoint<Subscriber1>(c => c
                     .When(s => s.Subscribe<Event>()))
@@ -87,17 +86,12 @@
         {
             public Subscriber1()
             {
-                EndpointSetup<DefaultServer>(c =>
-                {
-                    c.DisableFeature<AutoSubscribe>();
-                    c.MessageDrivenPubSubRouting().RegisterPublisher(typeof(Event), Conventions.EndpointNamingConvention(typeof(Publisher)));
-                });
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(),
+                    metadata => metadata.RegisterPublisherFor<Event>(typeof(Publisher)));
             }
 
             public class EventHandler : IHandleMessages<Event>
             {
-                Context testContext;
-
                 public EventHandler(Context testContext)
                 {
                     this.testContext = testContext;
@@ -108,6 +102,8 @@
                     testContext.Subscriber1ReceivedMessages++;
                     return Task.FromResult(0);
                 }
+
+                Context testContext;
             }
         }
 
@@ -115,17 +111,12 @@
         {
             public Subscriber2()
             {
-                EndpointSetup<DefaultServer>(c =>
-                {
-                    c.DisableFeature<AutoSubscribe>();
-                    c.MessageDrivenPubSubRouting().RegisterPublisher(typeof(Event), Conventions.EndpointNamingConvention(typeof(Publisher)));
-                });
+                EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(),
+                    metadata => metadata.RegisterPublisherFor<Event>(typeof(Publisher)));
             }
 
             public class EventHandler : IHandleMessages<Event>
             {
-                Context testContext;
-
                 public EventHandler(Context testContext)
                 {
                     this.testContext = testContext;
@@ -136,6 +127,8 @@
                     testContext.Subscriber2ReceivedMessages++;
                     return Task.FromResult(0);
                 }
+
+                Context testContext;
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_unsubscribing_from_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_unsubscribing_from_event.cs
@@ -1,0 +1,134 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing.NativePublishSubscribe
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+    using ScenarioDescriptors;
+
+    public class When_unsubscribing_from_event : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task ShouldNoLongerReceiveEvent()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(c => c
+                    .When(
+                        ctx => ctx.Subscriber1Subscribed && ctx.Subscriber2Subscribed,
+                        s => s.Publish(new Event()))
+                    .When(
+                        ctx => ctx.Subscriber2Unsubscribed,
+                        async s =>
+                        {
+                            await s.Publish(new Event());
+                            await s.Publish(new Event());
+                            await s.Publish(new Event());
+
+                        }))
+                .WithEndpoint<Subscriber1>(c => c
+                    .When(async (s, ctx) =>
+                    {
+                        await s.Subscribe<Event>();
+                        ctx.Subscriber1Subscribed = true;
+                    }))
+                .WithEndpoint<Subscriber2>(c => c
+                    .When(async (s, ctx) =>
+                    {
+                        await s.Subscribe<Event>();
+                        ctx.Subscriber2Subscribed = true;
+                    })
+                    .When(
+                        ctx => ctx.Subscriber2ReceivedMessages >= 1,
+                        async (s, ctx) =>
+                        {
+                            await s.Unsubscribe<Event>();
+                            ctx.Subscriber2Unsubscribed = true;
+                        }))
+                .Done(c => c.Subscriber1ReceivedMessages >= 4)
+                .Repeat(r => r.For<AllTransportsWithCentralizedPubSubSupport>())
+                .Should(c =>
+                {
+                    Assert.AreEqual(4, c.Subscriber1ReceivedMessages);
+                    Assert.AreEqual(1, c.Subscriber2ReceivedMessages);
+                    Assert.IsTrue(c.Subscriber2Unsubscribed);
+                })
+                .Run();
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Subscriber1Subscribed { get; set; }
+            public bool Subscriber2Subscribed { get; set; }
+            public bool Subscriber2Unsubscribed { get; set; }
+            public int Subscriber1ReceivedMessages { get; set; }
+            public int Subscriber2ReceivedMessages { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class Subscriber1 : EndpointConfigurationBuilder
+        {
+            public Subscriber1()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.DisableFeature<AutoSubscribe>();
+                });
+            }
+
+            public class EventHandler : IHandleMessages<Event>
+            {
+                Context testContext;
+
+                public EventHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(Event message, IMessageHandlerContext context)
+                {
+                    testContext.Subscriber1ReceivedMessages++;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Subscriber2 : EndpointConfigurationBuilder
+        {
+            public Subscriber2()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.DisableFeature<AutoSubscribe>();
+                });
+            }
+
+            public class EventHandler : IHandleMessages<Event>
+            {
+                Context testContext;
+
+                public EventHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(Event message, IMessageHandlerContext context)
+                {
+                    testContext.Subscriber2ReceivedMessages++;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class Event : IEvent
+        {
+        }
+    }
+}


### PR DESCRIPTION
relates to https://github.com/Particular/NServiceBus/issues/4254

Adds tests to verify unsubscribing from an event works as there were no tests for this behavior yet. There is a test for message driven subscriptions and one for native pubsub.

The native test hasn't been tested with a native pubsub transport yet.

/cc @SeanFeldman 