### PR TITLE
No longer require persistence to be configured

### DIFF
--- a/src/NServiceBus.Core/Persistence/PersistenceStartup.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceStartup.cs
@@ -46,8 +46,6 @@
             return supportedStorages?.Contains(typeof(T)) ?? false;
         }
 
-        const string errorMessage = "No persistence has been selected, select a persistence by calling endpointConfiguration.UsePersistence<T>() in the class that implements either IConfigureThisEndpoint or INeedInitialization, where T can be any of the supported persistence option. If previously using RavenDB, note that it has been moved to its own stand alone nuget 'NServiceBus.RavenDB'. This package will need to be installed and then enabled by calling endpointConfiguration.UsePersistence<RavenDBPersistence>().";
-
         static ILog Logger = LogManager.GetLogger(typeof(PersistenceStartup));
     }
 }

--- a/src/NServiceBus.Core/Persistence/PersistenceStartup.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceStartup.cs
@@ -14,12 +14,7 @@
 
             if (!settings.TryGet("PersistenceDefinitions", out definitions))
             {
-                if (settings.Get<bool>("Endpoint.SendOnly"))
-                {
-                    return;
-                }
-
-                throw new Exception(errorMessage);
+                return;
             }
 
             var enabledPersistences = PersistenceStorageMerger.Merge(definitions, settings);


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus/issues/4422

I ran the following test cases after the change, and the following exceptions where thrown at startup:

### MSMQ - No persistence selected

The selected persistence doesn't have support for timeout storage. Select another persistence or disable the timeout manager feature using endpointConfiguration.DisableFeature<TimeoutManager>()


### MSMQ -  With timeout persistence selected

The selected persistence doesn't have support for subscription storage. Select another persistence or disable the message-driven subscriptions feature using endpointConfiguration.DisableFeature<MessageDrivenSubscriptions>()


### MSMQ - With saga present but no saga storage

The selected persistence doesn't have support for saga storage. Select another persistence or disable the sagas feature using endpointConfiguration.DisableFeature<Sagas>()


### MSMQ - With outbox enabled but no outbox storage

The selected persistence doesn't have support for outbox storage. Select another persistence or disable the outbox feature using endpointConfiguration.DisableFeature<Outbox>()
 
### MSMQ - With gateway enabled but no gateway storage 

The selected persistence doesn't have support for gateway deduplication storage. Select another persistence or disable the gateway feature using endpointConfiguration.DisableFeature<Gateway>()

Do we need to add any acceptance tests for the above cases?

@Particular/nservicebus-maintainers please review
