### PR TITLE
Context-aware distribution strategy

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -84,7 +84,7 @@
     <Compile Include="Routing\MessageDrivenSubscriptions\When_unsubscribing_to_scaled_out_publisher.cs" />
     <Compile Include="Routing\NativePublishSubscribe\When_unsubscribing_from_event.cs" />
     <Compile Include="Routing\When_configure_routes_for_unobtrusive_messages.cs" />
-    <Compile Include="Routing\When_doing_content_based_routing_with_commands.cs" />
+    <Compile Include="Routing\When_using_custom_routing_strategy.cs" />
     <Compile Include="Routing\When_extending_command_routing.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_extending_event_routing.cs" />
     <Compile Include="Routing\When_registering_publishers_unobtrusive_messages_config.cs" />

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Routing\MessageDrivenSubscriptions\When_unsubscribing_to_scaled_out_publisher.cs" />
     <Compile Include="Routing\NativePublishSubscribe\When_unsubscribing_from_event.cs" />
     <Compile Include="Routing\When_configure_routes_for_unobtrusive_messages.cs" />
+    <Compile Include="Routing\When_doing_content_based_routing_with_commands.cs" />
     <Compile Include="Routing\When_extending_command_routing.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_extending_event_routing.cs" />
     <Compile Include="Routing\When_registering_publishers_unobtrusive_messages_config.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/When_doing_content_based_routing_with_commands.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_doing_content_based_routing_with_commands.cs
@@ -82,7 +82,7 @@
                     throw new NotImplementedException(); // should never be called
                 }
 
-                public override string SelectReceiver(string[] receiverAddresses, IOutgoingContext outgoingContext)
+                public override string SelectDestination(string[] receiverAddresses, IOutgoingContext outgoingContext)
                 {
                     var sendContext = outgoingContext as IOutgoingSendContext;
                     var message = sendContext?.Message.Instance as MyCommand;

--- a/src/NServiceBus.AcceptanceTests/Routing/When_doing_content_based_routing_with_commands.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_doing_content_based_routing_with_commands.cs
@@ -9,7 +9,6 @@
     using AcceptanceTesting.Customization;
     using Configuration.AdvanceExtensibility;
     using EndpointTemplates;
-    using NServiceBus.Pipeline;
     using NServiceBus.Routing;
     using NUnit.Framework;
     using Settings;
@@ -82,13 +81,12 @@
                     throw new NotImplementedException(); // should never be called
                 }
 
-                public override string SelectDestination(string[] receiverAddresses, IOutgoingContext outgoingContext)
+                public override string SelectDestination(DistributionContext context)
                 {
-                    var sendContext = outgoingContext as IOutgoingSendContext;
-                    var message = sendContext?.Message.Instance as MyCommand;
+                    var message = context.Message.Instance as MyCommand;
                     if (message != null)
                     {
-                        return receiverAddresses.Single(a => a.Contains(message.Instance));
+                        return context.ReceiverAddresses.Single(a => a.Contains(message.Instance));
                     }
                     throw new InvalidOperationException("Unable to route!");
                 }

