### PR TITLE
Only invoke saga type indicated by NServiceBus.SagaType header if present

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Sagas\When_a_base_class_message_starts_a_saga.cs" />
     <Compile Include="Sagas\When_finder_cant_find_saga_instance.cs" />
     <Compile Include="Sagas\When_finder_returns_existing_saga.cs" />
+    <Compile Include="Sagas\When_sagas_share_timeout_messages.cs" />
     <Compile Include="Sagas\When_saga_started_concurrently.cs" />
     <Compile Include="Satellites\When_satellite_txmode_does_not_match_endpoints_txmode.cs" />
     <Compile Include="Sagas\When_using_a_received_message_for_timeout.cs" />

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_share_timeout_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_share_timeout_messages.cs
@@ -1,0 +1,107 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_sagas_share_timeout_messages : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_invoke_instance_that_requested_the_timeout()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(e => e.When(s => s.SendLocal(new StartSagaMessage()
+                {
+                    Id = Guid.NewGuid().ToString()
+                })))
+                .Done(c => c.Saga1ReceivedTimeout || c.Saga2ReceivedTimeout)
+                .Run(TimeSpan.FromSeconds(30));
+
+            Assert.IsTrue(context.Saga2ReceivedTimeout);
+            Assert.IsFalse(context.Saga1ReceivedTimeout);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Saga1ReceivedTimeout { get; set; }
+            public bool Saga2ReceivedTimeout { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.EnableFeature<TimeoutManager>();
+                });
+            }
+
+            public class Saga1 : Saga<Saga1.SagaData1>,
+                IAmStartedByMessages<StartSagaMessage>,
+                IHandleTimeouts<MySagaTimeout>
+            {
+                public Context Context { get; set; }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData1> mapper)
+                {
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.Id).ToSaga(s => s.CorrelationProperty);
+                }
+
+                public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
+                {
+                    return Task.FromResult(0);
+                }
+
+                public Task Timeout(MySagaTimeout state, IMessageHandlerContext context)
+                {
+                    Context.Saga1ReceivedTimeout = true;
+                    return Task.FromResult(0);
+                }
+
+                public class SagaData1 : ContainSagaData
+                {
+                    public string CorrelationProperty { get; set; }
+                }
+
+            }
+
+            public class Saga2 : Saga<Saga2.SagaData2>, IAmStartedByMessages<StartSagaMessage>, IHandleTimeouts<MySagaTimeout>
+            {
+                public Context Context { get; set; }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData2> mapper)
+                {
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.Id).ToSaga(s => s.CorrelationProperty);
+                }
+
+                public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
+                {
+                    return RequestTimeout<MySagaTimeout>(context, TimeSpan.FromSeconds(10));
+                }
+
+                public Task Timeout(MySagaTimeout state, IMessageHandlerContext context)
+                {
+                    Context.Saga2ReceivedTimeout = true;
+                    return Task.FromResult(0);
+                }
+                public class SagaData2 : ContainSagaData
+                {
+                    public string CorrelationProperty { get; set; }
+                }
+            }
+        }
+
+        public class StartSagaMessage : ICommand
+        {
+            public string Id { get; set; }
+        }
+
+        public class MySagaTimeout
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_share_timeout_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_share_timeout_messages.cs
@@ -64,7 +64,7 @@
 
                 public class TimeoutSharingSagaData1 : ContainSagaData
                 {
-                    public string CorrelationProperty { get; set; }
+                    public virtual string CorrelationProperty { get; set; }
                 }
 
             }
@@ -90,14 +90,14 @@
                 }
                 public class TimeoutSharingSagaData2 : ContainSagaData
                 {
-                    public string CorrelationProperty { get; set; }
+                    public virtual string CorrelationProperty { get; set; }
                 }
             }
         }
 
         public class StartSagaMessage : ICommand
         {
-            public virtual string Id { get; set; }
+            public string Id { get; set; }
         }
 
         public class MySagaTimeout

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_share_timeout_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_share_timeout_messages.cs
@@ -40,13 +40,13 @@
                 });
             }
 
