### PR TITLE
Improve acceptance testing exceptions

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -48,7 +48,7 @@ namespace NServiceBus.AcceptanceTesting
 
             if (runSummary.Result.Failed)
             {
-                throw runSummary.Result.Exception;
+                runSummary.Result.Exception.Throw();
             }
 
             return (TContext)runDescriptor.ScenarioContext;

--- a/src/NServiceBus.AcceptanceTesting/Support/MessageFailedException.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/MessageFailedException.cs
@@ -15,5 +15,8 @@ namespace NServiceBus.AcceptanceTesting.Support
         public ScenarioContext ScenarioContext { get; }
 
         public FailedMessage FailedMessage { get; }
+
+        // Show the stack trace of the exception which caused the message to fail
+        public override string StackTrace => FailedMessage.Exception.StackTrace;
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -5,6 +5,7 @@
     using System.Diagnostics;
     using System.Globalization;
     using System.Linq;
+    using System.Runtime.ExceptionServices;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -55,7 +56,7 @@
             catch (Exception ex)
             {
                 runResult.Failed = true;
-                runResult.Exception = ex;
+                runResult.Exception = ExceptionDispatchInfo.Capture(ex);
             }
 
             runResult.TotalTime = runTimer.Elapsed;
@@ -205,7 +206,7 @@
     {
         public bool Failed { get; set; }
 
-        public Exception Exception { get; set; }
+        public ExceptionDispatchInfo Exception { get; set; }
 
         public TimeSpan TotalTime { get; set; }
 

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -68,7 +68,7 @@
                 }
                 else
                 {
-                    string message = $"Failed to subscribe to {messageType} at publisher queue {destination}, reason {ex.Message}";
+                    var message = $"Failed to subscribe to {messageType} at publisher queue {destination}, reason {ex.Message}";
                     Logger.Error(message, ex);
                     throw new QueueNotFoundException(destination, message, ex);
                 }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -68,7 +68,7 @@
                 }
                 else
                 {
-                    string message = $"Failed to unsubscribe for {messageType} at publisher queue {destination}, reason {ex.Message}";
+                    var message = $"Failed to unsubscribe for {messageType} at publisher queue {destination}, reason {ex.Message}";
                     Logger.Error(message, ex);
                     throw new QueueNotFoundException(destination, message, ex);
                 }


### PR DESCRIPTION
Two changes which could improve exceptions occuring during acceptance testing:
* MessageFailedException show the stacktrace of the original exception.
* When exceptions are rethrown by the framework, it uses ExceptionDispatchInfo to restore the stack trace. This should help to idenfity the cause of an exception in case the acceptance testing framework itself threw it (e.g. couldn't start an endpoint).

Thoughts? Imho I'm not sure about the value of change number two, as essentially all exceptions are thrown by the acceptance testing framework anyway (that's why MessageFailedException overrides the stack trace, as you would still see the stacktrace from the acceptance testing framework) but it points at a more specific point potentially helping to detect the original cause.