### PR TITLE
Add basic tx recovery for the learning transport

### DIFF
--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -51,7 +51,9 @@ namespace NServiceBus
         public Task Enlist(string messagePath, string messageContents)
         {
             if (immediateDispatch)
+            {
                 return AsyncFile.WriteText(messagePath, messageContents);
+            }
 
             var inProgressFileName = Path.GetFileNameWithoutExtension(messagePath) + ".out";
 

--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -109,7 +109,7 @@ namespace NServiceBus
             var pendingDir = new DirectoryInfo(transactionDir);
 
             //only need to move the incoming file
-            foreach (var file in pendingDir.EnumerateFiles("*.txt"))
+            foreach (var file in pendingDir.EnumerateFiles(TxtFileExtension))
             {
                 File.Move(file.FullName, Path.Combine(basePath, file.Name));
             }
@@ -123,7 +123,7 @@ namespace NServiceBus
 
             //for now just rollback the completed ones as well. We could consider making this smarter in the future
             // but its good enough for now since duplicates is a possibility anyway
-            foreach (var file in committedDir.EnumerateFiles("*.txt"))
+            foreach (var file in committedDir.EnumerateFiles(TxtFileExtension))
             {
                 File.Move(file.FullName, Path.Combine(basePath, file.Name));
             }
@@ -142,6 +142,7 @@ namespace NServiceBus
 
         const string CommittedDirName = ".committed";
         const string PendingDirName = ".pending";
+        const string TxtFileExtension = "*.txt";
 
         class OutgoingFile
         {

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -45,7 +45,15 @@
             cancellationToken = cancellationTokenSource.Token;
 
             if (purgeOnStartup)
+            {
                 Array.ForEach(Directory.GetFiles(path), File.Delete);
+            }
+
+            if (transactionMode != TransportTransactionMode.None)
+            {
+                DirectoryBasedTransaction.RecoverPartiallyCompletedTransactions(path);
+            }
+
             messagePumpTask = Task.Run(ProcessMessages, cancellationToken);
 
             delayedMessagePoller.Start();
@@ -123,8 +131,9 @@
             {
                 return new NoTransaction(path);
             }
+
             var immediateDispatch = transactionMode == TransportTransactionMode.ReceiveOnly;
-            return new DirectoryBasedTransaction(path, immediateDispatch);
+            return new DirectoryBasedTransaction(path, Guid.NewGuid().ToString(), immediateDispatch);
         }
 
         async Task InnerProcessFile(ILearningTransportTransaction transaction, string nativeMessageId)

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -24,9 +24,7 @@
             transactionMode = settings.RequiredTransactionMode;
 
             path = Path.Combine(basePath, settings.InputQueue);
-
-            Directory.CreateDirectory(Path.Combine(path, ".committed"));
-
+            
             purgeOnStartup = settings.PurgeOnStartup;
 
             receiveCircuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker("LearningTransportReceive", TimeSpan.FromSeconds(30), ex => criticalError.Raise("Failed to receive from " + settings.InputQueue, ex));


### PR DESCRIPTION
Adds basic transaction recoverability to the learning transport. This mostly makes sure that users debugging won't  loose messages if they stop endpoints in the middle of debugging