### PR TITLE
Add exception for registration of custom pipelines

### DIFF
--- a/src/NServiceBus.Core/Pipeline/PipelineCache.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineCache.cs
@@ -32,7 +32,7 @@ namespace NServiceBus
             {
                 return (IPipeline<TContext>) lazyPipeline.Value;
             }
-            return default(IPipeline<TContext>);
+            throw new InvalidOperationException("Registration of custom pipelines is not supported.");
         }
 
         void FromMainPipeline<TContext>(IBuilder builder, ReadOnlySettings settings)

--- a/src/NServiceBus.Core/Pipeline/PipelineCache.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineCache.cs
@@ -32,7 +32,7 @@ namespace NServiceBus
             {
                 return (IPipeline<TContext>) lazyPipeline.Value;
             }
-            throw new InvalidOperationException("Registration of custom pipelines is not supported.");
+            throw new InvalidOperationException("Custom pipelines are not supported.");
         }
 
         void FromMainPipeline<TContext>(IBuilder builder, ReadOnlySettings settings)


### PR DESCRIPTION
Solves #4354 

Added an exception when retrieval of a custom pipeline is attempted.

Ready for review @Particular/nservicebus-maintainers 