### PR TITLE
[SPIKE] Spike raw dispatch pipeline

### DIFF
--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
@@ -5,13 +5,13 @@ namespace NServiceBus
     using Routing;
     using Timeout.Core;
     using Transport;
+    using Pipeline;
 
     class StoreTimeoutBehavior
     {
-        public StoreTimeoutBehavior(ExpiredTimeoutsPoller poller, IDispatchMessages dispatcher, IPersistTimeouts persister, string owningTimeoutManager)
+        public StoreTimeoutBehavior(ExpiredTimeoutsPoller poller, IPersistTimeouts persister, string owningTimeoutManager)
         {
             this.poller = poller;
-            this.dispatcher = dispatcher;
             this.persister = persister;
             this.owningTimeoutManager = owningTimeoutManager;
         }
@@ -65,7 +65,7 @@ namespace NServiceBus
                 {
                     var outgoingMessage = new OutgoingMessage(context.MessageId, data.Headers, data.State);
                     var transportOperation = new TransportOperation(outgoingMessage, new UnicastAddressTag(data.Destination));
-                    await dispatcher.Dispatch(new TransportOperations(transportOperation), context.TransportTransaction, context.Extensions).ConfigureAwait(false);
+                    await context.Dispatch(transportOperation).ConfigureAwait(false);
                     return;
                 }
 
@@ -81,7 +81,6 @@ namespace NServiceBus
             return context.Headers.TryGetValue(Headers.ReplyToAddress, out replyToAddress) ? replyToAddress : null;
         }
 
