### PR TITLE
Fix reading large text files

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -185,6 +185,7 @@
     <Compile Include="Routing\Routers\UnicastSendRouterTests.cs" />
     <Compile Include="Routing\Routers\UnicastSendRouteOptionsTests.cs" />
     <Compile Include="Routing\TypeRouteSourceTests.cs" />
+    <Compile Include="Transports\Learning\AsyncFileTests.cs" />
     <Compile Include="Transports\MSMQ\InstanceMapping\InstanceMappingFileFeatureTests.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\MessageDrivenSubscriptionsConfigExtensionsTests.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\PublishersTests.cs" />

--- a/src/NServiceBus.Core.Tests/Transports/Learning/AsyncFileTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/Learning/AsyncFileTests.cs
@@ -1,0 +1,30 @@
+﻿namespace NServiceBus.Core.Tests.Transports.Learning
+{
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    public class AsyncFileTests
+    {
+        [Test]
+        public async Task When_file_content_larger_than_buffer_size()
+        {
+            var originalContent = string.Join("", Enumerable.Repeat("a#~×ψؾࢯ‽%1", 2000));
+            const string filePath = "test.txt";
+
+            try
+            {
+                await AsyncFile.WriteText(filePath, originalContent);
+
+                var content = await AsyncFile.ReadText(filePath);
+
+                Assert.AreEqual(originalContent, content);
+            }
+            finally
+            {
+                File.Delete(filePath);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Transports/Learning/AsyncFile.cs
+++ b/src/NServiceBus.Core/Transports/Learning/AsyncFile.cs
@@ -69,21 +69,12 @@ namespace NServiceBus
             return WriteBytes(filePath, bytes);
         }
 
-        public static async Task<string> ReadText(string filePath, CancellationToken token = default(CancellationToken))
+        public static async Task<string> ReadText(string filePath)
         {
-            var utf8 = Encoding.UTF8;
-            using (var stream = CreateReadStream(filePath))
+            using (var stream = new StreamReader(CreateReadStream(filePath), Encoding.UTF8))
             {
-                var builder = new StringBuilder();
-
-                var buffer = new byte[0x1000];
-                int numRead;
-                while ((numRead = await stream.ReadAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false)) != 0)
-                {
-                    builder.Append(utf8.GetString(buffer, 0, numRead));
-                }
-
-                return builder.ToString();
+                var result = await stream.ReadToEndAsync().ConfigureAwait(false);
+                return result;
             }
         }
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -146,7 +146,7 @@
         {
             try
             {
-                var message = await AsyncFile.ReadText(transaction.FileToProcess, cancellationToken)
+                var message = await AsyncFile.ReadText(transaction.FileToProcess)
                     .ConfigureAwait(false);
                 string bodyPath;
                 Dictionary<string, string> headers;


### PR DESCRIPTION
The previous approach had a good chance to corrupt the input content once the content is larger than the buffer size. I used a `StreamReader` as it is able to deal with encoding internally and read the correct utf-8 blocks.

It might be an option use `StreamWriter` in WriteText too.

ping @SimonCropp @andreasohlund @danielmarbach 

(this PR is targeting https://github.com/Particular/NServiceBus/pull/4550)