### PR TITLE
Fix typo in OutgoingSendContext

### DIFF
--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingSendContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingSendContext.cs
@@ -6,16 +6,16 @@
 
     class OutgoingSendContext : OutgoingContext, IOutgoingSendContext
     {
-        public OutgoingSendContext(OutgoingLogicalMessage message, string messageId, Dictionary<string, string> headers, ContextBag extensinos, IBehaviorContext parentContext)
+        public OutgoingSendContext(OutgoingLogicalMessage message, string messageId, Dictionary<string, string> headers, ContextBag extensions, IBehaviorContext parentContext)
             : base(messageId, headers, parentContext)
         {
             Guard.AgainstNull(nameof(parentContext), parentContext);
             Guard.AgainstNull(nameof(message), message);
-            Guard.AgainstNull(nameof(extensinos), extensinos);
+            Guard.AgainstNull(nameof(extensions), extensions);
 
             Message = message;
 
-            Merge(extensinos);
+            Merge(extensions);
         }
 
         public OutgoingLogicalMessage Message { get; }


### PR DESCRIPTION
Fixes typo introduced in #4614 

We'll manually deal with any versioning problems this introduces.