### PR TITLE
Remove dtc warning

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -14,7 +14,6 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Security" />
-    <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />

--- a/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
@@ -1,9 +1,7 @@
 ﻿namespace NServiceBus.Features
 {
     using System;
-    using System.Threading.Tasks;
     using ConsistencyGuarantees;
-    using Logging;
     using Persistence;
 
     /// <summary>

--- a/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
@@ -29,47 +29,7 @@
             }
 
             //note: in the future we should change the persister api to give us a "outbox factory" so that we can register it in DI here instead of relying on the persister to do it
-
-            context.RegisterStartupTask(new DtcRunningWarning());
             context.Pipeline.Register("ForceBatchDispatchToBeIsolated", new ForceBatchDispatchToBeIsolatedBehavior(), "Makes sure that we dispatch straight to the transport so that we can safely set the outbox record to dispatched one the dispatch pipeline returns.");
         }
-
-    }
-
-    class DtcRunningWarning : FeatureStartupTask
-    {
-        protected override Task OnStart(IMessageSession session)
-        {
-#if NET452
-            try
-            {
-                var sc = new System.ServiceProcess.ServiceController
-                {
-                    ServiceName = "MSDTC",
-                    MachineName = "."
-                };
-
-                if (sc.Status == System.ServiceProcess.ServiceControllerStatus.Running)
-                {
-                    log.Warn(@"The MSDTC service is running on this machine.
-Because Outbox is enabled disabling MSDTC is recommended. This ensures that the Outbox behavior is working as expected and no other resources are enlisting in distributed transactions.");
-                }
-            }
-            // ReSharper disable once EmptyGeneralCatchClause
-            catch (Exception)
-            {
-                // Ignore if we can't check it.
-            }
-#endif
-
-            return TaskEx.CompletedTask;
-        }
-
-        protected override Task OnStop(IMessageSession session)
-        {
-            return TaskEx.CompletedTask;
-        }
-
-        static ILog log = LogManager.GetLogger<DtcRunningWarning>();
     }
 }

--- a/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
@@ -34,7 +34,6 @@
             context.Pipeline.Register("ForceBatchDispatchToBeIsolated", new ForceBatchDispatchToBeIsolatedBehavior(), "Makes sure that we dispatch straight to the transport so that we can safely set the outbox record to dispatched one the dispatch pipeline returns.");
         }
 
-        static ILog log = LogManager.GetLogger<Outbox>();
     }
 
     class DtcRunningWarning : FeatureStartupTask


### PR DESCRIPTION
Considering the following

 * the MSTDC service warning cannot run on  net core
 * we dont care if it succeeds
 * just because an endpoint is running on a machine with the outbox it is still be valid to have other services on the machine that rely on msdtc
 * this would be better handled in guidance https://github.com/Particular/docs.particular.net/pull/2967
 * means we can drop the reference to System.ServiceProcess
 