### PR TITLE
Mutator behaviors cache the outcome of the builder call and will no longer call it if no mutators were returned

### DIFF
--- a/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateIncomingMessageBehaviorTests.cs
@@ -13,9 +13,11 @@
         [Test]
         public async Task Should_not_call_MutateIncoming_when_hasIncomingMessageMutators_is_false()
         {
-            var behavior = new MutateIncomingMessageBehavior(hasIncomingMessageMutators: false);
+            var behavior = new MutateIncomingMessageBehavior();
 
             var context = new TestableIncomingLogicalMessageContext();
+
+            await behavior.Invoke(context, ctx => TaskEx.CompletedTask);
 
             var mutator = new MutatorThatIndicatesIfItWasCalled();
             context.Builder.Register<IMutateIncomingMessages>(() => mutator);
@@ -28,7 +30,7 @@
         [Test]
         public void Should_throw_friendly_exception_when_IMutateIncomingMessages_MutateIncoming_returns_null()
         {
-            var behavior = new MutateIncomingMessageBehavior(hasIncomingMessageMutators: true);
+            var behavior = new MutateIncomingMessageBehavior();
 
             var logicalMessage = new LogicalMessage(new MessageMetadata(typeof(TestMessage)), new TestMessage());
 
@@ -45,7 +47,7 @@
         [Test]
         public async Task When_no_mutator_updates_the_body_should_not_update_the_body()
         {
-            var behavior = new MutateIncomingMessageBehavior(hasIncomingMessageMutators: true);
+            var behavior = new MutateIncomingMessageBehavior();
 
             var context = new InterceptUpdateMessageIncomingLogicalMessageContext();
 
@@ -59,7 +61,7 @@
         [Test]
         public async Task When_no_mutator_available_should_not_update_the_body()
         {
-            var behavior = new MutateIncomingMessageBehavior(hasIncomingMessageMutators: true);
+            var behavior = new MutateIncomingMessageBehavior();
 
             var context = new InterceptUpdateMessageIncomingLogicalMessageContext();
 
@@ -73,7 +75,7 @@
         [Test]
         public async Task When_mutator_modifies_the_body_should_update_the_body()
         {
-            var behavior = new MutateIncomingMessageBehavior(hasIncomingMessageMutators: true);
+            var behavior = new MutateIncomingMessageBehavior();
 
             var context = new InterceptUpdateMessageIncomingLogicalMessageContext();
 

--- a/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateOutgoingMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MutateInstanceMessage/MutateOutgoingMessageBehaviorTests.cs
@@ -14,9 +14,11 @@
         [Test]
         public async Task Should_not_call_MutateOutgoing_when_hasOutgoingMessageMutators_is_false()
         {
-            var behavior = new MutateOutgoingMessageBehavior(hasOutgoingMessageMutators: false);
+            var behavior = new MutateOutgoingMessageBehavior();
 
             var context = new TestableOutgoingLogicalMessageContext();
+
+            await behavior.Invoke(context, ctx => TaskEx.CompletedTask);
 
             var mutator = new MutatorThatIndicatesIfItWasCalled();
             context.Builder.Register<IMutateOutgoingMessages>(() => mutator);
@@ -29,7 +31,7 @@
         [Test]
         public void Should_throw_friendly_exception_when_IMutateOutgoingMessages_MutateOutgoing_returns_null()
         {
-            var behavior = new MutateOutgoingMessageBehavior(hasOutgoingMessageMutators: true);
+            var behavior = new MutateOutgoingMessageBehavior();
 
             var context = new TestableOutgoingLogicalMessageContext();
             context.Extensions.Set(new IncomingMessage("messageId", new Dictionary<string, string>(), new byte[0]));
@@ -42,7 +44,7 @@
         [Test]
         public async Task When_no_mutator_updates_the_body_should_not_update_the_body()
         {
-            var behavior = new MutateOutgoingMessageBehavior(hasOutgoingMessageMutators: true);
+            var behavior = new MutateOutgoingMessageBehavior();
 
             var context = new InterceptUpdateMessageOutgoingLogicalMessageContext();
 
@@ -56,7 +58,7 @@
         [Test]
         public async Task When_no_mutator_available_should_not_update_the_body()
         {
-            var behavior = new MutateOutgoingMessageBehavior(hasOutgoingMessageMutators: true);
+            var behavior = new MutateOutgoingMessageBehavior();
 
             var context = new InterceptUpdateMessageOutgoingLogicalMessageContext();
 
@@ -70,7 +72,7 @@
         [Test]
         public async Task When_mutator_modifies_the_body_should_update_the_body()
         {
-            var behavior = new MutateOutgoingMessageBehavior(hasOutgoingMessageMutators: true);
+            var behavior = new MutateOutgoingMessageBehavior();
 
             var context = new InterceptUpdateMessageOutgoingLogicalMessageContext();
 

--- a/src/NServiceBus.Core.Tests/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MutateTransportMessage/MutateIncomingTransportMessageBehaviorTests.cs
@@ -11,9 +11,11 @@
         [Test]
         public async Task Should_not_call_MutateIncoming_when_hasIncomingTransportMessageMutators_is_false()
         {
-            var behavior = new MutateIncomingTransportMessageBehavior(hasIncomingTransportMessageMutators: false);
+            var behavior = new MutateIncomingTransportMessageBehavior();
 
             var context = new TestableIncomingPhysicalMessageContext();
+
+            await behavior.Invoke(context, ctx => TaskEx.CompletedTask);
 
             var mutator = new MutatorThatIndicatesIfItWasCalled();
             context.Builder.Register<IMutateIncomingTransportMessages>(() => mutator);
@@ -26,7 +28,7 @@
         [Test]
         public void Should_throw_friendly_exception_when_IMutateIncomingTransportMessages_MutateIncoming_returns_null()
         {
-            var behavior = new MutateIncomingTransportMessageBehavior(hasIncomingTransportMessageMutators: true);
+            var behavior = new MutateIncomingTransportMessageBehavior();
 
             var context = new TestableIncomingPhysicalMessageContext();
 
@@ -38,7 +40,7 @@
         [Test]
         public async Task When_no_mutator_updates_the_body_should_not_update_the_body()
         {
-            var behavior = new MutateIncomingTransportMessageBehavior(hasIncomingTransportMessageMutators: true);
+            var behavior = new MutateIncomingTransportMessageBehavior();
 
             var context = new InterceptUpdateMessageIncomingPhysicalMessageContext();
 
@@ -52,7 +54,7 @@
         [Test]
         public async Task When_no_mutator_available_should_not_update_the_body()
         {
-            var behavior = new MutateIncomingTransportMessageBehavior(hasIncomingTransportMessageMutators: true);
+            var behavior = new MutateIncomingTransportMessageBehavior();
 
             var context = new InterceptUpdateMessageIncomingPhysicalMessageContext();
 
@@ -66,7 +68,7 @@
         [Test]
         public async Task When_mutator_modifies_the_body_should_update_the_body()
         {
-            var behavior = new MutateIncomingTransportMessageBehavior(hasIncomingTransportMessageMutators: true);
+            var behavior = new MutateIncomingTransportMessageBehavior();
 
             var context = new InterceptUpdateMessageIncomingPhysicalMessageContext();
 

--- a/src/NServiceBus.Core.Tests/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MutateTransportMessage/MutateOutgoingTransportMessageBehaviorTests.cs
@@ -12,14 +12,17 @@
         [Test]
         public async Task Should_not_call_MutateOutgoing_when_hasOutgoingTransportMessageMutators_is_false()
         {
-            var behavior = new MutateOutgoingTransportMessageBehavior(hasOutgoingTransportMessageMutators: false);
+            var behavior = new MutateOutgoingTransportMessageBehavior();
 
-            var context = new TestableOutgoingPhysicalMessageContext();
+            var physicalContext = new TestableOutgoingPhysicalMessageContext();
+            physicalContext.Extensions.Set(new OutgoingLogicalMessage(typeof(FakeMessage), new FakeMessage()));
+
+            await behavior.Invoke(physicalContext, ctx => TaskEx.CompletedTask);
 
             var mutator = new MutatorThatIndicatesIfItWasCalled();
-            context.Builder.Register<IMutateOutgoingTransportMessages>(() => mutator);
+            physicalContext.Builder.Register<IMutateOutgoingTransportMessages>(() => mutator);
 
-            await behavior.Invoke(context, ctx => TaskEx.CompletedTask);
+            await behavior.Invoke(physicalContext, ctx => TaskEx.CompletedTask);
 
             Assert.IsFalse(mutator.MutateOutgoingCalled);
         }
@@ -27,7 +30,7 @@
         [Test]
         public void Should_throw_friendly_exception_when_IMutateOutgoingTransportMessages_MutateOutgoing_returns_null()
         {
-            var behavior = new MutateOutgoingTransportMessageBehavior(hasOutgoingTransportMessageMutators: true);
+            var behavior = new MutateOutgoingTransportMessageBehavior();
 
             var physicalContext = new TestableOutgoingPhysicalMessageContext();
             physicalContext.Extensions.Set(new OutgoingLogicalMessage(typeof(FakeMessage), new FakeMessage()));
@@ -39,7 +42,7 @@
         [Test]
         public async Task When_no_mutator_updates_the_body_should_not_update_the_body()
         {
-            var behavior = new MutateOutgoingTransportMessageBehavior(hasOutgoingTransportMessageMutators: true);
+            var behavior = new MutateOutgoingTransportMessageBehavior();
 
             var context = new InterceptUpdateMessageOutgoingPhysicalMessageContext();
             context.Extensions.Set(new OutgoingLogicalMessage(typeof(FakeMessage), new FakeMessage()));
@@ -54,7 +57,7 @@
         [Test]
         public async Task When_no_mutator_available_should_not_update_the_body()
         {
-            var behavior = new MutateOutgoingTransportMessageBehavior(hasOutgoingTransportMessageMutators: true);
+            var behavior = new MutateOutgoingTransportMessageBehavior();
 
             var context = new InterceptUpdateMessageOutgoingPhysicalMessageContext();
             context.Extensions.Set(new OutgoingLogicalMessage(typeof(FakeMessage), new FakeMessage()));
@@ -69,7 +72,7 @@
         [Test]
         public async Task When_mutator_modifies_the_body_should_update_the_body()
         {
-            var behavior = new MutateOutgoingTransportMessageBehavior(hasOutgoingTransportMessageMutators: true);
+            var behavior = new MutateOutgoingTransportMessageBehavior();
 
             var context = new InterceptUpdateMessageOutgoingPhysicalMessageContext();
             context.Extensions.Set(new OutgoingLogicalMessage(typeof(FakeMessage), new FakeMessage()));

--- a/src/NServiceBus.Core.Tests/UnitOfWork/UnitOfWorkBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/UnitOfWork/UnitOfWorkBehaviorTests.cs
@@ -15,11 +15,14 @@
         {
             var builder = new FakeBuilder();
 
-            var unitOfWork = new UnitOfWork();
+            var behavior = new UnitOfWorkBehavior();
 
+            await InvokeBehavior(builder, behavior: behavior);
+
+            var unitOfWork = new UnitOfWork();
             builder.Register<IManageUnitsOfWork>(unitOfWork);
 
-            await InvokeBehavior(builder, hasUnitsOfWork: false);
+            await InvokeBehavior(builder, behavior: behavior); 
 
             Assert.IsFalse(unitOfWork.BeginCalled);
             Assert.IsFalse(unitOfWork.EndCalled);
@@ -159,9 +162,9 @@
                 Throws.Exception.With.Message.EqualTo("Return a Task or mark the method as async."));
         }
 
-        static Task InvokeBehavior(FakeBuilder builder, Exception toThrow = null, bool hasUnitsOfWork = true)
+        static Task InvokeBehavior(FakeBuilder builder, Exception toThrow = null, UnitOfWorkBehavior behavior = null)
         {
-            var runner = new UnitOfWorkBehavior(hasUnitsOfWork);
+            var runner = behavior ?? new UnitOfWorkBehavior();
 
             var context = new TestableIncomingPhysicalMessageContext();
             context.Builder = builder;

--- a/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
@@ -3,12 +3,10 @@
     using System.Threading.Tasks;
     using Extensibility;
     using Janitor;
-    using MessageMutator;
     using NServiceBus.Outbox;
     using Persistence;
     using Transport;
     using Unicast;
-    using UnitOfWork;
 
     class ReceiveFeature : Feature
     {
@@ -22,14 +20,11 @@
             context.Pipeline.Register("TransportReceiveToPhysicalMessageProcessingConnector", b => b.Build<TransportReceiveToPhysicalMessageProcessingConnector>(), "Allows to abort processing the message");
             context.Pipeline.Register("LoadHandlersConnector", b => b.Build<LoadHandlersConnector>(), "Gets all the handlers to invoke from the MessageHandler registry based on the message type.");
 
-            var hasUnitsOfWork = context.Container.HasComponent<IManageUnitsOfWork>();
-            context.Pipeline.Register("ExecuteUnitOfWork", new UnitOfWorkBehavior(hasUnitsOfWork), "Executes the UoW");
+            context.Pipeline.Register("ExecuteUnitOfWork", new UnitOfWorkBehavior(), "Executes the UoW");
 
-            var hasIncomingTransportMessageMutators = context.Container.HasComponent<IMutateIncomingTransportMessages>();
-            context.Pipeline.Register("MutateIncomingTransportMessage", new MutateIncomingTransportMessageBehavior(hasIncomingTransportMessageMutators), "Executes IMutateIncomingTransportMessages");
+            context.Pipeline.Register("MutateIncomingTransportMessage", new MutateIncomingTransportMessageBehavior(), "Executes IMutateIncomingTransportMessages");
 
-            var hasIncomingMessageMutators = context.Container.HasComponent<IMutateIncomingMessages>();
-            context.Pipeline.Register("MutateIncomingMessages", new MutateIncomingMessageBehavior(hasIncomingMessageMutators), "Executes IMutateIncomingMessages");
+            context.Pipeline.Register("MutateIncomingMessages", new MutateIncomingMessageBehavior(), "Executes IMutateIncomingMessages");
 
             context.Pipeline.Register("InvokeHandlers", new InvokeHandlerTerminator(), "Calls the IHandleMessages<T>.Handle(T)");
 

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPipelineFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPipelineFeature.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Features
 {
-    using MessageMutator;
     using Transport;
 
     class OutgoingPipelineFeature : Feature
@@ -12,11 +11,9 @@
 
         protected internal override void Setup(FeatureConfigurationContext context)
         {
-            var hasOutgoingMessageMutators = context.Container.HasComponent<IMutateOutgoingMessages>();
-            context.Pipeline.Register("MutateOutgoingMessages", new MutateOutgoingMessageBehavior(hasOutgoingMessageMutators), "Executes IMutateOutgoingMessages");
+            context.Pipeline.Register("MutateOutgoingMessages", new MutateOutgoingMessageBehavior(), "Executes IMutateOutgoingMessages");
 
-            var hasOutgoingTransportMessageMutators = context.Container.HasComponent<IMutateOutgoingTransportMessages>();
-            context.Pipeline.Register("MutateOutgoingTransportMessage", new MutateOutgoingTransportMessageBehavior(hasOutgoingTransportMessageMutators), "Executes IMutateOutgoingTransportMessages");
+            context.Pipeline.Register("MutateOutgoingTransportMessage", new MutateOutgoingTransportMessageBehavior(), "Executes IMutateOutgoingTransportMessages");
 
             context.Pipeline.Register(new AttachSenderRelatedInfoOnMessageBehavior(), "Makes sure that outgoing messages contains relevant info on the sending endpoint.");
 

--- a/src/NServiceBus.Testing.Fakes/FakeBuilder.cs
+++ b/src/NServiceBus.Testing.Fakes/FakeBuilder.cs
@@ -79,7 +79,7 @@ namespace NServiceBus.Testing
                 return factories[type]().Cast<T>();
             }
 
-            throw new Exception($"Cannot build instance of type {type} because there was no instance of factory registered for it.");
+            return Enumerable.Empty<T>();
         }
 
         /// <summary>


### PR DESCRIPTION
Closes https://github.com/Particular/NServiceBus/issues/4463

Instead of caching whether there are mutators during the setup phase the behaviors are made stateful and toogle the state after first message execution. So when there are no mutators registered the internal state flag toggles and future calls will no longer try to resolve mutators. This change makes the following assumptions:

- Container registrations cannot change after the first resolve (that is true for most containers) and also baked into our container abstraction
- Concurrent message handling might end up "unnecessarily" trying to resolve mutators but eventually the flag will toggle. Which is good enough

