### PR TITLE
Remove system.web usage from EndpointConfiguration

### DIFF
--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -5,7 +5,6 @@ namespace NServiceBus
     using System.Linq;
     using System.Reflection;
     using System.Transactions;
-    using System.Web;
     using Configuration.AdvancedExtensibility;
     using Container;
     using Hosting.Helpers;
@@ -134,11 +133,7 @@ namespace NServiceBus
         {
             if (scannedTypes == null)
             {
-                var directoryToScan = AppDomain.CurrentDomain.BaseDirectory;
-                if (HttpRuntime.AppDomainAppId != null)
-                {
-                    directoryToScan = HttpRuntime.BinDirectory;
-                }
+                var directoryToScan = AppDomain.CurrentDomain.RelativeSearchPath ?? AppDomain.CurrentDomain.BaseDirectory;
 
                 scannedTypes = GetAllowedTypes(directoryToScan);
             }


### PR DESCRIPTION
Cherry pick of https://github.com/Particular/NServiceBus/pull/4759 on the `EndpointConfiguration` side which doesn't seem to be affected by the ASP.NET app_data issues we have to consider.