### PR TITLE
Obsolete IProvideConfiguration

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
+++ b/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
@@ -27,7 +27,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
     <NoWarn>436</NoWarn>
   </PropertyGroup>

--- a/src/NServiceBus.AcceptanceTesting/Support/IEndpointSetupTemplate.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/IEndpointSetupTemplate.cs
@@ -1,5 +1,4 @@
-﻿#pragma warning disable CS0618
-namespace NServiceBus.AcceptanceTesting.Support
+﻿namespace NServiceBus.AcceptanceTesting.Support
 {
     using System;
     using System.Threading.Tasks;
@@ -7,7 +6,8 @@ namespace NServiceBus.AcceptanceTesting.Support
 
     public interface IEndpointSetupTemplate
     {
+#pragma warning disable CS0618
         Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointConfiguration, IConfigurationSource configSource, Action<EndpointConfiguration> configurationBuilderCustomization);
+#pragma warning restore CS0618
     }
 }
-#pragma warning restore CS0618

--- a/src/NServiceBus.AcceptanceTesting/Support/IEndpointSetupTemplate.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/IEndpointSetupTemplate.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus.AcceptanceTesting.Support
+﻿#pragma warning disable CS0618
+namespace NServiceBus.AcceptanceTesting.Support
 {
     using System;
     using System.Threading.Tasks;
@@ -9,3 +10,4 @@
         Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointConfiguration, IConfigurationSource configSource, Action<EndpointConfiguration> configurationBuilderCustomization);
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioConfigSource.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioConfigSource.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus.AcceptanceTesting.Support
+﻿#pragma warning disable CS0618
+namespace NServiceBus.AcceptanceTesting.Support
 {
     using System.Configuration;
     using Config.ConfigurationSource;
@@ -26,3 +27,4 @@
         }
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.AcceptanceTests/Core/Config/When_multiple_configuration_providers.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Config/When_multiple_configuration_providers.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.AcceptanceTests.Config
+﻿// test will be removed in the next major version
+#pragma warning disable CS0618
+namespace NServiceBus.AcceptanceTests.Config
 {
     using System;
     using AcceptanceTesting;
@@ -58,3 +60,4 @@
         }
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.AcceptanceTests/Core/Config/When_only_abstract_config_override_is_found.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Config/When_only_abstract_config_override_is_found.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.AcceptanceTests.Config
+﻿// disable obsolete warnings. Tests will be removed in next major version
+#pragma warning disable CS0618
+namespace NServiceBus.AcceptanceTests.Config
 {
     using System;
     using System.Threading.Tasks;
@@ -36,3 +38,4 @@
         }
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_config.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Encryption/When_using_Rijndael_with_config.cs
@@ -7,9 +7,8 @@ namespace NServiceBus.AcceptanceTests.Core.Encryption
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using NServiceBus.Config;
-    using NServiceBus.Config.ConfigurationSource;
     using NUnit.Framework;
+    using System.Text;
 
     public class When_using_Rijndael_with_config : NServiceBusAcceptanceTest
     {
@@ -65,7 +64,7 @@ namespace NServiceBus.AcceptanceTests.Core.Encryption
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>(builder => builder.RijndaelEncryptionService());
+                EndpointSetup<DefaultServer>(builder => builder.RijndaelEncryptionService("1st", Encoding.ASCII.GetBytes("gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6")));
             }
 
             public class Handler : IHandleMessages<MessageWithSecretData>
