### PR TITLE
Allow AppDomain assemblies to be scanned

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -30,6 +30,19 @@ namespace NServiceBus
     {
         public AllAssemblies() { }
     }
+    public class AssemblyScannerConfiguration
+    {
+        public AssemblyScannerConfiguration() { }
+        public bool ScanAppDomainAssemblies { get; set; }
+        public bool ScanAssembliesInNestedDirectories { get; set; }
+        public bool ThrowExceptions { get; set; }
+        public void ExcludeAssemblies(params string[] assemblies) { }
+        public void ExcludeTypes(params System.Type[] types) { }
+    }
+    public class static AssemblyScannerConfigurationExtensions
+    {
+        public static void AssemblyScanner(this NServiceBus.EndpointConfiguration configuration, System.Action<NServiceBus.AssemblyScannerConfiguration> configure) { }
+    }
     public class static AuditConfigReader
     {
         public static bool TryGetAuditQueueAddress(this NServiceBus.Settings.ReadOnlySettings settings, out string address) { }
@@ -374,7 +387,13 @@ namespace NServiceBus
             "he member currently throws a NotImplementedException. Will be removed in version" +
             " 7.0.0.", true)]
         public void EndpointName(string name) { }
+        [System.ObsoleteAttribute("Use the AssemblyScanner configuration API. Use `AssemblyScannerConfigurationExten" +
+            "sions.AssemblyScanner` instead. Will be treated as an error from version 7.0.0. " +
+            "Will be removed in version 8.0.0.", false)]
         public void ExcludeAssemblies(params string[] assemblies) { }
