### PR TITLE
Cleanup: MSMQ unit tests should delete the queues that it creates.

### DIFF
--- a/src/NServiceBus.Core.Tests/Msmq/MsmqExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqExtensionsTests.cs
@@ -8,7 +8,7 @@
     [TestFixture]
     public class MsmqExtensionsTests
     {
-        static string LocalEveryoneGroupName = new SecurityIdentifier(WellKnownSidType.WorldSid, null).Translate(typeof(NTAccount)).ToString();
+        static readonly string LocalEveryoneGroupName = new SecurityIdentifier(WellKnownSidType.WorldSid, null).Translate(typeof(NTAccount)).ToString();
 
         string path;
         MessageQueue queue;

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
@@ -9,8 +9,8 @@
     [TestFixture]
     public class MsmqQueueCreatorTests
     {
-        string testQueueNameForSending = "NServiceBus.Core.Tests.MsmqQueueCreatorTests.Sending";
-        string testQueueNameForReceiving = "NServiceBus.Core.Tests.MsmqQueueCreatorTests.Receiving";
+        const string testQueueNameForSending = "NServiceBus.Core.Tests.MsmqQueueCreatorTests.Sending";
+        const string testQueueNameForReceiving = "NServiceBus.Core.Tests.MsmqQueueCreatorTests.Receiving";
 
         [SetUp]
         public void Setup()
@@ -149,10 +149,10 @@
         {
             var path = MsmqAddress.Parse(testQueueNameForReceiving).PathWithoutPrefix;
 
-            using (var existingQueue = MessageQueue.Create(path))
+            using (var queue = MessageQueue.Create(path))
             {
-                existingQueue.SetPermissions(LocalEveryoneGroupName, MessageQueueAccessRights.GenericWrite, AccessControlEntryType.Revoke);
-                existingQueue.SetPermissions(LocalAnonymousLogonName, MessageQueueAccessRights.WriteMessage, AccessControlEntryType.Revoke);
+                queue.SetPermissions(LocalEveryoneGroupName, MessageQueueAccessRights.GenericWrite, AccessControlEntryType.Revoke);
+                queue.SetPermissions(LocalAnonymousLogonName, MessageQueueAccessRights.WriteMessage, AccessControlEntryType.Revoke);
             }
 
             var creator = new MsmqQueueCreator(true);
@@ -163,13 +163,13 @@
             creator.CreateQueueIfNecessary(bindings, WindowsIdentity.GetCurrent().Name);
 
 
-            var queue = GetQueue(testQueueNameForReceiving);
+            var existingQueue = GetQueue(testQueueNameForReceiving);
 
             MessageQueueAccessRights? nullBecauseRevoked;
             AccessControlEntryType? accessControlEntryType;
 
-            Assert.False(queue.TryGetPermissions(LocalEveryoneGroupName, out nullBecauseRevoked, out accessControlEntryType));
-            Assert.False(queue.TryGetPermissions(LocalAnonymousLogonName, out nullBecauseRevoked, out accessControlEntryType));
+            Assert.False(existingQueue.TryGetPermissions(LocalEveryoneGroupName, out nullBecauseRevoked, out accessControlEntryType));
+            Assert.False(existingQueue.TryGetPermissions(LocalAnonymousLogonName, out nullBecauseRevoked, out accessControlEntryType));
             Assert.IsNull(accessControlEntryType);
         }
 
@@ -223,9 +223,9 @@
         }
 
 
-        static string LocalEveryoneGroupName = new SecurityIdentifier(WellKnownSidType.WorldSid, null).Translate(typeof(NTAccount)).ToString();
-        static string LocalAnonymousLogonName = new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Translate(typeof(NTAccount)).ToString();
-        static string NetworkServiceAccountName = new SecurityIdentifier(WellKnownSidType.NetworkServiceSid, null).Translate(typeof(NTAccount)).ToString();
-        static string LocalAdministratorsGroupName = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null).Translate(typeof(NTAccount)).ToString();
+        static readonly string LocalEveryoneGroupName = new SecurityIdentifier(WellKnownSidType.WorldSid, null).Translate(typeof(NTAccount)).ToString();
+        static readonly string LocalAnonymousLogonName = new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Translate(typeof(NTAccount)).ToString();
+        static readonly string NetworkServiceAccountName = new SecurityIdentifier(WellKnownSidType.NetworkServiceSid, null).Translate(typeof(NTAccount)).ToString();
+        static readonly string LocalAdministratorsGroupName = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null).Translate(typeof(NTAccount)).ToString();
     }
 }

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqQueueCreatorTests.cs
@@ -17,7 +17,6 @@
         {
             DeleteQueueIfPresent(testQueueNameForSending);
             DeleteQueueIfPresent(testQueueNameForReceiving);
-            DeleteQueueIfPresent(GetReallyLongQueueName());
         }
 
         [TearDown]
