### PR TITLE
InMemorySagaPerister allocates less for saga with fields of simple types.

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Msmq\MsmqSubscriptionStorageTests.cs" />
     <Compile Include="Persistence\InMemory\InMemorySubscriptionStorageTests.cs" />
     <Compile Include="Persistence\InMemory\SagaWithoutUniquePropertyData.cs" />
+    <Compile Include="Persistence\InMemory\When_persisting_a_saga_with_complex_types_full_copy_is_created.cs" />
     <Compile Include="Persistence\InMemory\When_persisting_a_saga_with_InMemory_and_an_escalated_DTC_transaction.cs" />
     <Compile Include="Persistence\InMemory\When_persisting_a_saga_with_no_defined_unique_property.cs" />
     <Compile Include="Persistence\InMemory\When_completing_a_saga_with_no_defined_unique_property.cs" />

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -144,7 +144,7 @@
     <Compile Include="Msmq\MsmqSubscriptionStorageTests.cs" />
     <Compile Include="Persistence\InMemory\InMemorySubscriptionStorageTests.cs" />
     <Compile Include="Persistence\InMemory\SagaWithoutUniquePropertyData.cs" />
-    <Compile Include="Persistence\InMemory\When_persisting_a_saga_with_complex_types_full_copy_is_created.cs" />
+    <Compile Include="Persistence\InMemory\When_persisting_a_saga_with_complex_types.cs" />
     <Compile Include="Persistence\InMemory\When_persisting_a_saga_with_InMemory_and_an_escalated_DTC_transaction.cs" />
     <Compile Include="Persistence\InMemory\When_persisting_a_saga_with_no_defined_unique_property.cs" />
     <Compile Include="Persistence\InMemory\When_completing_a_saga_with_no_defined_unique_property.cs" />

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_complex_types.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_complex_types.cs
@@ -7,10 +7,10 @@
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_persisting_a_saga_with_complex_types_full_copy_is_created
+    public class When_persisting_a_saga_with_complex_types
     {
         [Test]
-        public async Task It_should_persist_deep_copy()
+        public async Task It_should_get_deep_copy()
         {
             var sagaData = new SagaWithComplexType
             {

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_complex_types_full_copy_is_created.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_complex_types_full_copy_is_created.cs
@@ -1,0 +1,42 @@
+﻿namespace NServiceBus.Core.Tests.Persistence.InMemory
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_persisting_a_saga_with_complex_types_full_copy_is_created
+    {
+        [Test]
+        public async Task It_should_persist_deep_copy()
+        {
+            var sagaData = new SagaWithComplexType
+            {
+                Id = Guid.NewGuid(),
+                Ints = new List<int> { 1, 2 }
+            };
+
+            var persister = new InMemorySagaPersister();
+            using (var session = new InMemorySynchronizedStorageSession())
+            {
+                await persister.Save(sagaData, null, session, new ContextBag());
+                await session.CompleteAsync();
+            }
+
+            using (var session = new InMemorySynchronizedStorageSession())
+            {
+                var retrieved = await persister.Get<SagaWithComplexType>(sagaData.Id, session, new ContextBag());
+
+                CollectionAssert.AreEqual(sagaData.Ints, retrieved.Ints);
+                Assert.False(ReferenceEquals(sagaData.Ints, retrieved.Ints));
+            }
+        }
+
+        class SagaWithComplexType : ContainSagaData
+        {
+            public List<int> Ints { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
@@ -168,7 +168,7 @@ namespace NServiceBus
 
             public IContainSagaData GetSagaCopy()
             {
-                var canBeClonedShallowly = cloneMethods.GetOrAdd(data.GetType(), CanBeMemberwiselyCloned);
+                var canBeClonedShallowly = canBeClonedShallowlyCache.GetOrAdd(data.GetType(), CanBeMemberwiselyCloned);
                 return canBeClonedShallowly ? memberwiseClone(data) : DeepClone(data);
             }
 
@@ -212,7 +212,7 @@ namespace NServiceBus
 
             readonly IContainSagaData data;
             static JsonMessageSerializer serializer = new JsonMessageSerializer(null);
-            static ConcurrentDictionary<Type, bool> cloneMethods = new ConcurrentDictionary<Type, bool>();
+            static ConcurrentDictionary<Type, bool> canBeClonedShallowlyCache = new ConcurrentDictionary<Type, bool>();
             static Func<IContainSagaData, IContainSagaData> memberwiseClone;
         }
 


### PR DESCRIPTION
After this PR `InMemorySagaPersister` allocates less memory for sagas that have only fields of following types: primitive types, strings, Guids. This is provided by using [MemberwiseClone](https://msdn.microsoft.com/en-us/library/system.object.memberwiseclone(v=vs.110).aspx) instead of the JSON serializer.

This gem enables **not calling any serializer** for getting sagas that types consist of fields with following types:
- [primitive types](https://msdn.microsoft.com/en-us/library/system.type.isprimitive(v=vs.110).aspx?query=memberwiseclone): Boolean, Byte, SByte, Int16, UInt16, Int32, UInt32, Int64, UInt64, IntPtr, UIntPtr, Char, Double, and Single
- string
- Guid


### Tests
For the following saga

```
public class SagaWithGuid : ContainSagaData
{
  public Guid Guid;
}
```

initialized before tests with
```
new SagaWithGuid 
{
    Id = Guid.NewGuid(),
    Guid = Guid.NewGuid(),
    OriginalMessageId = Guid.NewGuid().ToString(),
    Originator = "Originator"
};
```

Getting saga with ` Task<TSagaData> Get<TSagaData>(Guid sagaId, ...` has following performance

Method |        Median |      StdDev | Scaled |  Gen 0 | Gen 1 | Gen 2 | Bytes Allocated/Op |
------------- |-------------- |------------ |------- |------- |------ |------ |------------------- |
Current | 6,301.7050 ns | 276.7486 ns |   1.00 | 879.00 |     - |     - |           1,669.12 |
Proposed with this PR |   399.4142 ns |  22.6731 ns |   0.06 |  91.97 |     - |     - |             162.40 |