--- a/src/NServiceBus.AcceptanceTests/Routing/When_doing_content_based_routing_with_commands.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_doing_content_based_routing_with_commands.cs
@@ -1,0 +1,139 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using Configuration.AdvanceExtensibility;
+    using EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+    using Settings;
+
+    public class When_doing_content_based_routing_with_commands : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_route_commands_correctly()
+        {
+            var ctx = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(b =>
+                    b.When(c => c.EndpointsStarted, async session =>
+                    {
+                        await session.Send(new MyCommand { Instance = Discriminator1 });
+                        await session.Send(new MyCommand { Instance = Discriminator2 });
+                        await session.Send(new MyCommand { Instance = Discriminator1 });
+                        await session.Send(new MyCommand { Instance = Discriminator2 });
+                    })
+                )
+                .WithEndpoint<Receiver>(b => b.CustomConfig(cfg => cfg.MakeInstanceUniquelyAddressable(Discriminator1)))
+                .WithEndpoint<Receiver>(b => b.CustomConfig(cfg => cfg.MakeInstanceUniquelyAddressable(Discriminator2)))
+                .Done(c => c.MessageDeliveredReceiver1 >= 2 && c.MessageDeliveredReceiver2 >=2)
+                .Run();
+
+            Assert.AreEqual(2, ctx.MessageDeliveredReceiver1);
+            Assert.AreEqual(2, ctx.MessageDeliveredReceiver2);
+        }
+
+        static string Discriminator1 = "553E9649";
+        static string Discriminator2 = "F9D0022C";
+
+        static string ReceiverEndpoint = Conventions.EndpointNamingConvention(typeof(Receiver));
+
+        public class Context : ScenarioContext
+        {
+            public int MessageDeliveredReceiver1;
+            public int MessageDeliveredReceiver2;
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.GetSettings().GetOrCreate<UnicastRoutingTable>()
+                        .AddOrReplaceRoutes("CustomRoutingFeature", new List<RouteTableEntry>
+                        {
+                            new RouteTableEntry(typeof(MyCommand), UnicastRoute.CreateFromEndpointName(ReceiverEndpoint))
+                        });
+                    c.GetSettings().GetOrCreate<EndpointInstances>()
+                        .AddOrReplaceInstances("CustomRoutingFeature", new List<EndpointInstance>
+                        {
+                            new EndpointInstance(ReceiverEndpoint, Discriminator1),
+                            new EndpointInstance(ReceiverEndpoint, Discriminator2)
+                        });
+                    c.GetSettings().GetOrCreate<DistributionPolicy>()
+                        .SetDistributionStrategy(new ContentBasedRoutingStrategy(ReceiverEndpoint));
+                });
+            }
+
+            class ContentBasedRoutingStrategy : DistributionStrategy
+            {
+                public ContentBasedRoutingStrategy(string endpoint) : base(endpoint, DistributionStrategyScope.Send)
+                {
+                }
+
+                public override string SelectReceiver(string[] receiverAddresses)
+                {
+                    throw new NotImplementedException(); // should never be called
+                }
+
+                public override string SelectReceiver(string[] receiverAddresses, IOutgoingContext outgoingContext)
+                {
+                    var sendContext = outgoingContext as IOutgoingSendContext;
+                    var message = sendContext?.Message.Instance as MyCommand;
+                    if (message != null)
+                    {
+                        return receiverAddresses.Single(a => a.Contains(message.Instance));
+                    }
+                    throw new InvalidOperationException("Unable to route!");
+                }
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MyCommandHandler : IHandleMessages<MyCommand>
+            {
+                public MyCommandHandler(Context testContext, ReadOnlySettings settings)
+                {
+                    this.testContext = testContext;
+                    this.settings = settings;
+                }
+
+                public Task Handle(MyCommand message, IMessageHandlerContext context)
+                {
+                    var instanceDiscriminator = settings.Get<string>("EndpointInstanceDiscriminator");
+
+                    if (instanceDiscriminator == Discriminator1)
+                    {
+                        Interlocked.Increment(ref testContext.MessageDeliveredReceiver1);
+                    }
+                    if (instanceDiscriminator == Discriminator2)
+                    {
+                        Interlocked.Increment(ref testContext.MessageDeliveredReceiver2);
+                    }
+
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+                ReadOnlySettings settings;
+            }
+        }
+
+        public class MyCommand : ICommand
+        {
+            public string Instance { get; set; } 
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Routing/When_doing_content_based_routing_with_commands.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_doing_content_based_routing_with_commands.cs
@@ -40,8 +40,6 @@
         static string Discriminator1 = "553E9649";
         static string Discriminator2 = "F9D0022C";
 
-        static string ReceiverEndpoint = Conventions.EndpointNamingConvention(typeof(Receiver));
-
         public class Context : ScenarioContext
         {
             public int MessageDeliveredReceiver1;
@@ -52,21 +50,23 @@
         {
             public Sender()
             {
+                var receiverEndpoint = Conventions.EndpointNamingConvention(typeof(Receiver));
+
                 EndpointSetup<DefaultServer>(c =>
                 {
                     c.GetSettings().GetOrCreate<UnicastRoutingTable>()
                         .AddOrReplaceRoutes("CustomRoutingFeature", new List<RouteTableEntry>
                         {
-                            new RouteTableEntry(typeof(MyCommand), UnicastRoute.CreateFromEndpointName(ReceiverEndpoint))
+                            new RouteTableEntry(typeof(MyCommand), UnicastRoute.CreateFromEndpointName(receiverEndpoint))
                         });
                     c.GetSettings().GetOrCreate<EndpointInstances>()
                         .AddOrReplaceInstances("CustomRoutingFeature", new List<EndpointInstance>
                         {
-                            new EndpointInstance(ReceiverEndpoint, Discriminator1),
-                            new EndpointInstance(ReceiverEndpoint, Discriminator2)
+                            new EndpointInstance(receiverEndpoint, Discriminator1),
+                            new EndpointInstance(receiverEndpoint, Discriminator2)
                         });
                     c.GetSettings().GetOrCreate<DistributionPolicy>()
-                        .SetDistributionStrategy(new ContentBasedRoutingStrategy(ReceiverEndpoint));
+                        .SetDistributionStrategy(new ContentBasedRoutingStrategy(receiverEndpoint));
                 });
             }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/When_using_custom_routing_strategy.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_using_custom_routing_strategy.cs
@@ -13,7 +13,7 @@
     using NUnit.Framework;
     using Settings;
 
-    public class When_doing_content_based_routing_with_commands : NServiceBusAcceptanceTest
+    public class When_using_custom_routing_strategy : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_route_commands_correctly()
@@ -86,7 +86,8 @@
                     var message = context.Message.Instance as MyCommand;
                     if (message != null)
                     {
-                        return context.ReceiverAddresses.Single(a => a.Contains(message.Instance));
+                        var address = context.ToTransportAddress(new EndpointInstance(Endpoint, message.Instance));
+                        return context.ReceiverAddresses.Single(a => a.Contains(address));
                     }
                     throw new InvalidOperationException("Unable to route!");
                 }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2577,8 +2577,8 @@ namespace NServiceBus.Routing
         protected DistributionStrategy(string endpoint, NServiceBus.DistributionStrategyScope scope) { }
         public string Endpoint { get; }
         public NServiceBus.DistributionStrategyScope Scope { get; }
+        public virtual string SelectDestination(string[] receiverAddresses, NServiceBus.Pipeline.IOutgoingContext outgoingContext) { }
         public abstract string SelectReceiver(string[] receiverAddresses);
-        public virtual string SelectReceiver(string[] receiverAddresses, NServiceBus.Pipeline.IOutgoingContext outgoingContext) { }
     }
     public sealed class EndpointInstance
     {

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2574,12 +2574,13 @@ namespace NServiceBus.Routing
     }
     public class DistributionContext
     {
-        public DistributionContext(string[] receiverAddresses, NServiceBus.Pipeline.OutgoingLogicalMessage message, string messageId, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.Extensibility.ContextBag context) { }
+        public DistributionContext(string[] receiverAddresses, NServiceBus.Pipeline.OutgoingLogicalMessage message, string messageId, System.Collections.Generic.Dictionary<string, string> headers, System.Func<NServiceBus.Routing.EndpointInstance, string> addressTranslation, NServiceBus.Extensibility.ContextBag context) { }
         public NServiceBus.Extensibility.ContextBag Context { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public NServiceBus.Pipeline.OutgoingLogicalMessage Message { get; }
         public string MessageId { get; }
         public string[] ReceiverAddresses { get; }
+        public string ToTransportAddress(NServiceBus.Routing.EndpointInstance endpointInstance) { }
     }
     public abstract class DistributionStrategy
     {

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2578,6 +2578,7 @@ namespace NServiceBus.Routing
         public string Endpoint { get; }
         public NServiceBus.DistributionStrategyScope Scope { get; }
         public abstract string SelectReceiver(string[] receiverAddresses);
+        public virtual string SelectReceiver(string[] receiverAddresses, NServiceBus.Pipeline.IOutgoingContext outgoingContext) { }
     }
     public sealed class EndpointInstance
     {

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2572,12 +2572,21 @@ namespace NServiceBus.Routing
     {
         protected AddressTag() { }
     }
+    public class DistributionContext
+    {
+        public DistributionContext(string[] receiverAddresses, NServiceBus.Pipeline.OutgoingLogicalMessage message, string messageId, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.Extensibility.ContextBag context) { }
+        public NServiceBus.Extensibility.ContextBag Context { get; }
+        public System.Collections.Generic.Dictionary<string, string> Headers { get; }
+        public NServiceBus.Pipeline.OutgoingLogicalMessage Message { get; }
+        public string MessageId { get; }
+        public string[] ReceiverAddresses { get; }
+    }
     public abstract class DistributionStrategy
     {
         protected DistributionStrategy(string endpoint, NServiceBus.DistributionStrategyScope scope) { }
         public string Endpoint { get; }
         public NServiceBus.DistributionStrategyScope Scope { get; }
-        public virtual string SelectDestination(string[] receiverAddresses, NServiceBus.Pipeline.IOutgoingContext outgoingContext) { }
+        public virtual string SelectDestination(NServiceBus.Routing.DistributionContext context) { }
         public abstract string SelectReceiver(string[] receiverAddresses);
     }
     public sealed class EndpointInstance

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastPublishRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastPublishRouterConnectorTests.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using Extensibility;
+    using NServiceBus.Pipeline;
     using NServiceBus.Routing;
     using NUnit.Framework;
     using Testing;
@@ -25,7 +25,7 @@
 
         class FakePublishRouter : IUnicastPublishRouter
         {
-            public Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, IDistributionPolicy distributionPolicy, ContextBag contextBag)
+            public Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, IDistributionPolicy distributionPolicy, IOutgoingPublishContext publishContext)
             {
                 IEnumerable<UnicastRoutingStrategy> unicastRoutingStrategies = new List<UnicastRoutingStrategy>
                 {

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
@@ -231,7 +231,7 @@
         {
             public UnicastRoutingStrategy FixedDestination { get; set; }
 
-            public UnicastRoutingStrategy Route(Type messageType, IDistributionPolicy distributionPolicy)
+            public UnicastRoutingStrategy Route(Type messageType, IDistributionPolicy distributionPolicy, IOutgoingSendContext outgoingContext)
             {
                 return FixedDestination;
             }

--- a/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Core.Tests.Routing
 {
     using System.Collections.Generic;
     using NUnit.Framework;
+    using Testing;
 
     [TestFixture]
     public class RoutingPolicyTests
@@ -39,7 +40,7 @@ namespace NServiceBus.Core.Tests.Routing
 
         static string InvokeDistributionStrategy(IDistributionPolicy policy, string endpointName, string[] instanceAddress)
         {
-            return policy.GetDistributionStrategy(endpointName, DistributionStrategyScope.Send).SelectReceiver(instanceAddress);
+            return policy.GetDistributionStrategy(endpointName, DistributionStrategyScope.Send).SelectReceiver(instanceAddress, new TestableOutgoingContext());
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
@@ -40,7 +40,7 @@ namespace NServiceBus.Core.Tests.Routing
 
         static string InvokeDistributionStrategy(IDistributionPolicy policy, string endpointName, string[] instanceAddress)
         {
-            return policy.GetDistributionStrategy(endpointName, DistributionStrategyScope.Send).SelectDestination(new DistributionContext(instanceAddress, null, null, null, null));
+            return policy.GetDistributionStrategy(endpointName, DistributionStrategyScope.Send).SelectDestination(new DistributionContext(instanceAddress, null, null, null, null, null));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
@@ -1,8 +1,8 @@
 namespace NServiceBus.Core.Tests.Routing
 {
     using System.Collections.Generic;
+    using NServiceBus.Routing;
     using NUnit.Framework;
-    using Testing;
 
     [TestFixture]
     public class RoutingPolicyTests
@@ -40,7 +40,7 @@ namespace NServiceBus.Core.Tests.Routing
 
         static string InvokeDistributionStrategy(IDistributionPolicy policy, string endpointName, string[] instanceAddress)
         {
-            return policy.GetDistributionStrategy(endpointName, DistributionStrategyScope.Send).SelectDestination(instanceAddress, new TestableOutgoingContext());
+            return policy.GetDistributionStrategy(endpointName, DistributionStrategyScope.Send).SelectDestination(new DistributionContext(instanceAddress, null, null, null, null));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
@@ -40,7 +40,7 @@ namespace NServiceBus.Core.Tests.Routing
 
         static string InvokeDistributionStrategy(IDistributionPolicy policy, string endpointName, string[] instanceAddress)
         {
-            return policy.GetDistributionStrategy(endpointName, DistributionStrategyScope.Send).SelectReceiver(instanceAddress, new TestableOutgoingContext());
+            return policy.GetDistributionStrategy(endpointName, DistributionStrategyScope.Send).SelectDestination(instanceAddress, new TestableOutgoingContext());
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
@@ -20,10 +20,11 @@
                 "3"
             };
 
+            var distributionContext = new DistributionContext(instances, null, null, null, null, null);
             var result = new List<string>();
-            result.Add(strategy.SelectReceiver(instances));
-            result.Add(strategy.SelectReceiver(instances));
-            result.Add(strategy.SelectReceiver(instances));
+            result.Add(strategy.SelectDestination(distributionContext));
+            result.Add(strategy.SelectDestination(distributionContext));
+            result.Add(strategy.SelectDestination(distributionContext));
 
             Assert.That(result.Count, Is.EqualTo(3));
             Assert.That(result, Has.Exactly(1).EqualTo(instances[0]));
@@ -43,11 +44,12 @@
                 "3"
             };
 
+            var distributionContext = new DistributionContext(instances, null, null, null, null, null);
             var result = new List<string>();
-            result.Add(strategy.SelectReceiver(instances));
-            result.Add(strategy.SelectReceiver(instances));
-            result.Add(strategy.SelectReceiver(instances));
-            result.Add(strategy.SelectReceiver(instances));
+            result.Add(strategy.SelectDestination(distributionContext));
+            result.Add(strategy.SelectDestination(distributionContext));
+            result.Add(strategy.SelectDestination(distributionContext));
+            result.Add(strategy.SelectDestination(distributionContext));
 
             Assert.That(result.Last(), Is.EqualTo(result.First()));
         }
@@ -63,11 +65,13 @@
                 "2",
             };
 
+            var distributionContext = new DistributionContext(instances, null, null, null, null, null);
             var result = new List<string>();
-            result.Add(strategy.SelectReceiver(instances));
-            result.Add(strategy.SelectReceiver(instances));
+            result.Add(strategy.SelectDestination(distributionContext));
+            result.Add(strategy.SelectDestination(distributionContext));
             instances = instances.Concat(new [] { "3" }).ToArray(); // add new instance
-            result.Add(strategy.SelectReceiver(instances));
+            distributionContext = new DistributionContext(instances, null, null, null, null, null);
+            result.Add(strategy.SelectDestination(distributionContext));
 
             Assert.That(result.Count, Is.EqualTo(3));
             Assert.That(result, Has.Exactly(1).EqualTo(instances[0]));
@@ -87,11 +91,13 @@
                 "3"
             };
 
+            var distributionContext = new DistributionContext(instances, null, null, null, null, null);
             var result = new List<string>();
-            result.Add(strategy.SelectReceiver(instances));
-            result.Add(strategy.SelectReceiver(instances));
+            result.Add(strategy.SelectDestination(distributionContext));
+            result.Add(strategy.SelectDestination(distributionContext));
             instances = instances.Take(2).ToArray(); // remove last instance.
-            result.Add(strategy.SelectReceiver(instances));
+            distributionContext = new DistributionContext(instances, null, null, null, null, null);
+            result.Add(strategy.SelectDestination(distributionContext));
 
             Assert.That(result.Count, Is.EqualTo(3));
             Assert.That(result, Has.Exactly(2).EqualTo(instances[0]));

--- a/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
@@ -7,6 +7,7 @@
     using Extensibility;
     using NServiceBus.Routing;
     using NUnit.Framework;
+    using Testing;
     using Unicast.Messages;
     using Unicast.Subscriptions;
     using Unicast.Subscriptions.MessageDrivenSubscriptions;
@@ -25,7 +26,7 @@
             subscriptionStorage.Subscribers.Add(new Subscriber("address1", null));
             subscriptionStorage.Subscribers.Add(new Subscriber("address2", null));
 
-            var routes = await router.Route(typeof(Event), new DistributionPolicy(), new ContextBag());
+            var routes = await router.Route(typeof(Event), new DistributionPolicy(), new TestableOutgoingPublishContext());
 
             var destinations = routes.Select(ExtractDestination).ToList();
             Assert.AreEqual(2, destinations.Count);
@@ -43,7 +44,7 @@
             subscriptionStorage.Subscribers.Add(new Subscriber("shipping1", shipping));
             subscriptionStorage.Subscribers.Add(new Subscriber("shipping2", shipping));
 
-            var routes = (await router.Route(typeof(Event), new DistributionPolicy(), new ContextBag())).ToArray();
+            var routes = (await router.Route(typeof(Event), new DistributionPolicy(), new TestableOutgoingPublishContext())).ToArray();
 
             var destinations = routes.Select(ExtractDestination).ToList();
             Assert.AreEqual(2, destinations.Count);
@@ -60,7 +61,7 @@
             subscriptionStorage.Subscribers.Add(new Subscriber("address", "sales"));
             subscriptionStorage.Subscribers.Add(new Subscriber("address", "shipping"));
 
-            var routes = await router.Route(typeof(Event), new DistributionPolicy(), new ContextBag());
+            var routes = await router.Route(typeof(Event), new DistributionPolicy(), new TestableOutgoingPublishContext());
 
             Assert.AreEqual(1, routes.Count());
             Assert.AreEqual("address", ExtractDestination(routes.Single()));
@@ -77,7 +78,7 @@
                 new EndpointInstance(logicalEndpoint, "2")
             });
 
-            var routes = await router.Route(typeof(Event), new DistributionPolicy(), new ContextBag());
+            var routes = await router.Route(typeof(Event), new DistributionPolicy(), new TestableOutgoingPublishContext());
 
             Assert.AreEqual(1, routes.Count());
             Assert.AreEqual("address", ExtractDestination(routes.First()));
@@ -86,7 +87,7 @@
         [Test]
         public async Task Should_return_empty_list_when_no_routes_found()
         {
-            var routes = await router.Route(typeof(Event), new DistributionPolicy(), new ContextBag());
+            var routes = await router.Route(typeof(Event), new DistributionPolicy(), new TestableOutgoingPublishContext());
 
             Assert.IsEmpty(routes);
         }

--- a/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
@@ -107,6 +107,7 @@
             subscriptionStorage = new FakeSubscriptionStorage();
             router = new UnicastPublishRouter(
                 metadataRegistry,
+                i => string.Empty,
                 subscriptionStorage);
         }
 

--- a/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastSendRouterTests.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using NServiceBus.Routing;
     using NUnit.Framework;
+    using Testing;
 
     [TestFixture]
     public class UnicastSendRouterTests
@@ -17,7 +18,7 @@
             var logicalEndpointName = "Sales";
             routingTable.AddOrReplaceRoutes("A", new List<RouteTableEntry> {new RouteTableEntry(typeof(Command), UnicastRoute.CreateFromEndpointName(logicalEndpointName)) });
 
-            var route = router.Route(typeof(Command), new DistributionPolicy());
+            var route = router.Route(typeof(Command), new DistributionPolicy(), new TestableOutgoingSendContext());
 
             Assert.AreEqual(logicalEndpointName, ExtractDestination(route));
         }
@@ -34,7 +35,7 @@
                 new EndpointInstance(sales, "2"),
             });
 
-            var route = router.Route(typeof(Command), new DistributionPolicy());
+            var route = router.Route(typeof(Command), new DistributionPolicy(), new TestableOutgoingSendContext());
 
             Assert.AreEqual("Sales-1", ExtractDestination(route));
         }