+        [System.ObsoleteAttribute("Use the AssemblyScanner configuration API. Use `AssemblyScannerConfigurationExten" +
+            "sions.AssemblyScanner` instead. Will be treated as an error from version 7.0.0. " +
+            "Will be removed in version 8.0.0.", false)]
         public void ExcludeTypes(params System.Type[] types) { }
         [System.ObsoleteAttribute("Use `EndpointConfiguration.OverridePublicReturnAddress(string address)` instead. " +
             "The member currently throws a NotImplementedException. Will be removed in versio" +
@@ -384,6 +403,9 @@ namespace NServiceBus
         [System.ObsoleteAttribute("Use `EndpointConfiguration.ExcludeAssemblies` instead. The member currently throw" +
             "s a NotImplementedException. Will be removed in version 7.0.0.", true)]
         public void ScanAssembliesInDirectory(string probeDirectory) { }
+        [System.ObsoleteAttribute("Use the AssemblyScanner configuration API. Use `AssemblyScannerConfigurationExten" +
+            "sions.AssemblyScanner` instead. Will be treated as an error from version 7.0.0. " +
+            "Will be removed in version 8.0.0.", false)]
         public void ScanAssembliesInNestedDirectories() { }
         public void SendOnly() { }
         [System.ObsoleteAttribute("Use `EndpointConfiguration.ExcludeTypes` instead. The member currently throws a N" +
@@ -1957,6 +1979,7 @@ namespace NServiceBus.Hosting.Helpers
             "tect an NServiceBus reference. The member currently throws a NotImplementedExcep" +
             "tion. Will be removed in version 7.0.0.", true)]
         public System.Collections.Generic.List<System.Reflection.Assembly> MustReferenceAtLeastOneAssembly { get; }
+        public bool ScanAppDomainAssemblies { get; set; }
         public bool ThrowExceptions { get; set; }
         public NServiceBus.Hosting.Helpers.AssemblyScannerResults GetScannableAssemblies() { }
     }

--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -76,37 +76,40 @@ namespace NServiceBus
         /// <summary>
         /// Append a list of <see cref="Assembly" />s to the ignored list. The string is the file name of the assembly.
         /// </summary>
+        [ObsoleteEx(
+            Message = "Use the AssemblyScanner configuration API.",
+            ReplacementTypeOrMember = "AssemblyScannerConfigurationExtensions.AssemblyScanner",
+            TreatAsErrorFromVersion = "7.0",
+            RemoveInVersion = "8.0")]
         public void ExcludeAssemblies(params string[] assemblies)
         {
-            Guard.AgainstNull(nameof(assemblies), assemblies);
-
-            if (assemblies.Any(string.IsNullOrWhiteSpace))
-            {
-                throw new ArgumentException("Passed in a null or empty assembly name.", nameof(assemblies));
-            }
-            excludedAssemblies = excludedAssemblies.Union(assemblies, StringComparer.OrdinalIgnoreCase).ToList();
+            Settings.GetOrCreate<AssemblyScannerConfiguration>().ExcludeAssemblies(assemblies);
         }
 
         /// <summary>
         /// Append a list of <see cref="Type" />s to the ignored list.
         /// </summary>
+        [ObsoleteEx(
+            Message = "Use the AssemblyScanner configuration API.",
+            ReplacementTypeOrMember = "AssemblyScannerConfigurationExtensions.AssemblyScanner",
+            TreatAsErrorFromVersion = "7.0",
+            RemoveInVersion = "8.0")]
         public void ExcludeTypes(params Type[] types)
         {
-            Guard.AgainstNull(nameof(types), types);
-            if (types.Any(x => x == null))
-            {
-                throw new ArgumentException("Passed in a null or empty type.", nameof(types));
-            }
-
-            excludedTypes = excludedTypes.Union(types).ToList();
+            Settings.GetOrCreate<AssemblyScannerConfiguration>().ExcludeTypes(types);
         }
 
         /// <summary>
         /// Specify to scan nested directories when performing assembly scanning.
         /// </summary>
+        [ObsoleteEx(
+            Message = "Use the AssemblyScanner configuration API.",
+            ReplacementTypeOrMember = "AssemblyScannerConfigurationExtensions.AssemblyScanner",
+            TreatAsErrorFromVersion = "7.0",
+            RemoveInVersion = "8.0")]
         public void ScanAssembliesInNestedDirectories()
         {
-            scanAssembliesInNestedDirectories = true;
+            Settings.GetOrCreate<AssemblyScannerConfiguration>().ScanAssembliesInNestedDirectories = true;
         }
 
         /// <summary>
@@ -252,11 +255,14 @@ namespace NServiceBus
 
         List<Type> GetAllowedTypes(string path)
         {
+            var assemblyScannerSettings = Settings.GetOrCreate<AssemblyScannerConfiguration>();
             var assemblyScanner = new AssemblyScanner(path)
             {
-                AssembliesToSkip = excludedAssemblies,
-                TypesToSkip = excludedTypes,
-                ScanNestedDirectories = scanAssembliesInNestedDirectories
+                AssembliesToSkip = assemblyScannerSettings.ExcludedAssemblies,
+                TypesToSkip = assemblyScannerSettings.ExcludedTypes,
+                ScanNestedDirectories = assemblyScannerSettings.ScanAssembliesInNestedDirectories,
+                ThrowExceptions = assemblyScannerSettings.ThrowExceptions,
+                ScanAppDomainAssemblies = assemblyScannerSettings.ScanAppDomainAssemblies
             };
             return assemblyScanner
                 .GetScannableAssemblies()
@@ -265,10 +271,14 @@ namespace NServiceBus
 
         List<Type> GetAllowedCoreTypes()
         {
+            var assemblyScannerSettings = Settings.GetOrCreate<AssemblyScannerConfiguration>();
             var assemblyScanner = new AssemblyScanner(Assembly.GetExecutingAssembly())
             {
-                TypesToSkip = excludedTypes,
-                ScanNestedDirectories = scanAssembliesInNestedDirectories
+                AssembliesToSkip = assemblyScannerSettings.ExcludedAssemblies,
+                TypesToSkip = assemblyScannerSettings.ExcludedTypes,
+                ScanNestedDirectories = assemblyScannerSettings.ScanAssembliesInNestedDirectories,
+                ThrowExceptions = assemblyScannerSettings.ThrowExceptions,
+                ScanAppDomainAssemblies = assemblyScannerSettings.ScanAppDomainAssemblies
             };
             return assemblyScanner
                 .GetScannableAssemblies()
@@ -277,11 +287,8 @@ namespace NServiceBus
 
         ConventionsBuilder conventionsBuilder;
         IContainer customBuilder;
-        List<string> excludedAssemblies = new List<string>();
-        List<Type> excludedTypes = new List<Type>();
         PipelineConfiguration pipelineCollection;
         List<Action<IConfigureComponents>> registrations = new List<Action<IConfigureComponents>>();
-        bool scanAssembliesInNestedDirectories;
         List<Type> scannedTypes;
     }
 }

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
@@ -1,0 +1,62 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Hosting.Helpers;
+
+    /// <summary>
+    /// Configure the <see cref="AssemblyScanner"/>.
+    /// </summary>
+    public class AssemblyScannerConfiguration
+    {
+        /// <summary>
+        /// Defines whether assemblies loaded into the current <see cref="AppDomain"/> should be scanned. Default value is <code>false</code>.
+        /// </summary>
+        public bool ScanAppDomainAssemblies { get; set; } = false;
+
+        /// <summary>
+        /// Defines whether exceptions occurint during assembly scanning should be rethrown or ignored. Default value is <code>false</code>.
+        /// </summary>
+        public bool ThrowExceptions { get; set; } = false;
+
+        /// <summary>
+        /// Defines whether nested directories should be included in the assembly scanning process. Default value is <code>false</code>.
+        /// </summary>
+        public bool ScanAssembliesInNestedDirectories { get; set; } = false;
+
+        /// <summary>
+        /// A list of <see cref="Assembly" />s to ignore in the assembly scanning.
+        /// </summary>
+        /// <param name="assemblies">The file name of the assembly.</param>
+        public void ExcludeAssemblies(params string[] assemblies)
+        {
+            Guard.AgainstNull(nameof(assemblies), assemblies);
+
+            if (assemblies.Any(string.IsNullOrWhiteSpace))
+            {
+                throw new ArgumentException("Passed in a null or empty assembly name.", nameof(assemblies));
+            }
+
+            ExcludedAssemblies.AddRange(assemblies);
+        }
+
+        /// <summary>
+        /// A list of <see cref="Type" />s to ignore in the assembly scanning.
+        /// </summary>
+        public void ExcludeTypes(params Type[] types)
+        {
+            Guard.AgainstNull(nameof(types), types);
+            if (types.Any(x => x == null))
+            {
+                throw new ArgumentException("Passed in a null or empty type.", nameof(types));
+            }
+
+            ExcludedTypes.AddRange(types);
+        }
+
+        internal List<string> ExcludedAssemblies { get; } = new List<string>(0);
+        internal List<Type> ExcludedTypes { get; } = new List<Type>(0);
+    }
+}

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
@@ -17,7 +17,7 @@
         public bool ScanAppDomainAssemblies { get; set; } = false;
 
         /// <summary>
