### PR TITLE
[WIP]Remove ref to System.Configuration

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -17,7 +17,6 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Configuration" />
     <Reference Include="System.Security" />
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Transactions" />


### PR DESCRIPTION
Was just curious how it built locally with us still using things like `ConfigurationManager` , please TC set me straight again...