### PR TITLE
Scan AppDomain assemblies by default

### DIFF
--- a/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
@@ -71,7 +71,7 @@ namespace NServiceBus.Core.Tests.AssemblyScanner
         {
             var circularDirectory = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestDlls\circular");
             var classLibB = Path.Combine(circularDirectory, "ClassLibraryB.dll");
-          
+
             // Put ClassLibraryB.dll in CurrentDomain.BaseDirectory so it resolves correctly
             var tempClassLibB = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ClassLibraryB.dll");
 
@@ -102,6 +102,7 @@ namespace NServiceBus.Core.Tests.AssemblyScanner
             });
 
             var scanner = new AssemblyScanner(DynamicAssembly.TestAssemblyDirectory);
+            scanner.ScanAppDomainAssemblies = false;
             scanner.CoreAssemblyName = busAssembly.DynamicName;
 
             var result = scanner.GetScannableAssemblies();
@@ -122,6 +123,7 @@ namespace NServiceBus.Core.Tests.AssemblyScanner
             var assemblyWithoutReference = new DynamicAssembly("AssemblyWithoutReference");
 
             var scanner = new AssemblyScanner(DynamicAssembly.TestAssemblyDirectory);
+            scanner.ScanAppDomainAssemblies = false;
             scanner.CoreAssemblyName = busAssembly.DynamicName;
 
             var result = scanner.GetScannableAssemblies();
@@ -148,6 +150,7 @@ namespace NServiceBus.Core.Tests.AssemblyScanner
 
             var scanner = new AssemblyScanner(DynamicAssembly.TestAssemblyDirectory);
             scanner.ThrowExceptions = false;
+            scanner.ScanAppDomainAssemblies = false;
             scanner.CoreAssemblyName = busAssemblyV2.Name;
 
             var result = scanner.GetScannableAssemblies();
@@ -180,6 +183,7 @@ namespace NServiceBus.Core.Tests.AssemblyScanner
             });
 
             var scanner = new AssemblyScanner(DynamicAssembly.TestAssemblyDirectory);
+            scanner.ScanAppDomainAssemblies = false;
             scanner.CoreAssemblyName = busAssembly.DynamicName;
 
             var result = scanner.GetScannableAssemblies();
@@ -335,6 +339,7 @@ class InterfaceMessageHandler : IHandleMessages<IBaseEvent>
             Assembly.LoadFrom(handlerAsm.FilePath);
 
             var scanner = new AssemblyScanner(DynamicAssembly.TestAssemblyDirectory);