@@ -42,7 +43,7 @@
         [Test]
         public void Should_return_empty_list_when_no_routes_found()
         {
-            var route = router.Route(typeof(Command), new DistributionPolicy());
+            var route = router.Route(typeof(Command), new DistributionPolicy(), new TestableOutgoingSendContext());
 
             Assert.IsNull(route);
         }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Recoverability\DelayedRetryExecutor.cs" />
     <Compile Include="Recoverability\Settings\RecoverabilitySettings.cs" />
     <Compile Include="ReleaseDateAttribute.cs" />
+    <Compile Include="Routing\DistributionContext.cs" />
     <Compile Include="Routing\DistributionStrategyScope.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\AssemblyPublisherSource.cs" />
     <Compile Include="Routing\AssemblyRouteSource.cs" />

--- a/src/NServiceBus.Core/Routing/DistributionContext.cs
+++ b/src/NServiceBus.Core/Routing/DistributionContext.cs
@@ -1,0 +1,49 @@
+namespace NServiceBus.Routing
+{
+    using System.Collections.Generic;
+    using Extensibility;
+    using Pipeline;
+
+    /// <summary>
+    /// The distribution context for the DistributionStrategy implementers.
+    /// </summary>
+    public class DistributionContext
+    {
+        /// <summary>
+        /// Creates a new distribution context.
+        /// </summary>
+        public DistributionContext(string[] receiverAddresses, OutgoingLogicalMessage message, string messageId, Dictionary<string, string> headers, ContextBag context)
+        {
+            ReceiverAddresses = receiverAddresses;
+            Message = message;
+            MessageId = messageId;
+            Headers = headers;
+            Context = context;
+        }
+
+        /// <summary>
+        /// The receiver addresses that can be taken into account for distribution.
+        /// </summary>
+        public string[] ReceiverAddresses { get; }
+
+        /// <summary>
+        /// The id of the outgoing message.
+        /// </summary>
+        public string MessageId { get; private set; }
+
+        /// <summary>
+        /// The headers of the outgoing message.
+        /// </summary>
+        public Dictionary<string, string> Headers { get; }
+
+        /// <summary>
+        /// The outgoing message.
+        /// </summary>
+        public OutgoingLogicalMessage Message { get; }
+
+        /// <summary>
+        /// The context bag.
+        /// </summary>
+        public ContextBag Context { get; }
+    }
+}