-            public class Saga1 : Saga<Saga1.SagaData1>,
+            public class TimeoutSharingSaga1 : Saga<TimeoutSharingSaga1.TimeoutSharingSagaData1>,
                 IAmStartedByMessages<StartSagaMessage>,
                 IHandleTimeouts<MySagaTimeout>
             {
                 public Context Context { get; set; }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData1> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TimeoutSharingSagaData1> mapper)
                 {
                     mapper.ConfigureMapping<StartSagaMessage>(m => m.Id).ToSaga(s => s.CorrelationProperty);
                 }
@@ -62,18 +62,18 @@
                     return Task.FromResult(0);
                 }
 
-                public class SagaData1 : ContainSagaData
+                public class TimeoutSharingSagaData1 : ContainSagaData
                 {
                     public string CorrelationProperty { get; set; }
                 }
 
             }
 
-            public class Saga2 : Saga<Saga2.SagaData2>, IAmStartedByMessages<StartSagaMessage>, IHandleTimeouts<MySagaTimeout>
+            public class TimeoutSharingSaga2 : Saga<TimeoutSharingSaga2.TimeoutSharingSagaData2>, IAmStartedByMessages<StartSagaMessage>, IHandleTimeouts<MySagaTimeout>
             {
                 public Context Context { get; set; }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData2> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TimeoutSharingSagaData2> mapper)
                 {
                     mapper.ConfigureMapping<StartSagaMessage>(m => m.Id).ToSaga(s => s.CorrelationProperty);
                 }
@@ -88,7 +88,7 @@
                     Context.Saga2ReceivedTimeout = true;
                     return Task.FromResult(0);
                 }
-                public class SagaData2 : ContainSagaData
+                public class TimeoutSharingSagaData2 : ContainSagaData
                 {
                     public string CorrelationProperty { get; set; }
                 }
@@ -97,7 +97,7 @@
 
         public class StartSagaMessage : ICommand
         {
-            public string Id { get; set; }
+            public virtual string Id { get; set; }
         }
 
         public class MySagaTimeout

--- a/src/NServiceBus.Core/Sagas/SagaMetadataCollection.cs
+++ b/src/NServiceBus.Core/Sagas/SagaMetadataCollection.cs
@@ -72,6 +72,11 @@ namespace NServiceBus.Sagas
             return byType[sagaType];
         }
 
+        internal bool TryFind(Type sagaType, out SagaMetadata targetSagaMetaData)
+        {
+            return byType.TryGetValue(sagaType, out targetSagaMetaData);
+        }
+
         Dictionary<Type, SagaMetadata> byEntity = new Dictionary<Type, SagaMetadata>();
         Dictionary<Type, SagaMetadata> byType = new Dictionary<Type, SagaMetadata>();
     }

--- a/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
@@ -72,7 +72,7 @@
                     {
                         if (targetSagaMetaData.SagaType != currentSagaMetadata.SagaType)
                         {
-                            logger.Warn($"Message was intended for {targetSagaType.FullName} so {currentSagaMetadata.SagaType.FullName} will not be invoked");
+                            //Message was intended for a different saga so no need to continue with this invocation
                             return;
                         }
                     }

--- a/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
@@ -46,30 +46,62 @@
                 return;
             }
 
