### PR TITLE
Fix case of hardcoded queue name

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_publishing_from_sendonly.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_publishing_from_sendonly.cs
@@ -95,7 +95,7 @@
             {
                 addressTask = Task.FromResult(new[]
                 {
-                    new Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber("publishingFromSendonly.subscriber", null)
+                    new Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber("PublishingFromSendonly.Subscriber", null)
                 }.AsEnumerable());
             }
 


### PR DESCRIPTION
Fix case of hardcoded queue name to be consistent with case of the created queue

Fixes #4812

Tested with SQS and MSMQ