-        IDispatchMessages dispatcher;
         string owningTimeoutManager;
         IPersistTimeouts persister;
 

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
@@ -71,7 +71,6 @@
                 (builder, messageContext) =>
                 {
                     var dispatchBehavior = new DispatchTimeoutBehavior(
-                        builder.Build<IDispatchMessages>(),
                         builder.Build<IPersistTimeouts>(),
                         requiredTransactionSupport);
 
@@ -91,7 +90,6 @@
                 {
                     var storeBehavior = new StoreTimeoutBehavior(
                         builder.Build<ExpiredTimeoutsPoller>(),
-                        builder.Build<IDispatchMessages>(),
                         builder.Build<IPersistTimeouts>(),
                         context.Settings.EndpointName().ToString());
 

--- a/src/NServiceBus.Core/IMessageSessionRaw.cs
+++ b/src/NServiceBus.Core/IMessageSessionRaw.cs
@@ -1,0 +1,16 @@
+namespace NServiceBus
+{
+    using System.Threading.Tasks;
+    using Transport;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface IMessageSessionRaw
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        Task Dispatch(params TransportOperation[] operations);
+    }
+}

--- a/src/NServiceBus.Core/MessageSession.cs
+++ b/src/NServiceBus.Core/MessageSession.cs
@@ -2,8 +2,10 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
+    using Pipeline;
+    using Transport;
 
-    class MessageSession : IMessageSession
+    class MessageSession : IMessageSession, IMessageSessionRaw
     {
         public MessageSession(RootContext context)
         {
@@ -38,6 +40,13 @@ namespace NServiceBus
         public Task Unsubscribe(Type eventType, UnsubscribeOptions options)
         {
             return MessageOperations.Unsubscribe(context, eventType, options);
+        }
+
+        public Task Dispatch(params TransportOperation[] operations)
+        {
+            var cache = context.Extensions.Get<IPipelineCache>();
+            var pipeline = cache.Pipeline<IDispatchContext>();
+            return pipeline.Invoke(new DispatchContext(operations, context));
         }
 
         RootContext context;

--- a/src/NServiceBus.Core/MessageSessionExtensions.cs
+++ b/src/NServiceBus.Core/MessageSessionExtensions.cs
@@ -1,0 +1,25 @@
+namespace NServiceBus
+{
+    using System;
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class MessageSessionExtensions
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="session"></param>
+        /// <returns></returns>
+        public static IMessageSessionRaw Raw(this IMessageSession session)
+        {
+            var raw = session as IMessageSessionRaw;
+            if (raw == null)
+            {
+                throw new NotSupportedException();
+            }
+            return raw;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/ConnectorContextExtensions.cs
+++ b/src/NServiceBus.Core/Pipeline/ConnectorContextExtensions.cs
@@ -148,6 +148,28 @@ namespace NServiceBus
         }
 
         /// <summary>
+        /// Creates a <see cref="IDispatchContext" /> based on the current context.
+        /// </summary>
+        public static IDispatchContext CreateDispatchContext(this StageConnector<ISubscribeContext, IDispatchContext> stageConnector, IReadOnlyCollection<TransportOperation> transportOperations, ISubscribeContext sourceContext)
+        {
+            Guard.AgainstNull(nameof(transportOperations), transportOperations);
+            Guard.AgainstNull(nameof(sourceContext), sourceContext);
+
+            return new DispatchContext(transportOperations, sourceContext);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="IDispatchContext" /> based on the current context.
+        /// </summary>
+        public static IDispatchContext CreateDispatchContext(this StageConnector<IUnsubscribeContext, IDispatchContext> stageConnector, IReadOnlyCollection<TransportOperation> transportOperations, IUnsubscribeContext sourceContext)
+        {
+            Guard.AgainstNull(nameof(transportOperations), transportOperations);
+            Guard.AgainstNull(nameof(sourceContext), sourceContext);
+
+            return new DispatchContext(transportOperations, sourceContext);
+        }
+
+        /// <summary>
         /// Creates a <see cref="IOutgoingLogicalMessageContext" /> based on the current context.
         /// </summary>
         public static IOutgoingLogicalMessageContext CreateOutgoingLogicalMessageContext(this StageConnector<IOutgoingPublishContext, IOutgoingLogicalMessageContext> stageConnector, OutgoingLogicalMessage outgoingMessage, IReadOnlyCollection<RoutingStrategy> routingStrategies, IOutgoingPublishContext sourceContext)

--- a/src/NServiceBus.Core/Pipeline/MessageContextExtensions.cs
+++ b/src/NServiceBus.Core/Pipeline/MessageContextExtensions.cs
@@ -1,0 +1,53 @@
+﻿namespace NServiceBus.Pipeline
+{
+    using System.Threading.Tasks;
+    using Extensibility;
+    using ObjectBuilder;
+    using Transport;
+
+    /// <summary>
+    /// Raw dispatch
+    /// </summary>
+    public static class RawDispatchExtensions
+    {
+        // If this would be on IExtensible we could allow raw dispatches elsewhere
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="operations"></param>
+        /// <returns></returns>
+        public static Task Dispatch(this MessageContext context, params TransportOperation[] operations)
+        {
+            var cache = context.Extensions.Get<IPipelineCache>();
+            var pipeline = cache.Pipeline<IDispatchContext>();
+            return pipeline.Invoke(new DispatchContext(operations, new ContextToGetItWorking(context)));
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="operations"></param>
+        /// <returns></returns>
+        public static Task Dispatch(this ErrorContext context, params TransportOperation[] operations)
+        {
+            var cache = context.Extensions.Get<IPipelineCache>();
+            var pipeline = cache.Pipeline<IDispatchContext>();
+            return pipeline.Invoke(new DispatchContext(operations, new ContextToGetItWorking(context)));
+        }
+
+        class ContextToGetItWorking : ContextBag, IBehaviorContext
+        {
+            public ContextToGetItWorking(IExtendable extendable) : base(extendable.Extensions)
+            {
+
+            }
+
+            public ContextBag Extensions => this;
+            public IBuilder Builder => Get<IBuilder>();
+        }
+    }
+
+
+}

--- a/src/NServiceBus.Core/Pipeline/SatellitePipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/SatellitePipelineExecutor.cs
@@ -6,20 +6,24 @@
 
     class SatellitePipelineExecutor : IPipelineExecutor
     {
-        public SatellitePipelineExecutor(IBuilder builder, SatelliteDefinition definition)
+        public SatellitePipelineExecutor(IBuilder builder, SatelliteDefinition definition, IPipelineCache pipelineCache)
         {
+            this.pipelineCache = pipelineCache;
             this.builder = builder;
             satelliteDefinition = definition;
         }
 
         public Task Invoke(MessageContext messageContext)
         {
+            messageContext.Extensions.Set(builder);
             messageContext.Extensions.Set(messageContext.TransportTransaction);
+            messageContext.Extensions.Set(pipelineCache);
 
             return satelliteDefinition.OnMessage(builder, messageContext);
         }
 
         SatelliteDefinition satelliteDefinition;
         IBuilder builder;
+        IPipelineCache pipelineCache;
     }
 }

--- a/src/NServiceBus.Core/Recoverability/Recoverability.cs
+++ b/src/NServiceBus.Core/Recoverability/Recoverability.cs
@@ -53,7 +53,7 @@
 
                     var headerCustomizations = context.Settings.Get<Action<Dictionary<string, string>>>(FaultHeaderCustomization);
 
-                    return new MoveToErrorsExecutor(b.Build<IDispatchMessages>(), staticFaultMetadata, headerCustomizations);
+                    return new MoveToErrorsExecutor(staticFaultMetadata, headerCustomizations);
                 };
 
                 var transactionsOn = context.Settings.GetRequiredTransactionModeForReceives() != TransportTransactionMode.None;
@@ -67,7 +67,6 @@
                     {
                         return new DelayedRetryExecutor(
                             localAddress,
-                            b.Build<IDispatchMessages>(),
                             context.Settings.DoesTransportSupportConstraint<DelayedDeliveryConstraint>()
                                 ? null
                                 : context.Settings.Get<TimeoutManagerAddressConfiguration>().TransportAddress);

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
@@ -83,7 +83,7 @@
 
             Logger.Error($"Moving message '{message.MessageId}' to the error queue '{ errorQueue }' because processing failed due to an exception:", errorContext.Exception);
 
-            await moveToErrorsExecutor.MoveToErrorQueue(errorQueue, message, errorContext.Exception, errorContext.TransportTransaction).ConfigureAwait(false);
+            await moveToErrorsExecutor.MoveToErrorQueue(errorQueue, message, errorContext).ConfigureAwait(false);
 
             if (raiseNotifications)
             {
@@ -98,7 +98,7 @@
 
             Logger.Warn($"Delayed Retry will reschedule message '{message.MessageId}' after a delay of {action.Delay} because of an exception:", errorContext.Exception);
 
-            var currentDelayedRetriesAttempts = await delayedRetryExecutor.Retry(message, action.Delay, errorContext.TransportTransaction).ConfigureAwait(false);
+            var currentDelayedRetriesAttempts = await delayedRetryExecutor.Retry(message, action.Delay, errorContext).ConfigureAwait(false);
 
             if (raiseNotifications)
             {

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -57,6 +57,20 @@
             return messageTypesHandled;
         }
 
+        class SomeStartupTaskWhichDoesRawSends : FeatureStartupTask {
+            protected override Task OnStart(IMessageSession session)
+            {
+                var rawSession = session.Raw();
+                return rawSession.Dispatch();
+            }
+
+            protected override Task OnStop(IMessageSession session)
+            {
+                var rawSession = session.Raw();
+                return rawSession.Dispatch();
+            }
+        }
+        
         class ApplySubscriptions : FeatureStartupTask
         {
             public ApplySubscriptions(IEnumerable<Type> messagesHandledByThisEndpoint)

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeConnector.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeConnector.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using Extensibility;
     using Logging;
     using Pipeline;
     using Routing;
@@ -11,17 +10,16 @@
     using Unicast.Queuing;
     using Unicast.Transport;
 
-    class MessageDrivenSubscribeTerminator : PipelineTerminator<ISubscribeContext>
+    class MessageDrivenSubscribeConnector : StageConnector<ISubscribeContext, IDispatchContext>
     {
-        public MessageDrivenSubscribeTerminator(SubscriptionRouter subscriptionRouter, string subscriberAddress, string subscriberEndpoint, IDispatchMessages dispatcher)
+        public MessageDrivenSubscribeConnector(SubscriptionRouter subscriptionRouter, string subscriberAddress, string subscriberEndpoint)
         {
             this.subscriptionRouter = subscriptionRouter;
             this.subscriberAddress = subscriberAddress;
             this.subscriberEndpoint = subscriberEndpoint;
-            this.dispatcher = dispatcher;
         }
 
-        protected override Task Terminate(ISubscribeContext context)
+        public override Task Invoke(ISubscribeContext context, Func<IDispatchContext, Task> stage)
         {
             var eventType = context.EventType;
 
@@ -45,26 +43,25 @@
                 subscriptionMessage.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
                 subscriptionMessage.Headers[Headers.NServiceBusVersion] = GitFlowVersion.MajorMinorPatch;
 
-                subscribeTasks.Add(SendSubscribeMessageWithRetries(publisherAddress, subscriptionMessage, eventType.AssemblyQualifiedName, context.Extensions));
+                subscribeTasks.Add(SendSubscribeMessageWithRetries(publisherAddress, subscriptionMessage, eventType.AssemblyQualifiedName, context, stage));
             }
             return Task.WhenAll(subscribeTasks);
         }
 
-        async Task SendSubscribeMessageWithRetries(string destination, OutgoingMessage subscriptionMessage, string messageType, ContextBag context, int retriesCount = 0)
+        async Task SendSubscribeMessageWithRetries(string destination, OutgoingMessage subscriptionMessage, string messageType, ISubscribeContext context, Func<IDispatchContext, Task> stage, int retriesCount = 0)
         {
-            var state = context.GetOrCreate<Settings>();
+            var state = context.Extensions.GetOrCreate<Settings>();
             try
             {
                 var transportOperation = new TransportOperation(subscriptionMessage, new UnicastAddressTag(destination));
-                var transportTransaction = context.GetOrCreate<TransportTransaction>();
-                await dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction, context).ConfigureAwait(false);
+                await stage(this.CreateDispatchContext(new[] { transportOperation }, context)).ConfigureAwait(false);
             }
             catch (QueueNotFoundException ex)
             {
                 if (retriesCount < state.MaxRetries)
                 {
                     await Task.Delay(state.RetryDelay).ConfigureAwait(false);
-                    await SendSubscribeMessageWithRetries(destination, subscriptionMessage, messageType, context, ++retriesCount).ConfigureAwait(false);
+                    await SendSubscribeMessageWithRetries(destination, subscriptionMessage, messageType, context, stage, ++retriesCount).ConfigureAwait(false);
                 }
                 else
                 {
@@ -75,13 +72,13 @@
             }
         }
 
-        IDispatchMessages dispatcher;
         string subscriberAddress;
+
         string subscriberEndpoint;
 
         SubscriptionRouter subscriptionRouter;
 
-        static ILog Logger = LogManager.GetLogger<MessageDrivenSubscribeTerminator>();
+        static ILog Logger = LogManager.GetLogger<MessageDrivenSubscribeConnector>();
 
         public class Settings
         {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -55,8 +55,8 @@ namespace NServiceBus.Features
                 var subscriberAddress = context.Settings.LocalAddress();
                 var subscriptionRouter = new SubscriptionRouter(publishers, endpointInstances, i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)));
 
-                context.Pipeline.Register(b => new MessageDrivenSubscribeTerminator(subscriptionRouter, subscriberAddress, context.Settings.EndpointName(), b.Build<IDispatchMessages>()), "Sends subscription requests when message driven subscriptions is in use");
-                context.Pipeline.Register(b => new MessageDrivenUnsubscribeTerminator(subscriptionRouter, subscriberAddress, context.Settings.EndpointName(), b.Build<IDispatchMessages>()), "Sends requests to unsubscribe when message driven subscriptions is in use");
+                context.Pipeline.Register(new MessageDrivenSubscribeConnector(subscriptionRouter, subscriberAddress, context.Settings.EndpointName()), "Sends subscription requests when message driven subscriptions is in use");
+                context.Pipeline.Register(new MessageDrivenUnsubscribeConnector(subscriptionRouter, subscriberAddress, context.Settings.EndpointName()), "Sends requests to unsubscribe when message driven subscriptions is in use");
 
                 var authorizer = context.Settings.GetSubscriptionAuthorizer();
                 if (authorizer == null)

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -113,7 +113,7 @@ namespace NServiceBus
                 var satelliteRecoverabilityExecutor = recoverabilityExecutorFactory.Create(satellitePipeline.RecoverabilityPolicy, eventAggregator, satellitePipeline.ReceiveAddress);
                 var satellitePushSettings = new PushSettings(satellitePipeline.ReceiveAddress, errorQueue, purgeOnStartup, satellitePipeline.RequiredTransportTransactionMode);
 
-                receivers.Add(new TransportReceiver(satellitePipeline.Name, builder.Build<IPushMessages>(), satellitePushSettings, satellitePipeline.RuntimeSettings, new SatellitePipelineExecutor(builder, satellitePipeline), satelliteRecoverabilityExecutor, criticalError));
+                receivers.Add(new TransportReceiver(satellitePipeline.Name, pipelineCache, builder.Build<IPushMessages>(), satellitePushSettings, satellitePipeline.RuntimeSettings, new SatellitePipelineExecutor(builder, satellitePipeline, pipelineCache), satelliteRecoverabilityExecutor, criticalError));
             }
 
             return receivers;
@@ -130,7 +130,7 @@ namespace NServiceBus
 
             var receivers = new List<TransportReceiver>();
 
-            receivers.Add(new TransportReceiver(MainReceiverId, builder.Build<IPushMessages>(), pushSettings, dequeueLimitations, mainPipelineExecutor, recoverabilityExecutor, criticalError));
+            receivers.Add(new TransportReceiver(MainReceiverId, pipelineCache, builder.Build<IPushMessages>(), pushSettings, dequeueLimitations, mainPipelineExecutor, recoverabilityExecutor, criticalError));
 
             if (settings.InstanceSpecificQueue() != null)
             {
@@ -138,7 +138,7 @@ namespace NServiceBus
                 var instanceSpecificRecoverabilityExecutor = recoverabilityExecutorFactory.CreateDefault(eventAggregator, instanceSpecificQueue);
                 var sharedReceiverPushSettings = new PushSettings(settings.InstanceSpecificQueue(), errorQueue, purgeOnStartup, requiredTransactionSupport);
 
-                receivers.Add(new TransportReceiver(MainReceiverId, builder.Build<IPushMessages>(), sharedReceiverPushSettings, dequeueLimitations, mainPipelineExecutor, instanceSpecificRecoverabilityExecutor, criticalError));
+                receivers.Add(new TransportReceiver(MainReceiverId, pipelineCache, builder.Build<IPushMessages>(), sharedReceiverPushSettings, dequeueLimitations, mainPipelineExecutor, instanceSpecificRecoverabilityExecutor, criticalError));
             }
 
             return receivers;

--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -2,16 +2,26 @@
 {
     using System;
     using System.Collections.Generic;
+    using Extensibility;
 
     /// <summary>
     /// The context for messages that has failed processing.
     /// </summary>
-    public class ErrorContext
+    public class ErrorContext : IExtendable
     {
+
         /// <summary>
         /// Initializes the error context.
         /// </summary>
         public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, byte[] body, TransportTransaction transportTransaction, int immediateProcessingFailures)
+        : this(exception, headers, transportMessageId, body, transportTransaction, immediateProcessingFailures, new ContextBag())
+        {
+        }
+
+        /// <summary>
+        /// Initializes the error context.
+        /// </summary>
+        public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, byte[] body, TransportTransaction transportTransaction, int immediateProcessingFailures, ContextBag context)
         {
             Exception = exception;
             TransportTransaction = transportTransaction;
@@ -46,5 +56,10 @@
         /// Failed incoming message.
         /// </summary>
         public IncomingMessage Message { get; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public ContextBag Extensions { get; }
     }
 }


### PR DESCRIPTION
Attention: Does not even compile. I didn't want to spend too much time on this 

While brainstorming how we could get rid of the builder calls I looked how we could get rid of the builder calls for the dispatcher. This is an attempt to do so.

- Only one builder call in the core
- Dedicated dispatch pipeline which is allowed to access the builder
- Allows to intercept all outgoing messages even with message driven pub sub
  - Solves a lot of hacks downstreams need to do for Atts and message stamping. For example in ASQ we had to hack the serializer to be able to stamp all messages
  - Makes the dispatch part finally extendable
- FeatureStartupTasks no longer need to inject IDispatcher directly. They can just treat the message session as Raw. I went with an additional interface to minimize breaking changes and hide the raw capability from the eyes of the standard user.
- Satellites and Recoverability can also easily access the dispatch pipeline over the MessageContext or ErrorContext
- The timeout poller dispatcher access hasn't been spiked yet but since it is a core infrastructure I wouldn't worry too much

For me beside reducing the builder calls the fact that it allows properly extend the raw dispatches is a huge plus.

