### PR TITLE
Features marked as implicitly used

### DIFF
--- a/src/NServiceBus.Core/Features/Feature.cs
+++ b/src/NServiceBus.Core/Features/Feature.cs
@@ -3,11 +3,13 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using JetBrains.Annotations;
     using Settings;
 
     /// <summary>
     /// Used to control the various features supported by the framework.
     /// </summary>
+    [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
     public abstract partial class Feature
     {
         /// <summary>


### PR DESCRIPTION
Features are scanned and loaded. This marks features as implicitly used similarly to `IHandleMessages`