### PR TITLE
Make sure exceptions when reading file triggers CircuitBreaker

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_publishing_to_scaled_out_subscribers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_publishing_to_scaled_out_subscribers.cs
@@ -9,7 +9,7 @@
     public class When_publishing_to_scaled_out_subscribers : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Each_event_should_be_delivered_to_single_instance_of_each_subscriber()
+        public async Task Should_route_event_to_shared_queue()
         {
             Requires.NativePubSubSupport();
 

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_unsubscribing_from_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_unsubscribing_from_event.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Routing.NativePublishSubscribe
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -55,11 +56,11 @@
 
         public class Context : ScenarioContext
         {
-            public bool Subscriber1Subscribed { get; set; }
-            public bool Subscriber2Subscribed { get; set; }
-            public bool Subscriber2Unsubscribed { get; set; }
-            public int Subscriber1ReceivedMessages { get; set; }
-            public int Subscriber2ReceivedMessages { get; set; }
+            public bool Subscriber1Subscribed;
+            public bool Subscriber2Subscribed;
+            public bool Subscriber2Unsubscribed;
+            public int Subscriber1ReceivedMessages;
+            public int Subscriber2ReceivedMessages;
         }
 
         public class Publisher : EndpointConfigurationBuilder
@@ -86,7 +87,8 @@
 
                 public Task Handle(Event message, IMessageHandlerContext context)
                 {
-                    testContext.Subscriber1ReceivedMessages++;
+                    Interlocked.Increment(ref testContext.Subscriber1ReceivedMessages);
+
                     return Task.FromResult(0);
                 }
 
@@ -110,7 +112,8 @@
 
                 public Task Handle(Event message, IMessageHandlerContext context)
                 {
-                    testContext.Subscriber2ReceivedMessages++;
+                    Interlocked.Increment(ref testContext.Subscriber2ReceivedMessages);
+
                     return Task.FromResult(0);
                 }
 

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_registering_deserializers_with_settings.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_registering_deserializers_with_settings.cs
@@ -29,7 +29,6 @@ namespace NServiceBus.AcceptanceTests.Serialization
                         sendOptions.SetHeader("ContentType", "MyCustomSerializer");
                         return session.SendLocal(new MyRequest());
                     }))
-                .WithEndpoint<XmlCustomSerializationReceiver>()
                 .Done(c => c.DeserializeCalled)
                 .Run();
 

--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -59,11 +59,11 @@ namespace NServiceBus
             return AsyncFile.WriteText(txPath, messageContents);
         }
 
-        public void Complete()
+        public Task<bool> Complete()
         {
             if (!committed)
             {
-                return;
+                return Task.FromResult(false);
             }
 
             foreach (var outgoingFile in outgoingFiles)
@@ -72,6 +72,8 @@ namespace NServiceBus
             }
 
             Directory.Delete(commitDir, true);
+
+            return Task.FromResult(true);
         }
 
         public static void RecoverPartiallyCompletedTransactions(string basePath)

--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -20,7 +20,7 @@ namespace NServiceBus
 
         public string FileToProcess { get; private set; }
 
-        public Task<bool> BeginTransaction(string incomingFilePath)
+        public bool BeginTransaction(string incomingFilePath)
         {
             Directory.CreateDirectory(transactionDir);
             FileToProcess = Path.Combine(transactionDir, Path.GetFileName(incomingFilePath));
@@ -31,12 +31,11 @@ namespace NServiceBus
             }
             catch (FileNotFoundException)
             {
-                return Task.FromResult(false);
+                return false;
             }
 
-
             //seem like File.Move is not atomic at least within the same process so we need this extra check
-            return Task.FromResult(File.Exists(FileToProcess));
+            return File.Exists(FileToProcess);
         }
 
         public Task Commit()
@@ -71,11 +70,11 @@ namespace NServiceBus
             return AsyncFile.WriteText(txPath, messageContents);
         }
 
-        public Task<bool> Complete()
+        public bool Complete()
         {
             if (!committed)
             {
-                return Task.FromResult(false);
+                return false;
             }
 
             foreach (var outgoingFile in outgoingFiles)
@@ -85,7 +84,7 @@ namespace NServiceBus
 
             Directory.Delete(commitDir, true);
 
-            return Task.FromResult(true);
+            return true;
         }
 
         public static void RecoverPartiallyCompletedTransactions(string basePath)