@@ -110,18 +109,6 @@ namespace NServiceBus.AcceptanceTests.Core.Encryption
         public class MySecretSubProperty
         {
             public WireEncryptedString Secret { get; set; }
-        }
-
-        public class ConfigureEncryption : IProvideConfiguration<RijndaelEncryptionServiceConfig>
-        {
-            public RijndaelEncryptionServiceConfig GetConfiguration()
-            {
-                return new RijndaelEncryptionServiceConfig
-                {
-                    KeyIdentifier = "1st",
-                    Key = "gdDbqRpqdRbTs3mhdZh9qCaDaxJXl+e6"
-                };
-            }
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultPublisher.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultPublisher.cs
@@ -1,4 +1,3 @@
-
 namespace NServiceBus.AcceptanceTests.EndpointTemplates
 {
     using System;

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultPublisher.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultPublisher.cs
@@ -1,3 +1,4 @@
+#pragma warning disable CS0618
 namespace NServiceBus.AcceptanceTests.EndpointTemplates
 {
     using System;
@@ -13,3 +14,4 @@ namespace NServiceBus.AcceptanceTests.EndpointTemplates
         }
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultPublisher.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultPublisher.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS0618
+
 namespace NServiceBus.AcceptanceTests.EndpointTemplates
 {
     using System;
@@ -8,10 +8,11 @@ namespace NServiceBus.AcceptanceTests.EndpointTemplates
 
     public class DefaultPublisher : IEndpointSetupTemplate
     {
+#pragma warning disable CS0618
         public Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointConfiguration, IConfigurationSource configSource, Action<EndpointConfiguration> configurationBuilderCustomization)
+#pragma warning restore CS0618
         {
             return new DefaultServer().GetConfiguration(runDescriptor, endpointConfiguration, configSource, configurationBuilderCustomization);
         }
     }
 }
-#pragma warning restore CS0618

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
@@ -21,7 +21,9 @@
             this.typesToInclude = typesToInclude;
         }
 
+#pragma warning disable CS0618
         public async Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointConfiguration, IConfigurationSource configSource, Action<EndpointConfiguration> configurationBuilderCustomization)
+#pragma warning restore CS0618
         {
             var settings = runDescriptor.Settings;
 

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ServerWithNoDefaultPersistenceDefinitions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ServerWithNoDefaultPersistenceDefinitions.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CS0618
+﻿
 namespace NServiceBus.AcceptanceTests.EndpointTemplates
 {
     using System;
@@ -21,7 +21,9 @@ namespace NServiceBus.AcceptanceTests.EndpointTemplates
             this.typesToInclude = typesToInclude;
         }
 
+#pragma warning disable CS0618
         public async Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointConfiguration, IConfigurationSource configSource, Action<EndpointConfiguration> configurationBuilderCustomization)
+#pragma warning restore CS0618
         {
             var settings = runDescriptor.Settings;
 
@@ -52,4 +54,3 @@ namespace NServiceBus.AcceptanceTests.EndpointTemplates
         List<Type> typesToInclude;
     }
 }
