### PR TITLE
MessageContext inherits from IExtendable

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
+++ b/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
@@ -52,11 +52,11 @@
 
                     context.AddSatelliteReceiver("Test satellite", satelliteAddress, PushRuntimeSettings.Default,
                         (c, ec) => RecoverabilityAction.MoveToError(c.Failed.ErrorQueue),
-                        (builder, pushContext) =>
+                        (builder, messageContext) =>
                         {
                             var testContext = builder.Build<Context>();
                             testContext.MessageReceived = true;
-                            testContext.TransportTransactionAddedToContext = ReferenceEquals(pushContext.Context.Get<TransportTransaction>(), pushContext.TransportTransaction);
+                            testContext.TransportTransactionAddedToContext = ReferenceEquals(messageContext.Extensions.Get<TransportTransaction>(), messageContext.TransportTransaction);
                             return Task.FromResult(true);
                         });
 

--- a/src/NServiceBus.AcceptanceTests/Satellites/When_satellite_txmode_does_not_match_endpoints_txmode.cs
+++ b/src/NServiceBus.AcceptanceTests/Satellites/When_satellite_txmode_does_not_match_endpoints_txmode.cs
@@ -48,7 +48,7 @@
 #pragma warning disable 612, 618
                     context.AddSatelliteReceiver("Test satellite", satelliteAddress, TransportTransactionMode.None, PushRuntimeSettings.Default,
                         (c, ec) => RecoverabilityAction.MoveToError(c.Failed.ErrorQueue),
-                        (builder, pushContext) =>
+                        (builder, messageContext) =>
                         {
                             var testContext = builder.Build<Context>();
                             testContext.MessageReceived = true;

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -3257,11 +3257,13 @@ namespace NServiceBus.Transport
     {
         public static string GetTransportAddress(this NServiceBus.Settings.ReadOnlySettings settings, NServiceBus.LogicalAddress logicalAddress) { }
     }
-    public class MessageContext
+    public class MessageContext : NServiceBus.Extensibility.IExtendable
     {
-        public MessageContext(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, System.Threading.CancellationTokenSource receiveCancellationTokenSource, NServiceBus.Extensibility.ContextBag context) { }
+        public MessageContext(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, System.Threading.CancellationTokenSource receiveCancellationTokenSource, NServiceBus.Extensibility.ContextBag extensions) { }
         public byte[] Body { get; }
+        [System.ObsoleteAttribute("Use `Extensions` instead. Will be removed in version 7.0.0.", true)]
         public NServiceBus.Extensibility.ContextBag Context { get; }
+        public NServiceBus.Extensibility.ContextBag Extensions { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public string MessageId { get; }
         public System.Threading.CancellationTokenSource ReceiveCancellationTokenSource { get; }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/DispatchTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/DispatchTimeoutBehavior.cs
@@ -19,7 +19,7 @@ namespace NServiceBus
         {
             var timeoutId = context.Headers["Timeout.Id"];
 
-            var timeoutData = await persister.Peek(timeoutId, context.Context).ConfigureAwait(false);
+            var timeoutData = await persister.Peek(timeoutId, context.Extensions).ConfigureAwait(false);
 
             if (timeoutData == null)
             {
@@ -31,9 +31,9 @@ namespace NServiceBus
 
             var outgoingMessage = new OutgoingMessage(context.MessageId, timeoutData.Headers, timeoutData.State);
             var transportOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(timeoutData.Destination), dispatchConsistency);
-            await dispatcher.Dispatch(new TransportOperations(transportOperation), context.TransportTransaction, context.Context).ConfigureAwait(false);
+            await dispatcher.Dispatch(new TransportOperations(transportOperation), context.TransportTransaction, context.Extensions).ConfigureAwait(false);
 
-            var timeoutRemoved = await persister.TryRemove(timeoutId, context.Context).ConfigureAwait(false);
+            var timeoutRemoved = await persister.TryRemove(timeoutId, context.Extensions).ConfigureAwait(false);
             if (!timeoutRemoved)
             {
                 // timeout was concurrently removed between Peek and TryRemove. Throw an exception to rollback the dispatched message if possible.

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
@@ -33,7 +33,7 @@ namespace NServiceBus
                     throw new InvalidOperationException("Invalid saga id specified, clear timeouts is only supported for saga instances");
                 }
 
-                await persister.RemoveTimeoutBy(sagaId, context.Context).ConfigureAwait(false);
+                await persister.RemoveTimeoutBy(sagaId, context.Extensions).ConfigureAwait(false);
             }
             else
             {
@@ -65,11 +65,11 @@ namespace NServiceBus
                 {
                     var outgoingMessage = new OutgoingMessage(context.MessageId, data.Headers, data.State);
                     var transportOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(data.Destination));
-                    await dispatcher.Dispatch(new TransportOperations(transportOperation), context.TransportTransaction, context.Context).ConfigureAwait(false);
+                    await dispatcher.Dispatch(new TransportOperations(transportOperation), context.TransportTransaction, context.Extensions).ConfigureAwait(false);
                     return;
                 }
 
-                await persister.Add(data, context.Context).ConfigureAwait(false);
+                await persister.Add(data, context.Extensions).ConfigureAwait(false);
 
                 poller.NewTimeoutRegistered(data.Time);
             }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
@@ -68,14 +68,14 @@
             var satelliteAddress = context.Settings.GetTransportAddress(satelliteLogicalAddress);
 
             context.AddSatelliteReceiver("Timeout Dispatcher Processor", satelliteAddress, requiredTransactionSupport, pushRuntimeSettings, RecoverabilityPolicy,
-                (builder, pushContext) =>
+                (builder, messageContext) =>
                 {
                     var dispatchBehavior = new DispatchTimeoutBehavior(
                         builder.Build<IDispatchMessages>(),
                         builder.Build<IPersistTimeouts>(),
                         requiredTransactionSupport);
 
-                    return dispatchBehavior.Invoke(pushContext);
+                    return dispatchBehavior.Invoke(messageContext);
                 });
 
             return satelliteAddress;
@@ -87,7 +87,7 @@
             var satelliteAddress = context.Settings.GetTransportAddress(satelliteLogicalAddress);
 
             context.AddSatelliteReceiver("Timeout Message Processor", satelliteAddress, requiredTransactionSupport, pushRuntimeSettings, RecoverabilityPolicy,
-                (builder, pushContext) =>
+                (builder, messageContext) =>
                 {
                     var storeBehavior = new StoreTimeoutBehavior(
                         builder.Build<ExpiredTimeoutsPoller>(),
@@ -95,7 +95,7 @@
                         builder.Build<IPersistTimeouts>(),
                         context.Settings.EndpointName().ToString());
 
-                    return storeBehavior.Invoke(pushContext);
+                    return storeBehavior.Invoke(messageContext);
                 });
 
             context.Settings.Get<TimeoutManagerAddressConfiguration>().Set(satelliteAddress);

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -27,7 +27,7 @@ namespace NServiceBus
                 var message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.Body);
                 var context = new TransportReceiveContext(message, messageContext.TransportTransaction, messageContext.ReceiveCancellationTokenSource, rootContext);
 
-                context.Extensions.Merge(messageContext.Context);
+                context.Extensions.Merge(messageContext.Extensions);
 
                 await mainPipeline.Invoke(context).ConfigureAwait(false);
 

--- a/src/NServiceBus.Core/Pipeline/SatellitePipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/SatellitePipelineExecutor.cs
@@ -14,7 +14,7 @@
 
         public Task Invoke(MessageContext messageContext)
         {
-            messageContext.Context.Set(messageContext.TransportTransaction);
+            messageContext.Extensions.Set(messageContext.TransportTransaction);
 
             return satelliteDefinition.OnMessage(builder, messageContext);
         }

--- a/src/NServiceBus.Core/Recoverability/Recoverability.cs
+++ b/src/NServiceBus.Core/Recoverability/Recoverability.cs
@@ -208,7 +208,7 @@
                     var outgoingMessage = new OutgoingMessage(messageContext.MessageId, outgoingHeaders, messageContext.Body);
                     var outgoingOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(mainQueueTransportAddress));
 
-                    return messageDispatcher.Dispatch(new TransportOperations(outgoingOperation), messageContext.TransportTransaction, messageContext.Context);
+                    return messageDispatcher.Dispatch(new TransportOperations(outgoingOperation), messageContext.TransportTransaction, messageContext.Extensions);
                 });
         }
 

