### PR TITLE
Add acceptance tests for RouteReply... options

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -84,6 +84,9 @@
     <Compile Include="Routing\MessageDrivenSubscriptions\When_unsubscribing_to_scaled_out_publisher.cs" />
     <Compile Include="Routing\NativePublishSubscribe\When_unsubscribing_from_event.cs" />
     <Compile Include="Routing\When_configure_routes_for_unobtrusive_messages.cs" />
+    <Compile Include="Routing\When_routing_reply_to_any_instance.cs" />
+    <Compile Include="Routing\When_routing_reply_to_specific_address.cs" />
+    <Compile Include="Routing\When_routing_reply_to_specific_instance.cs" />
     <Compile Include="Routing\When_using_custom_routing_strategy.cs" />
     <Compile Include="Routing\When_extending_command_routing.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_extending_event_routing.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/When_routing_reply_to_any_instance.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_routing_reply_to_any_instance.cs
@@ -1,0 +1,95 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_routing_reply_to_any_instance : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_route_reply_to_shared_queue()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(e => e
+                    .When(s =>
+                    {
+                        var options = new SendOptions();
+                        options.RouteReplyToAnyInstance();
+                        return s.Send(new RequestReplyMessage(), options);
+                    }))
+                .WithEndpoint<Replier>()
+                .Done(c => c.ReplyReceived)
+                .Run();
+
+            Assert.IsTrue(context.ReplyReceived);
+            StringAssert.DoesNotContain(instanceDiscriminator, context.ReplyToAddress);
+        }
+
+        const string instanceDiscriminator = "instance-42";
+
+        class Context : ScenarioContext
+        {
+            public string ReplyToAddress { get; set; }
+            public bool ReplyReceived { get; set; }
+        }
+
+        class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c => c.MakeInstanceUniquelyAddressable(instanceDiscriminator))
+                    .AddMapping<RequestReplyMessage>(typeof(Replier));
+            }
+
+            class ReplyMessageHandler : IHandleMessages<ReplyMessage>
+            {
+                public ReplyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(ReplyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ReplyReceived = true;
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        class Replier : EndpointConfigurationBuilder
+        {
+            public Replier()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class RequestReplyMessageHandler : IHandleMessages<RequestReplyMessage>
+            {
+                public RequestReplyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(RequestReplyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ReplyToAddress = context.ReplyToAddress;
+                    return context.Reply(new ReplyMessage());
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class RequestReplyMessage : ICommand
+        {
+        }
+
+        public class ReplyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Routing/When_routing_reply_to_specific_address.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_routing_reply_to_specific_address.cs
@@ -1,0 +1,104 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_routing_reply_to_specific_address : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_route_reply_to_instance_specific_queue()
+        {
+            var replyHandlerAddress = Conventions.EndpointNamingConvention(typeof(ReplyHandler));
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(e => e
+                    .When(s =>
+                    {
+                        var options = new SendOptions();
+                        options.RouteReplyTo(replyHandlerAddress);
+                        return s.Send(new RequestReplyMessage(), options);
+                    }))
+                .WithEndpoint<Replier>()
+                .WithEndpoint<ReplyHandler>()
+                .Done(c => c.ReplyReceived)
+                .Run();
+
+            Assert.IsTrue(context.ReplyReceived);
+            StringAssert.Contains(replyHandlerAddress, context.ReplyToAddress);
+        }
+
+        class Context : ScenarioContext
+        {
+            public string ReplyToAddress { get; set; }
+            public bool ReplyReceived { get; set; }
+        }
+
+        class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>().AddMapping<RequestReplyMessage>(typeof(Replier));
+            }
+        }
+
+        class Replier : EndpointConfigurationBuilder
+        {
+            public Replier()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class RequestReplyMessageHandler : IHandleMessages<RequestReplyMessage>
+            {
+                public RequestReplyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(RequestReplyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ReplyToAddress = context.ReplyToAddress;
+                    return context.Reply(new ReplyMessage());
+                }
+
+                Context testContext;
+            }
+        }
+
+        class ReplyHandler : EndpointConfigurationBuilder
+        {
+            public ReplyHandler()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class ReplyMessageHandler : IHandleMessages<ReplyMessage>
+            {
+                public ReplyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(ReplyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ReplyReceived = true;
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class RequestReplyMessage : ICommand
+        {
+        }
+
+        public class ReplyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Routing/When_routing_reply_to_specific_instance.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_routing_reply_to_specific_instance.cs
@@ -1,0 +1,95 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    [TestFixture]
+    class When_routing_reply_to_specific_instance : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_route_reply_to_instance_specific_queue()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(e => e
+                    .When(s =>
+                    {
+                        var options = new SendOptions();
+                        options.RouteReplyToThisInstance();
+                        return s.Send(new RequestReplyMessage(), options);
+                    }))
+                .WithEndpoint<Replier>()
+                .Done(c => c.ReplyReceived)
+                .Run();
+
+            Assert.IsTrue(context.ReplyReceived);
+            StringAssert.Contains(instanceDiscriminator, context.ReplyToAddress);
+        }
+
+        const string instanceDiscriminator = "instance-42";
+
+        class Context : ScenarioContext
+        {
+            public string ReplyToAddress { get; set; }
+            public bool ReplyReceived { get; set; }
+        }
+
+        class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c => c.MakeInstanceUniquelyAddressable(instanceDiscriminator))
+                    .AddMapping<RequestReplyMessage>(typeof(Replier));
+            }
+
+            class ReplyMessageHandler : IHandleMessages<ReplyMessage>
+            {
+                public ReplyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(ReplyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ReplyReceived = true;
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        class Replier : EndpointConfigurationBuilder
+        {
+            public Replier()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class RequestReplyMessageHandler : IHandleMessages<RequestReplyMessage>
+            {
+                public RequestReplyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(RequestReplyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ReplyToAddress = context.ReplyToAddress;
+                    return context.Reply(new ReplyMessage());
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class RequestReplyMessage : ICommand
+        {
+        }
+
+        public class ReplyMessage : IMessage
+        {
+        }
+    }
+}


### PR DESCRIPTION
Because of https://github.com/Particular/NServiceBus/issues/4476 I checked for existing acceptance tests to verify the sendoptions work in v6 but I didn't found any, so I added them.

ping @Particular/nservicebus-maintainers @SzymonPobiega 