-        /// Defines whether exceptions occurint during assembly scanning should be rethrown or ignored. Default value is <code>false</code>.
+        /// Defines whether exceptions occuring during assembly scanning should be rethrown or ignored. Default value is <code>false</code>.
         /// </summary>
         public bool ThrowExceptions { get; set; } = false;
 

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfigurationExtensions.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus
+{
+    using System;
+
+    /// <summary>
+    /// Contains extension methods to configure the <see cref="AssemblyScanner"/> behavior.
+    /// </summary>
+    public static class AssemblyScannerConfigurationExtensions
+    {
+        /// <summary>
+        /// Configure the <see cref="AssemblyScanner"/>.
+        /// </summary>
+        public static void AssemblyScanner(this EndpointConfiguration configuration, Action<AssemblyScannerConfiguration> configure)
+        {
+            Guard.AgainstNull(nameof(configuration), configuration);
+            Guard.AgainstNull(nameof(configure), configure);
+
+            var config = configuration.Settings.GetOrCreate<AssemblyScannerConfiguration>();
+            configure(config);
+        }
+    }
+}

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -103,6 +103,8 @@
     <Compile Include="DelayedDelivery\TimeoutManager\TimeoutManagerConfiguration.cs" />
     <Compile Include="DelayedDelivery\TimeoutManager\TimeoutManagerConfigurationExtensions.cs" />
     <Compile Include="Features\SatelliteDefinitions.cs" />
+    <Compile Include="Hosting\Helpers\AssemblyScannerConfiguration.cs" />
+    <Compile Include="Hosting\Helpers\AssemblyScannerConfigurationExtensions.cs" />
     <Compile Include="Notifications.cs" />
     <Compile Include="Notifications\EventAggregator.cs" />
     <Compile Include="Encryption\WireEncryptedStringConversions.cs" />


### PR DESCRIPTION
relates to https://github.com/Particular/NServiceBus/issues/4472

This PR contains a set of changes related to the AssemblyScanner:
* The AssemblyScanner can be configured to also scan AppDomain assemblies instead of just assemblies in the basepath folder. This is an opt-in behavior which is disabled by default.
  * This might resolve issues when applications run with a different base path which does not contain the required assemblies although the assemblies are already loaded into the AppDomain.
  * When NServiceBus.Core is loaded into the AppDomain (which is very likely), it is very important to also scan the already loaded assembly. Scanning an NServiceBus assembly from a different location, will not fail but it will internally fail type comparison checks and fail to setup features which will cause exceptions when starting the endpoint due to missing container registrations.
* The AssemblyScanner now also swallows exceptions thrown by Assembly.LoadReflectionOnlyFrom when ThrowsExceptions is set to false. This was not the case previously and could result in endpoint startup failures even when Assembly.LoadFrom would actually work. This is due to a different behavior for LoadReflectionOnly, which does not "deduplicate" multiple loads of the same assembly.
* Added a new configuration API to make both these options available to the user via EndpointConfiguration. The API can be used like this:

```
endpointConfiguration.AssemblyScanner(cfg => {
  cfg.ScanAppDomainAssemblies = true;
  cfg.ThrowExceptions = false;
  cfg.ExcludeTypes(typeof(MyType), typeof(YourType));
});
```

The old configuration options are marked as obsolete with warning but will continue to work.