### PR TITLE
Fixing randomly failing log assertion

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Stopping/When_pump_throws_on_stop.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Stopping/When_pump_throws_on_stop.cs
@@ -19,7 +19,7 @@ namespace NServiceBus.AcceptanceTests.Core.Stopping
                 .Done(c => c.EndpointsStarted)
                 .Run();
 
-            Assert.IsNotNull(context.Logs.Single(l =>
+            Assert.IsNotNull(context.Logs.SingleOrDefault(l =>
                 l.Level == LogLevel.Warn
                 && l.Message.Contains("Receiver Main listening to queue PumpThrowsOnStop.EndpointThatThrowsOnPumpStop threw an exception on stopping. System.InvalidOperationException: ExceptionInPumpStop")));
         }

--- a/src/NServiceBus.AcceptanceTests/Core/Stopping/When_pump_throws_on_stop.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Stopping/When_pump_throws_on_stop.cs
@@ -12,16 +12,16 @@ namespace NServiceBus.AcceptanceTests.Core.Stopping
     public class When_pump_throws_on_stop : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_log_exception()
+        public async Task Should_not_throw_but_log_exception()
         {
             var context = await Scenario.Define<ScenarioContext>()
                 .WithEndpoint<EndpointThatThrowsOnPumpStop>()
                 .Done(c => c.EndpointsStarted)
                 .Run();
 
-            var logItem = context.Logs.FirstOrDefault(item => item.Message.Contains("Receiver") && item.Level == LogLevel.Warn);
-            Assert.IsNotNull(logItem);
-            StringAssert.Contains("Receiver Main listening to queue PumpThrowsOnStop.EndpointThatThrowsOnPumpStop threw an exception on stopping. System.InvalidOperationException: ExceptionInPumpStop", logItem.Message);
+            Assert.IsNotNull(context.Logs.Single(l =>
+                l.Level == LogLevel.Warn
+                && l.Message.Contains("Receiver Main listening to queue PumpThrowsOnStop.EndpointThatThrowsOnPumpStop threw an exception on stopping. System.InvalidOperationException: ExceptionInPumpStop")));
         }
 
         public class EndpointThatThrowsOnPumpStop : EndpointConfigurationBuilder


### PR DESCRIPTION
Fixes #4387 
The assertion could randomly fail because the the pump for the legacy retries satellite will fail additionally to the main pump. This causes multiple log entries matching the LINQ filter in the result where it can switch randomly between the main and the legacy retries satellite to be the first.

Switched the log filter to be more specific on the log filter to avoid this race condition.

An alternative would be to disable the legacy retries satellite for this test but then any other satellite receiver could introduce the same race condition again.