### PR TITLE
Move AttachCausationHeadersBehavior into IOutgoingLogicalMessage stage

### DIFF
--- a/src/NServiceBus.Core.Tests/Causation/AttachCausationHeadersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Causation/AttachCausationHeadersBehaviorTests.cs
@@ -14,7 +14,7 @@
         public async Task Should_set_the_conversation_id_to_new_guid_when_not_sent_from_handler()
         {
             var behavior = new AttachCausationHeadersBehavior();
-            var context = new TestableOutgoingPhysicalMessageContext();
+            var context = new TestableOutgoingLogicalMessageContext();
 
             await behavior.Invoke(context, ctx => TaskEx.CompletedTask);
 
@@ -27,7 +27,7 @@
             var incomingConversationId = Guid.NewGuid().ToString();
 
             var behavior = new AttachCausationHeadersBehavior();
-            var context = new TestableOutgoingPhysicalMessageContext();
+            var context = new TestableOutgoingLogicalMessageContext();
 
             var transportMessage = new IncomingMessage("xyz", new Dictionary<string, string>
             {
@@ -46,7 +46,7 @@
             var userConversationId = Guid.NewGuid().ToString();
 
             var behavior = new AttachCausationHeadersBehavior();
-            var context = new TestableOutgoingPhysicalMessageContext
+            var context = new TestableOutgoingLogicalMessageContext
             {
                 Headers =
                 {
@@ -66,7 +66,7 @@
             var userDefinedConversationId = Guid.NewGuid().ToString();
 
             var behavior = new AttachCausationHeadersBehavior();
-            var context = new TestableOutgoingPhysicalMessageContext
+            var context = new TestableOutgoingLogicalMessageContext
             {
                 Headers =
                 {
@@ -88,7 +88,7 @@
         public async Task Should_set_the_related_to_header_with_the_id_of_the_current_message()
         {
             var behavior = new AttachCausationHeadersBehavior();
-            var context = new TestableOutgoingPhysicalMessageContext();
+            var context = new TestableOutgoingLogicalMessageContext();
 
             context.Extensions.Set(new IncomingMessage("the message id", new Dictionary<string, string>(), new byte[0]));
 

--- a/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
+++ b/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
@@ -9,8 +9,7 @@ namespace NServiceBus
     {
         public Task Invoke(IOutgoingLogicalMessageContext context, Func<IOutgoingLogicalMessageContext, Task> next)
         {
-            IncomingMessage incomingMessage;
-            context.TryGetIncomingPhysicalMessage(out incomingMessage);
+            context.TryGetIncomingPhysicalMessage(out var incomingMessage);
 
             SetRelatedToHeader(context, incomingMessage);
             SetConversationIdHeader(context, incomingMessage);
@@ -30,11 +29,9 @@ namespace NServiceBus
 
         static void SetConversationIdHeader(IOutgoingLogicalMessageContext context, IncomingMessage incomingMessage)
         {
-            string conversationIdFromCurrentMessageContext;
-            string userDefinedConversationId;
-            var hasUserDefinedConversationId = context.Headers.TryGetValue(Headers.ConversationId, out userDefinedConversationId);
+            var hasUserDefinedConversationId = context.Headers.TryGetValue(Headers.ConversationId, out var userDefinedConversationId);
 
-            if (incomingMessage != null && incomingMessage.Headers.TryGetValue(Headers.ConversationId, out conversationIdFromCurrentMessageContext))
+            if (incomingMessage != null && incomingMessage.Headers.TryGetValue(Headers.ConversationId, out var conversationIdFromCurrentMessageContext))
             {
                 if (hasUserDefinedConversationId)
                 {

--- a/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
+++ b/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
@@ -5,9 +5,9 @@ namespace NServiceBus
     using Pipeline;
     using Transport;
 
-    class AttachCausationHeadersBehavior : IBehavior<IOutgoingPhysicalMessageContext, IOutgoingPhysicalMessageContext>
+    class AttachCausationHeadersBehavior : IBehavior<IOutgoingLogicalMessageContext, IOutgoingLogicalMessageContext>
     {
-        public Task Invoke(IOutgoingPhysicalMessageContext context, Func<IOutgoingPhysicalMessageContext, Task> next)
+        public Task Invoke(IOutgoingLogicalMessageContext context, Func<IOutgoingLogicalMessageContext, Task> next)
         {
             IncomingMessage incomingMessage;
             context.TryGetIncomingPhysicalMessage(out incomingMessage);
@@ -18,7 +18,7 @@ namespace NServiceBus
             return next(context);
         }
 
-        static void SetRelatedToHeader(IOutgoingPhysicalMessageContext context, IncomingMessage incomingMessage)
+        static void SetRelatedToHeader(IOutgoingLogicalMessageContext context, IncomingMessage incomingMessage)
         {
             if (incomingMessage == null)
             {
@@ -28,7 +28,7 @@ namespace NServiceBus
             context.Headers[Headers.RelatedTo] = incomingMessage.MessageId;
         }
 
-        static void SetConversationIdHeader(IOutgoingPhysicalMessageContext context, IncomingMessage incomingMessage)
+        static void SetConversationIdHeader(IOutgoingLogicalMessageContext context, IncomingMessage incomingMessage)
         {
             string conversationIdFromCurrentMessageContext;
             string userDefinedConversationId;


### PR DESCRIPTION
Relates to: https://groups.google.com/forum/#!topic/particularsoftware/gSnIX2VYywg

TL;DR; It's hard for user code to get access to the conversation id because
* The conversation id will be set in the outgoing physical stage if not already present
* there is no guaranteed order of behaviors in the same stage
* the `IRoutingContext` stage is not the best stage to add a behavior interested in conversation ids as there are other messages going through that stage as well (audits, forwarded messages)

It seems like all other behaviors adding headers are already running in the logical phase anyway. So it seems to be a reasonable change to switch this behavior as well, so it is safe to check the headers within the physical stage.

This shouldn't cause breaking changes as it's not really intended to set this header within the logical stage anyway (it will also throw if there is an incoming message with a conversation id), but it's probably still best to mention it in the upgrade guide

TODO:
* [ ] document in upgrade guide

