### PR TITLE
Fix exception reporting

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -104,7 +104,7 @@ namespace NServiceBus.AcceptanceTesting
 
             if (runResult.Failed)
             {
-                Console.WriteLine("Test failed: {0}", runResult.Exception);
+                Console.WriteLine("Test failed: {0}", runResult.Exception.SourceException);
             }
             else
             {


### PR DESCRIPTION
noticed this during testing. ExceptionDispatchInfo doesn't provide a useful ToString().