--- a/src/NServiceBus.Core/Routing/DistributionContext.cs
+++ b/src/NServiceBus.Core/Routing/DistributionContext.cs
@@ -1,19 +1,21 @@
 namespace NServiceBus.Routing
 {
+    using System;
     using System.Collections.Generic;
     using Extensibility;
     using Pipeline;
 
     /// <summary>
-    /// The distribution context for the DistributionStrategy implementers.
+    /// The context for custom <see cref="DistributionStrategy" /> implementations.
     /// </summary>
     public class DistributionContext
     {
         /// <summary>
         /// Creates a new distribution context.
         /// </summary>
-        public DistributionContext(string[] receiverAddresses, OutgoingLogicalMessage message, string messageId, Dictionary<string, string> headers, ContextBag context)
+        public DistributionContext(string[] receiverAddresses, OutgoingLogicalMessage message, string messageId, Dictionary<string, string> headers, Func<EndpointInstance, string> addressTranslation, ContextBag context)
         {
+            this.addressTranslation = addressTranslation;
             ReceiverAddresses = receiverAddresses;
             Message = message;
             MessageId = messageId;
@@ -45,5 +47,17 @@ namespace NServiceBus.Routing
         /// The context bag.
         /// </summary>
         public ContextBag Context { get; }
+
+        /// <summary>
+        /// Converts a given logical address to the transport address.
+        /// </summary>
+        /// <param name="endpointInstance">The endpoint instance.</param>
+        /// <returns>The transport address.</returns>
+        public string ToTransportAddress(EndpointInstance endpointInstance)
+        {
+            return addressTranslation(endpointInstance);
+        }
+
+        Func<EndpointInstance, string> addressTranslation;
     }
 }

--- a/src/NServiceBus.Core/Routing/DistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionStrategy.cs
@@ -1,7 +1,5 @@
 namespace NServiceBus.Routing
 {
-    using Pipeline;
-
     /// <summary>
     /// Determines which instance of a given endpoint a message is to be sent.
     /// </summary>
@@ -28,9 +26,9 @@ namespace NServiceBus.Routing
         /// <summary>
         /// Selects a destination instance for a message from all known addresses of a logical endpoint.
         /// </summary>
-        public virtual string SelectDestination(string[] receiverAddresses, IOutgoingContext outgoingContext)
+        public virtual string SelectDestination(DistributionContext context)
         {
-            return SelectReceiver(receiverAddresses);
+            return SelectReceiver(context.ReceiverAddresses);
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Routing/DistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionStrategy.cs
@@ -28,7 +28,7 @@ namespace NServiceBus.Routing
         /// <summary>
         /// Selects a destination instance for a message from all known addresses of a logical endpoint.
         /// </summary>
-        public virtual string SelectReceiver(string[] receiverAddresses, IOutgoingContext outgoingContext)
+        public virtual string SelectDestination(string[] receiverAddresses, IOutgoingContext outgoingContext)
         {
             return SelectReceiver(receiverAddresses);
         }

--- a/src/NServiceBus.Core/Routing/DistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionStrategy.cs
@@ -26,6 +26,7 @@ namespace NServiceBus.Routing
         /// <summary>
         /// Selects a destination instance for a message from all known addresses of a logical endpoint.
         /// </summary>
+        /// <remarks>When this method is overridden, do not call the base method. The base method implementation calls into <see cref="SelectReceiver"/> for backward compatibility reasons.</remarks>
         public virtual string SelectDestination(DistributionContext context)
         {
             return SelectReceiver(context.ReceiverAddresses);

--- a/src/NServiceBus.Core/Routing/DistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionStrategy.cs
@@ -1,5 +1,7 @@
 namespace NServiceBus.Routing
 {
+    using Pipeline;
+
     /// <summary>
     /// Determines which instance of a given endpoint a message is to be sent.
     /// </summary>
@@ -22,6 +24,14 @@ namespace NServiceBus.Routing
         /// Selects a destination instance for a message from all known addresses of a logical endpoint.
         /// </summary>
         public abstract string SelectReceiver(string[] receiverAddresses);
+
+        /// <summary>
+        /// Selects a destination instance for a message from all known addresses of a logical endpoint.
+        /// </summary>
+        public virtual string SelectReceiver(string[] receiverAddresses, IOutgoingContext outgoingContext)
+        {
+            return SelectReceiver(receiverAddresses);
+        }
 
         /// <summary>
         /// The name of the endpoint this distribution strategy resolves instances for.

--- a/src/NServiceBus.Core/Routing/IUnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/IUnicastPublishRouter.cs
@@ -3,11 +3,11 @@ namespace NServiceBus
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using Extensibility;
+    using Pipeline;
     using Routing;
 
     interface IUnicastPublishRouter
     {
-        Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, IDistributionPolicy distributionPolicy, ContextBag contextBag);
+        Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, IDistributionPolicy distributionPolicy, IOutgoingPublishContext publishContext);
     }
 }

--- a/src/NServiceBus.Core/Routing/IUnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/IUnicastSendRouter.cs
@@ -1,10 +1,11 @@
 namespace NServiceBus
 {
     using System;
+    using Pipeline;
     using Routing;
 
     interface IUnicastSendRouter
     {
-        UnicastRoutingStrategy Route(Type messageType, IDistributionPolicy distributionPolicy);
+        UnicastRoutingStrategy Route(Type messageType, IDistributionPolicy distributionPolicy, IOutgoingSendContext sendContext);
     }
 }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -46,7 +46,7 @@ namespace NServiceBus.Features
 
             context.Pipeline.Register(b =>
             {
-                var unicastPublishRouter = new UnicastPublishRouter(b.Build<MessageMetadataRegistry>(), b.Build<ISubscriptionStorage>());
+                var unicastPublishRouter = new UnicastPublishRouter(b.Build<MessageMetadataRegistry>(), i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)), b.Build<ISubscriptionStorage>());
                 return new UnicastPublishRouterConnector(unicastPublishRouter, distributionPolicy);
             }, "Determines how the published messages should be routed");
 

