### PR TITLE
Remove EncryptedValue usage from XmlMessageSerializer

### DIFF
--- a/src/NServiceBus.Core/Serializers/XML/XmlMessageSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlMessageSerializer.cs
@@ -94,11 +94,6 @@ namespace NServiceBus
         {
             var messageTypes = types.ToList();
 
-            if (!messageTypes.Contains(typeof(EncryptedValue)))
-            {
-                messageTypes.Add(typeof(EncryptedValue));
-            }
-
             foreach (var t in messageTypes)
             {
                 cache.InitType(t);


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/1082

`EncryptedValue` is added to the message types to initialize the XML Serializers cache. We can't do that any longer in the external encryption package. We could keep this code until we remove the core encryption code but at that point I don't see what that code is for. It also looks like the type could be initialized on demand but I wasn't able to reproduce a situation where this type needs to be initialized in the first place.

Maybe @andreasohlund or @SimonCropp have a bit more background about this?
ping @Particular/nservicebus-maintainers @kbaley 