### PR TITLE
[WIP]Adds a new pipeline stage in order to be able to implement UoW on top of SynchronizedStorageSession.

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/When_using_custom_unit_of_work.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/When_using_custom_unit_of_work.cs
@@ -1,0 +1,92 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.UnitOfWork.TransactionScope
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    public class When_using_custom_unit_of_work : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_allow_unit_of_work_to_be_shared_between_handlers()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(g => g.When(b => b.SendLocal(new MyMessage())))
+                .Done(c => c.Done)
+                .Run();
+
+            Assert.AreEqual(2, context.Counter, "Both handlers should increment value on same instance");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Done { get; set; }
+            public int Counter { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>((c, r) =>
+                {
+                    c.UseTransport(r.GetTransportType())
+                        .Transactions(TransportTransactionMode.ReceiveOnly);
+                    c.Pipeline.Register(b => new CustomUnitOfWorkBehavior(b.Build<Context>()), "Manages custom unit of work.");
+                });
+            }
+
+            class CustomUnitOfWorkBehavior : Behavior<IUnitOfWorkContext>
+            {
+                Context testContext;
+
+                public CustomUnitOfWorkBehavior(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public override async Task Invoke(IUnitOfWorkContext context, Func<Task> next)
+                {
+                    var uow = new UnitOfWork();
+                    context.Extensions.Set(uow);
+
+                    await next().ConfigureAwait(false);
+
+                    testContext.Counter = uow.Counter;
+                    testContext.Done = true;
+                }
+            }
+
+            class UnitOfWork
+            {
+                public int Counter { get; set; }
+            }
+
+            class FirstMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    var uow = context.Extensions.Get<UnitOfWork>();
+                    uow.Counter++;
+                    return Task.FromResult(0);
+                }
+            }
+
+            class SecondMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    var uow = context.Extensions.Get<UnitOfWork>();
+                    uow.Counter++;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Core\Stopping\When_feature_startup_task_throws_on_stop.cs" />
     <Compile Include="Core\Stopping\When_pump_throws_on_stop.cs" />
     <Compile Include="Core\Stopping\When_transport_infrastructure_throws_on_stop.cs" />
+    <Compile Include="Core\UnitOfWork\When_using_custom_unit_of_work.cs" />
     <Compile Include="DataBus\When_sending_databus_properties_with_unobtrusive.cs" />
     <Compile Include="Basic\When_sending_interface_message_with_conventions.cs" />
     <Compile Include="Core\DelayedDelivery\TimeoutManager\When_using_external_timeout_manager.cs" />

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -173,6 +173,7 @@ namespace NServiceBus
         public static NServiceBus.Pipeline.IIncomingLogicalMessageContext CreateIncomingLogicalMessageContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.Pipeline.IIncomingPhysicalMessageContext, NServiceBus.Pipeline.IIncomingLogicalMessageContext> stageConnector, NServiceBus.Pipeline.LogicalMessage logicalMessage, NServiceBus.Pipeline.IIncomingPhysicalMessageContext sourceContext) { }
         public static NServiceBus.Pipeline.IIncomingPhysicalMessageContext CreateIncomingPhysicalMessageContext(this NServiceBus.Pipeline.StageForkConnector<NServiceBus.Pipeline.ITransportReceiveContext, NServiceBus.Pipeline.IIncomingPhysicalMessageContext, NServiceBus.Pipeline.IBatchDispatchContext> stageForkConnector, NServiceBus.Transport.IncomingMessage incomingMessage, NServiceBus.Pipeline.ITransportReceiveContext sourceContext) { }
         public static NServiceBus.Pipeline.IIncomingPhysicalMessageContext CreateIncomingPhysicalMessageContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.Pipeline.ITransportReceiveContext, NServiceBus.Pipeline.IIncomingPhysicalMessageContext> stageConnector, NServiceBus.Transport.IncomingMessage incomingMessage, NServiceBus.Pipeline.ITransportReceiveContext sourceContext) { }
