### PR TITLE
Acceptance testing

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -108,7 +108,7 @@
                 {
                     await Task.Run(async () =>
                     {
-                        var executedWhens = new List<Guid>();
+                        var executedWhens = new HashSet<Guid>();
 
                         while (!token.IsCancellationRequested)
                         {
@@ -139,6 +139,8 @@
                                     executedWhens.Add(when.Id);
                                 }
                             }
+
+                            await Task.Yield(); // enforce yield current context, tight loop could introduce starvation
                         }
                     }, token).ConfigureAwait(false);
                 }

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -210,7 +210,7 @@
                             }
                         }
 
-                        await Task.Delay(1).ConfigureAwait(false);
+                        await Task.Yield();
                     }
 
                     startTime = DateTime.UtcNow;
@@ -222,7 +222,7 @@
                             throw new Exception("Some failed messages were not handled by the recoverability feature.");
                         }
 
-                        await Task.Delay(1).ConfigureAwait(false);
+                        await Task.Yield();
                     }
                 }
                 finally

--- a/src/NServiceBus.AcceptanceTesting/Support/TaskExtensions.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/TaskExtensions.cs
@@ -27,7 +27,7 @@
 
                     if (t.IsFaulted && t.Exception != null)
                     {
-                        tcs.TrySetException(t.Exception.InnerException);
+                        tcs.TrySetException(t.Exception.GetBaseException());
                     }
 
                     if (t.IsCanceled)


### PR DESCRIPTION
This introduced a few changes to the acceptance testing library:

* The Timebox method uses [AggregateException.GetBaseException ](https://referencesource.microsoft.com/#mscorlib/system/AggregateException.cs,308) instead of InnerException
* When condition will yield the context to not starve resources
* Done condition yields as well

The when condition yield was introduced to remove a starvation issue we saw with ASQ and ASB. Since the when condition checks are very likely to execute synchronously as long as the condition is not reached we might be starving the thread that is entering wich then leads to timeouts of the tests.

## ASQ

Fixes the hanging build see https://builds.particular.net/viewLog.html?buildId=204512&buildTypeId=NServiceBus_Transports_NServiceBusAzureStorageQueues_1Build&tab=testsInfo

## ASB

Will try out with unstable package when released