### PR TITLE
Allow user defined conversation ids

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_setting_conversation_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_setting_conversation_id.cs
@@ -98,11 +98,11 @@
             }
         }
 
-        class MessageWithCoversationId : ICommand
+        public class MessageWithCoversationId : ICommand
         {
         }
 
-        class IntermediateMessage : ICommand
+        public class IntermediateMessage : ICommand
         {
         }
     }

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_setting_conversation_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_setting_conversation_id.cs
@@ -1,0 +1,109 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Pipeline
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_using_custom_conversation_id : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_apply_custom_conversation_id_when_no_incoming_message()
+        {
+            var customConversationId = Guid.NewGuid().ToString();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<ReceivingEndpoint>(e => e
+                    .When(s =>
+                    {
+                        var options = new SendOptions();
+                        options.RouteToThisEndpoint();
+                        options.SetHeader(Headers.ConversationId, customConversationId);
+                        return s.Send(new MessageWithCoversationId(), options);
+                    }))
+                .Done(c => !string.IsNullOrEmpty(c.ReceivedConversationId))
+                .Run();
+
+            Assert.AreEqual(customConversationId, context.ReceivedConversationId);
+        }
+
+        [Test]
+        public async Task Should_use_incoming_conversation_id_when_available()
+        {
+            var initialConversationId = Guid.NewGuid().ToString();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<IntermediateEndpoint>(e => e
+                    .When(s =>
+                    {
+                        var options = new SendOptions();
+                        options.RouteToThisEndpoint();
+                        options.SetHeader(Headers.ConversationId, initialConversationId);
+                        return s.Send(new IntermediateMessage(), options);
+                    }))
+                .WithEndpoint<ReceivingEndpoint>()
+                .Done(c => !string.IsNullOrEmpty(c.ReceivedConversationId))
+                .Run();
+
+            Assert.AreEqual(initialConversationId, context.ReceivedConversationId);
+        }
+
+        class Context : ScenarioContext
+        {
+            public string ReceivedConversationId { get; set; }
+        }
+
+        class ReceivingEndpoint : EndpointConfigurationBuilder
+        {
+            public ReceivingEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class ConversationIdMessageHandler : IHandleMessages<MessageWithCoversationId>
+            {
+                Context testContext;
+
+                public ConversationIdMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MessageWithCoversationId message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedConversationId = context.MessageHeaders[Headers.ConversationId];
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        class IntermediateEndpoint : EndpointConfigurationBuilder
+        {
+            public IntermediateEndpoint()
+            {
+                EndpointSetup<DefaultServer>(e => e.ConfigureTransport().Routing()
+                    .RouteToEndpoint(typeof(MessageWithCoversationId), typeof(ReceivingEndpoint)));
+            }
+
+            public class IntermediateMessageHandler : IHandleMessages<IntermediateMessage>
+            {
+                public Task Handle(IntermediateMessage message, IMessageHandlerContext context)
+                {
+                    var options = new SendOptions();
+                    options.SetHeader(Headers.ConversationId, "intermediate message header");
+                    return context.Send(new MessageWithCoversationId(), options);
+                }
+            }
+        }
+
+        class MessageWithCoversationId : ICommand
+        {
+        }
+
+        class IntermediateMessage : ICommand
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_setting_conversation_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_setting_conversation_id.cs
@@ -21,7 +21,7 @@
                         var options = new SendOptions();
                         options.RouteToThisEndpoint();
                         options.SetHeader(Headers.ConversationId, customConversationId);
-                        return s.Send(new MessageWithCoversationId(), options);
+                        return s.Send(new MessageWithConversationId(), options);
                     }))
                 .Done(c => !string.IsNullOrEmpty(c.ReceivedConversationId))
                 .Run();
@@ -62,7 +62,7 @@
                 EndpointSetup<DefaultServer>();
             }
 
-            public class ConversationIdMessageHandler : IHandleMessages<MessageWithCoversationId>
+            public class ConversationIdMessageHandler : IHandleMessages<MessageWithConversationId>
             {
                 Context testContext;
 
@@ -71,7 +71,7 @@
                     this.testContext = testContext;
                 }
 
-                public Task Handle(MessageWithCoversationId message, IMessageHandlerContext context)
+                public Task Handle(MessageWithConversationId message, IMessageHandlerContext context)
                 {
                     testContext.ReceivedConversationId = context.MessageHeaders[Headers.ConversationId];
                     return Task.FromResult(0);
@@ -84,7 +84,7 @@
             public IntermediateEndpoint()
             {
                 EndpointSetup<DefaultServer>(e => e.ConfigureTransport().Routing()
-                    .RouteToEndpoint(typeof(MessageWithCoversationId), typeof(ReceivingEndpoint)));
+                    .RouteToEndpoint(typeof(MessageWithConversationId), typeof(ReceivingEndpoint)));
             }
 
             public class IntermediateMessageHandler : IHandleMessages<IntermediateMessage>
