### PR TITLE
use fullname on saga message mapping exception

### DIFF
--- a/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
@@ -147,36 +147,36 @@
         [Test]
         public void ValidateThatMappingOnSagaIdHasTypeGuidForMessageProps()
         {
-            var ex = Assert.Throws<InvalidOperationException>(() => SagaMetadata.Create(typeof(SagaWithIdMappedToNonGuidMessageProperty)));
-            Assert.True(ex.Message.Contains(typeof(SomeMessage).Name));
+            var ex = Assert.Throws<Exception>(() => SagaMetadata.Create(typeof(SagaWithIdMappedToNonGuidMessageProperty)));
+            StringAssert.Contains(typeof(SomeMessage).FullName, ex.Message);
         }
 
         [Test]
         public void ValidateThatMappingOnSagaIdFromStringToGuidForMessagePropsThrowsException()
         {
-            var ex = Assert.Throws<InvalidOperationException>(() => SagaMetadata.Create(typeof(SagaWithIdMappedToStringMessageProperty)));
-            Assert.True(ex.Message.Contains(typeof(SomeMessage).Name));
+            var ex = Assert.Throws<Exception>(() => SagaMetadata.Create(typeof(SagaWithIdMappedToStringMessageProperty)));
+            StringAssert.Contains(typeof(SomeMessage).FullName, ex.Message);
         }
 
         [Test]
         public void ValidateThatMappingOnNonSagaIdGuidPropertyFromStringToGuidForMessagePropsThrowsException()
         {
-            var ex = Assert.Throws<InvalidOperationException>(() => SagaMetadata.Create(typeof(SagaWithNonIdPropertyMappedToStringMessageProperty)));
-            Assert.True(ex.Message.Contains(typeof(SomeMessage).Name));
+            var ex = Assert.Throws<Exception>(() => SagaMetadata.Create(typeof(SagaWithNonIdPropertyMappedToStringMessageProperty)));
+            StringAssert.Contains(typeof(SomeMessage).FullName, ex.Message);
         }
 
         [Test]
         public void ValidateThatMappingOnSagaIdHasTypeGuidForMessageFields()
         {
-            var ex = Assert.Throws<InvalidOperationException>(() => SagaMetadata.Create(typeof(SagaWithIdMappedToNonGuidMessageField)));
-            Assert.True(ex.Message.Contains(typeof(SomeMessage).Name));
+            var ex = Assert.Throws<Exception>(() => SagaMetadata.Create(typeof(SagaWithIdMappedToNonGuidMessageField)));
+            StringAssert.Contains(typeof(SomeMessage).Name, ex.Message);
         }
 
         [Test]
         public void ValidateThatSagaPropertyIsNotAField()
         {
-            var ex = Assert.Throws<InvalidOperationException>(() => SagaMetadata.Create(typeof(SagaWithSagaDataMemberAsFieldInsteadOfProperty)));
-            Assert.True(ex.Message.Contains(typeof(SagaWithSagaDataMemberAsFieldInsteadOfProperty.SagaData).Name));
+            var ex = Assert.Throws<Exception>(() => SagaMetadata.Create(typeof(SagaWithSagaDataMemberAsFieldInsteadOfProperty)));
+            StringAssert.Contains(typeof(SagaWithSagaDataMemberAsFieldInsteadOfProperty.SagaData).FullName, ex.Message);
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
@@ -147,35 +147,35 @@
         [Test]
         public void ValidateThatMappingOnSagaIdHasTypeGuidForMessageProps()
         {
-            var ex = Assert.Throws<Exception>(() => SagaMetadata.Create(typeof(SagaWithIdMappedToNonGuidMessageProperty)));
+            var ex = Assert.Throws<InvalidOperationException>(() => SagaMetadata.Create(typeof(SagaWithIdMappedToNonGuidMessageProperty)));
             StringAssert.Contains(typeof(SomeMessage).FullName, ex.Message);
         }
 
         [Test]
         public void ValidateThatMappingOnSagaIdFromStringToGuidForMessagePropsThrowsException()
         {
-            var ex = Assert.Throws<Exception>(() => SagaMetadata.Create(typeof(SagaWithIdMappedToStringMessageProperty)));
+            var ex = Assert.Throws<InvalidOperationException>(() => SagaMetadata.Create(typeof(SagaWithIdMappedToStringMessageProperty)));
             StringAssert.Contains(typeof(SomeMessage).FullName, ex.Message);
         }
 
         [Test]
         public void ValidateThatMappingOnNonSagaIdGuidPropertyFromStringToGuidForMessagePropsThrowsException()
         {
-            var ex = Assert.Throws<Exception>(() => SagaMetadata.Create(typeof(SagaWithNonIdPropertyMappedToStringMessageProperty)));
+            var ex = Assert.Throws<InvalidOperationException>(() => SagaMetadata.Create(typeof(SagaWithNonIdPropertyMappedToStringMessageProperty)));
             StringAssert.Contains(typeof(SomeMessage).FullName, ex.Message);
         }
 
         [Test]
         public void ValidateThatMappingOnSagaIdHasTypeGuidForMessageFields()
         {
-            var ex = Assert.Throws<Exception>(() => SagaMetadata.Create(typeof(SagaWithIdMappedToNonGuidMessageField)));
+            var ex = Assert.Throws<InvalidOperationException>(() => SagaMetadata.Create(typeof(SagaWithIdMappedToNonGuidMessageField)));
             StringAssert.Contains(typeof(SomeMessage).Name, ex.Message);
         }
 
         [Test]
         public void ValidateThatSagaPropertyIsNotAField()
         {
-            var ex = Assert.Throws<Exception>(() => SagaMetadata.Create(typeof(SagaWithSagaDataMemberAsFieldInsteadOfProperty)));
+            var ex = Assert.Throws<InvalidOperationException>(() => SagaMetadata.Create(typeof(SagaWithSagaDataMemberAsFieldInsteadOfProperty)));
             StringAssert.Contains(typeof(SagaWithSagaDataMemberAsFieldInsteadOfProperty.SagaData).FullName, ex.Message);
         }
 

--- a/src/NServiceBus.Core/Sagas/SagaMetadata.cs
+++ b/src/NServiceBus.Core/Sagas/SagaMetadata.cs
@@ -405,15 +405,11 @@ Sagas must have at least one message that is allowed to start the saga. Add at l
 
                 var propertyInfo = memberExpr.Member as PropertyInfo;
 
-                const string message = "When mapping a message to a saga, the member type on the message and the saga property must match. {0}.{1} is of type {2} and {3}.{4} is of type {5}.";
-
                 if (propertyInfo != null)
                 {
                     if (propertyInfo.PropertyType != sagaProp.PropertyType)
                     {
-                        throw new InvalidOperationException(string.Format(message,
-                            propertyInfo.DeclaringType.Name, propertyInfo.Name, propertyInfo.PropertyType,
-                            sagaProp.DeclaringType.Name, sagaProp.Name, sagaProp.PropertyType));
+                        throw new Exception($"When mapping a message to a saga, the member type on the message and the saga property must match. {propertyInfo.DeclaringType.FullName}.{propertyInfo.Name} is of type {propertyInfo.PropertyType.Name} and {sagaProp.DeclaringType.FullName}.{sagaProp.Name} is of type {sagaProp.PropertyType.Name}.");
                     }
 
                     return;

--- a/src/NServiceBus.Core/Sagas/SagaMetadata.cs
+++ b/src/NServiceBus.Core/Sagas/SagaMetadata.cs
@@ -371,7 +371,7 @@ Sagas must have at least one message that is allowed to start the saga. Add at l
                 var sagaProp = sagaMember as PropertyInfo;
                 if (sagaProp == null)
                 {
-                    throw new Exception($"Mapping expressions for saga members must point to properties. Change member {sagaMember.Name} on {typeof(TSagaEntity).FullName} to a property.");
+                    throw new InvalidOperationException($"Mapping expressions for saga members must point to properties. Change member {sagaMember.Name} on {typeof(TSagaEntity).FullName} to a property.");
                 }
 
                 ValidateMapping(messageExpression, sagaProp);
@@ -409,7 +409,7 @@ Sagas must have at least one message that is allowed to start the saga. Add at l
                 {
                     if (propertyInfo.PropertyType != sagaProp.PropertyType)
                     {
-                        throw new Exception($"When mapping a message to a saga, the member type on the message and the saga property must match. {propertyInfo.DeclaringType.FullName}.{propertyInfo.Name} is of type {propertyInfo.PropertyType.Name} and {sagaProp.DeclaringType.FullName}.{sagaProp.Name} is of type {sagaProp.PropertyType.Name}.");
+                        throw new InvalidOperationException($"When mapping a message to a saga, the member type on the message and the saga property must match. {propertyInfo.DeclaringType.FullName}.{propertyInfo.Name} is of type {propertyInfo.PropertyType.Name} and {sagaProp.DeclaringType.FullName}.{sagaProp.Name} is of type {sagaProp.PropertyType.Name}.");
                     }
 
                     return;
@@ -421,7 +421,7 @@ Sagas must have at least one message that is allowed to start the saga. Add at l
                 {
                     if (fieldInfo.FieldType != sagaProp.PropertyType)
                     {
-                        throw new Exception($"When mapping a message to a saga, the member type on the message and the saga property must match. {fieldInfo.DeclaringType.FullName}.{fieldInfo.Name} is of type {fieldInfo.FieldType.Name} and {sagaProp.DeclaringType.FullName}.{sagaProp.Name} is of type {sagaProp.PropertyType.Name}.");
+                        throw new InvalidOperationException($"When mapping a message to a saga, the member type on the message and the saga property must match. {fieldInfo.DeclaringType.FullName}.{fieldInfo.Name} is of type {fieldInfo.FieldType.Name} and {sagaProp.DeclaringType.FullName}.{sagaProp.Name} is of type {sagaProp.PropertyType.Name}.");
                     }
                 }
             }

--- a/src/NServiceBus.Core/Sagas/SagaMetadata.cs
+++ b/src/NServiceBus.Core/Sagas/SagaMetadata.cs
@@ -421,9 +421,7 @@ Sagas must have at least one message that is allowed to start the saga. Add at l
                 {
                     if (fieldInfo.FieldType != sagaProp.PropertyType)
                     {
-                        throw new InvalidOperationException(string.Format(message,
-                            fieldInfo.DeclaringType.Name, fieldInfo.Name, fieldInfo.FieldType,
-                            sagaProp.DeclaringType.Name, sagaProp.Name, sagaProp.PropertyType));
+                        throw new Exception($"When mapping a message to a saga, the member type on the message and the saga property must match. {fieldInfo.DeclaringType.FullName}.{fieldInfo.Name} is of type {fieldInfo.FieldType.Name} and {sagaProp.DeclaringType.FullName}.{sagaProp.Name} is of type {sagaProp.PropertyType.Name}.");
                     }
                 }
             }

--- a/src/NServiceBus.Core/Sagas/SagaMetadata.cs
+++ b/src/NServiceBus.Core/Sagas/SagaMetadata.cs
@@ -371,7 +371,7 @@ Sagas must have at least one message that is allowed to start the saga. Add at l
                 var sagaProp = sagaMember as PropertyInfo;
                 if (sagaProp == null)
                 {
-                    throw new InvalidOperationException($"Mapping expressions for saga members must point to properties. Change member {sagaMember.Name} on {typeof(TSagaEntity).Name} to a property.");
+                    throw new Exception($"Mapping expressions for saga members must point to properties. Change member {sagaMember.Name} on {typeof(TSagaEntity).FullName} to a property.");
                 }
 
                 ValidateMapping(messageExpression, sagaProp);


### PR DESCRIPTION
use fullname when "member type on the message and the saga property must match