### PR TITLE
Wait for the expired message poller to stop

### DIFF
--- a/src/NServiceBus.Core/Transports/Learning/DelayedMessagePoller.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DelayedMessagePoller.cs
@@ -11,7 +11,7 @@
         public DelayedMessagePoller(string basePath)
         {
             this.basePath = basePath;
-            delayedMessagePoller = new AsyncTimer();
+            timer = new AsyncTimer();
 
             delayedRootDirectory = Path.Combine(basePath, ".delayed");
             Directory.CreateDirectory(delayedRootDirectory);
@@ -41,7 +41,7 @@
 
         public void Start()
         {
-            delayedMessagePoller.Start(() =>
+            timer.Start(() =>
             {
                 MoveDelayedMessagesToMainDirectory();
                 return TaskEx.CompletedTask;
@@ -50,11 +50,11 @@
 
         public Task Stop()
         {
-            return delayedMessagePoller.Stop();
+            return timer.Stop();
         }
 
         string delayedRootDirectory;
-        IAsyncTimer delayedMessagePoller;
+        IAsyncTimer timer;
         string basePath;
 
         static ILog Logger = LogManager.GetLogger<DelayedMessagePoller>();

--- a/src/NServiceBus.Core/Transports/Learning/DelayedMessagePoller.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DelayedMessagePoller.cs
@@ -49,10 +49,20 @@
             delayedMessagePoller.Change(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(-1));
         }
 
+        public void Stop()
+        {
+            using (var waitHandle = new ManualResetEvent(false))
+            {
+                delayedMessagePoller.Dispose(waitHandle);
+
+                waitHandle.WaitOne();
+            }
+        }
+
         string delayedRootDirectory;
         Timer delayedMessagePoller;
+        string basePath;
 
         static ILog Logger = LogManager.GetLogger<DelayedMessagePoller>();
-        string basePath;
     }
 }

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -63,7 +63,8 @@
         {
             cancellationTokenSource.Cancel();
 
-            delayedMessagePoller.Stop();
+            await delayedMessagePoller.Stop()
+                .ConfigureAwait(false);
 
             await messagePumpTask
                 .ConfigureAwait(false);

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -63,6 +63,8 @@
         {
             cancellationTokenSource.Cancel();
 
+            delayedMessagePoller.Stop();
+
             await messagePumpTask
                 .ConfigureAwait(false);
 

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -20,6 +20,9 @@
         public void SetUp()
         {
             testId = Guid.NewGuid().ToString();
+
+            //when using [TestCase] NUnit will reuse the same test instance so we need to make sure that the message pump is a fresh one
+            MessagePump = null;
         }
 
         static IConfigureTransportInfrastructure CreateConfigurer()


### PR DESCRIPTION
To allow for graceful shutdowns.


We've seen 

```
"Failed to trigger delayed messages System.IO.DirectoryNotFoundException: Could not find a part of the path 'c:\\temp\\att_tests\\BlowingUpJustAfterDispatch.NonDtcReceivingEndpoint\\Retries\\.delayed'.\r\n   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)\r\n   at System.IO.FileSystemEnumerableIterator`1.CommonInit()\r\n   at System.IO.DirectoryInfo.EnumerateDirectories()\r\n   at NServiceBus.DelayedMessagePoller.MoveDelayedMessagesToMainDirectory(Object state) in C:\\Projects\\NServiceBus\\src\\NServiceBus.Core\\Transports\\Learning\\DelayedMessagePoller.cs:line 24"
```

In the logs, this should fix that