### PR TITLE
Use conventions to translate endpoint address

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_publishing_from_sendonly.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_publishing_from_sendonly.cs
@@ -12,6 +12,7 @@
     using Persistence;
     using Unicast.Subscriptions;
     using Unicast.Subscriptions.MessageDrivenSubscriptions;
+    using Conventions = AcceptanceTesting.Customization.Conventions;
 
     public class When_publishing_from_sendonly : NServiceBusAcceptanceTest
     {
@@ -94,7 +95,7 @@
             {
                 addressTask = Task.FromResult(new[]
                 {
-                    new Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber("PublishingFromSendonly.Subscriber", null)
+                    new Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber(Conventions.EndpointNamingConvention(typeof(Subscriber)), null)
                 }.AsEnumerable());
             }
 


### PR DESCRIPTION
different attempt to fix https://github.com/Particular/NServiceBus/issues/4812

Should be more reliable instead of hard-coding values.
@ahofman can you verify this resolves the issue as well?