### PR TITLE
Remove System.Web dependency by using reflection

### DIFF
--- a/src/NServiceBus.Core.Tests/Logging/DefaultFactoryTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/DefaultFactoryTests.cs
@@ -19,14 +19,13 @@
             Assert.Throws<ArgumentNullException>(() => defaultFactory.Directory(" "));
         }
 
-#if NET452
         [Test]
-        public void When_not_running_in_http_DeriveAppDataPath_should_throw()
+        public void When_not_running_ASP_NET_should_choose_BaseDirectory_as_logging_directory()
         {
-            var exception = Assert.Throws<Exception>(() => DefaultFactory.DeriveAppDataPath());
-            Assert.AreEqual("Detected running in a website and attempted to use HostingEnvironment.MapPath(\"~/App_Data/\") to derive the logging path. Failed since MapPath returned null. To avoid using HostingEnvironment.MapPath to derive the logging directory you can instead configure it to a specific path using LogManager.Use<DefaultFactory>().Directory(\"pathToLoggingDirectory\");", exception.Message);
+            var directory = DefaultFactory.FindDefaultLoggingDirectory();
+
+            Assert.AreEqual(AppDomain.CurrentDomain.BaseDirectory, directory);
         }
-#endif
     }
 
 

--- a/src/NServiceBus.Core/Logging/DefaultFactory.cs
+++ b/src/NServiceBus.Core/Logging/DefaultFactory.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Logging
 {
     using System;
     using System.IO;
+    using System.Reflection;
     using IODirectory = System.IO.Directory;
 
     /// <summary>
@@ -26,6 +27,7 @@ namespace NServiceBus.Logging
             var loggerFactory = new DefaultLoggerFactory(level.Value, directory.Value);
             var message = $"Logging to '{directory}' with level {level}";
             loggerFactory.Write(GetType().Name, LogLevel.Info, message);
+
             return loggerFactory;
         }
 
@@ -43,18 +45,32 @@ namespace NServiceBus.Logging
         public void Directory(string directory)
         {
             Guard.AgainstNullAndEmpty(nameof(directory), directory);
+
             if (!IODirectory.Exists(directory))
             {
                 var message = $"Could not find logging directory: '{directory}'";
                 throw new DirectoryNotFoundException(message);
             }
+
             this.directory = new Lazy<string>(() => directory);
         }
 
-#if NET452
         internal static string FindDefaultLoggingDirectory()
         {
-            if (System.Web.HttpRuntime.AppDomainAppId == null)
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (assembly.GetName().Name == "System.Web")
+                {
+                    systemWebAssembly = assembly;
+                    break;
+                }
+            }
+
+            var httpRuntime = systemWebAssembly?.GetType("System.Web.HttpRuntime");
+            var appDomainAppId = httpRuntime?.GetProperty("AppDomainAppId", BindingFlags.Public | BindingFlags.Static);
+            var result = appDomainAppId?.GetValue(null);
+
+            if (result == null)
             {
                 return AppDomain.CurrentDomain.BaseDirectory;
             }
@@ -62,14 +78,15 @@ namespace NServiceBus.Logging
             return DeriveAppDataPath();
         }
 
-        internal static string DeriveAppDataPath()
+        static string DeriveAppDataPath()
         {
-            //we are in a website so attempt to MapPath
             var appDataPath = TryMapPath();
+
             if (appDataPath == null)
             {
                 throw new Exception(GetMapPathError("Failed since MapPath returned null"));
             }
+
             if (IODirectory.Exists(appDataPath))
             {
                 return appDataPath;
@@ -82,7 +99,11 @@ namespace NServiceBus.Logging
         {
             try
             {
-                return System.Web.Hosting.HostingEnvironment.MapPath("~/App_Data/");
+                var hostingEnvironment = systemWebAssembly?.GetType("System.Web.Hosting.HostingEnvironment");
+                var mapPath = hostingEnvironment?.GetMethod("MapPath", BindingFlags.Static | BindingFlags.Public);
+                var result = mapPath?.Invoke(null, new[] { "~/App_Data/" }) as string;
+
+                return result;
             }
             catch (Exception exception)
             {
@@ -94,9 +115,8 @@ namespace NServiceBus.Logging
         {
             return $"Detected running in a website and attempted to use HostingEnvironment.MapPath(\"~/App_Data/\") to derive the logging path. {reason}. To avoid using HostingEnvironment.MapPath to derive the logging directory you can instead configure it to a specific path using LogManager.Use<DefaultFactory>().Directory(\"pathToLoggingDirectory\");";
         }
-#else
-        internal static string FindDefaultLoggingDirectory() => AppDomain.CurrentDomain.BaseDirectory;
-#endif
+
+        static Assembly systemWebAssembly;
 
         Lazy<string> directory;
 

--- a/src/NServiceBus.Core/Logging/DefaultFactory.cs
+++ b/src/NServiceBus.Core/Logging/DefaultFactory.cs
@@ -57,6 +57,8 @@ namespace NServiceBus.Logging
 
         internal static string FindDefaultLoggingDirectory()
         {
+            Assembly systemWebAssembly = null;
+
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
                 if (assembly.GetName().Name == "System.Web")
@@ -75,12 +77,12 @@ namespace NServiceBus.Logging
                 return AppDomain.CurrentDomain.BaseDirectory;
             }
 
-            return DeriveAppDataPath();
+            return DeriveAppDataPath(systemWebAssembly);
         }
 
-        static string DeriveAppDataPath()
+        static string DeriveAppDataPath(Assembly systemWebAssembly)
         {
-            var appDataPath = TryMapPath();
+            var appDataPath = TryMapPath(systemWebAssembly);
 
             if (appDataPath == null)
             {
@@ -95,7 +97,7 @@ namespace NServiceBus.Logging
             throw new Exception(GetMapPathError($"Failed since path returned ({appDataPath}) does not exist. Ensure this directory is created and restart the endpoint."));
         }
 
-        static string TryMapPath()
+        static string TryMapPath(Assembly systemWebAssembly)
         {
             try
             {
@@ -115,8 +117,6 @@ namespace NServiceBus.Logging
         {
             return $"Detected running in a website and attempted to use HostingEnvironment.MapPath(\"~/App_Data/\") to derive the logging path. {reason}. To avoid using HostingEnvironment.MapPath to derive the logging directory you can instead configure it to a specific path using LogManager.Use<DefaultFactory>().Directory(\"pathToLoggingDirectory\");";
         }
-
-        static Assembly systemWebAssembly;
 
         Lazy<string> directory;
 

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -16,7 +16,6 @@
     <Reference Include="System.Security" />
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Transactions" />
-    <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
 


### PR DESCRIPTION
Another attempt to get rid of our System.Web dependency. As mentioned in https://github.com/Particular/NServiceBus/pull/4851#issuecomment-315615137, this first checks to see if System.Web is already loaded, and if it is, uses reflection to get access to the parts we need.

This means we'll use AppData for the default log location if we're running in an ASP.NET application, but otherwise we'll use `AppDomain.CurrentDomain.BaseDirectory`.

CC: @SimonCropp 