### PR TITLE
Add isolated dispatch on failure test

### DIFF
--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -49,6 +49,7 @@
     <Compile Include="NServiceBusTransportTest.cs" />
     <Compile Include="TransportConfigurationResult.cs" />
     <Compile Include="TypeScanner.cs" />
+    <Compile Include="When_failure_happens_after_isolated_send.cs" />
     <Compile Include="When_failure_happens_after_send.cs" />
     <Compile Include="When_on_error_throws.cs" />
     <Compile Include="When_on_message_throws_after_delayed_retry.cs" />

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -145,7 +145,8 @@
         protected Task SendMessage(string address,
             Dictionary<string, string> headers = null,
             TransportTransaction transportTransaction = null,
-            List<DeliveryConstraint> deliveryConstraints = null)
+            List<DeliveryConstraint> deliveryConstraints = null,
+            DispatchConsistency dispatchConsistency = DispatchConsistency.Default)
         {
             var messageId = Guid.NewGuid().ToString();
             var message = new OutgoingMessage(messageId, headers ?? new Dictionary<string, string>(), new byte[0]);
@@ -161,7 +162,7 @@
             {
                 transportTransaction = new TransportTransaction();
             }
-            var transportOperation = new TransportOperation(message, new UnicastAddressTag(address), DispatchConsistency.Default, deliveryConstraints ?? new List<DeliveryConstraint>());
+            var transportOperation = new TransportOperation(message, new UnicastAddressTag(address), dispatchConsistency, deliveryConstraints ?? new List<DeliveryConstraint>());
 
             return dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction, new ContextBag());
         }

--- a/src/NServiceBus.TransportTests/When_failure_happens_after_isolated_send.cs
+++ b/src/NServiceBus.TransportTests/When_failure_happens_after_isolated_send.cs
@@ -22,13 +22,13 @@
                 {
                     if (context.Headers.ContainsKey("CompleteTest"))
                     {
-                        onMessageCalled.SetResult(true);
+                        onMessageCalled.SetResult(false);
                         return;
                     }
 
                     if (context.Headers.ContainsKey("IsolatedSend"))
                     {
-                        onMessageCalled.SetResult(false);
+                        onMessageCalled.SetResult(true);
                         return;
                     }
 
@@ -49,12 +49,9 @@
                     return ErrorHandleResult.Handled;
                 }, transactionMode);
 
-            await SendMessage(InputQueueName, new Dictionary<string, string>
-            {
-                {"MyHeader", "MyValue"}
-            });
+            await SendMessage(InputQueueName);
 
-            Assert.False(await onMessageCalled.Task, "Should emit isolated sends");
+            Assert.True(await onMessageCalled.Task, "Should emit isolated sends");
         }
     }
 }

