### PR TITLE
Replace P/Invoke with managed equivalent

### DIFF
--- a/src/NServiceBus.Core/Logging/ColoredConsoleLogger.cs
+++ b/src/NServiceBus.Core/Logging/ColoredConsoleLogger.cs
@@ -1,19 +1,18 @@
 ﻿namespace NServiceBus
 {
     using System;
-    using System.Runtime.InteropServices;
+    using System.IO;
     using Logging;
 
     static class ColoredConsoleLogger
     {
         static ColoredConsoleLogger()
         {
-            const int STD_OUTPUT_HANDLE = -11;
-            logToConsole = GetStdHandle(STD_OUTPUT_HANDLE) != IntPtr.Zero;
+            using (var stream = Console.OpenStandardOutput())
+            {
+                logToConsole = stream != Stream.Null;
+            }
         }
-
-        [DllImport("kernel32.dll", SetLastError = true)]
-        static extern IntPtr GetStdHandle(int nStdHandle);
 
         public static void Write(string message, LogLevel logLevel)
         {
@@ -21,6 +20,7 @@
             {
                 return;
             }
+
             try
             {
                 Console.ForegroundColor = GetColor(logLevel);
@@ -38,6 +38,7 @@
             {
                 return ConsoleColor.Red;
             }
+
             if (logLevel == LogLevel.Warn)
             {
                 return ConsoleColor.DarkYellow;


### PR DESCRIPTION
While testing some assembly loading scenarios, I tried to run an endpoint on linux, and it blew up about missing kernel32.dll. I had no idea we had a `DllImport` lurking in the code.

From what I can tell, using `Environment.UserInteractive` should be a decent replacement for the previous code that was attempting to see if standard output was available.