### PR TITLE
Create proxy assembly with .NET Core compatible API

### DIFF
--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/ConcreteProxyCreator.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/ConcreteProxyCreator.cs
@@ -11,11 +11,7 @@ namespace NServiceBus
     {
         public ConcreteProxyCreator()
         {
-            var assemblyBuilder = AppDomain.CurrentDomain.DefineDynamicAssembly(
-                new AssemblyName("NServiceBusMessageProxies"),
-                AssemblyBuilderAccess.Run
-                );
-
+            var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(new AssemblyName("NServiceBusMessageProxies"), AssemblyBuilderAccess.Run);
             moduleBuilder = assemblyBuilder.DefineDynamicModule("NServiceBusMessageProxies");
         }
 


### PR DESCRIPTION
`AppDomain.CurrentDomain.DefineDynamicAssembly` is not supported in .net core 2.0 but `AssemblyBuilder.DefineDynamicAssembly` is. As this API also seems to be available in net452 we can always use this API if(!) there is no different behavior.