### PR TITLE
Skip exe files from scanning when excluded

### DIFF
--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -468,7 +468,7 @@ namespace NServiceBus.Hosting.Helpers
         static string DistillLowerAssemblyName(string assemblyOrFileName)
         {
             var lowerAssemblyName = assemblyOrFileName.ToLowerInvariant();
-            if (lowerAssemblyName.EndsWith(".dll"))
+            if (lowerAssemblyName.EndsWith(".dll") || lowerAssemblyName.EndsWith(".exe"))
             {
                 lowerAssemblyName = lowerAssemblyName.Substring(0, lowerAssemblyName.Length - 4);
             }


### PR DESCRIPTION
fixes https://github.com/Particular/NServiceBus/issues/4633 and adds two related unit tests.

Had to adjust the assembly generation code slightly to allow generating exe files.
cc @danielmarbach 