### PR TITLE
Move acceptance tests

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Basic/When_handling_current_message_later.cs
+++ b/src/NServiceBus.AcceptanceTests/Basic/When_handling_current_message_later.cs
@@ -101,7 +101,6 @@
             }
         }
 
-        
         public class SomeMessage : IMessage
         {
             public Guid Id { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_typed_feature.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_typed_feature.cs
@@ -1,4 +1,4 @@
-namespace NServiceBus.AcceptanceTests.Basic
+﻿namespace NServiceBus.AcceptanceTests.Core.Feature
 {
     using System.Threading.Tasks;
     using AcceptanceTesting;
@@ -6,41 +6,41 @@ namespace NServiceBus.AcceptanceTests.Basic
     using Features;
     using NUnit.Framework;
 
-    public class When_depending_on_untyped_feature : NServiceBusAcceptanceTest
+    public class When_depending_on_typed_feature : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_enable_when_untyped_dependency_enabled()
+        public async Task Should_enable_when_typed_dependency_enabled()
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithFeatures>(b => b.CustomConfig(c =>
                 {
-                    c.EnableFeature<UntypedDependentFeature>();
+                    c.EnableFeature<TypedDependentFeature>();
                     c.EnableFeature<DependencyFeature>();
                 }))
                 .Done(c => c.EndpointsStarted)
                 .Run();
 
-            Assert.That(context.UntypedDependencyFeatureSetUp, Is.True);
+            Assert.That(context.TypedDependencyFeatureSetUp, Is.True);
         }
 
         [Test]
-        public async Task Should_disable_when_untyped_dependency_disabled()
+        public async Task Should_disable_when_typed_dependency_disabled()
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithFeatures>(b => b.CustomConfig(c =>
                 {
-                    c.DisableFeature<UntypedDependentFeature>();
+                    c.DisableFeature<TypedDependentFeature>();
                     c.EnableFeature<DependencyFeature>();
                 }))
                 .Done(c => c.EndpointsStarted)
                 .Run();
 
-            Assert.That(context.UntypedDependencyFeatureSetUp, Is.False);
+            Assert.That(context.TypedDependencyFeatureSetUp, Is.False);
         }
 
         class Context : ScenarioContext
         {
-            public bool UntypedDependencyFeatureSetUp { get; set; }
+            public bool TypedDependencyFeatureSetUp { get; set; }
         }
 
         public class EndpointWithFeatures : EndpointConfigurationBuilder
@@ -51,18 +51,17 @@ namespace NServiceBus.AcceptanceTests.Basic
             }
         }
 
-        public class UntypedDependentFeature : Feature
+        public class TypedDependentFeature : Feature
         {
-            public UntypedDependentFeature()
+            public TypedDependentFeature()
             {
-                var featureTypeFullName = typeof(DependencyFeature).FullName;
-                DependsOn(featureTypeFullName);
+                DependsOn<DependencyFeature>();
             }
 
             protected override void Setup(FeatureConfigurationContext context)
             {
                 var testContext = (Context) context.Settings.Get<ScenarioContext>();
-                testContext.UntypedDependencyFeatureSetUp = true;
+                testContext.TypedDependencyFeatureSetUp = true;
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_untyped_feature.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_untyped_feature.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.Basic
+namespace NServiceBus.AcceptanceTests.Core.Feature
 {
     using System.Threading.Tasks;
     using AcceptanceTesting;
@@ -6,41 +6,40 @@
     using Features;
     using NUnit.Framework;
 
-    public class When_depending_on_typed_feature : NServiceBusAcceptanceTest
+    public class When_depending_on_untyped_feature : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_enable_when_typed_dependency_enabled()
+        public async Task Should_enable_when_untyped_dependency_enabled()
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithFeatures>(b => b.CustomConfig(c =>
                 {
-                    c.EnableFeature<TypedDependentFeature>();
+                    c.EnableFeature<UntypedDependentFeature>();
                     c.EnableFeature<DependencyFeature>();
                 }))
                 .Done(c => c.EndpointsStarted)
                 .Run();
 
-            Assert.That(context.TypedDependencyFeatureSetUp, Is.True);
+            Assert.That(context.UntypedDependencyFeatureSetUp, Is.True);
         }
 
         [Test]
-        public async Task Should_disable_when_typed_dependency_disabled()
+        public async Task Should_disable_when_untyped_dependency_disabled()
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithFeatures>(b => b.CustomConfig(c =>
                 {
-                    c.DisableFeature<TypedDependentFeature>();
+                    c.DisableFeature<UntypedDependentFeature>();
                     c.EnableFeature<DependencyFeature>();
                 }))
                 .Done(c => c.EndpointsStarted)
                 .Run();
 
-            Assert.That(context.TypedDependencyFeatureSetUp, Is.False);
+            Assert.That(context.UntypedDependencyFeatureSetUp, Is.False);
         }
 
         class Context : ScenarioContext
         {
-            public bool TypedDependencyFeatureSetUp { get; set; }
             public bool UntypedDependencyFeatureSetUp { get; set; }
         }
 
@@ -52,17 +51,18 @@
             }
         }
 
