### PR TITLE
Avoid duplicate service registrations

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
@@ -65,14 +65,15 @@
                 {
                     config.GetSettings().Set("TimeToWaitBeforeTriggeringCriticalErrorForTimeoutPersisterReceiver", TimeSpan.FromSeconds(7));
                     config.EnableFeature<TimeoutManager>();
+                    config.DisableFeature<InMemoryTimeoutPersistence>(); // we register our custom timeout persister
                 });
             }
 
             public TestContext TestContext { get; set; }
 
-            class Initializer : Feature
+            class CustomTimeoutPersister : Feature
             {
-                public Initializer()
+                public CustomTimeoutPersister()
                 {
                     EnableByDefault();
                 }

--- a/src/NServiceBus.AcceptanceTests/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
@@ -65,19 +65,20 @@
                 {
                     config.GetSettings().Set("TimeToWaitBeforeTriggeringCriticalErrorForTimeoutPersisterReceiver", TimeSpan.FromSeconds(7));
                     config.EnableFeature<TimeoutManager>();
-                    config.DisableFeature<InMemoryTimeoutPersistence>(); // we register our custom timeout persister
+                    config.UsePersistence<CustomTimeoutPersister, StorageType.Timeouts>();
                 });
             }
+        }
 
-            public TestContext TestContext { get; set; }
-
-            class CustomTimeoutPersister : Feature
+        public class CustomTimeoutPersister : PersistenceDefinition
+        {
+            public CustomTimeoutPersister()
             {
-                public CustomTimeoutPersister()
-                {
-                    EnableByDefault();
-                }
+                Supports<StorageType.Timeouts>(s => s.EnableFeatureByDefault<CustomTimeoutPersisterFeature>());
+            }
 
+            public class CustomTimeoutPersisterFeature : Feature
+            {
                 protected override void Setup(FeatureConfigurationContext context)
                 {
                     var testContext = context.Settings.Get<TimeoutTestContext>();

--- a/src/NServiceBus.AcceptanceTests/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
@@ -7,6 +7,7 @@
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
+    using Persistence;
 
     class When_timeout_storage_is_unavailable_temporarily : NServiceBusAcceptanceTest
     {


### PR DESCRIPTION
Should fix some of the https://github.com/Particular/NServiceBus.Transport.Msmq/pull/29 which result in a dependency not resolvable. This is caused by having multiple implementations of IQueryTimeouts registered and therefore LightInject not able to resolve while Autofac would just pick the latest. I think that test would probably also fail using other containers not using the autofac approach.