### PR TITLE
Fix default behavior to throw exceptions

### DIFF
--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
@@ -17,9 +17,9 @@
         public bool ScanAppDomainAssemblies { get; set; } = false;
 
         /// <summary>
-        /// Defines whether exceptions occuring during assembly scanning should be rethrown or ignored. Default value is <code>false</code>.
+        /// Defines whether exceptions occuring during assembly scanning should be rethrown or ignored. Default value is <code>true</code>.
         /// </summary>
-        public bool ThrowExceptions { get; set; } = false;
+        public bool ThrowExceptions { get; set; } = true;
 
         /// <summary>
         /// Defines whether nested directories should be included in the assembly scanning process. Default value is <code>false</code>.


### PR DESCRIPTION
we should throw exceptions by default. Seems like I've missed this in the original PR (https://github.com/Particular/NServiceBus/pull/4485).

ping @Particular/nservicebus-maintainers 