### PR TITLE
Merge Publish|Reply|SubscribeOptions into current ContextBag not parent one

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -151,6 +151,8 @@
     <Compile Include="Persistence\InMemory\When_completing_a_saga_with_no_defined_unique_property.cs" />
     <Compile Include="Persistence\InMemory\When_updating_a_saga_with_no_defined_unique_property.cs" />
     <Compile Include="Persistence\PersistenceStartupTests.cs" />
+    <Compile Include="Routing\SubscribeContextTests.cs" />
+    <Compile Include="Routing\UnsubscribeContextTests.cs" />
     <Compile Include="Pipeline\PipelineTests.cs" />
     <Compile Include="Pipeline\HeaderOptionExtensionsTests.cs" />
     <Compile Include="Pipeline\Incoming\SerializeMessageConnectorTests.cs" />

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingPublishContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingPublishContextTests.cs
@@ -46,5 +46,22 @@
             Assert.AreEqual("updatedValue", updatedValue);
             Assert.AreEqual("anotherValue", anotherValue2);
         }
+
+        [Test]
+        public void ShouldNotMergeOptionsToParentContext()
+        {
+            var message = new OutgoingLogicalMessage(typeof(object), new object());
+            var options = new PublishOptions();
+            options.Context.Set("someKey", "someValue");
+
+            var parentContext = new RootContext(null,null,null);
+
+            new OutgoingPublishContext(message, options, parentContext);
+
+            string parentContextValue;
+            var valueFound = parentContext.TryGet("someKey", out parentContextValue);
+
+            Assert.IsFalse(valueFound);
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingReplyContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingReplyContextTests.cs
@@ -47,7 +47,6 @@
             Assert.AreEqual("anotherValue", anotherValue2);
         }
 
-
         [Test]
         public void ShouldNotMergeOptionsToParentContext()
         {

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingReplyContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingReplyContextTests.cs
@@ -46,5 +46,23 @@
             Assert.AreEqual("updatedValue", updatedValue);
             Assert.AreEqual("anotherValue", anotherValue2);
         }
+
+
+        [Test]
+        public void ShouldNotMergeOptionsToParentContext()
+        {
+            var message = new OutgoingLogicalMessage(typeof(object), new object());
+            var options = new ReplyOptions();
+            options.Context.Set("someKey", "someValue");
+
+            var parentContext = new RootContext(null, null, null);
+
+            new OutgoingReplyContext(message, options, parentContext);
+
+            string parentContextValue;
+            var valueFound = parentContext.TryGet("someKey", out parentContextValue);
+
+            Assert.IsFalse(valueFound);
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingSendContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingSendContextTests.cs
@@ -46,5 +46,22 @@
             Assert.AreEqual("updatedValue", updatedValue);
             Assert.AreEqual("anotherValue", anotherValue2);
         }
