### PR TITLE
Remove incorrect assertions from transport test

### DIFF
--- a/src/NServiceBus.TransportTests/When_on_error_throws.cs
+++ b/src/NServiceBus.TransportTests/When_on_error_throws.cs
@@ -46,8 +46,6 @@
             var errorContext = await onErrorCalled.Task;
 
             Assert.AreEqual("Simulated exception", errorContext.Exception.Message);
-            Assert.AreEqual(2, errorContext.ImmediateProcessingFailures);
-            Assert.IsNotNull(criticalError);
         }
     }
 }

--- a/src/NServiceBus.TransportTests/When_on_error_throws.cs
+++ b/src/NServiceBus.TransportTests/When_on_error_throws.cs
@@ -14,7 +14,6 @@
         public async Task Should_reinvoke_on_error_with_original_exception(TransportTransactionMode transactionMode)
         {
             var onErrorCalled = new TaskCompletionSource<ErrorContext>();
-            Exception criticalError = null;
 
             OnTestTimeout(() => onErrorCalled.SetCanceled());
 
@@ -38,8 +37,7 @@
 
                     return Task.FromResult(ErrorHandleResult.Handled);
                 },
-                transactionMode,
-                (s, exception) => criticalError = exception);
+                transactionMode);
 
             await SendMessage(InputQueueName);
 


### PR DESCRIPTION
The two assertions that were added to this test later on aren't valid for all transports. For example, we've been commenting them out for RabbitMQ.

I wanted to go ahead and get this change in before the 6.2 release.

CC: @Particular/rabbitmq-transport-maintainers @Particular/azure-maintainers 