@@ -93,12 +93,12 @@
                 {
                     var options = new SendOptions();
                     options.SetHeader(Headers.ConversationId, "intermediate message header");
-                    return context.Send(new MessageWithCoversationId(), options);
+                    return context.Send(new MessageWithConversationId(), options);
                 }
             }
         }
 
-        public class MessageWithCoversationId : ICommand
+        public class MessageWithConversationId : ICommand
         {
         }
 

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Core\DelayedDelivery\TimeoutManager\When_using_external_timeout_manager_code_first.cs" />
     <Compile Include="Core\Feature\When_feature_startup_task_fails.cs" />
     <Compile Include="Core\Outbox\When_outbox_double_optin_found.cs" />
+    <Compile Include="Core\Pipeline\When_setting_conversation_id.cs" />
     <Compile Include="Core\Recoverability\When_configuring_unrecoverable_exception.cs" />
     <Compile Include="Core\Recoverability\When_failing_mutated_message.cs" />
     <Compile Include="Core\Routing\When_extending_command_routing_with_thisinstance.cs" />

--- a/src/NServiceBus.Core.Tests/Causation/AttachCausationHeadersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Causation/AttachCausationHeadersBehaviorTests.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using NServiceBus.Pipeline;
     using NUnit.Framework;
     using Testing;
     using Transport;
@@ -15,7 +14,7 @@
         public async Task Should_set_the_conversation_id_to_new_guid_when_not_sent_from_handler()
         {
             var behavior = new AttachCausationHeadersBehavior();
-            var context = InitializeContext();
+            var context = new TestableOutgoingPhysicalMessageContext();
 
             await behavior.Invoke(context, ctx => TaskEx.CompletedTask);
 
@@ -28,7 +27,7 @@
             var incomingConversationId = Guid.NewGuid().ToString();
 
             var behavior = new AttachCausationHeadersBehavior();
-            var context = InitializeContext();
+            var context = new TestableOutgoingPhysicalMessageContext();
 
             var transportMessage = new IncomingMessage("xyz", new Dictionary<string, string>
             {
@@ -41,14 +40,19 @@
             Assert.AreEqual(incomingConversationId, context.Headers[Headers.ConversationId]);
         }
 
-        [Test, Ignore("Will be refactored to use a explicit override via options instead and not rely on the header being set")]
-        public async Task Should_not_override_a_conversation_id_specified_by_the_user()
+        [Test]
+        public async Task When_no_incoming_message_should_not_override_a_conversation_id_specified_by_the_user()
         {
             var userConversationId = Guid.NewGuid().ToString();
 
             var behavior = new AttachCausationHeadersBehavior();
-            var context = InitializeContext();
-
+            var context = new TestableOutgoingPhysicalMessageContext
+            {
+                Headers =
+                {
+                    [Headers.ConversationId] = userConversationId
+                }
+            };
 
             await behavior.Invoke(context, ctx => TaskEx.CompletedTask);
 
@@ -56,21 +60,40 @@
         }
 
         [Test]
+        public async Task When_incoming_message_should_override_a_conversation_id_specified_by_the_user()
+        {
+            var incomingConversationId = Guid.NewGuid().ToString();
+
+            var behavior = new AttachCausationHeadersBehavior();
+            var context = new TestableOutgoingPhysicalMessageContext
+            {
+                Headers =
+                {
+                    [Headers.ConversationId] = Guid.NewGuid().ToString()
+                }
+            };
+            var transportMessage = new IncomingMessage("xyz", new Dictionary<string, string>
+            {
+                {Headers.ConversationId, incomingConversationId}
+            }, new byte[0]);
+            context.Extensions.Set(transportMessage);
+
+            await behavior.Invoke(context, ctx => TaskEx.CompletedTask);
+
+            Assert.AreEqual(incomingConversationId, context.Headers[Headers.ConversationId]);
+        }
+
+        [Test]
         public async Task Should_set_the_related_to_header_with_the_id_of_the_current_message()
         {
             var behavior = new AttachCausationHeadersBehavior();
-            var context = InitializeContext();
+            var context = new TestableOutgoingPhysicalMessageContext();
 
             context.Extensions.Set(new IncomingMessage("the message id", new Dictionary<string, string>(), new byte[0]));
 
             await behavior.Invoke(context, ctx => TaskEx.CompletedTask);
 
             Assert.AreEqual("the message id", context.Headers[Headers.RelatedTo]);
-        }
-
-        static IOutgoingPhysicalMessageContext InitializeContext()
-        {
-            return new TestableOutgoingPhysicalMessageContext();
         }
     }
 }

