### PR TITLE
Move failure info clearing for more consistency

### DIFF
--- a/src/NServiceBus.Core/Transports/Msmq/MsmqFailureInfoStorage.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqFailureInfoStorage.cs
@@ -67,11 +67,6 @@ namespace NServiceBus
 
         public void ClearFailureInfoForMessage(string messageId)
         {
-            if (string.IsNullOrEmpty(messageId))
-            {
-                return;
-            }
-
             lock (lockObject)
             {
                 failureInfoPerMessage.Remove(messageId);

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqFailureInfoStorage.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqFailureInfoStorage.cs
@@ -67,6 +67,11 @@ namespace NServiceBus
 
         public void ClearFailureInfoForMessage(string messageId)
         {
+            if (string.IsNullOrEmpty(messageId))
+            {
+                return;
+            }
+
             lock (lockObject)
             {
                 failureInfoPerMessage.Remove(messageId);

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveOnlyNativeTransactionStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveOnlyNativeTransactionStrategy.cs
@@ -49,6 +49,7 @@
                         msmqTransaction.Abort();
                     }
                 }
+                failureInfoStorage.ClearFailureInfoForMessage(message.Id);
             }
             // We'll only get here if Commit/Abort/Dispose throws which should be rare.
             // Note: If that happens the attempts counter will be inconsistent since the message might be picked up again before we can register the failure in the LRU cache.
@@ -67,40 +68,35 @@
         {
             MsmqFailureInfoStorage.ProcessingFailureInfo failureInfo;
 
-            var shouldTryProcessMessage = true;
-
             if (failureInfoStorage.TryGetFailureInfoForMessage(message.Id, out failureInfo))
             {
                 var errorHandleResult = await HandleError(message, headers, failureInfo.Exception, transportTransaction, failureInfo.NumberOfProcessingAttempts).ConfigureAwait(false);
 
-                shouldTryProcessMessage = errorHandleResult != ErrorHandleResult.Handled;
+                if (errorHandleResult == ErrorHandleResult.Handled)
+                {
+                    return true;
+                }
             }
 
-            if (shouldTryProcessMessage)
+            try
             {
-                try
+                using (var bodyStream = message.BodyStream)
                 {
-                    using (var bodyStream = message.BodyStream)
-                    {
-                        var shouldAbortMessageProcessing = await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction).ConfigureAwait(false);
+                    var shouldAbortMessageProcessing = await TryProcessMessage(message.Id, headers, bodyStream, transportTransaction).ConfigureAwait(false);
 
-                        if (shouldAbortMessageProcessing)
-                        {
-                            return false;
-                        }
+                    if (shouldAbortMessageProcessing)
+                    {
+                        return false;
                     }
                 }
-                catch (Exception exception)
-                {
-                    failureInfoStorage.RecordFailureInfoForMessage(message.Id, exception);
-
-                    return false;
-                }
+                return true;
             }
+            catch (Exception exception)
+            {
+                failureInfoStorage.RecordFailureInfoForMessage(message.Id, exception);
 
-            failureInfoStorage.ClearFailureInfoForMessage(message.Id);
-
-            return true;
+                return false;
+            }
         }
 
         MsmqFailureInfoStorage failureInfoStorage;

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveOnlyNativeTransactionStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveOnlyNativeTransactionStrategy.cs
@@ -43,13 +43,13 @@
                     if (shouldCommit)
                     {
                         msmqTransaction.Commit();
+                        failureInfoStorage.ClearFailureInfoForMessage(message.Id);
                     }
                     else
                     {
                         msmqTransaction.Abort();
                     }
                 }
-                failureInfoStorage.ClearFailureInfoForMessage(message.Id);
             }
             // We'll only get here if Commit/Abort/Dispose throws which should be rare.
             // Note: If that happens the attempts counter will be inconsistent since the message might be picked up again before we can register the failure in the LRU cache.

--- a/src/NServiceBus.Core/Transports/Msmq/SendsAtomicWithReceiveNativeTransactionStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/SendsAtomicWithReceiveNativeTransactionStrategy.cs
@@ -43,13 +43,13 @@ namespace NServiceBus
                     if (shouldCommit)
                     {
                         msmqTransaction.Commit();
+                        failureInfoStorage.ClearFailureInfoForMessage(message.Id);
                     }
                     else
                     {
                         msmqTransaction.Abort();
                     }
                 }
-                failureInfoStorage.ClearFailureInfoForMessage(message.Id);
             }
             // We'll only get here if Commit/Abort/Dispose throws which should be rare.
             // Note: If that happens the attempts counter will be inconsistent since the message might be picked up again before we can register the failure in the LRU cache.

