### PR TITLE
Make the message mapper discover types at runtime

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Forwarding\When_requesting_message_to_be_forwarded.cs" />
     <Compile Include="Core\Pipeline\When_subscribed_to_ReceivePipelineCompleted.cs" />
     <Compile Include="EndpointTemplates\IConfigureEndpointTestExecution.cs" />
+    <Compile Include="Serialization\When_receiving_interface_message_where_child_is_excluded.cs" />
     <Compile Include="TimeToBeReceived\When_TimeToBeReceived_used_with_unobtrusive_mode.cs" />
     <Compile Include="Core\Recoverability\When_custom_policy_provided.cs" />
     <Compile Include="Recoverability\When_custom_policy_moves_to_overridden_error_queue.cs" />

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_receiving_interface_message_where_child_is_excluded.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_receiving_interface_message_where_child_is_excluded.cs
@@ -1,0 +1,82 @@
+﻿namespace NServiceBus.AcceptanceTests.Serialization
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_receiving_interface_message_where_child_is_excluded : NServiceBusAcceptanceTest
+    {
+        static string ReceiverEndpoint => AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(Receiver));
+
+        [Test]
+        public async Task Should_process_base_message()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(e => e.When(session => session.Send<ISomeMessage>(m => { })))
+                .WithEndpoint<Receiver>()
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            Assert.True(context.MessageReceived);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool MessageReceived { get; set; }
+        }
+
+        class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                    {
+                        //c.UseSerialization<JsonSerializer>();
+
+                        c.ConfigureTransport().Routing().RouteToEndpoint(typeof(ISomeMessage), ReceiverEndpoint);
+                    } //only reproduces on json
+
+                );
+            }
+        }
+
+
+        class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                    {
+                        //c.UseSerialization<JsonSerializer>(); //only reproduces on json
+                    })
+                    .ExcludeType<ISomeMessage>();
+            }
+
+            class MessageHandler : IHandleMessages<ISomeBaseMessage>
+            {
+                public MessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(ISomeBaseMessage message, IMessageHandlerContext context)
+                {
+                    testContext.MessageReceived = true;
+
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public interface ISomeMessage : ISomeBaseMessage
+        {
+        }
+
+        public interface ISomeBaseMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_receiving_interface_message_where_child_is_excluded.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_receiving_interface_message_where_child_is_excluded.cs
@@ -2,12 +2,13 @@
 {
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
     using EndpointTemplates;
     using NUnit.Framework;
 
     public class When_receiving_interface_message_where_child_is_excluded : NServiceBusAcceptanceTest
     {
-        static string ReceiverEndpoint => AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(Receiver));
+        static string ReceiverEndpoint => Conventions.EndpointNamingConvention(typeof(Receiver));
 
         [Test]
         public async Task Should_process_base_message()
@@ -32,15 +33,12 @@
             {
                 EndpointSetup<DefaultServer>(c =>
                     {
-                        //c.UseSerialization<JsonSerializer>();
-
+                        c.UseSerialization<JsonSerializer>(); //only reproduces on json
                         c.ConfigureTransport().Routing().RouteToEndpoint(typeof(ISomeMessage), ReceiverEndpoint);
-                    } //only reproduces on json
-
+                    }
                 );
             }
         }
-
 
         class Receiver : EndpointConfigurationBuilder
         {
@@ -48,7 +46,7 @@
             {
                 EndpointSetup<DefaultServer>(c =>
                     {
-                        //c.UseSerialization<JsonSerializer>(); //only reproduces on json
+                        c.UseSerialization<JsonSerializer>(); //only reproduces on json
                     })
                     .ExcludeType<ISomeMessage>();
             }

--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
@@ -248,6 +248,15 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
             return t.FullName;
         }
 
+        internal void EnsureTypesAreInitialized(List<Type> messageTypes)
+        {
+            foreach (var messageType in messageTypes)
+            {
+                //todo: optimize
+                InitType(messageType);
+            }
+        }
+
         readonly object messageInitializationLock = new object();
 
         ConcreteProxyCreator concreteProxyCreator;

--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
@@ -248,15 +248,6 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
             return t.FullName;
         }
 
