### PR TITLE
Make saga id generation pluggable

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Sagas\When_finder_cant_find_saga_instance.cs" />
     <Compile Include="Sagas\When_finder_returns_existing_saga.cs" />
     <Compile Include="Sagas\When_sagas_share_timeout_messages.cs" />
+    <Compile Include="Sagas\When_overriding_saga_id_creation.cs" />
     <Compile Include="Sagas\When_saga_started_concurrently.cs" />
     <Compile Include="Satellites\When_satellite_txmode_does_not_match_endpoints_txmode.cs" />
     <Compile Include="Sagas\When_using_a_received_message_for_timeout.cs" />

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_overriding_saga_id_creation.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_overriding_saga_id_creation.cs
@@ -6,7 +6,6 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using Extensibility;
     using Features;
     using NServiceBus.Sagas;
     using NUnit.Framework;
@@ -80,9 +79,9 @@
 
         class CustomSagaIdGenerator : ISagaIdGenerator
         {
-            public Guid Generate(string propertyName, object propertyValue, SagaMetadata metadata, ContextBag context)
+            public Guid Generate(SagaIdGeneratorContext context)
             {
-                return ToGuid($"{metadata.SagaEntityType.FullName}_{propertyName}_{propertyValue}");
+                return ToGuid($"{context.SagaMetadata.SagaEntityType.FullName}_{context.CorrelationPropertyName}_{context.CorrelationPropertyValue}");
             }
 
             static Guid ToGuid(string src)

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_overriding_saga_id_creation.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_overriding_saga_id_creation.cs
@@ -1,0 +1,100 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using System.Security.Cryptography;
+    using System.Text;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Extensibility;
+    using Features;
+    using NServiceBus.Sagas;
+    using NUnit.Framework;
+
+    public class When_overriding_saga_id_creation : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_generate_saga_id_accordingly()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointThatHostsASaga>(
+                    b => b.When(session => session.SendLocal(new StartSaga
+                    {
+                        CustomerId = "42",
+                    })))
+                .Done(c => c.SagaId.HasValue)
+                .Run();
+
+            Assert.AreEqual(new Guid("5ebef5b7-815e-653c-2ee7-37ed83d7d7b5"), context.SagaId);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid? SagaId { get; set; }
+        }
+
+        public class EndpointThatHostsASaga : EndpointConfigurationBuilder
+        {
+            public EndpointThatHostsASaga()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.EnableFeature<TimeoutManager>();
+                    config.RegisterComponents(c => c.RegisterSingleton<ISagaIdGenerator>(new CustomSagaIdGenerator()));
+                });
+            }
+
+            public class MySaga : Saga<MySaga.MySagaData>,
+                IAmStartedByMessages<StartSaga>
+            {
+                public Context TestContext { get; set; }
+
+                public Task Handle(StartSaga message, IMessageHandlerContext context)
+                {
+                    Data.CustomerId = message.CustomerId;
+                    TestContext.SagaId = Data.Id;
+
+                    return Task.FromResult(0);
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MySagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartSaga>(m => m.CustomerId).ToSaga(s => s.CustomerId);
+                }
+
+                public class MySagaData : ContainSagaData
+                {
+                    public virtual string CustomerId { get; set; }
+                }
+
+                public class TimeHasPassed
+                {
+                }
+            }
+        }
+
+        public class StartSaga : IMessage
+        {
+            public string CustomerId { get; set; }
+        }
+
+        class CustomSagaIdGenerator : ISagaIdGenerator
+        {
+            public Guid Generate(string propertyName, object propertyValue, SagaMetadata metadata, ContextBag context)
+            {
+                return ToGuid($"{metadata.SagaEntityType.FullName}_{propertyName}_{propertyValue}");
+            }
+
+            static Guid ToGuid(string src)
+            {
+                var stringbytes = Encoding.UTF8.GetBytes(src);
+                using (var provider = new SHA1CryptoServiceProvider())
+                {
+                    var hashedBytes = provider.ComputeHash(stringbytes);
+                    Array.Resize(ref hashedBytes, 16);
+                    return new Guid(hashedBytes);
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_overriding_saga_id_creation.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_overriding_saga_id_creation.cs
@@ -48,7 +48,7 @@
             {
                 public Guid Generate(SagaIdGeneratorContext context)
                 {
-                    return ToGuid($"{context.SagaMetadata.SagaEntityType.FullName}_{context.CorrelationPropertyName}_{context.CorrelationPropertyValue}");
+                    return ToGuid($"{context.SagaMetadata.SagaEntityType.FullName}_{context.CorrelationProperty.Name}_{context.CorrelationProperty.Value}");
                 }
 
                 static Guid ToGuid(string src)

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_overriding_saga_id_creation.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_overriding_saga_id_creation.cs
@@ -5,6 +5,7 @@
     using System.Text;
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using Configuration.AdvanceExtensibility;
     using EndpointTemplates;
     using Features;
     using NServiceBus.Sagas;
@@ -39,7 +40,7 @@
                 EndpointSetup<DefaultServer>(config =>
                 {
                     config.EnableFeature<TimeoutManager>();
-                    config.RegisterComponents(c => c.RegisterSingleton<ISagaIdGenerator>(new CustomSagaIdGenerator()));
+                    config.GetSettings().Set<ISagaIdGenerator>(new CustomSagaIdGenerator());
                 });
             }
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_overriding_saga_id_creation.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_overriding_saga_id_creation.cs
@@ -24,7 +24,7 @@
                 .Done(c => c.SagaId.HasValue)
                 .Run();
 
-            Assert.AreEqual(new Guid("5ebef5b7-815e-653c-2ee7-37ed83d7d7b5"), context.SagaId);
+            Assert.AreEqual(new Guid("595cce7c-15d6-1c2a-6319-1b75c04426b4"), context.SagaId);
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2844,7 +2844,7 @@ namespace NServiceBus.Sagas
     }
     public interface ISagaIdGenerator
     {
-        System.Guid Generate(string propertyName, object propertyValue, NServiceBus.Sagas.SagaMetadata metadata, NServiceBus.Extensibility.ContextBag context);
+        System.Guid Generate(NServiceBus.Sagas.SagaIdGeneratorContext context);
     }
     public interface ISagaPersister
     {
@@ -2869,6 +2869,13 @@ namespace NServiceBus.Sagas
         public string MessageTypeName { get; }
         public System.Collections.Generic.Dictionary<string, object> Properties { get; }
         public System.Type Type { get; }
+    }
+    public class SagaIdGeneratorContext : NServiceBus.Extensibility.ContextBag
+    {
+        public SagaIdGeneratorContext(string correlationPropertyName, object correlationPropertyValue, NServiceBus.Sagas.SagaMetadata sagaMetadata, NServiceBus.Extensibility.ContextBag parentBag) { }
+        public string CorrelationPropertyName { get; }
+        public object CorrelationPropertyValue { get; }
+        public NServiceBus.Sagas.SagaMetadata SagaMetadata { get; }
     }
     public class SagaMessage
     {

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1730,7 +1730,7 @@ namespace NServiceBus.Extensibility
 {
     public class ContextBag : NServiceBus.Extensibility.ReadOnlyContextBag
     {
-        public ContextBag(NServiceBus.Extensibility.ContextBag parentBag = null) { }
+        public ContextBag(NServiceBus.Extensibility.ContextBag parentContext = null) { }
         public T Get<T>() { }
         public T GetOrCreate<T>()
             where T :  class, new () { }
@@ -2872,7 +2872,7 @@ namespace NServiceBus.Sagas
     }
     public class SagaIdGeneratorContext : NServiceBus.Extensibility.ContextBag
     {
-        public SagaIdGeneratorContext(string correlationPropertyName, object correlationPropertyValue, NServiceBus.Sagas.SagaMetadata sagaMetadata, NServiceBus.Extensibility.ContextBag parentBag) { }
+        public SagaIdGeneratorContext(string correlationPropertyName, object correlationPropertyValue, NServiceBus.Sagas.SagaMetadata sagaMetadata, NServiceBus.Extensibility.ContextBag parentContext) { }
         public string CorrelationPropertyName { get; }
         public object CorrelationPropertyValue { get; }
         public NServiceBus.Sagas.SagaMetadata SagaMetadata { get; }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1730,7 +1730,7 @@ namespace NServiceBus.Extensibility
 {
     public class ContextBag : NServiceBus.Extensibility.ReadOnlyContextBag
     {
-        public ContextBag(NServiceBus.Extensibility.ContextBag parentContext = null) { }
+        public ContextBag(NServiceBus.Extensibility.ContextBag parent = null) { }
         public T Get<T>() { }
         public T GetOrCreate<T>()
             where T :  class, new () { }
@@ -2872,9 +2872,8 @@ namespace NServiceBus.Sagas
     }
     public class SagaIdGeneratorContext : NServiceBus.Extensibility.IExtendable
     {
-        public SagaIdGeneratorContext(string correlationPropertyName, object correlationPropertyValue, NServiceBus.Sagas.SagaMetadata sagaMetadata, NServiceBus.Extensibility.ContextBag extensions) { }
-        public string CorrelationPropertyName { get; }
-        public object CorrelationPropertyValue { get; }
+        public SagaIdGeneratorContext(NServiceBus.Sagas.SagaCorrelationProperty correlationProperty, NServiceBus.Sagas.SagaMetadata sagaMetadata, NServiceBus.Extensibility.ContextBag extensions) { }
+        public NServiceBus.Sagas.SagaCorrelationProperty CorrelationProperty { get; }
         public NServiceBus.Extensibility.ContextBag Extensions { get; }
         public NServiceBus.Sagas.SagaMetadata SagaMetadata { get; }
     }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2870,11 +2870,12 @@ namespace NServiceBus.Sagas
         public System.Collections.Generic.Dictionary<string, object> Properties { get; }
         public System.Type Type { get; }
     }
-    public class SagaIdGeneratorContext : NServiceBus.Extensibility.ContextBag
+    public class SagaIdGeneratorContext : NServiceBus.Extensibility.IExtendable
     {
-        public SagaIdGeneratorContext(string correlationPropertyName, object correlationPropertyValue, NServiceBus.Sagas.SagaMetadata sagaMetadata, NServiceBus.Extensibility.ContextBag parentContext) { }
+        public SagaIdGeneratorContext(string correlationPropertyName, object correlationPropertyValue, NServiceBus.Sagas.SagaMetadata sagaMetadata, NServiceBus.Extensibility.ContextBag extensions) { }
         public string CorrelationPropertyName { get; }
         public object CorrelationPropertyValue { get; }
+        public NServiceBus.Extensibility.ContextBag Extensions { get; }
         public NServiceBus.Sagas.SagaMetadata SagaMetadata { get; }
     }
     public class SagaMessage

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2842,6 +2842,10 @@ namespace NServiceBus.Sagas
     {
         System.Threading.Tasks.Task Handle(object message, NServiceBus.IMessageProcessingContext context);
     }
+    public interface ISagaIdGenerator
+    {
+        System.Guid Generate(string propertyName, object propertyValue, NServiceBus.Sagas.SagaMetadata metadata, NServiceBus.Extensibility.ContextBag context);
+    }
     public interface ISagaPersister
     {
         System.Threading.Tasks.Task Complete(NServiceBus.IContainSagaData sagaData, NServiceBus.Persistence.SynchronizedStorageSession session, NServiceBus.Extensibility.ContextBag context);

--- a/src/NServiceBus.Core/Extensibility/ContextBag.cs
+++ b/src/NServiceBus.Core/Extensibility/ContextBag.cs
@@ -10,9 +10,9 @@ namespace NServiceBus.Extensibility
         /// <summary>
         /// Initialized a new instance of <see cref="ContextBag" />.
         /// </summary>
-        public ContextBag(ContextBag parentBag = null)
+        public ContextBag(ContextBag parentContext = null)
         {
-            this.parentBag = parentBag;
+            this.parentContext = parentContext;
         }
 
         /// <summary>
@@ -53,9 +53,9 @@ namespace NServiceBus.Extensibility
                 return true;
             }
 
-            if (parentBag != null)
+            if (parentContext != null)
             {
-                return parentBag.TryGet(key, out result);
+                return parentContext.TryGet(key, out result);
             }
 
             result = default(T);
@@ -146,7 +146,7 @@ namespace NServiceBus.Extensibility
             return result;
         }
 
-        ContextBag parentBag;
+        ContextBag parentContext;
 
         Dictionary<string, object> stash = new Dictionary<string, object>();
     }

--- a/src/NServiceBus.Core/Extensibility/ContextBag.cs
+++ b/src/NServiceBus.Core/Extensibility/ContextBag.cs
@@ -10,9 +10,9 @@ namespace NServiceBus.Extensibility
         /// <summary>
         /// Initialized a new instance of <see cref="ContextBag" />.
         /// </summary>
-        public ContextBag(ContextBag parentContext = null)
+        public ContextBag(ContextBag parent = null)
         {
-            this.parentContext = parentContext;
+            this.parent = parent;
         }
 
         /// <summary>
@@ -53,9 +53,9 @@ namespace NServiceBus.Extensibility
                 return true;
             }
 
-            if (parentContext != null)
+            if (parent != null)
             {
-                return parentContext.TryGet(key, out result);
+                return parent.TryGet(key, out result);
             }
 
             result = default(T);
@@ -146,7 +146,7 @@ namespace NServiceBus.Extensibility
             return result;
         }
 
-        ContextBag parentContext;
+        ContextBag parent;
 
         Dictionary<string, object> stash = new Dictionary<string, object>();
     }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -179,6 +179,8 @@
     <Compile Include="Routing\RoutingFeatureSettingsExtensions.cs" />
     <Compile Include="Routing\UnicastPublishRouter.cs" />
     <Compile Include="Routing\UnicastSendRouter.cs" />