@@ -25,7 +24,6 @@
         {
             DeleteQueueIfPresent(testQueueNameForSending);
             DeleteQueueIfPresent(testQueueNameForReceiving);
-            DeleteQueueIfPresent(GetReallyLongQueueName());
         }
 
         [Test]
@@ -175,17 +173,6 @@
             Assert.IsNull(accessControlEntryType);
         }
 
-        [Test]
-        public void Should_allow_queue_names_above_the_limit_for_set_permission()
-        {
-            var testQueueName = GetReallyLongQueueName();
-            var creator = new MsmqQueueCreator(true);
-            var bindings = new QueueBindings();
-
-            bindings.BindReceiving(testQueueName);
-
-            Assert.DoesNotThrow(() => creator.CreateQueueIfNecessary(bindings, WindowsIdentity.GetCurrent().Name));
-        }
 
         [Test]
         public void Should_blow_up_for_invalid_accounts()
@@ -233,12 +220,6 @@
             {
                 MessageQueue.Delete(path);
             }
-        }
-
-        string GetReallyLongQueueName()
-        {
-            var maxQueueNameForSetPermissionToWork = 102 - Environment.MachineName.Length;
-            return testQueueNameForReceiving.PadRight(maxQueueNameForSetPermissionToWork - testQueueNameForReceiving.Length + 1, 'a');
         }
 
 

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqSubscriptionStorageIntegrationTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqSubscriptionStorageIntegrationTests.cs
@@ -9,7 +9,7 @@
 
     public class MsmqSubscriptionStorageIntegrationTests
     {
-        string testQueueName = "NServiceBus.Core.Tests.MsmqSubscriptionStorageIntegrationTests";
+        const string testQueueName = "NServiceBus.Core.Tests.MsmqSubscriptionStorageIntegrationTests";
 
         [SetUp]
         public void Setup()

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqSubscriptionStorageIntegrationTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqSubscriptionStorageIntegrationTests.cs
@@ -41,6 +41,7 @@
             {
                 CollectionAssert.IsEmpty(queue.GetAllMessages());
             }
+            MessageQueue.Delete(queuePath);
         }
 
         [Test]
@@ -75,6 +76,7 @@
             {
                 CollectionAssert.IsEmpty(queue.GetAllMessages());
             }
