### PR TITLE
Invoke proper handler for sags that reuse messages as timeouts

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Sagas\When_finder_returns_existing_saga.cs" />
     <Compile Include="Sagas\When_saga_started_concurrently.cs" />
     <Compile Include="Satellites\When_satellite_txmode_does_not_match_endpoints_txmode.cs" />
+    <Compile Include="Sagas\When_using_a_received_message_for_timeout.cs" />
     <Compile Include="Serialization\When_configuring_custom_xml_namespace.cs" />
     <Compile Include="Serialization\When_registering_additional_deserializers.cs" />
     <Compile Include="Basic\When_no_content_type.cs" />
@@ -316,7 +317,7 @@
     <Compile Include="Sagas\When_started_by_event_from_another_saga.cs" />
     <Compile Include="Sagas\When_saga_exists_for_start_message.cs" />
     <Compile Include="Sagas\When_two_sagas_subscribe_to_the_same_event.cs" />
-    <Compile Include="Sagas\When_using_a_received_message_for_timeout.cs" />
+    <Compile Include="Sagas\When_handling_message_with_handler_and_timeout_handler.cs" />
     <Compile Include="Sagas\When_receiving_that_completes_the_saga.cs" />
     <Compile Include="Sagas\When_receiving_that_should_start_a_saga.cs" />
     <Compile Include="Sagas\When_saga_message_goes_through_delayed_retries.cs" />

--- a/src/NServiceBus.Core/Pipeline/Incoming/MessageHandler.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/MessageHandler.cs
@@ -29,6 +29,8 @@
         /// </summary>
         public Type HandlerType { get; private set; }
 
+        internal bool IsTimeoutHandler { get; set; }
+
         /// <summary>
         /// Invokes the message handler.
         /// </summary>


### PR DESCRIPTION
@bording this is a cherry pick of the 6.1.1/6.0.5 fix that should be correct.

Would we prefer this over https://github.com/Particular/NServiceBus/pull/4404 ?