### PR TITLE
make log dir consistent

### DIFF
--- a/src/NServiceBus.Core.Tests/Logging/DefaultFactoryTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/DefaultFactoryTests.cs
@@ -19,14 +19,6 @@
             Assert.Throws<ArgumentNullException>(() => defaultFactory.Directory(" "));
         }
 
-#if NET452
-        [Test]
-        public void When_not_running_in_http_DeriveAppDataPath_should_throw()
-        {
-            var exception = Assert.Throws<Exception>(() => DefaultFactory.DeriveAppDataPath());
-            Assert.AreEqual("Detected running in a website and attempted to use HostingEnvironment.MapPath(\"~/App_Data/\") to derive the logging path. Failed since MapPath returned null. To avoid using HostingEnvironment.MapPath to derive the logging directory you can instead configure it to a specific path using LogManager.Use<DefaultFactory>().Directory(\"pathToLoggingDirectory\");", exception.Message);
-        }
-#endif
     }
 
 

--- a/src/NServiceBus.Core/Logging/DefaultFactory.cs
+++ b/src/NServiceBus.Core/Logging/DefaultFactory.cs
@@ -14,7 +14,7 @@ namespace NServiceBus.Logging
         /// </summary>
         public DefaultFactory()
         {
-            directory = new Lazy<string>(FindDefaultLoggingDirectory);
+            directory = new Lazy<string>(() => AppDomain.CurrentDomain.BaseDirectory);
             level = new Lazy<LogLevel>(() => LogLevel.Info);
         }
 
@@ -50,53 +50,6 @@ namespace NServiceBus.Logging
             }
             this.directory = new Lazy<string>(() => directory);
         }
-
-#if NET452
-        internal static string FindDefaultLoggingDirectory()
-        {
-            if (System.Web.HttpRuntime.AppDomainAppId == null)
-            {
-                return AppDomain.CurrentDomain.BaseDirectory;
-            }
-
-            return DeriveAppDataPath();
-        }
-
-        internal static string DeriveAppDataPath()
-        {
-            //we are in a website so attempt to MapPath
-            var appDataPath = TryMapPath();
-            if (appDataPath == null)
-            {
-                throw new Exception(GetMapPathError("Failed since MapPath returned null"));
-            }
-            if (IODirectory.Exists(appDataPath))
-            {
-                return appDataPath;
-            }
-
-            throw new Exception(GetMapPathError($"Failed since path returned ({appDataPath}) does not exist. Ensure this directory is created and restart the endpoint."));
-        }
-
-        static string TryMapPath()
-        {
-            try
-            {
-                return System.Web.Hosting.HostingEnvironment.MapPath("~/App_Data/");
-            }
-            catch (Exception exception)
-            {
-                throw new Exception(GetMapPathError("Failed since MapPath threw an exception"), exception);
-            }
-        }
-
-        static string GetMapPathError(string reason)
-        {
-            return $"Detected running in a website and attempted to use HostingEnvironment.MapPath(\"~/App_Data/\") to derive the logging path. {reason}. To avoid using HostingEnvironment.MapPath to derive the logging directory you can instead configure it to a specific path using LogManager.Use<DefaultFactory>().Directory(\"pathToLoggingDirectory\");";
-        }
-#else
-        internal static string FindDefaultLoggingDirectory() => AppDomain.CurrentDomain.BaseDirectory;
-#endif
 
         Lazy<string> directory;
 

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -16,7 +16,6 @@
     <Reference Include="System.Security" />
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Transactions" />
-    <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 


### PR DESCRIPTION
also drops dependency on web

I dont think the default logging location should be different between net core and net4. if it is ok for net core running in a web context to default to `AppDomain.CurrentDomain.BaseDirectory` then it should also be ok for net4. any doco/guidance/upgrade guides required can then be consistent and applicable to both.