### PR TITLE
Avoid obsolete satellite API

### DIFF
--- a/src/NServiceBus.Msmq.AcceptanceTests/Distributor/DistributorEndpointTemplate.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/Distributor/DistributorEndpointTemplate.cs
@@ -42,7 +42,6 @@
                 context.AddSatelliteReceiver(
                     "Ready Messages satellite",
                     context.Settings.EndpointName() + ".Control",
-                    TransportTransactionMode.TransactionScope,
                     PushRuntimeSettings.Default,
                     OnError,
                     OnMessage);


### PR DESCRIPTION
just noticed that we get a compiler warning because we're using an API with an obsoletion warning in the MSMQ acceptance tests. The transaction scope parameter should be removed from the satellite registration.