### PR TITLE
Add machine mapping API for MSMQ

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -3427,6 +3427,10 @@ namespace NServiceBus.Transports.Msmq
     {
         public MsmqMessageSender() { }
     }
+    public class static MsmqRoutingExtensions
+    {
+        public static void MapEndpointToMachine(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> routingSettings, string logicalEndpoint, string machineName) { }
+    }
     [System.ObsoleteAttribute("The msmq transaction is now available via the pipeline context. Will be removed i" +
         "n version 7.0.0.", true)]
     public class MsmqUnitOfWork

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -180,6 +180,7 @@
     <Compile Include="Serialization\SerializationFeature.cs" />
     <Compile Include="Serialization\SerializationSettingsExtensions.cs" />
     <Compile Include="Serializers\XML\XmlSerialization.cs" />
+    <Compile Include="Transports\Msmq\MsmqRoutingExtensions.cs" />
     <Compile Include="Transports\Msmq\ReceiveOnlyNativeTransactionStrategy.cs" />
     <Compile Include="Transports\ReceiveSettingsExtensions.cs" />
     <Compile Include="Transports\ErrorContext.cs" />

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqRoutingExtensions.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqRoutingExtensions.cs
@@ -1,0 +1,40 @@
+﻿namespace NServiceBus.Transports.Msmq
+{
+    using System.Collections.Generic;
+    using Routing;
+    using Settings;
+
+    /// <summary>
+    /// Provides MSMQ transport specific routing extensions.
+    /// </summary>
+    public static class MsmqRoutingExtensions
+    {
+        /// <summary>
+        /// Specify the machine name of a given logical endpoint.
+        /// </summary>
+        /// <param name="routingSettings">The settings to extend.</param>
+        /// <param name="logicalEndpoint">The logical endpoint name.</param>
+        /// <param name="machineName">The machine name of the logical endpoint.</param>
+        public static void MapEndpointToMachine(this RoutingSettings<MsmqTransport> routingSettings, string logicalEndpoint, string machineName)
+        {
+            Guard.AgainstNull(nameof(routingSettings), routingSettings);
+            Guard.AgainstNullAndEmpty(nameof(logicalEndpoint), logicalEndpoint);
+            Guard.AgainstNullAndEmpty(nameof(machineName), machineName);
+
+            List<EndpointInstance> mappings;
+            if (!routingSettings.Settings.TryGet(machineMappingsSettingsKey, out mappings))
+            {
+                routingSettings.Settings.Set(machineMappingsSettingsKey, mappings = new List<EndpointInstance>());
+            }
+
+            mappings.Add(new EndpointInstance(logicalEndpoint).AtMachine(machineName));
+        }
+
+        internal static List<EndpointInstance> GetMachineMappings(this SettingsHolder settings)
+        {
+            return settings.GetOrDefault<List<EndpointInstance>>(machineMappingsSettingsKey) ?? new List<EndpointInstance>(0);
+        }
+
+        const string machineMappingsSettingsKey = "NServiceBus.Transport.MSMQ.MachineMappings";
+    }
+}

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransport.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransport.cs
@@ -4,6 +4,7 @@ namespace NServiceBus
     using Routing;
     using Settings;
     using Transport;
+    using Transports.Msmq;
 
     /// <summary>
     /// Transport definition for MSMQ.
@@ -36,6 +37,12 @@ namespace NServiceBus
             msmqSettings.UseDeadLetterQueueForMessagesWithTimeToBeReceived = settings.GetOrDefault<bool>(UseDeadLetterQueueForMessagesWithTimeToBeReceived);
 
             settings.Set<MsmqSettings>(msmqSettings);
+
+            var machineMappings = settings.GetMachineMappings();
+            if (machineMappings.Count > 0)
+            {
+                settings.GetOrCreate<EndpointInstances>().AddOrReplaceInstances("MsmqMachineMappings", machineMappings);
+            }
 
             return new MsmqTransportInfrastructure(settings);
         }


### PR DESCRIPTION
relates to https://github.com/Particular/NServiceBus/issues/4500

provides an MSMQ specific API to map logical endpoints to a machine via code first API. This is intended as an simple approach in case users don't scale out msmq and therefore don't gain much by using the instance mapping file in a very static environment. Note that the machine name can still be read from an app config file or any other source.

usage:
`config.UseTransport<MsmqTransport>().Routing().MapEndpointToMachine("sales", "machine-42");`

The API should be artificially limited to only support single instances per endpoint. On scale-out environments we would still recommend to use the instance-mapping file.

Note: it doesn't detect potential conflicts when using this API together with the instance mapping file. Is this something we should cover?


TODO:
* [ ] Limit API to only allow one instance registered per logical endpoint
* [ ] add docs


Thoughts @Particular/nservicebus-maintainers @WilliamBZA @DavidBoike @SzymonPobiega 