--- a/src/NServiceBus.Core/Transports/Learning/ILearningTransportTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/ILearningTransportTransaction.cs
@@ -6,7 +6,7 @@ namespace NServiceBus
     {
         string FileToProcess { get; }
 
-        void BeginTransaction(string incomingFilePath);
+        Task<bool> BeginTransaction(string incomingFilePath);
 
         Task Commit();
 

--- a/src/NServiceBus.Core/Transports/Learning/ILearningTransportTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/ILearningTransportTransaction.cs
@@ -16,6 +16,6 @@ namespace NServiceBus
 
         Task Enlist(string messagePath, string messageContents);
 
-        void Complete();
+        Task<bool> Complete();
     }
 }

--- a/src/NServiceBus.Core/Transports/Learning/ILearningTransportTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/ILearningTransportTransaction.cs
@@ -6,7 +6,7 @@ namespace NServiceBus
     {
         string FileToProcess { get; }
 
-        Task<bool> BeginTransaction(string incomingFilePath);
+        bool BeginTransaction(string incomingFilePath);
 
         Task Commit();
 
@@ -16,6 +16,6 @@ namespace NServiceBus
 
         Task Enlist(string messagePath, string messageContents);
 
-        Task<bool> Complete();
+        bool Complete();
     }
 }

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
@@ -91,16 +91,26 @@
 
         public override string ToTransportAddress(LogicalAddress logicalAddress)
         {
-            var endpoint = logicalAddress.EndpointInstance.Endpoint;
-            PathChecker.ThrowForBadPath(endpoint, "endpoint name");
+            var address = logicalAddress.EndpointInstance.Endpoint;
+            PathChecker.ThrowForBadPath(address, "endpoint name");
 
             var discriminator = logicalAddress.EndpointInstance.Discriminator ?? "";
             PathChecker.ThrowForBadPath(discriminator, "endpoint discriminator");
 
+            if (!string.IsNullOrEmpty(discriminator))
+            {
+                address += "-" + discriminator;
+            }
+
             var qualifier = logicalAddress.Qualifier ?? "";
             PathChecker.ThrowForBadPath(qualifier, "address qualifier");
 
-            return Path.Combine(endpoint, discriminator, qualifier);
+            if (!string.IsNullOrEmpty(qualifier))
+            {
+                address += "-" + qualifier;
+            }
+
+            return address;
         }
 
         string storagePath;

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
@@ -94,19 +94,21 @@
             var address = logicalAddress.EndpointInstance.Endpoint;
             PathChecker.ThrowForBadPath(address, "endpoint name");
 
-            var discriminator = logicalAddress.EndpointInstance.Discriminator ?? "";
-            PathChecker.ThrowForBadPath(discriminator, "endpoint discriminator");
-
+            var discriminator = logicalAddress.EndpointInstance.Discriminator;
+           
             if (!string.IsNullOrEmpty(discriminator))
             {
+                PathChecker.ThrowForBadPath(discriminator, "endpoint discriminator");
+
                 address += "-" + discriminator;
             }
 
-            var qualifier = logicalAddress.Qualifier ?? "";
-            PathChecker.ThrowForBadPath(qualifier, "address qualifier");
+            var qualifier = logicalAddress.Qualifier;
 
             if (!string.IsNullOrEmpty(qualifier))
             {
+                PathChecker.ThrowForBadPath(qualifier, "address qualifier");
+
                 address += "-" + qualifier;
             }
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -117,8 +117,7 @@
 
                     var transaction = GetTransaction();
 
-                    var ableToLockFile = await transaction.BeginTransaction(filePath)
-                        .ConfigureAwait(false);
+                    var ableToLockFile = transaction.BeginTransaction(filePath);
 
                     if (!ableToLockFile)
                     {
@@ -149,8 +148,7 @@
 
                                 }
 
-                                var wasCommitted = await transaction.Complete()
-                                    .ConfigureAwait(false);
+                                var wasCommitted = transaction.Complete();
 
                                 if (wasCommitted)
                                 {

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -122,7 +122,7 @@
 
                     if (!ableToLockFile)
                     {
-                        Console.Out.WriteLine("Skipping " + transaction.FileToProcess);
+                        concurrencyLimiter.Release();
                         continue;
                     }
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -145,7 +145,6 @@
                                     }
 
                                     transaction.Rollback();
-
                                 }
 
                                 var wasCommitted = transaction.Complete();
