### PR TITLE
rename MessageContext param back to "context" and fix obsolete

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -3316,9 +3316,10 @@ namespace NServiceBus.Transport
     }
     public class MessageContext : NServiceBus.Extensibility.IExtendable
     {
-        public MessageContext(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, System.Threading.CancellationTokenSource receiveCancellationTokenSource, NServiceBus.Extensibility.ContextBag extensions) { }
+        public MessageContext(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, System.Threading.CancellationTokenSource receiveCancellationTokenSource, NServiceBus.Extensibility.ContextBag context) { }
         public byte[] Body { get; }
-        [System.ObsoleteAttribute("Use `Extensions` instead. Will be removed in version 7.0.0.", true)]
+        [System.ObsoleteAttribute("Use `Extensions` instead. Will be treated as an error from version 7.0.0. Will be" +
+            " removed in version 7.0.0.", false)]
         public NServiceBus.Extensibility.ContextBag Context { get; }
         public NServiceBus.Extensibility.ContextBag Extensions { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }

--- a/src/NServiceBus.Core/Transports/MessageContext.cs
+++ b/src/NServiceBus.Core/Transports/MessageContext.cs
@@ -21,20 +21,20 @@
         /// It also allows the transport to communicate to the pipeline to abort if possible. Transports should check if the token
         /// has been aborted after invoking the pipeline and roll back the message accordingly.
         /// </param>
-        /// <param name="extensions">A <see cref="ContextBag" /> which can be used to extend the current object.</param>
-        public MessageContext(string messageId, Dictionary<string, string> headers, byte[] body, TransportTransaction transportTransaction, CancellationTokenSource receiveCancellationTokenSource, ContextBag extensions)
+        /// <param name="context">A <see cref="ContextBag" /> which can be used to extend the current object.</param>
+        public MessageContext(string messageId, Dictionary<string, string> headers, byte[] body, TransportTransaction transportTransaction, CancellationTokenSource receiveCancellationTokenSource, ContextBag context)
         {
             Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
             Guard.AgainstNull(nameof(body), body);
             Guard.AgainstNull(nameof(headers), headers);
             Guard.AgainstNull(nameof(transportTransaction), transportTransaction);
             Guard.AgainstNull(nameof(receiveCancellationTokenSource), receiveCancellationTokenSource);
-            Guard.AgainstNull(nameof(extensions), extensions);
+            Guard.AgainstNull(nameof(context), context);
 
             Headers = headers;
             Body = body;
             MessageId = messageId;
-            Extensions = extensions;
+            Extensions = context;
             TransportTransaction = transportTransaction;
             ReceiveCancellationTokenSource = receiveCancellationTokenSource;
         }
@@ -68,7 +68,10 @@
         /// <summary>
         /// Context provided by the transport.
         /// </summary>
-        [ObsoleteEx(ReplacementTypeOrMember = "Extensions", RemoveInVersion = "7")]
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "Extensions",
+            TreatAsErrorFromVersion = "7",
+            RemoveInVersion = "7")]
         public ContextBag Context => Extensions;
 
         /// <summary>


### PR DESCRIPTION
reverts breaking change introduced here
https://github.com/Particular/NServiceBus/commit/dc1ad7358735bd1b80520929bcbb65e8094ce67d