### PR TITLE
Use original exception as inner exception

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/MessageFailedException.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/MessageFailedException.cs
@@ -5,7 +5,8 @@ namespace NServiceBus.AcceptanceTesting.Support
 
     public class MessageFailedException : Exception
     {
-        public MessageFailedException(FailedMessage failedMessage, ScenarioContext scenarioContext) : base("A message has been moved to the error queue.")
+        public MessageFailedException(FailedMessage failedMessage, ScenarioContext scenarioContext)
+            : base("A message has been moved to the error queue.", failedMessage.Exception)
         {
             ScenarioContext = scenarioContext;
             FailedMessage = failedMessage;


### PR DESCRIPTION
helps to debug failed message as this will also print the inner exception which was the original cause of a failed message.