+    <Compile Include="Sagas\DefaultSagaIdGenerator.cs" />
+    <Compile Include="Sagas\ISagaIdGenerator.cs" />
     <Compile Include="Serialization\SerializationFeature.cs" />
     <Compile Include="Serialization\SerializationSettingsExtensions.cs" />
     <Compile Include="Serializers\XML\XmlSerialization.cs" />

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -181,6 +181,7 @@
     <Compile Include="Routing\UnicastSendRouter.cs" />
     <Compile Include="Sagas\DefaultSagaIdGenerator.cs" />
     <Compile Include="Sagas\ISagaIdGenerator.cs" />
+    <Compile Include="Sagas\SagaIdGeneratorContext.cs" />
     <Compile Include="Serialization\SerializationFeature.cs" />
     <Compile Include="Serialization\SerializationSettingsExtensions.cs" />
     <Compile Include="Serializers\XML\XmlSerialization.cs" />

--- a/src/NServiceBus.Core/Sagas/DefaultSagaIdGenerator.cs
+++ b/src/NServiceBus.Core/Sagas/DefaultSagaIdGenerator.cs
@@ -1,12 +1,11 @@
 ﻿namespace NServiceBus
 {
     using System;
-    using Extensibility;
     using Sagas;
 
     class DefaultSagaIdGenerator : ISagaIdGenerator
     {
-        public Guid Generate(string propertyName, object propertyValue, SagaMetadata metadata, ContextBag context)
+        public Guid Generate(SagaIdGeneratorContext context)
         {
             // intentionally ignore the property name and the value.
             return CombGuid.Generate();

--- a/src/NServiceBus.Core/Sagas/DefaultSagaIdGenerator.cs
+++ b/src/NServiceBus.Core/Sagas/DefaultSagaIdGenerator.cs
@@ -1,0 +1,15 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using Extensibility;
+    using Sagas;
+
+    class DefaultSagaIdGenerator : ISagaIdGenerator
+    {
+        public Guid Generate(string propertyName, object propertyValue, SagaMetadata metadata, ContextBag context)
+        {
+            // intentionally ignore the property name and the value.
+            return CombGuid.Generate();
+        }
+    }
+}

--- a/src/NServiceBus.Core/Sagas/ISagaIdGenerator.cs
+++ b/src/NServiceBus.Core/Sagas/ISagaIdGenerator.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Sagas
 {
     using System;
-    using Extensibility;
 
     /// <summary>
     /// Saga id generator.
@@ -11,11 +10,8 @@ namespace NServiceBus.Sagas
         /// <summary>
         /// Generates a saga id based on property name and property value.
         /// </summary>
-        /// <param name="propertyName">The property name. Might be null when a custom finder is used.</param>
-        /// <param name="propertyValue">The property value. Might be null when a custom finder is used.</param>
-        /// <param name="metadata">The saga metadata.</param>
-        /// <param name="context">The context bag.</param>
-        /// <returns>The saga id.</returns>
-        Guid Generate(string propertyName, object propertyValue, SagaMetadata metadata, ContextBag context);
+        /// <param name="context">Context for the id generation.</param>
+        /// <returns>The saga id to use.</returns>
+        Guid Generate(SagaIdGeneratorContext context);
     }
 }

--- a/src/NServiceBus.Core/Sagas/ISagaIdGenerator.cs
+++ b/src/NServiceBus.Core/Sagas/ISagaIdGenerator.cs
@@ -8,10 +8,10 @@ namespace NServiceBus.Sagas
     public interface ISagaIdGenerator
     {
         /// <summary>
-        /// Generates a saga id based on property name and property value.
+        /// Allows custom saga ID's to be generated.
         /// </summary>
         /// <param name="context">Context for the id generation.</param>
-        /// <returns>The saga id to use.</returns>
+        /// <returns>The saga id to use for the given saga.</returns>
         Guid Generate(SagaIdGeneratorContext context);
     }
 }

