### PR TITLE
Remove audit configuration API in acceptance testing framework

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Customization/EndpointConfigurationExtensions.cs
+++ b/src/NServiceBus.AcceptanceTesting/Customization/EndpointConfigurationExtensions.cs
@@ -14,5 +14,11 @@ namespace NServiceBus.AcceptanceTesting.Customization
         {
             config.TypesToScanInternal(typesToScan);
         }
+
+        public static void AuditProcessedMessagesTo<TAuditEndoint>(this EndpointConfiguration config)
+        {
+            var auditEndpointAddress = Conventions.EndpointNamingConvention(typeof(TAuditEndoint));
+            config.AuditProcessedMessagesTo(auditEndpointAddress);
+        }
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
@@ -18,12 +18,6 @@
             return this;
         }
 
-        public EndpointConfigurationBuilder AuditTo(string addressOfAuditQueue)
-        {
-            configuration.AddressOfAuditQueue = addressOfAuditQueue;
-            return this;
-        }
-
         public EndpointConfigurationBuilder CustomMachineName(string customMachineName)
         {
             configuration.CustomMachineName = customMachineName;
@@ -88,11 +82,7 @@
 
                 if (!configuration.SendOnly)
                 {
-                    if (configuration.AddressOfAuditQueue != null)
-                    {
-                        endpointConfiguration.AuditProcessedMessagesTo(configuration.AddressOfAuditQueue);
-                    }
-                    else if (configuration.AuditEndpoint != null)
+                    if (configuration.AuditEndpoint != null)
                     {
                         if (!routingTable.ContainsKey(configuration.AuditEndpoint))
                         {

--- a/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
@@ -3,19 +3,12 @@
     using System;
     using System.Collections.Generic;
     using Support;
-    using System.Configuration;
 
     public class EndpointConfigurationBuilder : IEndpointConfigurationFactory
     {
         public EndpointConfigurationBuilder()
         {
             configuration.EndpointMappings = new Dictionary<Type, Type>();
-        }
-
-        public EndpointConfigurationBuilder AuditTo<T>()
-        {
-            configuration.AuditEndpoint = typeof(T);
-            return this;
         }
 
         public EndpointConfigurationBuilder CustomMachineName(string customMachineName)
@@ -71,27 +64,14 @@
 
             publisherMetadata?.Invoke(configuration.PublisherMetadata);
 
-            configuration.GetConfiguration = async (runDescriptor, routingTable) =>
+            configuration.GetConfiguration = async runDescriptor =>
             {
                 var endpointSetupTemplate = new T();
-                var scenarioConfigSource = new ScenarioConfigSource(configuration, routingTable);
+                var scenarioConfigSource = new ScenarioConfigSource(configuration);
                 var endpointConfiguration = await endpointSetupTemplate.GetConfiguration(runDescriptor, configuration, scenarioConfigSource, bc =>
                 {
                     configurationBuilderCustomization(bc, runDescriptor);
                 }).ConfigureAwait(false);
-
-                if (!configuration.SendOnly)
-                {
-                    if (configuration.AuditEndpoint != null)
-                    {
-                        if (!routingTable.ContainsKey(configuration.AuditEndpoint))
-                        {
-                            throw new ConfigurationErrorsException($"{configuration.AuditEndpoint} was not found in routingTable. Ensure that WithEndpoint<{configuration.AuditEndpoint}>() method is called in the test.");
-                        }
-
-                        endpointConfiguration.AuditProcessedMessagesTo(routingTable[configuration.AuditEndpoint]);
-                    }
-                }
 
                 return endpointConfiguration;
             };

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointCustomizationConfiguration.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointCustomizationConfiguration.cs
@@ -20,7 +20,7 @@
 
         public IList<Type> TypesToInclude { get; set; }
 
-        public Func<RunDescriptor, IDictionary<Type, string>, Task<EndpointConfiguration>> GetConfiguration { get; set; }
+        public Func<RunDescriptor, Task<EndpointConfiguration>> GetConfiguration { get; set; }
 
         public PublisherMetadata PublisherMetadata { get; private set; }
 
@@ -43,7 +43,6 @@
 
         public string CustomEndpointName { get; set; }
 
-        public Type AuditEndpoint { get; set; }
         public bool SendOnly { get; set; }
 
         string endpointName;

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointCustomizationConfiguration.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointCustomizationConfiguration.cs
@@ -37,8 +37,6 @@
 
         public Type BuilderType { get; set; }
 
-        public string AddressOfAuditQueue { get; set; }
-
         public IDictionary<Type, object> UserDefinedConfigSections { get; private set; }
 
         public string CustomMachineName { get; set; }

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -23,8 +23,7 @@
 
         public bool FailOnErrorMessage => !behavior.DoNotFailOnErrorMessages;
 
-        public async Task Initialize(RunDescriptor run, EndpointBehavior endpointBehavior,
-            IDictionary<Type, string> routingTable, string endpointName)
+        public async Task Initialize(RunDescriptor run, EndpointBehavior endpointBehavior, string endpointName)
         {
             try
             {
@@ -46,7 +45,7 @@
                 {
                     throw new Exception($"Missing EndpointSetup<T> in the constructor of {endpointName} endpoint.");
                 }
-                endpointConfiguration = await configuration.GetConfiguration(run, routingTable).ConfigureAwait(false);
+                endpointConfiguration = await configuration.GetConfiguration(run).ConfigureAwait(false);
                 RegisterInheritanceHierarchyOfContextInSettings(scenarioContext);
 
                 endpointBehavior.CustomConfig.ForEach(customAction => customAction(endpointConfiguration, scenarioContext));

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioConfigSource.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioConfigSource.cs
@@ -1,20 +1,17 @@
 ﻿namespace NServiceBus.AcceptanceTesting.Support
 {
-    using System;
-    using System.Collections.Generic;
     using System.Configuration;
     using Config;
     using Config.ConfigurationSource;
+    using Customization;
 
     public class ScenarioConfigSource : IConfigurationSource
     {
         EndpointCustomizationConfiguration configuration;
-        IDictionary<Type, string> routingTable;
 
-        public ScenarioConfigSource(EndpointCustomizationConfiguration configuration, IDictionary<Type, string> routingTable)
+        public ScenarioConfigSource(EndpointCustomizationConfiguration configuration)
         {
             this.configuration = configuration;
-            this.routingTable = routingTable;
         }
 
         public T GetConfiguration<T>() where T : class, new()
@@ -54,7 +51,7 @@
                      {
                          AssemblyName = messageType.Assembly.FullName,
                          TypeFullName = messageType.FullName,
-                         Endpoint = routingTable[endpoint]
+                         Endpoint = Conventions.EndpointNamingConvention(endpoint)
                      });
             }
 

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -162,18 +162,6 @@
             return runResult;
         }
 
-        static IDictionary<Type, string> CreateRoutingTable(IEnumerable<EndpointBehavior> behaviorDescriptors)
-        {
-            var routingTable = new Dictionary<Type, string>();
-
-            foreach (var behaviorDescriptor in behaviorDescriptors)
-            {
-                routingTable[behaviorDescriptor.EndpointBuilderType] = GetEndpointNameForRun(behaviorDescriptor);
-            }
-
-            return routingTable;
-        }
-
         static void PrintSettings(IEnumerable<KeyValuePair<string, object>> settings)
         {
             Console.WriteLine();
@@ -329,11 +317,9 @@
 
         static async Task<EndpointRunner[]> InitializeRunners(RunDescriptor runDescriptor, List<EndpointBehavior> endpointBehaviors)
         {
-            var routingTable = CreateRoutingTable(endpointBehaviors);
-
             var runnerInitializations = endpointBehaviors.Select(async endpointBehavior =>
             {
-                var endpointName = GetEndpointNameForRun(endpointBehavior);
+                var endpointName = Conventions.EndpointNamingConvention(endpointBehavior.EndpointBuilderType);
 
                 if (endpointName.Length > 77)
                 {
@@ -344,7 +330,7 @@
 
                 try
                 {
-                    await runner.Initialize(runDescriptor, endpointBehavior, routingTable, endpointName).ConfigureAwait(false);
+                    await runner.Initialize(runDescriptor, endpointBehavior, endpointName).ConfigureAwait(false);
                 }
                 catch (Exception)
                 {
@@ -365,11 +351,6 @@
                 Console.WriteLine(e);
                 throw;
             }
-        }
-
-        static string GetEndpointNameForRun(EndpointBehavior endpointBehavior)
-        {
-            return Conventions.EndpointNamingConvention(endpointBehavior.EndpointBuilderType);
         }
     }
 

--- a/src/NServiceBus.AcceptanceTests/Audit/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_a_message_is_audited.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
     using EndpointTemplates;
     using MessageMutator;
     using NUnit.Framework;
@@ -43,8 +44,8 @@
         {
             public EndpointWithAuditOn()
             {
-                EndpointSetup<DefaultServer>()
-                    .AuditTo<AuditSpyEndpoint>();
+                EndpointSetup<DefaultServer>(c => c
+                    .AuditProcessedMessagesTo<AuditSpyEndpoint>());
             }
 
             class BodyMutator : IMutateIncomingTransportMessages, INeedInitialization
@@ -124,7 +125,7 @@
             }
         }
 
-        
+
         public class MessageToBeAudited : IMessage
         {
             public Guid RunId { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Audit/When_a_replymessage_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_a_replymessage_is_audited.cs
@@ -7,6 +7,7 @@
     using Features;
     using MessageMutator;
     using NUnit.Framework;
+    using AcceptanceTesting.Customization;
 
     public class When_a_replymessage_is_audited : NServiceBusAcceptanceTest
     {
@@ -60,9 +61,12 @@
         {
             public EndpointWithAuditOn()
             {
-                EndpointSetup<DefaultServer>(c => c.DisableFeature<Outbox>())
-                    .AddMapping<Request>(typeof(Server))
-                    .AuditTo<AuditSpyEndpoint>();
+                EndpointSetup<DefaultServer>(c =>
+                    {
+                        c.DisableFeature<Outbox>();
+                        c.AuditProcessedMessagesTo<AuditSpyEndpoint>();
+                    })
+                    .AddMapping<Request>(typeof(Server));
             }
 
             public class MessageToBeAuditedHandler : IHandleMessages<ResponseToBeAudited>

--- a/src/NServiceBus.AcceptanceTests/Audit/When_auditing.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_auditing.cs
@@ -43,7 +43,7 @@
         {
             public EndpointWithAuditOff()
             {
-                // Although the AuditTo seems strange here, this test tries to fake the scenario where
+                // Although the AuditProcessedMessagesTo seems strange here, this test tries to fake the scenario where
                 // even though the user has specified audit config, because auditing is explicitly turned
                 // off, no messages should be audited.
                 EndpointSetup<DefaultServer>(c =>

--- a/src/NServiceBus.AcceptanceTests/Audit/When_auditing.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_auditing.cs
@@ -2,6 +2,7 @@
 {
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
@@ -45,8 +46,11 @@
                 // Although the AuditTo seems strange here, this test tries to fake the scenario where
                 // even though the user has specified audit config, because auditing is explicitly turned
                 // off, no messages should be audited.
-                EndpointSetup<DefaultServer>(c => c.DisableFeature<Audit>())
-                    .AuditTo<EndpointThatHandlesAuditMessages>();
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.DisableFeature<Audit>();
+                    c.AuditProcessedMessagesTo<EndpointThatHandlesAuditMessages>();
+                });
             }
 
             class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
@@ -65,8 +69,7 @@
         {
             public EndpointWithAuditOn()
             {
-                EndpointSetup<DefaultServer>()
-                    .AuditTo<EndpointThatHandlesAuditMessages>();
+                EndpointSetup<DefaultServer>(c => c.AuditProcessedMessagesTo<EndpointThatHandlesAuditMessages>());
             }
 
             class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>

--- a/src/NServiceBus.AcceptanceTests/Audit/When_auditing_message_with_TimeToBeReceived.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_auditing_message_with_TimeToBeReceived.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
     using EndpointTemplates;
     using NUnit.Framework;
 
@@ -31,8 +32,7 @@
         {
             public EndpointWithAuditOn()
             {
-                EndpointSetup<DefaultServer>()
-                    .AuditTo<EndpointThatHandlesAuditMessages>();
+                EndpointSetup<DefaultServer>(c => c.AuditProcessedMessagesTo<EndpointThatHandlesAuditMessages>());
             }
 
             class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>

--- a/src/NServiceBus.AcceptanceTests/Causation/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Causation/When_a_message_is_audited.cs
@@ -2,6 +2,7 @@
 {
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
     using EndpointTemplates;
     using NUnit.Framework;
 
@@ -33,7 +34,7 @@
         {
             public CausationEndpoint()
             {
-                EndpointSetup<DefaultServer>().AuditTo<AuditSpyEndpoint>();
+                EndpointSetup<DefaultServer>(c => c.AuditProcessedMessagesTo<AuditSpyEndpoint>());
             }
 
             public Context Context { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Hosting/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Hosting/When_a_message_is_audited.cs
@@ -2,6 +2,7 @@
 {
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
     using EndpointTemplates;
     using NUnit.Framework;
 
@@ -35,8 +36,8 @@
         {
             public EndpointWithAuditOn()
             {
-                EndpointSetup<DefaultServer>()
-                    .AuditTo<AuditSpyEndpoint>();
+                EndpointSetup<DefaultServer>(c => c
+                    .AuditProcessedMessagesTo<AuditSpyEndpoint>());
             }
 
             public class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>

--- a/src/NServiceBus.AcceptanceTests/Licensing/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Licensing/When_a_message_is_audited.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
     using EndpointTemplates;
     using Logging;
     using NUnit.Framework;
@@ -57,8 +58,11 @@
         {
             public EndpointWithAuditOn()
             {
-                EndpointSetup<DefaultServer>(c => c.License(ExpiredLicense))
-                    .AuditTo<AuditSpyEndpoint>();
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.License(ExpiredLicense);
+                    c.AuditProcessedMessagesTo<AuditSpyEndpoint>();
+                });
             }
 
             public class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>

--- a/src/NServiceBus.AcceptanceTests/Performance/When_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/When_message_is_audited.cs
@@ -6,6 +6,7 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using NUnit.Framework;
+    using AcceptanceTesting.Customization;
 
     public class When_message_is_audited : NServiceBusAcceptanceTest
     {
@@ -42,8 +43,8 @@
         {
             public EndpointWithAuditOn()
             {
-                EndpointSetup<DefaultServer>()
-                    .AuditTo<EndpointThatHandlesAuditMessages>();
+                EndpointSetup<DefaultServer>(c => c
+                    .AuditProcessedMessagesTo<EndpointThatHandlesAuditMessages>());
             }
 
             class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>

--- a/src/NServiceBus.AcceptanceTests/Performance/When_message_is_faulted.cs
+++ b/src/NServiceBus.AcceptanceTests/Performance/When_message_is_faulted.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
     using EndpointTemplates;
     using NUnit.Framework;
 
@@ -51,7 +52,11 @@
         {
             public EndpointWithAuditOn()
             {
-                EndpointSetup<DefaultServer>((c, r) => { c.SendFailedMessagesTo("errorQueueForAcceptanceTest"); }).AuditTo<EndpointThatHandlesAuditMessages>();
+                EndpointSetup<DefaultServer>((c, r) =>
+                {
+                    c.SendFailedMessagesTo("errorQueueForAcceptanceTest");
+                    c.AuditProcessedMessagesTo<EndpointThatHandlesAuditMessages>();
+                });
             }
 
             class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>

--- a/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Reliability/Outbox/When_a_message_is_audited.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
     using Configuration.AdvanceExtensibility;
     using EndpointTemplates;
     using Pipeline;
@@ -42,8 +43,8 @@
                         b.GetSettings().Set("DisableOutboxTransportCheck", true);
                         b.EnableOutbox();
                         b.Pipeline.Register("BlowUpAfterDispatchBehavior", new BlowUpAfterDispatchBehavior(), "For testing");
-                    })
-                    .AuditTo<AuditSpyEndpoint>();
+                        b.AuditProcessedMessagesTo<AuditSpyEndpoint>();
+                    });
             }
 
             class BlowUpAfterDispatchBehavior : IBehavior<IBatchDispatchContext, IBatchDispatchContext>


### PR DESCRIPTION
It becomes much cleaner if we just use the `EndpointConfiguration` API instead. added a little extension method which does the type -> address translation.