### PR TITLE
Add TreatAsErrorFromVersion attribute

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1436,14 +1436,15 @@ namespace NServiceBus.Config
         Base64 = 1,
     }
     [System.ObsoleteAttribute("Logging configuration via configuration section is discouraged. Use `LogManager.U" +
-        "se<DefaultFactory>()` instead. Will be removed in version 7.0.0.", true)]
+        "se<DefaultFactory>()` instead. Will be treated as an error from version 7.0.0. W" +
+        "ill be removed in version 8.0.0.", false)]
     public class Logging : System.Configuration.ConfigurationSection
     {
         public Logging() { }
         [System.Configuration.ConfigurationPropertyAttribute("Threshold", DefaultValue="Info", IsRequired=true)]
         [System.ObsoleteAttribute("Logging configuration via configuration section is discouraged. Use `LogManager.U" +
-            "se<DefaultFactory>().Level(LogLevel)` instead. Will be removed in version 7.0.0." +
-            "", true)]
+            "se<DefaultFactory>().Level(LogLevel)` instead. Will be treated as an error from " +
+            "version 7.0.0. Will be removed in version 8.0.0.", false)]
         public string Threshold { get; set; }
     }
     [System.ObsoleteAttribute("Use `EndpointConfiguration.EnlistWithLegacyMSMQDistributor` instead. Will be remo" +
@@ -1495,13 +1496,15 @@ namespace NServiceBus.Config
         public void RemoveAt(int index) { }
     }
     [System.ObsoleteAttribute("Error queue configuration via configuration section is discouraged. Use `Endpoint" +
-        "Configuration.SendFailedMessagesTo` instead. Will be removed in version 7.0.0.", true)]
+        "Configuration.SendFailedMessagesTo` instead. Will be treated as an error from ve" +
+        "rsion 7.0.0. Will be removed in version 8.0.0.", false)]
     public class MessageForwardingInCaseOfFaultConfig : System.Configuration.ConfigurationSection
     {
         public MessageForwardingInCaseOfFaultConfig() { }
         [System.Configuration.ConfigurationPropertyAttribute("ErrorQueue", IsRequired=true)]
         [System.ObsoleteAttribute("Error queue configuration via configuration section is discouraged. Use `Endpoint" +
-            "Configuration.SendFailedMessagesTo` instead. Will be removed in version 7.0.0.", true)]
+            "Configuration.SendFailedMessagesTo` instead. Will be treated as an error from ve" +
+            "rsion 7.0.0. Will be removed in version 8.0.0.", false)]
         public string ErrorQueue { get; set; }
     }
     public class MsmqSubscriptionStorageConfig : System.Configuration.ConfigurationSection

--- a/src/NServiceBus.Core/Logging/Logging.cs
+++ b/src/NServiceBus.Core/Logging/Logging.cs
@@ -8,7 +8,8 @@ namespace NServiceBus.Config
     [ObsoleteEx(
         Message = "Logging configuration via configuration section is discouraged.",
         ReplacementTypeOrMember = "LogManager.Use<DefaultFactory>()",
-        RemoveInVersion = "7")]
+        TreatAsErrorFromVersion = "7",
+        RemoveInVersion = "8")]
     public class Logging : ConfigurationSection
     {
         /// <summary>
@@ -18,7 +19,8 @@ namespace NServiceBus.Config
         [ObsoleteEx(
             Message = "Logging configuration via configuration section is discouraged.",
             ReplacementTypeOrMember = "LogManager.Use<DefaultFactory>().Level(LogLevel)",
-            RemoveInVersion = "7")]
+            TreatAsErrorFromVersion = "7",
+            RemoveInVersion = "8")]
         public string Threshold
         {
             get { return this["Threshold"] as string; }

--- a/src/NServiceBus.Core/Recoverability/Faults/MessageForwardingInCaseOfFaultConfig.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/MessageForwardingInCaseOfFaultConfig.cs
@@ -5,14 +5,22 @@ namespace NServiceBus.Config
     /// <summary>
     /// Message Forwarding In Case Of Fault Config.
     /// </summary>
-    [ObsoleteEx(Message = "Error queue configuration via configuration section is discouraged.", ReplacementTypeOrMember = "EndpointConfiguration.SendFailedMessagesTo", RemoveInVersion = "7")]
+    [ObsoleteEx(
+        Message = "Error queue configuration via configuration section is discouraged.",
+        ReplacementTypeOrMember = "EndpointConfiguration.SendFailedMessagesTo",
+        TreatAsErrorFromVersion = "7",
+        RemoveInVersion = "8")]
     public class MessageForwardingInCaseOfFaultConfig : ConfigurationSection
     {
         /// <summary>
         /// The queue to which errors will be forwarded.
         /// </summary>
         [ConfigurationProperty("ErrorQueue", IsRequired = true)]
-        [ObsoleteEx(Message = "Error queue configuration via configuration section is discouraged.", ReplacementTypeOrMember = "EndpointConfiguration.SendFailedMessagesTo", RemoveInVersion = "7")]
+        [ObsoleteEx(
+            Message = "Error queue configuration via configuration section is discouraged.",
+            ReplacementTypeOrMember = "EndpointConfiguration.SendFailedMessagesTo",
+            TreatAsErrorFromVersion = "7",
+            RemoveInVersion = "8")]
         public string ErrorQueue
         {
             get { return this["ErrorQueue"] as string; }


### PR DESCRIPTION
Adding `TreatAsErrorFromVersion ` to avoid compilation errors.
Switched the removal version to 8, as it seems to be rather useless to have them both at the same value and we can keep them around just without the ConfigSection base class.