--- a/src/NServiceBus.Core/Sagas/ISagaIdGenerator.cs
+++ b/src/NServiceBus.Core/Sagas/ISagaIdGenerator.cs
@@ -1,0 +1,21 @@
+namespace NServiceBus.Sagas
+{
+    using System;
+    using Extensibility;
+
+    /// <summary>
+    /// Saga id generator.
+    /// </summary>
+    public interface ISagaIdGenerator
+    {
+        /// <summary>
+        /// Generates a saga id based on property name and property value.
+        /// </summary>
+        /// <param name="propertyName">The property name. Might be null when a custom finder is used.</param>
+        /// <param name="propertyValue">The property value. Might be null when a custom finder is used.</param>
+        /// <param name="metadata">The saga metadata.</param>
+        /// <param name="context">The context bag.</param>
+        /// <returns>The saga id.</returns>
+        Guid Generate(string propertyName, object propertyValue, SagaMetadata metadata, ContextBag context);
+    }
+}

--- a/src/NServiceBus.Core/Sagas/PropertySagaFinder.cs
+++ b/src/NServiceBus.Core/Sagas/PropertySagaFinder.cs
@@ -22,14 +22,13 @@ namespace NServiceBus
 
             var sagaPropertyName = (string) finderDefinition.Properties["saga-property-name"];
 
