### PR TITLE
Enforce message size limit

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/LearningTransport/When_disabling_payload_restrictions.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/LearningTransport/When_disabling_payload_restrictions.cs
@@ -1,0 +1,57 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Pipeline
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_disabling_payload_restrictions : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_allow_messages_above_64kb()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<LargePayloadEndpoint>(b => b.When(session => session.SendLocal(new SomeMessage
+                {
+                    LargeProperty = new byte[1024 * 64]
+                })))
+                .Done(c => c.MessageReceived)
+                .Run();
+
+            Assert.True(context.MessageReceived, "Message was not received");
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool MessageReceived { get; set; }
+        }
+
+        class LargePayloadEndpoint : EndpointConfigurationBuilder
+        {
+            public LargePayloadEndpoint()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseTransport<LearningTransport>()
+                        .NoPayloadSizeRestriction();
+                });
+            }
+
+            class SomeMessageHandler : IHandleMessages<SomeMessage>
+            {
+                public Context TestContext { get; set; }
+
+                public Task Handle(SomeMessage message, IMessageHandlerContext context)
+                {
+                    TestContext.MessageReceived = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class SomeMessage : IMessage
+        {
+            public byte[] LargeProperty { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Core\CriticalError\When_raising_critical_error_at_startup.cs" />
     <Compile Include="Core\Feature\When_depending_on_untyped_feature.cs" />
     <Compile Include="Core\Feature\When_registering_a_startup_task.cs" />
+    <Compile Include="Core\LearningTransport\When_disabling_payload_restrictions.cs" />
     <Compile Include="Core\Pipeline\When_extending_behavior_context.cs" />
     <Compile Include="Core\Conventions\When_receiving_unobtrusive_message_without_handler.cs" />
     <Compile Include="Core\Config\When_multiple_configuration_providers.cs" />

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -815,6 +815,7 @@ namespace NServiceBus
     }
     public class static LearningTransportConfigurationExtensions
     {
+        public static void NoPayloadSizeRestriction(this NServiceBus.TransportExtensions<NServiceBus.LearningTransport> transportExtensions) { }
         public static void StorageDirectory(this NServiceBus.TransportExtensions<NServiceBus.LearningTransport> transportExtensions, string path) { }
     }
     public class static LoadMessageHandlersExtensions

--- a/src/NServiceBus.Core.Tests/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehaviorTests.cs
@@ -52,8 +52,9 @@
             var delay = TimeSpan.FromDays(1);
 
             var context = CreateContext(new UnicastRoutingStrategy("target"), new DelayDeliveryWith(delay), new DiscardIfNotReceivedBefore(TimeSpan.FromSeconds(30)));
+            context.Message.Headers[Headers.EnclosedMessageTypes] = "TestMessage";
 
-            Assert.That(async () => await behavior.Invoke(context, ctx => TaskEx.CompletedTask), Throws.InstanceOf<Exception>().And.Message.Contains("Postponed delivery of messages with TimeToBeReceived set is not supported. Remove the TimeToBeReceived attribute to postpone messages of this type."));
+            Assert.That(async () => await behavior.Invoke(context, ctx => TaskEx.CompletedTask), Throws.InstanceOf<Exception>().And.Message.Contains("Postponed delivery of messages with TimeToBeReceived set is not supported. Remove the TimeToBeReceived attribute to postpone messages of type 'TestMessage'."));
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -187,6 +187,7 @@
     <Compile Include="Routing\TypeRouteSourceTests.cs" />
     <Compile Include="Transports\Learning\HeaderSerializerTests.cs" />
     <Compile Include="Transports\Learning\AsyncFileTests.cs" />
+    <Compile Include="Transports\Learning\LearningTransportDispatcherTests.cs" />
     <Compile Include="Transports\MSMQ\InstanceMapping\InstanceMappingFileFeatureTests.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\MessageDrivenSubscriptionsConfigExtensionsTests.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\PublishersTests.cs" />

--- a/src/NServiceBus.Core.Tests/Transports/Learning/LearningTransportDispatcherTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/Learning/LearningTransportDispatcherTests.cs
@@ -16,19 +16,17 @@
         {
             var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "payload-too-big");
             var dispatcher = new LearningTransportDispatcher(path, 64);
-            var messageAtThreshold = new OutgoingMessage("id", new Dictionary<string, string>(), new byte[MessageSizeLimit]);
-            var messageAboveThreshold = new OutgoingMessage("id", new Dictionary<string, string>(), new byte[MessageSizeLimit + 1]);
-
+            var headers = new Dictionary<string, string> { { Headers.EnclosedMessageTypes, "TestMessage" } };
+            var messageAtThreshold = new OutgoingMessage("id", headers, new byte[MessageSizeLimit]);
+            var messageAboveThreshold = new OutgoingMessage("id", headers, new byte[MessageSizeLimit + 1]);
 
             await dispatcher.Dispatch(new TransportOperations(new TransportOperation(messageAtThreshold, new UnicastAddressTag("my-destination"))), new TransportTransaction(), new ContextBag());
-
-
             var ex = Assert.ThrowsAsync<Exception>(async () => await dispatcher.Dispatch(new TransportOperations(new TransportOperation(messageAboveThreshold, new UnicastAddressTag("my-destination"))), new TransportTransaction(), new ContextBag()));
 
-            StringAssert.Contains("Message body including headers", ex.Message);
+            StringAssert.Contains("The total size of the 'TestMessage' message", ex.Message);
         }
 
-        const int MessageSizeLimit = 64 * 1024 - emptyHeaderSize;
-        const int emptyHeaderSize = 3;
+        const int MessageSizeLimit = 64 * 1024 - headerSize;
+        const int headerSize = 57;
     }
 }