-#pragma warning restore CS0618

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ServerWithNoDefaultPersistenceDefinitions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ServerWithNoDefaultPersistenceDefinitions.cs
@@ -1,5 +1,4 @@
-﻿
-namespace NServiceBus.AcceptanceTests.EndpointTemplates
+﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
 {
     using System;
     using System.Collections.Generic;

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ServerWithNoDefaultPersistenceDefinitions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ServerWithNoDefaultPersistenceDefinitions.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
+﻿#pragma warning disable CS0618
+namespace NServiceBus.AcceptanceTests.EndpointTemplates
 {
     using System;
     using System.Collections.Generic;
@@ -51,3 +52,4 @@
         List<Type> typesToInclude;
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1640,11 +1640,17 @@ namespace NServiceBus.Config.ConfigurationSource
     {
         public DefaultConfigurationSource() { }
     }
+    [System.ObsoleteAttribute("The use of the IConfigurationSource is discouraged. Code configuration is prefere" +
+        "d over configuration sources. Will be treated as an error from version 7.0.0. Wi" +
+        "ll be removed in version 8.0.0.", false)]
     public interface IConfigurationSource
     {
         T GetConfiguration<T>()
             where T :  class, new ();
     }
+    [System.ObsoleteAttribute("The use of the IConfigurationSource is discouraged. Code configuration is prefere" +
+        "d over configuration sources. Will be treated as an error from version 7.0.0. Wi" +
+        "ll be removed in version 8.0.0.", false)]
     public interface IProvideConfiguration<T>
     {
         T GetConfiguration();

--- a/src/NServiceBus.Core/ConfigurationSource/IConfigurationSource.cs
+++ b/src/NServiceBus.Core/ConfigurationSource/IConfigurationSource.cs
@@ -6,6 +6,9 @@ namespace NServiceBus.Config.ConfigurationSource
     /// If you want to change the source of only a specific set of configuration data,
     /// implement <see cref="IProvideConfiguration&lt;T&gt;" /> instead.
     /// </summary>
+    [ObsoleteEx(Message = "The use of the IConfigurationSource is discouraged. Code configuration is prefered over configuration sources.",
+        RemoveInVersion = "8.0",
+        TreatAsErrorFromVersion = "7.0")]
     public interface IConfigurationSource
     {
         /// <summary>
@@ -17,6 +20,9 @@ namespace NServiceBus.Config.ConfigurationSource
     /// <summary>
     /// Abstraction of a configuration source for a given piece of configuration data.
     /// </summary>
+    [ObsoleteEx(Message = "The use of the IConfigurationSource is discouraged. Code configuration is prefered over configuration sources.",
+        RemoveInVersion = "8.0",
+        TreatAsErrorFromVersion = "7.0")]
     public interface IProvideConfiguration<T>
     {
         /// <summary>

--- a/src/NServiceBus.Msmq.AcceptanceTests/Distributor/DistributorEndpointTemplate.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/Distributor/DistributorEndpointTemplate.cs
@@ -23,6 +23,8 @@
             public bool IsWorkerRegistered => WorkerSessionId != null;
         }
 
+// Disable obsolete warning until MessageEndpointMappings has been removed from config and we can remove the parameter completetely
+#pragma warning disable CS0612, CS0619, CS0618
         public async Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointConfiguration, IConfigurationSource configSource, Action<EndpointConfiguration> configurationBuilderCustomization)
         {
             var config = await new DefaultServer(new List<Type>
@@ -34,6 +36,7 @@
             config.EnableFeature<FakeReadyMessageProcessor>();
             return config;
         }
+#pragma warning restore CS0612, CS0619, CS0618
 
         class FakeReadyMessageProcessor : Feature
         {

--- a/src/NServiceBus.Msmq.AcceptanceTests/Distributor/DistributorEndpointTemplate.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/Distributor/DistributorEndpointTemplate.cs
@@ -24,8 +24,9 @@
         }
 
 // Disable obsolete warning until MessageEndpointMappings has been removed from config and we can remove the parameter completetely
-#pragma warning disable CS0612, CS0619, CS0618
+#pragma warning disable CS0618
         public async Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointConfiguration, IConfigurationSource configSource, Action<EndpointConfiguration> configurationBuilderCustomization)
+#pragma warning restore CS0618
         {
             var config = await new DefaultServer(new List<Type>
             {
@@ -36,7 +37,7 @@
             config.EnableFeature<FakeReadyMessageProcessor>();
             return config;
         }
-#pragma warning restore CS0612, CS0619, CS0618
+
 
         class FakeReadyMessageProcessor : Feature
         {

--- a/src/NServiceBus.Msmq.AcceptanceTests/Distributor/DistributorEndpointTemplate.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/Distributor/DistributorEndpointTemplate.cs
@@ -38,7 +38,6 @@
             return config;
         }
 
-
         class FakeReadyMessageProcessor : Feature
         {
             protected override void Setup(FeatureConfigurationContext context)

--- a/src/NServiceBus.Msmq.AcceptanceTests/NServiceBus.Msmq.AcceptanceTests.csproj
+++ b/src/NServiceBus.Msmq.AcceptanceTests/NServiceBus.Msmq.AcceptanceTests.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>

--- a/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionStorage/When_subscription_exists_for_non_tx_endpoint.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionStorage/When_subscription_exists_for_non_tx_endpoint.cs
@@ -70,6 +70,8 @@
                 });
             }
 
+// Disable obsolete warning until MessageEndpointMappings has been removed from config and we can replace with code api
+#pragma warning disable CS0612, CS0619, CS0618
             class QueueNameOverride : IProvideConfiguration<MsmqSubscriptionStorageConfig>
             {
                 public MsmqSubscriptionStorageConfig GetConfiguration()
@@ -80,6 +82,7 @@
                     };
                 }
             }
+#pragma warning restore CS0612, CS0619, CS0618
         }
 
         public class Subscriber : EndpointConfigurationBuilder