+            var lookupValues = context.GetOrCreate<SagaLookupValues>();
+            lookupValues.Add<TSagaData>(sagaPropertyName, propertyValue);
+
             if (sagaPropertyName.ToLower() == "id")
             {
                 return await sagaPersister.Get<TSagaData>((Guid) propertyValue, storageSession, context).ConfigureAwait(false);
             }
-
-            var lookupValues = context.GetOrCreate<SagaLookupValues>();
-
-            lookupValues.Add<TSagaData>(sagaPropertyName, propertyValue);
 
             return await sagaPersister.Get<TSagaData>(sagaPropertyName, propertyValue, storageSession, context).ConfigureAwait(false);
         }

--- a/src/NServiceBus.Core/Sagas/SagaIdGeneratorContext.cs
+++ b/src/NServiceBus.Core/Sagas/SagaIdGeneratorContext.cs
@@ -12,6 +12,9 @@ namespace NServiceBus.Sagas
         /// </summary>
         public SagaIdGeneratorContext(string correlationPropertyName, object correlationPropertyValue, SagaMetadata sagaMetadata, ContextBag parentBag) : base(parentBag)
         {
+            Guard.AgainstNull(nameof(sagaMetadata),sagaMetadata);
+            Guard.AgainstNull(nameof(parentBag), parentBag);
+
             CorrelationPropertyName = correlationPropertyName;
             CorrelationPropertyValue = correlationPropertyValue;
             SagaMetadata = sagaMetadata;

--- a/src/NServiceBus.Core/Sagas/SagaIdGeneratorContext.cs
+++ b/src/NServiceBus.Core/Sagas/SagaIdGeneratorContext.cs
@@ -1,0 +1,35 @@
+namespace NServiceBus.Sagas
+{
+    using Extensibility;
+
+    /// <summary>
+    /// Context provided to the saga id generator.
+    /// </summary>
+    public class SagaIdGeneratorContext : ContextBag
+    {
+        /// <summary>
+        /// Constructs a new context.
+        /// </summary>
+        public SagaIdGeneratorContext(string correlationPropertyName, object correlationPropertyValue, SagaMetadata sagaMetadata, ContextBag parentBag) : base(parentBag)
+        {
+            CorrelationPropertyName = correlationPropertyName;
+            CorrelationPropertyValue = correlationPropertyValue;
+            SagaMetadata = sagaMetadata;
+        }
+
+        /// <summary>
+        /// Name of property used to correlate messages to this saga.
+        /// </summary>
+        public string CorrelationPropertyName { get; private set; }
+
+        /// <summary>
+        /// Value of the correlation property.
+        /// </summary>
+        public object CorrelationPropertyValue { get; private set; }
+
+        /// <summary>
+        /// Metadata for the targeted saga.
+        /// </summary>
+        public SagaMetadata SagaMetadata { get; private set; }
+    }
+}

--- a/src/NServiceBus.Core/Sagas/SagaIdGeneratorContext.cs
+++ b/src/NServiceBus.Core/Sagas/SagaIdGeneratorContext.cs
@@ -7,13 +7,18 @@ namespace NServiceBus.Sagas
     /// </summary>
     public class SagaIdGeneratorContext : ContextBag
     {
+
         /// <summary>
         /// Constructs a new context.
         /// </summary>
-        public SagaIdGeneratorContext(string correlationPropertyName, object correlationPropertyValue, SagaMetadata sagaMetadata, ContextBag parentBag) : base(parentBag)
+        /// <param name="correlationPropertyName">Name of property used to correlate messages to this saga. Can be <code>null</code> if a custom saga finder is used for the given message.</param>
+        /// <param name="correlationPropertyValue">Value of the correlation property. Can be <code>null</code> if a custom saga finder is used for the given message.</param>
+        /// <param name="sagaMetadata">Metadata for the targeted saga.</param>
+        /// <param name="parentContext">Parent context.</param>
+        public SagaIdGeneratorContext(string correlationPropertyName, object correlationPropertyValue, SagaMetadata sagaMetadata, ContextBag parentContext) : base(parentContext)
         {
             Guard.AgainstNull(nameof(sagaMetadata),sagaMetadata);
-            Guard.AgainstNull(nameof(parentBag), parentBag);
+            Guard.AgainstNull(nameof(parentContext), parentContext);
 
             CorrelationPropertyName = correlationPropertyName;
             CorrelationPropertyValue = correlationPropertyValue;

--- a/src/NServiceBus.Core/Sagas/SagaIdGeneratorContext.cs
+++ b/src/NServiceBus.Core/Sagas/SagaIdGeneratorContext.cs
@@ -7,39 +7,32 @@ namespace NServiceBus.Sagas
     /// </summary>
     public class SagaIdGeneratorContext : IExtendable
     {
-
         /// <summary>
         /// Constructs a new context.
         /// </summary>
-        /// <param name="correlationPropertyName">Name of property used to correlate messages to this saga. Can be <code>null</code> if a custom saga finder is used for the given message.</param>
-        /// <param name="correlationPropertyValue">Value of the correlation property. Can be <code>null</code> if a custom saga finder is used for the given message.</param>
+        /// <param name="correlationProperty">The saga property used to correlate messages to this saga.</param>
         /// <param name="sagaMetadata">Metadata for the targeted saga.</param>
         /// <param name="extensions">A <see cref="ContextBag" /> which can be used to extend the current object.</param>
-        public SagaIdGeneratorContext(string correlationPropertyName, object correlationPropertyValue, SagaMetadata sagaMetadata, ContextBag extensions)
+        public SagaIdGeneratorContext(SagaCorrelationProperty correlationProperty, SagaMetadata sagaMetadata, ContextBag extensions)
         {
+            Guard.AgainstNull(nameof(correlationProperty), correlationProperty);
             Guard.AgainstNull(nameof(sagaMetadata), sagaMetadata);
             Guard.AgainstNull(nameof(extensions), extensions);
 
-            CorrelationPropertyName = correlationPropertyName;
-            CorrelationPropertyValue = correlationPropertyValue;
+            CorrelationProperty = correlationProperty;
             SagaMetadata = sagaMetadata;
             Extensions = extensions;
         }
 
         /// <summary>
-        /// Name of property used to correlate messages to this saga.
+        /// The saga property used to correlate messages to this saga.
         /// </summary>
-        public string CorrelationPropertyName { get; private set; }
-
-        /// <summary>
-        /// Value of the correlation property.
-        /// </summary>
-        public object CorrelationPropertyValue { get; private set; }
+        public SagaCorrelationProperty CorrelationProperty { get; }
 
         /// <summary>
         /// Metadata for the targeted saga.
         /// </summary>
-        public SagaMetadata SagaMetadata { get; private set; }
+        public SagaMetadata SagaMetadata { get; }
 
         /// <summary>
         /// A <see cref="ContextBag" /> which can be used to extend the current object.

--- a/src/NServiceBus.Core/Sagas/SagaIdGeneratorContext.cs
+++ b/src/NServiceBus.Core/Sagas/SagaIdGeneratorContext.cs
@@ -15,7 +15,6 @@ namespace NServiceBus.Sagas
         /// <param name="extensions">A <see cref="ContextBag" /> which can be used to extend the current object.</param>
         public SagaIdGeneratorContext(SagaCorrelationProperty correlationProperty, SagaMetadata sagaMetadata, ContextBag extensions)
         {
-            Guard.AgainstNull(nameof(correlationProperty), correlationProperty);
             Guard.AgainstNull(nameof(sagaMetadata), sagaMetadata);
             Guard.AgainstNull(nameof(extensions), extensions);
 

--- a/src/NServiceBus.Core/Sagas/SagaIdGeneratorContext.cs
+++ b/src/NServiceBus.Core/Sagas/SagaIdGeneratorContext.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Sagas
     /// <summary>
     /// Context provided to the saga id generator.
     /// </summary>
-    public class SagaIdGeneratorContext : ContextBag
+    public class SagaIdGeneratorContext : IExtendable
     {
 
         /// <summary>
@@ -14,15 +14,16 @@ namespace NServiceBus.Sagas
         /// <param name="correlationPropertyName">Name of property used to correlate messages to this saga. Can be <code>null</code> if a custom saga finder is used for the given message.</param>
         /// <param name="correlationPropertyValue">Value of the correlation property. Can be <code>null</code> if a custom saga finder is used for the given message.</param>
         /// <param name="sagaMetadata">Metadata for the targeted saga.</param>
-        /// <param name="parentContext">Parent context.</param>
-        public SagaIdGeneratorContext(string correlationPropertyName, object correlationPropertyValue, SagaMetadata sagaMetadata, ContextBag parentContext) : base(parentContext)
+        /// <param name="extensions">A <see cref="ContextBag" /> which can be used to extend the current object.</param>
+        public SagaIdGeneratorContext(string correlationPropertyName, object correlationPropertyValue, SagaMetadata sagaMetadata, ContextBag extensions)
         {
-            Guard.AgainstNull(nameof(sagaMetadata),sagaMetadata);
-            Guard.AgainstNull(nameof(parentContext), parentContext);
+            Guard.AgainstNull(nameof(sagaMetadata), sagaMetadata);
+            Guard.AgainstNull(nameof(extensions), extensions);
 
             CorrelationPropertyName = correlationPropertyName;
             CorrelationPropertyValue = correlationPropertyValue;
             SagaMetadata = sagaMetadata;
+            Extensions = extensions;
         }
 
         /// <summary>
@@ -39,5 +40,10 @@ namespace NServiceBus.Sagas
         /// Metadata for the targeted saga.
         /// </summary>
         public SagaMetadata SagaMetadata { get; private set; }
+
+        /// <summary>
+        /// A <see cref="ContextBag" /> which can be used to extend the current object.
+        /// </summary>
+        public ContextBag Extensions { get; }
     }
 }

--- a/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
@@ -320,7 +320,7 @@
 
             var lookupValues = context.Extensions.GetOrCreate<SagaLookupValues>();
 
-            SagaIdGeneratorContext sagaIdGeneratorContext;
+            SagaCorrelationProperty correlationProperty;
             SagaLookupValues.LookupValue value;
 
             if (lookupValues.TryGet(sagaEntityType, out value))
@@ -332,12 +332,14 @@
 
                 propertyInfo.SetValue(sagaEntity, convertedValue);
 
-                sagaIdGeneratorContext = new SagaIdGeneratorContext(value.PropertyName, value.PropertyValue, metadata, context.Extensions);
+                correlationProperty = new SagaCorrelationProperty(value.PropertyName, value.PropertyValue);
             }
             else
             {
-                sagaIdGeneratorContext = new SagaIdGeneratorContext(null, null, metadata, context.Extensions);
+                correlationProperty = SagaCorrelationProperty.None;
             }
+
+            var sagaIdGeneratorContext = new SagaIdGeneratorContext(correlationProperty, metadata, context.Extensions);
 
             sagaEntity.Id = sagaIdGenerator.Generate(sagaIdGeneratorContext);
 

--- a/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
@@ -12,8 +12,9 @@
 
     class SagaPersistenceBehavior : IBehavior<IInvokeHandlerContext, IInvokeHandlerContext>
     {
-        public SagaPersistenceBehavior(ISagaPersister persister, ICancelDeferredMessages timeoutCancellation, SagaMetadataCollection sagaMetadataCollection)
+        public SagaPersistenceBehavior(ISagaPersister persister, ISagaIdGenerator sagaIdGenerator, ICancelDeferredMessages timeoutCancellation, SagaMetadataCollection sagaMetadataCollection)
         {
+            this.sagaIdGenerator = sagaIdGenerator;
             sagaPersister = persister;
             this.timeoutCancellation = timeoutCancellation;
             this.sagaMetadataCollection = sagaMetadataCollection;
@@ -308,7 +309,6 @@
 
             var sagaEntity = (IContainSagaData)Activator.CreateInstance(sagaEntityType);
 
-            sagaEntity.Id = CombGuid.Generate();
             sagaEntity.OriginalMessageId = context.MessageId;
 
             string replyToAddress;
@@ -329,8 +329,14 @@
                     .ConvertFromInvariantString(value.PropertyValue.ToString());
 
                 propertyInfo.SetValue(sagaEntity, convertedValue);
-            }
 
+                sagaEntity.Id = sagaIdGenerator.Generate(value.PropertyName, value.PropertyValue, metadata, context.Extensions);
+            }
+            else
+            {
+                sagaEntity.Id = sagaIdGenerator.Generate(null, null, metadata, context.Extensions);
+            }
+            
             return sagaEntity;
         }
 
@@ -342,5 +348,6 @@
 
         static Task<IContainSagaData> DefaultSagaDataCompletedTask = Task.FromResult(default(IContainSagaData));
         static ILog logger = LogManager.GetLogger<SagaPersistenceBehavior>();
+        ISagaIdGenerator sagaIdGenerator;
     }
 }

