### PR TITLE
Don't change MSMQ permissions on existing queues

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_dispatch_fails_on_removal_SendsAtomicWithReceive.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_dispatch_fails_on_removal_SendsAtomicWithReceive.cs
@@ -11,7 +11,7 @@
     using NUnit.Framework;
     using Timeout.Core;
 
-    class When_timeout_dispatch_fails_on_timeout_removal_using_sendsAtomicWithReceive : NServiceBusAcceptanceTest
+    class When_dispatch_fails_on_removal_SendsAtomicWithReceive : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_move_control_message_to_errors_and_dispatch_original_message_to_handler()

--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_dispatch_fails_on_removal_TXScopes.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_dispatch_fails_on_removal_TXScopes.cs
@@ -13,7 +13,7 @@
     using Timeout.Core;
     using Conventions = AcceptanceTesting.Customization.Conventions;
 
-    public class When_timeout_dispatch_fails_on_timeout_removal_using_dtc : NServiceBusAcceptanceTest
+    public class When_dispatch_fails_on_removal_TXScopes : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_move_control_message_to_errors_and_not_dispatch_original_message_to_handler()

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -59,7 +59,7 @@
     <Compile Include="Basic\When_extending_behavior_context.cs" />
     <Compile Include="Basic\When_receiving_unobtrusive_message_without_handler.cs" />
     <Compile Include="Config\When_multiple_configuration_providers.cs" />
-    <Compile Include="Core\DelayedDelivery\TimeoutManager\When_timeout_dispatch_fails_on_timeout_removal_using_sendsAtomicWithReceive.cs" />
+    <Compile Include="Core\DelayedDelivery\TimeoutManager\When_dispatch_fails_on_removal_SendsAtomicWithReceive.cs" />
     <Compile Include="Core\Feature\When_feature_startup_task_fails.cs" />
     <Compile Include="Core\LegacyRetries\When_legacy_retries_left_in_retry_queue.cs" />
     <Compile Include="Core\MessageDurability\When_sending_a_non_durable_message_with_conventions.cs" />
@@ -111,7 +111,7 @@
     <Compile Include="Correlation\When_replying_to_received_message_without_correlationid.cs" />
     <Compile Include="DelayedDelivery\When_deferring_a_message_to_the_past.cs" />
     <Compile Include="Core\DelayedDelivery\TimeoutManager\When_timeout_dispatch_fails.cs" />
