### PR TITLE
Use official extension point to add PDBs

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -11,16 +11,12 @@
     <PackageProjectUrl>https://docs.particular.net/nuget/$(PackageId)</PackageProjectUrl>
     <PackageOutputPath>..\..\nugets</PackageOutputPath>
     <!--<GeneratePackageOnBuild>true</GeneratePackageOnBuild>-->
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);IncludePDBsInPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
-  <!-- Target is needed until we can enable GeneratePackageOnBuild again -->
-  <Target Name="IncludePDBsInPackage" BeforeTargets="_GetPackageFiles" Condition="'$(IncludeBuildOutput)' != 'false'">
+  <Target Name="IncludePDBsInPackage" Condition="'$(IncludeBuildOutput)' != 'false'">
     <ItemGroup>
-      <None Include="$(OutputPath)\**\$(AssemblyName).pdb">
-        <Pack>true</Pack>
-        <PackagePath>lib\</PackagePath>
-        <Visible>false</Visible>
-      </None>
+      <TfmSpecificPackageFile Include="$(OutputPath)\$(AssemblyName).pdb" PackagePath="lib/$(TargetFramework)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This uses the official TFM-specific content extension point introduced in https://github.com/NuGet/NuGet.Client/pull/1255 to add the PDBs to the packages.

CC: @SimonCropp 