### PR TITLE
Remove code to detect unobtrusive messages used by handlers

### DIFF
--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -97,37 +97,11 @@ namespace NServiceBus.Hosting.Helpers
                 }
             }
 
-            // This extra step is to ensure unobtrusive message types are included in the Types list.
-            var list = GetHandlerMessageTypes(results.Types);
-            results.Types.AddRange(list);
-
             results.RemoveDuplicates();
 
             return results;
         }
-
-        static List<Type> GetHandlerMessageTypes(List<Type> list)
-        {
-            var foundMessageTypes = new List<Type>();
-            foreach (var type in list)
-            {
-                if (type.IsAbstract || type.IsGenericTypeDefinition)
-                {
-                    continue;
-                }
-
-                foreach (var @interface in type.GetInterfaces())
-                {
-                    if (@interface.IsGenericType && @interface.GetGenericTypeDefinition() == IHandleMessagesType)
-                    {
-                        var messageType = @interface.GetGenericArguments()[0];
-                        foundMessageTypes.Add(messageType);
-                    }
-                }
-            }
-            return foundMessageTypes;
-        }
-
+        
         bool TryLoadScannableAssembly(string assemblyPath, AssemblyScannerResults results, out Assembly assembly)
         {
             assembly = null;
@@ -451,7 +425,5 @@ namespace NServiceBus.Hosting.Helpers
             // And other windows azure stuff
             "Microsoft.WindowsAzure"
         };
-
-        static Type IHandleMessagesType = typeof(IHandleMessages<>);
     }
 }


### PR DESCRIPTION
This is just a spike/discussion to decide if we should remove the code in the scanner that looks for message that are referenced by a handler. v6.3 is able to load messages on the fly so its no longer needed.

AutoSubscribe is driven by the `T` in `IHandleMessages<T>` so not needed there either.

Only thing that could break is user code that relies on all messages being available in the scanned types collection? (but that isn't waterproof as proven by: https://github.com/Particular/NServiceBus/pull/4635 )