### PR TITLE
Fix TimeSpan check

### DIFF
--- a/src/NServiceBus.Core/DetectObsoleteConfigurationSettings.cs
+++ b/src/NServiceBus.Core/DetectObsoleteConfigurationSettings.cs
@@ -37,7 +37,7 @@
                 throw new NotSupportedException($"The {nameof(UnicastBusConfig.DistributorDataAddress)} attribute in the {nameof(UnicastBusConfig)} configuration section is no longer supported. Remove this from the configuration section. Switch to the code API by using `{nameof(EndpointConfiguration)}.EnlistWithLegacyMSMQDistributor` instead.");
             }
 
-            if (unicastBusConfig?.TimeToBeReceivedOnForwardedMessages != null)
+            if (unicastBusConfig?.TimeToBeReceivedOnForwardedMessages > TimeSpan.Zero)
             {
                 Logger.Warn($"The use of the {nameof(UnicastBusConfig.TimeToBeReceivedOnForwardedMessages)} attribute in the {nameof(UnicastBusConfig)} configuration section is discouraged and will be removed in the next major version.");
             }


### PR DESCRIPTION
TimeSpan will be `TimeSpan.Zero` as it's non-nullable in case a unicastBufConfig instance exists.

This will cause a warning about the usage of this attribute although it isn't configured.