--- a/src/NServiceBus.Core.Tests/Transports/Learning/LearningTransportDispatcherTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/Learning/LearningTransportDispatcherTests.cs
@@ -16,8 +16,8 @@
         {
             var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "payload-to-big");
             var dispatcher = new LearningTransportDispatcher(path, 64);
-            var messageAtThreshold = new OutgoingMessage("id", new Dictionary<string, string>(), new byte[64 * 1024- emptyHeaderSize]);
-            var messageAboveThreshold = new OutgoingMessage("id", new Dictionary<string, string>(), new byte[64 * 1024 - emptyHeaderSize + 1]);
+            var messageAtThreshold = new OutgoingMessage("id", new Dictionary<string, string>(), new byte[MessageSizeLimit]);
+            var messageAboveThreshold = new OutgoingMessage("id", new Dictionary<string, string>(), new byte[MessageSizeLimit + 1]);
 
 
             await dispatcher.Dispatch(new TransportOperations(new TransportOperation(messageAtThreshold, new UnicastAddressTag("my-destination"))), new TransportTransaction(), new ContextBag());
@@ -28,6 +28,7 @@
             StringAssert.Contains("Message body including headers", ex.Message);
         }
 
+        const int MessageSizeLimit = 64 * 1024 - emptyHeaderSize;
         const int emptyHeaderSize = 3;
     }
 }

--- a/src/NServiceBus.Core.Tests/Transports/Learning/LearningTransportDispatcherTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/Learning/LearningTransportDispatcherTests.cs
@@ -1,0 +1,33 @@
+﻿namespace NServiceBus.Core.Tests.Transports.Learning
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+    using Transport;
+
+    public class LearningTransportDispatcherTests
+    {
+        [Test]
+        public async Task Should_throw_for_size_above_threshold()
+        {
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "payload-to-big");
+            var dispatcher = new LearningTransportDispatcher(path, 64);
+            var messageAtThreshold = new OutgoingMessage("id", new Dictionary<string, string>(), new byte[64 * 1024- emptyHeaderSize]);
+            var messageAboveThreshold = new OutgoingMessage("id", new Dictionary<string, string>(), new byte[64 * 1024 - emptyHeaderSize + 1]);
+
+
+            await dispatcher.Dispatch(new TransportOperations(new TransportOperation(messageAtThreshold, new UnicastAddressTag("my-destination"))), new TransportTransaction(), new ContextBag());
+
+
+            var ex = Assert.ThrowsAsync<Exception>(async () => await dispatcher.Dispatch(new TransportOperations(new TransportOperation(messageAboveThreshold, new UnicastAddressTag("my-destination"))), new TransportTransaction(), new ContextBag()));
+
+            StringAssert.Contains("Message body including headers", ex.Message);
+        }
+
+        const int emptyHeaderSize = 3;
+    }
+}

