### PR TITLE
Remove need to call ToArray() in case when an array is already passed

### DIFF
--- a/src/NServiceBus.Core/Pipeline/Outgoing/ImmediateDispatchTerminator.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/ImmediateDispatchTerminator.cs
@@ -15,7 +15,8 @@
         protected override Task Terminate(IDispatchContext context)
         {
             var transaction = context.Extensions.GetOrCreate<TransportTransaction>();
-            return dispatcher.Dispatch(new TransportOperations(context.Operations.ToArray()), transaction, context.Extensions);
+            var operations = context.Operations as TransportOperation[] ?? context.Operations.ToArray();
+            return dispatcher.Dispatch(new TransportOperations(operations), transaction, context.Extensions);
         }
 
         IDispatchMessages dispatcher;


### PR DESCRIPTION
Remove need to call ToArray() in case when an array is already passed (is the case when batched dispatches are passed to the terminator)

Another option would have been to break the public types but I felt this is unnecessary.