### PR TITLE
Prevent debugging timeouts on all endpoint activities

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/TaskExtensions.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/TaskExtensions.cs
@@ -8,6 +8,7 @@
 
     static class TaskExtensions
     {
+        //this method will not timeout a task if the debugger is attached.
         public static Task Timebox(this IEnumerable<Task> tasks, TimeSpan timeoutAfter, string messageWhenTimeboxReached)
         {
             var taskCompletionSource = new TaskCompletionSource<object>();

--- a/src/NServiceBus.AcceptanceTesting/Support/TaskExtensions.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/TaskExtensions.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -10,7 +11,7 @@
         public static Task Timebox(this IEnumerable<Task> tasks, TimeSpan timeoutAfter, string messageWhenTimeboxReached)
         {
             var taskCompletionSource = new TaskCompletionSource<object>();
-            var tokenSource = new CancellationTokenSource(timeoutAfter);
+            var tokenSource = Debugger.IsAttached ? new CancellationTokenSource() : new CancellationTokenSource(timeoutAfter);
             var registration = tokenSource.Token.Register(s =>
             {
                 var tcs = (TaskCompletionSource<object>) s;


### PR DESCRIPTION
Connects to #4402 

This will prevent timeouts, when debugging, during `StartEndpoints`, `StopEndpoints` and `ExecuteWhens`.