-            var sagaMetadata = sagaMetadataCollection.Find(context.MessageHandler.Instance.GetType());
-            var sagaInstanceState = new ActiveSagaInstance(saga, sagaMetadata, () => DateTime.UtcNow);
+
+            var currentSagaMetadata = sagaMetadataCollection.Find(context.MessageHandler.Instance.GetType());
+
+            string targetSagaTypeString;
+            string targetSagaId;
+
+            if (context.Headers.TryGetValue(Headers.SagaType, out targetSagaTypeString) && context.Headers.TryGetValue(Headers.SagaId, out targetSagaId))
+            {
+                var targetSagaType = Type.GetType(targetSagaTypeString, false);
+
+                if (targetSagaType == null)
+                {
+                    logger.Warn($"Saga headers indicated that the message was intended for {targetSagaTypeString} but that type isn't available. Will fallback to query persister for a saga instance of type {currentSagaMetadata.SagaType.FullName} and saga id {targetSagaId} instead");
+                }
+                else
+                {
+                    SagaMetadata targetSagaMetaData;
+
+                    if (!sagaMetadataCollection.TryFind(targetSagaType, out targetSagaMetaData))
+                    {
+                        logger.Warn($"Saga headers indicated that the message was intended for {targetSagaType.FullName} but no metadata was found for that saga type. Will fallback to query persister for a saga instance of type {currentSagaMetadata.SagaType.FullName} and saga id {targetSagaId} instead");
+                    }
+                    else
+                    {
+                        if (targetSagaMetaData.SagaType != currentSagaMetadata.SagaType)
+                        {
+                            logger.Warn($"Message was intended for {targetSagaType.FullName} so {currentSagaMetadata.SagaType.FullName} will not be invoked");
+                            return;
+                        }
+                    }
+                }
+            }
+
+            var sagaInstanceState = new ActiveSagaInstance(saga, currentSagaMetadata, () => DateTime.UtcNow);
 
             //so that other behaviors can access the saga
             context.Extensions.Set(sagaInstanceState);
 
-            var loadedEntity = await TryLoadSagaEntity(sagaMetadata, context).ConfigureAwait(false);
+            var loadedEntity = await TryLoadSagaEntity(currentSagaMetadata, context).ConfigureAwait(false);
 
             if (loadedEntity == null)
             {
                 //if this message are not allowed to start the saga
-                if (IsMessageAllowedToStartTheSaga(context, sagaMetadata))
+                if (IsMessageAllowedToStartTheSaga(context, currentSagaMetadata))
                 {
                     context.Extensions.Get<SagaInvocationResult>().SagaFound();
-                    sagaInstanceState.AttachNewEntity(CreateNewSagaEntity(sagaMetadata, context));
+                    sagaInstanceState.AttachNewEntity(CreateNewSagaEntity(currentSagaMetadata, context));
                 }
                 else
                 {
                     if (!context.Headers.ContainsKey(Headers.SagaId))
                     {
-                        var finderDefinition = GetSagaFinder(sagaMetadata, context);
+                        var finderDefinition = GetSagaFinder(currentSagaMetadata, context);
                         if (finderDefinition == null)
                         {
-                            throw new Exception($"Message type {context.MessageBeingHandled.GetType().Name} is handled by saga {sagaMetadata.SagaType.Name}, but the saga does not contain a property mapping or custom saga finder to map the message to saga data. Consider adding a mapping in the saga's {nameof(Saga.ConfigureHowToFindSaga)} method.");
+                            throw new Exception($"Message type {context.MessageBeingHandled.GetType().Name} is handled by saga {currentSagaMetadata.SagaType.Name}, but the saga does not contain a property mapping or custom saga finder to map the message to saga data. Consider adding a mapping in the saga's {nameof(Saga.ConfigureHowToFindSaga)} method.");
                         }
                     }
 


### PR DESCRIPTION
We currently try to invoke all available saga types if there is a saga id header present. This change does a best effort to only invoke the saga that was actually targeted (indicated by the `NServiceBus.SagaType` header). The SagaType header is used for timeouts and [autocorrelation for sagas](https://docs.particular.net/nservicebus/sagas/#sagas-and-requestresponse)

If the type can't be found we'll fallback to the existing behavior of calling the persister for all saga types available.

This improves performance but also allow saga persisters to have saga ids that are only unique within the scope of a given saga type. (see the acpt test added)

The InMemory persister didn't not handle this properly but this change makes this work.

We contemplated to throw if the saga type in the header couldn't be used but that would be a breaking change and would require the persisters to provide a way to alias the sagas to allow users to rename them.

This will be raised as a separate issue and considered for vNext