### PR TITLE
Add special character saga correlation property acceptance test

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="EndpointTemplates\TestSuiteConstraints.cs" />
     <Compile Include="Forwarding\When_requesting_message_to_be_forwarded.cs" />
     <Compile Include="Core\Pipeline\When_subscribed_to_ReceivePipelineCompleted.cs" />
+    <Compile Include="Sagas\When_correlating_on_special_characters.cs" />
     <Compile Include="SelfVerification\When_using_custom_components.cs" />
     <Compile Include="EndpointTemplates\IConfigureEndpointTestExecution.cs" />
     <Compile Include="Serialization\When_receiving_interface_message_where_child_is_excluded.cs" />

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_correlating_on_special_characters.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_correlating_on_special_characters.cs
@@ -13,7 +13,7 @@
             const string propertyValue = "ʕノ•ᴥ•ʔノ ︵ ┻━┻";
 
             var context = await Scenario.Define<Context>()
-                .WithEndpoint<SagaEndpoint>(e => e
+                .WithEndpoint<SpecialCharacterSagaEndpoint>(e => e
                     .When(s => s.SendLocal(new MessageWithSpecialPropertyValues
                     {
                         SpecialCharacterValues = propertyValue
@@ -29,16 +29,16 @@
             public string RehydratedValueForCorrelatedHandler { get; set; }
         }
 
-        public class SagaEndpoint : EndpointConfigurationBuilder
+        public class SpecialCharacterSagaEndpoint : EndpointConfigurationBuilder
         {
-            public SagaEndpoint()
+            public SpecialCharacterSagaEndpoint()
             {
                 EndpointSetup<DefaultServer>();
             }
 
             public class SagaDataWithSpecialPropertyValues : ContainSagaData
             {
-                public string SpecialCharacterValues { get; set; }
+                public virtual string SpecialCharacterValues { get; set; }
             }
 
             public class SagaHandlingSpecialPropertyValues : 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_correlating_on_special_characters.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_correlating_on_special_characters.cs
@@ -1,0 +1,88 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    class When_correlating_on_special_characters : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Saga_persistence_and_correlation_should_work()
+        {
+            const string propertyValue = "ʕノ•ᴥ•ʔノ ︵ ┻━┻";
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SagaEndpoint>(e => e
+                    .When(s => s.SendLocal(new MessageWithSpecialPropertyValues
+                    {
+                        SpecialCharacterValues = propertyValue
+                    })))
+                .Done(c => c.RehydratedValueForCorrelatedHandler != null)
+                .Run();
+
+            Assert.AreEqual(propertyValue, context.RehydratedValueForCorrelatedHandler);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public string RehydratedValueForCorrelatedHandler { get; set; }
+        }
+
+        public class SagaEndpoint : EndpointConfigurationBuilder
+        {
+            public SagaEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class SagaDataWithSpecialPropertyValues : ContainSagaData
+            {
+                public string SpecialCharacterValues { get; set; }
+            }
+
+            public class SagaHandlingSpecialPropertyValues : 
+                Saga<SagaDataWithSpecialPropertyValues>, 
+                IAmStartedByMessages<MessageWithSpecialPropertyValues>,
+                IHandleMessages<FollowupMessageWithSpecialPropertyValues>
+            {
+                Context testContext;
+
+                public SagaHandlingSpecialPropertyValues(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaDataWithSpecialPropertyValues> mapper)
+                {
+                    mapper.ConfigureMapping<MessageWithSpecialPropertyValues>(m => m.SpecialCharacterValues).ToSaga(s => s.SpecialCharacterValues);
+                    mapper.ConfigureMapping<FollowupMessageWithSpecialPropertyValues>(m => m.SpecialCharacterValues).ToSaga(s => s.SpecialCharacterValues);
+                }
+
+                public Task Handle(MessageWithSpecialPropertyValues message, IMessageHandlerContext context)
+                {
+                    return context.SendLocal(new FollowupMessageWithSpecialPropertyValues
+                    {
+                        SpecialCharacterValues = message.SpecialCharacterValues
+                    });
+                }
+
+                public Task Handle(FollowupMessageWithSpecialPropertyValues message, IMessageHandlerContext context)
+                {
+                    testContext.RehydratedValueForCorrelatedHandler = Data.SpecialCharacterValues;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MessageWithSpecialPropertyValues : ICommand
+        {
+            public string SpecialCharacterValues { get; set; }
+        }
+
+        public class FollowupMessageWithSpecialPropertyValues : ICommand
+        {
+            public string SpecialCharacterValues { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Adds an acceptance tests which uses special characters in the correlation property value. This should help ensure that there is no potential message loss or other conflicts due to improper persistence of those characters.