--- a/src/NServiceBus.Core/Routing/Routers/UnicastPublishRouterConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/UnicastPublishRouterConnector.cs
@@ -40,7 +40,7 @@ namespace NServiceBus
 
         async Task<List<UnicastRoutingStrategy>> GetRoutingStrategies(IOutgoingPublishContext context, Type eventType)
         {
-            var addressLabels = await unicastPublishRouter.Route(eventType, distributionPolicy, context.Extensions).ConfigureAwait(false);
+            var addressLabels = await unicastPublishRouter.Route(eventType, distributionPolicy, context).ConfigureAwait(false);
             return addressLabels.ToList();
         }
 

--- a/src/NServiceBus.Core/Routing/Routers/UnicastSendRouterConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/UnicastSendRouterConnector.cs
@@ -56,7 +56,7 @@ namespace NServiceBus
             var distributionPolicy = state.Option == RouteOption.RouteToSpecificInstance ? new SpecificInstanceDistributionPolicy(state.SpecificInstance, transportAddressTranslation) : defaultDistributionPolicy;
 
             var routingStrategy = string.IsNullOrEmpty(destination)
-                ? unicastSendRouter.Route(messageType, distributionPolicy)
+                ? unicastSendRouter.Route(messageType, distributionPolicy, context)
                 : RouteToDestination(destination);
 
             if (routingStrategy == null)