--- a/src/NServiceBus.Core/Transports/Msmq/TransactionScopeStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/TransactionScopeStrategy.cs
@@ -46,6 +46,8 @@ namespace NServiceBus
 
                     scope.Complete();
                 }
+
+                failureInfoStorage.ClearFailureInfoForMessage(message.Id);
             }
             // We'll only get here if Complete/Dispose throws which should be rare.
             // Note: If that happens the attempts counter will be inconsistent since the message might be picked up again before we can register the failure in the LRU cache.
@@ -73,7 +75,6 @@ namespace NServiceBus
 
                 if (errorHandleResult == ErrorHandleResult.Handled)
                 {
-                    failureInfoStorage.ClearFailureInfoForMessage(message.Id);
                     return true;
                 }
             }
@@ -90,7 +91,6 @@ namespace NServiceBus
                     }
                 }
 
-                failureInfoStorage.ClearFailureInfoForMessage(message.Id);
                 return true;
             }
             catch (Exception exception)

--- a/src/NServiceBus.Core/Transports/Msmq/TransactionScopeStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/TransactionScopeStrategy.cs
@@ -90,7 +90,6 @@ namespace NServiceBus
                         return false;
                     }
                 }
-
                 return true;
             }
             catch (Exception exception)

--- a/src/NServiceBus.Core/Transports/Msmq/TransactionScopeStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/TransactionScopeStrategy.cs
@@ -46,8 +46,10 @@ namespace NServiceBus
 
                     scope.Complete();
                 }
-
-                failureInfoStorage.ClearFailureInfoForMessage(message.Id);
+                if (message != null)
+                {
+                    failureInfoStorage.ClearFailureInfoForMessage(message.Id);
+                }
             }
             // We'll only get here if Complete/Dispose throws which should be rare.
             // Note: If that happens the attempts counter will be inconsistent since the message might be picked up again before we can register the failure in the LRU cache.

--- a/src/NServiceBus.Core/Transports/Msmq/TransactionScopeStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/TransactionScopeStrategy.cs
@@ -46,10 +46,8 @@ namespace NServiceBus
 
                     scope.Complete();
                 }
-                if (message != null)
-                {
-                    failureInfoStorage.ClearFailureInfoForMessage(message.Id);
-                }
+
+                failureInfoStorage.ClearFailureInfoForMessage(message.Id);
             }
             // We'll only get here if Complete/Dispose throws which should be rare.
             // Note: If that happens the attempts counter will be inconsistent since the message might be picked up again before we can register the failure in the LRU cache.

--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -54,7 +54,7 @@
     <Compile Include="When_on_error_throws.cs" />
     <Compile Include="When_on_message_throws_after_delayed_retry.cs" />
     <Compile Include="When_on_message_throws_after_immediate_retry.cs" />
-    <Compile Include="When_scope_dispose_throws.cs" />
+    <Compile Include="When_scope_complete_throws.cs" />
     <Compile Include="When_message_is_available.cs" />
     <Compile Include="When_on_message_throws.cs" />
     <Compile Include="When_requesting_immediate_retry.cs" />

--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="When_message_is_available.cs" />
     <Compile Include="When_on_message_throws.cs" />
     <Compile Include="When_requesting_immediate_retry.cs" />
+    <Compile Include="When_scope_throws_after_successful_message_processing.cs" />
     <Compile Include="When_sending_from_on_error.cs" />
     <Compile Include="When_transaction_level_TransactionScope.cs" />
     <Compile Include="When_user_aborts_processing.cs" />

--- a/src/NServiceBus.TransportTests/When_scope_complete_throws.cs
+++ b/src/NServiceBus.TransportTests/When_scope_complete_throws.cs
@@ -6,7 +6,7 @@
     using NUnit.Framework;
     using Transport;
 
-    public class When_scope_dispose_throws : NServiceBusTransportTest
+    public class When_scope_complete_throws : NServiceBusTransportTest
     {
         //[TestCase(TransportTransactionMode.None)] -- not relevant
         //[TestCase(TransportTransactionMode.ReceiveOnly)] -- unable to hook where required to throw after a message has been successfully processed but before transaction is successfully commited
@@ -21,7 +21,7 @@
                 context =>
                 {
                     // handler enlists a failing transaction enlistment to the DTC transaction which will fail when commiting the transaction.
-                    Transaction.Current.EnlistDurable(EnlistmentWhichFailesDuringPrepare.Id, new EnlistmentWhichFailesDuringPrepare(), EnlistmentOptions.None);
+                    Transaction.Current.EnlistDurable(EnlistmentWhichFailsDuringPrepare.Id, new EnlistmentWhichFailsDuringPrepare(), EnlistmentOptions.None);
                     return Task.FromResult(0);
                 },
                 context =>
@@ -41,7 +41,7 @@
             Assert.LessOrEqual(1, errorContext.ImmediateProcessingFailures);
         }
 
