### PR TITLE
Log level FATAL is written as ERROR (v5.2)

### DIFF
--- a/src/NServiceBus.Core/Logging/DefaultLog.cs
+++ b/src/NServiceBus.Core/Logging/DefaultLog.cs
@@ -86,7 +86,7 @@ namespace NServiceBus.Logging
 
         public void Fatal(string message, Exception exception)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Error, message + Environment.NewLine + exception);
+            defaultLoggerFactory.Write(name, LogLevel.Fatal, message + Environment.NewLine + exception);
         }
 
         public void FatalFormat(string format, params object[] args)


### PR DESCRIPTION
Same as #4558 but for 5.2, currently against support-5.2 as there is no hotfix branch yet.