### PR TITLE
Expose the context get that takes a string key

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1805,6 +1805,7 @@ namespace NServiceBus.Extensibility
     {
         public ContextBag(NServiceBus.Extensibility.ContextBag parentBag = null) { }
         public T Get<T>() { }
+        public T Get<T>(string key) { }
         public T GetOrCreate<T>()
             where T :  class, new () { }
         public void Remove<T>() { }
@@ -1829,6 +1830,7 @@ namespace NServiceBus.Extensibility
     public interface ReadOnlyContextBag
     {
         T Get<T>();
+        T Get<T>(string key);
         bool TryGet<T>(out T result);
         bool TryGet<T>(string key, out T result);
     }

--- a/src/NServiceBus.Core/Extensibility/ContextBag.cs
+++ b/src/NServiceBus.Core/Extensibility/ContextBag.cs
@@ -49,7 +49,7 @@ namespace NServiceBus.Extensibility
             object value;
             if (stash.TryGetValue(key, out value))
             {
-                result = (T) value;
+                result = (T)value;
                 return true;
             }
 
@@ -60,6 +60,20 @@ namespace NServiceBus.Extensibility
 
             result = default(T);
             return false;
+        }
+
+        /// <inheritdoc />
+        public T Get<T>(string key)
+        {
+            Guard.AgainstNullAndEmpty(nameof(key), key);
+            T result;
+
+            if (!TryGet(key, out result))
+            {
+                throw new KeyNotFoundException("No item found in behavior context with key: " + key);
+            }
+
+            return result;
         }
 
         /// <summary>
@@ -131,19 +145,6 @@ namespace NServiceBus.Extensibility
             {
                 stash[kvp.Key] = kvp.Value;
             }
-        }
-
-        T Get<T>(string key)
-        {
-            Guard.AgainstNullAndEmpty(nameof(key), key);
-            T result;
-
-            if (!TryGet(key, out result))
-            {
-                throw new KeyNotFoundException("No item found in behavior context with key: " + key);
-            }
-
-            return result;
         }
 
         ContextBag parentBag;

--- a/src/NServiceBus.Core/Extensibility/ReadonlyContextBag.cs
+++ b/src/NServiceBus.Core/Extensibility/ReadonlyContextBag.cs
@@ -8,7 +8,7 @@ namespace NServiceBus.Extensibility
         /// <summary>
         /// Retrieves the specified type from the context.
         /// </summary>
-        /// <typeparam name="T">The type to retrieve. The Fullname of will be used to look up the instance.</typeparam>
+        /// <typeparam name="T">The type to retrieve. The fully qualified name of the type will be used to look up the instance.</typeparam>
         /// <returns>The type instance.</returns>
         T Get<T>();
 

--- a/src/NServiceBus.Core/Extensibility/ReadonlyContextBag.cs
+++ b/src/NServiceBus.Core/Extensibility/ReadonlyContextBag.cs
@@ -8,9 +8,17 @@ namespace NServiceBus.Extensibility
         /// <summary>
         /// Retrieves the specified type from the context.
         /// </summary>
-        /// <typeparam name="T">The type to retrieve.</typeparam>
+        /// <typeparam name="T">The type to retrieve. The Fullname of will be used to look up the instance.</typeparam>
         /// <returns>The type instance.</returns>
         T Get<T>();
+
+        /// <summary>
+        /// Retrieves the specified type from the context.
+        /// </summary>
+        /// <typeparam name="T">The type to retrieve.</typeparam>
+        /// <param name="key">The key of the value being looked up.</param>
+        /// <returns>The type instance.</returns>
+        T Get<T>(string key);
 
         /// <summary>
         /// Tries to retrieves the specified type from the context.


### PR DESCRIPTION
Had a customer call today and couldn't explain why they had to use TryGet if the key was a string and not a type.

This PR exposes the string key verion of ContextBag.Get

WIP until develop is targeting v7 since this is a breaking change