### PR TITLE
Switch from property to factory method in TestSuiteConstraints 

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/CoreTestSuiteConstraints.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/CoreTestSuiteConstraints.cs
@@ -9,7 +9,9 @@
         public bool SupportsNativePubSub => false;
         public bool SupportsNativeDeferral => false;
         public bool SupportsOutbox => true;
-        public IConfigureEndpointTestExecution TransportConfiguration => new ConfigureEndpointMsmqTransport();
-        public IConfigureEndpointTestExecution PersistenceConfiguration => new ConfigureEndpointInMemoryPersistence();
+
+        public IConfigureEndpointTestExecution CreateEndpointConfiguration() => new ConfigureEndpointMsmqTransport();
+
+        public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointInMemoryPersistence();
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Core/CoreTestSuiteConstraints.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/CoreTestSuiteConstraints.cs
@@ -9,7 +9,7 @@
         public bool SupportsNativePubSub => false;
         public bool SupportsNativeDeferral => false;
         public bool SupportsOutbox => true;
-        public IConfigureEndpointTestExecution CreateEndpointConfiguration() => new ConfigureEndpointMsmqTransport();
+        public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureEndpointMsmqTransport();
         public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointInMemoryPersistence();
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Core/CoreTestSuiteConstraints.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/CoreTestSuiteConstraints.cs
@@ -9,9 +9,7 @@
         public bool SupportsNativePubSub => false;
         public bool SupportsNativeDeferral => false;
         public bool SupportsOutbox => true;
-
         public IConfigureEndpointTestExecution CreateEndpointConfiguration() => new ConfigureEndpointMsmqTransport();
-
         public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointInMemoryPersistence();
     }
 }

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.AcceptanceTests.EndpointTemplates
 {
-    using System;
     using System.Threading.Tasks;
     using AcceptanceTesting.Support;
     using ObjectBuilder;
@@ -9,22 +8,12 @@
     {
         public static Task DefineTransport(this EndpointConfiguration config, RunSettings settings, EndpointCustomizationConfiguration endpointCustomizationConfiguration)
         {
-            if (TestSuiteConstraints.Current.TransportConfiguration == null)
-            {
-                throw new Exception($"No valid transport configuration found. Configure a transport by assigning {nameof(TestSuiteConstraints)}.{nameof(TestSuiteConstraints.TransportConfiguration)}.");
-            }
-
-            return ConfigureTestExecution(TestSuiteConstraints.Current.TransportConfiguration, config, settings, endpointCustomizationConfiguration.EndpointName, endpointCustomizationConfiguration.PublisherMetadata);
+            return ConfigureTestExecution(TestSuiteConstraints.Current.CreateEndpointConfiguration(), config, settings, endpointCustomizationConfiguration.EndpointName, endpointCustomizationConfiguration.PublisherMetadata);
         }
 
         public static Task DefinePersistence(this EndpointConfiguration config, RunSettings settings, EndpointCustomizationConfiguration endpointCustomizationConfiguration)
         {
-            if (TestSuiteConstraints.Current.PersistenceConfiguration == null)
-            {
-                throw new Exception($"No valid persistence configuration found. Configure a persistence by assigning {nameof(TestSuiteConstraints)}.{nameof(TestSuiteConstraints.PersistenceConfiguration)}.");
-            }
-
-            return ConfigureTestExecution(TestSuiteConstraints.Current.PersistenceConfiguration, config, settings, endpointCustomizationConfiguration.EndpointName, endpointCustomizationConfiguration.PublisherMetadata);
+            return ConfigureTestExecution(TestSuiteConstraints.Current.CreatePersistenceConfiguration(), config, settings, endpointCustomizationConfiguration.EndpointName, endpointCustomizationConfiguration.PublisherMetadata);
         }
 
         public static void RegisterComponentsAndInheritanceHierarchy(this EndpointConfiguration builder, RunDescriptor runDescriptor)

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -8,7 +8,7 @@
     {
         public static Task DefineTransport(this EndpointConfiguration config, RunSettings settings, EndpointCustomizationConfiguration endpointCustomizationConfiguration)
         {
-            return ConfigureTestExecution(TestSuiteConstraints.Current.CreateEndpointConfiguration(), config, settings, endpointCustomizationConfiguration.EndpointName, endpointCustomizationConfiguration.PublisherMetadata);
+            return ConfigureTestExecution(TestSuiteConstraints.Current.CreateTransportConfiguration(), config, settings, endpointCustomizationConfiguration.EndpointName, endpointCustomizationConfiguration.PublisherMetadata);
         }
 
         public static Task DefinePersistence(this EndpointConfiguration config, RunSettings settings, EndpointCustomizationConfiguration endpointCustomizationConfiguration)

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/TestSuiteConstraints.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/TestSuiteConstraints.cs
@@ -14,9 +14,9 @@
 
         bool SupportsOutbox { get; }
 
-        IConfigureEndpointTestExecution TransportConfiguration { get; }
+        IConfigureEndpointTestExecution CreateTransportConfiguration();
 
-        IConfigureEndpointTestExecution PersistenceConfiguration { get; }
+        IConfigureEndpointTestExecution CreatePersistenceConfiguration();
     }
 
     // ReSharper disable once PartialTypeWithSinglePart


### PR DESCRIPTION
After looking at the code with @bording we concluded that the properties for the transport and persistence configuration are quite risky as some implementation expect a dedicated instance of the configuration class for each endpoint spinned up (mostly for the cleanup logic).

currently, this does not cause issues (besides unnecessary created instances) in the MSMQ implementation (which relies on the per-endpoint behavior) as we're implementing a custom getter which always returns a new instance, but when using `public IConfigureEndpointTestExecution TransportConfiguration {get;} = new ConfigureEndpointMsmqTransport();`, the framework would no longer work correctly.