--- a/src/NServiceBus.Core/Transports/MessageContext.cs
+++ b/src/NServiceBus.Core/Transports/MessageContext.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// Allows the transport to pass relevant info to the pipeline.
     /// </summary>
-    public class MessageContext
+    public class MessageContext : IExtendable
     {
         /// <summary>
         /// Initializes the context.
@@ -21,20 +21,20 @@
         /// It also allows the transport to communicate to the pipeline to abort if possible. Transports should check if the token
         /// has been aborted after invoking the pipeline and roll back the message accordingly.
         /// </param>
-        /// <param name="context">Any context that the transport wants to be available on the pipeline.</param>
-        public MessageContext(string messageId, Dictionary<string, string> headers, byte[] body, TransportTransaction transportTransaction, CancellationTokenSource receiveCancellationTokenSource, ContextBag context)
+        /// <param name="extensions">A <see cref="ContextBag" /> which can be used to extend the current object.</param>
+        public MessageContext(string messageId, Dictionary<string, string> headers, byte[] body, TransportTransaction transportTransaction, CancellationTokenSource receiveCancellationTokenSource, ContextBag extensions)
         {
             Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
             Guard.AgainstNull(nameof(body), body);
             Guard.AgainstNull(nameof(headers), headers);
             Guard.AgainstNull(nameof(transportTransaction), transportTransaction);
             Guard.AgainstNull(nameof(receiveCancellationTokenSource), receiveCancellationTokenSource);
-            Guard.AgainstNull(nameof(context), context);
+            Guard.AgainstNull(nameof(extensions), extensions);
 
             Headers = headers;
             Body = body;
             MessageId = messageId;
-            Context = context;
+            Extensions = extensions;
             TransportTransaction = transportTransaction;
             ReceiveCancellationTokenSource = receiveCancellationTokenSource;
         }
@@ -68,6 +68,12 @@
         /// <summary>
         /// Context provided by the transport.
         /// </summary>
-        public ContextBag Context { get; }
+        [ObsoleteEx(ReplacementTypeOrMember = "Extensions", RemoveInVersion = "7")]
+        public ContextBag Context => Extensions;
+
+        /// <summary>
+        /// A <see cref="ContextBag" /> which can be used to extend the current object.
+        /// </summary>
+        public ContextBag Extensions { get; }
     }
 }


### PR DESCRIPTION
Aligning context with what has been proposed by @andreasohlund in #4468 

According to https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md this is a non-breaking change

> Adding an interface implementation to a type
> This is acceptable because it will not adversely affect existing clients. Any changes which could be made to the type being changed in this situation, will have to work within the boundaries of acceptable changes defined here, in order for the new implementation to remain acceptable. Extreme caution is urged when adding interfaces that directly affect the ability of the designer or serializer to generate code or data, that cannot be consumed down-level. An example is the ISerializable interface.

