### PR TITLE
Preserve DateTimeOffset timezone information when deserializing

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -126,6 +126,7 @@
     <Compile Include="ScenarioDescriptors\AllTransactionSettings.cs" />
     <Compile Include="ScenarioDescriptors\TransactionSettings.cs" />
     <Compile Include="NonDTC\When_dispatching_deferred_message_fails_without_dtc.cs" />
+    <Compile Include="Serialization\When_serializing_a_message.cs" />
     <Compile Include="Timeouts\TemporarilyUnavailableTimeoutPersister.cs" />
     <Compile Include="Timeouts\OutdatedTimeoutPersister.cs" />
     <Compile Include="Timeouts\TransportWithFakeQueues.cs" />

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_serializing_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_serializing_a_message.cs
@@ -20,7 +20,7 @@
 
             var context = Scenario.Define<Context>()
                 .WithEndpoint<DateTimeReceiver>(b => b.When(
-                    (bus) => bus.SendLocal(new DateTimeMessage
+                    bus => bus.SendLocal(new DateTimeMessage
                     {
                         DateTime = expectedDateTime,
                         DateTimeLocal = expectedDateTimeLocal,

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_serializing_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_serializing_a_message.cs
@@ -1,0 +1,76 @@
+﻿namespace NServiceBus.AcceptanceTests.Serialization
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using System;
+
+    [TestFixture]
+    public class When_serializing_a_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void DateTime_properties_should_keep_their_original_timezone_information()
+        {
+            var expectedDateTime = new DateTime(2010, 10, 13, 12, 32, 42, DateTimeKind.Unspecified);
+            var expectedDateTimeLocal = new DateTime(2010, 10, 13, 12, 32, 42, DateTimeKind.Local);
+            var expectedDateTimeUtc = new DateTime(2010, 10, 13, 12, 32, 42, DateTimeKind.Utc);
+            var expectedDateTimeOffset = new DateTimeOffset(2012, 12, 12, 12, 12, 12, TimeSpan.FromHours(6));
+            var expectedDateTimeOffsetLocal = DateTimeOffset.Now;
+            var expectedDateTimeOffsetUtc = DateTimeOffset.UtcNow;
+
+            var context = Scenario.Define<Context>()
+                .WithEndpoint<DateTimeReceiver>(b => b.When(
+                    (bus) => bus.SendLocal(new DateTimeMessage
+                    {
+                        DateTime = expectedDateTime,
+                        DateTimeLocal = expectedDateTimeLocal,
+                        DateTimeUtc = expectedDateTimeUtc,
+                        DateTimeOffset = expectedDateTimeOffset,
+                        DateTimeOffsetLocal = expectedDateTimeOffsetLocal,
+                        DateTimeOffsetUtc = expectedDateTimeOffsetUtc
+                    })))
+                .Done(c => c.ReceivedMessage != null)
+                .Run();
+
+            Assert.AreEqual(expectedDateTime, context.ReceivedMessage.DateTime);
+            Assert.AreEqual(expectedDateTimeLocal, context.ReceivedMessage.DateTimeLocal);
+            Assert.AreEqual(expectedDateTimeUtc, context.ReceivedMessage.DateTimeUtc);
+            Assert.AreEqual(expectedDateTimeOffset, context.ReceivedMessage.DateTimeOffset);
+            Assert.AreEqual(expectedDateTimeOffsetLocal, context.ReceivedMessage.DateTimeOffsetLocal);
+            Assert.AreEqual(expectedDateTimeOffsetUtc, context.ReceivedMessage.DateTimeOffsetUtc);
+        }
+
+        class DateTimeReceiver : EndpointConfigurationBuilder
+        {
+            public DateTimeReceiver()
+            {
+                EndpointSetup<DefaultServer>(c => { c.UseSerialization<JsonSerializer>(); });
+            }
+
+            class DateTimeMessageHandler : IHandleMessages<DateTimeMessage>
+            {
+                public Context Context { get; set; }
+
+                public void Handle(DateTimeMessage message)
+                {
+                    Context.ReceivedMessage = message;
+                }
+            }
+        }
+
+        public class DateTimeMessage : IMessage
+        {
+            public DateTime DateTime { get; set; }
+            public DateTime DateTimeLocal { get; set; }
+            public DateTime DateTimeUtc { get; set; }
+            public DateTimeOffset DateTimeOffset { get; set; }
+            public DateTimeOffset DateTimeOffsetLocal { get; set; }
+            public DateTimeOffset DateTimeOffsetUtc { get; set; }
+        }
+
+        class Context : ScenarioContext
+        {
+            public DateTimeMessage ReceivedMessage { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_serializing_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_serializing_a_message.cs
@@ -38,6 +38,10 @@
             Assert.AreEqual(expectedDateTimeOffset, context.ReceivedMessage.DateTimeOffset);
             Assert.AreEqual(expectedDateTimeOffsetLocal, context.ReceivedMessage.DateTimeOffsetLocal);
             Assert.AreEqual(expectedDateTimeOffsetUtc, context.ReceivedMessage.DateTimeOffsetUtc);
+            Assert.AreEqual(expectedDateTimeOffsetLocal, context.ReceivedMessage.DateTimeOffsetLocal);
+            Assert.AreEqual(expectedDateTimeOffsetLocal.Offset, context.ReceivedMessage.DateTimeOffsetLocal.Offset);
+            Assert.AreEqual(expectedDateTimeOffsetUtc, context.ReceivedMessage.DateTimeOffsetUtc);
+            Assert.AreEqual(expectedDateTimeOffsetUtc.Offset, context.ReceivedMessage.DateTimeOffsetUtc.Offset);
         }
 
         class DateTimeReceiver : EndpointConfigurationBuilder

--- a/src/NServiceBus.Core/Serializers/Json/JsonMessageSerializerBase.cs
+++ b/src/NServiceBus.Core/Serializers/Json/JsonMessageSerializerBase.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.Serializers.Json
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Runtime.Serialization.Formatters;

--- a/src/NServiceBus.Core/Serializers/Json/JsonMessageSerializerBase.cs
+++ b/src/NServiceBus.Core/Serializers/Json/JsonMessageSerializerBase.cs
@@ -9,7 +9,6 @@ namespace NServiceBus.Serializers.Json
     using Internal;
     using MessageInterfaces;
     using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
     using Serialization;
 
     /// <summary>
@@ -23,7 +22,7 @@ namespace NServiceBus.Serializers.Json
         {
             TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple,
             TypeNameHandling = TypeNameHandling.Auto,
-            Converters = { new IsoDateTimeConverter { DateTimeStyles = DateTimeStyles.RoundtripKind }, new XContainerConverter() }
+            Converters = { new XContainerConverter() }
         };
 
         /// <summary>
@@ -94,10 +93,6 @@ namespace NServiceBus.Serializers.Json
                     TypeNameHandling = TypeNameHandling.None,
                     Converters =
                     {
-                        new IsoDateTimeConverter
-                        {
-                            DateTimeStyles = DateTimeStyles.RoundtripKind
-                        },
                         new XContainerConverter()
                     }
                 };

--- a/src/NServiceBus.sln.DotSettings
+++ b/src/NServiceBus.sln.DotSettings
@@ -7,6 +7,7 @@
 	<s:Boolean x:Key="/Default/CodeEditing/Localization/CSharpLocalizationOptions/DontAnalyseVerbatimStrings/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/AnalysisEnabled/@EntryValue">SOLUTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AssignToImplicitGlobalInFunctionScope/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:Boolean x:Key="/Default/CodeInspection/ExcludedFiles/FileMasksToSkip/=_002A_002A_005C_002APackages_005C_002A_002A_005C_002A_002E_002A/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=BaseObjectEqualsIsObjectEquals/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CheckNamespace/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ClassNeverInstantiated_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>


### PR DESCRIPTION
## Who's affected

* Everyone using `JsonSerializer` in combination with messages that contain `DateTimeOffset `properties.

## Symptoms

Noted that an object's DateTimeOffset property get converted to the running servers UTC timezone when sent. (Using "JsonSerializer", and ASB)

i.e. if Server is UTC+5, and DateTimeOffset is 12:00+1, it gets converted to 16:00, resulting in "2016-12-01T16:00:00+05:00"

## Steps to reproduce

To verify that this is not an issue with Json.Net serializer, I've extracted the settings used in NSB.JsonSerializer, and Serialize the Command-object just before sending it to the Bus, and when serialized it shows the Correct unmodified Serialization with UTC+1 timezone

        var str = Newtonsoft.Json.JsonConvert.SerializeObject(cmd, new JsonSerializerSettings {
          TypeNameAssemblyFormat = FormatterAssemblyStyle.Simple,
          TypeNameHandling = TypeNameHandling.None,
          Converters =
                    {
                        new IsoDateTimeConverter
                        {
                            DateTimeStyles = DateTimeStyles.RoundtripKind
                        }
                    }
        });.

Fixes #4367