--- a/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionStorage/When_subscription_exists_for_non_tx_endpoint.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionStorage/When_subscription_exists_for_non_tx_endpoint.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests.SubscriptionStorage
+﻿// Disable obsolete warning until MessageEndpointMappings has been removed from config
+#pragma warning disable CS0618
+namespace NServiceBus.Transport.Msmq.AcceptanceTests.SubscriptionStorage
 {
     using System.Messaging;
     using System.Threading.Tasks;
@@ -70,8 +72,6 @@
                 });
             }
 
-// Disable obsolete warning until MessageEndpointMappings has been removed from config and we can replace with code api
-#pragma warning disable CS0612, CS0619, CS0618
             class QueueNameOverride : IProvideConfiguration<MsmqSubscriptionStorageConfig>
             {
                 public MsmqSubscriptionStorageConfig GetConfiguration()
@@ -82,7 +82,6 @@
                     };
                 }
             }
-#pragma warning restore CS0612, CS0619, CS0618
         }
 
         public class Subscriber : EndpointConfigurationBuilder
@@ -115,3 +114,4 @@
         }
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionStorage/When_subscription_exists_for_tx_endpoint.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionStorage/When_subscription_exists_for_tx_endpoint.cs
@@ -69,6 +69,8 @@
                 });
             }
 
+            // Disable obsolete warning until MessageEndpointMappings has been removed from config and we can replace with code api
+#pragma warning disable CS0612, CS0619, CS0618
             class QueueNameOverride : IProvideConfiguration<MsmqSubscriptionStorageConfig>
             {
                 public MsmqSubscriptionStorageConfig GetConfiguration()
@@ -79,6 +81,7 @@
                     };
                 }
             }
+#pragma warning restore CS0612, CS0619, CS0618
         }
 
         public class Subscriber : EndpointConfigurationBuilder

--- a/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionStorage/When_subscription_exists_for_tx_endpoint.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionStorage/When_subscription_exists_for_tx_endpoint.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests.SubscriptionStorage
+﻿// Disable obsolete warning until MessageEndpointMappings has been removed
+#pragma warning disable CS0618
+namespace NServiceBus.Transport.Msmq.AcceptanceTests.SubscriptionStorage
 {
     using System.Messaging;
     using System.Threading.Tasks;
@@ -68,9 +70,7 @@
                     b.UsePersistence<MsmqPersistence>();
                 });
             }
-
-            // Disable obsolete warning until MessageEndpointMappings has been removed from config and we can replace with code api
-#pragma warning disable CS0612, CS0619, CS0618
+            
             class QueueNameOverride : IProvideConfiguration<MsmqSubscriptionStorageConfig>
             {
                 public MsmqSubscriptionStorageConfig GetConfiguration()
@@ -81,7 +81,6 @@
                     };
                 }
             }
-#pragma warning restore CS0612, CS0619, CS0618
         }
 
         public class Subscriber : EndpointConfigurationBuilder
@@ -110,3 +109,4 @@
         }
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionStorage/When_using_subscription_store_on_non_tx_endpoint.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionStorage/When_using_subscription_store_on_non_tx_endpoint.cs
@@ -62,6 +62,8 @@
                 });
             }
 
+// Disable obsolete warning until MessageEndpointMappings has been removed from config and we can replace with code api
+#pragma warning disable CS0612, CS0619, CS0618
             class QueueNameOverride : IProvideConfiguration<MsmqSubscriptionStorageConfig>
             {
                 public MsmqSubscriptionStorageConfig GetConfiguration()
@@ -72,6 +74,7 @@
                     };
                 }
             }
+#pragma warning restore CS0612, CS0619, CS0618
         }
 
         public class Subscriber : EndpointConfigurationBuilder

