### PR TITLE
.NET Core 2.0 Preview 2 changes

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,19 +8,6 @@
     <PlatformCompatIgnore>Linux;MacOSX</PlatformCompatIgnore>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <Authors>NServiceBus Ltd</Authors>
-    <Company>NServiceBus Ltd</Company>
-    <PackageLicenseUrl>http://particular.net/LicenseAgreement</PackageLicenseUrl>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Copyright>Copyright 2010-$([System.DateTime]::UtcNow.ToString(yyyy)) NServiceBus. All rights reserved</Copyright>
-    <PackageTags>nservicebus servicebus msmq cqrs publish subscribe</PackageTags>
-    <PackageIconUrl>http://s3.amazonaws.com/nuget.images/NServiceBus_32.png</PackageIconUrl>
-    <PackageProjectUrl>http://particular.net/</PackageProjectUrl>
-    <PackageOutputPath>..\..\nugets</PackageOutputPath>
-    <!--<GeneratePackageOnBuild>true</GeneratePackageOnBuild>-->
-  </PropertyGroup>
-
   <!-- Workaround for GitVersion 4.0 not creating GitVersionInformation by default -->
   <PropertyGroup>
     <UpdateAssemblyInfo>true</UpdateAssemblyInfo>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,16 @@
+<Project>
+
+  <PropertyGroup>
+    <Authors>NServiceBus Ltd</Authors>
+    <Company>NServiceBus Ltd</Company>
+    <PackageLicenseUrl>http://particular.net/LicenseAgreement</PackageLicenseUrl>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <Copyright>Copyright 2010-$([System.DateTime]::UtcNow.ToString(yyyy)) NServiceBus. All rights reserved</Copyright>
+    <PackageTags>nservicebus servicebus msmq cqrs publish subscribe</PackageTags>
+    <PackageIconUrl>http://s3.amazonaws.com/nuget.images/NServiceBus_32.png</PackageIconUrl>
+    <PackageProjectUrl>http://particular.net/</PackageProjectUrl>
+    <PackageOutputPath>..\..\nugets</PackageOutputPath>
+    <!--<GeneratePackageOnBuild>true</GeneratePackageOnBuild>-->
+  </PropertyGroup>
+
+</Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -8,7 +8,7 @@
     <Copyright>Copyright 2010-$([System.DateTime]::UtcNow.ToString(yyyy)) NServiceBus. All rights reserved</Copyright>
     <PackageTags>nservicebus servicebus msmq cqrs publish subscribe</PackageTags>
     <PackageIconUrl>http://s3.amazonaws.com/nuget.images/NServiceBus_32.png</PackageIconUrl>
-    <PackageProjectUrl>http://particular.net/</PackageProjectUrl>
+    <PackageProjectUrl>https://docs.particular.net/nuget/$(PackageId)</PackageProjectUrl>
     <PackageOutputPath>..\..\nugets</PackageOutputPath>
     <!--<GeneratePackageOnBuild>true</GeneratePackageOnBuild>-->
   </PropertyGroup>

--- a/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
+++ b/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
@@ -17,10 +17,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="$(OutputPath)\**\$(AssemblyName).pdb">
+    <None Include="$(OutputPath)\**\$(AssemblyName).pdb">
       <Pack>true</Pack>
       <PackagePath>lib\</PackagePath>
-    </Content>
+      <Visible>false</Visible>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170618-03" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="[3.7.1, 4.0.0)" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />

--- a/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
+++ b/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170618-03" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="[3.7.1, 4.0.0)" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" PrivateAssets="All" />
   </ItemGroup>

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="ApprovalTests" Version="3.0.13" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170618-03" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0-beta6" />
     <PackageReference Include="NuDoq" Version="1.2.5" />
     <PackageReference Include="NUnit" Version="3.6.1" />

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -5,6 +5,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1701;1702;1705;NU1701</NoWarn>
     <Optimize>False</Optimize>
   </PropertyGroup>
 

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -55,17 +55,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="$(OutputPath)\**\$(AssemblyName).pdb">
+    <None Include="$(OutputPath)\**\$(AssemblyName).pdb">
       <Pack>true</Pack>
       <PackagePath>lib\</PackagePath>
-    </Content>
+      <Visible>false</Visible>
+    </None>
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="..\..\packaging\nuget\tools\init.ps1">
+    <None Include="..\..\packaging\nuget\tools\init.ps1">
       <Pack>true</Pack>
       <PackagePath>tools</PackagePath>
-    </Content>
+      <Visible>false</Visible>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -31,9 +31,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0-preview1-25305-02" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0-preview1-25305-02" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="4.4.0-preview1-25305-02" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="4.4.0-preview2-25405-01" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">

--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170618-03" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="[3.7.1, 4.0.0)" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" PrivateAssets="All" />
   </ItemGroup>

--- a/src/NServiceBus.sln
+++ b/src/NServiceBus.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26608.5
+VisualStudioVersion = 15.0.26621.2
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{2904B75F-8F07-4C07-BABC-BC42533B3E75}"
 EndProject
@@ -70,5 +70,8 @@ Global
 		{EE97B7B8-63A8-4ECE-AE81-C4F5617830F2} = {2904B75F-8F07-4C07-BABC-BC42533B3E75}
 		{82BB433F-96BB-43D1-98E4-EEDE437D70AE} = {2904B75F-8F07-4C07-BABC-BC42533B3E75}
 		{65578230-EF42-43A6-A943-624F2DF01E66} = {2904B75F-8F07-4C07-BABC-BC42533B3E75}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A32A19A8-C700-4AC8-8A34-1D56DA9CDF95}
 	EndGlobalSection
 EndGlobal

--- a/src/NServiceBus.sln
+++ b/src/NServiceBus.sln
@@ -23,6 +23,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E3BC3CE8-9EA6-41BE-89AD-23876257B740}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
This adds some changes related to updating to the .NET Core 2.0 Preview 2 release.

I noticed that the items being included in the project files so they would be packed were actually showing up in Solution Explorer, so I added `<Visible>false</Visible>` to hide them

I also change them from `Content` to `None` items since that's a more correct build action for them, and I verified that the files still show up in the resulting packages. It appears the the problem with Compile items might just be exclusive to that single build action item.

I also had to suppress the newly introduced NU1701 warning, which informs you if a package you're referencing is being referenced via the .NET Framework shim instead of it having a native .NET Core/.NET Standard target.

It would be ideal if we could suppress this on a per-item basis, but I don't currently see a way to do that, so I had to globally suppress it for now.