### PR TITLE
Change develop release tag to alpharelease

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,6 +2,6 @@ assembly-versioning-scheme: Major
 next-version: 7.0
 branches:
   develop:
-    tag: alpha
+    tag: alpharelease
   release:
     tag: rc


### PR DESCRIPTION
Changing the prerelease tag to something that sorts higher than "alpha" but lower than "beta" gets us out of needing to tag each release like we're currently needing to do. The lower commit count metadata value won't be a problem this way.