### PR TITLE
[SPIKE] Raw endpoints that can even benefit from recoverability

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Encryption\When_using_Rijndael_with_unobtrusive_mode.cs" />
     <Compile Include="Forwarding\When_requesting_message_to_be_forwarded.cs" />
     <Compile Include="Performance\TimeToBeReceived\When_TimeToBeReceived_used_with_unobtrusive_mode.cs" />
+    <Compile Include="Raw\When_custom_policy_provided.cs" />
     <Compile Include="Recoverability\Retries\When_custom_policy_provided.cs" />
     <Compile Include="Recoverability\When_custom_policy_moves_to_overridden_error_queue.cs" />
     <Compile Include="Recoverability\When_message_is_moved_to_error_queue_with_header_customizations.cs" />

--- a/src/NServiceBus.AcceptanceTests/Raw/When_custom_policy_provided.cs
+++ b/src/NServiceBus.AcceptanceTests/Raw/When_custom_policy_provided.cs
@@ -1,0 +1,70 @@
+namespace NServiceBus.AcceptanceTests.Recoverability.Retries
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_custom_policy_provided_for_raw : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_pass_recoverability_configuration()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b =>
+                    b.When(bus => bus.SendLocal(new MessageToBeRetried()))
+                        .DoNotFailOnErrorMessages())
+                .Done(c => c.FailedMessages.Any())
+                .Run();
+
+            Assert.That(context.Configuration.Immediate.MaxNumberOfRetries, Is.EqualTo(MaxImmediateRetries));
+            Assert.That(context.Configuration.Delayed.MaxNumberOfRetries, Is.EqualTo(MaxDelayedRetries));
+            Assert.That(context.Configuration.Delayed.TimeIncrease, Is.EqualTo(DelayedRetryDelayIncrease));
+        }
+
+        static TimeSpan DelayedRetryDelayIncrease = TimeSpan.FromMinutes(1);
+        const int MaxImmediateRetries = 2;
+        const int MaxDelayedRetries = 2;
+
+        class Context : ScenarioContext
+        {
+            public RecoverabilityConfig Configuration { get; set; }
+            public bool RawCalled { get; set; }
+        }
+
+        class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>((config, context) =>
+                {
+                    var testContext = (Context) context.ScenarioContext;
+
+                    config.Raw((message, dispatcher) =>
+                    {
+                        testContext.RawCalled = true;
+                        throw new SimulatedException();
+                    });
+
+                    config.EnableFeature<TimeoutManager>();
+                    config.Recoverability()
+                        .Immediate(immediate => immediate.NumberOfRetries(MaxImmediateRetries))
+                        .Delayed(delayed => delayed.NumberOfRetries(MaxDelayedRetries).TimeIncrease(DelayedRetryDelayIncrease))
+                        .CustomPolicy((cfg, errorContext) =>
+                        {
+                            testContext.Configuration = cfg;
+
+                            return RecoverabilityAction.MoveToError(cfg.Failed.ErrorQueue);
+                        });
+                });
+            }
+        }
+
+        public class MessageToBeRetried : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -4,6 +4,7 @@ namespace NServiceBus
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using System.Threading.Tasks;
     using System.Transactions;
     using System.Web;
     using Config.ConfigurationSource;
@@ -115,6 +116,14 @@ namespace NServiceBus
         public void SendOnly()
         {
             Settings.Set("Endpoint.SendOnly", true);
+        }
+
+        /// <summary>
+        /// Configures the endpoint to a raw endpoint.
+        /// </summary>
+        public void Raw(Func<MessageContext, IDispatchMessages, Task> onMessage)
+        {
+            Settings.Set("Endpoint.Raw", onMessage);
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Pipeline\Outgoing\AttachSenderRelatedInfoOnMessageBehavior.cs" />
     <Compile Include="Pipeline\Outgoing\SerializeMessageConnector.cs" />
     <Compile Include="Pipeline\PipelineCache.cs" />
+    <Compile Include="Pipeline\RawPipelineExecutor.cs" />
     <Compile Include="Pipeline\SatellitePipelineExecutor.cs" />
     <Compile Include="Pipeline\StageForkConnector.cs" />
     <Compile Include="Pipeline\ConnectorContextExtensions.cs" />

--- a/src/NServiceBus.Core/Pipeline/RawPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/RawPipelineExecutor.cs
@@ -1,0 +1,23 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Threading.Tasks;
+    using Transport;
+
+    class RawPipelineExecutor : IPipelineExecutor
+    {
+        public RawPipelineExecutor(IDispatchMessages dispatcher, Func<MessageContext, IDispatchMessages, Task> rawPipeline)
+        {
+            dispatchMessages = dispatcher;
+            this.rawPipeline = rawPipeline;
+        }
+
+        public Task Invoke(MessageContext messageContext)
+        {
+            return rawPipeline(messageContext, dispatchMessages);
+        }
+
+        Func<MessageContext, IDispatchMessages, Task> rawPipeline;
+        IDispatchMessages dispatchMessages;
+    }
+}


### PR DESCRIPTION
Proposal for #3389 

@SzymonPobiega I think this approach would be much simpler than exposing a heap load of types. We could build very powerful features, and the raw pipeline could still benefit from things like recoverability, for example, we could even build a dedicated mini-pipeline if necessary. Of course, the drawback of this approach is that it is backed into the core which is not the case in your proposal.

@Particular/nservicebus-maintainers thoughts?