### PR TITLE
Add obsolete warning to property encryption APIs

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_config.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_config.cs
@@ -9,6 +9,8 @@
     using NServiceBus.Config.ConfigurationSource;
     using NUnit.Framework;
 
+    // disable obsolete warnings. Tests will be removed in next major version
+    #pragma warning disable CS0618
     public class When_using_Rijndael_with_config : NServiceBusAcceptanceTest
     {
         [Test]

--- a/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_config.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_config.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.AcceptanceTests.Core.Encryption
+﻿// disable obsolete warnings. Tests will be removed in next major version
+#pragma warning disable CS0618
+namespace NServiceBus.AcceptanceTests.Core.Encryption
 {
     using System;
     using System.Collections.Generic;
@@ -9,8 +11,6 @@
     using NServiceBus.Config.ConfigurationSource;
     using NUnit.Framework;
 
-    // disable obsolete warnings. Tests will be removed in next major version
-    #pragma warning disable CS0618
     public class When_using_Rijndael_with_config : NServiceBusAcceptanceTest
     {
         [Test]
@@ -125,3 +125,4 @@
         }
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_custom.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_custom.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.AcceptanceTests.Core.Encryption
+﻿// disable obsolete warnings. Tests will be removed in next major version
+#pragma warning disable CS0618
+namespace NServiceBus.AcceptanceTests.Core.Encryption
 {
     using System;
     using System.Collections.Generic;
@@ -8,8 +10,6 @@
     using EndpointTemplates;
     using NUnit.Framework;
 
-    // disable obsolete warnings. Tests will be removed in next major version
-    #pragma warning disable CS0618
     public class When_using_Rijndael_with_custom : NServiceBusAcceptanceTest
     {
         [Test]
@@ -117,3 +117,4 @@
         }
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_custom.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_custom.cs
@@ -8,6 +8,8 @@
     using EndpointTemplates;
     using NUnit.Framework;
 
+    // disable obsolete warnings. Tests will be removed in next major version
+    #pragma warning disable CS0618
     public class When_using_Rijndael_with_custom : NServiceBusAcceptanceTest
     {
         [Test]
@@ -93,7 +95,7 @@
             }
         }
 
-        
+
         public class MessageWithSecretData : IMessage
         {
             public WireEncryptedString Secret { get; set; }
@@ -101,14 +103,14 @@
             public List<CreditCardDetails> CreditCards { get; set; }
         }
 
-        
+
         public class CreditCardDetails
         {
             public DateTime ValidTo { get; set; }
             public WireEncryptedString Number { get; set; }
         }
 
-        
+
         public class MySecretSubProperty
         {
             public WireEncryptedString Secret { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_multikey.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_multikey.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.AcceptanceTests.Core.Encryption
+﻿// disable obsolete warnings. Tests will be removed in next major version
+#pragma warning disable CS0618
+namespace NServiceBus.AcceptanceTests.Core.Encryption
 {
     using System.Collections.Generic;
     using System.Text;
@@ -8,8 +10,6 @@
     using NUnit.Framework;
     using ScenarioDescriptors;
 
-    // disable obsolete warnings. Tests will be removed in next major version
-    #pragma warning disable CS0618
     public class When_using_Rijndael_with_multikey : NServiceBusAcceptanceTest
     {
         [Test]
@@ -81,3 +81,4 @@
         }
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_multikey.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_multikey.cs
@@ -8,6 +8,8 @@
     using NUnit.Framework;
     using ScenarioDescriptors;
 
+    // disable obsolete warnings. Tests will be removed in next major version
+    #pragma warning disable CS0618
     public class When_using_Rijndael_with_multikey : NServiceBusAcceptanceTest
     {
         [Test]

--- a/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_unobtrusive_mode.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_unobtrusive_mode.cs
@@ -1,3 +1,5 @@
+// disable obsolete warnings. Tests will be removed in next major version
+#pragma warning disable CS0618
 namespace NServiceBus.AcceptanceTests.Core.Encryption
 {
     using System;
@@ -9,8 +11,6 @@ namespace NServiceBus.AcceptanceTests.Core.Encryption
     using EndpointTemplates;
     using NUnit.Framework;
 
-    // disable obsolete warnings. Tests will be removed in next major version
-    #pragma warning disable CS0618
     public class When_using_Rijndael_with_unobtrusive_mode : NServiceBusAcceptanceTest
     {
         [Test]
@@ -139,3 +139,4 @@ namespace NServiceBus.AcceptanceTests.Core.Encryption
         }
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_unobtrusive_mode.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_unobtrusive_mode.cs
@@ -9,6 +9,8 @@ namespace NServiceBus.AcceptanceTests.Core.Encryption
     using EndpointTemplates;
     using NUnit.Framework;
 
+    // disable obsolete warnings. Tests will be removed in next major version
+    #pragma warning disable CS0618
     public class When_using_Rijndael_with_unobtrusive_mode : NServiceBusAcceptanceTest
     {
         [Test]

--- a/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_without_incoming_key_identifier.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_without_incoming_key_identifier.cs
@@ -9,6 +9,8 @@
     using NUnit.Framework;
     using ScenarioDescriptors;
 
+    // disable obsolete warnings. Tests will be removed in next major version
+    #pragma warning disable CS0618
     public class When_using_Rijndael_without_incoming_key_identifier : NServiceBusAcceptanceTest
     {
         [Test]

--- a/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_without_incoming_key_identifier.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_without_incoming_key_identifier.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.AcceptanceTests.Core.Encryption
+﻿// disable obsolete warnings. Tests will be removed in next major version
+#pragma warning disable CS0618
+namespace NServiceBus.AcceptanceTests.Core.Encryption
 {
     using System.Collections.Generic;
     using System.Text;
@@ -9,8 +11,6 @@
     using NUnit.Framework;
     using ScenarioDescriptors;
 
-    // disable obsolete warnings. Tests will be removed in next major version
-    #pragma warning disable CS0618
     public class When_using_Rijndael_without_incoming_key_identifier : NServiceBusAcceptanceTest
     {
         [Test]
@@ -93,3 +93,4 @@
         }
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_encryption_with_custom_service.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_encryption_with_custom_service.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.AcceptanceTests.Core.Encryption
+﻿// disable obsolete warnings. Tests will be removed in next major version
+#pragma warning disable CS0618
+namespace NServiceBus.AcceptanceTests.Core.Encryption
 {
     using System;
     using System.Collections.Generic;
@@ -9,8 +11,6 @@
     using NServiceBus.Pipeline;
     using NUnit.Framework;
 
-    // disable obsolete warnings. Tests will be removed in next major version
-    #pragma warning disable CS0618
     public class When_using_encryption_with_custom_service : NServiceBusAcceptanceTest
     {
         [Test]
@@ -129,3 +129,4 @@
         }
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_encryption_with_custom_service.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_encryption_with_custom_service.cs
@@ -9,6 +9,8 @@
     using NServiceBus.Pipeline;
     using NUnit.Framework;
 
+    // disable obsolete warnings. Tests will be removed in next major version
+    #pragma warning disable CS0618
     public class When_using_encryption_with_custom_service : NServiceBusAcceptanceTest
     {
         [Test]
@@ -89,7 +91,7 @@
             }
         }
 
-        
+
         public class MessageWithSecretData : IMessage
         {
             public WireEncryptedString Secret { get; set; }
@@ -97,14 +99,14 @@
             public List<CreditCardDetails> CreditCards { get; set; }
         }
 
-        
+
         public class CreditCardDetails
         {
             public DateTime ValidTo { get; set; }
             public WireEncryptedString Number { get; set; }
         }
 
-        
+
         public class MySecretSubProperty
         {
             public WireEncryptedString Secret { get; set; }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -144,13 +144,28 @@ namespace NServiceBus
         public static bool CreateQueues(this NServiceBus.Settings.ReadOnlySettings settings) { }
         public static void DoNotCreateQueues(this NServiceBus.EndpointConfiguration config) { }
     }
+    [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+        "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+        "removed in version 8.0.0.", false)]
     public class static ConfigureRijndaelEncryptionService
     {
+        [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+            "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+            "removed in version 8.0.0.", false)]
         public static void RegisterEncryptionService(this NServiceBus.EndpointConfiguration config, System.Func<NServiceBus.IEncryptionService> func) { }
         [System.ObsoleteAttribute(@"It is no longer possible to access the builder to create an encryption service. If container access is required use the container directly in the factory. Use `RegisterEncryptionService(this EndpointConfiguration config, Func<IEncryptionService> func)` instead. The member currently throws a NotImplementedException. Will be removed in version 7.0.0.", true)]
         public static void RegisterEncryptionService(this NServiceBus.EndpointConfiguration config, System.Func<NServiceBus.ObjectBuilder.IBuilder, NServiceBus.IEncryptionService> func) { }
+        [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+            "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+            "removed in version 8.0.0.", false)]
         public static void RijndaelEncryptionService(this NServiceBus.EndpointConfiguration config) { }
+        [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+            "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+            "removed in version 8.0.0.", false)]
         public static void RijndaelEncryptionService(this NServiceBus.EndpointConfiguration config, string encryptionKeyIdentifier, byte[] encryptionKey, System.Collections.Generic.IList<byte[]> decryptionKeys = null) { }
+        [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+            "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+            "removed in version 8.0.0.", false)]
         public static void RijndaelEncryptionService(this NServiceBus.EndpointConfiguration config, string encryptionKeyIdentifier, System.Collections.Generic.IDictionary<string, byte[]> keys, System.Collections.Generic.IList<byte[]> decryptionKeys = null) { }
     }
     public class static ConfigureTransportConnectionString
@@ -325,10 +340,19 @@ namespace NServiceBus
     {
         public static NServiceBus.ConventionsBuilder DefiningExpressMessagesAs(this NServiceBus.ConventionsBuilder builder, System.Func<System.Type, bool> definesExpressMessageType) { }
     }
+    [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+        "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+        "removed in version 8.0.0.", false)]
     public class EncryptedValue
     {
         public EncryptedValue() { }
+        [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+            "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+            "removed in version 8.0.0.", false)]
         public string Base64Iv { get; set; }
+        [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+            "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+            "removed in version 8.0.0.", false)]
         public string EncryptedBase64Value { get; set; }
     }
     public class static Endpoint
@@ -585,9 +609,18 @@ namespace NServiceBus
     {
         NServiceBus.Routing.DistributionStrategy GetDistributionStrategy(string endpointName, NServiceBus.DistributionStrategyScope scope);
     }
+    [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+        "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+        "removed in version 8.0.0.", false)]
     public interface IEncryptionService
     {
+        [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+            "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+            "removed in version 8.0.0.", false)]
         string Decrypt(NServiceBus.EncryptedValue encryptedValue, NServiceBus.Pipeline.IIncomingLogicalMessageContext context);
+        [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+            "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+            "removed in version 8.0.0.", false)]
         NServiceBus.EncryptedValue Encrypt(string value, NServiceBus.Pipeline.IOutgoingLogicalMessageContext context);
     }
     public interface IEndpointInstance : NServiceBus.IMessageSession
@@ -1271,15 +1304,30 @@ namespace NServiceBus
             where T : NServiceBus.Transport.TransportDefinition, new () { }
         public static NServiceBus.TransportExtensions UseTransport(this NServiceBus.EndpointConfiguration endpointConfiguration, System.Type transportDefinitionType) { }
     }
+    [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+        "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+        "removed in version 8.0.0.", false)]
     public class WireEncryptedString : System.Runtime.Serialization.ISerializable
     {
+        [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+            "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+            "removed in version 8.0.0.", false)]
         public WireEncryptedString() { }
+        [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+            "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+            "removed in version 8.0.0.", false)]
         public WireEncryptedString(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         [System.ObsoleteAttribute("No longer required. Will be removed in version 7.0.0.", true)]
         public string Base64Iv { get; set; }
         [System.ObsoleteAttribute("No longer required. Will be removed in version 7.0.0.", true)]
         public string EncryptedBase64Value { get; set; }
+        [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+            "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+            "removed in version 8.0.0.", false)]
         public NServiceBus.EncryptedValue EncryptedValue { get; set; }
+        [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+            "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+            "removed in version 8.0.0.", false)]
         public string Value { get; set; }
         public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
     }
@@ -1336,6 +1384,9 @@ namespace NServiceBus.Config
         "ures.Feature` and use `configuration.EnableFeature<YourClass>()`. Will be remove" +
         "d in version 7.0.0.", true)]
     public interface IWantToRunWhenConfigurationIsComplete { }
+    [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+        "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+        "removed in version 8.0.0.", false)]
     public enum KeyFormat
     {
         Ascii = 0,
@@ -1407,6 +1458,9 @@ namespace NServiceBus.Config
         [System.Configuration.ConfigurationPropertyAttribute("Queue", IsRequired=true)]
         public string Queue { get; set; }
     }
+    [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+        "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+        "removed in version 8.0.0.", false)]
     public class RijndaelEncryptionServiceConfig : System.Configuration.ConfigurationSection
     {
         public RijndaelEncryptionServiceConfig() { }
@@ -1419,6 +1473,9 @@ namespace NServiceBus.Config
         [System.Configuration.ConfigurationPropertyAttribute("KeyIdentifier", IsRequired=false)]
         public string KeyIdentifier { get; set; }
     }
+    [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+        "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+        "removed in version 8.0.0.", false)]
     public class RijndaelExpiredKey : System.Configuration.ConfigurationElement
     {
         public RijndaelExpiredKey() { }
@@ -1429,6 +1486,9 @@ namespace NServiceBus.Config
         [System.Configuration.ConfigurationPropertyAttribute("KeyIdentifier", IsRequired=false)]
         public string KeyIdentifier { get; set; }
     }
+    [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+        "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+        "removed in version 8.0.0.", false)]
     public class RijndaelExpiredKeyCollection : System.Configuration.ConfigurationElementCollection
     {
         public RijndaelExpiredKeyCollection() { }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1297,9 +1297,7 @@ namespace NServiceBus
             where T : NServiceBus.Transport.TransportDefinition, new () { }
         public static NServiceBus.TransportExtensions UseTransport(this NServiceBus.EndpointConfiguration endpointConfiguration, System.Type transportDefinitionType) { }
     }
-    [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
-        "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
-        "removed in version 8.0.0.", false)]
+    [System.ObsoleteAttribute(@"Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package. Use `NServiceBus.Encryption.MessageProperty.WireEncryptedString` instead. Will be treated as an error from version 7.0.0. Will be removed in version 8.0.0.", false)]
     public class WireEncryptedString : System.Runtime.Serialization.ISerializable
     {
         [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -215,6 +215,9 @@ namespace NServiceBus
         public System.TimeSpan GetTimeToBeReceived(System.Type messageType) { }
         public bool IsCommandType(System.Type t) { }
         public bool IsDataBusProperty(System.Reflection.PropertyInfo property) { }
+        [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
+            "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
+            "removed in version 8.0.0.", false)]
         public bool IsEncryptedProperty(System.Reflection.PropertyInfo property) { }
         public bool IsEventType(System.Type t) { }
         [System.ObsoleteAttribute("No longer an extension point. The member currently throws a NotImplementedExcepti" +

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1297,7 +1297,7 @@ namespace NServiceBus
             where T : NServiceBus.Transport.TransportDefinition, new () { }
         public static NServiceBus.TransportExtensions UseTransport(this NServiceBus.EndpointConfiguration endpointConfiguration, System.Type transportDefinitionType) { }
     }
-    [System.ObsoleteAttribute(@"Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package. Use `NServiceBus.Encryption.MessageProperty.WireEncryptedString` instead. Will be treated as an error from version 7.0.0. Will be removed in version 8.0.0.", false)]
+    [System.ObsoleteAttribute(@"Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package. Use `NServiceBus.Encryption.MessageProperty.EncryptedString` instead. Will be treated as an error from version 7.0.0. Will be removed in version 8.0.0.", false)]
     public class WireEncryptedString : System.Runtime.Serialization.ISerializable
     {
         [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -144,28 +144,17 @@ namespace NServiceBus
         public static bool CreateQueues(this NServiceBus.Settings.ReadOnlySettings settings) { }
         public static void DoNotCreateQueues(this NServiceBus.EndpointConfiguration config) { }
     }
-    [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
-        "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
-        "removed in version 8.0.0.", false)]
     public class static ConfigureRijndaelEncryptionService
     {
-        [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
-            "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
-            "removed in version 8.0.0.", false)]
+        [System.ObsoleteAttribute(@"Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package. Use `NServiceBus.Encryption.MessageProperty.EncryptionConfigurationExtensions.EnableMessagePropertyEncryption` instead. Will be treated as an error from version 7.0.0. Will be removed in version 8.0.0.", false)]
         public static void RegisterEncryptionService(this NServiceBus.EndpointConfiguration config, System.Func<NServiceBus.IEncryptionService> func) { }
         [System.ObsoleteAttribute(@"It is no longer possible to access the builder to create an encryption service. If container access is required use the container directly in the factory. Use `RegisterEncryptionService(this EndpointConfiguration config, Func<IEncryptionService> func)` instead. The member currently throws a NotImplementedException. Will be removed in version 7.0.0.", true)]
         public static void RegisterEncryptionService(this NServiceBus.EndpointConfiguration config, System.Func<NServiceBus.ObjectBuilder.IBuilder, NServiceBus.IEncryptionService> func) { }
-        [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
-            "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
-            "removed in version 8.0.0.", false)]
+        [System.ObsoleteAttribute(@"Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package. Use `NServiceBus.Encryption.MessageProperty.EncryptionConfigurationExtensions.EnableMessagePropertyEncryption` instead. Will be treated as an error from version 7.0.0. Will be removed in version 8.0.0.", false)]
         public static void RijndaelEncryptionService(this NServiceBus.EndpointConfiguration config) { }
-        [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
-            "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
-            "removed in version 8.0.0.", false)]
+        [System.ObsoleteAttribute(@"Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package. Use `NServiceBus.Encryption.MessageProperty.EncryptionConfigurationExtensions.EnableMessagePropertyEncryption` instead. Will be treated as an error from version 7.0.0. Will be removed in version 8.0.0.", false)]
         public static void RijndaelEncryptionService(this NServiceBus.EndpointConfiguration config, string encryptionKeyIdentifier, byte[] encryptionKey, System.Collections.Generic.IList<byte[]> decryptionKeys = null) { }
-        [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
-            "ssageProperty\' package. Will be treated as an error from version 7.0.0. Will be " +
-            "removed in version 8.0.0.", false)]
+        [System.ObsoleteAttribute(@"Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package. Use `NServiceBus.Encryption.MessageProperty.EncryptionConfigurationExtensions.EnableMessagePropertyEncryption` instead. Will be treated as an error from version 7.0.0. Will be removed in version 8.0.0.", false)]
         public static void RijndaelEncryptionService(this NServiceBus.EndpointConfiguration config, string encryptionKeyIdentifier, System.Collections.Generic.IDictionary<string, byte[]> keys, System.Collections.Generic.IList<byte[]> decryptionKeys = null) { }
     }
     public class static ConfigureTransportConnectionString
@@ -232,6 +221,7 @@ namespace NServiceBus
         public NServiceBus.Conventions Conventions { get; }
         public NServiceBus.ConventionsBuilder DefiningCommandsAs(System.Func<System.Type, bool> definesCommandType) { }
         public NServiceBus.ConventionsBuilder DefiningDataBusPropertiesAs(System.Func<System.Reflection.PropertyInfo, bool> definesDataBusProperty) { }
+        [System.ObsoleteAttribute(@"Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package. This convention configuration does not work in combination with the NServiceBus.Encryption.MessageProperty package. Will be treated as an error from version 7.0.0. Will be removed in version 8.0.0.", false)]
         public NServiceBus.ConventionsBuilder DefiningEncryptedPropertiesAs(System.Func<System.Reflection.PropertyInfo, bool> definesEncryptedProperty) { }
         public NServiceBus.ConventionsBuilder DefiningEventsAs(System.Func<System.Type, bool> definesEventType) { }
         public NServiceBus.ConventionsBuilder DefiningMessagesAs(System.Func<System.Type, bool> definesMessageType) { }

--- a/src/NServiceBus.Core/Conventions.cs
+++ b/src/NServiceBus.Core/Conventions.cs
@@ -112,10 +112,13 @@
             }
         }
 
-
         /// <summary>
         /// Returns true if the given property should be encrypted.
         /// </summary>
+        [ObsoleteEx(
+            Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            RemoveInVersion = "8",
+            TreatAsErrorFromVersion = "7")]
         public bool IsEncryptedProperty(PropertyInfo property)
         {
             Guard.AgainstNull(nameof(property), property);

--- a/src/NServiceBus.Core/ConventionsBuilder.cs
+++ b/src/NServiceBus.Core/ConventionsBuilder.cs
@@ -51,6 +51,10 @@ namespace NServiceBus
         /// <summary>
         /// Sets the function to be used to evaluate whether a property should be encrypted or not.
         /// </summary>
+        [ObsoleteEx(
+            Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package. This convention configuration does not work in combination with the NServiceBus.Encryption.MessageProperty package.",
+            RemoveInVersion = "8",
+            TreatAsErrorFromVersion = "7")]
         public ConventionsBuilder DefiningEncryptedPropertiesAs(Func<PropertyInfo, bool> definesEncryptedProperty)
         {
             Guard.AgainstNull(nameof(definesEncryptedProperty), definesEncryptedProperty);

--- a/src/NServiceBus.Core/Encryption/ConfigureRijndaelEncryptionService.cs
+++ b/src/NServiceBus.Core/Encryption/ConfigureRijndaelEncryptionService.cs
@@ -11,10 +11,6 @@ namespace NServiceBus
     /// <summary>
     /// Contains extension methods to NServiceBus.Configure.
     /// </summary>
-    [ObsoleteEx(
-        Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
-        RemoveInVersion = "8",
-        TreatAsErrorFromVersion = "7")]
     public static partial class ConfigureRijndaelEncryptionService
     {
         /// <summary>
@@ -23,6 +19,7 @@ namespace NServiceBus
         /// <param name="config">The <see cref="EndpointConfiguration" /> instance to apply the settings to.</param>
         [ObsoleteEx(
             Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            ReplacementTypeOrMember = "NServiceBus.Encryption.MessageProperty.EncryptionConfigurationExtensions.EnableMessagePropertyEncryption",
             RemoveInVersion = "8",
             TreatAsErrorFromVersion = "7")]
         public static void RijndaelEncryptionService(this EndpointConfiguration config)
@@ -105,6 +102,7 @@ namespace NServiceBus
         /// <param name="decryptionKeys">A list of decryption keys.</param>
         [ObsoleteEx(
             Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            ReplacementTypeOrMember = "NServiceBus.Encryption.MessageProperty.EncryptionConfigurationExtensions.EnableMessagePropertyEncryption",
             RemoveInVersion = "8",
             TreatAsErrorFromVersion = "7")]
         public static void RijndaelEncryptionService(this EndpointConfiguration config, string encryptionKeyIdentifier, byte[] encryptionKey, IList<byte[]> decryptionKeys = null)
@@ -129,6 +127,7 @@ namespace NServiceBus
         /// </summary>
         [ObsoleteEx(
             Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            ReplacementTypeOrMember = "NServiceBus.Encryption.MessageProperty.EncryptionConfigurationExtensions.EnableMessagePropertyEncryption",
             RemoveInVersion = "8",
             TreatAsErrorFromVersion = "7")]
         public static void RijndaelEncryptionService(this EndpointConfiguration config, string encryptionKeyIdentifier, IDictionary<string, byte[]> keys, IList<byte[]> decryptionKeys = null)
@@ -184,6 +183,7 @@ namespace NServiceBus
         /// </param>
         [ObsoleteEx(
             Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            ReplacementTypeOrMember = "NServiceBus.Encryption.MessageProperty.EncryptionConfigurationExtensions.EnableMessagePropertyEncryption",
             RemoveInVersion = "8",
             TreatAsErrorFromVersion = "7")]
         public static void RegisterEncryptionService(this EndpointConfiguration config, Func<IEncryptionService> func)

--- a/src/NServiceBus.Core/Encryption/ConfigureRijndaelEncryptionService.cs
+++ b/src/NServiceBus.Core/Encryption/ConfigureRijndaelEncryptionService.cs
@@ -11,12 +11,20 @@ namespace NServiceBus
     /// <summary>
     /// Contains extension methods to NServiceBus.Configure.
     /// </summary>
+    [ObsoleteEx(
+        Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+        RemoveInVersion = "8",
+        TreatAsErrorFromVersion = "7")]
     public static partial class ConfigureRijndaelEncryptionService
     {
         /// <summary>
         /// Use 256 bit AES encryption based on the Rijndael cipher.
         /// </summary>
         /// <param name="config">The <see cref="EndpointConfiguration" /> instance to apply the settings to.</param>
+        [ObsoleteEx(
+            Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            RemoveInVersion = "8",
+            TreatAsErrorFromVersion = "7")]
         public static void RijndaelEncryptionService(this EndpointConfiguration config)
         {
             Guard.AgainstNull(nameof(config), config);
@@ -38,7 +46,7 @@ namespace NServiceBus
                 section.KeyIdentifier,
                 keys,
                 decryptionKeys
-                );
+            );
         }
 
         internal static void ValidateConfigSection(RijndaelEncryptionServiceConfig section)
@@ -95,6 +103,10 @@ namespace NServiceBus
         /// <param name="encryptionKeyIdentifier">Encryption key identifier.</param>
         /// <param name="encryptionKey">Encryption Key.</param>
         /// <param name="decryptionKeys">A list of decryption keys.</param>
+        [ObsoleteEx(
+            Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            RemoveInVersion = "8",
+            TreatAsErrorFromVersion = "7")]
         public static void RijndaelEncryptionService(this EndpointConfiguration config, string encryptionKeyIdentifier, byte[] encryptionKey, IList<byte[]> decryptionKeys = null)
 
         {
@@ -115,6 +127,10 @@ namespace NServiceBus
         /// <summary>
         /// Use 256 bit AES encryption based on the Rijndael cipher.
         /// </summary>
+        [ObsoleteEx(
+            Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            RemoveInVersion = "8",
+            TreatAsErrorFromVersion = "7")]
         public static void RijndaelEncryptionService(this EndpointConfiguration config, string encryptionKeyIdentifier, IDictionary<string, byte[]> keys, IList<byte[]> decryptionKeys = null)
         {
             Guard.AgainstNull(nameof(config), config);
@@ -149,13 +165,13 @@ namespace NServiceBus
             string encryptionKeyIdentifier,
             IDictionary<string, byte[]> keys,
             IList<byte[]> expiredKeys
-            )
+        )
         {
             return new RijndaelEncryptionService(
                 encryptionKeyIdentifier,
                 keys,
                 expiredKeys
-                );
+            );
         }
 
         /// <summary>
@@ -166,6 +182,10 @@ namespace NServiceBus
         /// A delegate that constructs the instance of <see cref="IEncryptionService" /> to use for all
         /// encryption.
         /// </param>
+        [ObsoleteEx(
+            Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            RemoveInVersion = "8",
+            TreatAsErrorFromVersion = "7")]
         public static void RegisterEncryptionService(this EndpointConfiguration config, Func<IEncryptionService> func)
         {
             Guard.AgainstNull(nameof(config), config);

--- a/src/NServiceBus.Core/Encryption/EncryptedValue.cs
+++ b/src/NServiceBus.Core/Encryption/EncryptedValue.cs
@@ -6,16 +6,28 @@ namespace NServiceBus
     /// Class used to represent an encrypted value with an initialization vector.
     /// </summary>
     [Serializable]
+    [ObsoleteEx(
+        Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+        RemoveInVersion = "8",
+        TreatAsErrorFromVersion = "7")]
     public class EncryptedValue
     {
         /// <summary>
         /// The encrypted value represented as a Base64 string.
         /// </summary>
+        [ObsoleteEx(
+            Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            RemoveInVersion = "8",
+            TreatAsErrorFromVersion = "7")]
         public string EncryptedBase64Value { get; set; }
 
         /// <summary>
         /// The initialization vector represented as a Base64 string.
         /// </summary>
+        [ObsoleteEx(
+            Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            RemoveInVersion = "8",
+            TreatAsErrorFromVersion = "7")]
         public string Base64Iv { get; set; }
     }
 }

--- a/src/NServiceBus.Core/Encryption/IEncryptionService.cs
+++ b/src/NServiceBus.Core/Encryption/IEncryptionService.cs
@@ -5,16 +5,28 @@ namespace NServiceBus
     /// <summary>
     /// Abstraction for encryption capabilities.
     /// </summary>
+    [ObsoleteEx(
+        Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+        RemoveInVersion = "8",
+        TreatAsErrorFromVersion = "7")]
     public interface IEncryptionService
     {
         /// <summary>
         /// Encrypts the given value returning an EncryptedValue.
         /// </summary>
+        [ObsoleteEx(
+            Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            RemoveInVersion = "8",
+            TreatAsErrorFromVersion = "7")]
         EncryptedValue Encrypt(string value, IOutgoingLogicalMessageContext context);
 
         /// <summary>
         /// Decrypts the given EncryptedValue object returning the source string.
         /// </summary>
+        [ObsoleteEx(
+            Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            RemoveInVersion = "8",
+            TreatAsErrorFromVersion = "7")]
         string Decrypt(EncryptedValue encryptedValue, IIncomingLogicalMessageContext context);
     }
 }

--- a/src/NServiceBus.Core/Encryption/KeyFormat.cs
+++ b/src/NServiceBus.Core/Encryption/KeyFormat.cs
@@ -3,6 +3,10 @@ namespace NServiceBus.Config
     /// <summary>
     /// The format in which an encryption value is specified.
     /// </summary>
+    [ObsoleteEx(
+        Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+        RemoveInVersion = "8",
+        TreatAsErrorFromVersion = "7")]
     public enum KeyFormat
     {
         /// <summary>

--- a/src/NServiceBus.Core/Encryption/RijndaelEncryptionServiceConfig.cs
+++ b/src/NServiceBus.Core/Encryption/RijndaelEncryptionServiceConfig.cs
@@ -5,6 +5,10 @@ namespace NServiceBus.Config
     /// <summary>
     /// Used to configure Rijndael encryption service.
     /// </summary>
+    [ObsoleteEx(
+        Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+        RemoveInVersion = "8",
+        TreatAsErrorFromVersion = "7")]
     public class RijndaelEncryptionServiceConfig : ConfigurationSection
     {
         /// <summary>

--- a/src/NServiceBus.Core/Encryption/RijndaelExpiredKey.cs
+++ b/src/NServiceBus.Core/Encryption/RijndaelExpiredKey.cs
@@ -5,6 +5,10 @@ namespace NServiceBus.Config
     /// <summary>
     /// A configuration element representing a Rijndael encryption key.
     /// </summary>
+    [ObsoleteEx(
+            Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            RemoveInVersion = "8",
+            TreatAsErrorFromVersion = "7")]
     public class RijndaelExpiredKey : ConfigurationElement
     {
         /// <summary>

--- a/src/NServiceBus.Core/Encryption/RijndaelExpiredKeyCollection.cs
+++ b/src/NServiceBus.Core/Encryption/RijndaelExpiredKeyCollection.cs
@@ -5,6 +5,10 @@ namespace NServiceBus.Config
     /// <summary>
     /// A configuration element collection of <see cref="RijndaelExpiredKey" />s.
     /// </summary>
+    [ObsoleteEx(
+        Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+        RemoveInVersion = "8",
+        TreatAsErrorFromVersion = "7")]
     public class RijndaelExpiredKeyCollection : ConfigurationElementCollection
     {
         /// <summary>

--- a/src/NServiceBus.Core/Encryption/WireEncryptedString.cs
+++ b/src/NServiceBus.Core/Encryption/WireEncryptedString.cs
@@ -7,11 +7,19 @@
     /// A string whose value will be encrypted when sent over the wire.
     /// </summary>
     [Serializable]
+    [ObsoleteEx(
+        Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+        RemoveInVersion = "8",
+        TreatAsErrorFromVersion = "7")]
     public class WireEncryptedString : ISerializable
     {
         /// <summary>
         /// Initializes a new instance of <see cref="WireEncryptedString" />.
         /// </summary>
+        [ObsoleteEx(
+            Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            RemoveInVersion = "8",
+            TreatAsErrorFromVersion = "7")]
         public WireEncryptedString()
         {
         }
@@ -19,6 +27,10 @@
         /// <summary>
         /// Initializes a new instance of <see cref="WireEncryptedString" />.
         /// </summary>
+        [ObsoleteEx(
+            Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            RemoveInVersion = "8",
+            TreatAsErrorFromVersion = "7")]
         public WireEncryptedString(SerializationInfo info, StreamingContext context)
         {
             Guard.AgainstNull(nameof(info), info);
@@ -28,11 +40,19 @@
         /// <summary>
         /// The unencrypted string.
         /// </summary>
+        [ObsoleteEx(
+            Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            RemoveInVersion = "8",
+            TreatAsErrorFromVersion = "7")]
         public string Value { get; set; }
 
         /// <summary>
         /// The encrypted value of this string.
         /// </summary>
+        [ObsoleteEx(
+            Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+            RemoveInVersion = "8",
+            TreatAsErrorFromVersion = "7")]
         public EncryptedValue EncryptedValue
         {
             get { return encryptedValue; }

--- a/src/NServiceBus.Core/Encryption/WireEncryptedString.cs
+++ b/src/NServiceBus.Core/Encryption/WireEncryptedString.cs
@@ -9,6 +9,7 @@
     [Serializable]
     [ObsoleteEx(
         Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
+        ReplacementTypeOrMember = "NServiceBus.Encryption.MessageProperty.WireEncryptedString",
         RemoveInVersion = "8",
         TreatAsErrorFromVersion = "7")]
     public class WireEncryptedString : ISerializable

--- a/src/NServiceBus.Core/Encryption/WireEncryptedString.cs
+++ b/src/NServiceBus.Core/Encryption/WireEncryptedString.cs
@@ -9,7 +9,7 @@
     [Serializable]
     [ObsoleteEx(
         Message = "Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package.",
-        ReplacementTypeOrMember = "NServiceBus.Encryption.MessageProperty.WireEncryptedString",
+        ReplacementTypeOrMember = "NServiceBus.Encryption.MessageProperty.EncryptedString",
         RemoveInVersion = "8",
         TreatAsErrorFromVersion = "7")]
     public class WireEncryptedString : ISerializable


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/1082

Add an obsolete warning to the public encryption APIs to point at the newly available package.