### PR TITLE
Poison message in MSMQ fails to be sent to remote error queue and is retried indefinitely

### DIFF
--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveStrategy.cs
@@ -83,7 +83,7 @@ namespace NServiceBus
 
         protected void MovePoisonMessageToErrorQueue(Message message, MessageQueueTransaction transaction)
         {
-            var error = $"Message '{message.Id}' is classfied as a poison message and will be moved to '{errorQueue.QueueName}'";
+            var error = $"Message '{message.Id}' is classfied as a poison message and will be moved to the configured error queue.";
 
             Logger.Error(error);
 
@@ -92,7 +92,7 @@ namespace NServiceBus
 
         protected void MovePoisonMessageToErrorQueue(Message message, MessageQueueTransactionType transactionType)
         {
-            var error = $"Message '{message.Id}' is classfied as a poison message and will be moved to '{errorQueue.QueueName}'";
+            var error = $"Message '{message.Id}' is classfied as a poison message and will be moved to the configured error queue.";
 
             Logger.Error(error);
 

--- a/src/NServiceBus.Core/Transports/Msmq/ReceiveStrategy.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/ReceiveStrategy.cs
@@ -83,7 +83,7 @@ namespace NServiceBus
 
         protected void MovePoisonMessageToErrorQueue(Message message, MessageQueueTransaction transaction)
         {
-            var error = $"Message '{message.Id}' is classfied as a poison message and will be moved to the configured error queue.";
+            var error = $"Message '{message.Id}' is classified as a poison message and will be moved to the configured error queue.";
 
             Logger.Error(error);
 
@@ -92,7 +92,7 @@ namespace NServiceBus
 
         protected void MovePoisonMessageToErrorQueue(Message message, MessageQueueTransactionType transactionType)
         {
-            var error = $"Message '{message.Id}' is classfied as a poison message and will be moved to the configured error queue.";
+            var error = $"Message '{message.Id}' is classified as a poison message and will be moved to the configured error queue.";
 
             Logger.Error(error);
 


### PR DESCRIPTION
Connects to https://github.com/Particular/NServiceBus/issues/4792