### PR TITLE
Preserve DateTimeOffset timezone information when deserializing

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -208,6 +208,7 @@
     <Compile Include="Satellites\When_a_message_is_available.cs" />
     <Compile Include="Serialization\When_registering_deserializers_with_settings.cs" />
     <Compile Include="Serialization\When_sanitizing_xml_messages.cs" />
+    <Compile Include="Serialization\When_serializing_a_message.cs" />
     <Compile Include="Serialization\When_skip_wrapping_xml.cs" />
     <Compile Include="Serialization\When_wrapping_is_not_skipped.cs" />
     <Compile Include="Serialization\When_xml_serializer_used_with_unobtrusive_mode.cs" />

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_serializing_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_serializing_a_message.cs
@@ -7,7 +7,7 @@
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_serializing_a_message
+    public class When_serializing_a_message:NServiceBusAcceptanceTest
     {
         [Test]
         public async Task DateTime_properties_should_keep_their_original_timezone_information()
@@ -83,7 +83,7 @@
             }
         }
 
-        class DateTimeMessage:IMessage
+        public class DateTimeMessage:IMessage
         {
             public DateTime DateTime { get; set; }
             public DateTime DateTimeLocal { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_serializing_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_serializing_a_message.cs
@@ -1,0 +1,107 @@
+﻿namespace NServiceBus.AcceptanceTests.Serialization
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_serializing_a_message
+    {
+        [Test]
+        public async Task DateTime_properties_should_keep_their_original_timezone_information()
+        {
+            var expectedDateTime = new DateTime(2010, 10, 13, 12, 32, 42, DateTimeKind.Unspecified);
+            var expectedDateTimeLocal = new DateTime(2010, 10, 13, 12, 32, 42, DateTimeKind.Local);
+            var expectedDateTimeUtc = new DateTime(2010, 10, 13, 12, 32, 42, DateTimeKind.Utc);
+            var expectedDateTimeOffset = new DateTimeOffset(2012, 12, 12, 12, 12, 12, TimeSpan.FromHours(6));
+            var expectedDateTimeOffsetLocal = DateTimeOffset.Now;
+            var expectedDateTimeOffsetUtc = DateTimeOffset.UtcNow;
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<DateTimeSender>(b => b.When(
+                    (session, c) =>
+                    {
+                        return session.Send(new DateTimeMessage
+                        {
+                            DateTime = expectedDateTime,
+                            DateTimeLocal = expectedDateTimeLocal,
+                            DateTimeUtc = expectedDateTimeUtc,
+                            DateTimeOffset = expectedDateTimeOffset,
+                            DateTimeOffsetLocal = expectedDateTimeOffsetLocal,
+                            DateTimeOffsetUtc = expectedDateTimeOffsetUtc
+                        });
+                    }))
+                .WithEndpoint<DateTimeReceiver>()
+                .Done(c=>c.HandlerGotTheRequest = true)
+                .Run();
+
+            Assert.True(context.HandlerGotTheRequest);
+            Assert.AreEqual(expectedDateTime,context.MessageDateTime);
+            Assert.AreEqual(expectedDateTimeLocal,context.MessageDateTimeLocal);
+            Assert.AreEqual(expectedDateTimeUtc,context.MessageDateTimeUtc);
+            Assert.AreEqual(expectedDateTimeOffset,context.MessageDateTimeOffset);
+            Assert.AreEqual(expectedDateTimeOffsetLocal,context.MessageDateTimeOffsetLocal);
+            Assert.AreEqual(expectedDateTimeOffsetUtc,context.MessageDateTimeOffsetUtc);
+
+        }
+        class DateTimeSender : EndpointConfigurationBuilder
+        {
+            public DateTimeSender()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                    {
+                        c.UseSerialization<JsonSerializer>();
+                    })
+                    .AddMapping<DateTimeMessage>(typeof(DateTimeReceiver));
+            }
+        }
+
+        class DateTimeReceiver : EndpointConfigurationBuilder
+        {
+            public DateTimeReceiver()
+            {
+                EndpointSetup<DefaultServer>(c => { c.UseSerialization<JsonSerializer>(); });
+            }
+
+            class DateTimeMessageHandler : IHandleMessages<DateTimeMessage>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(DateTimeMessage request, IMessageHandlerContext context)
+                {
+                    Context.MessageDateTime = request.DateTime;
+                    Context.MessageDateTimeLocal = request.DateTimeLocal;
+                    Context.MessageDateTimeUtc = request.DateTimeUtc;
+                    Context.MessageDateTimeOffset = request.DateTimeOffset;
+                    Context.MessageDateTimeOffsetLocal = request.DateTimeOffsetLocal;
+                    Context.MessageDateTimeOffsetUtc = request.DateTimeOffsetUtc;
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        class DateTimeMessage:IMessage
+        {
+            public DateTime DateTime { get; set; }
+            public DateTime DateTimeLocal { get; set; }
+            public DateTime DateTimeUtc { get; set; }
+            public DateTimeOffset DateTimeOffset { get; set; }
+            public DateTimeOffset DateTimeOffsetLocal { get; set; }
+            public DateTimeOffset DateTimeOffsetUtc { get; set; }
+        }
+
+        class Context : ScenarioContext
+        {
+            public DateTime MessageDateTime  { get; set; }
+            public DateTime MessageDateTimeLocal  { get; set; }
+            public DateTime MessageDateTimeUtc  { get; set; }
+            public DateTimeOffset MessageDateTimeOffset { get; set; }
+            public DateTimeOffset MessageDateTimeOffsetLocal  { get; set; }
+            public DateTimeOffset MessageDateTimeOffsetUtc  { get; set; }
+            public bool HandlerGotTheRequest { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Serializers/Json/JsonMessageSerializerTest.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/Json/JsonMessageSerializerTest.cs
@@ -340,7 +340,6 @@ namespace NServiceBus.Serializers.Json.Tests
             }
         }
 
-
         [Test]
         public void When_Using_Property_WithXContainerAssignable_should_preserve_xml()
         {
@@ -394,11 +393,54 @@ namespace NServiceBus.Serializers.Json.Tests
         }
 
         [Test]
-        public void Test()
+        public void Should_preserve_timezones()
         {
-            var expectedDate = new DateTime(2010, 10, 13, 12, 32, 42, DateTimeKind.Unspecified);
-            var expectedDateLocal = new DateTime(2010, 10, 13, 12, 32, 42, DateTimeKind.Local);
-            var expectedDateUtc = new DateTime(2010, 10, 13, 12, 32, 42, DateTimeKind.Utc);
+            var expectedDateTime = new DateTime(2010, 10, 13, 12, 32, 42, DateTimeKind.Unspecified);
+            var expectedDateTimeLocal = new DateTime(2010, 10, 13, 12, 32, 42, DateTimeKind.Local);
+            var expectedDateTimeUtc = new DateTime(2010, 10, 13, 12, 32, 42, DateTimeKind.Utc);
+            var expectedDateTimeOffset = new DateTimeOffset(2012, 12, 12, 12, 12, 12, TimeSpan.FromHours(6));
+            var expectedDateTimeOffsetLocal = DateTimeOffset.Now;
+            var expectedDateTimeOffsetUtc = DateTimeOffset.UtcNow;
+
+            using (var stream = new MemoryStream())
+            {
+                var serializer = new JsonMessageSerializer(new MessageMapper());
+                serializer.Serialize(new DateTimeMessage
+                {
+                    DateTime = expectedDateTime,
+                    DateTimeLocal = expectedDateTimeLocal,
+                    DateTimeUtc = expectedDateTimeUtc,
+                    DateTimeOffset = expectedDateTimeOffset,
+                    DateTimeOffsetLocal = expectedDateTimeOffsetLocal,
+                    DateTimeOffsetUtc = expectedDateTimeOffsetUtc
+                }, stream);
+                stream.Position = 0;
+
+                var result = serializer.Deserialize(stream, new List<Type>
+                {
+                    typeof(DateTimeMessage)
+                }).Cast<DateTimeMessage>().Single();
+
+                Assert.AreEqual(expectedDateTime.Kind, result.DateTime.Kind);
+                Assert.AreEqual(expectedDateTime, result.DateTime);
+                Assert.AreEqual(expectedDateTimeLocal.Kind, result.DateTimeLocal.Kind);
+                Assert.AreEqual(expectedDateTimeLocal, result.DateTimeLocal);
+                Assert.AreEqual(expectedDateTimeUtc.Kind, result.DateTimeUtc.Kind);
+                Assert.AreEqual(expectedDateTimeUtc, result.DateTimeUtc);
+
+                Assert.AreEqual(expectedDateTimeOffset, result.DateTimeOffset);
+                Assert.AreEqual(expectedDateTimeOffset.Offset, result.DateTimeOffset.Offset);
+                Assert.AreEqual(expectedDateTimeOffsetLocal, result.DateTimeOffsetLocal);
+                Assert.AreEqual(expectedDateTimeOffsetLocal.Offset, result.DateTimeOffsetLocal.Offset);
+                Assert.AreEqual(expectedDateTimeOffsetUtc, result.DateTimeOffsetUtc);
+                Assert.AreEqual(expectedDateTimeOffsetUtc.Offset, result.DateTimeOffsetUtc.Offset);
+            }
+
+        }
+
+        [Test]
+        public void Should_handle_types_correctly()
+        {
             var expectedGuid = Guid.NewGuid();
 
             var obj = new A
@@ -431,10 +473,7 @@ namespace NServiceBus.Serializers.Json.Tests
                         },
                         BBString = "BBStr"
                     }
-                },
-                DateTime = expectedDate,
-                DateTimeLocal = expectedDateLocal,
-                DateTimeUtc = expectedDateUtc
+                }
             };
 
             new Random().NextBytes(obj.Data);
