### PR TITLE
Fix the build action for the source packages

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -32,12 +32,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="**\*.cs">
+    <_PackageFiles Include="**\*.cs">
+      <BuildAction>Compile</BuildAction>
       <PackagePath>content\App_Packages\NSB.AcceptanceTests\;contentFiles\cs\any\NSB.AcceptanceTests\</PackagePath>
-    </Content>
-    <Content Remove="**\obj\**\*.cs" />
-    <Content Remove="Core\**\*.cs" />
-    <Content Remove="AssemblyInfo.cs" />
+    </_PackageFiles>
+    <_PackageFiles Remove="**\obj\**\*.cs" />
+    <_PackageFiles Remove="Core\**\*.cs" />
+    <_PackageFiles Remove="AssemblyInfo.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
+++ b/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
@@ -23,10 +23,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="**\*.cs">
+    <_PackageFiles Include="**\*.cs">
+      <BuildAction>Compile</BuildAction>
       <PackagePath>content\App_Packages\NSB.ContainerTests\;contentFiles\cs\any\NSB.ContainerTests\</PackagePath>
-    </Content>
-    <Content Remove="**\obj\**\*.cs" />
+    </_PackageFiles>
+    <_PackageFiles Remove="**\obj\**\*.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Testing.Fakes/NServiceBus.Testing.Fakes.csproj
+++ b/src/NServiceBus.Testing.Fakes/NServiceBus.Testing.Fakes.csproj
@@ -19,10 +19,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="**\*.cs">
+    <_PackageFiles Include="**\*.cs">
+      <BuildAction>Compile</BuildAction>
       <PackagePath>content\App_Packages\NSB.Testing.Fakes\;contentFiles\cs\any\NSB.Testing.Fakes\</PackagePath>
-    </Content>
-    <Content Remove="**\obj\**\*.cs" />
+    </_PackageFiles>
+    <_PackageFiles Remove="**\obj\**\*.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -27,11 +27,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="**\*.cs">
+    <_PackageFiles Include="**\*.cs">
+      <BuildAction>Compile</BuildAction>
       <PackagePath>content\App_Packages\NSB.TransportTests\;contentFiles\cs\any\NSB.TransportTests\</PackagePath>
-    </Content>
-    <Content Remove="**\obj\**\*.cs" />
-    <Content Remove="ConfigureLearningTransportInfrastructure.cs" />
+    </_PackageFiles>
+    <_PackageFiles Remove="**\obj\**\*.cs" />
+    <_PackageFiles Remove="ConfigureLearningTransportInfrastructure.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This ensures that the source files included in the package via the contentFiles mechanism have the correct Compile build action instead of Content.

It should be possible to directly use the existing Compile items and update them to set pack=true, but there appears to be a bug right now where doing that breaks if the project is multi-targeted, ending up with no files in the package. 😢 