-        public class TypedDependentFeature : Feature
+        public class UntypedDependentFeature : Feature
         {
-            public TypedDependentFeature()
+            public UntypedDependentFeature()
             {
-                DependsOn<DependencyFeature>();
+                var featureTypeFullName = typeof(DependencyFeature).FullName;
+                DependsOn(featureTypeFullName);
             }
 
             protected override void Setup(FeatureConfigurationContext context)
             {
                 var testContext = (Context) context.Settings.Get<ScenarioContext>();
-                testContext.TypedDependencyFeatureSetUp = true;
+                testContext.UntypedDependencyFeatureSetUp = true;
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_aborting_the_behavior_chain.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_aborting_the_behavior_chain.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.Basic
+﻿namespace NServiceBus.AcceptanceTests.Core.Pipeline
 {
     using System.Threading.Tasks;
     using AcceptanceTesting;

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_extending_behavior_context.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_extending_behavior_context.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.Basic
+﻿namespace NServiceBus.AcceptanceTests.Core.Pipeline
 {
     using System;
     using System.Threading.Tasks;

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_extending_sendoptions.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_extending_sendoptions.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.ApiExtension
+﻿namespace NServiceBus.AcceptanceTests.Core.Pipeline
 {
     using System;
     using System.Threading.Tasks;
@@ -80,7 +80,6 @@
             }
         }
 
-        
         public class SendMessage : ICommand
         {
             public string Secret { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_extending_the_publish_api.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_extending_the_publish_api.cs
@@ -1,14 +1,14 @@
-﻿namespace NServiceBus.AcceptanceTests.ApiExtension
+﻿namespace NServiceBus.AcceptanceTests.Core.Pipeline
 {
     using System;
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using AcceptanceTests.Routing;
     using EndpointTemplates;
     using Extensibility;
     using Features;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
-    using Routing;
 
     public class When_extending_the_publish_api : NServiceBusAcceptanceTest
     {

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_handling_message_with_several_messagehandlers.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_handling_message_with_several_messagehandlers.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.Basic
+﻿namespace NServiceBus.AcceptanceTests.Core.Pipeline
 {
     using System;
     using System.Threading.Tasks;
@@ -39,7 +39,6 @@
             }
         }
 
-        
         public class MyMessage : IMessage
         {
             public Guid Id { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_replacing_behavior.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_replacing_behavior.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.Pipeline
+﻿namespace NServiceBus.AcceptanceTests.Core.Pipeline
 {
     using System;
     using System.Threading.Tasks;

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_using_per_uow_component_in_the_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_using_per_uow_component_in_the_pipeline.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.Pipeline
+﻿namespace NServiceBus.AcceptanceTests.Core.Pipeline
 {
     using System;
     using System.Threading;

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_Deferring_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_Deferring_a_message.cs
@@ -12,7 +12,7 @@
         [Test]
         public async Task Should_delay_delivery()
         {
-            var delay = TimeSpan.FromMilliseconds(1);
+            var delay = TimeSpan.FromSeconds(1);
 
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) =>
@@ -59,7 +59,6 @@
             }
         }
 
-        
         public class MyMessage : IMessage
         {
         }

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_Deferring_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_Deferring_a_message.cs
@@ -12,7 +12,7 @@
         [Test]
         public async Task Should_delay_delivery()
         {
-            var delay = TimeSpan.FromSeconds(1);
+            var delay = TimeSpan.FromSeconds(2);
 
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) =>

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_to_non_local.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_to_non_local.cs
@@ -12,7 +12,7 @@
         [Test]
         public async Task Message_should_be_received()
         {
-            var delay = TimeSpan.FromSeconds(1);
+            var delay = TimeSpan.FromSeconds(2);
 
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) =>

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_to_non_local.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_to_non_local.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.Basic
+﻿namespace NServiceBus.AcceptanceTests.DelayedDelivery
 {
     using System;
     using System.Threading.Tasks;
@@ -12,24 +12,31 @@
         [Test]
         public async Task Message_should_be_received()
         {
+            var delay = TimeSpan.FromSeconds(1);
+
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) =>
                 {
                     var options = new SendOptions();
 
-                    options.DelayDeliveryWith(TimeSpan.FromMilliseconds(3));
+                    options.DelayDeliveryWith(delay);
+
+                    c.SentAt = DateTime.UtcNow;
+
                     return session.Send(new MyMessage(), options);
                 }))
                 .WithEndpoint<Receiver>()
                 .Done(c => c.WasCalled)
                 .Run();
 
-            Assert.IsTrue(context.WasCalled);
+            Assert.GreaterOrEqual(context.ReceivedAt - context.SentAt, delay);
         }
 
         public class Context : ScenarioContext
         {
             public bool WasCalled { get; set; }
+            public DateTime SentAt { get; set; }
+            public DateTime ReceivedAt { get; set; }
         }
 
         public class Endpoint : EndpointConfigurationBuilder
@@ -54,13 +61,13 @@
 
                 public Task Handle(MyMessage message, IMessageHandlerContext context)
                 {
+                    Context.ReceivedAt = DateTime.UtcNow;
                     Context.WasCalled = true;
                     return Task.FromResult(0);
                 }
             }
         }
 
-        
         public class MyMessage : ICommand
         {
         }

--- a/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_empty_id_header.cs
+++ b/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_empty_id_header.cs
@@ -6,7 +6,7 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using NServiceBus.Pipeline;
+    using Pipeline;
     using NUnit.Framework;
 
     public class When_message_has_empty_id_header : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_no_id_header.cs
+++ b/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_no_id_header.cs
@@ -5,7 +5,7 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using NServiceBus.Pipeline;
+    using Pipeline;
     using NUnit.Framework;
 
     public class When_message_has_no_id_header : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -55,8 +55,8 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Basic\When_depending_on_untyped_feature.cs" />
-    <Compile Include="Basic\When_extending_behavior_context.cs" />
+    <Compile Include="Core\Feature\When_depending_on_untyped_feature.cs" />
+    <Compile Include="Core\Pipeline\When_extending_behavior_context.cs" />
     <Compile Include="Basic\When_receiving_unobtrusive_message_without_handler.cs" />
     <Compile Include="Config\When_multiple_configuration_providers.cs" />
     <Compile Include="Core\CoreTestSuiteConstraints.cs" />
@@ -116,7 +116,7 @@
     <Compile Include="ScenarioDescriptors\TypeScanner.cs" />
     <Compile Include="Serialization\When_configuring_custom_xml_namespace.cs" />
     <Compile Include="Serialization\When_registering_additional_deserializers.cs" />
-    <Compile Include="Basic\When_no_content_type.cs" />
+    <Compile Include="Serialization\When_no_content_type.cs" />
     <Compile Include="Basic\When_registering_handlers_explicitly.cs" />
     <Compile Include="Causation\When_a_message_is_faulted.cs" />
     <Compile Include="Causation\When_a_message_is_audited.cs" />
@@ -138,13 +138,13 @@
     <Compile Include="Core\FakeTransport\FakeTransportInfrastructure.cs" />
     <Compile Include="Core\FakeTransport\FakeTransportSetingsExtensions.cs" />
     <Compile Include="Core\FakeTransport\ProcessingOptimizations\When_using_concurrency_limit.cs" />
-    <Compile Include="Basic\When_depending_on_typed_feature.cs" />
+    <Compile Include="Core\Feature\When_depending_on_typed_feature.cs" />
     <Compile Include="Hosting\When_overriding_input_queue_name.cs" />
     <Compile Include="Hosting\When_a_message_is_faulted.cs" />
     <Compile Include="MessageId\When_message_has_empty_id_header.cs" />
     <Compile Include="MessageId\When_message_has_no_id_header.cs" />
     <Compile Include="CriticalError\When_raising_critical_error.cs" />
-    <Compile Include="Basic\When_deferring_to_non_local.cs" />
+    <Compile Include="DelayedDelivery\When_deferring_to_non_local.cs" />
     <Compile Include="Core\DelayedDelivery\TimeoutManager\When_TimeoutManager_is_disabled.cs" />
     <Compile Include="Mutators\When_incoming_mutator_changes_message_type.cs" />
     <Compile Include="Mutators\When_mutating.cs" />
@@ -163,8 +163,8 @@
     <Compile Include="Core\Persistence\When_a_persistence_does_not_support_saga.cs" />
     <Compile Include="Core\Persistence\When_a_persistence_does_not_support_subscriptions.cs" />
     <Compile Include="Core\Persistence\When_a_persistence_does_not_support_timeouts.cs" />
-    <Compile Include="Pipeline\When_using_per_uow_component_in_the_pipeline.cs" />
-    <Compile Include="Pipeline\When_replacing_behavior.cs" />
+    <Compile Include="Core\Pipeline\When_using_per_uow_component_in_the_pipeline.cs" />
+    <Compile Include="Core\Pipeline\When_replacing_behavior.cs" />
     <Compile Include="Core\Persistence\When_a_persistence_does_not_provide_ISynchronizationContext.cs" />
     <Compile Include="Recoverability\Retries\When_message_is_deferred_by_delayed_retries_using_dtc.cs" />
     <Compile Include="Recoverability\Retries\When_message_fails_retries.cs" />
@@ -190,9 +190,9 @@
     <Compile Include="Audit\When_a_replymessage_is_audited.cs" />
     <Compile Include="Performance\When_message_is_audited.cs" />
     <Compile Include="Basic\When_receiving_with_catch_all_handlers_registered.cs" />
-    <Compile Include="Basic\When_handling_message_with_several_messagehandlers.cs" />
+    <Compile Include="Core\Pipeline\When_handling_message_with_several_messagehandlers.cs" />
     <Compile Include="Serialization\When_registering_custom_serializer.cs" />
-    <Compile Include="ApiExtension\When_extending_sendoptions.cs" />
+    <Compile Include="Core\Pipeline\When_extending_sendoptions.cs" />
     <Compile Include="Basic\When_sending_with_conventions.cs" />
     <Compile Include="Basic\When_sending_from_a_send_only.cs" />
     <Compile Include="Basic\When_using_a_greedy_convention.cs" />
@@ -237,7 +237,7 @@
     <Compile Include="Routing\When_publishing_an_interface.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_publishing_from_sendonly.cs" />
     <Compile Include="Routing\When_publishing_an_event_implementing_two_unrelated_interfaces.cs" />
-    <Compile Include="ApiExtension\When_extending_the_publish_api.cs" />
+    <Compile Include="Core\Pipeline\When_extending_the_publish_api.cs" />
     <Compile Include="Routing\When_replying_to_message.cs" />
     <Compile Include="RunDescriptorExtensions.cs" />
     <Compile Include="Sagas\When_forgetting_to_set_a_corr_property.cs" />
@@ -295,9 +295,9 @@
     <Compile Include="Audit\When_auditing.cs" />
     <Compile Include="Audit\When_a_message_is_audited.cs" />
     <Compile Include="Correlation\When_sending_with_no_correlation_id.cs" />
-    <Compile Include="Basic\When_aborting_the_behavior_chain.cs" />
+    <Compile Include="Core\Pipeline\When_aborting_the_behavior_chain.cs" />
     <Compile Include="Basic\When_handling_current_message_later.cs" />
-    <Compile Include="Basic\When_multiple_mappings_exists.cs" />
+    <Compile Include="Routing\When_multiple_mappings_exists.cs" />
     <Compile Include="Correlation\When_using_a_custom_correlation_id.cs" />
     <Compile Include="Config\When_only_abstract_config_override_is_found.cs" />
     <Compile Include="Core\Encryption\When_using_encryption_with_custom_service.cs" />

--- a/src/NServiceBus.AcceptanceTests/NonTx/When_sending_inside_ambient_tx.cs
+++ b/src/NServiceBus.AcceptanceTests/NonTx/When_sending_inside_ambient_tx.cs
@@ -5,7 +5,7 @@
     using System.Transactions;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using NServiceBus.Pipeline;
+    using Pipeline;
     using NUnit.Framework;
 
     public class When_sending_inside_ambient_tx : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_message_is_moved_to_error_queue.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_message_is_moved_to_error_queue.cs
@@ -5,7 +5,7 @@
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using EndpointTemplates;
-    using NServiceBus.Pipeline;
+    using Pipeline;
     using NUnit.Framework;
 
     public class When_message_is_moved_to_error_queue : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_audited.cs
@@ -6,7 +6,7 @@
     using AcceptanceTesting;
     using Configuration.AdvanceExtensibility;
     using EndpointTemplates;
-    using NServiceBus.Pipeline;
+    using Pipeline;
     using NUnit.Framework;
 
     public class When_a_message_is_audited : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_blowing_up_just_after_dispatch.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_blowing_up_just_after_dispatch.cs
@@ -6,7 +6,7 @@
     using AcceptanceTesting;
     using Configuration.AdvanceExtensibility;
     using EndpointTemplates;
-    using NServiceBus.Pipeline;
+    using Pipeline;
     using NUnit.Framework;
 
     public class When_blowing_up_just_after_dispatch : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_dispatching_forwarded_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_dispatching_forwarded_messages.cs
@@ -6,7 +6,7 @@
     using AcceptanceTesting;
     using Configuration.AdvanceExtensibility;
     using EndpointTemplates;
-    using NServiceBus.Pipeline;
+    using Pipeline;
     using NUnit.Framework;
 
     public class When_dispatching_forwarded_messages : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using NServiceBus.Pipeline;
+    using Pipeline;
     using NUnit.Framework;
 
     [TestFixture]

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs
@@ -6,7 +6,7 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using NServiceBus.Pipeline;
+    using Pipeline;
     using NUnit.Framework;
 
     [TestFixture]

--- a/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_autoSubscribe.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/AutomaticSubscriptions/When_starting_an_endpoint_with_autoSubscribe.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.AcceptanceTests.Routing.AutomaticSubscriptions
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using NServiceBus.Pipeline;
+    using Pipeline;
     using NUnit.Framework;
 
     [TestFixture]

--- a/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehavior.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/SubscriptionBehavior.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Threading.Tasks;
     using AcceptanceTesting;
-    using NServiceBus.Pipeline;
+    using Pipeline;
     using Transport;
 
     class SubscriptionBehavior<TContext> : IBehavior<ITransportReceiveContext, ITransportReceiveContext> where TContext : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/When_multiple_mappings_exists.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_multiple_mappings_exists.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.Basic
+﻿namespace NServiceBus.AcceptanceTests.Routing
 {
     using System.Threading.Tasks;
     using AcceptanceTesting;

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface.cs
@@ -5,7 +5,7 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using Features;
-    using NServiceBus.Pipeline;
+    using Pipeline;
     using NUnit.Framework;
 
     public class When_publishing_an_interface : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface_with_unobtrusive.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface_with_unobtrusive.cs
@@ -5,7 +5,7 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using Features;
-    using NServiceBus.Pipeline;
+    using Pipeline;
     using NUnit.Framework;
 
     public class When_publishing_an_interface_with_unobtrusive : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_adding_state_to_context.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_adding_state_to_context.cs
@@ -6,7 +6,7 @@ namespace NServiceBus.AcceptanceTests.Sagas
     using EndpointTemplates;
     using Extensibility;
     using NServiceBus;
-    using NServiceBus.Pipeline;
+    using Pipeline;
     using NServiceBus.Sagas;
     using NUnit.Framework;
     using Persistence;

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_no_content_type.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_no_content_type.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.Basic
+﻿namespace NServiceBus.AcceptanceTests.Serialization
 {
     using System.Threading.Tasks;
     using AcceptanceTesting;


### PR DESCRIPTION
This is the first bit of work that @timbussmann and I have finished for #4457. Most of the changes are moving tests to better folders. Some of those moves included putting tests into the /Core folder so as not to be pushed to downstreams any longer.

There is also a small amount of test code cleanup for some tests that were either not Asserting what the test name claimed or running deferral checks using unrealistic times.