@@ -466,12 +505,6 @@ namespace NServiceBus.Serializers.Json.Tests
             Assert.AreEqual(obj.Data, a.Data);
             Assert.AreEqual(23, a.I);
             Assert.AreEqual("Foo", a.S);
-            Assert.AreEqual(expectedDate.Kind, a.DateTime.Kind);
-            Assert.AreEqual(expectedDate, a.DateTime);
-            Assert.AreEqual(expectedDateLocal.Kind, a.DateTimeLocal.Kind);
-            Assert.AreEqual(expectedDateLocal, a.DateTimeLocal);
-            Assert.AreEqual(expectedDateUtc.Kind, a.DateTimeUtc.Kind);
-            Assert.AreEqual(expectedDateUtc, a.DateTimeUtc);
             Assert.AreEqual("ccc", ((C) a.Bs[0].C).Cstr);
             Assert.AreEqual(expectedGuid, a.AGuid);
 
@@ -710,10 +743,6 @@ namespace NServiceBus.Serializers.Json.Tests
         public Guid AGuid { get; set; }
         public int I { get; set; }
 
-        public DateTime DateTime { get; set; }
-        public DateTime DateTimeLocal { get; set; }
-        public DateTime DateTimeUtc { get; set; }
-
         public List<int> Ints { get; set; }
         public List<B> Bs { get; set; }
         public byte[] Data;