--- a/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
@@ -320,7 +320,9 @@
 
             var lookupValues = context.Extensions.GetOrCreate<SagaLookupValues>();
 
+            SagaIdGeneratorContext sagaIdGeneratorContext;
             SagaLookupValues.LookupValue value;
+
             if (lookupValues.TryGet(sagaEntityType, out value))
             {
                 var propertyInfo = sagaEntityType.GetProperty(value.PropertyName);
@@ -330,13 +332,15 @@
 
                 propertyInfo.SetValue(sagaEntity, convertedValue);
 
-                sagaEntity.Id = sagaIdGenerator.Generate(value.PropertyName, value.PropertyValue, metadata, context.Extensions);
+                sagaIdGeneratorContext = new SagaIdGeneratorContext(value.PropertyName, value.PropertyValue, metadata, context.Extensions);
             }
             else
             {
-                sagaEntity.Id = sagaIdGenerator.Generate(null, null, metadata, context.Extensions);
+                sagaIdGeneratorContext = new SagaIdGeneratorContext(null, null, metadata, context.Extensions);
             }
-            
+
+            sagaEntity.Id = sagaIdGenerator.Generate(sagaIdGeneratorContext);
+
             return sagaEntity;
         }
 

--- a/src/NServiceBus.Core/Sagas/Sagas.cs
+++ b/src/NServiceBus.Core/Sagas/Sagas.cs
@@ -43,10 +43,7 @@
                 throw new Exception("The selected persistence doesn't have support for saga storage. Select another persistence or disable the sagas feature using endpointConfiguration.DisableFeature<Sagas>()");
             }
 
