### PR TITLE
Update Particular.CodeRules package

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -39,6 +39,7 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
+    <NoWarn>PCR0001</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Particular.CodeRules.0.2.0\build\Particular.CodeRules.props" Condition="Exists('..\packages\Particular.CodeRules.0.2.0\build\Particular.CodeRules.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -27,6 +28,7 @@
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
+    <NoWarn>PCR0001</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -365,6 +367,9 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Particular.CodeRules.0.2.0\tools\..\analyzers\dotnet\cs\Particular.CodeRules.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -372,6 +377,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\NuGetPackager.0.6.1\build\NuGetPackager.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGetPackager.0.6.1\build\NuGetPackager.targets'))" />
     <Error Condition="!Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets'))" />
+    <Error Condition="!Exists('..\packages\Particular.CodeRules.0.2.0\build\Particular.CodeRules.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Particular.CodeRules.0.2.0\build\Particular.CodeRules.props'))" />
   </Target>
   <Import Project="..\packages\NuGetPackager.0.6.1\build\NuGetPackager.targets" Condition="Exists('..\packages\NuGetPackager.0.6.1\build\NuGetPackager.targets')" />
   <Import Project="..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" />

--- a/src/NServiceBus.AcceptanceTests/Pipeline/When_a_message_is_faulted.cs
+++ b/src/NServiceBus.AcceptanceTests/Pipeline/When_a_message_is_faulted.cs
@@ -50,8 +50,7 @@
                     TestContext.OriginRelatedTo = context.MessageId;
                     TestContext.OriginConversationId = context.MessageHeaders.ContainsKey(Headers.ConversationId) ? context.MessageHeaders[Headers.ConversationId] : null;
 
-                    context.SendLocal(new MessageThatFails());
-                    return Task.FromResult(0);
+                    return context.SendLocal(new MessageThatFails());
                 }
             }
 

--- a/src/NServiceBus.AcceptanceTests/packages.config
+++ b/src/NServiceBus.AcceptanceTests/packages.config
@@ -3,4 +3,5 @@
   <package id="GitVersionTask" version="3.6.5" targetFramework="net452" developmentDependency="true" />
   <package id="NuGetPackager" version="0.6.1" targetFramework="net452" developmentDependency="true" />
   <package id="NUnit" version="3.6.1" targetFramework="net452" />
+  <package id="Particular.CodeRules" version="0.2.0" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/src/NServiceBus.Core/CriticalError/CriticalError.cs
+++ b/src/NServiceBus.Core/CriticalError/CriticalError.cs
@@ -65,13 +65,11 @@ namespace NServiceBus
 
         void RaiseForEndpoint(string errorMessage, Exception exception)
         {
-#pragma warning disable PCR0002
             Task.Run(() =>
             {
                 var context = new CriticalErrorContext(endpoint.Stop, errorMessage, exception);
                 return criticalErrorAction(context);
-            });
-#pragma warning restore PCR0002
+            }).Ignore();
         }
 
         internal void SetEndpoint(IEndpointInstance endpointInstance)

--- a/src/NServiceBus.Core/CriticalError/CriticalError.cs
+++ b/src/NServiceBus.Core/CriticalError/CriticalError.cs
@@ -65,11 +65,13 @@ namespace NServiceBus
 
         void RaiseForEndpoint(string errorMessage, Exception exception)
         {
+#pragma warning disable PCR0002
             Task.Run(() =>
             {
                 var context = new CriticalErrorContext(endpoint.Stop, errorMessage, exception);
                 return criticalErrorAction(context);
             });
+#pragma warning restore PCR0002
         }
 
         internal void SetEndpoint(IEndpointInstance endpointInstance)

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Particular.CodeRules.0.1.1\build\Particular.CodeRules.props" Condition="Exists('..\packages\Particular.CodeRules.0.1.1\build\Particular.CodeRules.props')" />
+  <Import Project="..\packages\Particular.CodeRules.0.2.0\build\Particular.CodeRules.props" Condition="Exists('..\packages\Particular.CodeRules.0.2.0\build\Particular.CodeRules.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -830,9 +830,8 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Particular.CodeRules.0.1.1\tools\..\analyzers\dotnet\cs\Particular.CodeRules.dll" />
+    <Analyzer Include="..\packages\Particular.CodeRules.0.2.0\tools\..\analyzers\dotnet\cs\Particular.CodeRules.dll" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild" Condition=" '$(Configuration)' == 'Release' ">
     <MakeDir Directories="$(TargetDir)temp\" />
@@ -849,9 +848,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.29.4\build\dotnet\Fody.targets'))" />
-    <Error Condition="!Exists('..\packages\Particular.CodeRules.0.1.1\build\Particular.CodeRules.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Particular.CodeRules.0.1.1\build\Particular.CodeRules.props'))" />
     <Error Condition="!Exists('..\packages\NuGetPackager.0.6.1\build\NuGetPackager.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGetPackager.0.6.1\build\NuGetPackager.targets'))" />
     <Error Condition="!Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets'))" />
+    <Error Condition="!Exists('..\packages\Particular.CodeRules.0.2.0\build\Particular.CodeRules.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Particular.CodeRules.0.2.0\build\Particular.CodeRules.props'))" />
   </Target>
   <Import Project="..\packages\Fody.1.29.4\build\dotnet\Fody.targets" Condition="Exists('..\packages\Fody.1.29.4\build\dotnet\Fody.targets')" />
   <Import Project="..\packages\NuGetPackager.0.6.1\build\NuGetPackager.targets" Condition="Exists('..\packages\NuGetPackager.0.6.1\build\NuGetPackager.targets')" />

--- a/src/NServiceBus.Core/packages.config
+++ b/src/NServiceBus.Core/packages.config
@@ -7,6 +7,6 @@
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net452" />
   <package id="NuGetPackager" version="0.6.1" targetFramework="net452" developmentDependency="true" />
   <package id="Obsolete.Fody" version="4.1.0" targetFramework="net452" developmentDependency="true" />
-  <package id="Particular.CodeRules" version="0.1.1" targetFramework="net452" developmentDependency="true" />
+  <package id="Particular.CodeRules" version="0.2.0" targetFramework="net452" developmentDependency="true" />
   <package id="Particular.Licensing.Sources" version="0.1.60" targetFramework="net452" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
After seeing https://github.com/Particular/NServiceBus/pull/4673 I added the Particular.CodeRules package to the acceptance tests too and disabled the `missing ConfigureAwait` warning to find missing awaits which is now supported with the 0.2 version of the package.

It found an additional test with a missing await which I fixed right away. cc @andreasohlund 