--- a/src/NServiceBus.Core.Tests/Transports/Learning/LearningTransportDispatcherTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/Learning/LearningTransportDispatcherTests.cs
@@ -14,7 +14,7 @@
         [Test]
         public async Task Should_throw_for_size_above_threshold()
         {
-            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "payload-to-big");
+            var path = Path.Combine(TestContext.CurrentContext.TestDirectory, "payload-too-big");
             var dispatcher = new LearningTransportDispatcher(path, 64);
             var messageAtThreshold = new OutgoingMessage("id", new Dictionary<string, string>(), new byte[MessageSizeLimit]);
             var messageAboveThreshold = new OutgoingMessage("id", new Dictionary<string, string>(), new byte[MessageSizeLimit + 1]);

--- a/src/NServiceBus.Core/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehavior.cs
@@ -29,7 +29,7 @@ namespace NServiceBus
             DiscardIfNotReceivedBefore discardIfNotReceivedBefore;
             if (context.Extensions.TryGetDeliveryConstraint(out discardIfNotReceivedBefore))
             {
-                throw new Exception("Postponed delivery of messages with TimeToBeReceived set is not supported. Remove the TimeToBeReceived attribute to postpone messages of this type.");
+                throw new Exception($"Postponed delivery of messages with TimeToBeReceived set is not supported. Remove the TimeToBeReceived attribute to postpone messages of type '{context.Message.Headers[Headers.EnclosedMessageTypes]}'.");
             }
 
             var newRoutingStrategies = context.RoutingStrategies.Select(s => RerouteToTimeoutManager(s, context, deliverAt));

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportConfigurationExtensions.cs
@@ -18,5 +18,16 @@
 
             transportExtensions.Settings.Set(LearningTransportInfrastructure.StorageLocationKey, path);
         }
+
+        /// <summary>
+        /// Allows messages of any size to be sent.
+        /// </summary>
+        /// <param name="transportExtensions">The transport extensions to extend.</param>
+        public static void NoPayloadSizeRestriction(this TransportExtensions<LearningTransport> transportExtensions)
+        {
+            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
+
+            transportExtensions.Settings.Set(LearningTransportInfrastructure.NoPayloadSizeRestrictionKey, true);
+        }
     }
 }

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportDispatcher.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportDispatcher.cs
@@ -65,14 +65,7 @@ namespace NServiceBus
 
             if (headerSize + message.Body.Length > maxMessageSizeKB * 1024)
             {
-                string messageType;
-
-                if (!message.Headers.TryGetValue(Headers.EnclosedMessageTypes, out messageType))
-                {
-                    messageType = "Message body";
-                }
-
-                throw new Exception($"{messageType} including headers({headerSize} bytes) is larger than {maxMessageSizeKB}kB and will not be supported on some production transports. Consider using the NServiceBus Data Bus or the claim check pattern in general to avoid messages with a large payload. Use `.UseTransport<LearningTransport>().NoPayloadSizeRestriction()` to proceed with the current message size.");
+                throw new Exception($"The total size of the '{message.Headers[Headers.EnclosedMessageTypes]}' message body ({message.Body.Length} bytes) plus headers ({headerSize} bytes) is larger than {maxMessageSizeKB} KB and will not be supported on some production transports. Consider using the NServiceBus DataBus or the claim check pattern to avoid messages with a large payload. Use 'EndpointConfiguration.UseTransport<LearningTransport>().NoPayloadSizeRestriction()' to disable this check and proceed with the current message size.");
             }
 
             var nativeMessageId = Guid.NewGuid().ToString();

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportDispatcher.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportDispatcher.cs
@@ -71,7 +71,7 @@ namespace NServiceBus
                 {
                     messageType = "Message body";
                 }