-        class EnlistmentWhichFailesDuringPrepare : IEnlistmentNotification
+        class EnlistmentWhichFailsDuringPrepare : IEnlistmentNotification
         {
             public static readonly Guid Id = Guid.NewGuid();
 

--- a/src/NServiceBus.TransportTests/When_scope_dispose_throws.cs
+++ b/src/NServiceBus.TransportTests/When_scope_dispose_throws.cs
@@ -15,7 +15,6 @@
         public async Task Should_call_on_error(TransportTransactionMode transactionMode)
         {
             var onErrorCalled = new TaskCompletionSource<ErrorContext>();
-
             OnTestTimeout(() => onErrorCalled.SetResult(null));
 
             await StartPump(context =>
@@ -39,7 +38,8 @@
 
             // since some transports doesn't have native retry counters we can't expect the attempts to be fully consistent since if
             // dispose throws the message might be picked up before the counter is incremented
-            Assert.LessOrEqual(2, errorContext.ImmediateProcessingFailures);
+
+            Assert.LessOrEqual(1, errorContext.ImmediateProcessingFailures);
         }
 
         class EnlistmentWhichFailesDuringPrepare : IEnlistmentNotification

--- a/src/NServiceBus.TransportTests/When_scope_dispose_throws.cs
+++ b/src/NServiceBus.TransportTests/When_scope_dispose_throws.cs
@@ -24,6 +24,11 @@
             },
             context =>
             {
+                //perform a immediate retry to make sure the transport increments the counter properly
+                if (context.ImmediateProcessingFailures < 2)
+                {
+                    return Task.FromResult(ErrorHandleResult.RetryRequired);
+                }
                 onErrorCalled.SetResult(context);
                 return Task.FromResult(ErrorHandleResult.Handled);
             }
@@ -37,7 +42,7 @@
 
             // since some transports doesn't have native retry counters we can't expect the attempts to be fully consistent since if
             // dispose throws the message might be picked up before the counter is incremented
-            Assert.LessOrEqual(1, errorContext.ImmediateProcessingFailures);
+            Assert.LessOrEqual(2, errorContext.ImmediateProcessingFailures);
         }
     }
 
@@ -48,7 +53,8 @@
         public void Prepare(PreparingEnlistment preparingEnlistment)
         {
             // fail during prepare, this will cause scope.Dispose to throw
-            preparingEnlistment.ForceRollback();
+            //preparingEnlistment.ForceRollback();
+            throw new Exception("shit");
         }
 
         public void Commit(Enlistment enlistment)

--- a/src/NServiceBus.TransportTests/When_scope_dispose_throws.cs
+++ b/src/NServiceBus.TransportTests/When_scope_dispose_throws.cs
@@ -17,7 +17,8 @@
             var onErrorCalled = new TaskCompletionSource<ErrorContext>();
             OnTestTimeout(() => onErrorCalled.SetResult(null));
 
-            await StartPump(context =>
+            await StartPump(
+                context =>
                 {
                     // handler enlists a failing transaction enlistment to the DTC transaction which will fail when commiting the transaction.
                     Transaction.Current.EnlistDurable(EnlistmentWhichFailesDuringPrepare.Id, new EnlistmentWhichFailesDuringPrepare(), EnlistmentOptions.None);
@@ -27,8 +28,7 @@
                 {
                     onErrorCalled.SetResult(context);
                     return Task.FromResult(ErrorHandleResult.Handled);
-                }
-                , transactionMode);
+                }, transactionMode);
 
             await SendMessage(InputQueueName);
 
@@ -38,7 +38,6 @@
 
             // since some transports doesn't have native retry counters we can't expect the attempts to be fully consistent since if
             // dispose throws the message might be picked up before the counter is incremented
-
             Assert.LessOrEqual(1, errorContext.ImmediateProcessingFailures);
         }
 
@@ -48,7 +47,7 @@
 
             public void Prepare(PreparingEnlistment preparingEnlistment)
             {
-                // fail during prepare, this will cause scope.Dispose to throw
+                // fail during prepare, this will cause scope.Complete to throw
                 preparingEnlistment.ForceRollback();
             }
 