@@ -772,5 +801,15 @@ namespace NServiceBus.Serializers.Json.Tests
     class InterfaceMessageWithInterfacePropertyImplementation : IMessageWithInterfaceProperty
     {
         public IInterfaceProperty InterfaceProperty { get; set; }
+    }
+
+    class DateTimeMessage
+    {
+        public DateTime DateTime { get; set; }
+        public DateTime DateTimeLocal { get; set; }
+        public DateTime DateTimeUtc { get; set; }
+        public DateTimeOffset DateTimeOffset { get; set; }
+        public DateTimeOffset DateTimeOffsetLocal { get; set; }
+        public DateTimeOffset DateTimeOffsetUtc { get; set; }
     }
 }

--- a/src/NServiceBus.Core/Serializers/Json/JsonMessageSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/Json/JsonMessageSerializer.cs
@@ -2,14 +2,12 @@ namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Runtime.Serialization.Formatters;
     using System.Text;
     using MessageInterfaces;
     using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
     using Serialization;
 
     class JsonMessageSerializer : IMessageSerializer
@@ -89,10 +87,6 @@ namespace NServiceBus
                     TypeNameHandling = TypeNameHandling.None,
                     Converters =
                     {
-                        new IsoDateTimeConverter
-                        {
-                            DateTimeStyles = DateTimeStyles.RoundtripKind
-                        },
                         new XContainerJsonConverter()
                     }
                 };
@@ -209,10 +203,6 @@ namespace NServiceBus
             TypeNameHandling = TypeNameHandling.Auto,
             Converters =
             {
-                new IsoDateTimeConverter
-                {
-                    DateTimeStyles = DateTimeStyles.RoundtripKind
-                },
                 new XContainerJsonConverter()
             }
         };


### PR DESCRIPTION
addresses the behavior described in https://github.com/Particular/NServiceBus/issues/4355 for v6 by removing the `IsoDateTimeConverter`. Since 4.5 Json.net seems to use the ISO format by default so that shouldn't be necessary, but the used converter doesn't seem to be able to preserve timezone information.

Note that this change doesn't set the `DateParseHandling.DateTimeOffset` on the settings, as it seems this isn't necessary when the property type is defined as a DateTimeOffset (seems to be relevant when using dynamics I guess?)

Should we also add acceptance tests for that behavior so other serializers can verify that behavior too?