+            MessageQueue.Delete(queuePath);
         }
 
         class MyMessage

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqSubscriptionStorageIntegrationTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqSubscriptionStorageIntegrationTests.cs
@@ -9,6 +9,13 @@
 
     public class MsmqSubscriptionStorageIntegrationTests
     {
+        [TearDown]
+        public void TearDown()
+        {
+            DeleteQueueIfPresent("MsmqSubscriptionStorageQueueTests.PersistTransactional");
+            DeleteQueueIfPresent("MsmqSubscriptionStorageQueueTests.PersistNonTransactional");
+        }
+
         [Test]
         public async Task ShouldRemoveSubscriptionsInTransactionalMode()
         {
@@ -41,7 +48,6 @@
             {
                 CollectionAssert.IsEmpty(queue.GetAllMessages());
             }
-            MessageQueue.Delete(queuePath);
         }
 
         [Test]
@@ -76,7 +82,16 @@
             {
                 CollectionAssert.IsEmpty(queue.GetAllMessages());
             }
-            MessageQueue.Delete(queuePath);
+        }
+
+        void DeleteQueueIfPresent(string queueName)
+        {
+            var path = MsmqAddress.Parse(queueName).PathWithoutPrefix;
+
+            if (MessageQueue.Exists(path))
+            {
+                MessageQueue.Delete(path);
+            }
         }
 
         class MyMessage

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqSubscriptionStorageIntegrationTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqSubscriptionStorageIntegrationTests.cs
@@ -9,23 +9,25 @@
 
     public class MsmqSubscriptionStorageIntegrationTests
     {
+        string testQueueName = "NServiceBus.Core.Tests.MsmqSubscriptionStorageIntegrationTests";
+
+        [SetUp]
+        public void Setup()
+        {
+            DeleteQueueIfPresent(testQueueName);
+        }
+
         [TearDown]
         public void TearDown()
         {
-            DeleteQueueIfPresent("MsmqSubscriptionStorageQueueTests.PersistTransactional");
-            DeleteQueueIfPresent("MsmqSubscriptionStorageQueueTests.PersistNonTransactional");
+            DeleteQueueIfPresent(testQueueName);
         }
 
         [Test]
         public async Task ShouldRemoveSubscriptionsInTransactionalMode()
         {
-            var address = MsmqAddress.Parse("MsmqSubscriptionStorageQueueTests.PersistTransactional");
+            var address = MsmqAddress.Parse(testQueueName);
             var queuePath = address.PathWithoutPrefix;
-
-            if (MessageQueue.Exists(queuePath))
-            {
-                MessageQueue.Delete(queuePath);
-            }
 
             MessageQueue.Create(queuePath, true);
 
@@ -53,13 +55,8 @@
         [Test]
         public async Task ShouldRemoveSubscriptionsInNonTransactionalMode()
         {
-            var address = MsmqAddress.Parse("MsmqSubscriptionStorageQueueTests.PersistNonTransactional");
+            var address = MsmqAddress.Parse(testQueueName);
             var queuePath = address.PathWithoutPrefix;
-
-            if (MessageQueue.Exists(queuePath))
-            {
-                MessageQueue.Delete(queuePath);
-            }
 
             MessageQueue.Create(queuePath, false);
 

--- a/src/NServiceBus.Core.Tests/Msmq/QueuePermissionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/QueuePermissionsTests.cs
@@ -12,7 +12,7 @@
     public class QueuePermissionsTests
     {
         StringBuilder logOutput;
-        string testQueueName = "NServiceBus.Core.Tests.QueuePermissionsTests";
+        const string testQueueName = "NServiceBus.Core.Tests.QueuePermissionsTests";
 
         [OneTimeSetUp]
         public void TestFixtureSetup()

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqQueueCreator.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqQueueCreator.cs
@@ -77,7 +77,7 @@ namespace NServiceBus
 
         bool useTransactionalQueues;
 
-        static string LocalAdministratorsGroupName = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null).Translate(typeof(NTAccount)).ToString();
+        static readonly string LocalAdministratorsGroupName = new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null).Translate(typeof(NTAccount)).ToString();
         static ILog Logger = LogManager.GetLogger<MsmqQueueCreator>();
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/QueuePermissions.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/QueuePermissions.cs
@@ -65,8 +65,8 @@
             }
         }
 
-        internal static string LocalEveryoneGroupName = new SecurityIdentifier(WellKnownSidType.WorldSid, null).Translate(typeof(NTAccount)).ToString();
-        internal static string LocalAnonymousLogonName = new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Translate(typeof(NTAccount)).ToString();
+        static readonly string LocalEveryoneGroupName = new SecurityIdentifier(WellKnownSidType.WorldSid, null).Translate(typeof(NTAccount)).ToString();
+        static readonly string LocalAnonymousLogonName = new SecurityIdentifier(WellKnownSidType.AnonymousSid, null).Translate(typeof(NTAccount)).ToString();
 
         static ILog Logger = LogManager.GetLogger(typeof(QueuePermissions));
     }


### PR DESCRIPTION
There were some unit tests that wasn't deleting the test queues that it created, leaving a bunch of queues behind after the tests have been run polluting the environment. 

@Particular/msmq-transport-maintainers - please review

cc / @Particular/nservicebus-maintainers 

