### PR TITLE
Removing DataContractSerializer from Learning Saga Persister

### DIFF
--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaManifest.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaManifest.cs
@@ -2,12 +2,10 @@
 {
     using System;
     using System.IO;
-    using System.Runtime.Serialization.Json;
 
     class SagaManifest
     {
         public string StorageDirectory { get; set; }
-        public DataContractJsonSerializer Serializer { get; set; }
         public Type SagaEntityType { get; set; }
 
         public string GetFilePath(Guid sagaId)

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaManifestCollection.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaManifestCollection.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Runtime.Serialization.Json;
     using Sagas;
 
     class SagaManifestCollection
@@ -22,7 +21,6 @@
                 var manifest = new SagaManifest
                 {
                     StorageDirectory = sagaStorageDir,
-                    Serializer = new DataContractJsonSerializer(metadata.SagaEntityType),
                     SagaEntityType = metadata.SagaEntityType
                 };
 

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaStorageFile.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaStorageFile.cs
@@ -16,11 +16,12 @@ namespace NServiceBus
             this.manifest = manifest;
             jsonWriter = new JsonTextWriter(new StreamWriter(fileStream, Encoding.Unicode))
             {
-                CloseOutput = true
+                CloseOutput = true,
+                Formatting = Formatting.Indented,
             };
             jsonReader = new JsonTextReader(new StreamReader(fileStream, Encoding.Unicode))
             {
-                CloseInput = true
+                CloseInput = true,
             };
 
             lastModificationSeenAt = File.GetLastWriteTimeUtc(fileStream.Name);


### PR DESCRIPTION
For most of the things we use NewtonSoftJsonSerializer which is ILMerged into the core. Many other packages have newtonsoft also ILMerged. I see no reason not to use newtonsoft json for the learning saga persister as well since the data contract serializer has to many restrictions. Thoughts?