-            if (!context.Container.HasComponent<ISagaIdGenerator>())
-            {
-                context.Container.RegisterSingleton<ISagaIdGenerator>(new DefaultSagaIdGenerator());
-            }
+            var sagaIdGenerator = context.Settings.GetOrDefault<ISagaIdGenerator>() ?? new DefaultSagaIdGenerator();
 
             var sagaMetaModel = context.Settings.Get<SagaMetadataCollection>();
             sagaMetaModel.Initialize(context.Settings.GetAvailableTypes(), conventions);
@@ -62,7 +59,7 @@
             }
 
             // Register the Saga related behaviors for incoming messages
-            context.Pipeline.Register("InvokeSaga", b => new SagaPersistenceBehavior(b.Build<ISagaPersister>(), b.Build<ISagaIdGenerator>(), b.Build<ICancelDeferredMessages>(), sagaMetaModel), "Invokes the saga logic");
+            context.Pipeline.Register("InvokeSaga", b => new SagaPersistenceBehavior(b.Build<ISagaPersister>(), sagaIdGenerator, b.Build<ICancelDeferredMessages>(), sagaMetaModel), "Invokes the saga logic");
             context.Pipeline.Register("InvokeSagaNotFound", new InvokeSagaNotFoundBehavior(), "Invokes saga not found logic");
             context.Pipeline.Register("AttachSagaDetailsToOutGoingMessage", new AttachSagaDetailsToOutGoingMessageBehavior(), "Makes sure that outgoing messages have saga info attached to them");
         }
