### PR TITLE
Update Janitor to 1.2.2

### DIFF
--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ExpiredTimeoutsPoller.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ExpiredTimeoutsPoller.cs
@@ -4,7 +4,6 @@ namespace NServiceBus
     using System.Threading;
     using System.Threading.Tasks;
     using Extensibility;
-    using Janitor;
     using Logging;
     using Routing;
     using Timeout.Core;
@@ -141,7 +140,6 @@ namespace NServiceBus
         string dispatcherAddress;
         object lockObject = new object();
         DateTime startSlice;
-        [SkipWeaving]
         Task timeoutPollerTask;
 
         IQueryTimeouts timeoutsFetcher;

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -53,8 +53,8 @@
     <Reference Include="Autofac">
       <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Janitor, Version=1.2.0.0, Culture=neutral, PublicKeyToken=d34c7d3bba3746e6, processorArchitecture=MSIL">
-      <HintPath>..\packages\Janitor.Fody.1.2.0.0\lib\dotnet\Janitor.dll</HintPath>
+    <Reference Include="Janitor, Version=1.2.2.0, Culture=neutral, PublicKeyToken=d34c7d3bba3746e6, processorArchitecture=MSIL">
+      <HintPath>..\packages\Janitor.Fody.1.2.2.0\lib\dotnet\Janitor.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />

--- a/src/NServiceBus.Core/packages.config
+++ b/src/NServiceBus.Core/packages.config
@@ -3,7 +3,7 @@
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
   <package id="Fody" version="1.29.4" targetFramework="net452" developmentDependency="true" />
   <package id="GitVersionTask" version="3.6.3" targetFramework="net452" developmentDependency="true" />
-  <package id="Janitor.Fody" version="1.2.0.0" targetFramework="net452" developmentDependency="true" />
+  <package id="Janitor.Fody" version="1.2.2.0" targetFramework="net452" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net452" />
   <package id="NuGetPackager" version="0.6.0" targetFramework="net452" developmentDependency="true" />
   <package id="Obsolete.Fody" version="4.1.0" targetFramework="net452" developmentDependency="true" />


### PR DESCRIPTION
1.2.2 does no longer dispose tasks. Therefore we can remove the [SkipWeaving] again.

ping @danielmarbach 