### PR TITLE
Use AsyncLocal for ContextAppender

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/AsyncLocal.cs
+++ b/src/NServiceBus.AcceptanceTesting/AsyncLocal.cs
@@ -1,0 +1,38 @@
+﻿#if NET452
+namespace System.Threading
+{
+    using Runtime.Remoting.Messaging;
+
+    /// <summary>
+    /// Provides a polyfill of AsyncLocal in .NET 4.5.2
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    sealed class AsyncLocal<T>
+    {
+        readonly string id;
+
+        /// <summary>Gets or sets the value of the ambient data. </summary>
+        /// <returns>The value of the ambient data. </returns>
+        public T Value
+        {
+            get
+            {
+                var localValue = CallContext.LogicalGetData(id);
+                if (localValue != null)
+                    return (T)localValue;
+                return default(T);
+            }
+            set
+            {
+                // ReSharper disable once ArrangeAccessorOwnerBody
+                CallContext.LogicalSetData(id, value);
+            }
+        }
+
+        public AsyncLocal()
+        {
+            id = Guid.NewGuid().ToString();
+        }
+    }
+}
+#endif

--- a/src/NServiceBus.AcceptanceTesting/AsyncLocal.cs
+++ b/src/NServiceBus.AcceptanceTesting/AsyncLocal.cs
@@ -3,10 +3,7 @@ namespace System.Threading
 {
     using Runtime.Remoting.Messaging;
 
-    /// <summary>
-    /// Provides a polyfill of AsyncLocal in .NET 4.5.2
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
+    // Provides a polyfill of AsyncLocal in .NET 4.5.2
     sealed class AsyncLocal<T>
     {
         readonly string id;

--- a/src/NServiceBus.AcceptanceTesting/AsyncLocal.cs
+++ b/src/NServiceBus.AcceptanceTesting/AsyncLocal.cs
@@ -8,15 +8,16 @@ namespace System.Threading
     {
         readonly string id;
 
-        /// <summary>Gets or sets the value of the ambient data. </summary>
-        /// <returns>The value of the ambient data. </returns>
+        // Gets or sets the value of the ambient data. 
         public T Value
         {
             get
             {
                 var localValue = CallContext.LogicalGetData(id);
                 if (localValue != null)
+                {
                     return (T)localValue;
+                }
                 return default(T);
             }
             set

--- a/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
+++ b/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
@@ -4,14 +4,13 @@
     using System.Diagnostics;
     using Logging;
 
-    // This class is written under the assumption that acceptance tests are executed sequentially.
     class ContextAppender : ILog
     {
-        public bool IsDebugEnabled => ScenarioContext.GetContext().LogLevel <= LogLevel.Debug;
-        public bool IsInfoEnabled => ScenarioContext.GetContext().LogLevel <= LogLevel.Info;
-        public bool IsWarnEnabled => ScenarioContext.GetContext().LogLevel <= LogLevel.Warn;
-        public bool IsErrorEnabled => ScenarioContext.GetContext().LogLevel <= LogLevel.Error;
-        public bool IsFatalEnabled => ScenarioContext.GetContext().LogLevel <= LogLevel.Fatal;
+        public bool IsDebugEnabled => ScenarioContext.Current.LogLevel <= LogLevel.Debug;
+        public bool IsInfoEnabled => ScenarioContext.Current.LogLevel <= LogLevel.Info;
+        public bool IsWarnEnabled => ScenarioContext.Current.LogLevel <= LogLevel.Warn;
+        public bool IsErrorEnabled => ScenarioContext.Current.LogLevel <= LogLevel.Error;
+        public bool IsFatalEnabled => ScenarioContext.Current.LogLevel <= LogLevel.Fatal;
 
 
         public void Debug(string message)
@@ -102,7 +101,7 @@
 
         static void Log(string message, LogLevel messageSeverity)
         {
-            var context = ScenarioContext.GetContext();
+            var context = ScenarioContext.Current;
 
             if (context.LogLevel > messageSeverity)
             {

--- a/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
+++ b/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
@@ -2,17 +2,16 @@
 {
     using System;
     using System.Diagnostics;
-    using System.Runtime.Remoting.Messaging;
     using Logging;
 
     // This class is written under the assumption that acceptance tests are executed sequentially.
     class ContextAppender : ILog
     {
-        public bool IsDebugEnabled => ((ScenarioContext)CallContext.LogicalGetData("ScenarioContext")).LogLevel <= LogLevel.Debug;
-        public bool IsInfoEnabled => ((ScenarioContext)CallContext.LogicalGetData("ScenarioContext")).LogLevel <= LogLevel.Info;
-        public bool IsWarnEnabled => ((ScenarioContext)CallContext.LogicalGetData("ScenarioContext")).LogLevel <= LogLevel.Warn;
-        public bool IsErrorEnabled => ((ScenarioContext)CallContext.LogicalGetData("ScenarioContext")).LogLevel <= LogLevel.Error;
-        public bool IsFatalEnabled => ((ScenarioContext)CallContext.LogicalGetData("ScenarioContext")).LogLevel <= LogLevel.Fatal;
+        public bool IsDebugEnabled => ScenarioContext.GetContext().LogLevel <= LogLevel.Debug;
+        public bool IsInfoEnabled => ScenarioContext.GetContext().LogLevel <= LogLevel.Info;
+        public bool IsWarnEnabled => ScenarioContext.GetContext().LogLevel <= LogLevel.Warn;
+        public bool IsErrorEnabled => ScenarioContext.GetContext().LogLevel <= LogLevel.Error;
+        public bool IsFatalEnabled => ScenarioContext.GetContext().LogLevel <= LogLevel.Fatal;
 
 
         public void Debug(string message)
@@ -103,7 +102,7 @@
 
         static void Log(string message, LogLevel messageSeverity)
         {
-            var context = (ScenarioContext) CallContext.LogicalGetData("ScenarioContext");
+            var context = ScenarioContext.GetContext();
 
             if (context.LogLevel > messageSeverity)
             {

--- a/src/NServiceBus.AcceptanceTesting/ContextAppenderFactory.cs
+++ b/src/NServiceBus.AcceptanceTesting/ContextAppenderFactory.cs
@@ -5,18 +5,6 @@ namespace NServiceBus.AcceptanceTesting
 
     class ContextAppenderFactory : ILoggerFactory
     {
-        static ScenarioContext context;
-        
-
-        /// <summary>
-        /// Because ILoggerFactory interface methods are only used in a static context. This is the only way to set the currently executing context.
-        /// </summary>
-        /// <param name="newContext">The new context to be set</param>
-        public static void SetContext(ScenarioContext newContext)
-        {
-            context = newContext;
-        }
-
         public ILog GetLogger(Type type)
         {
             return GetLogger(type.FullName);
@@ -24,7 +12,7 @@ namespace NServiceBus.AcceptanceTesting
 
         public ILog GetLogger(string name)
         {
-            return new ContextAppender(context.LogLevel, () => context);
+            return new ContextAppender();
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
@@ -9,6 +9,12 @@
 
     public class ScenarioContext
     {
+        internal static ScenarioContext Current
+        {
+            get => asyncContext.Value;
+            set => asyncContext.Value = value;
+        }
+
         public Guid TestRunId { get; } = Guid.NewGuid();
 
         public bool EndpointsStarted { get; set; }
@@ -37,6 +43,8 @@
             LogLevel = level;
         }
 
+        static readonly AsyncLocal<ScenarioContext> asyncContext = new AsyncLocal<ScenarioContext>();
+
         public class LogItem
         {
             public string Message { get; set; }
@@ -46,18 +54,6 @@
             {
                 return $"{Level}: {Message}";
             }
-        }
-
-        static readonly AsyncLocal<ScenarioContext> asyncContext = new AsyncLocal<ScenarioContext>();
-
-        internal static ScenarioContext GetContext()
-        {
-            return asyncContext.Value;
-        }
-
-        internal static void SetContext(ScenarioContext scenarioContext)
-        {
-            asyncContext.Value = scenarioContext;
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Threading;
     using Faults;
     using Logging;
 
@@ -45,6 +46,18 @@
             {
                 return $"{Level}: {Message}";
             }
+        }
+
+        static readonly AsyncLocal<ScenarioContext> asyncContext = new AsyncLocal<ScenarioContext>();
+
+        internal static ScenarioContext GetContext()
+        {
+            return asyncContext.Value;
+        }
+
+        internal static void SetContext(ScenarioContext scenarioContext)
+        {
+            asyncContext.Value = scenarioContext;
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -3,7 +3,6 @@ namespace NServiceBus.AcceptanceTesting
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Runtime.Remoting.Messaging;
     using System.Threading.Tasks;
     using Logging;
     using Support;
@@ -34,7 +33,7 @@ namespace NServiceBus.AcceptanceTesting
             var runDescriptor = new RunDescriptor(scenarioContext);
             runDescriptor.Settings.Merge(settings);
 
-            CallContext.LogicalSetData("ScenarioContext", scenarioContext);
+            ScenarioContext.SetContext(scenarioContext);
 
             LogManager.UseFactory(new ContextAppenderFactory());
 

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -33,7 +33,7 @@ namespace NServiceBus.AcceptanceTesting
             var runDescriptor = new RunDescriptor(scenarioContext);
             runDescriptor.Settings.Merge(settings);
 
-            ScenarioContext.SetContext(scenarioContext);
+            ScenarioContext.Current = scenarioContext;
 
             LogManager.UseFactory(new ContextAppenderFactory());
 

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.AcceptanceTesting
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Runtime.Remoting.Messaging;
     using System.Threading.Tasks;
     using Logging;
     using Support;
@@ -32,6 +33,8 @@ namespace NServiceBus.AcceptanceTesting
 
             var runDescriptor = new RunDescriptor(scenarioContext);
             runDescriptor.Settings.Merge(settings);
+
+            CallContext.LogicalSetData("ScenarioContext", scenarioContext);
 
             LogManager.UseFactory(new ContextAppenderFactory());
 

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -16,9 +16,7 @@
         {
             Console.WriteLine("Started test @ {0}", DateTime.Now.ToString(CultureInfo.InvariantCulture));
 
-            ContextAppenderFactory.SetContext(runDescriptor.ScenarioContext);
             var runResult = await PerformTestRun(behaviorDescriptors, runDescriptor, done).ConfigureAwait(false);
-            ContextAppenderFactory.SetContext(null);
 
             Console.WriteLine("Finished test @ {0}", DateTime.Now.ToString(CultureInfo.InvariantCulture));
 


### PR DESCRIPTION
CallContext flows with the execution context. Meaning even if a Transport internally uses Task.Run the call context set from the acceptance test will float into it.

https://blogs.msdn.microsoft.com/pfxteam/2012/06/15/executioncontext-vs-synchronizationcontext/

Arguably it might be better to use AsyncLocal and upgrade to 4.6 and higher since CallContext might be not Core compliant (haven't checked).  I would prefer the AsyncLocal solution.

With that, we can make sure there is always a ScenarioContext available without being exposed to the inlining of the static context assignment into the factory and then run into races where scenario context is suddenly null.