+
+        [Test]
+        public void ShouldNotMergeOptionsToParentContext()
+        {
+            var message = new OutgoingLogicalMessage(typeof(object), new object());
+            var options = new SendOptions();
+            options.Context.Set("someKey", "someValue");
+
+            var parentContext = new RootContext(null, null, null);
+
+            new OutgoingSendContext(message, options, parentContext);
+
+            string parentContextValue;
+            var valueFound = parentContext.TryGet("someKey", out parentContextValue);
+
+            Assert.IsFalse(valueFound);
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/SubscribeContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SubscribeContextTests.cs
@@ -1,0 +1,47 @@
+﻿namespace NServiceBus.Core.Tests.Routing
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class SubscribeContextTests
+    {
+        [Test]
+        public void ShouldShallowCloneContext()
+        {
+            var options = new SubscribeOptions();
+            options.Context.Set("someKey", "someValue");
+
+            var testee = new SubscribeContext(new RootContext(null, null, null), typeof(object), options);
+            testee.Extensions.Set("someKey", "updatedValue");
+            testee.Extensions.Set("anotherKey", "anotherValue");
+
+            string value;
+            string anotherValue;
+            options.Context.TryGet("someKey", out value);
+            Assert.AreEqual("someValue", value);
+            Assert.IsFalse(options.Context.TryGet("anotherKey", out anotherValue));
+            string updatedValue;
+            string anotherValue2;
+            testee.Extensions.TryGet("someKey", out updatedValue);
+            testee.Extensions.TryGet("anotherKey", out anotherValue2);
+            Assert.AreEqual("updatedValue", updatedValue);
+            Assert.AreEqual("anotherValue", anotherValue2);
+        }
+
+        [Test]
+        public void ShouldNotMergeOptionsToParentContext()
+        {
+            var options = new SubscribeOptions();
+            options.Context.Set("someKey", "someValue");
+
+            var parentContext = new RootContext(null, null, null);
+
+            new SubscribeContext(parentContext, typeof(object), options);
+
+            string parentContextValue;
+            var valueFound = parentContext.TryGet("someKey", out parentContextValue);
+
+            Assert.IsFalse(valueFound);
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Routing/UnsubscribeContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnsubscribeContextTests.cs
@@ -1,0 +1,47 @@
+﻿namespace NServiceBus.Core.Tests.Routing
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class UnsubscribeContextTests
+    {
+        [Test]
+        public void ShouldShallowCloneContext()
+        {
+            var options = new UnsubscribeOptions();
+            options.Context.Set("someKey", "someValue");
+            
+            var testee = new UnsubscribeContext(new RootContext(null, null, null), typeof(object), options);
+            testee.Extensions.Set("someKey", "updatedValue");
+            testee.Extensions.Set("anotherKey", "anotherValue");
+
+            string value;
+            string anotherValue;
+            options.Context.TryGet("someKey", out value);
+            Assert.AreEqual("someValue", value);
+            Assert.IsFalse(options.Context.TryGet("anotherKey", out anotherValue));
+            string updatedValue;
+            string anotherValue2;
+            testee.Extensions.TryGet("someKey", out updatedValue);
+            testee.Extensions.TryGet("anotherKey", out anotherValue2);
+            Assert.AreEqual("updatedValue", updatedValue);
+            Assert.AreEqual("anotherValue", anotherValue2);
+        }
+
+        [Test]
+        public void ShouldNotMergeOptionsToParentContext()
+        {
+            var options = new UnsubscribeOptions();
+            options.Context.Set("someKey", "someValue");
+
+            var parentContext = new RootContext(null, null, null);
+
+            new UnsubscribeContext(parentContext, typeof(object), options);
+
+            string parentContextValue;
+            var valueFound = parentContext.TryGet("someKey", out parentContextValue);
+
+            Assert.IsFalse(valueFound);
+        }
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPublishContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPublishContext.cs
@@ -8,12 +8,13 @@
         public OutgoingPublishContext(OutgoingLogicalMessage message, PublishOptions options, IBehaviorContext parentContext)
             : base(options.MessageId, new Dictionary<string, string>(options.OutgoingHeaders), parentContext)
         {
-            Message = message;
             Guard.AgainstNull(nameof(parentContext), parentContext);
             Guard.AgainstNull(nameof(message), message);
             Guard.AgainstNull(nameof(options), options);
 
-            parentContext.Extensions.Merge(options.Context);
+            Message = message;
+
+            Merge(options.Context);
         }
 
         public OutgoingLogicalMessage Message { get; }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingReplyContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingReplyContext.cs
@@ -8,12 +8,13 @@
         public OutgoingReplyContext(OutgoingLogicalMessage message, ReplyOptions options, IBehaviorContext parentContext)
             : base(options.MessageId, new Dictionary<string, string>(options.OutgoingHeaders), parentContext)
         {
-            Message = message;
             Guard.AgainstNull(nameof(parentContext), parentContext);
             Guard.AgainstNull(nameof(message), message);
             Guard.AgainstNull(nameof(options), options);
 
-            parentContext.Extensions.Merge(options.Context);
+            Message = message;
+
+            Merge(options.Context);
         }
 
         public OutgoingLogicalMessage Message { get; }

--- a/src/NServiceBus.Core/Routing/SubscribeContext.cs
+++ b/src/NServiceBus.Core/Routing/SubscribeContext.cs
@@ -12,7 +12,7 @@
             Guard.AgainstNull(nameof(eventType), eventType);
             Guard.AgainstNull(nameof(options), options);
 
-            parentContext.Extensions.Merge(options.Context);
+            Merge(options.Context);
 
             EventType = eventType;
         }

--- a/src/NServiceBus.Core/Routing/UnsubscribeContext.cs
+++ b/src/NServiceBus.Core/Routing/UnsubscribeContext.cs
@@ -12,7 +12,7 @@
             Guard.AgainstNull(nameof(eventType), eventType);
             Guard.AgainstNull(nameof(options), options);
 
-            parentContext.Extensions.Merge(options.Context);
+            Merge(options.Context);
 
             EventType = eventType;
         }


### PR DESCRIPTION
Connected to #4573

Fixes a bug [reported in Google Groups](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/particularsoftware/cCudnYmX55g/qr8FFzHfCAAJ) where sendoptions was being incorrectly merged into the parent context instead of the current one.

Could not write tests to verify this since the `ContextBag.TryGet` method first attempts to get the value from the current context and, if not found there, it will try to get the value from the parent context. As such any test written would pass, incorrectly, for the bug'd code.