--- a/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
@@ -5,6 +5,7 @@ namespace NServiceBus
     using System.Linq;
     using System.Threading.Tasks;
     using Extensibility;
+    using Pipeline;
     using Routing;
     using Unicast.Messages;
     using Unicast.Subscriptions;
@@ -18,18 +19,18 @@ namespace NServiceBus
             this.subscriptionStorage = subscriptionStorage;
         }
 
-        public async Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, IDistributionPolicy distributionPolicy, ContextBag contextBag)
+        public async Task<IEnumerable<UnicastRoutingStrategy>> Route(Type messageType, IDistributionPolicy distributionPolicy, IOutgoingPublishContext publishContext)
         {
             var typesToRoute = messageMetadataRegistry.GetMessageMetadata(messageType).MessageHierarchy;
 
-            var subscribers = await GetSubscribers(contextBag, typesToRoute).ConfigureAwait(false);
+            var subscribers = await GetSubscribers(publishContext, typesToRoute).ConfigureAwait(false);
 
-            var selectedDestinations = SelectDestinationsForEachEndpoint(distributionPolicy, subscribers);
+            var selectedDestinations = SelectDestinationsForEachEndpoint(publishContext, distributionPolicy, subscribers);
 
             return selectedDestinations.Select(destination => new UnicastRoutingStrategy(destination));
         }
 
