### PR TITLE
Support assemblies inlined via Costura

### DIFF
--- a/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
@@ -196,10 +196,9 @@
             Directory.CreateDirectory(Path.Combine(DynamicAssembly.TestAssemblyDirectory, "subdir"));
             var destFileName = Path.Combine(DynamicAssembly.TestAssemblyDirectory, "subdir", busAssembly.FileName);
             File.Copy(busAssembly.FilePath, destFileName);
-            Assembly.LoadFrom(destFileName);
 
             var scanner = new AssemblyScanner(DynamicAssembly.TestAssemblyDirectory);
-            scanner.ScanAppDomainAssemblies = true;
+            scanner.ScanNestedDirectories = true;
             scanner.CoreAssemblyName = busAssembly.DynamicName;
 
             var exception = Assert.Throws<Exception>(() => scanner.GetScannableAssemblies());

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -82,7 +82,8 @@ namespace NServiceBus.Hosting.Helpers
             var processed = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
             foreach (var assemblyFile in ScanDirectoryForAssemblyFiles(baseDirectoryToScan, ScanNestedDirectories))
             {
-                if (TryLoadScannableAssembly(assemblyFile.FullName, results, processed, out var assembly))
+                Assembly assembly;
+                if (TryLoadScannableAssembly(assemblyFile.FullName, results, processed, out assembly))
                 {
                     ScanAssembly(assembly, results);
                 }

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -188,6 +188,16 @@ namespace NServiceBus.Hosting.Helpers
             {
                 return;
             }
+
+            if (IsRuntimeAssembly(assembly.GetName()))
+            {
+                return;
+            }
+            if (!IsIncluded(assembly.GetName().Name))
+            {
+                return;
+            }
+
             try
             {
                 //will throw if assembly cannot be loaded
@@ -482,6 +492,8 @@ namespace NServiceBus.Hosting.Helpers
         {
             // NSB Build-Dependencies
             "nunit",
+            "nunit.framework",
+            "nunit.applicationdomain",
 
             // NSB OSS Dependencies
             "nlog",

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -60,11 +60,10 @@ namespace NServiceBus.Hosting.Helpers
         public AssemblyScannerResults GetScannableAssemblies()
         {
             var results = new AssemblyScannerResults();
-            var processed = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 
             if (assemblyToScan != null)
             {
-                ScanAssembly(assemblyToScan, results, processed);
+                ScanAssembly(assemblyToScan, results);
                 return results;
             }
 
@@ -75,16 +74,17 @@ namespace NServiceBus.Hosting.Helpers
                 {
                     if (!assembly.IsDynamic)
                     {
-                        ScanAssembly(assembly, results, processed);
+                        ScanAssembly(assembly, results);
                     }
                 }
             }
 
+            var processed = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
             foreach (var assemblyFile in ScanDirectoryForAssemblyFiles(baseDirectoryToScan, ScanNestedDirectories))
             {
                 if (TryLoadScannableAssembly(assemblyFile.FullName, results, processed, out var assembly))
                 {
-                    ScanAssembly(assembly, results, processed);
+                    ScanAssembly(assembly, results);
                 }
             }
 
@@ -182,7 +182,7 @@ namespace NServiceBus.Hosting.Helpers
             }
         }
 
-        void ScanAssembly(Assembly assembly, AssemblyScannerResults results, Dictionary<string, bool> processed)
+        void ScanAssembly(Assembly assembly, AssemblyScannerResults results)
         {
             if (assembly == null)
             {

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj.DotSettings
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp70</s:String></wpf:ResourceDictionary>

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj.DotSettings
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj.DotSettings
@@ -1,2 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp70</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
When "inlining" assemblies with Costura, those assemblies are loaded into the AppDomain but even when the assembly scanner is configured to include AppDomain assemblies, those assemblies are not loaded.

This is caused by the current implementation which always tries to load assemblies from disk even when already loaded. As the assemblies inlined via costura show the path of the "host" assembly, it's not possible to load the correct assembly via file path, therefore those assemblies aren't scanned. But in case the assembly is already loaded into the appdomain, we do not need to load the assembly again.

This is WIP and misses some functionaility, as AppDomain assemblies are currently always scanned, regardless whether they are referencing NSB or not.

@Particular/nservicebus-maintainers I start to seriously doubt the usefulness of the ReflectionOnlyLoad part of the assembly scanning which tries to identify whether an assembly references NSB. It adds a shitload of complexity for a very small optimization.

ping @andreasohlund 