--- a/src/NServiceBus.TransportTests/When_failure_happens_after_isolated_send.cs
+++ b/src/NServiceBus.TransportTests/When_failure_happens_after_isolated_send.cs
@@ -8,8 +8,8 @@
 
     public class When_failure_happens_after_isolated_send : NServiceBusTransportTest
     {
-        //[TestCase(TransportTransactionMode.None)] - not relevant
-        //[TestCase(TransportTransactionMode.ReceiveOnly)] - not relevant
+        [TestCase(TransportTransactionMode.None)]
+        [TestCase(TransportTransactionMode.ReceiveOnly)]
         [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
         [TestCase(TransportTransactionMode.TransactionScope)]
         public async Task Should_emit_messages(TransportTransactionMode transactionMode)

--- a/src/NServiceBus.TransportTests/When_failure_happens_after_isolated_send.cs
+++ b/src/NServiceBus.TransportTests/When_failure_happens_after_isolated_send.cs
@@ -1,0 +1,60 @@
+﻿namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using Transport;
+
+    public class When_failure_happens_after_isolated_send : NServiceBusTransportTest
+    {
+        //[TestCase(TransportTransactionMode.None)] - not relevant
+        //[TestCase(TransportTransactionMode.ReceiveOnly)] - not relevant
+        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
+        [TestCase(TransportTransactionMode.TransactionScope)]
+        public async Task Should_emit_messages(TransportTransactionMode transactionMode)
+        {
+            var onMessageCalled = new TaskCompletionSource<bool>();
+
+            OnTestTimeout(() => onMessageCalled.SetCanceled());
+
+            await StartPump(async context =>
+                {
+                    if (context.Headers.ContainsKey("CompleteTest"))
+                    {
+                        onMessageCalled.SetResult(true);
+                        return;
+                    }
+
+                    if (context.Headers.ContainsKey("EnlistedSend"))
+                    {
+                        onMessageCalled.SetResult(false);
+                        return;
+                    }
+
+                    await SendMessage(InputQueueName, new Dictionary<string, string>
+                    {
+                        {"EnlistedSend", "true"}
+                    }, context.TransportTransaction, null, DispatchConsistency.Isolated);
+
+                    throw new Exception("Simulated exception");
+                },
+                async context =>
+                {
+                    await SendMessage(InputQueueName, new Dictionary<string, string>
+                    {
+                        {"CompleteTest", "true"}
+                    }, context.TransportTransaction, null, DispatchConsistency.Isolated);
+
+                    return ErrorHandleResult.Handled;
+                }, transactionMode);
+
+            await SendMessage(InputQueueName, new Dictionary<string, string>
+            {
+                {"MyHeader", "MyValue"}
+            });
+
+            Assert.False(await onMessageCalled.Task, "Should emit enlisted sends");
+        }
+    }
+}

--- a/src/NServiceBus.TransportTests/When_failure_happens_after_isolated_send.cs
+++ b/src/NServiceBus.TransportTests/When_failure_happens_after_isolated_send.cs
@@ -20,12 +20,6 @@
 
             await StartPump(async context =>
                 {
-                    if (context.Headers.ContainsKey("CompleteTest"))
-                    {
-                        onMessageCalled.SetResult(false);
-                        return;
-                    }
-
                     if (context.Headers.ContainsKey("IsolatedSend"))
                     {
                         onMessageCalled.SetResult(true);
@@ -39,15 +33,8 @@
 
                     throw new Exception("Simulated exception");
                 },
-                async context =>
-                {
-                    await SendMessage(InputQueueName, new Dictionary<string, string>
-                    {
-                        {"CompleteTest", "true"}
-                    }, context.TransportTransaction, null, DispatchConsistency.Isolated);
-
-                    return ErrorHandleResult.Handled;
-                }, transactionMode);
+                errorContext => Task.FromResult(ErrorHandleResult.Handled),
+                transactionMode);
 
             await SendMessage(InputQueueName);
 

--- a/src/NServiceBus.TransportTests/When_failure_happens_after_isolated_send.cs
+++ b/src/NServiceBus.TransportTests/When_failure_happens_after_isolated_send.cs
@@ -26,7 +26,7 @@
                         return;
                     }
 
-                    if (context.Headers.ContainsKey("EnlistedSend"))
+                    if (context.Headers.ContainsKey("IsolatedSend"))
                     {
                         onMessageCalled.SetResult(false);
                         return;
@@ -34,7 +34,7 @@
 
                     await SendMessage(InputQueueName, new Dictionary<string, string>
                     {
-                        {"EnlistedSend", "true"}
+                        {"IsolatedSend", "true"}
                     }, context.TransportTransaction, null, DispatchConsistency.Isolated);
 
                     throw new Exception("Simulated exception");
@@ -54,7 +54,7 @@
                 {"MyHeader", "MyValue"}
             });
 
-            Assert.False(await onMessageCalled.Task, "Should emit enlisted sends");
+            Assert.False(await onMessageCalled.Task, "Should emit isolated sends");
         }
     }
 }


### PR DESCRIPTION
Added test to verify that messages are emitted after a failure when running in isolated dispatch.

As per #4392