### PR TITLE
Stabilize struct conventions

### DIFF
--- a/src/NServiceBus.Core.Tests/StructConventionsTests.ApproveStructsWhichDontFollowStructGuidelines.approved.txt
+++ b/src/NServiceBus.Core.Tests/StructConventionsTests.ApproveStructsWhichDontFollowStructGuidelines.approved.txt
@@ -10,15 +10,12 @@ AVOID defining a struct unless the type has all of the following characteristics
 In all other cases, you should define your types as classes.
 -------------------------------------------------- REMEMBER --------------------------------------------------
 
+NServiceBus.Features.SLAMonitoring+EstimatedTimeToSLABreachCounter+DataPoint violates the following rules:
+   - The size is 24 bytes, which exceeds the recommended maximum of 16 bytes.
+
 NServiceBus.LogicalAddress violates the following rules:
    - The following fields are reference types, which are potentially mutable:
       - Field <EndpointInstance>k__BackingField of type NServiceBus.Routing.EndpointInstance is a reference type.
-
-NServiceBus.MessageQueueExtensions+ACE_HEADER violates the following rules:
-   - The following fields are public, so the type is not immutable:
-      - Field AceType of type System.Byte is public.
-      - Field AceFlags of type System.Byte is public.
-      - Field AceSize of type System.Int16 is public.
 
 NServiceBus.MessageQueueExtensions+ACCESS_ALLOWED_ACE violates the following rules:
    - The following fields are public, so the type is not immutable:
@@ -26,12 +23,15 @@ NServiceBus.MessageQueueExtensions+ACCESS_ALLOWED_ACE violates the following rul
       - Field Mask of type System.UInt32 is public.
       - Field SidStart of type System.Int32 is public.
 
+NServiceBus.MessageQueueExtensions+ACE_HEADER violates the following rules:
+   - The following fields are public, so the type is not immutable:
+      - Field AceFlags of type System.Byte is public.
+      - Field AceSize of type System.Int16 is public.
+      - Field AceType of type System.Byte is public.
+
 NServiceBus.MessageQueueExtensions+ACL_SIZE_INFORMATION violates the following rules:
    - The following fields are public, so the type is not immutable:
       - Field AceCount of type System.UInt32 is public.
-      - Field AclBytesInUse of type System.UInt32 is public.
       - Field AclBytesFree of type System.UInt32 is public.
-
-NServiceBus.Features.SLAMonitoring+EstimatedTimeToSLABreachCounter+DataPoint violates the following rules:
-   - The size is 24 bytes, which exceeds the recommended maximum of 16 bytes.
+      - Field AclBytesInUse of type System.UInt32 is public.
 

--- a/src/NServiceBus.Core.Tests/StructConventionsTests.cs
+++ b/src/NServiceBus.Core.Tests/StructConventionsTests.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Core.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Reflection;
     using System.Runtime.InteropServices;
     using System.Text;
@@ -29,7 +30,7 @@ In all other cases, you should define your types as classes.
 ");
 
             var assembly = typeof(Endpoint).Assembly;
-            foreach (var type in assembly.GetTypes())
+            foreach (var type in assembly.GetTypes().OrderBy(t => t.FullName))
             {
                 if (!type.IsValueType || type.IsEnum || type.IsSpecialName|| type.Namespace == null || !type.Namespace.StartsWith("NServiceBus") || type.FullName.Contains("__")) continue;
 
@@ -62,7 +63,7 @@ In all other cases, you should define your types as classes.
 
             var fields = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
-            foreach (var fieldInfo in fields)
+            foreach (var fieldInfo in fields.OrderBy(f => f.Name))
             {
                 if (fieldInfo.FieldType == typeof(string) && (fieldInfo.IsInitOnly || fieldInfo.IsLiteral))
                 {
@@ -85,7 +86,7 @@ In all other cases, you should define your types as classes.
 
             var fields = type.GetFields();
 
-            foreach (var fieldInfo in fields)
+            foreach (var fieldInfo in fields.OrderBy(f => f.Name))
             {
                 if (!fieldInfo.IsInitOnly && !fieldInfo.IsLiteral)
                 {
@@ -103,7 +104,7 @@ In all other cases, you should define your types as classes.
 
             var properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
-            foreach (var property in properties)
+            foreach (var property in properties.OrderBy(p => p.Name))
             {
                 if (property.CanWrite)
                 {


### PR DESCRIPTION
Build fails from time to time with reordered LogicalAddress

https://builds.particular.net/viewLog.html?buildId=214731&buildTypeId=NServiceBusCore_Build

This now sorts the fields, properties and types ascending