### PR TITLE
[SPIKE] Introduce RouteToThisEndpointStrategy to remove builder usage

### DIFF
--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPipelineFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPipelineFeature.cs
@@ -15,7 +15,7 @@
             context.Pipeline.Register(new AttachSenderRelatedInfoOnMessageBehavior(), "Makes sure that outgoing messages contains relevant info on the sending endpoint.");
 
             context.Pipeline.Register(new OutgoingPhysicalToRoutingConnector(), "Starts the message dispatch pipeline");
-            context.Pipeline.Register(new RoutingToDispatchConnector(), "Decides if the current message should be batched or immediately be dispatched to the transport");
+            context.Pipeline.Register(new RoutingToDispatchConnector(context.Settings.LocalAddress()), "Decides if the current message should be batched or immediately be dispatched to the transport");
             context.Pipeline.Register(new BatchToDispatchConnector(), "Passes batched messages over to the immediate dispatch part of the pipeline");
             context.Pipeline.Register(b => new ImmediateDispatchTerminator(b.Build<IDispatchMessages>()), "Hands the outgoing messages over to the transport for immediate delivery");
         }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
@@ -12,6 +12,11 @@
 
     class RoutingToDispatchConnector : StageConnector<IRoutingContext, IDispatchContext>
     {
+        public RoutingToDispatchConnector(string localAddress)
+        {
+            this.localAddress = localAddress;
+        }
+        
         public override Task Invoke(IRoutingContext context, Func<IDispatchContext, Task> stage)
         {
             var state = context.Extensions.GetOrCreate<State>();
@@ -21,7 +26,14 @@
             var index = 0;
             foreach (var strategy in context.RoutingStrategies)
             {
-                var addressLabel = strategy.Apply(context.Message.Headers);
+                var appliedStrategy = strategy;
+                if (appliedStrategy is RouteToThisEndpointStrategy)
+                {
+                    // hack until we get rid of HandleCurrentMessageLater
+                    appliedStrategy = new UnicastRoutingStrategy(localAddress);
+                }
+                
+                var addressLabel = appliedStrategy.Apply(context.Message.Headers);
                 var message = new OutgoingMessage(context.Message.MessageId, context.Message.Headers, context.Message.Body);
                 operations[index] = new TransportOperation(message, addressLabel, dispatchConsistency, context.Extensions.GetDeliveryConstraints());
                 index++;
@@ -61,6 +73,7 @@
 
         static ILog log = LogManager.GetLogger<RoutingToDispatchConnector>();
         static readonly bool isDebugEnabled = log.IsDebugEnabled;
+        string localAddress;
 
         public class State
         {

--- a/src/NServiceBus.Core/Routing/RouteToThisEndpointStrategy.cs
+++ b/src/NServiceBus.Core/Routing/RouteToThisEndpointStrategy.cs
@@ -1,0 +1,17 @@
+﻿namespace NServiceBus.Routing
+{
+    using System.Collections.Generic;
+
+    class RouteToThisEndpointStrategy : RoutingStrategy
+    {
+        RouteToThisEndpointStrategy() { }
+
+        public static RoutingStrategy Instance = new RouteToThisEndpointStrategy();
+        
+        public override AddressTag Apply(Dictionary<string, string> headers)
+        {
+            // will never be called
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/NServiceBus.Core/Unicast/MessageOperationsInvokeHandlerContext.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperationsInvokeHandlerContext.cs
@@ -3,7 +3,6 @@ namespace NServiceBus
     using System.Threading.Tasks;
     using Pipeline;
     using Routing;
-    using Settings;
     using Transport;
 
     static class MessageOperationsInvokeHandlerContext
@@ -16,7 +15,6 @@ namespace NServiceBus
             }
 
             var messageBeingProcessed = context.Extensions.Get<IncomingMessage>();
-            var settings = context.Builder.Build<ReadOnlySettings>();
 
             var cache = context.Extensions.Get<IPipelineCache>();
             var pipeline = cache.Pipeline<IRoutingContext>();
@@ -26,7 +24,7 @@ namespace NServiceBus
                 messageBeingProcessed.Headers,
                 messageBeingProcessed.Body);
 
-            var routingContext = new RoutingContext(outgoingMessage, new UnicastRoutingStrategy(settings.LocalAddress()), context);
+            var routingContext = new RoutingContext(outgoingMessage, RouteToThisEndpointStrategy.Instance, context);
 
             return pipeline.Invoke(routingContext);
         }


### PR DESCRIPTION
I know it is not beautiful but it would allow us to remove the builder call in `HandleCurrentMessageLater` for now without any further breaking changes and the hack affects only the RoutingToDispatchConnector.

This clearly shows that `HandleCurrentMessageLater` bypasses the routing layer but still envies the local address (that's why we needed to resolve the settings).

Maybe that triggers also other ideas

Thoughts?