### PR TITLE
Skip weaving the timeoutPollerTask

### DIFF
--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ExpiredTimeoutsPoller.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ExpiredTimeoutsPoller.cs
@@ -4,6 +4,7 @@ namespace NServiceBus
     using System.Threading;
     using System.Threading.Tasks;
     using Extensibility;
+    using Janitor;
     using Logging;
     using Routing;
     using Timeout.Core;
@@ -140,6 +141,7 @@ namespace NServiceBus
         string dispatcherAddress;
         object lockObject = new object();
         DateTime startSlice;
+        [SkipWeaving]
         Task timeoutPollerTask;
 
         IQueryTimeouts timeoutsFetcher;


### PR DESCRIPTION
Closes https://github.com/Particular/NServiceBus/issues/4415

The old generated code

```
public void Dispose()
{
    if (Interlocked.Exchange(ref this.disposeSignaled, 1) != 0)
    return;
    if (this.tokenSource != null)
    {
    this.tokenSource.Dispose();
    this.tokenSource = (CancellationTokenSource) null;
    }
    if (this.timeoutPollerTask != null)
    {
    this.timeoutPollerTask.Dispose();
    this.timeoutPollerTask = (Task) null;
    }
    this.disposed = true;
}
```

to

```
public void Dispose()
{
    if (Interlocked.Exchange(ref this.disposeSignaled, 1) != 0)
    return;
    if (this.tokenSource != null)
    {
    this.tokenSource.Dispose();
    this.tokenSource = (CancellationTokenSource) null;
    }
    this.disposed = true;
}
```

https://blogs.msdn.microsoft.com/pfxteam/2012/03/25/do-i-need-to-dispose-of-tasks/