### PR TITLE
Provide code first api to configure external TM

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_using_external_timeout_manager_code_first.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_using_external_timeout_manager_code_first.cs
@@ -1,0 +1,118 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.DelayedDelivery.TimeoutManager
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using Features;
+    using NServiceBus.DelayedDelivery;
+    using NUnit.Framework;
+
+    public class When_using_external_timeout_manager_code_first : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_send_delayed_messages_to_external_TimeoutManager()
+        {
+            Requires.TimeoutStorage();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithTimeoutManager>()
+                .WithEndpoint<Endpoint>(b => b.When((session, c) =>
+                {
+                    var options = new SendOptions();
+
+                    options.DelayDeliveryWith(TimeSpan.FromDays(5));
+                    options.RouteToThisEndpoint();
+
+                    return session.Send(new DelayedMessage(), options);
+                }))
+                .Done(c => c.ExternalTimeoutManagerInvoked)
+                .Run();
+
+            Assert.IsTrue(context.TimeoutManagerHeaderDetected);
+        }
+
+        [Test]
+        public async Task Should_send_delayed_retries_to_external_TimeoutManager()
+        {
+            Requires.TimeoutStorage();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithTimeoutManager>()
+                .WithEndpoint<Endpoint>(b => b
+                    .CustomConfig(e => e.Recoverability()
+                        .Delayed(s => s.NumberOfRetries(1).TimeIncrease(TimeSpan.FromSeconds(1))))
+                    .When((session, c) => session.SendLocal(new FailingMessage())))
+                .Done(c => c.ExternalTimeoutManagerInvoked)
+                .Run();
+
+            Assert.IsTrue(context.TimeoutManagerHeaderDetected);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool TimeoutManagerHeaderDetected { get; set; }
+            public bool ExternalTimeoutManagerInvoked { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                var timeoutManagerAddress = Conventions.EndpointNamingConvention(typeof(EndpointWithTimeoutManager));
+
+                EndpointSetup<DefaultServer>(config =>
+                {
+                    config.DisableFeature<TimeoutManager>();
+                    config.UseExternalTimeoutManager(timeoutManagerAddress);
+                });
+            }
+
+            public class FailingMessageHandler : IHandleMessages<FailingMessage>
+            {
+                public Task Handle(FailingMessage message, IMessageHandlerContext context)
+                {
+                    throw new Exception("please try again");
+                }
+            }
+        }
+
+        public class EndpointWithTimeoutManager : EndpointConfigurationBuilder
+        {
+            public EndpointWithTimeoutManager()
+            {
+                EndpointSetup<DefaultServer>(config => config.EnableFeature<TimeoutManager>());
+            }
+
+            public class MyMessageHandler :
+                IHandleMessages<DelayedMessage>,
+                IHandleMessages<FailingMessage>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(DelayedMessage message, IMessageHandlerContext context)
+                {
+                    Context.TimeoutManagerHeaderDetected = context.MessageHeaders.ContainsKey("NServiceBus.Timeout.Expire");
+                    Context.ExternalTimeoutManagerInvoked = true;
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(FailingMessage message, IMessageHandlerContext context)
+                {
+                    Context.TimeoutManagerHeaderDetected = context.MessageHeaders.ContainsKey("NServiceBus.Timeout.Expire");
+                    Context.ExternalTimeoutManagerInvoked = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class DelayedMessage : ICommand
+        {
+        }
+
+        public class FailingMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_using_external_timeout_manager_xml_config.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_using_external_timeout_manager_xml_config.cs
@@ -9,7 +9,7 @@
     using NServiceBus.Config;
     using NUnit.Framework;
 
-    public class When_using_external_timeout_manager : NServiceBusAcceptanceTest
+    public class When_using_external_timeout_manager_xml_config : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_delay_delivery()

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Config\When_multiple_configuration_providers.cs" />
     <Compile Include="Core\CoreTestSuiteConstraints.cs" />
     <Compile Include="Core\DelayedDelivery\TimeoutManager\When_dispatch_fails_on_removal_SendsAtomicWithReceive.cs" />
+    <Compile Include="Core\DelayedDelivery\TimeoutManager\When_using_external_timeout_manager_code_first.cs" />
     <Compile Include="Core\Feature\When_feature_startup_task_fails.cs" />
     <Compile Include="Core\LegacyRetries\When_legacy_retries_left_in_retry_queue.cs" />
     <Compile Include="Core\MessageDurability\When_sending_a_non_durable_message_with_conventions.cs" />
@@ -72,7 +73,7 @@
     <Compile Include="Core\Stopping\When_transport_infrastructure_throws_on_stop.cs" />
     <Compile Include="DataBus\When_sending_databus_properties_with_unobtrusive.cs" />
     <Compile Include="Basic\When_sending_interface_message_with_conventions.cs" />
-    <Compile Include="Core\DelayedDelivery\TimeoutManager\When_using_external_timeout_manager.cs" />
+    <Compile Include="Core\DelayedDelivery\TimeoutManager\When_using_external_timeout_manager_xml_config.cs" />
     <Compile Include="Core\Encryption\When_using_Rijndael_with_unobtrusive_mode.cs" />
     <Compile Include="EndpointTemplates\Requires.cs" />
     <Compile Include="EndpointTemplates\TestSuiteConstraints.cs" />

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1689,6 +1689,10 @@ namespace NServiceBus.DelayedDelivery
         public DoNotDeliverBefore(System.DateTime at) { }
         public System.DateTime At { get; }
     }
+    public class static ExternalTimeoutManagerConfigurationExtensions
+    {
+        public static void UseExternalTimeoutManager(this NServiceBus.EndpointConfiguration endpointConfiguration, string externalTimeoutManagerAddress) { }
+    }
 }
 namespace NServiceBus.DeliveryConstraints
 {

--- a/src/NServiceBus.Core/DelayedDelivery/DelayedDeliveryFeature.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/DelayedDeliveryFeature.cs
@@ -12,7 +12,10 @@
             DependsOnOptionally<TimeoutManager>();
             Defaults(s =>
             {
-                var timeoutManagerAddressConfiguration = new TimeoutManagerAddressConfiguration(s.GetConfigSection<UnicastBusConfig>()?.TimeoutManagerAddress);
+                var timeoutManagerAddressConfiguration =
+                    new TimeoutManagerAddressConfiguration(
+                        s.GetConfigSection<UnicastBusConfig>()?.TimeoutManagerAddress
+                        ?? s.GetExternalTimeoutManagerAddress());
                 s.Set<TimeoutManagerAddressConfiguration>(timeoutManagerAddressConfiguration);
             });
         }

--- a/src/NServiceBus.Core/DelayedDelivery/DelayedDeliveryFeature.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/DelayedDeliveryFeature.cs
@@ -14,8 +14,8 @@
             {
                 var timeoutManagerAddressConfiguration =
                     new TimeoutManagerAddressConfiguration(
-                        s.GetConfigSection<UnicastBusConfig>()?.TimeoutManagerAddress
-                        ?? s.GetExternalTimeoutManagerAddress());
+                        s.GetExternalTimeoutManagerAddress()
+                        ?? s.GetConfigSection<UnicastBusConfig>()?.TimeoutManagerAddress);
                 s.Set<TimeoutManagerAddressConfiguration>(timeoutManagerAddressConfiguration);
             });
         }

