### PR TITLE
Isolate receive statistic perf counters in separate feature

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -971,10 +971,6 @@ namespace NServiceBus
         public static void MakeInstanceUniquelyAddressable(this NServiceBus.EndpointConfiguration config, string discriminator) { }
         public static void OverrideLocalAddress(this NServiceBus.EndpointConfiguration config, string baseInputQueueName) { }
     }
-    public class ReceiveStatisticsPerformanceCounterFeature : NServiceBus.Features.Feature
-    {
-        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
-    }
     public abstract class RecoverabilityAction
     {
         protected internal RecoverabilityAction() { }
@@ -1930,6 +1926,10 @@ namespace NServiceBus.Features
         protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
     public class Outbox : NServiceBus.Features.Feature
+    {
+        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+    }
+    public class ReceiveStatisticsPerformanceCounters : NServiceBus.Features.Feature
     {
         protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -971,6 +971,10 @@ namespace NServiceBus
         public static void MakeInstanceUniquelyAddressable(this NServiceBus.EndpointConfiguration config, string discriminator) { }
         public static void OverrideLocalAddress(this NServiceBus.EndpointConfiguration config, string baseInputQueueName) { }
     }
+    public class ReceiveStatisticsPerformanceCounterFeature : NServiceBus.Features.Feature
+    {
+        protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+    }
     public abstract class RecoverabilityAction
     {
         protected internal RecoverabilityAction() { }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Notifications\IEventAggregator.cs" />
     <Compile Include="Notifications\NotificationSubscriptions.cs" />
     <Compile Include="Notifications\EventAggregatorExtensions.cs" />
+    <Compile Include="Performance\ReceiveStatisticsPerformanceCounterFeature.cs" />
     <Compile Include="Persistence\Msmq\SubscriptionStorage\MsmqSubscriptionMessage.cs" />
     <Compile Include="Pipeline\PipelineExecutionExtensions.cs" />
     <Compile Include="Pipeline\ForkConnector.cs" />

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -116,7 +116,7 @@
     <Compile Include="Notifications\IEventAggregator.cs" />
     <Compile Include="Notifications\NotificationSubscriptions.cs" />
     <Compile Include="Notifications\EventAggregatorExtensions.cs" />
-    <Compile Include="Performance\ReceiveStatisticsPerformanceCounterFeature.cs" />
+    <Compile Include="Performance\ReceiveStatisticsPerformanceCounters.cs" />
     <Compile Include="Persistence\Msmq\SubscriptionStorage\MsmqSubscriptionMessage.cs" />
     <Compile Include="Pipeline\PipelineExecutionExtensions.cs" />
     <Compile Include="Pipeline\ForkConnector.cs" />

--- a/src/NServiceBus.Core/Performance/ReceiveStatisticsFeature.cs
+++ b/src/NServiceBus.Core/Performance/ReceiveStatisticsFeature.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus
 {
-    using System.Threading.Tasks;
     using Features;
 
     class ReceiveStatisticsFeature : Feature
@@ -12,36 +11,8 @@
 
         protected internal override void Setup(FeatureConfigurationContext context)
         {
-            var logicalAddress = context.Settings.LogicalAddress();
-            var performanceDiagnosticsBehavior = new ReceivePerformanceDiagnosticsBehavior(logicalAddress.EndpointInstance.Endpoint);
-
-            context.Pipeline.Register(performanceDiagnosticsBehavior, "Provides various performance counters for receive statistics");
             context.Pipeline.Register("ProcessingStatistics", new ProcessingStatisticsBehavior(), "Collects timing for ProcessingStarted and adds the state to determine ProcessingEnded");
             context.Pipeline.Register("AuditProcessingStatistics", new AuditProcessingStatisticsBehavior(), "Add ProcessingStarted and ProcessingEnded headers");
-
-            context.RegisterStartupTask(new WarmupCooldownTask(performanceDiagnosticsBehavior));
-        }
-
-        class WarmupCooldownTask : FeatureStartupTask
-        {
-            public WarmupCooldownTask(ReceivePerformanceDiagnosticsBehavior behavior)
-            {
-                this.behavior = behavior;
-            }
-
-            protected override Task OnStart(IMessageSession session)
-            {
-                behavior.Warmup();
-                return TaskEx.CompletedTask;
-            }
-
-            protected override Task OnStop(IMessageSession session)
-            {
-                behavior.Cooldown();
-                return TaskEx.CompletedTask;
-            }
-
-            readonly ReceivePerformanceDiagnosticsBehavior behavior;
         }
     }
 }

--- a/src/NServiceBus.Core/Performance/ReceiveStatisticsPerformanceCounterFeature.cs
+++ b/src/NServiceBus.Core/Performance/ReceiveStatisticsPerformanceCounterFeature.cs
@@ -3,13 +3,19 @@
     using System.Threading.Tasks;
     using Features;
 
-    class ReceiveStatisticsPerformanceCounterFeature : Feature
+    /// <summary>
+    /// Provides performance counters for receive operations.
+    /// </summary>
+    public class ReceiveStatisticsPerformanceCounterFeature : Feature
     {
-        public ReceiveStatisticsPerformanceCounterFeature()
+        internal ReceiveStatisticsPerformanceCounterFeature()
         {
             EnableByDefault();
         }
 
+        /// <summary>
+        /// See <see cref="Feature.Setup" />.
+        /// </summary>
         protected internal override void Setup(FeatureConfigurationContext context)
         {
             var logicalAddress = context.Settings.LogicalAddress();

--- a/src/NServiceBus.Core/Performance/ReceiveStatisticsPerformanceCounterFeature.cs
+++ b/src/NServiceBus.Core/Performance/ReceiveStatisticsPerformanceCounterFeature.cs
@@ -1,0 +1,45 @@
+﻿namespace NServiceBus
+{
+    using System.Threading.Tasks;
+    using Features;
+
+    class ReceiveStatisticsPerformanceCounterFeature : Feature
+    {
+        public ReceiveStatisticsPerformanceCounterFeature()
+        {
+            EnableByDefault();
+        }
+
+        protected internal override void Setup(FeatureConfigurationContext context)
+        {
+            var logicalAddress = context.Settings.LogicalAddress();
+            var performanceDiagnosticsBehavior = new ReceivePerformanceDiagnosticsBehavior(logicalAddress.EndpointInstance.Endpoint);
+
+            context.Pipeline.Register(performanceDiagnosticsBehavior, "Provides various performance counters for receive statistics");
+
+            context.RegisterStartupTask(new WarmupCooldownTask(performanceDiagnosticsBehavior));
+        }
+
+        class WarmupCooldownTask : FeatureStartupTask
+        {
+            public WarmupCooldownTask(ReceivePerformanceDiagnosticsBehavior behavior)
+            {
+                this.behavior = behavior;
+            }
+
+            protected override Task OnStart(IMessageSession session)
+            {
+                behavior.Warmup();
+                return TaskEx.CompletedTask;
+            }
+
+            protected override Task OnStop(IMessageSession session)
+            {
+                behavior.Cooldown();
+                return TaskEx.CompletedTask;
+            }
+
+            readonly ReceivePerformanceDiagnosticsBehavior behavior;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Performance/ReceiveStatisticsPerformanceCounters.cs
+++ b/src/NServiceBus.Core/Performance/ReceiveStatisticsPerformanceCounters.cs
@@ -1,14 +1,13 @@
-﻿namespace NServiceBus
+﻿namespace NServiceBus.Features
 {
     using System.Threading.Tasks;
-    using Features;
 
     /// <summary>
     /// Provides performance counters for receive operations.
     /// </summary>
-    public class ReceiveStatisticsPerformanceCounterFeature : Feature
+    public class ReceiveStatisticsPerformanceCounters : Feature
     {
-        internal ReceiveStatisticsPerformanceCounterFeature()
+        internal ReceiveStatisticsPerformanceCounters()
         {
             EnableByDefault();
         }


### PR DESCRIPTION
To allow the external package to disable it


Note: The feature needs to be obsoleted in the same way as the other perf counter features (separate pull to come)