@@ -207,6 +206,7 @@
             if (headers.TryGetValue(Headers.TimeToBeReceived, out var ttbrString))
             {
                 var ttbr = TimeSpan.Parse(ttbrString);
+                
                 //file.move preserves create time
                 var sentTime = File.GetCreationTimeUtc(transaction.FileToProcess);
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -143,10 +143,11 @@
         {
             try
             {
-                var wasCommitted = await ProcessFile(transaction, nativeMessageId)
+                await ProcessFile(transaction, nativeMessageId)
                     .ConfigureAwait(false);
 
-                transaction.Complete();
+                var wasCommitted = await transaction.Complete()
+                    .ConfigureAwait(false);
 
                 if (wasCommitted)
                 {
@@ -166,7 +167,7 @@
             }
         }
 
-        async Task<bool> ProcessFile(ILearningTransportTransaction transaction, string messageId)
+        async Task ProcessFile(ILearningTransportTransaction transaction, string messageId)
         {
             try
             {
@@ -187,7 +188,7 @@
                         await transaction.Commit()
                             .ConfigureAwait(false);
 
-                        return true;
+                        return;
                     }
                 }
 
@@ -224,7 +225,7 @@
                     {
                         transaction.Rollback();
 
-                        return false;
+                        return;
                     }
                 }
 
@@ -232,19 +233,16 @@
                 {
                     transaction.Rollback();
 
-                    return false;
+                    return;
                 }
 
                 await transaction.Commit()
                     .ConfigureAwait(false);
 
-                return true;
             }
             catch (Exception)
             {
                 transaction.Rollback();
-
-                return false;
             }
         }
 

--- a/src/NServiceBus.Core/Transports/Learning/NoTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/NoTransaction.cs
@@ -13,11 +13,22 @@ namespace NServiceBus
 
         public string FileToProcess { get; private set; }
 
-        public void BeginTransaction(string incomingFilePath)
+        public Task<bool> BeginTransaction(string incomingFilePath)
         {
             Directory.CreateDirectory(processingDirectory);
             FileToProcess = Path.Combine(processingDirectory, Path.GetFileName(incomingFilePath));
-            File.Move(incomingFilePath, FileToProcess);
+
+            try
+            {
+                File.Move(incomingFilePath, FileToProcess);
+            }
+            catch (FileNotFoundException)
+            {
+                return Task.FromResult(false);
+            }
+            
+            //seem like File.Move is not atomic at least within the same process so we need this extra check
+            return Task.FromResult(File.Exists(FileToProcess));
         }
 
         public Task Enlist(string messagePath, string messageContents) => AsyncFile.WriteText(messagePath, messageContents);

--- a/src/NServiceBus.Core/Transports/Learning/NoTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/NoTransaction.cs
@@ -13,7 +13,7 @@ namespace NServiceBus
 
         public string FileToProcess { get; private set; }
 
-        public Task<bool> BeginTransaction(string incomingFilePath)
+        public bool BeginTransaction(string incomingFilePath)
         {
             Directory.CreateDirectory(processingDirectory);
             FileToProcess = Path.Combine(processingDirectory, Path.GetFileName(incomingFilePath));
@@ -24,11 +24,11 @@ namespace NServiceBus
             }
             catch (FileNotFoundException)
             {
-                return Task.FromResult(false);
+                return false;
             }
             
             //seem like File.Move is not atomic at least within the same process so we need this extra check
-            return Task.FromResult(File.Exists(FileToProcess));
+            return File.Exists(FileToProcess);
         }
 
         public Task Enlist(string messagePath, string messageContents) => AsyncFile.WriteText(messagePath, messageContents);
@@ -39,11 +39,11 @@ namespace NServiceBus
 
         public void ClearPendingOutgoingOperations() { }
 
-        public Task<bool> Complete()
+        public bool Complete()
         {
             Directory.Delete(processingDirectory, true);
 
-            return Task.FromResult(true);
+            return true;
         }
 
         string processingDirectory;

--- a/src/NServiceBus.Core/Transports/Learning/NoTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/NoTransaction.cs
@@ -28,7 +28,12 @@ namespace NServiceBus
 
         public void ClearPendingOutgoingOperations() { }
 
-        public void Complete() => Directory.Delete(processingDirectory, true);
+        public Task<bool> Complete()
+        {
+            Directory.Delete(processingDirectory, true);
+
+            return Task.FromResult(true);
+        }
 
         string processingDirectory;
     }

--- a/src/NServiceBus.Core/Utils/AsyncTimer.cs
+++ b/src/NServiceBus.Core/Utils/AsyncTimer.cs
@@ -22,7 +22,7 @@ namespace NServiceBus
                     }
                     catch (OperationCanceledException)
                     {
-                        // nop
+                        // no-op
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
This makes sure that we always log errors during transaction Rollback, Commit and Complete