-        internal void EnsureTypesAreInitialized(List<Type> messageTypes)
-        {
-            foreach (var messageType in messageTypes)
-            {
-                //todo: optimize
-                InitType(messageType);
-            }
-        }
-
         readonly object messageInitializationLock = new object();
 
         ConcreteProxyCreator concreteProxyCreator;

--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
@@ -106,7 +106,7 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
         /// </summary>
         public T CreateInstance<T>()
         {
-            return (T) CreateInstance(typeof(T));
+            return (T)CreateInstance(typeof(T));
         }
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
             RuntimeMethodHandle constructor;
             if (typeToConstructor.TryGetValue(mapped.TypeHandle, out constructor))
             {
-                return ((ConstructorInfo) MethodBase.GetMethodFromHandle(constructor, mapped.TypeHandle)).Invoke(null);
+                return ((ConstructorInfo)MethodBase.GetMethodFromHandle(constructor, mapped.TypeHandle)).Invoke(null);
             }
 
             return FormatterServices.GetUninitializedObject(mapped);

--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
@@ -149,11 +149,6 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
 
         void InnerInitialize(Type t)
         {
-            if (t == null)
-            {
-                return;
-            }
-
             if (t.IsSimpleType() || t.IsGenericTypeDefinition)
             {
                 return;

--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
@@ -137,7 +137,7 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
 
         void InitType(Type t)
         {
-            if (initializedTypes.ContainsKey(t))
+            if (t == null || initializedTypes.ContainsKey(t))
             {
                 return;
             }

--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
@@ -106,7 +106,7 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
         /// </summary>
         public T CreateInstance<T>()
         {
-            return (T)CreateInstance(typeof(T));
+            return (T) CreateInstance(typeof(T));
         }
 
         /// <summary>
@@ -129,16 +129,25 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
             RuntimeMethodHandle constructor;
             if (typeToConstructor.TryGetValue(mapped.TypeHandle, out constructor))
             {
-                return ((ConstructorInfo)MethodBase.GetMethodFromHandle(constructor, mapped.TypeHandle)).Invoke(null);
+                return ((ConstructorInfo) MethodBase.GetMethodFromHandle(constructor, mapped.TypeHandle)).Invoke(null);
             }
 
             return FormatterServices.GetUninitializedObject(mapped);
         }
 
-        /// <summary>
-        /// Generates a concrete implementation of the given type if it is an interface.
-        /// </summary>
         void InitType(Type t)
+        {
+            if (initializedTypes.Contains(t))
+            {
+                return;
+            }
+
+            InnerInitialize(t);
+
+            initializedTypes.Add(t);
+        }
+
+        void InnerInitialize(Type t)
         {
             if (t == null)
             {
@@ -249,6 +258,8 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
         }
 
         readonly object messageInitializationLock = new object();
+
+        HashSet<Type> initializedTypes = new HashSet<Type>();
 
         ConcreteProxyCreator concreteProxyCreator;
         ConcurrentDictionary<RuntimeTypeHandle, RuntimeTypeHandle> concreteToInterfaceTypeMapping = new ConcurrentDictionary<RuntimeTypeHandle, RuntimeTypeHandle>();

--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
@@ -137,14 +137,14 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
 
         void InitType(Type t)
         {
-            if (initializedTypes.Contains(t))
+            if (initializedTypes.ContainsKey(t))
             {
                 return;
             }
 
             InnerInitialize(t);
 
-            initializedTypes.Add(t);
+            initializedTypes.TryAdd(t, true);
         }
 
         void InnerInitialize(Type t)
@@ -259,7 +259,7 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
 
         readonly object messageInitializationLock = new object();
 
-        HashSet<Type> initializedTypes = new HashSet<Type>();
+        ConcurrentDictionary<Type, bool> initializedTypes = new ConcurrentDictionary<Type, bool>();
 
         ConcreteProxyCreator concreteProxyCreator;
         ConcurrentDictionary<RuntimeTypeHandle, RuntimeTypeHandle> concreteToInterfaceTypeMapping = new ConcurrentDictionary<RuntimeTypeHandle, RuntimeTypeHandle>();

--- a/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
@@ -7,17 +7,19 @@ namespace NServiceBus
     using System.Linq;
     using System.Threading.Tasks;
     using Logging;
+    using MessageInterfaces.MessageMapper.Reflection;
     using Pipeline;
     using Transport;
     using Unicast.Messages;
 
     class DeserializeLogicalMessagesConnector : StageConnector<IIncomingPhysicalMessageContext, IIncomingLogicalMessageContext>
     {
-        public DeserializeLogicalMessagesConnector(MessageDeserializerResolver deserializerResolver, LogicalMessageFactory logicalMessageFactory, MessageMetadataRegistry messageMetadataRegistry)
+        public DeserializeLogicalMessagesConnector(MessageDeserializerResolver deserializerResolver, LogicalMessageFactory logicalMessageFactory, MessageMetadataRegistry messageMetadataRegistry, MessageMapper mapper)
         {
             this.deserializerResolver = deserializerResolver;
             this.logicalMessageFactory = logicalMessageFactory;
             this.messageMetadataRegistry = messageMetadataRegistry;
+            this.mapper = mapper;
         }
 
         public override async Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingLogicalMessageContext, Task> stage)
@@ -103,8 +105,11 @@ namespace NServiceBus
                 }
             }
 
+         
             var messageTypes = messageMetadata.Select(metadata => metadata.MessageType).ToList();
             var messageSerializer = deserializerResolver.Resolve(physicalMessage.Headers);
+
+            mapper.EnsureTypesAreInitialized(messageTypes);
 
             // For nested behaviors who have an expectation ContentType existing
             // add the default content type
@@ -136,6 +141,7 @@ namespace NServiceBus
         MessageDeserializerResolver deserializerResolver;
         LogicalMessageFactory logicalMessageFactory;
         MessageMetadataRegistry messageMetadataRegistry;
+        MessageMapper mapper;
 
         static LogicalMessage[] NoMessagesFound = new LogicalMessage[0];
 

--- a/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
@@ -105,7 +105,6 @@ namespace NServiceBus
                 }
             }
 