--- a/src/NServiceBus.Core/DelayedDelivery/ExternalTimeoutManagerConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/ExternalTimeoutManagerConfigurationExtensions.cs
@@ -1,0 +1,30 @@
+﻿namespace NServiceBus.DelayedDelivery
+{
+    using Settings;
+
+    /// <summary>
+    /// Provides configuration extension to specify an external timeout manager address.
+    /// </summary>
+    public static class ExternalTimeoutManagerConfigurationExtensions
+    {
+        /// <summary>
+        /// Configures this endpoint to use an external timeout manager to handle delayed messages.
+        /// </summary>
+        /// <param name="endpointConfiguration">The configuration to extend.</param>
+        /// <param name="externalTimeoutManagerAddress">The address of the external timeout manager to use.</param>
+        public static void UseExternalTimeoutManager(this EndpointConfiguration endpointConfiguration, string externalTimeoutManagerAddress)
+        {
+            Guard.AgainstNull(nameof(EndpointConfiguration), endpointConfiguration);
+            Guard.AgainstNullAndEmpty(nameof(externalTimeoutManagerAddress), externalTimeoutManagerAddress);
+
+            endpointConfiguration.Settings.Set(ExternalTimeoutManagerConfigurationKey, externalTimeoutManagerAddress);
+        }
+
+        internal static string GetExternalTimeoutManagerAddress(this SettingsHolder settings)
+        {
+            return settings.GetOrDefault<string>(ExternalTimeoutManagerConfigurationKey);
+        }
+
+        const string ExternalTimeoutManagerConfigurationKey = "NServiceBus.ExternalTimeoutManagerAddress";
+    }
+}

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Audit\ConfigureAudit.cs" />
     <Compile Include="Audit\AuditToDispatchConnector.cs" />
     <Compile Include="Audit\InvokeAuditPipelineBehavior.cs" />
+    <Compile Include="DelayedDelivery\ExternalTimeoutManagerConfigurationExtensions.cs" />
     <Compile Include="DelayedDelivery\TimeoutManagerRoutingStrategy.cs" />
     <Compile Include="DelayedDelivery\TimeoutManager\TimeoutManagerConfiguration.cs" />
     <Compile Include="DelayedDelivery\TimeoutManager\TimeoutManagerConfigurationExtensions.cs" />


### PR DESCRIPTION
relates to https://github.com/Particular/PlatformDevelopment/issues/1153

provides a code first API to configure an external timeout manager using:
`config.UseExternalTimeoutManager(timeoutManagerAddress);`

@WilliamBZA @Particular/nservicebus-maintainers thoughts?