--- a/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
+++ b/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
@@ -31,14 +31,21 @@ namespace NServiceBus
         static void SetConversationIdHeader(IOutgoingPhysicalMessageContext context, IncomingMessage incomingMessage)
         {
             string conversationIdFromCurrentMessageContext;
+            string userDefinedConversationId;
+            var hasUserDefinedConversationId = context.Headers.TryGetValue(Headers.ConversationId, out userDefinedConversationId);
+
             if (incomingMessage != null && incomingMessage.Headers.TryGetValue(Headers.ConversationId, out conversationIdFromCurrentMessageContext))
             {
+                if (hasUserDefinedConversationId)
+                {
+                    throw new Exception($"Cannot set the {Headers.ConversationId} header to '{userDefinedConversationId}' as it cannot override the incoming header value ('{conversationIdFromCurrentMessageContext}').");
+                }
+
                 context.Headers[Headers.ConversationId] = conversationIdFromCurrentMessageContext;
                 return;
             }
 
-            string userDefinedConversationId;
-            if (context.Headers.TryGetValue(Headers.ConversationId, out userDefinedConversationId))
+            if (hasUserDefinedConversationId)
             {
                 // do not override user defined conversation id if no incoming message exists.
                 return;

--- a/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
+++ b/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
@@ -9,29 +9,42 @@ namespace NServiceBus
     {
         public Task Invoke(IOutgoingPhysicalMessageContext context, Func<IOutgoingPhysicalMessageContext, Task> next)
         {
-            ApplyHeaders(context);
+            IncomingMessage incomingMessage;
+            context.TryGetIncomingPhysicalMessage(out incomingMessage);
+
+            SetRelatedToHeader(context, incomingMessage);
+            SetConversationIdHeader(context, incomingMessage);
 
             return next(context);
         }
 
-        static void ApplyHeaders(IOutgoingPhysicalMessageContext context)
+        static void SetRelatedToHeader(IOutgoingPhysicalMessageContext context, IncomingMessage incomingMessage)
         {
-            var conversationId = CombGuid.Generate().ToString();
-
-            IncomingMessage incomingMessage;
-
-            if (context.TryGetIncomingPhysicalMessage(out incomingMessage))
+            if (incomingMessage == null)
             {
-                context.Headers[Headers.RelatedTo] = incomingMessage.MessageId;
-
-                string conversationIdFromCurrentMessageContext;
-                if (incomingMessage.Headers.TryGetValue(Headers.ConversationId, out conversationIdFromCurrentMessageContext))
-                {
-                    conversationId = conversationIdFromCurrentMessageContext;
-                }
+                return;
             }
 
-            context.Headers[Headers.ConversationId] = conversationId;
+            context.Headers[Headers.RelatedTo] = incomingMessage.MessageId;
+        }
+
+        static void SetConversationIdHeader(IOutgoingPhysicalMessageContext context, IncomingMessage incomingMessage)
+        {
+            string conversationIdFromCurrentMessageContext;
+            if (incomingMessage != null && incomingMessage.Headers.TryGetValue(Headers.ConversationId, out conversationIdFromCurrentMessageContext))
+            {
+                context.Headers[Headers.ConversationId] = conversationIdFromCurrentMessageContext;
+                return;
+            }
+
+            string userDefinedConversationId;
+            if (context.Headers.TryGetValue(Headers.ConversationId, out userDefinedConversationId))
+            {
+                // do not override user defined conversation id if no incoming message exists.
+                return;
+            }
+
+            context.Headers[Headers.ConversationId] = CombGuid.Generate().ToString();
         }
     }
 }


### PR DESCRIPTION
relates to https://groups.google.com/forum/#!topic/particularsoftware/k3cz3qKWJUc

user defined Conversation id headers will always be overwritten by the pipeline to be either:
* the conversation id of the incoming message
* a new conversation id otherwise

while the first behavior seems to be correct, users should be able to specify their custom conversation ids for new outgoing messages which are not triggered from incoming messages. The scenario behind this according to @andreasohlund is the ability to link a new message (e.g. a status update message, follow up message, etc.) to an existing conversation so that it will be shown properly by SI.

This PR changes the described behavior to the following:
* always use the conversation id of the incoming message if available
* use a user defined conversation id if no incoming message message with a conversation is available
* generate a new conversation otherwise

ping @indualagarsamy 