### PR TITLE
Register publishers for ATTs that were missed out

### DIFF
--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled.cs
@@ -29,9 +29,8 @@ namespace NServiceBus.AcceptanceTests.BestPractices
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>()
-                    .AddMapping<MyEvent>(typeof(Endpoint))
-                    .AddMapping<MyCommand>(typeof(Endpoint));
+                EndpointSetup<DefaultServer>(publisherMetadata: metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Endpoint)))
+                    .AddMapping<MyEvent>(typeof(Endpoint));
             }
 
             public class Handler : IHandleMessages<MyEvent>
@@ -41,10 +40,6 @@ namespace NServiceBus.AcceptanceTests.BestPractices
                     return Task.FromResult(0);
                 }
             }
-        }
-
-        public class MyCommand : ICommand
-        {
         }
 
         public class MyEvent : IEvent

--- a/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled_on_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/BestPractices/When_sending_events_bestpractices_disabled_on_endpoint.cs
@@ -21,10 +21,11 @@
             public Endpoint()
             {
                 EndpointSetup<DefaultServer>((c, r) =>
-                    {
-                        var routing = c.UseTransport(r.GetTransportType()).Routing();
-                        routing.DoNotEnforceBestPractices();
-                    })
+                {
+                    var routing = c.UseTransport(r.GetTransportType()).Routing();
+                    routing.DoNotEnforceBestPractices();
+                },
+                    metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Endpoint)))
                     .AddMapping<MyEvent>(typeof(Endpoint));
             }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_multi_subscribing_to_a_polymorphic_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_multi_subscribing_to_a_polymorphic_event.cs
@@ -59,7 +59,11 @@
         {
             public Subscriber()
             {
-                EndpointSetup<DefaultServer>();
+                EndpointSetup<DefaultServer>(publisherMetadata: metadata =>
+                        {
+                            metadata.RegisterPublisherFor<IMyEvent>(typeof(Publisher1));
+                            metadata.RegisterPublisherFor<MyEvent2>(typeof(Publisher2));
+                        });
             }
 
             public class MyEventHandler : IHandleMessages<IMyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_publishing_to_scaled_out_subscribers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_publishing_to_scaled_out_subscribers.cs
@@ -60,7 +60,7 @@
         {
             public SubscriberA()
             {
-                EndpointSetup<DefaultServer>();
+                EndpointSetup<DefaultServer>(publisherMetadata: metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>
@@ -79,7 +79,7 @@
         {
             public SubscriberB()
             {
-                EndpointSetup<DefaultServer>();
+                EndpointSetup<DefaultServer>(publisherMetadata: metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
             }
 
             public class MyEventHandler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_unsubscribing_from_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_unsubscribing_from_event.cs
@@ -80,7 +80,7 @@
                 EndpointSetup<DefaultServer>(c =>
                 {
                     c.DisableFeature<AutoSubscribe>();
-                });
+                }, metadata => metadata.RegisterPublisherFor<Event>(typeof(Publisher)));
             }
 
             public class EventHandler : IHandleMessages<Event>
@@ -107,7 +107,7 @@
                 EndpointSetup<DefaultServer>(c =>
                 {
                     c.DisableFeature<AutoSubscribe>();
-                });
+                }, metadata => metadata.RegisterPublisherFor<Event>(typeof(Publisher)));
             }
 
             public class EventHandler : IHandleMessages<Event>


### PR DESCRIPTION
These tests were failing for NSB.ASB transport with `EndpointOrientedTopology` as it requires publisher information to be registered.

@Particular/nservicebus-maintainers please review