-         
             var messageTypes = messageMetadata.Select(metadata => metadata.MessageType).ToList();
             var messageSerializer = deserializerResolver.Resolve(physicalMessage.Headers);
 

--- a/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
@@ -109,7 +109,7 @@ namespace NServiceBus
             var messageTypes = messageMetadata.Select(metadata => metadata.MessageType).ToList();
             var messageSerializer = deserializerResolver.Resolve(physicalMessage.Headers);
 
-            mapper.EnsureTypesAreInitialized(messageTypes);
+            mapper.Initialize(messageTypes);
 
             // For nested behaviors who have an expectation ContentType existing
             // add the default content type

--- a/src/NServiceBus.Core/Serialization/SerializationFeature.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationFeature.cs
@@ -39,7 +39,7 @@
             var resolver = new MessageDeserializerResolver(defaultSerializer, additionalDeserializers);
 
             var logicalMessageFactory = new LogicalMessageFactory(messageMetadataRegistry, mapper);
-            context.Pipeline.Register(new DeserializeLogicalMessagesConnector(resolver, logicalMessageFactory, messageMetadataRegistry), "Deserializes the physical message body into logical messages");
+            context.Pipeline.Register(new DeserializeLogicalMessagesConnector(resolver, logicalMessageFactory, messageMetadataRegistry, mapper), "Deserializes the physical message body into logical messages");
             context.Pipeline.Register(new SerializeMessageConnector(defaultSerializer, messageMetadataRegistry), "Converts a logical message into a physical message");
 
             context.Container.ConfigureComponent(_ => mapper, DependencyLifecycle.SingleInstance);


### PR DESCRIPTION
This means that we can still deserialize and process messages not found during scanning but we have handlers for

Replaces #4584
Replaces #4606

Fixes #4452
Fixes #4567
Fixes #4129