-        HashSet<string> SelectDestinationsForEachEndpoint(IDistributionPolicy distributionPolicy, IEnumerable<Subscriber> subscribers)
+        HashSet<string> SelectDestinationsForEachEndpoint(IOutgoingContext publishContext, IDistributionPolicy distributionPolicy, IEnumerable<Subscriber> subscribers)
         {
             //Make sure we are sending only one to each transport destination. Might happen when there are multiple routing information sources.
             var addresses = new HashSet<string>();
@@ -48,7 +49,7 @@ namespace NServiceBus
                 }
                 else
                 {
-                    var subscriber = distributionPolicy.GetDistributionStrategy(group.First().Endpoint, DistributionStrategyScope.Publish).SelectReceiver(group.Select(s => s.TransportAddress).ToArray());
+                    var subscriber = distributionPolicy.GetDistributionStrategy(group.First().Endpoint, DistributionStrategyScope.Publish).SelectReceiver(group.Select(s => s.TransportAddress).ToArray(), publishContext);
                     addresses.Add(subscriber);
                 }
             }
@@ -56,10 +57,10 @@ namespace NServiceBus
             return addresses;
         }
 
-        async Task<IEnumerable<Subscriber>> GetSubscribers(ContextBag contextBag, Type[] typesToRoute)
+        async Task<IEnumerable<Subscriber>> GetSubscribers(IExtendable publishContext, Type[] typesToRoute)
         {
             var messageTypes = typesToRoute.Select(t => new MessageType(t));
-            var subscribers = await subscriptionStorage.GetSubscriberAddressesForMessage(messageTypes, contextBag).ConfigureAwait(false);
+            var subscribers = await subscriptionStorage.GetSubscriberAddressesForMessage(messageTypes, publishContext.Extensions).ConfigureAwait(false);
             return subscribers;
         }
 

--- a/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
@@ -30,7 +30,7 @@ namespace NServiceBus
             return selectedDestinations.Select(destination => new UnicastRoutingStrategy(destination));
         }
 
-        HashSet<string> SelectDestinationsForEachEndpoint(IOutgoingContext publishContext, IDistributionPolicy distributionPolicy, IEnumerable<Subscriber> subscribers)
+        HashSet<string> SelectDestinationsForEachEndpoint(IOutgoingPublishContext publishContext, IDistributionPolicy distributionPolicy, IEnumerable<Subscriber> subscribers)
         {
             //Make sure we are sending only one to each transport destination. Might happen when there are multiple routing information sources.
             var addresses = new HashSet<string>();
@@ -49,7 +49,9 @@ namespace NServiceBus
                 }
                 else
                 {
-                    var subscriber = distributionPolicy.GetDistributionStrategy(group.First().Endpoint, DistributionStrategyScope.Publish).SelectDestination(group.Select(s => s.TransportAddress).ToArray(), publishContext);
+                    var instances = group.Select(s => s.TransportAddress).ToArray();
+                    var distributionContext = new DistributionContext(instances, publishContext.Message, publishContext.MessageId, publishContext.Headers, publishContext.Extensions);
+                    var subscriber = distributionPolicy.GetDistributionStrategy(group.First().Endpoint, DistributionStrategyScope.Publish).SelectDestination(distributionContext);
                     addresses.Add(subscriber);
                 }
             }

--- a/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
@@ -49,7 +49,7 @@ namespace NServiceBus
                 }
                 else
                 {
-                    var subscriber = distributionPolicy.GetDistributionStrategy(group.First().Endpoint, DistributionStrategyScope.Publish).SelectReceiver(group.Select(s => s.TransportAddress).ToArray(), publishContext);
+                    var subscriber = distributionPolicy.GetDistributionStrategy(group.First().Endpoint, DistributionStrategyScope.Publish).SelectDestination(group.Select(s => s.TransportAddress).ToArray(), publishContext);
                     addresses.Add(subscriber);
                 }
             }

