### PR TITLE
Ensure PDBs are included in package

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -13,4 +13,15 @@
     <!--<GeneratePackageOnBuild>true</GeneratePackageOnBuild>-->
   </PropertyGroup>
 
+  <!-- Target is needed until we can enable GeneratePackageOnBuild again -->
+  <Target Name="IncludePDBsInPackage" BeforeTargets="_GetPackageFiles" Condition="'$(IncludeBuildOutput)' != 'false'">
+    <ItemGroup>
+      <None Include="$(OutputPath)\**\$(AssemblyName).pdb">
+        <Pack>true</Pack>
+        <PackagePath>lib\</PackagePath>
+        <Visible>false</Visible>
+      </None>
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
+++ b/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
@@ -16,12 +16,4 @@
     <Description>Acceptance testing framework for NServiceBus endpoints. This is an unsupported package.</Description>
   </PropertyGroup>
 
-  <ItemGroup>
-    <None Include="$(OutputPath)\**\$(AssemblyName).pdb">
-      <Pack>true</Pack>
-      <PackagePath>lib\</PackagePath>
-      <Visible>false</Visible>
-    </None>
-  </ItemGroup>
-
 </Project>

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -51,14 +51,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(OutputPath)\**\$(AssemblyName).pdb">
-      <Pack>true</Pack>
-      <PackagePath>lib\</PackagePath>
-      <Visible>false</Visible>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="..\..\packaging\nuget\tools\init.ps1">
       <Pack>true</Pack>
       <PackagePath>tools</PackagePath>


### PR DESCRIPTION
This ensures that the PDBs will be included in the package. Before, there was a timing issue about when the item was evaluated and if the file already existed on disk. 

Once we no longer need the workaround for https://github.com/NuGet/Home/issues/4790, we can reenable GeneratePackageOnBuild, which seems to make everything work correctly with needing to be wrapped in the target.

I also went ahead and moved the logic into Directory.Build.targets instead of having it in both locations.