### PR TITLE
Spelling error in tooltip text

### DIFF
--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -38,7 +38,7 @@
         public int ImmediateProcessingFailures { get; }
 
         /// <summary>
-        /// Number of delayed deliveries performed so fat.
+        /// Number of delayed deliveries performed so far.
         /// </summary>
         public int DelayedDeliveriesPerformed { get; }
 


### PR DESCRIPTION
Raised from [Feedback in Docs](https://github.com/Particular/docs.particular.net/issues/2412).