### PR TITLE
Use TTBR delivery constraint & custom header in learning transport

### DIFF
--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportDispatcher.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportDispatcher.cs
@@ -56,17 +56,9 @@ namespace NServiceBus
             }));
         }
 
-
         async Task WriteMessage(string destination, IOutgoingTransportOperation transportOperation, TransportTransaction transaction)
         {
             var message = transportOperation.Message;
-            var headerPayload = HeaderSerializer.Serialize(message.Headers);
-            var headerSize = Encoding.UTF8.GetByteCount(headerPayload);
-
-            if (headerSize + message.Body.Length > maxMessageSizeKB * 1024)
-            {
-                throw new Exception($"The total size of the '{message.Headers[Headers.EnclosedMessageTypes]}' message body ({message.Body.Length} bytes) plus headers ({headerSize} bytes) is larger than {maxMessageSizeKB} KB and will not be supported on some production transports. Consider using the NServiceBus DataBus or the claim check pattern to avoid messages with a large payload. Use 'EndpointConfiguration.UseTransport<LearningTransport>().NoPayloadSizeRestriction()' to disable this check and proceed with the current message size.");
-            }
 
             var nativeMessageId = Guid.NewGuid().ToString();
             var destinationPath = Path.Combine(basePath, destination);
@@ -92,11 +84,6 @@ namespace NServiceBus
 
             if (timeToDeliver.HasValue)
             {
-                if (transportOperation.DeliveryConstraints.TryGet(out DiscardIfNotReceivedBefore timeToBeReceived) && timeToBeReceived.MaxTime < TimeSpan.MaxValue)
-                {
-                    throw new Exception($"Postponed delivery of messages with TimeToBeReceived set is not supported. Remove the TimeToBeReceived attribute to postpone messages of type '{message.Headers[Headers.EnclosedMessageTypes]}'.");
-                }
-
                 // we need to "ceil" the seconds to guarantee that we delay with at least the requested value
                 // since the folder name has only second resolution.
                 if (timeToDeliver.Value.Millisecond > 0)
@@ -109,7 +96,25 @@ namespace NServiceBus
                 Directory.CreateDirectory(destinationPath);
             }
 
+            if (transportOperation.DeliveryConstraints.TryGet(out DiscardIfNotReceivedBefore timeToBeReceived) && timeToBeReceived.MaxTime < TimeSpan.MaxValue)
+            {
+                if (timeToDeliver.HasValue)
+                {
+                    throw new Exception($"Postponed delivery of messages with TimeToBeReceived set is not supported. Remove the TimeToBeReceived attribute to postpone messages of type '{message.Headers[Headers.EnclosedMessageTypes]}'.");
+                }
+
+                message.Headers[LearningTransportHeaders.TimeToBeReceived] = timeToBeReceived.MaxTime.ToString();
+            }
+
             var messagePath = Path.Combine(destinationPath, nativeMessageId) + ".metadata.txt";
+
+            var headerPayload = HeaderSerializer.Serialize(message.Headers);
+            var headerSize = Encoding.UTF8.GetByteCount(headerPayload);
+
+            if (headerSize + message.Body.Length > maxMessageSizeKB * 1024)
+            {
+                throw new Exception($"The total size of the '{message.Headers[Headers.EnclosedMessageTypes]}' message body ({message.Body.Length} bytes) plus headers ({headerSize} bytes) is larger than {maxMessageSizeKB} KB and will not be supported on some production transports. Consider using the NServiceBus DataBus or the claim check pattern to avoid messages with a large payload. Use 'EndpointConfiguration.UseTransport<LearningTransport>().NoPayloadSizeRestriction()' to disable this check and proceed with the current message size.");
+            }
 
             if (transportOperation.RequiredDispatchConsistency != DispatchConsistency.Isolated && transaction.TryGet(out ILearningTransportTransaction directoryBasedTransaction))
             {
@@ -123,7 +128,6 @@ namespace NServiceBus
                     .ConfigureAwait(false);
             }
         }
-
 
         async Task<IEnumerable<string>> GetSubscribersFor(Type messageType)
         {

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportHeaders.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportHeaders.cs
@@ -1,0 +1,7 @@
+﻿namespace NServiceBus
+{
+    static class LearningTransportHeaders
+    {
+        public const string TimeToBeReceived = "NServiceBus.Transport.Learning.TimeToBeReceived";
+    }
+}

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -242,8 +242,10 @@
             var bodyPath = Path.Combine(bodyDir, $"{messageId}{BodyFileSuffix}");
             var headers = HeaderSerializer.Deserialize(message);
 
-            if (headers.TryGetValue(Headers.TimeToBeReceived, out var ttbrString))
+            if (headers.TryGetValue(LearningTransportHeaders.TimeToBeReceived, out var ttbrString))
             {
+                headers.Remove(LearningTransportHeaders.TimeToBeReceived);
+
                 var ttbr = TimeSpan.Parse(ttbrString);
 
                 //file.move preserves create time


### PR DESCRIPTION
Instead of using the diagnostic TTBR header, the learning transport now uses the `DiscardIfNotReceivedBefore` delivery constraint to determine the message is supposed to have a TTBR value set. This value is transferred to the receiving endpoint in a custom header that is removed by the receiver before passing the message along for processing. The ensures that the header is not propagated incorrectly when if the message is forwarded for any reason.

Addresses the problem described in #4807