### PR TITLE
Handle file locked issues

### DIFF
--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -25,7 +25,7 @@ namespace NServiceBus
             {
                 File.Move(incomingFilePath, FileToProcess);
             }
-            catch (FileNotFoundException)
+            catch (IOException)
             {
                 return false;
             }

--- a/src/NServiceBus.Core/Transports/Learning/NoTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/NoTransaction.cs
@@ -22,11 +22,11 @@ namespace NServiceBus
             {
                 File.Move(incomingFilePath, FileToProcess);
             }
-            catch (FileNotFoundException)
+            catch (IOException)
             {
                 return false;
             }
-            
+
             //seem like File.Move is not atomic at least within the same process so we need this extra check
             return File.Exists(FileToProcess);
         }


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus/issues/4720

This PR:

* Makes sure that we deal with all IOExceptions not only file not found
* That we always release the semaphore during failures in BeginTransaction
* That we shutdown the endpoint properly should something go horribly wrong (like not being able to create the transaction directory)