-    <Compile Include="Core\DelayedDelivery\TimeoutManager\When_timeout_dispatch_fails_on_timeout_removal_using_dtc.cs" />
+    <Compile Include="Core\DelayedDelivery\TimeoutManager\When_dispatch_fails_on_removal_TXScopes.cs" />
     <Compile Include="Core\DelayedDelivery\TimeoutManager\When_timeout_storage_fails.cs" />
     <Compile Include="EndpointTemplates\EndpointCustomizationConfigurationExtensions.cs" />
     <Compile Include="EndpointTemplates\ServerWithNoDefaultPersistenceDefinitions.cs" />

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_message_goes_through_delayed_retries.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_message_goes_through_delayed_retries.cs
@@ -15,7 +15,7 @@
         public Task Should_invoke_the_correct_handle_methods_on_the_saga()
         {
             return Scenario.Define<Context>()
-                .WithEndpoint<TestSaga09Endpt>(b => b
+                .WithEndpoint<Saga09Endpoint>(b => b
                     .When(session => session.SendLocal(new StartSagaMessage
                     {
                         SomeId = Guid.NewGuid()
@@ -31,9 +31,9 @@
             public int NumberOfTimesInvoked { get; set; }
         }
 
-        public class TestSaga09Endpt : EndpointConfigurationBuilder
+        public class Saga09Endpoint : EndpointConfigurationBuilder
         {
-            public TestSaga09Endpt()
+            public Saga09Endpoint()
             {
                 EndpointSetup<DefaultServer>(b =>
                 {

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_message_goes_through_delayed_retries.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_message_goes_through_delayed_retries.cs
@@ -15,7 +15,7 @@
         public Task Should_invoke_the_correct_handle_methods_on_the_saga()
         {
             return Scenario.Define<Context>()
-                .WithEndpoint<Saga09Endpoint>(b => b
+                .WithEndpoint<DelayedRetryEndpoint>(b => b
                     .When(session => session.SendLocal(new StartSagaMessage
                     {
                         SomeId = Guid.NewGuid()
@@ -31,9 +31,9 @@
             public int NumberOfTimesInvoked { get; set; }
         }
 
-        public class Saga09Endpoint : EndpointConfigurationBuilder
+        public class DelayedRetryEndpoint : EndpointConfigurationBuilder
         {
-            public Saga09Endpoint()
+            public DelayedRetryEndpoint()
             {
                 EndpointSetup<DefaultServer>(b =>
                 {

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_message_goes_through_delayed_retries.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_message_goes_through_delayed_retries.cs
@@ -15,7 +15,7 @@
         public Task Should_invoke_the_correct_handle_methods_on_the_saga()
         {
             return Scenario.Define<Context>()
-                .WithEndpoint<SagaMessageThroughDelayedRetryEndpoint>(b => b
+                .WithEndpoint<Endpoint>(b => b
                     .When(session => session.SendLocal(new StartSagaMessage
                     {
                         SomeId = Guid.NewGuid()
@@ -31,9 +31,9 @@
             public int NumberOfTimesInvoked { get; set; }
         }
 
-        public class SagaMessageThroughDelayedRetryEndpoint : EndpointConfigurationBuilder
+        public class Endpoint : EndpointConfigurationBuilder
         {
-            public SagaMessageThroughDelayedRetryEndpoint()
+            public Endpoint()
             {
                 EndpointSetup<DefaultServer>(b =>
                 {

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_message_goes_through_delayed_retries.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_message_goes_through_delayed_retries.cs
@@ -15,7 +15,7 @@
         public Task Should_invoke_the_correct_handle_methods_on_the_saga()
         {
             return Scenario.Define<Context>()
-                .WithEndpoint<Endpoint>(b => b
+                .WithEndpoint<TestSaga09Endpt>(b => b
                     .When(session => session.SendLocal(new StartSagaMessage
                     {
                         SomeId = Guid.NewGuid()
@@ -31,9 +31,9 @@
             public int NumberOfTimesInvoked { get; set; }
         }
 
-        public class Endpoint : EndpointConfigurationBuilder
+        public class TestSaga09Endpt : EndpointConfigurationBuilder
         {
-            public Endpoint()
+            public TestSaga09Endpt()
             {
                 EndpointSetup<DefaultServer>(b =>
                 {

--- a/src/NServiceBus.AcceptanceTests/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
@@ -14,7 +14,7 @@
         public Task Endpoint_should_start()
         {
             return Scenario.Define<TimeoutTestContext>()
-                .WithEndpoint<EndpointWithFlakyTimeoutPersister>()
+                .WithEndpoint<Endpoint>()
                 .Done(c => c.EndpointsStarted)
                 .Repeat(r => r.For<AllTransportsWithoutNativeDeferral>())
                 .Should(c => Assert.IsTrue(c.EndpointsStarted))
@@ -28,7 +28,7 @@
 
             var testContext =
                 await Scenario.Define<TimeoutTestContext>(c => { c.SecondsToWait = 10; })
-                    .WithEndpoint<EndpointWithFlakyTimeoutPersister>(b =>
+                    .WithEndpoint<Endpoint>(b =>
                     {
                         b.CustomConfig((busConfig, context) =>
                         {
@@ -51,14 +51,13 @@
             public bool FatalErrorOccurred { get; set; }
         }
 
-        
         public class MyMessage : IMessage
         {
         }
 
-        public class EndpointWithFlakyTimeoutPersister : EndpointConfigurationBuilder
+        public class Endpoint : EndpointConfigurationBuilder
         {
-            public EndpointWithFlakyTimeoutPersister()
+            public Endpoint()
             {
                 EndpointSetup<DefaultServer>(config => { config.EnableFeature<TimeoutManager>(); });
             }

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
@@ -179,7 +179,7 @@
         {
             var testQueueName = "MsmqQueueCreatorTests.tolong." + Guid.NewGuid().ToString().Replace("-", "");
 
-            var maxQueueNameForSetPermissionToWork = 103 - Environment.MachineName.Length;
+            var maxQueueNameForSetPermissionToWork = 102 - Environment.MachineName.Length;
 
             testQueueName += new string('a', maxQueueNameForSetPermissionToWork - testQueueName.Length + 1);
 

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
@@ -154,10 +154,10 @@
 
             var queue = GetQueue(testQueueName);
 
-            MessageQueueAccessRights? everyoneAccessRights;
+            MessageQueueAccessRights? nullBecauseRevoked;
 
-            Assert.False(queue.TryGetPermissions(LocalEveryoneGroupName, out everyoneAccessRights));
-            Assert.False(queue.TryGetPermissions(LocalAnonymousLogonName, out everyoneAccessRights));
+            Assert.False(queue.TryGetPermissions(LocalEveryoneGroupName, out nullBecauseRevoked));
+            Assert.False(queue.TryGetPermissions(LocalAnonymousLogonName, out nullBecauseRevoked));
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
@@ -22,12 +22,14 @@
             bindings.BindReceiving("MsmqQueueCreatorTests.receiver");
             bindings.BindSending("MsmqQueueCreatorTests.target1");
             bindings.BindSending("MsmqQueueCreatorTests.target2");
+            bindings.BindSending("MsmqQueueCreatorTests.target3@remote");
 
             creator.CreateQueueIfNecessary(bindings, WindowsIdentity.GetCurrent().Name);
 
             Assert.True(QueueExists("MsmqQueueCreatorTests.receiver"));
             Assert.True(QueueExists("MsmqQueueCreatorTests.target1"));
-            Assert.True(QueueExists("MsmqQueueCreatorTests.target1"));
+            Assert.True(QueueExists("MsmqQueueCreatorTests.target2"));
+            Assert.False(QueueExists("MsmqQueueCreatorTests.target3"));
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
@@ -11,9 +11,7 @@
         [Test]
         public void Should_create_all_queues()
         {
-            var settings = new MsmqSettings();
-
-            var creator = new QueueCreator(settings);
+            var creator = new QueueCreator(true);
             var bindings = new QueueBindings();
 
             DeleteQueueIfPresent("MsmqQueueCreatorTests.receiver");
@@ -35,9 +33,8 @@
         public void Should_setup_permissions()
         {
             var testQueueName = "MsmqQueueCreatorTests.permissions";
-            var settings = new MsmqSettings();
 
-            var creator = new QueueCreator(settings);
+            var creator = new QueueCreator(true);
             var bindings = new QueueBindings();
 
             DeleteQueueIfPresent(testQueueName);

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
@@ -185,23 +185,6 @@
             Assert.Throws<ArgumentNullException>(() => creator.CreateQueueIfNecessary(bindings, WindowsIdentity.GetCurrent().Name));
         }
 
-        [Test]
-        public void Verify_msmq_permissions_and_delete_has_lower_lenght_limit_compared_to_queue_name()
-        {
-            //increase to 50 and create will work but SetPermission and Delete will blow up
-            var testQueueName = "MsmqQueueCreatorTests." + Guid.NewGuid().ToString().Replace("-", "") + new string('a', 49 - Environment.MachineName.Length);
-            var path = MsmqAddress.Parse(testQueueName).PathWithoutPrefix;
-
-            Console.Out.WriteLine("Length: " + path.Length);
-
-            using (var existingQueue = MessageQueue.Create(path))
-            {
-                existingQueue.SetPermissions(LocalEveryoneGroupName, MessageQueueAccessRights.GenericWrite, AccessControlEntryType.Revoke);
-            }
-
-            MessageQueue.Delete(path);
-        }
-
         MessageQueue GetQueue(string queueName)
         {
             var path = MsmqAddress.Parse(queueName).PathWithoutPrefix;

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
@@ -59,6 +59,48 @@
             Assert.AreEqual(MessageQueueAccessRights.FullControl, localAdminAccessRights, "LocalAdmins should have full control");
         }
 
+        [Test]
+        public void Should_make_queues_transactional_if_requested()
+        {
+            const bool isTransactional = true;
+
+            var testQueueName = "MsmqQueueCreatorTests.txreceiver";
+
+            DeleteQueueIfPresent(testQueueName);
+
+            var creator = new QueueCreator(isTransactional);
+            var bindings = new QueueBindings();
+
+            bindings.BindReceiving(testQueueName);
+
+            creator.CreateQueueIfNecessary(bindings, WindowsIdentity.GetCurrent().Name);
+
+            var queue = GetQueue(testQueueName);
+
+            Assert.AreEqual(isTransactional, queue.Transactional);
+        }
+
+        [Test]
+        public void Should_make_queues_non_transactional_if_requested()
+        {
+            const bool isTransactional = false;
+
+            var testQueueName = "MsmqQueueCreatorTests.txreceiver";
+
+            DeleteQueueIfPresent(testQueueName);
+
+            var creator = new QueueCreator(isTransactional);
+            var bindings = new QueueBindings();
+
+            bindings.BindReceiving(testQueueName);
+
+            creator.CreateQueueIfNecessary(bindings, WindowsIdentity.GetCurrent().Name);
+
+            var queue = GetQueue(testQueueName);
+
+            Assert.AreEqual(isTransactional, queue.Transactional);
+        }
+
         MessageQueue GetQueue(string queueName)
         {
             var path = MsmqAddress.Parse(queueName).PathWithoutPrefix;

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Core.Tests.Msmq
 {
+    using System;
     using System.Messaging;
     using System.Security.Principal;
     using NUnit.Framework;
@@ -157,6 +158,17 @@
 
             Assert.False(queue.TryGetPermissions(LocalEveryoneGroupName, out everyoneAccessRights));
             Assert.False(queue.TryGetPermissions(LocalAnonymousLogonName, out everyoneAccessRights));
+        }
+
+        [Test]
+        public void Should_blow_up_if_name_is_null()
+        {
+            var creator = new QueueCreator(true);
+            var bindings = new QueueBindings();
+
+            bindings.BindReceiving(null);
+
+            Assert.Throws<ArgumentNullException>(() => creator.CreateQueueIfNecessary(bindings, WindowsIdentity.GetCurrent().Name));
         }
 
         MessageQueue GetQueue(string queueName)

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
@@ -22,15 +22,27 @@
             bindings.BindReceiving("MsmqQueueCreatorTests.receiver");
             bindings.BindSending("MsmqQueueCreatorTests.target1");
             bindings.BindSending("MsmqQueueCreatorTests.target2");
-            bindings.BindSending("MsmqQueueCreatorTests.target3@remote");
 
             creator.CreateQueueIfNecessary(bindings, WindowsIdentity.GetCurrent().Name);
 
             Assert.True(QueueExists("MsmqQueueCreatorTests.receiver"));
             Assert.True(QueueExists("MsmqQueueCreatorTests.target1"));
             Assert.True(QueueExists("MsmqQueueCreatorTests.target2"));
+        }
+
+        [Test]
+        public void Should_not_create_remote_queues()
+        {
+            var creator = new QueueCreator(true);
+            var bindings = new QueueBindings();
+
+            bindings.BindSending("MsmqQueueCreatorTests.target3@remote");
+
+            creator.CreateQueueIfNecessary(bindings, WindowsIdentity.GetCurrent().Name);
+
             Assert.False(QueueExists("MsmqQueueCreatorTests.target3"));
         }
+
 
         [Test]
         public void Should_setup_permissions()
@@ -177,7 +189,7 @@
         public void Verify_msmq_permissions_and_delete_has_lower_lenght_limit_compared_to_queue_name()
         {
             //increase to 50 and create will work but SetPermission and Delete will blow up
-            var testQueueName = "MsmqQueueCreatorTests." + Guid.NewGuid().ToString().Replace("-","") + new string('a', 49 - Environment.MachineName.Length);
+            var testQueueName = "MsmqQueueCreatorTests." + Guid.NewGuid().ToString().Replace("-", "") + new string('a', 49 - Environment.MachineName.Length);
             var path = MsmqAddress.Parse(testQueueName).PathWithoutPrefix;
 
             Console.Out.WriteLine("Length: " + path.Length);

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
@@ -12,7 +12,7 @@
         [Test]
         public void Should_create_all_queues()
         {
-            var creator = new QueueCreator(true);
+            var creator = new MsmqQueueCreator(true);
             var bindings = new QueueBindings();
 
             DeleteQueueIfPresent("MsmqQueueCreatorTests.receiver");
@@ -33,7 +33,7 @@
         [Test]
         public void Should_not_create_remote_queues()
         {
-            var creator = new QueueCreator(true);
+            var creator = new MsmqQueueCreator(true);
             var bindings = new QueueBindings();
             var remoteQueueName = "MsmqQueueCreatorTests.remote";
 
@@ -50,7 +50,7 @@
         {
             var testQueueName = "MsmqQueueCreatorTests.permissions";
 
-            var creator = new QueueCreator(true);
+            var creator = new MsmqQueueCreator(true);
             var bindings = new QueueBindings();
 
             DeleteQueueIfPresent(testQueueName);
@@ -82,7 +82,7 @@
 
             DeleteQueueIfPresent(testQueueName);
 
-            var creator = new QueueCreator(useTransactionalQueues: true);
+            var creator = new MsmqQueueCreator(useTransactionalQueues: true);
             var bindings = new QueueBindings();
 
             bindings.BindReceiving(testQueueName);
@@ -101,7 +101,7 @@
 
             DeleteQueueIfPresent(testQueueName);
 
-            var creator = new QueueCreator(useTransactionalQueues: false);
+            var creator = new MsmqQueueCreator(useTransactionalQueues: false);
             var bindings = new QueueBindings();
 
             bindings.BindReceiving(testQueueName);
@@ -155,7 +155,7 @@
                 existingQueue.SetPermissions(LocalAnonymousLogonName, MessageQueueAccessRights.WriteMessage, AccessControlEntryType.Revoke);
             }
 
-            var creator = new QueueCreator(true);
+            var creator = new MsmqQueueCreator(true);
             var bindings = new QueueBindings();
 
             bindings.BindReceiving(testQueueName);
@@ -182,7 +182,7 @@
 
             DeleteQueueIfPresent(testQueueName);
 
-            var creator = new QueueCreator(true);
+            var creator = new MsmqQueueCreator(true);
             var bindings = new QueueBindings();
 
             bindings.BindReceiving(testQueueName);
@@ -197,7 +197,7 @@
 
             DeleteQueueIfPresent(testQueueName);
 
-            var creator = new QueueCreator(true);
+            var creator = new MsmqQueueCreator(true);
             var bindings = new QueueBindings();
 
             bindings.BindReceiving(testQueueName);
@@ -210,7 +210,7 @@
         [Test]
         public void Should_blow_up_if_name_is_null()
         {
-            var creator = new QueueCreator(true);
+            var creator = new MsmqQueueCreator(true);
             var bindings = new QueueBindings();
 
             bindings.BindReceiving(null);

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus.Core.Tests.Msmq
+{
+    using System.Messaging;
+    using System.Security.Principal;
+    using NUnit.Framework;
+    using Transport;
+
+    [TestFixture]
+    public class MsmqQueueCreatorTests
+    {
+        [Test]
+        public void Should_create_all_queues()
+        {
+            var settings = new MsmqSettings();
+
+            var creator = new QueueCreator(settings);
+            var bindings = new QueueBindings();
+
+            DeleteQueueIfPresent("MsmqQueueCreatorTests.receiver");
+            DeleteQueueIfPresent("MsmqQueueCreatorTests.endpoint1");
+            DeleteQueueIfPresent("MsmqQueueCreatorTests.endpoint2");
+
+            bindings.BindReceiving("MsmqQueueCreatorTests.receiver");
+            bindings.BindSending("MsmqQueueCreatorTests.target1");
+            bindings.BindSending("MsmqQueueCreatorTests.target2");
+
+            creator.CreateQueueIfNecessary(bindings, WindowsIdentity.GetCurrent().Name);
+
+            Assert.True(QueueExists("MsmqQueueCreatorTests.receiver"));
+            Assert.True(QueueExists("MsmqQueueCreatorTests.target1"));
+            Assert.True(QueueExists("MsmqQueueCreatorTests.target1"));
+        }
+
+        [Test]
+        public void Should_setup_permissions()
+        {
+            var testQueueName = "MsmqQueueCreatorTests.permissions";
+            var settings = new MsmqSettings();
+
+            var creator = new QueueCreator(settings);
+            var bindings = new QueueBindings();
+
+            DeleteQueueIfPresent(testQueueName);
+
+            bindings.BindReceiving(testQueueName);
+
+            // use the network service account since that one won't be in the local admin group
+            creator.CreateQueueIfNecessary(bindings, NetworkServiceAccountName);
+
+            var createdQueue = GetQueue(testQueueName);
+
+            MessageQueueAccessRights? accountAccessRights;
+
+            Assert.True(createdQueue.TryGetPermissions(NetworkServiceAccountName, out accountAccessRights));
+            Assert.True(accountAccessRights.HasValue, "User should have access rights");
+            Assert.AreEqual(MessageQueueAccessRights.WriteMessage | MessageQueueAccessRights.ReceiveMessage, accountAccessRights, "User should have write/read access");
+
+            MessageQueueAccessRights? localAdminAccessRights;
+
+            Assert.True(createdQueue.TryGetPermissions(LocalAdministratorsGroupName, out localAdminAccessRights));
+            Assert.True(localAdminAccessRights.HasValue, "User should have access rights");
+            Assert.AreEqual(MessageQueueAccessRights.FullControl, localAdminAccessRights, "LocalAdmins should have full control");
+        }
+
+        MessageQueue GetQueue(string queueName)
+        {
+            var path = MsmqAddress.Parse(queueName).PathWithoutPrefix;
+
+            return new MessageQueue(path);
+        }
+
+        bool QueueExists(string queueName)
+        {
+            var path = MsmqAddress.Parse(queueName).PathWithoutPrefix;
+
+            return MessageQueue.Exists(path);
+        }
+
+        void DeleteQueueIfPresent(string queueName)
+        {
+            var path = MsmqAddress.Parse(queueName).PathWithoutPrefix;
+
+            if (!MessageQueue.Exists(path))
+            {
+                return;
+            }
+
+            MessageQueue.Delete(path);
+        }
+
+        static string NetworkServiceAccountName = new SecurityIdentifier(WellKnownSidType.NetworkServiceSid, null).Translate(typeof(NTAccount)).ToString();
+        static string LocalAdministratorsGroupName = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null).Translate(typeof(NTAccount)).ToString();
+    }
+}

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
@@ -82,7 +82,7 @@
 
             DeleteQueueIfPresent(testQueueName);
 
-            var creator = new MsmqQueueCreator(useTransactionalQueues: true);
+            var creator = new MsmqQueueCreator(true);
             var bindings = new QueueBindings();
 
             bindings.BindReceiving(testQueueName);
@@ -101,7 +101,7 @@
 
             DeleteQueueIfPresent(testQueueName);
 
-            var creator = new MsmqQueueCreator(useTransactionalQueues: false);
+            var creator = new MsmqQueueCreator(false);
             var bindings = new QueueBindings();
 
             bindings.BindReceiving(testQueueName);

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -136,6 +136,7 @@
     <Compile Include="MessageMapper\MessageMapperTests.cs" />
     <Compile Include="Msmq\MsmqMessagePumpTests.cs" />
     <Compile Include="Msmq\MsmqSubscriptionStorageIntegrationTests.cs" />
+    <Compile Include="Msmq\MsmqQueueCreatorTests.cs" />
     <Compile Include="Msmq\TimeToBeReceivedOverrideCheckerTest.cs" />
     <Compile Include="Msmq\MsmqExtensionsTests.cs" />
     <Compile Include="Msmq\MsmqHelpers.cs" />

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -674,7 +674,7 @@
     <Compile Include="Transports\Msmq\HeaderInfo.cs" />
     <Compile Include="Transports\Msmq\MessagePump.cs" />
     <Compile Include="Transports\Msmq\MsmqMessageDispatcher.cs" />
-    <Compile Include="Transports\Msmq\QueueCreator.cs" />
+    <Compile Include="Transports\Msmq\MsmqQueueCreator.cs" />
     <Compile Include="Transports\Msmq\MsmqUtilities.cs" />
     <Compile Include="Encryption\RijndaelEncryptionServiceConfig.cs" />
     <Compile Include="Unicast\UnicastBusConfig.cs" />

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqQueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqQueueCreator.cs
@@ -6,9 +6,9 @@ namespace NServiceBus
     using Logging;
     using Transport;
 
-    class QueueCreator : ICreateQueues
+    class MsmqQueueCreator : ICreateQueues
     {
-        public QueueCreator(bool useTransactionalQueues)
+        public MsmqQueueCreator(bool useTransactionalQueues)
         {
             this.useTransactionalQueues = useTransactionalQueues;
         }
@@ -83,6 +83,6 @@ namespace NServiceBus
         bool useTransactionalQueues;
 
         static string LocalAdministratorsGroupName = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null).Translate(typeof(NTAccount)).ToString();
-        static ILog Logger = LogManager.GetLogger<QueueCreator>();
+        static ILog Logger = LogManager.GetLogger<MsmqQueueCreator>();
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqQueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqQueueCreator.cs
@@ -61,11 +61,6 @@ namespace NServiceBus
                         queue.SetPermissions(identity, MessageQueueAccessRights.PeekMessage);
 
                         queue.SetPermissions(LocalAdministratorsGroupName, MessageQueueAccessRights.FullControl);
-
-                        // Everyone & Anonymous is granted write message permissions on all Windows / Windows Server versions after 2003.
-                        // But we keep this for now for backwards compatibility
-                        queue.SetPermissions(QueuePermissions.LocalEveryoneGroupName, MessageQueueAccessRights.WriteMessage);
-                        queue.SetPermissions(QueuePermissions.LocalAnonymousLogonName, MessageQueueAccessRights.WriteMessage);
                     }
                     catch (MessageQueueException permissionException) when (permissionException.MessageQueueErrorCode == MessageQueueErrorCode.FormatNameBufferTooSmall)
                     {

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
@@ -93,7 +93,7 @@ namespace NServiceBus
 
             return new TransportReceiveInfrastructure(
                 () => new MessagePump(guarantee => SelectReceiveStrategy(guarantee, scopeOptions.TransactionOptions)),
-                () => new QueueCreator(msmqSettings.UseTransactionalQueues),
+                () => new MsmqQueueCreator(msmqSettings.UseTransactionalQueues),
                 () =>
                 {
                     var bindings = settings.Get<QueueBindings>();

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
@@ -11,6 +11,7 @@ namespace NServiceBus
     using Settings;
     using Support;
     using Transport;
+    using Transports.Msmq;
 
     class MsmqTransportInfrastructure : TransportInfrastructure
     {

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
@@ -11,7 +11,6 @@ namespace NServiceBus
     using Settings;
     using Support;
     using Transport;
-    using Transports.Msmq;
 
     class MsmqTransportInfrastructure : TransportInfrastructure
     {

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
@@ -93,7 +93,7 @@ namespace NServiceBus
 
             return new TransportReceiveInfrastructure(
                 () => new MessagePump(guarantee => SelectReceiveStrategy(guarantee, scopeOptions.TransactionOptions)),
-                () => new QueueCreator(msmqSettings),
+                () => new QueueCreator(msmqSettings.UseTransactionalQueues),
                 () =>
                 {
                     var bindings = settings.Get<QueueBindings>();

--- a/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus
 {
+    using System;
     using System.Messaging;
     using System.Security.Principal;
     using System.Threading.Tasks;
@@ -60,11 +61,11 @@ namespace NServiceBus
                 {
                     Logger.DebugFormat($"Created queue, path: [{queuePath}], identity: [{identity}], transactional: [{settings.UseTransactionalQueues}]");
 
-                    queue.SetPermissions(LocalAdministratorsGroupName, MessageQueueAccessRights.FullControl, AccessControlEntryType.Allow);
+                    SetPermissions(queue, LocalAdministratorsGroupName, MessageQueueAccessRights.FullControl);
 
-                    queue.SetPermissions(identity, MessageQueueAccessRights.WriteMessage, AccessControlEntryType.Allow);
-                    queue.SetPermissions(identity, MessageQueueAccessRights.ReceiveMessage, AccessControlEntryType.Allow);
-                    queue.SetPermissions(identity, MessageQueueAccessRights.PeekMessage, AccessControlEntryType.Allow);
+                    SetPermissions(queue, identity, MessageQueueAccessRights.WriteMessage);
+                    SetPermissions(queue, identity, MessageQueueAccessRights.ReceiveMessage);
+                    SetPermissions(queue, identity, MessageQueueAccessRights.PeekMessage);
                 }
             }
             catch (MessageQueueException ex)
@@ -76,6 +77,18 @@ namespace NServiceBus
                 }
 
                 throw;
+            }
+        }
+
+        static void SetPermissions(MessageQueue queue, string identity, MessageQueueAccessRights accessRights)
+        {
+            try
+            {
+                queue.SetPermissions(identity, accessRights, AccessControlEntryType.Allow);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Failed to give {identity} {accessRights} on queue {queue.QueueName}", ex);
             }
         }
 

--- a/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
@@ -40,7 +40,7 @@ namespace NServiceBus
             Logger.Debug($"Creating '{address}' if needed.");
 
             MessageQueue queue;
-            if (MsmqUtilities.TryOpenQueue(msmqAddress, out queue) || MsmqUtilities.TryCreateQueue(msmqAddress, identity, settings.UseTransactionalQueues, out queue))
+            if (!MsmqUtilities.TryOpenQueue(msmqAddress, out queue) && MsmqUtilities.TryCreateQueue(msmqAddress, identity, settings.UseTransactionalQueues, out queue))
             {
                 using (queue)
                 {

--- a/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
@@ -88,7 +88,7 @@ namespace NServiceBus
             }
             catch (Exception ex)
             {
-                throw new Exception($"Failed to give {identity} {accessRights} on queue {queue.QueueName}", ex);
+                throw new Exception($"Failed to give '{identity}' {accessRights} access to queue '{queue.FormatName}'", ex);
             }
         }
 

--- a/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
@@ -62,6 +62,10 @@ namespace NServiceBus
 
                     SetPermissions(queue, LocalAdministratorsGroupName, MessageQueueAccessRights.FullControl);
 
+                    // Everyone & Anonymous by default granted to write message permissions on all Windows / Windows Server versions after 2003.
+                    SetPermissions(queue, LocalEveryoneGroupName, MessageQueueAccessRights.WriteMessage);
+                    SetPermissions(queue, LocalAnonymousLogonName, MessageQueueAccessRights.WriteMessage);
+
                     SetPermissions(queue, identity, MessageQueueAccessRights.WriteMessage);
                     SetPermissions(queue, identity, MessageQueueAccessRights.ReceiveMessage);
                     SetPermissions(queue, identity, MessageQueueAccessRights.PeekMessage);
@@ -94,6 +98,8 @@ namespace NServiceBus
         bool useTransactionalQueues;
 
         static string LocalAdministratorsGroupName = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null).Translate(typeof(NTAccount)).ToString();
+        static string LocalEveryoneGroupName = new SecurityIdentifier(WellKnownSidType.WorldSid, null).Translate(typeof(NTAccount)).ToString();
+        static string LocalAnonymousLogonName = new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Translate(typeof(NTAccount)).ToString();
         static ILog Logger = LogManager.GetLogger<QueueCreator>();
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
@@ -4,7 +4,6 @@ namespace NServiceBus
     using System.Messaging;
     using System.Security.Principal;
     using System.Threading.Tasks;
-    using Features;
     using Logging;
     using Transport;
     using Transports.Msmq;
@@ -33,11 +32,6 @@ namespace NServiceBus
 
         void CreateQueueIfNecessary(string address, string identity)
         {
-            if (address == null)
-            {
-                return;
-            }
-
             var msmqAddress = MsmqAddress.Parse(address);
 
             Logger.Debug($"Creating '{address}' if needed.");

--- a/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
@@ -6,7 +6,6 @@ namespace NServiceBus
     using System.Threading.Tasks;
     using Logging;
     using Transport;
-    using Transports.Msmq;
 
     class QueueCreator : ICreateQueues
     {

--- a/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
@@ -45,14 +45,14 @@ namespace NServiceBus
                 return;
             }
 
+            var queuePath = msmqAddress.PathWithoutPrefix;
 
-            if (MessageQueue.Exists(msmqAddress.PathWithoutPrefix))
+            if (MessageQueue.Exists(queuePath))
             {
                 Logger.Debug($"'{address}' already exists");
                 return;
             }
 
-            var queuePath = msmqAddress.PathWithoutPrefix;
             try
             {
                 using (var messageQueue = MessageQueue.Create(queuePath, settings.UseTransactionalQueues))

--- a/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
@@ -4,15 +4,14 @@ namespace NServiceBus
     using System.Messaging;
     using System.Security.Principal;
     using System.Threading.Tasks;
-    using Features;
     using Logging;
     using Transport;
 
     class QueueCreator : ICreateQueues
     {
-        public QueueCreator(MsmqSettings settings)
+        public QueueCreator(bool useTransactionalQueues)
         {
-            this.settings = settings;
+            this.useTransactionalQueues = useTransactionalQueues;
         }
 
         public Task CreateQueueIfNecessary(QueueBindings queueBindings, string identity)
@@ -57,9 +56,9 @@ namespace NServiceBus
 
             try
             {
-                using (var queue = MessageQueue.Create(queuePath, settings.UseTransactionalQueues))
+                using (var queue = MessageQueue.Create(queuePath, useTransactionalQueues))
                 {
-                    Logger.DebugFormat($"Created queue, path: [{queuePath}], identity: [{identity}], transactional: [{settings.UseTransactionalQueues}]");
+                    Logger.DebugFormat($"Created queue, path: [{queuePath}], identity: [{identity}], transactional: [{useTransactionalQueues}]");
 
                     SetPermissions(queue, LocalAdministratorsGroupName, MessageQueueAccessRights.FullControl);
 
@@ -92,7 +91,7 @@ namespace NServiceBus
             }
         }
 
-        MsmqSettings settings;
+        bool useTransactionalQueues;
 
         static string LocalAdministratorsGroupName = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null).Translate(typeof(NTAccount)).ToString();
         static ILog Logger = LogManager.GetLogger<QueueCreator>();

--- a/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
@@ -53,7 +53,7 @@ namespace NServiceBus
             {
                 using (var queue = MessageQueue.Create(queuePath, useTransactionalQueues))
                 {
-                    Logger.DebugFormat($"Created queue, path: [{queuePath}], identity: [{identity}], transactional: [{useTransactionalQueues}]");
+                    Logger.Debug($"Created queue, path: [{queuePath}], identity: [{identity}], transactional: [{useTransactionalQueues}]");
 
                     SetPermissions(queue, LocalAdministratorsGroupName, MessageQueueAccessRights.FullControl);
 

--- a/src/NServiceBus.Core/Transports/Msmq/QueuePermissions.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueuePermissions.cs
@@ -59,8 +59,6 @@
         {
 
             queue.SetPermissions(LocalAdministratorsGroupName, MessageQueueAccessRights.FullControl, AccessControlEntryType.Allow);
-            queue.SetPermissions(LocalEveryoneGroupName, MessageQueueAccessRights.WriteMessage, AccessControlEntryType.Allow);
-            queue.SetPermissions(LocalAnonymousLogonName, MessageQueueAccessRights.WriteMessage, AccessControlEntryType.Allow);
 
             queue.SetPermissions(account, MessageQueueAccessRights.WriteMessage, AccessControlEntryType.Allow);
             queue.SetPermissions(account, MessageQueueAccessRights.ReceiveMessage, AccessControlEntryType.Allow);

--- a/src/NServiceBus.Core/Transports/Msmq/QueuePermissions.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueuePermissions.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Transports.Msmq
+﻿namespace NServiceBus
 {
     using System.Diagnostics;
     using System.Messaging;

--- a/src/NServiceBus.Core/Transports/Msmq/QueuePermissions.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueuePermissions.cs
@@ -72,16 +72,6 @@
             }
         }
 
-        public static void SetPermissionsForQueue(MessageQueue queue, string account)
-        {
-            queue.SetPermissions(LocalAdministratorsGroupName, MessageQueueAccessRights.FullControl, AccessControlEntryType.Allow);
-
-            queue.SetPermissions(account, MessageQueueAccessRights.WriteMessage, AccessControlEntryType.Allow);
-            queue.SetPermissions(account, MessageQueueAccessRights.ReceiveMessage, AccessControlEntryType.Allow);
-            queue.SetPermissions(account, MessageQueueAccessRights.PeekMessage, AccessControlEntryType.Allow);
-        }
-
-        static string LocalAdministratorsGroupName = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null).Translate(typeof(NTAccount)).ToString();
         static string LocalEveryoneGroupName = new SecurityIdentifier(WellKnownSidType.WorldSid, null).Translate(typeof(NTAccount)).ToString();
         static string LocalAnonymousLogonName = new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Translate(typeof(NTAccount)).ToString();
 

--- a/src/NServiceBus.Core/Transports/Msmq/QueuePermissions.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueuePermissions.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Features
+﻿namespace NServiceBus.Transports.Msmq
 {
     using System.Diagnostics;
     using System.Messaging;
@@ -72,8 +72,8 @@
             }
         }
 
-        static string LocalEveryoneGroupName = new SecurityIdentifier(WellKnownSidType.WorldSid, null).Translate(typeof(NTAccount)).ToString();
-        static string LocalAnonymousLogonName = new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Translate(typeof(NTAccount)).ToString();
+        internal static string LocalEveryoneGroupName = new SecurityIdentifier(WellKnownSidType.WorldSid, null).Translate(typeof(NTAccount)).ToString();
+        internal static string LocalAnonymousLogonName = new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Translate(typeof(NTAccount)).ToString();
 
         static ILog Logger = LogManager.GetLogger(typeof(QueuePermissions));
     }

--- a/src/NServiceBus.Core/Transports/Msmq/QueuePermissions.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueuePermissions.cs
@@ -40,9 +40,9 @@
                 return;
             }
 
-            if (anonymousRights.HasValue && everyoneRights.HasValue)
+            if (anonymousRights.HasValue || everyoneRights.HasValue)
             {
-                var logMessage = $"Queue [{queue.QueueName}] is running with [{LocalEveryoneGroupName}] and [{LocalAnonymousLogonName}] permissions. Consider setting appropriate permissions, if required by the organization. For more information, consult the documentation.";
+                var logMessage = $"Queue [{queue.QueueName}] is running with [{LocalEveryoneGroupName}] and/or [{LocalAnonymousLogonName}] permissions. Consider setting appropriate permissions, if required by the organization. For more information, consult the documentation.";
 
                 if (Debugger.IsAttached)
                 {

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_starting_up_the_endpoint.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_starting_up_the_endpoint.cs
@@ -19,9 +19,9 @@
             var everyone = new SecurityIdentifier(WellKnownSidType.WorldSid, null).Translate(typeof(NTAccount)).ToString();
             var anonymous = new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Translate(typeof(NTAccount)).ToString();
 
-            var logItem = context.Logs.FirstOrDefault(item => item.Message.Contains($"[{everyone}] and [{anonymous}]"));
+            var logItem = context.Logs.FirstOrDefault(item => item.Message.Contains($"[{everyone}] and/or [{anonymous}]"));
             Assert.IsNotNull(logItem);
-            StringAssert.Contains($"is running with [{everyone}] and [{anonymous}] permissions. Consider setting appropriate permissions, if required by the organization", logItem.Message);
+            StringAssert.Contains($"is running with [{everyone}] and/or [{anonymous}] permissions. Consider setting appropriate permissions, if required by the organization", logItem.Message);
         }
 
         class Context : ScenarioContext


### PR DESCRIPTION
Fixes #4266 and #4323 

Changes:

* Only set permissions if we created the queue
* Only suppress .SetPermissions issues that is caused by to long queue names
* Added better test coverage