--- a/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
@@ -13,9 +13,10 @@ namespace NServiceBus
 
     class UnicastPublishRouter : IUnicastPublishRouter
     {
-        public UnicastPublishRouter(MessageMetadataRegistry messageMetadataRegistry, ISubscriptionStorage subscriptionStorage)
+        public UnicastPublishRouter(MessageMetadataRegistry messageMetadataRegistry, Func<EndpointInstance, string> transportAddressTranslation, ISubscriptionStorage subscriptionStorage)
         {
             this.messageMetadataRegistry = messageMetadataRegistry;
+            this.transportAddressTranslation = transportAddressTranslation;
             this.subscriptionStorage = subscriptionStorage;
         }
 
@@ -50,7 +51,7 @@ namespace NServiceBus
                 else
                 {
                     var instances = group.Select(s => s.TransportAddress).ToArray();
-                    var distributionContext = new DistributionContext(instances, publishContext.Message, publishContext.MessageId, publishContext.Headers, publishContext.Extensions);
+                    var distributionContext = new DistributionContext(instances, publishContext.Message, publishContext.MessageId, publishContext.Headers, transportAddressTranslation, publishContext.Extensions);
                     var subscriber = distributionPolicy.GetDistributionStrategy(group.First().Endpoint, DistributionStrategyScope.Publish).SelectDestination(distributionContext);
                     addresses.Add(subscriber);
                 }
@@ -67,6 +68,7 @@ namespace NServiceBus
         }
 
         MessageMetadataRegistry messageMetadataRegistry;
+        Func<EndpointInstance, string> transportAddressTranslation;
         ISubscriptionStorage subscriptionStorage;
     }
 }

--- a/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
@@ -34,7 +34,8 @@ namespace NServiceBus
 
 
             var instances = endpointInstances.FindInstances(route.Endpoint).Select(e => transportAddressTranslation(e)).ToArray();
-            var selectedInstanceAddress = distributionPolicy.GetDistributionStrategy(route.Endpoint, DistributionStrategyScope.Send).SelectDestination(instances, sendContext);
+            var distributionContext = new DistributionContext(instances, sendContext.Message, sendContext.MessageId, sendContext.Headers, sendContext.Extensions);
+            var selectedInstanceAddress = distributionPolicy.GetDistributionStrategy(route.Endpoint, DistributionStrategyScope.Send).SelectDestination(distributionContext);
             return new UnicastRoutingStrategy(selectedInstanceAddress);
         }
 

--- a/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
@@ -34,7 +34,7 @@ namespace NServiceBus
 
 
             var instances = endpointInstances.FindInstances(route.Endpoint).Select(e => transportAddressTranslation(e)).ToArray();
-            var distributionContext = new DistributionContext(instances, sendContext.Message, sendContext.MessageId, sendContext.Headers, sendContext.Extensions);
+            var distributionContext = new DistributionContext(instances, sendContext.Message, sendContext.MessageId, sendContext.Headers, transportAddressTranslation, sendContext.Extensions);
             var selectedInstanceAddress = distributionPolicy.GetDistributionStrategy(route.Endpoint, DistributionStrategyScope.Send).SelectDestination(distributionContext);
             return new UnicastRoutingStrategy(selectedInstanceAddress);
         }

--- a/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Linq;
+    using Pipeline;
     using Routing;
 
     class UnicastSendRouter : IUnicastSendRouter
@@ -13,7 +14,7 @@ namespace NServiceBus
             this.transportAddressTranslation = transportAddressTranslation;
         }
 
-        public UnicastRoutingStrategy Route(Type messageType, IDistributionPolicy distributionPolicy)
+        public UnicastRoutingStrategy Route(Type messageType, IDistributionPolicy distributionPolicy, IOutgoingSendContext sendContext)
         {
             var route = unicastRoutingTable.GetRouteFor(messageType);
             if (route == null)
@@ -33,7 +34,7 @@ namespace NServiceBus
 
 
             var instances = endpointInstances.FindInstances(route.Endpoint).Select(e => transportAddressTranslation(e)).ToArray();
-            var selectedInstanceAddress = distributionPolicy.GetDistributionStrategy(route.Endpoint, DistributionStrategyScope.Send).SelectReceiver(instances);
+            var selectedInstanceAddress = distributionPolicy.GetDistributionStrategy(route.Endpoint, DistributionStrategyScope.Send).SelectReceiver(instances, sendContext);
             return new UnicastRoutingStrategy(selectedInstanceAddress);
         }
 

--- a/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
@@ -34,7 +34,7 @@ namespace NServiceBus
 
 
             var instances = endpointInstances.FindInstances(route.Endpoint).Select(e => transportAddressTranslation(e)).ToArray();
-            var selectedInstanceAddress = distributionPolicy.GetDistributionStrategy(route.Endpoint, DistributionStrategyScope.Send).SelectReceiver(instances, sendContext);
+            var selectedInstanceAddress = distributionPolicy.GetDistributionStrategy(route.Endpoint, DistributionStrategyScope.Send).SelectDestination(instances, sendContext);
             return new UnicastRoutingStrategy(selectedInstanceAddress);
         }
 


### PR DESCRIPTION
Related to https://github.com/Particular/PlatformDevelopment/issues/1135
Doco PR https://github.com/Particular/docs.particular.net/pull/2445

Endpoints hosted in Service Fabric stateful services are partition affine. This is required because an endpoint can only access data inside reliable collections that are local to the partition of the stateful service. So if you have a service A with 26 partitions that hosts an endpoint the endpoint effectively is hosted/scaled out 26 times. 

To commands and events with message driven pub-sub to the right instance sticky to a given partition we need to be able to make sender side routing decisions based on the content. This PR extends the distribution strategy in a non-breaking way to be able to support content based sender side distribution that is required to achieve the partition affinity. I think overall this approach makes the distribution strategy much more powerful than it was before. 

I know it is awkward that when you override SelectReceivers then you still have to implement the other abstract method but that was the only way we could implement it in a non-breaking way. Since this is a low-level API, I think this is ok.

Thoughts @Particular/nservicebus-maintainers ?

Already discussed this with @timbussmann and he agrees that it is still aligned with Sender Side Distribution