### PR TITLE
Disable ATT test timeouts when debugger is attached

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -202,11 +202,15 @@
                     var maxTime = runDescriptor.Settings.TestExecutionTimeout ?? TimeSpan.FromSeconds(90);
                     while (!done() && !cts.Token.IsCancellationRequested)
                     {
-                        if (DateTime.UtcNow - startTime > maxTime)
+                        if (!Debugger.IsAttached)
                         {
-                            ThrowOnFailedMessages(runDescriptor, endpoints);
-                            throw new TimeoutException(GenerateTestTimedOutMessage(maxTime));
+                            if (DateTime.UtcNow - startTime > maxTime)
+                            {
+                                ThrowOnFailedMessages(runDescriptor, endpoints);
+                                throw new TimeoutException(GenerateTestTimedOutMessage(maxTime));
+                            }
                         }
+
 
                         await Task.Delay(1).ConfigureAwait(false);
                     }


### PR DESCRIPTION
Solves #4402 