### PR TITLE
Incorrect log level for FATAL

### DIFF
--- a/src/NServiceBus.Core/Logging/DefaultLog.cs
+++ b/src/NServiceBus.Core/Logging/DefaultLog.cs
@@ -84,7 +84,7 @@ namespace NServiceBus
 
         public void Fatal(string message, Exception exception)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Error, message + Environment.NewLine + exception);
+            defaultLoggerFactory.Write(name, LogLevel.Fatal, message + Environment.NewLine + exception);
         }
 
         public void FatalFormat(string format, params object[] args)


### PR DESCRIPTION
Incorrect log level written, written as ERROR instead of FATAL.