+        public static NServiceBus.Pipeline.IInvokeHandlerContext CreateInvokeHandlerContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.Pipeline.IUnitOfWorkContext, NServiceBus.Pipeline.IInvokeHandlerContext> stageConnector, NServiceBus.Pipeline.MessageHandler messageHandler, NServiceBus.Pipeline.IUnitOfWorkContext sourceContext) { }
         public static NServiceBus.Pipeline.IInvokeHandlerContext CreateInvokeHandlerContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.Pipeline.IIncomingLogicalMessageContext, NServiceBus.Pipeline.IInvokeHandlerContext> stageConnector, NServiceBus.Pipeline.MessageHandler messageHandler, NServiceBus.Persistence.CompletableSynchronizedStorageSession storageSession, NServiceBus.Pipeline.IIncomingLogicalMessageContext sourceContext) { }
         public static NServiceBus.Pipeline.IOutgoingLogicalMessageContext CreateOutgoingLogicalMessageContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.Pipeline.IOutgoingPublishContext, NServiceBus.Pipeline.IOutgoingLogicalMessageContext> stageConnector, NServiceBus.Pipeline.OutgoingLogicalMessage outgoingMessage, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Routing.RoutingStrategy> routingStrategies, NServiceBus.Pipeline.IOutgoingPublishContext sourceContext) { }
         public static NServiceBus.Pipeline.IOutgoingLogicalMessageContext CreateOutgoingLogicalMessageContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.Pipeline.IOutgoingReplyContext, NServiceBus.Pipeline.IOutgoingLogicalMessageContext> stageConnector, NServiceBus.Pipeline.OutgoingLogicalMessage outgoingMessage, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Routing.RoutingStrategy> routingStrategies, NServiceBus.Pipeline.IOutgoingReplyContext sourceContext) { }
@@ -182,6 +183,7 @@ namespace NServiceBus
         public static NServiceBus.Pipeline.IRoutingContext CreateRoutingContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.Pipeline.IForwardingContext, NServiceBus.Pipeline.IRoutingContext> stageConnector, NServiceBus.Transport.OutgoingMessage outgoingMessage, NServiceBus.Routing.RoutingStrategy routingStrategy, NServiceBus.Pipeline.IForwardingContext sourceContext) { }
         public static NServiceBus.Pipeline.IRoutingContext CreateRoutingContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.Pipeline.IAuditContext, NServiceBus.Pipeline.IRoutingContext> stageConnector, NServiceBus.Transport.OutgoingMessage outgoingMessage, NServiceBus.Routing.RoutingStrategy routingStrategy, NServiceBus.Pipeline.IAuditContext sourceContext) { }
         public static NServiceBus.Pipeline.IRoutingContext CreateRoutingContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.Pipeline.IOutgoingPhysicalMessageContext, NServiceBus.Pipeline.IRoutingContext> stageConnector, NServiceBus.Transport.OutgoingMessage outgoingMessage, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Routing.RoutingStrategy> routingStrategies, NServiceBus.Pipeline.IOutgoingPhysicalMessageContext sourceContext) { }
+        public static NServiceBus.Pipeline.IUnitOfWorkContext CreateUnitOfWorkContext(this NServiceBus.Pipeline.StageConnector<NServiceBus.Pipeline.IIncomingLogicalMessageContext, NServiceBus.Pipeline.IUnitOfWorkContext> stageConnector, NServiceBus.Persistence.CompletableSynchronizedStorageSession storageSession, NServiceBus.Pipeline.IIncomingLogicalMessageContext sourceContext) { }
     }
     public abstract class ContainSagaData : NServiceBus.IContainSagaData
     {
@@ -2415,6 +2417,14 @@ namespace NServiceBus.Pipeline
     {
         NServiceBus.Transport.IncomingMessage Message { get; }
         void AbortReceiveOperation();
+    }
+    public interface IUnitOfWorkContext : NServiceBus.Extensibility.IExtendable, NServiceBus.IMessageProcessingContext, NServiceBus.IPipelineContext, NServiceBus.Pipeline.IBehaviorContext, NServiceBus.Pipeline.IIncomingContext
+    {
+        System.Collections.Generic.Dictionary<string, string> Headers { get; }
+        object MessageBeingHandled { get; }
+        bool MessageHandled { get; set; }
+        NServiceBus.Unicast.Messages.MessageMetadata MessageMetadata { get; }
+        NServiceBus.Persistence.SynchronizedStorageSession SynchronizedStorageSession { get; }
     }
     public interface IUnsubscribeContext : NServiceBus.Extensibility.IExtendable, NServiceBus.Pipeline.IBehaviorContext
     {

--- a/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
@@ -11,9 +11,9 @@
         [Test]
         public void Should_throw_when_there_are_no_registered_message_handlers()
         {
-            var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(new Conventions()), new InMemorySynchronizedStorage(), new InMemoryTransactionalSynchronizedStorageAdapter());
+            var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(new Conventions()));
 
-            var context = new TestableIncomingLogicalMessageContext();
+            var context = new TestableUnitOfWorkContext();
 
             context.Extensions.Set<OutboxTransaction>(new InMemoryOutboxTransaction());
             context.Extensions.Set(new TransportTransaction());

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -115,6 +115,9 @@
     <Compile Include="Notifications\NotificationSubscriptions.cs" />
     <Compile Include="Notifications\EventAggregatorExtensions.cs" />
     <Compile Include="Persistence\Msmq\SubscriptionStorage\MsmqSubscriptionMessage.cs" />
+    <Compile Include="Pipeline\Incoming\IUnitOfWorkContext.cs" />
+    <Compile Include="Pipeline\Incoming\SynchronizedSessionConnector.cs" />
+    <Compile Include="Pipeline\Incoming\UnitOfWorkContext.cs" />
     <Compile Include="Pipeline\PipelineExecutionExtensions.cs" />
     <Compile Include="Pipeline\ForkConnector.cs" />
     <Compile Include="Pipeline\ForkExtensions.cs" />

--- a/src/NServiceBus.Core/Pipeline/ConnectorContextExtensions.cs
+++ b/src/NServiceBus.Core/Pipeline/ConnectorContextExtensions.cs
@@ -98,6 +98,28 @@ namespace NServiceBus
         }
 
         /// <summary>
