### PR TITLE
Log failed messages in acceptance tests

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -240,6 +240,11 @@
 
             if (unexpectedFailedMessages.Any())
             {
+                foreach (var failedMessage in unexpectedFailedMessages)
+                {
+                    Console.WriteLine($"Message: {failedMessage.MessageId} failed to process and was moved to the error queue: {failedMessage.Exception}");
+                }
+
                 throw new MessagesFailedException(unexpectedFailedMessages, runDescriptor.ScenarioContext);
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Basic/When_sending_from_a_send_only.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_sending_from_a_send_only.cs
@@ -103,7 +103,6 @@
             }
         }
 
-        
         public class MyMessage : ICommand
         {
             public Guid Id { get; set; }


### PR DESCRIPTION
When messages are moved to the error queue, the acceptance testing framework throws a `MessagesFailedException` containing a set of all failed messages. Since multiple messages can fail per test run, there is not a 1:1 relationship between the exception and the message, which results in no further details shown in the exceptions message. This causes some pain to investigate failed tests because the root cause exceptions are only accessible when explicitly handling the exception type or using the debugger.

This PR logs every failed (moved to error queue) message in the test output. E.g.:

> Message: c6e824c7-7e40-4338-940c-a701008bbecb failed to process and was moved to the error queue: System.Exception: test

note that there are other approaches on improving the exception thrown but this idea came up since it's a non breaking change and already provides a better experience when investigating failed tests caused by error queue messages.
