### PR TITLE
Reuse of incoming message as saga timeout message causes duplicate handler invocations

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Sagas\When_a_base_class_mapped_is_handled_by_a_saga.cs" />
     <Compile Include="Sagas\When_a_base_class_message_starts_a_saga.cs" />
     <Compile Include="Sagas\When_saga_started_concurrently.cs" />
+    <Compile Include="Sagas\When_using_a_received_message_for_timeout.cs" />
     <Compile Include="Serialization\When_configuring_custom_xml_namespace.cs" />
     <Compile Include="Serialization\When_registering_additional_deserializers.cs" />
     <Compile Include="Basic\When_no_content_type.cs" />
@@ -309,7 +310,7 @@
     <Compile Include="Sagas\When_started_by_event_from_another_saga.cs" />
     <Compile Include="Sagas\When_a_existing_saga_instance_exists.cs" />
     <Compile Include="Sagas\When_two_sagas_subscribe_to_the_same_event.cs" />
-    <Compile Include="Sagas\When_using_a_received_message_for_timeout.cs" />
+    <Compile Include="Sagas\When_handling_message_with_handler_and_timeout_handler.cs" />
     <Compile Include="Sagas\When_receiving_that_completes_the_saga.cs" />
     <Compile Include="Sagas\When_receiving_that_should_start_a_saga.cs" />
     <Compile Include="Sagas\When_saga_message_goes_through_delayed_retries.cs" />

--- a/src/NServiceBus.Core/Pipeline/Incoming/MessageHandler.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/MessageHandler.cs
@@ -29,6 +29,8 @@
         /// </summary>
         public Type HandlerType { get; private set; }
 
+        internal bool IsTimeoutHandler { get; set; }
+
         /// <summary>
         /// Invokes the message handler.
         /// </summary>


### PR DESCRIPTION
## Who's affected

NServiceBus Version 6 users with sagas reusing one or more of the incoming messages as timeout messages.

## Symptoms

When the saga is processed both the message handler and the timeout handler is invoked for the incoming message.  Any logic in the timeout handler would be invoked immediately and not when the timeout is due. 

Example of a problematic saga:
```
public class MySaga: Saga<MySagaData>, 
  IAmStartedByMessages<StartSagaMessage>, 
  IHandleTimeouts<StartSagaMessage>
{
                public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
                {
                    //will be invoked again incorrectly after 10 seconds
                    return RequestTimeout(context, TimeSpan.Seconds(10), message); //note that the incoming message is reused
                }

                public Task Timeout(StartSagaMessage message, IMessageHandlerContext context)
                {
                    //this will be invoked immediately and not after 10 seconds
                }
}
```