+            scanner.ScanAppDomainAssemblies = false;
 
             var result = scanner.GetScannableAssemblies();
 

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_directory_with_handler_dll_is_scanned.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_directory_with_handler_dll_is_scanned.cs
@@ -11,6 +11,7 @@
         public void dll_with_message_handlers_gets_loaded()
         {
             var assemblyScanner = new AssemblyScanner(TestContext.CurrentContext.TestDirectory);
+            assemblyScanner.ScanAppDomainAssemblies = false;
 
             var results = assemblyScanner
                 .GetScannableAssemblies();

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_directory_with_nested_directories.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_directory_with_nested_directories.cs
@@ -13,7 +13,10 @@ namespace NServiceBus.Core.Tests.AssemblyScanner
         public void Should_not_scan_nested_directories_by_default()
         {
             var endpointConfiguration = new EndpointConfiguration("myendpoint");
-            endpointConfiguration.AssemblyScanner().ExcludeTypes(typeof(When_using_initialization_with_non_default_ctor.FeatureWithInitialization));
+            var scannerConfiguration = endpointConfiguration.AssemblyScanner();
+
+            scannerConfiguration.ScanAppDomainAssemblies = false;
+            scannerConfiguration.ExcludeTypes(typeof(When_using_initialization_with_non_default_ctor.FeatureWithInitialization));
             endpointConfiguration.Build();
 
             var scannedTypes = endpointConfiguration.Settings.Get<IList<Type>>("TypesToScan");

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_top_level_only.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_top_level_only.cs
@@ -33,6 +33,7 @@ namespace NServiceBus.Core.Tests.AssemblyScanner
         {
             var results = new AssemblyScanner(baseDirectoryToScan)
             {
+                ScanAppDomainAssemblies = false,
                 ScanNestedDirectories = false
             }
             .GetScannableAssemblies();

--- a/src/NServiceBus.Core.Tests/Config/When_scanning_assemblies.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_scanning_assemblies.cs
@@ -42,6 +42,8 @@ namespace NServiceBus.Core.Tests.Config
         IEnumerable<Assembly> GetAssembliesInDirectory(string path, params string[] assembliesToSkip)
         {
             var assemblyScanner = new AssemblyScanner(path);
+            assemblyScanner.ScanAppDomainAssemblies = false;
+
             if (assembliesToSkip != null)
             {
                 assemblyScanner.AssembliesToSkip = assembliesToSkip.ToList();

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -27,29 +27,25 @@ namespace NServiceBus.Hosting.Helpers
         /// </summary>
         public AssemblyScanner(string baseDirectoryToScan)
         {
-            ThrowExceptions = true;
             this.baseDirectoryToScan = baseDirectoryToScan;
-            CoreAssemblyName = NServicebusCoreAssemblyName;
         }
 
         internal AssemblyScanner(Assembly assemblyToScan)
         {
             this.assemblyToScan = assemblyToScan;
-            ThrowExceptions = true;
-            CoreAssemblyName = NServicebusCoreAssemblyName;
         }
 
         /// <summary>
         /// Determines if the scanner should throw exceptions or not.
         /// </summary>
-        public bool ThrowExceptions { get; set; }
+        public bool ThrowExceptions { get; set; } = true;
 
         /// <summary>
         /// Determines if the scanner should scan assemblies loaded in the <see cref="AppDomain.CurrentDomain"/>.
         /// </summary>
         public bool ScanAppDomainAssemblies { get; set; }
 
-        internal string CoreAssemblyName { get; set; }
+        internal string CoreAssemblyName { get; set; } = NServicebusCoreAssemblyName;
 
         /// <summary>
         /// Traverses the specified base directory including all sub-directories, generating a list of assemblies that can be

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -43,7 +43,7 @@ namespace NServiceBus.Hosting.Helpers
         /// <summary>
         /// Determines if the scanner should scan assemblies loaded in the <see cref="AppDomain.CurrentDomain"/>.
         /// </summary>
-        public bool ScanAppDomainAssemblies { get; set; }
+        public bool ScanAppDomainAssemblies { get; set; } = true;
 
         internal string CoreAssemblyName { get; set; } = NServicebusCoreAssemblyName;
 

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
@@ -12,9 +12,9 @@
     public class AssemblyScannerConfiguration
     {
         /// <summary>
-        /// Defines whether assemblies loaded into the current <see cref="AppDomain"/> should be scanned. Default value is <code>false</code>.
+        /// Defines whether assemblies loaded into the current <see cref="AppDomain"/> should be scanned. Default value is <code>true</code>.
         /// </summary>
-        public bool ScanAppDomainAssemblies { get; set; }
+        public bool ScanAppDomainAssemblies { get; set; } = true;
 
         /// <summary>
         /// Defines whether exceptions occurring during assembly scanning should be rethrown or ignored. Default value is <code>true</code>.


### PR DESCRIPTION
As mentioned in https://github.com/Particular/NServiceBus/pull/4818#issuecomment-312367859, we need to scan AppDomain assemblies by default for .NET Core, so this goes ahead and makes it the default for both frameworks.

I suppose we could make this `true` for .NET Core only, but I'd prefer to keep the behavior the same if at all possible.

As part of this change, we'll need to update docs and list it in the upgrade guide.