+        /// Creates a <see cref="IUnitOfWorkContext" /> based on the current context.
+        /// </summary>
+        public static IUnitOfWorkContext CreateUnitOfWorkContext(this StageConnector<IIncomingLogicalMessageContext, IUnitOfWorkContext> stageConnector, CompletableSynchronizedStorageSession storageSession, IIncomingLogicalMessageContext sourceContext)
+        {
+            Guard.AgainstNull(nameof(storageSession), storageSession);
+            Guard.AgainstNull(nameof(sourceContext), sourceContext);
+
+            return new UnitOfWorkContext(storageSession, sourceContext);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IInvokeHandlerContext" /> based on the current context.
+        /// </summary>
+        public static IInvokeHandlerContext CreateInvokeHandlerContext(this StageConnector<IUnitOfWorkContext, IInvokeHandlerContext> stageConnector, MessageHandler messageHandler, IUnitOfWorkContext sourceContext)
+        {
+            Guard.AgainstNull(nameof(messageHandler), messageHandler);
+            Guard.AgainstNull(nameof(sourceContext), sourceContext);
+
+            return new InvokeHandlerContext(messageHandler, sourceContext);
+        }
+
+        /// <summary>
         /// Creates a <see cref="IInvokeHandlerContext" /> based on the current context.
         /// </summary>
         public static IInvokeHandlerContext CreateInvokeHandlerContext(this StageConnector<IIncomingLogicalMessageContext, IInvokeHandlerContext> stageConnector, MessageHandler messageHandler, CompletableSynchronizedStorageSession storageSession, IIncomingLogicalMessageContext sourceContext)

--- a/src/NServiceBus.Core/Pipeline/Incoming/IUnitOfWorkContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IUnitOfWorkContext.cs
@@ -1,0 +1,38 @@
+namespace NServiceBus.Pipeline
+{
+    using System.Collections.Generic;
+    using Persistence;
+    using Unicast.Messages;
+
+    /// <summary>
+    /// A context for creating setting up custom unit of work for handlers.
+    /// </summary>
+    public interface IUnitOfWorkContext : IIncomingContext
+    {
+        /// <summary>
+        /// Gets the synchronized storage session for processing the current message. NServiceBus makes sure the changes made
+        /// via this session will be persisted before the message receive is acknowledged.
+        /// </summary>
+        SynchronizedStorageSession SynchronizedStorageSession { get; }
+
+        /// <summary>
+        /// The message instance being handled.
+        /// </summary>
+        object MessageBeingHandled { get; }
+
+        /// <summary>
+        /// Message headers.
+        /// </summary>
+        Dictionary<string, string> Headers { get; }
+
+        /// <summary>
+        /// Metadata for the incoming message.
+        /// </summary>
+        MessageMetadata MessageMetadata { get; }
+
+        /// <summary>
+        /// Tells if the message has been handled.
+        /// </summary>
+        bool MessageHandled { get; set; }
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerContext.cs
@@ -8,6 +8,11 @@ namespace NServiceBus
 
     class InvokeHandlerContext : IncomingContext, IInvokeHandlerContext
     {
+        internal InvokeHandlerContext(MessageHandler handler, IUnitOfWorkContext parentContext)
+            : this(handler, parentContext.MessageId, parentContext.ReplyToAddress, parentContext.Headers, parentContext.MessageMetadata, parentContext.MessageBeingHandled, parentContext.SynchronizedStorageSession, parentContext)
+        {
+        }
+
         internal InvokeHandlerContext(MessageHandler handler, SynchronizedStorageSession storageSession, IIncomingLogicalMessageContext parentContext)
             : this(handler, parentContext.MessageId, parentContext.ReplyToAddress, parentContext.Headers, parentContext.Message.Metadata, parentContext.Message.Instance, storageSession, parentContext)
         {

--- a/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
@@ -2,64 +2,41 @@
 {
     using System;
     using System.Threading.Tasks;
-    using Extensibility;
-    using Outbox;
-    using Persistence;
     using Pipeline;
-    using Transport;
     using Unicast;
 
-    class LoadHandlersConnector : StageConnector<IIncomingLogicalMessageContext, IInvokeHandlerContext>
+    class LoadHandlersConnector : StageConnector<IUnitOfWorkContext, IInvokeHandlerContext>
     {
-        public LoadHandlersConnector(MessageHandlerRegistry messageHandlerRegistry, ISynchronizedStorage synchronizedStorage, ISynchronizedStorageAdapter adapter)
+        public LoadHandlersConnector(MessageHandlerRegistry messageHandlerRegistry)
         {
             this.messageHandlerRegistry = messageHandlerRegistry;
-            this.synchronizedStorage = synchronizedStorage;
-            this.adapter = adapter;
         }
 
-        public override async Task Invoke(IIncomingLogicalMessageContext context, Func<IInvokeHandlerContext, Task> stage)
+        public override async Task Invoke(IUnitOfWorkContext context, Func<IInvokeHandlerContext, Task> stage)
         {
-            var outboxTransaction = context.Extensions.Get<OutboxTransaction>();
-            var transportTransaction = context.Extensions.Get<TransportTransaction>();
-            using (var storageSession = await AdaptOrOpenNewSynchronizedStorageSession(transportTransaction, outboxTransaction, context.Extensions).ConfigureAwait(false))
+            var handlersToInvoke = messageHandlerRegistry.GetHandlersFor(context.MessageMetadata.MessageType);
+
+            if (!context.MessageHandled && handlersToInvoke.Count == 0)
             {
-                var handlersToInvoke = messageHandlerRegistry.GetHandlersFor(context.Message.MessageType);
-
-                if (!context.MessageHandled && handlersToInvoke.Count == 0)
-                {
-                    var error = $"No handlers could be found for message type: {context.Message.MessageType}";
-                    throw new InvalidOperationException(error);
-                }
-
-                foreach (var messageHandler in handlersToInvoke)
-                {
-                    messageHandler.Instance = context.Builder.Build(messageHandler.HandlerType);
-
-                    var handlingContext = this.CreateInvokeHandlerContext(messageHandler, storageSession, context);
-                    await stage(handlingContext).ConfigureAwait(false);
-
-                    if (handlingContext.HandlerInvocationAborted)
-                    {
-                        //if the chain was aborted skip the other handlers
-                        break;
-                    }
-                }
-                context.MessageHandled = true;
-                await storageSession.CompleteAsync().ConfigureAwait(false);
+                var error = $"No handlers could be found for message type: {context.MessageMetadata.MessageType}";
+                throw new InvalidOperationException(error);
             }
+
+            foreach (var messageHandler in handlersToInvoke)
+            {
+                messageHandler.Instance = context.Builder.Build(messageHandler.HandlerType);
+
+                var handlingContext = this.CreateInvokeHandlerContext(messageHandler, context);
+                await stage(handlingContext).ConfigureAwait(false);
+
+                if (handlingContext.HandlerInvocationAborted)
+                {
+                    //if the chain was aborted skip the other handlers
+                    break;
+                }
+            }
+            context.MessageHandled = true;
         }
-
-        async Task<CompletableSynchronizedStorageSession> AdaptOrOpenNewSynchronizedStorageSession(TransportTransaction transportTransaction, OutboxTransaction outboxTransaction, ContextBag contextBag)
-        {
-            return await adapter.TryAdapt(outboxTransaction, contextBag).ConfigureAwait(false)
-                   ?? await adapter.TryAdapt(transportTransaction, contextBag).ConfigureAwait(false)
-                   ?? await synchronizedStorage.OpenSession(contextBag).ConfigureAwait(false);
-        }
-
-        readonly ISynchronizedStorageAdapter adapter;
-        readonly ISynchronizedStorage synchronizedStorage;
-
 
         MessageHandlerRegistry messageHandlerRegistry;
     }

--- a/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
@@ -19,6 +19,7 @@
         {
             context.Pipeline.Register("TransportReceiveToPhysicalMessageProcessingConnector", b => b.Build<TransportReceiveToPhysicalMessageProcessingConnector>(), "Allows to abort processing the message");
             context.Pipeline.Register("LoadHandlersConnector", b => b.Build<LoadHandlersConnector>(), "Gets all the handlers to invoke from the MessageHandler registry based on the message type.");
+            context.Pipeline.Register("SynchronizedSessionConnector", b => b.Build<SynchronizedSessionConnector>(), "Manages SynchronizedStorageSession.");
 
             context.Pipeline.Register("ExecuteUnitOfWork", new UnitOfWorkBehavior(), "Executes the UoW");
 
@@ -35,12 +36,13 @@
                 return new TransportReceiveToPhysicalMessageProcessingConnector(storage);
             }, DependencyLifecycle.InstancePerCall);
 
+            context.Container.ConfigureComponent(b => new LoadHandlersConnector(b.Build<MessageHandlerRegistry>()), DependencyLifecycle.InstancePerCall);
             context.Container.ConfigureComponent(b =>
             {
                 var adapter = context.Container.HasComponent<ISynchronizedStorageAdapter>() ? b.Build<ISynchronizedStorageAdapter>() : new NoOpAdaper();
                 var syncStorage = context.Container.HasComponent<ISynchronizedStorage>() ? b.Build<ISynchronizedStorage>() : new NoOpSynchronizedStorage();
 
-                return new LoadHandlersConnector(b.Build<MessageHandlerRegistry>(), syncStorage, adapter);
+                return new SynchronizedSessionConnector(syncStorage, adapter);
             }, DependencyLifecycle.InstancePerCall);
         }
 

--- a/src/NServiceBus.Core/Pipeline/Incoming/SynchronizedSessionConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/SynchronizedSessionConnector.cs
@@ -1,0 +1,44 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using Outbox;
+    using Persistence;
+    using Pipeline;
+    using Transport;
+
+    class SynchronizedSessionConnector : StageConnector<IIncomingLogicalMessageContext, IUnitOfWorkContext>
+    {
+        public SynchronizedSessionConnector(ISynchronizedStorage synchronizedStorage, ISynchronizedStorageAdapter adapter)
+        {
+            this.adapter = adapter;
+            this.synchronizedStorage = synchronizedStorage;
+        }
+
+        public override async Task Invoke(IIncomingLogicalMessageContext context, Func<IUnitOfWorkContext, Task> stage)
+        {
+            var outboxTransaction = context.Extensions.Get<OutboxTransaction>();
+            var transportTransaction = context.Extensions.Get<TransportTransaction>();
+            using (var storageSession = await AdaptOrOpenNewSynchronizedStorageSession(transportTransaction, outboxTransaction, context.Extensions).ConfigureAwait(false))
+            {
+                var uowContext = this.CreateUnitOfWorkContext(storageSession, context);
+
+                await stage(uowContext).ConfigureAwait(false);
+                context.MessageHandled = uowContext.MessageHandled;
+
+                await storageSession.CompleteAsync().ConfigureAwait(false);
+            }
+        }
+
+        async Task<CompletableSynchronizedStorageSession> AdaptOrOpenNewSynchronizedStorageSession(TransportTransaction transportTransaction, OutboxTransaction outboxTransaction, ContextBag contextBag)
+        {
+            return await adapter.TryAdapt(outboxTransaction, contextBag).ConfigureAwait(false)
+                   ?? await adapter.TryAdapt(transportTransaction, contextBag).ConfigureAwait(false)
+                   ?? await synchronizedStorage.OpenSession(contextBag).ConfigureAwait(false);
+        }
+
+        ISynchronizedStorageAdapter adapter;
+        ISynchronizedStorage synchronizedStorage;
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/Incoming/UnitOfWorkContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/UnitOfWorkContext.cs
@@ -1,0 +1,31 @@
+namespace NServiceBus
+{
+    using System.Collections.Generic;
+    using Persistence;
+    using Pipeline;
+    using Unicast.Messages;
+
+    class UnitOfWorkContext : IncomingContext, IUnitOfWorkContext
+    {
+        internal UnitOfWorkContext(SynchronizedStorageSession storageSession, IIncomingLogicalMessageContext parentContext)
+            : this(parentContext.MessageId, parentContext.ReplyToAddress, parentContext.Headers, parentContext.Message.Metadata, parentContext.Message.Instance, storageSession, parentContext)
+        {
+            Set(storageSession);
+        }
+
+        public UnitOfWorkContext(string messageId, string replyToAddress, Dictionary<string, string> headers, MessageMetadata messageMetadata, object messageBeingHandled, SynchronizedStorageSession storageSession, IBehaviorContext parentContext)
+            : base(messageId, replyToAddress, headers, parentContext)
+        {
+            Set(storageSession);
+            Headers = headers;
+            MessageMetadata = messageMetadata;
+            MessageBeingHandled = messageBeingHandled;
+        }
+
+        public SynchronizedStorageSession SynchronizedStorageSession => Get<SynchronizedStorageSession>();
+        public object MessageBeingHandled { get; }
+        public Dictionary<string, string> Headers { get; }
+        public MessageMetadata MessageMetadata { get; }
+        public bool MessageHandled { get; set; }
+    }
+}

--- a/src/NServiceBus.Testing.Fakes/NServiceBus.Testing.Fakes.csproj
+++ b/src/NServiceBus.Testing.Fakes/NServiceBus.Testing.Fakes.csproj
@@ -78,6 +78,7 @@
     <Compile Include="TestableRoutingContext.cs" />
     <Compile Include="TestableSubscribeContext.cs" />
     <Compile Include="TestableTransportReceiveContext.cs" />
+    <Compile Include="TestableUnitOfWorkContext.cs" />
     <Compile Include="TestableUnsubscribeContext.cs" />
     <Compile Include="TestingLoggerFactory.cs" />
     <Compile Include="TextWriterLogger.cs" />

--- a/src/NServiceBus.Testing.Fakes/TestableUnitOfWorkContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableUnitOfWorkContext.cs
@@ -1,0 +1,39 @@
+﻿namespace NServiceBus.Testing
+{
+    using System.Collections.Generic;
+    using Persistence;
+    using Pipeline;
+    using Unicast.Messages;
+
+    /// <summary>
+    /// A testable implementation of <see cref="IUnitOfWorkContext"/>
+    /// </summary>
+    public class TestableUnitOfWorkContext : TestableIncomingContext, IUnitOfWorkContext
+    {
+        /// <summary>
+        /// Gets the synchronized storage session for processing the current message. NServiceBus makes sure the changes made
+        /// via this session will be persisted before the message receive is acknowledged.
+        /// </summary>
+        public SynchronizedStorageSession SynchronizedStorageSession { get; set; }
+
+        /// <summary>
+        /// The message instance being handled.
+        /// </summary>
+        public object MessageBeingHandled { get; set; } = new object();
+
+        /// <summary>
+        /// Message headers.
+        /// </summary>
+        public Dictionary<string, string> Headers { get; set; } = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Metadata for the incoming message.
+        /// </summary>
+        public MessageMetadata MessageMetadata { get; set; } = new MessageMetadata(typeof(object));
+
+        /// <summary>
+        /// Tells if the message has been handled.
+        /// </summary>
+        public bool MessageHandled { get; set; }
+    }
+}


### PR DESCRIPTION
Splits the `LoadHandlersConnector` into two and inserts `IUnitOfWorkContext` stage between them:
 * `SynchronizedSessionConnector` only manages the synchronized storage session
 * `LoadHandlersConnector` only loads the handlers

Related customer cases:
 * https://github.com/Particular/NServiceBus.NHibernate/issues/244#issuecomment-265140283
 * SalesForce case `00024734`

TODO:
- [ ] doco PR
- [ ] consider "soft" obsolete on `IManageUnitOfWork`
- [ ] update sample https://docs.particular.net/samples/pipeline/unit-of-work/