### PR TITLE
Remove incorrect default value in method summary

### DIFF
--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ConfigurationTimeoutExtensions.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ConfigurationTimeoutExtensions.cs
@@ -8,11 +8,10 @@
     public static class ConfigurationTimeoutExtensions
     {
         /// <summary>
-        /// A critical error is raised when timeout retrieval fails over a certain period of time.
-        /// This method allows to change the default and extend the wait time before raising a critical error.
+        /// Configures the amount of time to wait after a timeout retrieval fails before triggering a critical error.
         /// </summary>
         /// <param name="config">The <see cref="EndpointConfiguration" /> instance to apply the settings to.</param>
-        /// <param name="timeToWait">Time to wait before raising a critical error.</param>
+        /// <param name="timeToWait">The amount of time to wait before triggering a critical error.</param>
         public static void TimeToWaitBeforeTriggeringCriticalErrorOnTimeoutOutages(this EndpointConfiguration config, TimeSpan timeToWait)
         {
             Guard.AgainstNull(nameof(config), config);

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ConfigurationTimeoutExtensions.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/ConfigurationTimeoutExtensions.cs
@@ -8,9 +8,8 @@
     public static class ConfigurationTimeoutExtensions
     {
         /// <summary>
-        /// A critical error is raised when timeout retrieval fails.
-        /// By default we wait for 2 seconds for the storage to come back.
-        /// This method allows to change the default and extend the wait time.
+        /// A critical error is raised when timeout retrieval fails over a certain period of time.
+        /// This method allows to change the default and extend the wait time before raising a critical error.
         /// </summary>
         /// <param name="config">The <see cref="EndpointConfiguration" /> instance to apply the settings to.</param>
         /// <param name="timeToWait">Time to wait before raising a critical error.</param>


### PR DESCRIPTION
fixes https://github.com/Particular/NServiceBus/issues/4708

decided to not mention the default value as it seems very likely to be incorrect again in case of a change.