### PR TITLE
Make sender-side distribution APIs public

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -302,7 +302,7 @@ namespace NServiceBus
         InstancePerUnitOfWork = 1,
         InstancePerCall = 2,
     }
-    public class DistributionPolicy
+    public class DistributionPolicy : NServiceBus.IDistributionPolicy
     {
         public DistributionPolicy() { }
         public void SetDistributionStrategy(NServiceBus.Routing.DistributionStrategy distributionStrategy) { }
@@ -580,6 +580,10 @@ namespace NServiceBus
         string Key { get; set; }
         object GetValue();
         void SetValue(object value);
+    }
+    public interface IDistributionPolicy
+    {
+        NServiceBus.Routing.DistributionStrategy GetDistributionStrategy(string endpointName, NServiceBus.DistributionStrategyScope scope);
     }
     public interface IEncryptionService
     {
@@ -2589,6 +2593,7 @@ namespace NServiceBus.Routing
     {
         public EndpointInstances() { }
         public void AddOrReplaceInstances(string sourceKey, System.Collections.Generic.IList<NServiceBus.Routing.EndpointInstance> endpointInstances) { }
+        public System.Collections.Generic.IEnumerable<NServiceBus.Routing.EndpointInstance> FindInstances(string endpoint) { }
     }
     public interface IMessageDrivenSubscriptionTransport { }
     public class MulticastAddressTag : NServiceBus.Routing.AddressTag

--- a/src/NServiceBus.Core/Routing/EndpointInstances.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstances.cs
@@ -8,7 +8,12 @@ namespace NServiceBus.Routing
     /// </summary>
     public class EndpointInstances
     {
-        internal IEnumerable<EndpointInstance> FindInstances(string endpoint)
+        /// <summary>
+        /// Returns all known <see cref="EndpointInstance"/> for a given logical endpoint.
+        /// </summary>
+        /// <param name="endpoint">The logical endpoint name.</param>
+        /// <returns>Returns at least one <see cref="EndpointInstance"/>.</returns>
+        public IEnumerable<EndpointInstance> FindInstances(string endpoint)
         {
             HashSet<EndpointInstance> registeredInstances;
             return allInstances.TryGetValue(endpoint, out registeredInstances)

--- a/src/NServiceBus.Core/Routing/IDistributionPolicy.cs
+++ b/src/NServiceBus.Core/Routing/IDistributionPolicy.cs
@@ -2,8 +2,14 @@ namespace NServiceBus
 {
     using Routing;
 
-    interface IDistributionPolicy
+    /// <summary>
+    /// Provides access to <see cref="DistributionStrategy"/>.
+    /// </summary>
+    public interface IDistributionPolicy
     {
+        /// <summary>
+        /// Returns a <see cref="DistributionStrategy"/> for a given logical endpoint.
+        /// </summary>
         DistributionStrategy GetDistributionStrategy(string endpointName, DistributionStrategyScope scope);
     }
 }


### PR DESCRIPTION
These APIs need to be public in order for FileBasedRouting to apply sender-side distribution to the configured logical routes.

ping @SzymonPobiega @Scooletz 

please review @Particular/nservicebus-maintainers 