### PR TITLE
[WIP] Different instances invoked when saga has handlers for both base and specific message type

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Sagas\When_a_base_class_message_starts_a_saga.cs" />
     <Compile Include="Sagas\When_finder_cant_find_saga_instance.cs" />
     <Compile Include="Sagas\When_finder_returns_existing_saga.cs" />
+    <Compile Include="Sagas\When_saga_handles_both_base_and_specific_message.cs" />
     <Compile Include="Sagas\When_saga_started_concurrently.cs" />
     <Compile Include="Satellites\When_satellite_txmode_does_not_match_endpoints_txmode.cs" />
     <Compile Include="Sagas\When_using_a_received_message_for_timeout.cs" />

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_handles_both_base_and_specific_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_handles_both_base_and_specific_message.cs
@@ -1,0 +1,83 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_saga_handles_both_base_and_specific_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_invoke_handle_on_the_same_instance()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<PolymorphicSagaEndpoint>(b => b
+                    .When(session => session.SendLocal(new StartSagaMessage
+                    {
+                        SomeId = Guid.NewGuid()
+                    })))
+                .Done(c => c.BaseId != Guid.Empty && c.SpecificId != Guid.Empty)
+                .Run();
+
+            Assert.AreEqual(context.BaseId, context.SpecificId, "The same saga instance should be used");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid BaseId { get; set; }
+            public Guid SpecificId { get; set; }
+        }
+
+        public class PolymorphicSagaEndpoint : EndpointConfigurationBuilder
+        {
+            public PolymorphicSagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class PolymorphicSaga : Saga<PolymorphicSagaData>,
+                IAmStartedByMessages<StartSagaMessageBase>,
+                IAmStartedByMessages<StartSagaMessage>
+            {
+                public Context TestContext { get; set; }
+
+                public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
+                {
+                    TestContext.SpecificId = Data.Id;
+
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(StartSagaMessageBase message, IMessageHandlerContext context)
+                {
+                    TestContext.BaseId = Data.Id;
+
+                    return Task.FromResult(0);
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<PolymorphicSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartSagaMessageBase>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                }
+            }
+
+            public class PolymorphicSagaData : ContainSagaData
+            {
+                public virtual Guid SomeId { get; set; }
+            }
+        }
+
+        public class StartSagaMessage : StartSagaMessageBase
+        {
+        }
+
+        public class StartSagaMessageBase : IMessage
+        {
+            public Guid SomeId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/Incoming/MessageHandler.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/MessageHandler.cs
@@ -13,10 +13,19 @@
         /// </summary>
         /// <param name="invocation">The invocation with context delegate.</param>
         /// <param name="handlerType">The handler type.</param>
-        public MessageHandler(Func<object, object, IMessageHandlerContext, Task> invocation, Type handlerType)
+        public MessageHandler(Func<object, object, IMessageHandlerContext, Task> invocation, Type handlerType) : this(new[] { invocation }, handlerType)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the message handler with predefined invocation delegate and handler type.
+        /// </summary>
+        /// <param name="invocations">The invocation with context delegate.</param>
+        /// <param name="handlerType">The handler type.</param>
+        public MessageHandler(Func<object, object, IMessageHandlerContext, Task>[] invocations, Type handlerType)
         {
             HandlerType = handlerType;
-            this.invocation = invocation;
+            this.invocations = invocations;
         }
 
         /// <summary>
@@ -32,15 +41,18 @@
         internal bool IsTimeoutHandler { get; set; }
 
         /// <summary>
-        /// Invokes the message handler.
+        /// Performs the invocations.
         /// </summary>
         /// <param name="message">the message to pass to the handler.</param>
         /// <param name="handlerContext">the context to pass to the handler.</param>
-        public Task Invoke(object message, IMessageHandlerContext handlerContext)
+        public async Task Invoke(object message, IMessageHandlerContext handlerContext)
         {
-            return invocation(Instance, message, handlerContext);
+            foreach (var invocation in invocations)
+            {
+                await invocation(Instance, message, handlerContext).ConfigureAwait(false);
+            }
         }
 
-        Func<object, object, IMessageHandlerContext, Task> invocation;
+        Func<object, object, IMessageHandlerContext, Task>[] invocations;
     }
 }

--- a/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
@@ -36,6 +36,24 @@
             foreach (var handlersAndMessages in handlerAndMessagesHandledByHandlerCache)
             {
                 var handlerType = handlersAndMessages.Key;
+
+                if (typeof(Saga).IsAssignableFrom(handlerType))
+                {
+                    var handlerDelegates = handlersAndMessages.Value.Where(hd => hd.MessageType.IsAssignableFrom(messageType))
+                        .ToList();
+
+                    if (handlerDelegates.Any())
+                    {
+                        messageHandlers.Add(new MessageHandler(handlerDelegates.Select(hd=>hd.MethodDelegate).ToArray(), handlerType)
+                        {
+                            IsTimeoutHandler = handlerDelegates.First().IsTimeoutHandler
+                        });
+
+                    }
+
+                    continue;
+                }
+
                 // ReSharper disable once LoopCanBeConvertedToQuery
                 foreach (var handlerDelegate in handlersAndMessages.Value)
                 {


### PR DESCRIPTION
Added failing test showing different saga instances to be used for polymorphic sagas. This causes issues for the persisters similar to https://github.com/Particular/NServiceBus/issues/4397

### The plan

- [ ] For sagas make sure the invocations happens on the same saga instance

- [x] ~~Decide if we should do the same for handlers. It would be a behavior breaking change but it would make the doco correct, https://docs.particular.net/nservicebus/handlers-and-sagas~~

- [ ] Raise issue to move the saga persistence behavior to the logical receive stage in vNextMajor
- [ ] Raise issue to show the saga issue with multiple inheritance (since those messages will result in multiple invocations of the logical receive stage which in turn breaks the persisters again)