-              
+
                 throw new Exception($"{messageType} including headers({headerSize} bytes) is larger than {maxMessageSizeKB}kB and will not be supported on some production transports. Consider using the NServiceBus Data Bus or the claim check pattern in general to avoid messages with a large payload. Use `.UseTransport<LearningTransport>().NoPayloadSizeRestriction()` to proceed with the current message size.");
             }
 
@@ -117,7 +117,6 @@ namespace NServiceBus
             }
 
             var messagePath = Path.Combine(destinationPath, nativeMessageId) + ".metadata.txt";
-
 
             if (transportOperation.RequiredDispatchConsistency != DispatchConsistency.Isolated && transaction.TryGet(out ILearningTransportTransaction directoryBasedTransaction))
             {
@@ -188,6 +187,7 @@ namespace NServiceBus
         }
 
         static bool IsCoreMarkerInterface(Type type) => type == typeof(IMessage) || type == typeof(IEvent) || type == typeof(ICommand);
+
         int maxMessageSizeKB;
         string basePath;
     }

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportDispatcher.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportDispatcher.cs
@@ -94,7 +94,7 @@ namespace NServiceBus
             {
                 if (transportOperation.DeliveryConstraints.TryGet(out DiscardIfNotReceivedBefore timeToBeReceived) && timeToBeReceived.MaxTime < TimeSpan.MaxValue)
                 {
-                    throw new Exception($"Postponed delivery of messages with TimeToBeReceived set is not supported. Remove the TimeToBeReceived attribute to postpone messages of type {message.Headers[Headers.EnclosedMessageTypes]}.");
+                    throw new Exception($"Postponed delivery of messages with TimeToBeReceived set is not supported. Remove the TimeToBeReceived attribute to postpone messages of type '{message.Headers[Headers.EnclosedMessageTypes]}'.");
                 }
 
                 // we need to "ceil" the seconds to guarantee that we delay with at least the requested value

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
@@ -68,8 +68,9 @@
 
         public override TransportSendInfrastructure ConfigureSendInfrastructure()
         {
-            //todo: make size configurable
-            return new TransportSendInfrastructure(() => new LearningTransportDispatcher(storagePath, 64), () => Task.FromResult(StartupCheckResult.Success));
+            var maxPayloadSize = settings.GetOrDefault<bool>(NoPayloadSizeRestrictionKey) ? int.MaxValue / 1024 : 64; //64 kB is the max size of the ASQ transport
+
+            return new TransportSendInfrastructure(() => new LearningTransportDispatcher(storagePath, maxPayloadSize), () => Task.FromResult(StartupCheckResult.Success));
         }
 
         public override TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure()
@@ -104,6 +105,8 @@
 
         string storagePath;
         SettingsHolder settings;
+
         public const string StorageLocationKey = "LearningTransport.StoragePath";
+        public const string NoPayloadSizeRestrictionKey = "LearningTransport.NoPayloadSizeRestrictionKey";
     }
 }

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
@@ -68,7 +68,8 @@
 
         public override TransportSendInfrastructure ConfigureSendInfrastructure()
         {
-            return new TransportSendInfrastructure(() => new LearningTransportDispatcher(storagePath), () => Task.FromResult(StartupCheckResult.Success));
+            //todo: make size configurable
+            return new TransportSendInfrastructure(() => new LearningTransportDispatcher(storagePath, 64), () => Task.FromResult(StartupCheckResult.Success));
         }
 
         public override TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure()


### PR DESCRIPTION
Just a quick sanity check before I add a configuration option to override.


Do you like the `.UseTransport<LearningTransport>().NoPayloadSizeRestriction()` proposal?

Fixes #4664 