--- a/src/NServiceBus.TransportTests/When_scope_throws_after_successful_message_processing.cs
+++ b/src/NServiceBus.TransportTests/When_scope_throws_after_successful_message_processing.cs
@@ -21,7 +21,7 @@
             await StartPump(
                 context =>
                 {
-                    Transaction.Current.EnlistDurable(EnlistmentWhichFailesDuringPrepare.Id, new EnlistmentWhichFailesDuringPrepare(), EnlistmentOptions.None);
+                    Transaction.Current.EnlistDurable(EnlistmentWhichFailsDuringPrepare.Id, new EnlistmentWhichFailsDuringPrepare(), EnlistmentOptions.None);
                     return Task.FromResult(0);
                 },
                 context =>
@@ -45,7 +45,7 @@
         }
     }
 
-    class EnlistmentWhichFailesDuringPrepare : IEnlistmentNotification
+    class EnlistmentWhichFailsDuringPrepare : IEnlistmentNotification
     {
         public static readonly Guid Id = Guid.NewGuid();
 

--- a/src/NServiceBus.TransportTests/When_scope_throws_after_successful_message_processing.cs
+++ b/src/NServiceBus.TransportTests/When_scope_throws_after_successful_message_processing.cs
@@ -1,0 +1,76 @@
+﻿namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using System.Transactions;
+    using NUnit.Framework;
+    using Transport;
+
+    public class When_scope_throws_after_successful_message_processing : NServiceBusTransportTest
+    {
+        //[TestCase(TransportTransactionMode.None)] -- not relevant
+        //[TestCase(TransportTransactionMode.ReceiveOnly)] -- unable to hook where required to throw after a message has been successfully processed but before transaction is successfully commited
+        //[TestCase(TransportTransactionMode.SendsAtomicWithReceive)] -- unable to hook where required to throw after a message has been successfully processed but before transaction is successfully commited
+        [TestCase(TransportTransactionMode.TransactionScope)]
+        public async Task Should_properly_increment_immediate_processing_failures(TransportTransactionMode transactionMode)
+        {
+            var onErrorCalled = new TaskCompletionSource<ErrorContext>();
+
+            OnTestTimeout(() => onErrorCalled.SetCanceled());
+
+            await StartPump(context =>
+            {
+                Transaction.Current.EnlistDurable(EnlistmentWhichFailesDuringPrepare.Id, new EnlistmentWhichFailesDuringPrepare(), EnlistmentOptions.None);
+                return Task.FromResult(0);
+            },
+            context =>
+            {
+                //perform an immediate retry to make sure the transport increments the counter properly
+                if (context.ImmediateProcessingFailures < 2)
+                {
+                    return Task.FromResult(ErrorHandleResult.RetryRequired);
+                }
+                onErrorCalled.SetResult(context);
+
+                return Task.FromResult(ErrorHandleResult.Handled);
+            }
+            , transactionMode);
+
+            await SendMessage(InputQueueName);
+
+            var errorContext = await onErrorCalled.Task;
+
+            Assert.IsInstanceOf<TransactionAbortedException>(errorContext.Exception);
+
+            // since some transports doesn't have native retry counters we can't expect the attempts to be fully consistent since if
+            // dispose throws the message might be picked up before the counter is incremented
+            Assert.LessOrEqual(2, errorContext.ImmediateProcessingFailures);
+        }
+    }
+
+    class EnlistmentWhichFailesDuringPrepare : IEnlistmentNotification
+    {
+        public static readonly Guid Id = Guid.NewGuid();
+
+        public void Prepare(PreparingEnlistment preparingEnlistment)
+        {
+            // fail during prepare, this will cause scope.Dispose to throw
+            preparingEnlistment.ForceRollback();
+        }
+
+        public void Commit(Enlistment enlistment)
+        {
+            enlistment.Done();
+        }
+
+        public void Rollback(Enlistment enlistment)
+        {
+            enlistment.Done();
+        }
+
+        public void InDoubt(Enlistment enlistment)
+        {
+            enlistment.Done();
+        }
+    }
+}


### PR DESCRIPTION
This addresses a problem that @andreasohlund found where it was possible to get into what appeared to be an infinite loop #4419. This was being caused by the failure info counter not incrementing as expected. The problem wasn't with the incrementing, but instead the inconsistent clearing of the cached failure info that held the increment value. It was possible for the cached failure information to be removed on "success" only to have transactionscope fail on `scope.Complete()`, creating an exception and attempting to increment the counter in the failure info. Because the cached value had been removed a new cached failure info object was created with the incrementer set to 1.