### PR TITLE
Remove SendOnly from EndpointConfigurationBuilder

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
@@ -100,12 +100,5 @@
 
             return this;
         }
-
-        public EndpointConfigurationBuilder SendOnly()
-        {
-            configuration.SendOnly = true;
-
-            return this;
-        }
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointCustomizationConfiguration.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointCustomizationConfiguration.cs
@@ -41,8 +41,6 @@
 
         public string CustomEndpointName { get; set; }
 
-        public bool SendOnly { get; set; }
-
         string endpointName;
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -50,18 +50,10 @@
 
                 endpointBehavior.CustomConfig.ForEach(customAction => customAction(endpointConfiguration, scenarioContext));
 
-                if (configuration.SendOnly)
-                {
-                    endpointConfiguration.SendOnly();
-                }
-
                 startable = await Endpoint.Create(endpointConfiguration).ConfigureAwait(false);
 
-                if (!configuration.SendOnly)
-                {
-                    var transportInfrastructure = endpointConfiguration.GetSettings().Get<TransportInfrastructure>();
-                    scenarioContext.HasNativePubSubSupport = transportInfrastructure.OutboundRoutingPolicy.Publishes == OutboundRoutingType.Multicast;
-                }
+                var transportInfrastructure = endpointConfiguration.GetSettings().Get<TransportInfrastructure>();
+                scenarioContext.HasNativePubSubSupport = transportInfrastructure.OutboundRoutingPolicy.Publishes == OutboundRoutingType.Multicast;
             }
             catch (Exception ex)
             {

--- a/src/NServiceBus.AcceptanceTests/Core/Feature/When_registering_a_startup_task.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Feature/When_registering_a_startup_task.cs
@@ -32,7 +32,11 @@
         {
             public SendOnlyEndpoint()
             {
-                EndpointSetup<DefaultServer>(c => { c.EnableFeature<Bootstrapper>(); }).SendOnly();
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.SendOnly();
+                    c.EnableFeature<Bootstrapper>();
+                });
             }
 
             public class Bootstrapper : Feature

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_sending_from_a_send_only.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_sending_from_a_send_only.cs
@@ -36,7 +36,7 @@
         {
             public SendOnlyEndpoint()
             {
-                EndpointSetup<DefaultServer>().SendOnly();
+                EndpointSetup<DefaultServer>(c => c.SendOnly());
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_publishing_from_sendonly.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_publishing_from_sendonly.cs
@@ -40,9 +40,10 @@
             {
                 EndpointSetup<DefaultPublisher>(b =>
                 {
+                    b.SendOnly();
                     b.UsePersistence(typeof(HardCodedPersistence));
                     b.DisableFeature<AutoSubscribe>();
-                }).SendOnly();
+                });
             }
         }
 


### PR DESCRIPTION
a few more lines which are easy to remove from the ATT framework as it is redundant since the endpoint can be made readonly via the `EndpointConfiguration` directly.