### PR TITLE
Rename test to shorten path

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -90,7 +90,7 @@
     <Compile Include="Routing\When_replying_to_message_with_interface_and_unobtrusive.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_subscribing_to_a_base_event.cs" />
     <Compile Include="Routing\When_sending_a_base_command.cs" />
-    <Compile Include="Routing\MessageDrivenSubscriptions\When_subscribing_to_a_base_event_with_routes_to_base_and_specific_events.cs" />
+    <Compile Include="Routing\MessageDrivenSubscriptions\When_subscribing_to_event_with_routes_to_base_and_specific_events.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_subscribing_to_a_base_event_with_a_route_for_a_derived_event.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_subscribing_to_a_derived_event.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_subscribing_to_multiple_publishers.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_subscribing_to_event_with_routes_to_base_and_specific_events.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_subscribing_to_event_with_routes_to_base_and_specific_events.cs
@@ -7,7 +7,7 @@
     using NUnit.Framework;
     using ScenarioDescriptors;
 
-    public class When_subscribing_to_a_base_event_with_routes_to_base_and_specific_events : NServiceBusAcceptanceTest
+    public class When_subscribing_to_event_with_routes_to_base_and_specific_events : NServiceBusAcceptanceTest
     {
         [Test]
         public Task Event_from_both_publishers_should_be_delivered()


### PR DESCRIPTION
This is a test with a very long name which causes downstreams to exceed file path limitations when trying to extract this test on the nuget packages folder, failing the package update.

ping @Particular/nservicebus-maintainers 