### PR TITLE
[WIP]Full scan when conventions are in use

### DIFF
--- a/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
@@ -5,6 +5,7 @@
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
+    using System.Linq;
     using System.Reflection;
     using System.Text;
     using System.Threading;
@@ -226,10 +227,51 @@
             Assert.IsTrue(result.Assemblies.Contains(busAssembly));
         }
 
+        [Test, RunInApplicationDomain]
+        public void Include_child_type_even_if_only_handler_for_base_exists()
+        {
+            var messages =
+@"
+public interface IBaseEvent
+{
+}
+
+public interface IInheritedEvent : IBaseEvent
+{
+}
+";
+
+            var handler =
+@"
+using NServiceBus;
+using System.Threading.Tasks;
+
+class InterfaceMessageHandler : IHandleMessages<IBaseEvent>
+{
+    public Task Handle(IBaseEvent message, IMessageHandlerContext context)
+    {
+        return Task.FromResult(0);
+    }
+}
+";
+
+            var messagesAsm = new DynamicAssembly("Fake.Messages", content: messages);
+            Assembly.LoadFrom(messagesAsm.FilePath);
+
+            var handlerAsm = new DynamicAssembly("Fake.Handler", new[] { messagesAsm }, content: handler, referenceTheCore: true);
+            Assembly.LoadFrom(handlerAsm.FilePath);
+
+            var scanner = new AssemblyScanner(DynamicAssembly.TestAssemblyDirectory);
+
+            var result = scanner.GetScannableAssemblies();
+
+            Assert.True(result.Types.Any(t => t.Name == "IInheritedEvent"));
+        }
+
         [DebuggerDisplay("Name = {Name}, DynamicName = {DynamicName}, Namespace = {Namespace}, FileName = {FileName}")]
         class DynamicAssembly
         {
-            public DynamicAssembly(string nameWithoutExtension, DynamicAssembly[] references = null, Version version = null, bool fakeIdentity = false)
+            public DynamicAssembly(string nameWithoutExtension, DynamicAssembly[] references = null, Version version = null, bool fakeIdentity = false, string content = null, bool referenceTheCore = false)
             {
                 if (version == null)
                 {
@@ -268,12 +310,30 @@
                     param.ReferencedAssemblies.Add(reference.FilePath);
                 }
 
-                builder.AppendLine("public class Foo { public Foo() {");
-                foreach (var reference in references)
+                if (referenceTheCore)
                 {
-                    builder.AppendLine($"new {reference.Namespace}.Foo();");
+                    var targetCorePath = Path.Combine(TestAssemblyDirectory, "NServiceBus.Core.dll");
+                    File.Copy(Path.Combine(TestDirectory, "NServiceBus.Core.dll"), Path.Combine(TestAssemblyDirectory, "NServiceBus.Core.dll"));
+
+                    param.ReferencedAssemblies.Add(targetCorePath);
                 }
-                builder.AppendLine("} } }");
+
+                if (content == null)
+                {
+                    builder.AppendLine("public class Foo { public Foo() {");
+                    foreach (var reference in references)
+                    {
+                        builder.AppendLine($"new {reference.Namespace}.Foo();");
+                    }
+                    builder.AppendLine("} }");
+                }
+                else
+                {
+                    builder.AppendLine(content);
+                }
+
+                builder.AppendLine(" }");
+
 
                 var result = provider.CompileAssemblyFromSource(param, builder.ToString());
                 ThrowIfCompilationWasNotSuccessful(result);
@@ -303,7 +363,9 @@
 
             public Assembly Assembly { get; }
 
-            public static string TestAssemblyDirectory { get; } = Path.Combine(AppDomainRunner.DataStore.Get<string>("TestDirectory"), "assemblyscannerfiles");
+            public static string TestDirectory { get; } = AppDomainRunner.DataStore.Get<string>("TestDirectory");
+
+            public static string TestAssemblyDirectory { get; } = Path.Combine(TestDirectory, "assemblyscannerfiles");
 
             static void ThrowIfCompilationWasNotSuccessful(CompilerResults results)
             {

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
@@ -261,7 +261,10 @@ class InterfaceMessageHandler : IHandleMessages<IBaseEvent>
             var handlerAsm = new DynamicAssembly("Fake.Handler", new[] { messagesAsm }, content: handler, referenceTheCore: true);
             Assembly.LoadFrom(handlerAsm.FilePath);
 
-            var scanner = new AssemblyScanner(DynamicAssembly.TestAssemblyDirectory);
+            var scanner = new AssemblyScanner(DynamicAssembly.TestAssemblyDirectory)
+            {
+                IncludeAssembliesNotReferencingCoreAsWell = true //core will set this if a custom convention is used
+            };
 
             var result = scanner.GetScannableAssemblies();
 

--- a/src/NServiceBus.Core/Conventions.cs
+++ b/src/NServiceBus.Core/Conventions.cs
@@ -178,6 +178,7 @@
         ConventionCache CommandsConventionCache = new ConventionCache();
         ConventionCache EventsConventionCache = new ConventionCache();
 
+        internal bool CustomMessageConventionsUsed = false;
         internal Func<Type, bool> IsCommandTypeAction = t => typeof(ICommand).IsAssignableFrom(t) && typeof(ICommand) != t;
 
         internal Func<PropertyInfo, bool> IsDataBusPropertyAction = p => typeof(IDataBusProperty).IsAssignableFrom(p.PropertyType) && typeof(IDataBusProperty) != p.PropertyType;

--- a/src/NServiceBus.Core/ConventionsBuilder.cs
+++ b/src/NServiceBus.Core/ConventionsBuilder.cs
@@ -25,6 +25,10 @@ namespace NServiceBus
         {
             Guard.AgainstNull(nameof(definesMessageType), definesMessageType);
             Conventions.IsMessageTypeAction = definesMessageType;
+
+            //todo: move this to the Convetions class instead
+            Conventions.CustomMessageConventionsUsed = true;
+
             return this;
         }
 
@@ -35,6 +39,8 @@ namespace NServiceBus
         {
             Guard.AgainstNull(nameof(definesCommandType), definesCommandType);
             Conventions.IsCommandTypeAction = definesCommandType;
+            //todo: move this to the Convetions class instead
+            Conventions.CustomMessageConventionsUsed = true;
             return this;
         }
 
@@ -45,6 +51,8 @@ namespace NServiceBus
         {
             Guard.AgainstNull(nameof(definesEventType), definesEventType);
             Conventions.IsEventTypeAction = definesEventType;
+            //todo: move this to the Convetions class instead
+            Conventions.CustomMessageConventionsUsed = true;
             return this;
         }
 

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -50,6 +50,7 @@ namespace NServiceBus.Hosting.Helpers
         public bool ScanAppDomainAssemblies { get; set; }
 
         internal string CoreAssemblyName { get; set; }
+        internal bool IncludeAssembliesNotReferencingCoreAsWell { get; set; }
 
         /// <summary>
         /// Traverses the specified base directory including all sub-directories, generating a list of assemblies that can be
@@ -86,35 +87,9 @@ namespace NServiceBus.Hosting.Helpers
                 ScanAssembly(assemblyFile.FullName, results, processed);
             }
 
-            // This extra step is to ensure unobtrusive message types are included in the Types list.
-            var list = GetHandlerMessageTypes(results.Types);
-            results.Types.AddRange(list);
-
             results.RemoveDuplicates();
 
             return results;
-        }
-
-        static List<Type> GetHandlerMessageTypes(List<Type> list)
-        {
-            var foundMessageTypes = new List<Type>();
-            foreach (var type in list)
-            {
-                if (type.IsAbstract || type.IsGenericTypeDefinition)
-                {
-                    continue;
-                }
-
-                foreach (var @interface in type.GetInterfaces())
-                {
-                    if (@interface.IsGenericType && @interface.GetGenericTypeDefinition() == IHandleMessagesType)
-                    {
-                        var messageType = @interface.GetGenericArguments()[0];
-                        foundMessageTypes.Add(messageType);
-                    }
-                }
-            }
-            return foundMessageTypes;
         }
 
         static string AssemblyPath(Assembly assembly)
@@ -151,7 +126,7 @@ namespace NServiceBus.Hosting.Helpers
 
             try
             {
-                if (!ReferencesNServiceBus(assemblyPath, processed, CoreAssemblyName))
+                if (!IncludeAssembliesNotReferencingCoreAsWell && !ReferencesNServiceBus(assemblyPath, processed, CoreAssemblyName))
                 {
                     var skippedFile = new SkippedFile(assemblyPath, "Assembly does not reference at least one of the must referenced assemblies.");
                     results.SkippedFiles.Add(skippedFile);


### PR DESCRIPTION
Alternative to https://github.com/Particular/NServiceBus/pull/4576/ where we tell the scanner to disable its optimization where only assemblies referencing NServiceBus would be considered if the user have specified a custom message convention.

Closes #4567

Most likely fixes #4452