### PR TITLE
Remove System.Web

### DIFF
--- a/src/NServiceBus.Core.Tests/Logging/DefaultFactoryTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/DefaultFactoryTests.cs
@@ -8,7 +8,6 @@
     [TestFixture]
     public class DefaultFactoryTests
     {
-
         [Test]
         public void When_directory_is_bad_should_throw()
         {
@@ -18,13 +17,6 @@
             Assert.Throws<ArgumentNullException>(() => defaultFactory.Directory(null));
             Assert.Throws<ArgumentNullException>(() => defaultFactory.Directory(""));
             Assert.Throws<ArgumentNullException>(() => defaultFactory.Directory(" "));
-        }
-
-        [Test]
-        public void When_not_running_in_http_DeriveAppDataPath_should_throw()
-        {
-            var exception = Assert.Throws<Exception>(() => DefaultFactory.DeriveAppDataPath());
-            Assert.AreEqual("Detected running in a website and attempted to use HostingEnvironment.MapPath(\"~/App_Data/\") to derive the logging path. Failed since MapPath returned null. To avoid using HostingEnvironment.MapPath to derive the logging directory you can instead configure it to a specific path using LogManager.Use<DefaultFactory>().Directory(\"pathToLoggingDirectory\");", exception.Message);
         }
     }
 

--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -5,7 +5,6 @@ namespace NServiceBus
     using System.Linq;
     using System.Reflection;
     using System.Transactions;
-    using System.Web;
     using Configuration.AdvancedExtensibility;
     using Container;
     using Hosting.Helpers;
@@ -134,11 +133,7 @@ namespace NServiceBus
         {
             if (scannedTypes == null)
             {
-                var directoryToScan = AppDomain.CurrentDomain.BaseDirectory;
-                if (HttpRuntime.AppDomainAppId != null)
-                {
-                    directoryToScan = HttpRuntime.BinDirectory;
-                }
+                var directoryToScan = AppDomain.CurrentDomain.RelativeSearchPath ?? AppDomain.CurrentDomain.BaseDirectory;
 
                 scannedTypes = GetAllowedTypes(directoryToScan);
             }

--- a/src/NServiceBus.Core/Logging/DefaultFactory.cs
+++ b/src/NServiceBus.Core/Logging/DefaultFactory.cs
@@ -2,8 +2,6 @@ namespace NServiceBus.Logging
 {
     using System;
     using System.IO;
-    using System.Web;
-    using System.Web.Hosting;
     using IODirectory = System.IO.Directory;
 
     /// <summary>
@@ -16,7 +14,7 @@ namespace NServiceBus.Logging
         /// </summary>
         public DefaultFactory()
         {
-            directory = new Lazy<string>(FindDefaultLoggingDirectory);
+            directory = new Lazy<string>(() => AppDomain.CurrentDomain.BaseDirectory);
             level = new Lazy<LogLevel>(() => LogLevel.Info);
         }
 
@@ -53,51 +51,7 @@ namespace NServiceBus.Logging
             this.directory = new Lazy<string>(() => directory);
         }
 
-        internal static string FindDefaultLoggingDirectory()
-        {
-            if (HttpRuntime.AppDomainAppId == null)
-            {
-                return AppDomain.CurrentDomain.BaseDirectory;
-            }
-
-            return DeriveAppDataPath();
-        }
-
-        internal static string DeriveAppDataPath()
-        {
-            //we are in a website so attempt to MapPath
-            var appDataPath = TryMapPath();
-            if (appDataPath == null)
-            {
-                throw new Exception(GetMapPathError("Failed since MapPath returned null"));
-            }
-            if (IODirectory.Exists(appDataPath))
-            {
-                return appDataPath;
-            }
-
-            throw new Exception(GetMapPathError($"Failed since path returned ({appDataPath}) does not exist. Ensure this directory is created and restart the endpoint."));
-        }
-
-        static string TryMapPath()
-        {
-            try
-            {
-                return HostingEnvironment.MapPath("~/App_Data/");
-            }
-            catch (Exception exception)
-            {
-                throw new Exception(GetMapPathError("Failed since MapPath threw an exception"), exception);
-            }
-        }
-
-        static string GetMapPathError(string reason)
-        {
-            return $"Detected running in a website and attempted to use HostingEnvironment.MapPath(\"~/App_Data/\") to derive the logging path. {reason}. To avoid using HostingEnvironment.MapPath to derive the logging directory you can instead configure it to a specific path using LogManager.Use<DefaultFactory>().Directory(\"pathToLoggingDirectory\");";
-        }
-
         Lazy<string> directory;
-
         Lazy<LogLevel> level;
     }
 }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -21,7 +21,6 @@
     <Reference Include="System.Security" />
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Transactions" />
-    <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 


### PR DESCRIPTION
we need to remove our usage of `HttpRuntime` for .net core compatibility.

this is currently used in two places:
* Logging: when running an asp.net application, the logs have been put in the "app_data" folder. I changed that to log into the base directory instead by default. I think if we really want we could somehow identify whether we run in an asp.net application without using `System.Web` and build the app_data folder somehow, but I'm not sure about that value?
* Assembly scanning: Instead of scanning the base directory, we scan the "bin" subdirectory which is used by asp.net to place assemblies into. In that case `AppDomain.CurrentDomain.RelativeSearchPath` will point towards that bin path, while it will be `null` when not run in asp.net.

Maybe there are also better approaches around?