### PR TITLE
Do not use method groups

### DIFF
--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -93,7 +93,7 @@ namespace NServiceBus
         FeatureActivator BuildFeatureActivator(IEnumerable<Type> concreteTypes)
         {
             var featureActivator = new FeatureActivator(settings);
-            foreach (var type in concreteTypes.Where(IsFeature))
+            foreach (var type in concreteTypes.Where(t => IsFeature(t)))
             {
                 featureActivator.Add(type.Construct<Feature>());
             }

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -50,7 +50,7 @@
             var messageTypesHandled = handlerRegistry.GetMessageTypes() //get all potential messages
                 .Where(t => !conventions.IsInSystemConventionList(t)) //never auto-subscribe system messages
                 .Where(t => !conventions.IsCommandType(t)) //commands should never be subscribed to
-                .Where(conventions.IsEventType) //only events unless the user asked for all messages
+                .Where(t => conventions.IsEventType(t)) //only events unless the user asked for all messages
                 .Where(t => settings.AutoSubscribeSagas || handlerRegistry.GetHandlersFor(t).Any(handler => !typeof(Saga).IsAssignableFrom(handler.HandlerType))) //get messages with other handlers than sagas if needed
                 .ToList();
 

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -115,7 +115,7 @@
             {
                 //get the parent types
                 var parentMessages = GetParentTypes(messageType)
-                    .Where(conventions.IsMessageType)
+                    .Where(t => conventions.IsMessageType(t))
                     .OrderByDescending(PlaceInMessageHierarchy);
 
                 var metadata = new MessageMetadata(messageType, new[]

--- a/src/NServiceBus.sln.DotSettings
+++ b/src/NServiceBus.sln.DotSettings
@@ -22,6 +22,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConditionIsAlwaysTrueOrFalse/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConstantNullCoalescingCondition/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConstructorInitializerLoop/@EntryIndexedValue">ERROR</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertClosureToMethodGroup/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertConditionalTernaryToNullCoalescing/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertIfStatementToConditionalTernaryExpression/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertIfStatementToNullCoalescingExpression/@EntryIndexedValue">DO_NOT_SHOW</s:String>


### PR DESCRIPTION
It seems it would be easier if we are more consistent with our usage of delegates vs. method groups and try to avoid method groups as they bring lower performance due to missing caching (which might be supported one day: https://github.com/dotnet/roslyn/issues/5835)

I also disabled the resharper rule to hint at potential method group usage.

Thoughts @Particular/nservicebus-maintainers @SimonCropp ?