--- a/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionStorage/When_using_subscription_store_on_non_tx_endpoint.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionStorage/When_using_subscription_store_on_non_tx_endpoint.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests.SubscriptionStorage
+﻿// Disable obsolete warning until MessageEndpointMappings has been removed
+#pragma warning disable CS0618
+namespace NServiceBus.Transport.Msmq.AcceptanceTests.SubscriptionStorage
 {
     using System.Messaging;
     using System.Threading.Tasks;
@@ -62,8 +64,6 @@
                 });
             }
 
-// Disable obsolete warning until MessageEndpointMappings has been removed from config and we can replace with code api
-#pragma warning disable CS0612, CS0619, CS0618
             class QueueNameOverride : IProvideConfiguration<MsmqSubscriptionStorageConfig>
             {
                 public MsmqSubscriptionStorageConfig GetConfiguration()
@@ -74,7 +74,6 @@
                     };
                 }
             }
-#pragma warning restore CS0612, CS0619, CS0618
         }
 
         public class Subscriber : EndpointConfigurationBuilder
@@ -107,3 +106,4 @@
         }
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionStorage/When_using_subscription_store_on_tx_endpoint.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionStorage/When_using_subscription_store_on_tx_endpoint.cs
@@ -59,6 +59,8 @@
                 });
             }
 
+            // Disable obsolete warning until MessageEndpointMappings has been removed from config and we can replace with code api
+#pragma warning disable CS0612, CS0619, CS0618
             class QueueNameOverride : IProvideConfiguration<MsmqSubscriptionStorageConfig>
             {
                 public MsmqSubscriptionStorageConfig GetConfiguration()
@@ -69,6 +71,7 @@
                     };
                 }
             }
+#pragma warning restore CS0612, CS0619, CS0618
         }
 
         public class Subscriber : EndpointConfigurationBuilder

--- a/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionStorage/When_using_subscription_store_on_tx_endpoint.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/SubscriptionStorage/When_using_subscription_store_on_tx_endpoint.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests.SubscriptionStorage
+﻿// Disable obsolete warning until MessageEndpointMappings has been removed
+#pragma warning disable CS0618
+namespace NServiceBus.Transport.Msmq.AcceptanceTests.SubscriptionStorage
 {
     using System.Messaging;
     using System.Threading.Tasks;
@@ -59,8 +61,6 @@
                 });
             }
 
-            // Disable obsolete warning until MessageEndpointMappings has been removed from config and we can replace with code api
-#pragma warning disable CS0612, CS0619, CS0618
             class QueueNameOverride : IProvideConfiguration<MsmqSubscriptionStorageConfig>
             {
                 public MsmqSubscriptionStorageConfig GetConfiguration()
@@ -71,7 +71,6 @@
                     };
                 }
             }
-#pragma warning restore CS0612, CS0619, CS0618
         }
 
         public class Subscriber : EndpointConfigurationBuilder
@@ -100,3 +99,4 @@
         }
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_TimeToBeReceivedOnForwardedMessages_set_and_tx_scope_receives.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_TimeToBeReceivedOnForwardedMessages_set_and_tx_scope_receives.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests
+﻿#pragma warning disable CS0618
+namespace NServiceBus.Transport.Msmq.AcceptanceTests
 {
     using System;
     using AcceptanceTesting;
@@ -39,3 +40,4 @@
         }
     }
 }
+#pragma warning restore CS0618

--- a/src/NServiceBus.Msmq.AcceptanceTests/When_subscribing_with_address_containing_host_name.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/When_subscribing_with_address_containing_host_name.cs
@@ -1,4 +1,5 @@
-﻿namespace NServiceBus.Transport.Msmq.AcceptanceTests
+﻿#pragma warning disable CS0618
+namespace NServiceBus.Transport.Msmq.AcceptanceTests
 {
     using System.Threading.Tasks;
     using AcceptanceTesting;
@@ -78,3 +79,4 @@
         }
     }
 }
+#pragma warning restore CS0618


### PR DESCRIPTION
relates to https://github.com/Particular/PlatformDevelopment/issues/1153

I added TreatWarnignsAsErrors in some testing related projects as it helps to locate usages of obsoleted APIs.

@Particular/nservicebus-maintainers please review