### PR TITLE
Print log entries when acceptance test fails

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
@@ -14,20 +14,20 @@
 
         public bool HasNativePubSubSupport { get; set; }
 
-        public string Trace => string.Join(Environment.NewLine, traceQueue.ToArray());
-
         public void AddTrace(string trace)
         {
-            traceQueue.Enqueue($"{DateTime.Now:HH:mm:ss.ffffff} - {trace}");
+            Logs.Enqueue(new LogItem
+            {
+                Level = LogLevel.Info,
+                Message = trace
+            });
         }
 
         public ConcurrentDictionary<string, IReadOnlyCollection<FailedMessage>> FailedMessages = new ConcurrentDictionary<string, IReadOnlyCollection<FailedMessage>>();
 
         public ConcurrentQueue<LogItem> Logs = new ConcurrentQueue<LogItem>();
 
-        ConcurrentQueue<string> traceQueue = new ConcurrentQueue<string>();
-
-        internal LogLevel LogLevel { get; set; } = LogLevel.Info;
+        internal LogLevel LogLevel { get; set; } = LogLevel.Debug;
 
         internal ConcurrentDictionary<string, bool> UnfinishedFailedMessages = new ConcurrentDictionary<string, bool>();
 

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -48,6 +48,7 @@ namespace NServiceBus.AcceptanceTesting
 
             if (runSummary.Result.Failed)
             {
+                PrintLog(scenarioContext);
                 runSummary.Result.Exception.Throw();
             }
 
@@ -59,7 +60,7 @@ namespace NServiceBus.AcceptanceTesting
             return WithEndpoint<T>(b => { });
         }
 
-        public IScenarioWithEndpointBehavior<TContext> WithComponent(IComponentBehavior componentBehavior) 
+        public IScenarioWithEndpointBehavior<TContext> WithComponent(IComponentBehavior componentBehavior)
         {
             behaviors.Add(componentBehavior);
             return this;
@@ -78,9 +79,19 @@ namespace NServiceBus.AcceptanceTesting
 
         public IScenarioWithEndpointBehavior<TContext> Done(Func<TContext, bool> func)
         {
-            done = c => func((TContext) c);
+            done = c => func((TContext)c);
 
             return this;
+        }
+
+        void PrintLog(TContext scenarioContext)
+        {
+            Console.WriteLine($"Log entries (log level: {scenarioContext.LogLevel}):");
+            Console.WriteLine("------------------------------------------------------");
+            foreach (var logEntry in scenarioContext.Logs)
+            {
+                Console.WriteLine($"{logEntry.Level}: {logEntry.Message}");
+            }
         }
 
         static void DisplayRunResult(RunSummary summary)
@@ -117,18 +128,8 @@ namespace NServiceBus.AcceptanceTesting
 
             foreach (var prop in runResult.ScenarioContext.GetType().GetProperties())
             {
-                if (prop.Name == "Trace")
-                {
-                    continue;
-                }
-
                 Console.WriteLine("{0} = {1}", prop.Name, prop.GetValue(runResult.ScenarioContext, null));
             }
-
-            Console.WriteLine();
-            Console.WriteLine("Trace:");
-            Console.WriteLine(runResult.ScenarioContext.Trace);
-            Console.WriteLine("------------------------------------------------------");
         }
 
         static void PrintSettings(IEnumerable<KeyValuePair<string, object>> settings)

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -28,7 +28,6 @@
                 RunDescriptor = runDescriptor,
                 Endpoints = behaviorDescriptors
             };
-
         }
 
 


### PR DESCRIPTION
* Sets the default log level to `Debug`. The log entries are not used for anything by default. It does mean higher memory consumption though.
* When a test fails, it automatically dumps the full log
* Removed the "trace" category from the context. Tests can still add trace (not sure about it's value though), those entries will now just be added to the logs instead.