### PR TITLE
Inlined the msmq create/open code to allows us to dispose properly

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
@@ -14,7 +14,7 @@
         public Task Endpoint_should_start()
         {
             return Scenario.Define<TimeoutTestContext>()
-                .WithEndpoint<EndpointWithFlakyTimeoutPersister>()
+                .WithEndpoint<Endpoint>()
                 .Done(c => c.EndpointsStarted)
                 .Repeat(r => r.For<AllTransportsWithoutNativeDeferral>())
                 .Should(c => Assert.IsTrue(c.EndpointsStarted))
@@ -28,7 +28,7 @@
 
             var testContext =
                 await Scenario.Define<TimeoutTestContext>(c => { c.SecondsToWait = 10; })
-                    .WithEndpoint<EndpointWithFlakyTimeoutPersister>(b =>
+                    .WithEndpoint<Endpoint>(b =>
                     {
                         b.CustomConfig((busConfig, context) =>
                         {
@@ -51,14 +51,13 @@
             public bool FatalErrorOccurred { get; set; }
         }
 
-        [Serializable]
         public class MyMessage : IMessage
         {
         }
 
-        public class EndpointWithFlakyTimeoutPersister : EndpointConfigurationBuilder
+        public class Endpoint : EndpointConfigurationBuilder
         {
-            public EndpointWithFlakyTimeoutPersister()
+            public Endpoint()
             {
                 EndpointSetup<DefaultServer>(config => { config.EnableFeature<TimeoutManager>(); });
             }

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
@@ -11,9 +11,7 @@
         [Test]
         public void Should_create_all_queues()
         {
-            var settings = new MsmqSettings();
-
-            var creator = new QueueCreator(settings);
+            var creator = new QueueCreator(true);
             var bindings = new QueueBindings();
 
             DeleteQueueIfPresent("MsmqQueueCreatorTests.receiver");
@@ -35,9 +33,8 @@
         public void Should_setup_permissions()
         {
             var testQueueName = "MsmqQueueCreatorTests.permissions";
-            var settings = new MsmqSettings();
 
-            var creator = new QueueCreator(settings);
+            var creator = new QueueCreator(true);
             var bindings = new QueueBindings();
 
             DeleteQueueIfPresent(testQueueName);

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus.Core.Tests.Msmq
+{
+    using System.Messaging;
+    using System.Security.Principal;
+    using NUnit.Framework;
+    using Transport;
+
+    [TestFixture]
+    public class MsmqQueueCreatorTests
+    {
+        [Test]
+        public void Should_create_all_queues()
+        {
+            var settings = new MsmqSettings();
+
+            var creator = new QueueCreator(settings);
+            var bindings = new QueueBindings();
+
+            DeleteQueueIfPresent("MsmqQueueCreatorTests.receiver");
+            DeleteQueueIfPresent("MsmqQueueCreatorTests.endpoint1");
+            DeleteQueueIfPresent("MsmqQueueCreatorTests.endpoint2");
+
+            bindings.BindReceiving("MsmqQueueCreatorTests.receiver");
+            bindings.BindSending("MsmqQueueCreatorTests.target1");
+            bindings.BindSending("MsmqQueueCreatorTests.target2");
+
+            creator.CreateQueueIfNecessary(bindings, WindowsIdentity.GetCurrent().Name);
+
+            Assert.True(QueueExists("MsmqQueueCreatorTests.receiver"));
+            Assert.True(QueueExists("MsmqQueueCreatorTests.target1"));
+            Assert.True(QueueExists("MsmqQueueCreatorTests.target1"));
+        }
+
+        [Test]
+        public void Should_setup_permissions()
+        {
+            var testQueueName = "MsmqQueueCreatorTests.permissions";
+            var settings = new MsmqSettings();
+
+            var creator = new QueueCreator(settings);
+            var bindings = new QueueBindings();
+
+            DeleteQueueIfPresent(testQueueName);
+
+            bindings.BindReceiving(testQueueName);
+
+            // use the network service account since that one won't be in the local admin group
+            creator.CreateQueueIfNecessary(bindings, NetworkServiceAccountName);
+
+            var createdQueue = GetQueue(testQueueName);
+
+            MessageQueueAccessRights? accountAccessRights;
+
+            Assert.True(createdQueue.TryGetPermissions(NetworkServiceAccountName, out accountAccessRights));
+            Assert.True(accountAccessRights.HasValue, "User should have access rights");
+            Assert.AreEqual(MessageQueueAccessRights.WriteMessage | MessageQueueAccessRights.ReceiveMessage, accountAccessRights, "User should have write/read access");
+
+            MessageQueueAccessRights? localAdminAccessRights;
+
+            Assert.True(createdQueue.TryGetPermissions(LocalAdministratorsGroupName, out localAdminAccessRights));
+            Assert.True(localAdminAccessRights.HasValue, "User should have access rights");
+            Assert.AreEqual(MessageQueueAccessRights.FullControl, localAdminAccessRights, "LocalAdmins should have full control");
+        }
+
+        MessageQueue GetQueue(string queueName)
+        {
+            var path = MsmqAddress.Parse(queueName).PathWithoutPrefix;
+
+            return new MessageQueue(path);
+        }
+
+        bool QueueExists(string queueName)
+        {
+            var path = MsmqAddress.Parse(queueName).PathWithoutPrefix;
+
+            return MessageQueue.Exists(path);
+        }
+
+        void DeleteQueueIfPresent(string queueName)
+        {
+            var path = MsmqAddress.Parse(queueName).PathWithoutPrefix;
+
+            if (!MessageQueue.Exists(path))
+            {
+                return;
+            }
+
+            MessageQueue.Delete(path);
+        }
+
+        static string NetworkServiceAccountName = new SecurityIdentifier(WellKnownSidType.NetworkServiceSid, null).Translate(typeof(NTAccount)).ToString();
+        static string LocalAdministratorsGroupName = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null).Translate(typeof(NTAccount)).ToString();
+    }
+}

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Handlers\MessageHandlerRegistryTests.cs" />
     <Compile Include="MessageMapper\MessageMapperTests.cs" />
     <Compile Include="Msmq\MsmqMessagePumpTests.cs" />
+    <Compile Include="Msmq\MsmqQueueCreatorTests.cs" />
     <Compile Include="Msmq\TimeToBeReceivedOverrideCheckerTest.cs" />
     <Compile Include="Msmq\MsmqExtensionsTests.cs" />
     <Compile Include="Msmq\MsmqHelpers.cs" />

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
@@ -77,7 +77,7 @@ namespace NServiceBus
         {
             new CheckMachineNameForComplianceWithDtcLimitation().Check();
 
-            var builder = connectionString != null
+            var msmqSettings = connectionString != null
                 ? new MsmqConnectionStringBuilder(connectionString).RetrieveSettings()
                 : new MsmqSettings();
 
@@ -90,7 +90,7 @@ namespace NServiceBus
 
             return new TransportReceiveInfrastructure(
                 () => new MessagePump(guarantee => SelectReceiveStrategy(guarantee, scopeOptions.TransactionOptions)),
-                () => new QueueCreator(builder),
+                () => new QueueCreator(msmqSettings.UseTransactionalQueues),
                 () =>
                 {
                     var bindings = settings.Get<QueueBindings>();

--- a/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus
 {
+    using System;
     using System.Messaging;
     using System.Security.Principal;
     using System.Threading.Tasks;
@@ -60,11 +61,11 @@ namespace NServiceBus
                 {
                     Logger.DebugFormat($"Created queue, path: [{queuePath}], identity: [{identity}], transactional: [{settings.UseTransactionalQueues}]");
 
-                    queue.SetPermissions(LocalAdministratorsGroupName, MessageQueueAccessRights.FullControl, AccessControlEntryType.Allow);
+                    SetPermissions(queue, LocalAdministratorsGroupName, MessageQueueAccessRights.FullControl);
 
-                    queue.SetPermissions(identity, MessageQueueAccessRights.WriteMessage, AccessControlEntryType.Allow);
-                    queue.SetPermissions(identity, MessageQueueAccessRights.ReceiveMessage, AccessControlEntryType.Allow);
-                    queue.SetPermissions(identity, MessageQueueAccessRights.PeekMessage, AccessControlEntryType.Allow);
+                    SetPermissions(queue, identity, MessageQueueAccessRights.WriteMessage);
+                    SetPermissions(queue, identity, MessageQueueAccessRights.ReceiveMessage);
+                    SetPermissions(queue, identity, MessageQueueAccessRights.PeekMessage);
                 }
             }
             catch (MessageQueueException ex)
@@ -76,6 +77,18 @@ namespace NServiceBus
                 }
 
                 throw;
+            }
+        }
+
+        static void SetPermissions(MessageQueue queue, string identity, MessageQueueAccessRights accessRights)
+        {
+            try
+            {
+                queue.SetPermissions(identity, accessRights, AccessControlEntryType.Allow);
+            }
+            catch (Exception ex)
+            {
+                throw new Exception($"Failed to give {identity} {accessRights} on queue {queue.QueueName}", ex);
             }
         }
 

--- a/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
@@ -88,7 +88,7 @@ namespace NServiceBus
             }
             catch (Exception ex)
             {
-                throw new Exception($"Failed to give {identity} {accessRights} on queue {queue.QueueName}", ex);
+                throw new Exception($"Failed to give '{identity}' {accessRights} access to queue '{queue.FormatName}'", ex);
             }
         }
 

--- a/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
@@ -45,14 +45,14 @@ namespace NServiceBus
                 return;
             }
 
+            var queuePath = msmqAddress.PathWithoutPrefix;
 
-            if (MessageQueue.Exists(msmqAddress.PathWithoutPrefix))
+            if (MessageQueue.Exists(queuePath))
             {
                 Logger.Debug($"'{address}' already exists");
                 return;
             }
 
-            var queuePath = msmqAddress.PathWithoutPrefix;
             try
             {
                 using (var messageQueue = MessageQueue.Create(queuePath, settings.UseTransactionalQueues))

--- a/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueueCreator.cs
@@ -4,15 +4,14 @@ namespace NServiceBus
     using System.Messaging;
     using System.Security.Principal;
     using System.Threading.Tasks;
-    using Features;
     using Logging;
     using Transport;
 
     class QueueCreator : ICreateQueues
     {
-        public QueueCreator(MsmqSettings settings)
+        public QueueCreator(bool useTransactionalQueues)
         {
-            this.settings = settings;
+            this.useTransactionalQueues = useTransactionalQueues;
         }
 
         public Task CreateQueueIfNecessary(QueueBindings queueBindings, string identity)
@@ -57,9 +56,9 @@ namespace NServiceBus
 
             try
             {
-                using (var queue = MessageQueue.Create(queuePath, settings.UseTransactionalQueues))
+                using (var queue = MessageQueue.Create(queuePath, useTransactionalQueues))
                 {
-                    Logger.DebugFormat($"Created queue, path: [{queuePath}], identity: [{identity}], transactional: [{settings.UseTransactionalQueues}]");
+                    Logger.DebugFormat($"Created queue, path: [{queuePath}], identity: [{identity}], transactional: [{useTransactionalQueues}]");
 
                     SetPermissions(queue, LocalAdministratorsGroupName, MessageQueueAccessRights.FullControl);
 
@@ -92,7 +91,7 @@ namespace NServiceBus
             }
         }
 
-        MsmqSettings settings;
+        bool useTransactionalQueues;
 
         static string LocalAdministratorsGroupName = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null).Translate(typeof(NTAccount)).ToString();
         static ILog Logger = LogManager.GetLogger<QueueCreator>();

--- a/src/NServiceBus.Core/Transports/Msmq/QueuePermissions.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueuePermissions.cs
@@ -72,16 +72,6 @@
             }
         }
 
-        public static void SetPermissionsForQueue(MessageQueue queue, string account)
-        {
-            queue.SetPermissions(LocalAdministratorsGroupName, MessageQueueAccessRights.FullControl, AccessControlEntryType.Allow);
-
-            queue.SetPermissions(account, MessageQueueAccessRights.WriteMessage, AccessControlEntryType.Allow);
-            queue.SetPermissions(account, MessageQueueAccessRights.ReceiveMessage, AccessControlEntryType.Allow);
-            queue.SetPermissions(account, MessageQueueAccessRights.PeekMessage, AccessControlEntryType.Allow);
-        }
-
-        static string LocalAdministratorsGroupName = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null).Translate(typeof(NTAccount)).ToString();
         static string LocalEveryoneGroupName = new SecurityIdentifier(WellKnownSidType.WorldSid, null).Translate(typeof(NTAccount)).ToString();
         static string LocalAnonymousLogonName = new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Translate(typeof(NTAccount)).ToString();
 

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_starting_up_the_endpoint.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_starting_up_the_endpoint.cs
@@ -19,9 +19,9 @@
             var everyone = new SecurityIdentifier(WellKnownSidType.WorldSid, null).Translate(typeof(NTAccount)).ToString();
             var anonymous = new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Translate(typeof(NTAccount)).ToString();
 
-            var logItem = context.Logs.FirstOrDefault(item => item.Message.Contains($"[{everyone}] and [{anonymous}]"));
+            var logItem = context.Logs.FirstOrDefault(item => item.Message.Contains($"[{everyone}] and/or [{anonymous}]"));
             Assert.IsNotNull(logItem);
-            StringAssert.Contains($"is running with [{everyone}] and [{anonymous}] permissions. Consider setting appropriate permissions, if required by the organization", logItem.Message);
+            StringAssert.Contains($"is running with [{everyone}] and/or [{anonymous}] permissions. Consider setting appropriate permissions, if required by the organization", logItem.Message);
         }
 
         class Context : ScenarioContext


### PR DESCRIPTION
@ramonsmits I inlined the code to check for existence/create queues so that we can use `using` properly.

What do you think?

Targets #4304 