@@ -77,7 +74,7 @@
 
                 if (finder.Properties.TryGetValue("custom-finder-clr-type", out customFinderType))
                 {
-                    container.ConfigureComponent((Type) customFinderType, DependencyLifecycle.InstancePerCall);
+                    container.ConfigureComponent((Type)customFinderType, DependencyLifecycle.InstancePerCall);
                 }
             }
         }

--- a/src/NServiceBus.Core/Sagas/Sagas.cs
+++ b/src/NServiceBus.Core/Sagas/Sagas.cs
@@ -43,6 +43,11 @@
                 throw new Exception("The selected persistence doesn't have support for saga storage. Select another persistence or disable the sagas feature using endpointConfiguration.DisableFeature<Sagas>()");
             }
 
+            if (!context.Container.HasComponent<ISagaIdGenerator>())
+            {
+                context.Container.RegisterSingleton<ISagaIdGenerator>(new DefaultSagaIdGenerator());
+            }
+
             var sagaMetaModel = context.Settings.Get<SagaMetadataCollection>();
             sagaMetaModel.Initialize(context.Settings.GetAvailableTypes(), conventions);
 
@@ -57,7 +62,7 @@
             }
 
             // Register the Saga related behaviors for incoming messages
-            context.Pipeline.Register("InvokeSaga", b => new SagaPersistenceBehavior(b.Build<ISagaPersister>(), b.Build<ICancelDeferredMessages>(), sagaMetaModel), "Invokes the saga logic");
+            context.Pipeline.Register("InvokeSaga", b => new SagaPersistenceBehavior(b.Build<ISagaPersister>(), b.Build<ISagaIdGenerator>(), b.Build<ICancelDeferredMessages>(), sagaMetaModel), "Invokes the saga logic");
             context.Pipeline.Register("InvokeSagaNotFound", new InvokeSagaNotFoundBehavior(), "Invokes saga not found logic");
             context.Pipeline.Register("AttachSagaDetailsToOutGoingMessage", new AttachSagaDetailsToOutGoingMessageBehavior(), "Makes sure that outgoing messages have saga info attached to them");
         }


### PR DESCRIPTION
Closes #2445 

This enables:

- Simple sagas
- [A filebased development saga persister](https://github.com/Particular/NServiceBus/pull/4496)

Currently the core doesn't make assumptions that all messages need to have a message property which can be always mapped to an existing saga instance. When a new saga instance is created by default a new comb GUID is generated and then messages going out from that saga will contain the saga id header to be able to be correlated back. To ensure partition affinity with Service Fabric we need a deterministic way of creating from a message which started a saga a saga ID based on business identifiers. With that approach it is possible to route messages that need to be sent to an existing saga instance to the endpoint that is living on the partition that contains the saga data.
