### PR TITLE
Update Particular.Licensing.Sources to 0.1.62

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="NuGetPackager" Version="0.6.1" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.2.2" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="0.1.61" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="0.1.62" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The 0.1.62 package includes a change to the GenerateReleaseDate target to ensure it doesn't cause problems with Visual Studio's design-time builds.