### PR TITLE
Fix release date attribute

### DIFF
--- a/src/NServiceBus.Core/Properties/AssemblyInfo.cs
+++ b/src/NServiceBus.Core/Properties/AssemblyInfo.cs
@@ -11,4 +11,4 @@ using NServiceBus;
 [assembly: CLSCompliant(true)]
 
 // TODO: Introduce proper way to automatically generate these dates before first hotfix/next minor
-[assembly: ReleaseDate("2017-03-28", "2016-03-28")]
+[assembly: ReleaseDate("2017-03-28", "2017-03-28")]


### PR DESCRIPTION
While this doesn't actually impact the 3.2.0 release, I noticed yesterday that the second parameter of the `ReleaseDate` attribute wasn't updated correctly.

Before merging yesterday, I verified that only the first parameter actually matters from the standpoint of the licensing code.

Looking back at how GitVersion used to automatically update the values, the first parameter is the date of the commit tagged with X.Y.0, and the second value is the date of the current commit being built.

So the first parameter should be updated for each new minor release, and the second parameter should be updated for each build, assuming we want to mimic the old behavior perfectly.