### PR TITLE
[Spike] Quick spike for InMemoryStorage session access

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Sagas/When_finder_returns_existing_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_finder_returns_existing_saga.cs
@@ -46,13 +46,12 @@
                 // ReSharper disable once MemberCanBePrivate.Global
                 public Context Context { get; set; }
 
-                public ISagaPersister SagaPersister { get; set; }
-
-                public async Task<TestSaga08.SagaData08> FindBy(SomeOtherMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context)
+                public Task<TestSaga08.SagaData08> FindBy(SomeOtherMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context)
                 {
                     Context.FinderUsed = true;
-                    var sagaData = await SagaPersister.Get<TestSaga08.SagaData08>(message.SagaId, storageSession, (ContextBag)context).ConfigureAwait(false);
-                    return sagaData;
+                    var session = storageSession.Session();
+                    var sagaData = session.FirstOrDefault<TestSaga08.SagaData08>(context, s => s.Id == message.SagaId);
+                    return Task.FromResult(sagaData);
                 }
             }
 

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -603,6 +603,10 @@ namespace NServiceBus
     }
     [System.ObsoleteAttribute("Will be removed in version 7.0.0.", true)]
     public interface IIncludesBuilder { }
+    public interface IInMemoryStorageSession
+    {
+        System.Collections.Generic.IEnumerable<NServiceBus.IContainSagaData> Sagas(NServiceBus.Extensibility.ReadOnlyContextBag context);
+    }
     [System.ObsoleteAttribute("No longer used, can safely be removed. Will be removed in version 7.0.0.", true)]
     public interface IManageMessageHeaders { }
     public interface IMessage { }
@@ -680,6 +684,10 @@ namespace NServiceBus
         void Customize(NServiceBus.EndpointConfiguration configuration);
     }
     public class InMemoryPersistence : NServiceBus.Persistence.PersistenceDefinition { }
+    public class static InMemorySynchronizedStorageSessionExtensions
+    {
+        public static NServiceBus.IInMemoryStorageSession Session(this NServiceBus.Persistence.SynchronizedStorageSession session) { }
+    }
     public class static InstallConfigExtensions
     {
         public static void EnableInstallers(this NServiceBus.EndpointConfiguration config, string username = null) { }

--- a/src/NServiceBus.Core/Persistence/InMemory/InMemorySynchronizedStorage.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/InMemorySynchronizedStorage.cs
@@ -6,9 +6,20 @@ namespace NServiceBus
 
     class InMemorySynchronizedStorage : ISynchronizedStorage
     {
+        InMemorySagaPersister inMemorySagaPersister;
+
+        public InMemorySynchronizedStorage() : this(null)
+        {
+        }
+
+        public InMemorySynchronizedStorage(InMemorySagaPersister sagaPersister)
+        {
+            inMemorySagaPersister = sagaPersister;
+        }
+
         public Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag)
         {
-            var session = (CompletableSynchronizedStorageSession) new InMemorySynchronizedStorageSession();
+            var session = (CompletableSynchronizedStorageSession) new InMemorySynchronizedStorageSession(inMemorySagaPersister);
             return Task.FromResult(session);
         }
     }


### PR DESCRIPTION
Spike for #4318

An alternative approach to # #4328 

It introduced a predicate for scanning entries. It does not copy before testing predicate (predicate can change the queried saga). When found, only this one entry is added to the context.

Ping @danielmarbach @timbussmann 