### PR TITLE
Align AssemblyScanner config API with API design guidelines

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -41,7 +41,7 @@ namespace NServiceBus
     }
     public class static AssemblyScannerConfigurationExtensions
     {
-        public static void AssemblyScanner(this NServiceBus.EndpointConfiguration configuration, System.Action<NServiceBus.AssemblyScannerConfiguration> configure) { }
+        public static NServiceBus.AssemblyScannerConfiguration AssemblyScanner(this NServiceBus.EndpointConfiguration configuration) { }
     }
     public class static AuditConfigReader
     {

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfigurationExtensions.cs
@@ -1,7 +1,5 @@
 ﻿namespace NServiceBus
 {
-    using System;
-
     /// <summary>
     /// Contains extension methods to configure the <see cref="AssemblyScanner"/> behavior.
     /// </summary>
@@ -10,13 +8,12 @@
         /// <summary>
         /// Configure the <see cref="AssemblyScanner"/>.
         /// </summary>
-        public static void AssemblyScanner(this EndpointConfiguration configuration, Action<AssemblyScannerConfiguration> configure)
+        public static AssemblyScannerConfiguration AssemblyScanner(this EndpointConfiguration configuration)
         {
             Guard.AgainstNull(nameof(configuration), configuration);
-            Guard.AgainstNull(nameof(configure), configure);
 
             var config = configuration.Settings.GetOrCreate<AssemblyScannerConfiguration>();
-            configure(config);
+            return config;
         }
     }
 }


### PR DESCRIPTION
as this API was added in the 6.2 timeframe, it might makes sense to align it with the newly defined API design guidelines.