### PR TITLE
[WIP]Msgdriven pubsub uniquely addressable

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -82,6 +82,8 @@
     <Compile Include="Recoverability\When_custom_policy_moves_to_overridden_error_queue.cs" />
     <Compile Include="Recoverability\When_message_is_moved_to_error_queue_with_header_customizations.cs" />
     <Compile Include="Core\Routing\AutomaticSubscriptions\When_handling_local_event.cs" />
+    <Compile Include="Routing\MessageDrivenSubscriptions\When_subscribing_with_scaled_out_subscriber.cs" />
+    <Compile Include="Routing\MessageDrivenSubscriptions\When_subscribing_with_scaled_out_subscriber_with_distribution_strategy.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_unsubscribing_from_event.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_unsubscribing_to_scaled_out_publisher.cs" />
     <Compile Include="Routing\NativePublishSubscribe\When_unsubscribing_from_event.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_subscribing_with_scaled_out_subscriber.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_subscribing_with_scaled_out_subscriber.cs
@@ -1,0 +1,77 @@
+namespace NServiceBus.AcceptanceTests.Routing.MessageDrivenSubscriptions
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+    using Settings;
+
+    public class When_subscribing_with_scaled_out_subscriber : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_round_robin()
+        {
+            Requires.MessageDrivenPubSub();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(b => b.When(async s =>
+                {
+                    await s.Publish(new MyEvent());
+                    await s.Publish(new MyEvent());
+                }))
+                .WithEndpoint<Subscriber>(b => b.CustomConfig(c => c.MakeInstanceUniquelyAddressable("1")))
+                .WithEndpoint<Subscriber>(b => b.CustomConfig(c => c.MakeInstanceUniquelyAddressable("2")))
+                .Done(c => c.HandledOnDistriminator.Count >= 2)
+                .Run();
+
+            Assert.That(context.HandledOnDistriminator, Does.Contain("1"));
+            Assert.That(context.HandledOnDistriminator, Does.Contain("2"));
+            Assert.That(context.HandledOnDistriminator.Count, Is.EqualTo(2));
+        }
+
+        class Context : ScenarioContext
+        {
+            public List<string> HandledOnDistriminator { get; } = new List<string>();
+        }
+
+        class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>(c => { }, metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
+            }
+
+            class MyHandler : IHandleMessages<MyEvent>
+            {
+                Context testContext;
+                ReadOnlySettings settings;
+
+                public MyHandler(Context context, ReadOnlySettings settings)
+                {
+                    this.settings = settings;
+                    testContext = context;
+                }
+
+                public Task Handle(MyEvent message, IMessageHandlerContext context)
+                {
+                    var discriminator = settings.Get<string>("EndpointInstanceDiscriminator");
+                    testContext.HandledOnDistriminator.Add(discriminator);
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_subscribing_with_scaled_out_subscriber_with_distribution_strategy.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_subscribing_with_scaled_out_subscriber_with_distribution_strategy.cs
@@ -1,0 +1,133 @@
+namespace NServiceBus.AcceptanceTests.Routing.MessageDrivenSubscriptions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using Configuration.AdvanceExtensibility;
+    using EndpointTemplates;
+    using Features;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+    using Settings;
+
+    public class When_subscribing_with_scaled_out_subscriber_with_distribution_strategy : NServiceBusAcceptanceTest
+    {
+        static string Discriminator1 = "553E9619";
+        static string Discriminator2 = "F9D0023C";
+
+        [Test]
+        public async Task Should_honor_strategy()
+        {
+            Requires.MessageDrivenPubSub();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(b => b.When(c => c.PublisherReceivedSubscription.Count >= 2, async s =>
+                {
+                    await s.Publish(new MyEvent());
+                    await s.Publish(new MyEvent());
+                }))
+                .WithEndpoint<Subscriber>(b => b.CustomConfig(c => c.MakeInstanceUniquelyAddressable(Discriminator1)).When(s => s.Subscribe<MyEvent>()))
+                .WithEndpoint<Subscriber>(b => b.CustomConfig(c => c.MakeInstanceUniquelyAddressable(Discriminator2)).When(s => s.Subscribe<MyEvent>()))
+                .Done(c => c.HandledOnDistriminator.Count >= 2)
+                .Run();
+
+            Assert.That(context.HandledOnDistriminator, Does.Contain(Discriminator1));
+            Assert.That(context.HandledOnDistriminator, Does.Contain(Discriminator1));
+            Assert.That(context.HandledOnDistriminator.Count, Is.EqualTo(2));
+
+            Assert.That(context.ReceiverAddresses.Count, Is.EqualTo(2));
+            Assert.That(context.PublisherReceivedSubscription.Count, Is.EqualTo(2));
+
+            Assert.That(context.PublisherReceivedSubscription, Does.Contain(context.ReceiverAddresses.ElementAt(0)));
+            Assert.That(context.PublisherReceivedSubscription, Does.Contain(context.ReceiverAddresses.ElementAt(1)));
+        }
+
+        class Context : ScenarioContext
+        {
+            public List<string> HandledOnDistriminator { get; } = new List<string>();
+            public List<string> PublisherReceivedSubscription { get; } = new List<string>();
+            public HashSet<string> ReceiverAddresses { get; } = new HashSet<string>();
+        }
+
+        class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.GetSettings().GetOrCreate<DistributionPolicy>().SetDistributionStrategy(new SelectFirstDistributionStrategy((Context) ScenarioContext, Conventions.EndpointNamingConvention(typeof(Subscriber)), DistributionStrategyScope.Publish));
+                    c.OnEndpointSubscribed((SubscriptionEventArgs args, Context ctx) =>
+                    {
+                        ctx.PublisherReceivedSubscription.Add(args.SubscriberReturnAddress);
+                    });
+                });
+            }
+
+            class SelectFirstDistributionStrategy : DistributionStrategy
+            {
+                Context testContext;
+
+                public SelectFirstDistributionStrategy(Context context, string endpoint, DistributionStrategyScope scope) : base(endpoint, scope)
+                {
+                    testContext = context;
+                }
+
+                public override string SelectReceiver(string[] receiverAddresses)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public override string SelectDestination(DistributionContext context)
+                {
+                    foreach (var receiverAddress in context.ReceiverAddresses)
+                    {
+                        testContext.ReceiverAddresses.Add(receiverAddress);
+                    }
+
+                    var address = context.ToTransportAddress(new EndpointInstance(Endpoint, Discriminator1));
+                    return context.ReceiverAddresses.Single(a => a == address);
+                }
+            }
+        }
+
+        class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>((config, context) =>
+                {
+                    // currently there is no way to call RoutingSettings<T> extensions
+                    config.GetSettings().Set("SubscribeWithInstanceSpecificQueue", true);
+
+                    config.DisableFeature<AutoSubscribe>();
+                }, metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
+            }
+
+            class MyHandler : IHandleMessages<MyEvent>
+            {
+                Context testContext;
+                ReadOnlySettings settings;
+
+                public MyHandler(Context context, ReadOnlySettings settings)
+                {
+                    this.settings = settings;
+                    testContext = context;
+                }
+
+                public Task Handle(MyEvent message, IMessageHandlerContext context)
+                {
+                    var discriminator = settings.Get<string>("EndpointInstanceDiscriminator");
+                    testContext.HandledOnDistriminator.Add(discriminator);
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -818,6 +818,8 @@ namespace NServiceBus
             where T : NServiceBus.Transport.TransportDefinition, NServiceBus.Routing.IMessageDrivenSubscriptionTransport { }
         public static void RegisterPublisher<T>(this NServiceBus.RoutingSettings<T> routingSettings, System.Reflection.Assembly assembly, string @namespace, string publisherEndpoint)
             where T : NServiceBus.Transport.TransportDefinition, NServiceBus.Routing.IMessageDrivenSubscriptionTransport { }
+        public static void SubscribeWithInstanceSpecificQueue<T>(this NServiceBus.RoutingSettings<T> routingSettings)
+            where T : NServiceBus.Transport.TransportDefinition, NServiceBus.Routing.IMessageDrivenSubscriptionTransport { }
         public static void SubscriptionAuthorizer<T>(this NServiceBus.TransportExtensions<T> transportExtensions, System.Func<NServiceBus.Pipeline.IIncomingPhysicalMessageContext, bool> authorizer)
             where T : NServiceBus.Transport.TransportDefinition, NServiceBus.Routing.IMessageDrivenSubscriptionTransport { }
     }

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
@@ -21,13 +21,13 @@
             publishers.AddOrReplacePublishers("A", new List<PublisherTableEntry> {new PublisherTableEntry(typeof(object), PublisherAddress.CreateFromPhysicalAddresses("publisher1"))});
             router = new SubscriptionRouter(publishers, new EndpointInstances(), i => i.ToString());
             dispatcher = new FakeDispatcher();
-            subscribeTerminator = new MessageDrivenSubscribeTerminator(router, "replyToAddress", "Endpoint", dispatcher);
+            subscribeTerminator = new MessageDrivenSubscribeTerminator(router, "localAddress", "subscriberAddress", "Endpoint", dispatcher);
         }
 
         [Test]
         public async Task Should_include_TimeSent_and_Version_headers()
         {
-            var unsubscribeTerminator = new MessageDrivenUnsubscribeTerminator(router, "replyToAddress", "Endpoint", dispatcher);
+            var unsubscribeTerminator = new MessageDrivenUnsubscribeTerminator(router, "localAddress", "replyToAddress", "Endpoint", dispatcher);
 
             await subscribeTerminator.Invoke(new TestableSubscribeContext(), c => TaskEx.CompletedTask);
             await unsubscribeTerminator.Invoke(new TestableUnsubscribeContext(), c => TaskEx.CompletedTask);

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
@@ -25,7 +25,7 @@
             publishers.AddOrReplacePublishers("A", new List<PublisherTableEntry> {new PublisherTableEntry(typeof(object), PublisherAddress.CreateFromPhysicalAddresses("publisher1"))});
             router = new SubscriptionRouter(publishers, new EndpointInstances(), i => i.ToString());
             dispatcher = new FakeDispatcher();
-            terminator = new MessageDrivenUnsubscribeTerminator(router, "replyToAddress", "Endpoint", dispatcher);
+            terminator = new MessageDrivenUnsubscribeTerminator(router, "localAddress", "replyToAddress", "Endpoint", dispatcher);
         }
 
         [Test]

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -13,8 +13,9 @@
 
     class MessageDrivenSubscribeTerminator : PipelineTerminator<ISubscribeContext>
     {
-        public MessageDrivenSubscribeTerminator(SubscriptionRouter subscriptionRouter, string subscriberAddress, string subscriberEndpoint, IDispatchMessages dispatcher)
+        public MessageDrivenSubscribeTerminator(SubscriptionRouter subscriptionRouter, string localAddress, string subscriberAddress, string subscriberEndpoint, IDispatchMessages dispatcher)
         {
+            this.localAddress = localAddress;
             this.subscriptionRouter = subscriptionRouter;
             this.subscriberAddress = subscriberAddress;
             this.subscriberEndpoint = subscriberEndpoint;
@@ -36,8 +37,8 @@
                 var subscriptionMessage = ControlMessageFactory.Create(MessageIntentEnum.Subscribe);
 
                 subscriptionMessage.Headers[Headers.SubscriptionMessageType] = eventType.AssemblyQualifiedName;
-                subscriptionMessage.Headers[Headers.ReplyToAddress] = subscriberAddress;
-                subscriptionMessage.Headers[Headers.SubscriberTransportAddress] = subscriberAddress;
+                subscriptionMessage.Headers[Headers.ReplyToAddress] = localAddress; // shared queue, for v5 compliance
+                subscriptionMessage.Headers[Headers.SubscriberTransportAddress] = subscriberAddress; // instance specific queue or shared queue
                 subscriptionMessage.Headers[Headers.SubscriberEndpoint] = subscriberEndpoint;
                 subscriptionMessage.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
                 subscriptionMessage.Headers[Headers.NServiceBusVersion] = GitFlowVersion.MajorMinorPatch;
@@ -79,6 +80,7 @@
         SubscriptionRouter subscriptionRouter;
 
         static ILog Logger = LogManager.GetLogger<MessageDrivenSubscribeTerminator>();
+        string localAddress;
 
         public class Settings
         {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
@@ -84,6 +84,15 @@ namespace NServiceBus
             routingSettings.Settings.GetOrCreate<ConfiguredPublishers>().Add(new NamespacePublisherSource(assembly, @namespace, PublisherAddress.CreateFromEndpointName(publisherEndpoint)));
         }
 
+        /// <summary>
+        /// Instructs message driven subscription infrastructure to subscribe with the instance specific queue instead of the shared queue.
+        /// </summary>
+        /// <param name="routingSettings">The <see cref="RoutingSettings&lt;T&gt;" /> to extend.</param>
+        public static void SubscribeWithInstanceSpecificQueue<T>(this RoutingSettings<T> routingSettings) where T : TransportDefinition, IMessageDrivenSubscriptionTransport
+        {
+            routingSettings.Settings.Set("SubscribeWithInstanceSpecificQueue", true);
+        }
+
         static void ThrowOnAddress(string publisherEndpoint)
         {
             if (publisherEndpoint.Contains("@"))

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -13,10 +13,11 @@
 
     class MessageDrivenUnsubscribeTerminator : PipelineTerminator<IUnsubscribeContext>
     {
-        public MessageDrivenUnsubscribeTerminator(SubscriptionRouter subscriptionRouter, string replyToAddress, string endpoint, IDispatchMessages dispatcher)
+        public MessageDrivenUnsubscribeTerminator(SubscriptionRouter subscriptionRouter, string localAddress, string subscriberAddress, string endpoint, IDispatchMessages dispatcher)
         {
+            this.localAddress = localAddress;
             this.subscriptionRouter = subscriptionRouter;
-            this.replyToAddress = replyToAddress;
+            this.subscriberAddress = subscriberAddress;
             this.endpoint = endpoint;
             this.dispatcher = dispatcher;
         }
@@ -36,8 +37,8 @@
                 var unsubscribeMessage = ControlMessageFactory.Create(MessageIntentEnum.Unsubscribe);
 
                 unsubscribeMessage.Headers[Headers.SubscriptionMessageType] = eventType.AssemblyQualifiedName;
-                unsubscribeMessage.Headers[Headers.ReplyToAddress] = replyToAddress;
-                unsubscribeMessage.Headers[Headers.SubscriberTransportAddress] = replyToAddress;
+                unsubscribeMessage.Headers[Headers.ReplyToAddress] = localAddress;
+                unsubscribeMessage.Headers[Headers.SubscriberTransportAddress] = subscriberAddress;
                 unsubscribeMessage.Headers[Headers.SubscriberEndpoint] = endpoint;
                 unsubscribeMessage.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
                 unsubscribeMessage.Headers[Headers.NServiceBusVersion] = GitFlowVersion.MajorMinorPatch;
@@ -74,11 +75,12 @@
 
         readonly string endpoint;
         IDispatchMessages dispatcher;
-        string replyToAddress;
+        string subscriberAddress;
 
         SubscriptionRouter subscriptionRouter;
 
         static ILog Logger = LogManager.GetLogger<MessageDrivenUnsubscribeTerminator>();
+        string localAddress;
 
         public class Settings
         {


### PR DESCRIPTION
Discussed this with the majority of the @Particular/nservicebus-maintainers already as well as @SzymonPobiega @SeanFeldman and @boblangley 

This was also detected when preparing the sample for Service Fabric and trying it out with ASQ

This PR introduces an opt-in way to make message driven pub sub aware of instance specific queues. For backward compatibility reasons @SzymonPobiega suggested to use the ReplyToAddress to be the shared queue and only the V6 part to use the instance specific queue.

## Usage

```
UseTransport<MessageDrivenPubSubTransport>().Routing().SubscribeWithInstanceSpecificQueue()
```

## Effect

### v5

Subscription storages will look at `ReplyToAddress` which is still the shared queue so no changes

### v6

The instance specific queue is send as a subscriber address. When existing shared queue subscription was there now the subscription storage will contain the shared queue and the instance specific queues. When default round robin distribution kicks in it will distribute between shared queue and instance specific queues. This should not be an issue since we always have a pump listening on the shared queue anyway.

With no existing subscriptions it will just round robin between the instance specific queues.

### Log inside ASf

```
2017-02-22 12:27:47.711 INFO  NServiceBus.SubscriptionReceiverBehavior Subscribe from CandidateVoteCount-John on message type Contracts.VotePlaced, Contracts, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
2017-02-22 12:27:48.864 INFO  NServiceBus.SubscriptionReceiverBehavior Subscribe from CandidateVoteCount-Abby on message type Contracts.VotePlaced, Contracts, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
```
