### PR TITLE
Obsolete audit config properties

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using Support;
+    using System.Configuration;
 
     public class EndpointConfigurationBuilder : IEndpointConfigurationFactory
     {
@@ -84,6 +85,23 @@
                 {
                     configurationBuilderCustomization(bc, runDescriptor);
                 }).ConfigureAwait(false);
+
+                if (!configuration.SendOnly)
+                {
+                    if (configuration.AddressOfAuditQueue != null)
+                    {
+                        endpointConfiguration.AuditProcessedMessagesTo(configuration.AddressOfAuditQueue);
+                    }
+                    else if (configuration.AuditEndpoint != null)
+                    {
+                        if (!routingTable.ContainsKey(configuration.AuditEndpoint))
+                        {
+                            throw new ConfigurationErrorsException($"{configuration.AuditEndpoint} was not found in routingTable. Ensure that WithEndpoint<{configuration.AuditEndpoint}>() method is called in the test.");
+                        }
+
+                        endpointConfiguration.AuditProcessedMessagesTo(routingTable[configuration.AuditEndpoint]);
+                    }
+                }
 
                 return endpointConfiguration;
             };

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioConfigSource.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioConfigSource.cs
@@ -37,26 +37,6 @@
 
             }
 
-            if (type == typeof(AuditConfig))
-            {
-                if (!configuration.SendOnly)
-                {
-                    if (configuration.AddressOfAuditQueue != null)
-                    {
-                        return new AuditConfig { QueueName = configuration.AddressOfAuditQueue } as T;
-                    }
-
-                    if (configuration.AuditEndpoint != null)
-                    {
-                        if (!routingTable.ContainsKey(configuration.AuditEndpoint))
-                        {
-                            throw new ConfigurationErrorsException($"{configuration.AuditEndpoint} was not found in routingTable. Ensure that WithEndpoint<{configuration.AuditEndpoint}>() method is called in the test.");
-                        }
-
-                        return new AuditConfig { QueueName = routingTable[configuration.AuditEndpoint] } as T;
-                    }
-                }
-            }
 
             return ConfigurationManager.GetSection(type.Name) as T;
         }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1402,8 +1402,14 @@ namespace NServiceBus.Config
     {
         public AuditConfig() { }
         [System.Configuration.ConfigurationPropertyAttribute("OverrideTimeToBeReceived", IsRequired=false)]
+        [System.ObsoleteAttribute("Use of the application configuration file to configure audit is discouraged. Use " +
+            "`EndpointConfiguration.AuditProcessedMessagesTo` instead. Will be removed in ver" +
+            "sion 7.0.0.", true)]
         public System.TimeSpan OverrideTimeToBeReceived { get; set; }
         [System.Configuration.ConfigurationPropertyAttribute("QueueName", IsRequired=false)]
+        [System.ObsoleteAttribute("Use of the application configuration file to configure audit is discouraged. Use " +
+            "`EndpointConfiguration.AuditProcessedMessagesTo` instead. Will be removed in ver" +
+            "sion 7.0.0.", true)]
         public string QueueName { get; set; }
     }
     [System.ObsoleteAttribute("Use the feature concept instead via A class which inherits from `NServiceBus.Feat" +

--- a/src/NServiceBus.Core/Audit/AuditConfig.cs
+++ b/src/NServiceBus.Core/Audit/AuditConfig.cs
@@ -12,6 +12,10 @@
         /// Gets/sets the address to which messages received will be forwarded.
         /// </summary>
         [ConfigurationProperty("QueueName", IsRequired = false)]
+        [ObsoleteEx(
+        Message = "Use of the application configuration file to configure audit is discouraged",
+        ReplacementTypeOrMember = "EndpointConfiguration.AuditProcessedMessagesTo",
+        RemoveInVersion = "7.0")]
         public string QueueName
         {
             get
@@ -31,6 +35,10 @@
         /// Gets/sets the time to be received set on forwarded messages.
         /// </summary>
         [ConfigurationProperty("OverrideTimeToBeReceived", IsRequired = false)]
+        [ObsoleteEx(
+        Message = "Use of the application configuration file to configure audit is discouraged",
+        ReplacementTypeOrMember = "EndpointConfiguration.AuditProcessedMessagesTo",
+        RemoveInVersion = "7.0")]
         public TimeSpan OverrideTimeToBeReceived
         {
             get { return (TimeSpan) this["OverrideTimeToBeReceived"]; }

--- a/src/NServiceBus.Core/DetectObsoleteConfigurationSettings.cs
+++ b/src/NServiceBus.Core/DetectObsoleteConfigurationSettings.cs
@@ -19,6 +19,7 @@
             DetectObsoleteConfiguration(context.Settings.GetConfigSection<SecondLevelRetriesConfig>());
             DetectObsoleteConfiguration(context.Settings.GetConfigSection<TransportConfig>());
             DetectObsoleteConfiguration(context.Settings.GetConfigSection<Config.Logging>());
+            DetectObsoleteConfiguration(context.Settings.GetConfigSection<AuditConfig>());
             DetectObsoleteConfiguration(context.Settings.GetConfigSection<MessageForwardingInCaseOfFaultConfig>());
         }
 
@@ -42,6 +43,19 @@
             if (unicastBusConfig?.TimeToBeReceivedOnForwardedMessages > TimeSpan.Zero)
             {
                 Logger.Warn($"The use of the {nameof(UnicastBusConfig.TimeToBeReceivedOnForwardedMessages)} attribute in the {nameof(UnicastBusConfig)} configuration section is discouraged and will be removed in the next major version.");
+            }
+        }
+
+        static void DetectObsoleteConfiguration(AuditConfig auditConfig)
+        {
+            if (!string.IsNullOrWhiteSpace(auditConfig?.QueueName))
+            {
+                Logger.Warn($"The use of the {nameof(AuditConfig.QueueName)} attribute in the {nameof(AuditConfig)} configuration section is discouraged and will be removed in the next major version. Switch to the code API by using `{nameof(EndpointConfiguration)}.AuditProcessedMessagesTo` instead.");
+            }
+
+            if (auditConfig?.OverrideTimeToBeReceived != null)
+            {
+                Logger.Warn($"The use of the {nameof(AuditConfig.OverrideTimeToBeReceived)} attribute in the {nameof(AuditConfig)} configuration section is discouraged and will be removed in the next major version. Switch to the code API by using `{nameof(EndpointConfiguration)}.AuditProcessedMessagesTo` instead.");
             }
         }
 

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTimeToBeReceivedOverrideCheck.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTimeToBeReceivedOverrideCheck.cs
@@ -20,8 +20,9 @@
             var isTransactional = settings.GetRequiredTransactionModeForReceives() != TransportTransactionMode.None;
             var outBoxRunning = settings.IsFeatureActive(typeof(Features.Outbox));
 
-            var messageAuditingConfig = settings.GetConfigSection<AuditConfig>();
-            var auditTTBROverridden = messageAuditingConfig != null && messageAuditingConfig.OverrideTimeToBeReceived > TimeSpan.Zero;
+            AuditConfigReader.Result messageAuditingConfig;
+            AuditConfigReader.GetConfiguredAuditQueue(settings, out messageAuditingConfig);
+            var auditTTBROverridden = messageAuditingConfig?.TimeToBeReceived > TimeSpan.Zero;
 
             var unicastBusConfig = settings.GetConfigSection<UnicastBusConfig>();
             var forwardTTBROverridden = unicastBusConfig != null && unicastBusConfig.TimeToBeReceivedOnForwardedMessages > TimeSpan.Zero;

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_Audit_OverrideTimeToBeReceived_set_and_native_receive_tx.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_Audit_OverrideTimeToBeReceived_set_and_native_receive_tx.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using AcceptanceTesting;
-    using Config;
     using NServiceBus.AcceptanceTests;
     using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
@@ -33,8 +32,9 @@
                 {
                     config.UseTransport<MsmqTransport>()
                         .Transactions(TransportTransactionMode.ReceiveOnly);
-                })
-                    .WithConfig<AuditConfig>(c => c.OverrideTimeToBeReceived = TimeSpan.FromHours(1));
+
+                    config.AuditProcessedMessagesTo("audit", TimeSpan.FromHours(1));
+                });
             }
         }
     }


### PR DESCRIPTION
Connects to Particular/PlatformDevelopment#1153

Adds an obsolete on the use of the config properties on `AuditConfig` as well logs a warning on the use of the `AuditConfig` config section. This section will be removed in the next major.

Paging @timbussmann and @Particular/nservicebus-maintainers 