### PR TITLE
Add contentFiles section to source packages

### DIFF
--- a/packaging/nuget/nservicebus.acceptancetests.nuspec
+++ b/packaging/nuget/nservicebus.acceptancetests.nuspec
@@ -30,5 +30,9 @@
       src="..\..\src\NServiceBus.AcceptanceTests\**\*.cs"
       target="content\App_Packages\NSB.AcceptanceTests.$version$"
       exclude="**\bin\**\*.*;**\obj\**\*.*;..\..\src\NServiceBus.AcceptanceTests\Core\**\*.cs" />
+    <file
+      src="..\..\src\NServiceBus.AcceptanceTests\**\*.cs"
+      target="contentFiles\cs\any\NSB.AcceptanceTests"
+      exclude="**\bin\**\*.*;**\obj\**\*.*;..\..\src\NServiceBus.AcceptanceTests\Core\**\*.cs" />
   </files>
 </package>

--- a/packaging/nuget/nservicebus.acceptancetests.nuspec
+++ b/packaging/nuget/nservicebus.acceptancetests.nuspec
@@ -20,6 +20,7 @@
       <dependency id="NUnit" version="[3.6.1, 4.0.0)" />
     </dependencies>
   <frameworkAssemblies>
+    <frameworkAssembly assemblyName="Microsoft.CSharp" targetFramework="net452" />
     <frameworkAssembly assemblyName="System.Messaging" targetFramework="net452" />
     <frameworkAssembly assemblyName="System.Transactions" targetFramework="net452" />
     <frameworkAssembly assemblyName="System.Configuration" targetFramework="net452" />

--- a/packaging/nuget/nservicebus.containertests.nuspec
+++ b/packaging/nuget/nservicebus.containertests.nuspec
@@ -16,10 +16,11 @@
     <tags>nservicebus servicebus msmq cqrs publish subscribe</tags>
     <dependencies>
       <dependency id="NServiceBus" version="$version$" />
-  	  <dependency id="NUnit" version="[3.2.0, 4.0.0)" />
+  	  <dependency id="NUnit" version="[3.6.1, 4.0.0)" />
     </dependencies>
   </metadata>
   <files>
     <file src="..\..\src\NServiceBus.ContainerTests\**\*.cs" target="content\App_Packages\NSB.ContainerTests.$version$"  exclude="**\bin\**\*.*;**\obj\**\*.*"/>
+    <file src="..\..\src\NServiceBus.ContainerTests\**\*.cs" target="contentFiles\cs\any\NSB.ContainerTests"  exclude="**\bin\**\*.*;**\obj\**\*.*"/>
   </files>
 </package>

--- a/packaging/nuget/nservicebus.testing.fakes.nuspec
+++ b/packaging/nuget/nservicebus.testing.fakes.nuspec
@@ -22,5 +22,9 @@
       src="..\..\src\NServiceBus.Testing.Fakes\*.cs"
       target="content\App_Packages\NSB.Testing.Fakes.$version$"
       exclude="**\bin\**\*.*;**\obj\**\*.*;" />
+    <file
+      src="..\..\src\NServiceBus.Testing.Fakes\*.cs"
+      target="contentFiles\cs\any\NSB.Testing.Fakes"
+      exclude="**\bin\**\*.*;**\obj\**\*.*;" />
   </files>
 </package>

--- a/packaging/nuget/nservicebus.transporttests.nuspec
+++ b/packaging/nuget/nservicebus.transporttests.nuspec
@@ -27,6 +27,10 @@
     <file
       src="..\..\src\NServiceBus.TransportTests\**\*.cs"
       target="content\App_Packages\NSB.TransportTests.$version$"
-      exclude="**\bin\**\*.*;**\obj\**\*.*;..\..\src\NServiceBus.TransportTests\ConfigureMsmqTransportInfrastructure.cs" />
+      exclude="**\bin\**\*.*;**\obj\**\*.*;..\..\src\NServiceBus.TransportTests\ConfigureLearningTransportInfrastructure.cs" />
+    <file
+      src="..\..\src\NServiceBus.TransportTests\**\*.cs"
+      target="contentFiles\cs\any\NSB.TransportTests"
+      exclude="**\bin\**\*.*;**\obj\**\*.*;..\..\src\NServiceBus.TransportTests\ConfigureLearningTransportInfrastructure.cs" />
   </files>
 </package>


### PR DESCRIPTION
This adjusts all of the source packages to also include the source files in the `contentFiles` folder, which will be used when consuming the package in SDK-style csproj via PackageReference.

In an attempt to shorten the path to the file, I've removed the `App_Package` subfolder and the version.

This results in the following view from inside VS:
![image](https://cloud.githubusercontent.com/assets/753669/25596537/968901c6-2e97-11e7-8dae-fb357aab9efa.png)

The test files end up on disk inside the NuGet package cache folder. The paths end up looking something like:
````
C:\Users\Brandon\.nuget\packages\nservicebus.acceptancetests.sources\6.3.0-alpha0085\contentFiles\cs\any\NSB.AcceptanceTests\Audit\When_a_message_is_audited.cs
````
If we wanted to shorten things further, we could get rid of the remaining grouping folder ("NSB.AcceptanceTests" in the example above), but I'm not sure that would be a good idea since everything would then just be in the root of the project.

CC: @adamralph 