### PR TITLE
Make ActiveSagaInstance ctor public

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2694,6 +2694,7 @@ namespace NServiceBus.Sagas
 {
     public class ActiveSagaInstance
     {
+        public ActiveSagaInstance(NServiceBus.Saga saga, NServiceBus.Sagas.SagaMetadata metadata, System.Func<System.DateTime> currentUtcDateTimeProvider) { }
         public System.DateTime Created { get; }
         public NServiceBus.Saga Instance { get; }
         public bool IsNew { get; }

--- a/src/NServiceBus.Core/Sagas/ActiveSagaInstance.cs
+++ b/src/NServiceBus.Core/Sagas/ActiveSagaInstance.cs
@@ -11,7 +11,10 @@ namespace NServiceBus.Sagas
     {
         readonly Func<DateTime> currentUtcDateTimeProvider;
 
-        internal ActiveSagaInstance(Saga saga, SagaMetadata metadata, Func<DateTime> currentUtcDateTimeProvider)
+        /// <summary>
+        /// Creates a new <see cref="ActiveSagaInstance"/> instance.
+        /// </summary>
+        public ActiveSagaInstance(Saga saga, SagaMetadata metadata, Func<DateTime> currentUtcDateTimeProvider)
         {
             this.currentUtcDateTimeProvider = currentUtcDateTimeProvider;
             Instance = saga;


### PR DESCRIPTION
addresses https://github.com/Particular/NServiceBus/issues/4322

this would theoretically allow users to replace the `ActiveSagaInstance` on the context but I don't really see this as something we need to actively prevent as there isn't any realistic scenario to do this.

cc @SimonCropp 