### PR TITLE
Rename of wire compat test repo

### DIFF
--- a/releasing.md
+++ b/releasing.md
@@ -1,3 +1,3 @@
 ### Required updates as part of a release
-* Update references to NServiceBus.Core in the [Wire Compatibility Tests](https://github.com/Particular/NServiceBus.Msmq.WireCompatTests)
+* Update references to NServiceBus.Core in the [Wire Compatibility Tests](https://github.com/Particular/NServiceBus.WireCompatibilityTests)
 * If the Core release is a major version release, update references to NServiceBus.Core in [Serializer.CompatTests](https://github.com/Particular/NServiceBus.Serializers.CompatTests)


### PR DESCRIPTION
@Particular/nservicebus-maintainers repo for wire compat tests renamed like discussed in slack