### PR TITLE
[WIP]Make the message mapper handle new types added at runtime

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -82,6 +82,7 @@
     <Compile Include="EndpointTemplates\TestSuiteConstraints.cs" />
     <Compile Include="Forwarding\When_requesting_message_to_be_forwarded.cs" />
     <Compile Include="Core\Pipeline\When_subscribed_to_ReceivePipelineCompleted.cs" />
+    <Compile Include="Serialization\When_receiving_interface_message_where_child_is_excluded.cs" />
     <Compile Include="TimeToBeReceived\When_TimeToBeReceived_used_with_unobtrusive_mode.cs" />
     <Compile Include="Core\Recoverability\When_custom_policy_provided.cs" />
     <Compile Include="Recoverability\When_custom_policy_moves_to_overridden_error_queue.cs" />

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_receiving_interface_message_where_child_is_excluded.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_receiving_interface_message_where_child_is_excluded.cs
@@ -1,0 +1,82 @@
+﻿namespace NServiceBus.AcceptanceTests.Serialization
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_receiving_interface_message_where_child_is_excluded : NServiceBusAcceptanceTest
+    {
+        static string ReceiverEndpoint => AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(Receiver));
+
+        [Test]
+        public async Task Should_process_base_message()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(e => e.When(session => session.Send<ISomeMessage>(m => { })))
+                .WithEndpoint<Receiver>()
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            Assert.True(context.MessageReceived);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool MessageReceived { get; set; }
+        }
+
+        class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                    {
+                        //c.UseSerialization<JsonSerializer>();
+
+                        c.ConfigureTransport().Routing().RouteToEndpoint(typeof(ISomeMessage), ReceiverEndpoint);
+                    } //only reproduces on json
+
+                );
+            }
+        }
+
+
+        class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                    {
+                        //c.UseSerialization<JsonSerializer>(); //only reproduces on json
+                    })
+                    .ExcludeType<ISomeMessage>();
+            }
+
+            class MessageHandler : IHandleMessages<ISomeBaseMessage>
+            {
+                public MessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(ISomeBaseMessage message, IMessageHandlerContext context)
+                {
+                    testContext.MessageReceived = true;
+
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public interface ISomeMessage : ISomeBaseMessage
+        {
+        }
+
+        public interface ISomeBaseMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_receiving_interface_message_where_child_is_excluded.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_receiving_interface_message_where_child_is_excluded.cs
@@ -2,12 +2,13 @@
 {
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
     using EndpointTemplates;
     using NUnit.Framework;
 
     public class When_receiving_interface_message_where_child_is_excluded : NServiceBusAcceptanceTest
     {
-        static string ReceiverEndpoint => AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(Receiver));
+        static string ReceiverEndpoint = Conventions.EndpointNamingConvention(typeof(Receiver));
 
         [Test]
         public async Task Should_process_base_message()
@@ -32,11 +33,9 @@
             {
                 EndpointSetup<DefaultServer>(c =>
                     {
-                        c.UseSerialization<JsonSerializer>();
-
+                        c.UseSerialization<JsonSerializer>(); //only reproduces on json
                         c.ConfigureTransport().Routing().RouteToEndpoint(typeof(ISomeMessage), ReceiverEndpoint);
-                    } //only reproduces on json
-
+                    }
                 );
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_receiving_interface_message_where_child_is_excluded.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_receiving_interface_message_where_child_is_excluded.cs
@@ -32,7 +32,7 @@
             {
                 EndpointSetup<DefaultServer>(c =>
                     {
-                        //c.UseSerialization<JsonSerializer>();
+                        c.UseSerialization<JsonSerializer>();
 
                         c.ConfigureTransport().Routing().RouteToEndpoint(typeof(ISomeMessage), ReceiverEndpoint);
                     } //only reproduces on json
@@ -48,7 +48,7 @@
             {
                 EndpointSetup<DefaultServer>(c =>
                     {
-                        //c.UseSerialization<JsonSerializer>(); //only reproduces on json
+                        c.UseSerialization<JsonSerializer>(); //only reproduces on json
                     })
                     .ExcludeType<ISomeMessage>();
             }

--- a/src/NServiceBus.Core.Tests/MessageMapper/When_requesting_unmapped_types.cs
+++ b/src/NServiceBus.Core.Tests/MessageMapper/When_requesting_unmapped_types.cs
@@ -1,0 +1,25 @@
+namespace MessageMapperTests
+{
+    using System;
+    using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_requesting_unmapped_types
+    {
+        [Test]
+        public void Should_initialize_requested_type()
+        {
+            var mapper = new MessageMapper();
+            mapper.Initialize(new Type[]
+            {
+            });
+
+            Assert.NotNull(mapper.GetMappedTypeFor(typeof(UnmappedType)));
+        }
+
+        public interface UnmappedType
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -132,6 +132,7 @@
     <Compile Include="GlobalTestSetup.cs" />
     <Compile Include="Handlers\MessageHandlerRegistryTests.cs" />
     <Compile Include="MessageMapper\MessageMapperTests.cs" />
+    <Compile Include="MessageMapper\When_requesting_unmapped_types.cs" />
     <Compile Include="MessageMutators\MutatorRegistrationExtensionsTests.cs" />
     <Compile Include="Msmq\MsmqMessagePumpTests.cs" />
     <Compile Include="Msmq\MsmqSubscriptionStorageIntegrationTests.cs" />

--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
@@ -50,14 +50,14 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
             {
                 return mappedType;
             }
-          
+
             InitType(t);
 
             return TryGetMappedType(t, out mappedType) ? mappedType : null;
         }
 
-        bool TryGetMappedType(Type typeToMap,out Type mappedType)
-        {    
+        bool TryGetMappedType(Type typeToMap, out Type mappedType)
+        {
             RuntimeTypeHandle typeHandle;
             if (typeToMap.IsClass)
             {

--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
@@ -65,7 +65,8 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
                 return Type.GetTypeFromHandle(typeHandle);
             }
 
-            return null;
+            InitType(t);
+            return GetMappedTypeFor(t);
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
@@ -44,29 +44,48 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
         public Type GetMappedTypeFor(Type t)
         {
             Guard.AgainstNull(nameof(t), t);
-            RuntimeTypeHandle typeHandle;
-            if (t.IsClass)
+
+            Type mappedType;
+            if (TryGetMappedType(t, out mappedType))
             {
-                if (t.IsGenericTypeDefinition)
-                {
-                    return null;
-                }
-
-                if (concreteToInterfaceTypeMapping.TryGetValue(t.TypeHandle, out typeHandle))
-                {
-                    return Type.GetTypeFromHandle(typeHandle);
-                }
-
-                return t;
+                return mappedType;
             }
-
-            if (interfaceToConcreteTypeMapping.TryGetValue(t.TypeHandle, out typeHandle))
-            {
-                return Type.GetTypeFromHandle(typeHandle);
-            }
-
+          
             InitType(t);
-            return GetMappedTypeFor(t);
+
+            return TryGetMappedType(t, out mappedType) ? mappedType : null;
+        }
+
+        bool TryGetMappedType(Type typeToMap,out Type mappedType)
+        {    
+            RuntimeTypeHandle typeHandle;
+            if (typeToMap.IsClass)
+            {
+                if (typeToMap.IsGenericTypeDefinition)
+                {
+                    mappedType = null;
+                    return false;
+                }
+
+                if (concreteToInterfaceTypeMapping.TryGetValue(typeToMap.TypeHandle, out typeHandle))
+                {
+                    mappedType = Type.GetTypeFromHandle(typeHandle);
+                    return true;
+                }
+
+                mappedType = typeToMap;
+                return true;
+            }
+
+            if (interfaceToConcreteTypeMapping.TryGetValue(typeToMap.TypeHandle, out typeHandle))
+            {
+                mappedType = Type.GetTypeFromHandle(typeHandle);
+                return true;
+            }
+
+            mappedType = null;
+
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
This means that we can still deserialize and process messages not found during scanning but we have handlers for

Replaces https://github.com/Particular/NServiceBus/pull/4584

Fixes https://github.com/Particular/NServiceBus/issues/4452
Fixes https://github.com/Particular/NServiceBus/issues/4567
Fixes https://github.com/Particular/NServiceBus/issues/4129