### PR TITLE
Get Non-windows platforms working

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -25,7 +25,7 @@
     <PackageReference Include="GitVersionTask" Version="$(GitVersionTaskVersion)" PrivateAssets="All" />
   </ItemGroup>
 
-  <ImportGroup Condition="'$(ExcludeRestorePackageImports)' == 'true'">
+  <ImportGroup Condition="'$(ExcludeRestorePackageImports)' == 'true' And '$(MSBuildRuntimeType)' != 'Core'">
     <Import
       Project="$(UserProfile)\.nuget\packages\gitversiontask\$(GitVersionTaskVersion)\buildMultiTargeting\GitVersionTask.targets"
       Condition="Exists('$(UserProfile)\.nuget\packages\gitversiontask\$(GitVersionTaskVersion)\buildMultiTargeting\GitVersionTask.targets')" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,10 +4,6 @@
     <PackageReference Include="Terrajobst.PlatformCompat.Analyzers" Version="0.0.95-alpha" PrivateAssets="All" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <PlatformCompatIgnore>Linux;MacOSX</PlatformCompatIgnore>
-  </PropertyGroup>
-
   <!-- Workaround for GitVersion 4.0 not creating GitVersionInformation by default -->
   <PropertyGroup>
     <UpdateAssemblyInfo>true</UpdateAssemblyInfo>

--- a/src/NServiceBus.AcceptanceTests/ConfigureEndpointLearningPersistence.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureEndpointLearningPersistence.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
@@ -11,8 +12,19 @@ public class ConfigureEndpointLearningPersistence : IConfigureEndpointTestExecut
     {
         var testRunId = TestContext.CurrentContext.Test.ID;
 
-        //can't use bin dir since that will be too long on the build agents
-        storageDir = Path.Combine(@"c:\temp", testRunId);
+        string tempDir;
+
+        if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+        {
+            //can't use bin dir since that will be too long on the build agents
+            tempDir = @"c:\temp";
+        }
+        else
+        {
+            tempDir = Path.GetTempPath();
+        }
+
+        storageDir = Path.Combine(tempDir, testRunId);
 
         configuration.UsePersistence<InMemoryPersistence, StorageType.Subscriptions>();
         configuration.UsePersistence<InMemoryPersistence, StorageType.Timeouts>();

--- a/src/NServiceBus.AcceptanceTests/ConfigureEndpointLearningTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureEndpointLearningTransport.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using NServiceBus;
@@ -21,8 +22,19 @@ public class ConfigureEndpointLearningTransport : IConfigureEndpointTestExecutio
     {
         var testRunId = TestContext.CurrentContext.Test.ID;
 
-        //can't use bin dir since that will be too long on the build agents
-        storageDir = Path.Combine(@"c:\temp", testRunId);
+        string tempDir;
+
+        if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+        {
+            //can't use bin dir since that will be too long on the build agents
+            tempDir = @"c:\temp";
+        }
+        else
+        {
+            tempDir = Path.GetTempPath();
+        }
+
+        storageDir = Path.Combine(tempDir, testRunId);
 
         //we want the tests to be exposed to concurrency
         configuration.LimitMessageProcessingConcurrencyTo(PushRuntimeSettings.Default.MaxConcurrency);

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_overriding_saga_id_creation.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_overriding_saga_id_creation.cs
@@ -55,7 +55,9 @@
                 static Guid ToGuid(string src)
                 {
                     var stringbytes = Encoding.UTF8.GetBytes(src);
+#pragma warning disable PC001
                     using (var provider = new SHA1CryptoServiceProvider())
+#pragma warning restore PC001
                     {
                         var hashedBytes = provider.ComputeHash(stringbytes);
                         Array.Resize(ref hashedBytes, 16);

--- a/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties.cs
+++ b/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties.cs
@@ -41,7 +41,7 @@
             {
                 EndpointSetup<DefaultServer>(builder =>
                 {
-                    var basePath = Path.Combine(TestContext.CurrentContext.TestDirectory, @"databus\sender");
+                    var basePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "databus", "sender");
                     builder.UseDataBus<FileShareDataBus>().BasePath(basePath);
 
                     builder.ConfigureTransport().Routing().RouteToEndpoint(typeof(MyMessageWithLargePayload), typeof(Receiver));
@@ -55,7 +55,7 @@
             {
                 EndpointSetup<DefaultServer>(builder =>
                 {
-                    var basePath = Path.Combine(TestContext.CurrentContext.TestDirectory, @"databus\sender");
+                    var basePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "databus", "sender");
                     builder.UseDataBus<FileShareDataBus>().BasePath(basePath);
                     builder.RegisterMessageMutator(new Mutator());
                 });

--- a/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties_with_unobtrusive.cs
+++ b/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties_with_unobtrusive.cs
@@ -45,7 +45,7 @@
                         .DefiningCommandsAs(t => t.Namespace != null && t.FullName == typeof(MyMessageWithLargePayload).FullName)
                         .DefiningDataBusPropertiesAs(t => t.Name.Contains("Payload"));
 
-                    var basePath = Path.Combine(TestContext.CurrentContext.TestDirectory, @"databus\sender");
+                    var basePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "databus", "sender");
                     builder.UseDataBus<FileShareDataBus>().BasePath(basePath);
 
                     builder.ConfigureTransport().Routing().RouteToEndpoint(typeof(MyMessageWithLargePayload), typeof(Receiver));
@@ -63,7 +63,7 @@
                         .DefiningCommandsAs(t => t.Namespace != null && t.FullName == typeof(MyMessageWithLargePayload).FullName)
                         .DefiningDataBusPropertiesAs(t => t.Name.Contains("Payload"));
 
-                    var basePath = Path.Combine(TestContext.CurrentContext.TestDirectory, @"databus\sender");
+                    var basePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "databus", "sender");
                     builder.UseDataBus<FileShareDataBus>().BasePath(basePath);
                     builder.RegisterMessageMutator(new Mutator());
                 });

--- a/src/NServiceBus.AcceptanceTests/DeterministicGuid.cs
+++ b/src/NServiceBus.AcceptanceTests/DeterministicGuid.cs
@@ -9,7 +9,9 @@
         public static Guid Create(params object[] data)
         {
             // use MD5 hash to get a 16-byte hash of the string
+#pragma warning disable PC001
             using (var provider = new MD5CryptoServiceProvider())
+#pragma warning restore PC001
             {
                 var inputBytes = Encoding.Default.GetBytes(string.Concat(data));
                 var hashBytes = provider.ComputeHash(inputBytes);

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);PCR0001</NoWarn>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
+++ b/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Core.Tests/ArgumentExceptionTests.cs
+++ b/src/NServiceBus.Core.Tests/ArgumentExceptionTests.cs
@@ -136,7 +136,7 @@
 
         static void WriteMethod(MethodDefinition method, TextWriter writer)
         {
-            writer.WriteLine($"\r\n{method.DeclaringType.Name}.{method.Name}");
+            writer.WriteLine($"{Environment.NewLine}{method.DeclaringType.Name}.{method.Name}");
 
             var mapping = method.DebugInformation.GetSequencePointMapping();
 

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
@@ -414,11 +414,10 @@ class InterfaceMessageHandler : IHandleMessages<IBaseEvent>
             {
                 if (results.Errors.HasErrors)
                 {
-                    var errors = new StringBuilder("Compiler Errors :\r\n");
+                    var errors = new StringBuilder($"Compiler Errors :{Environment.NewLine}");
                     foreach (CompilerError error in results.Errors)
                     {
-                        errors.AppendFormat("Line {0},{1}\t: {2}\n",
-                            error.Line, error.Column, error.ErrorText);
+                        errors.Append($"Line {error.Line},{error.Column}\t: {error.ErrorText}{Environment.NewLine}");
                     }
                     throw new Exception(errors.ToString());
                 }

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_assemblies_with_circular_dependencies.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_assemblies_with_circular_dependencies.cs
@@ -11,7 +11,7 @@
         [Test]
         public void ReferencesNServiceBus_circular()
         {
-            var scanner = new AssemblyScanner(Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestDlls\circular"));
+            var scanner = new AssemblyScanner(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestDlls", "circular"));
             scanner.ScanAppDomainAssemblies = false;
 
             var result = scanner.GetScannableAssemblies();

--- a/src/NServiceBus.Core.Tests/DocumentationTests.cs
+++ b/src/NServiceBus.Core.Tests/DocumentationTests.cs
@@ -28,8 +28,8 @@
 
             if (list.Any())
             {
-                var errors = string.Join("\r\n", list);
-                throw new Exception("Some members have empty documentation or have a sentence that does not end with a period:\r\n" + errors);
+                var errors = string.Join(Environment.NewLine, list);
+                throw new Exception($"Some members have empty documentation or have a sentence that does not end with a period:{Environment.NewLine}{errors}");
             }
         }
 

--- a/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
@@ -23,7 +23,7 @@
                 logger1.Write("Foo");
                 var files1 = tempPath.GetFiles();
                 Assert.AreEqual(1, files1.Count);
-                Assert.AreEqual("Foo\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(files1.First()));
+                Assert.AreEqual($"Foo{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(files1.First()));
                 var logger2 = new RollingLogger(tempPath.TempDirectory)
                 {
                     GetDate = () => dateTime
@@ -31,7 +31,7 @@
                 logger2.Write("Bar");
                 var files2 = tempPath.GetFiles();
                 Assert.AreEqual(1, files2.Count);
-                Assert.AreEqual("Foo\r\nBar\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(files2.First()));
+                Assert.AreEqual($"Foo{Environment.NewLine}Bar{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(files2.First()));
             }
         }
 
@@ -48,7 +48,7 @@
                 var single = tempPath.GetSingle();
                 File.Delete(single);
                 logger.Write("Bar");
-                Assert.AreEqual("Bar\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(single));
+                Assert.AreEqual($"Bar{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(single));
             }
         }
 
@@ -67,7 +67,7 @@
                 {
                     logger.Write("Bar");
                 }
-                Assert.AreEqual("Foo\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(single));
+                Assert.AreEqual($"Foo{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(single));
             }
         }
 
@@ -89,7 +89,7 @@
                 var singleFile = tempPath.GetSingle();
                 File.Delete(singleFile);
                 logger.Write("Bar");
-                Assert.AreEqual("Bar\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(singleFile));
+                Assert.AreEqual($"Bar{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(singleFile));
             }
         }
 
@@ -129,11 +129,11 @@
 
                 var first = files[0];
                 Assert.AreEqual("nsb_log_2010-10-01_0.txt", Path.GetFileName(first));
-                Assert.AreEqual("Some long text\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(files.First()));
+                Assert.AreEqual($"Some long text{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(files.First()));
 
                 var second = files[1];
                 Assert.AreEqual("nsb_log_2010-10-01_1.txt", Path.GetFileName(second));
-                Assert.AreEqual("Bar\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(second));
+                Assert.AreEqual($"Bar{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(second));
             }
         }
 
@@ -158,11 +158,11 @@
 
                 var first = files[0];
                 Assert.AreEqual("nsb_log_2010-10-01_0.txt", Path.GetFileName(first));
-                Assert.AreEqual("Foo\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(files.First()));
+                Assert.AreEqual($"Foo{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(files.First()));
 
                 var second = files[1];
                 Assert.AreEqual("nsb_log_2010-10-02_0.txt", Path.GetFileName(second));
-                Assert.AreEqual("Bar\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(second));
+                Assert.AreEqual($"Bar{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(second));
             }
         }
 
@@ -174,7 +174,7 @@
                 var logger = new RollingLogger(tempPath.TempDirectory);
                 logger.Write("Foo");
                 var singleFile = tempPath.GetSingle();
-                Assert.AreEqual("Foo\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(singleFile));
+                Assert.AreEqual($"Foo{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(singleFile));
             }
         }
 
@@ -187,7 +187,7 @@
                 logger.Write("Foo");
                 logger.Write("Bar");
                 var singleFile = tempPath.GetSingle();
-                Assert.AreEqual("Foo\r\nBar\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(singleFile));
+                Assert.AreEqual($"Foo{Environment.NewLine}Bar{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(singleFile));
             }
         }
 
@@ -207,11 +207,11 @@
 
                 var first = files[0];
                 Assert.AreEqual("nsb_log_2010-10-01_0.txt", Path.GetFileName(first));
-                Assert.AreEqual("Some long text\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(first));
+                Assert.AreEqual($"Some long text{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(first));
 
                 var second = files[1];
                 Assert.AreEqual("nsb_log_2010-10-01_1.txt", Path.GetFileName(second));
-                Assert.AreEqual("Bar\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(second));
+                Assert.AreEqual($"Bar{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(second));
             }
         }
 
@@ -241,7 +241,7 @@
                 logger.Write("Foo");
                 logger.Write("Some long text");
                 var singleFile = tempPath.GetSingle();
-                Assert.AreEqual("Foo\r\nSome long text\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(singleFile));
+                Assert.AreEqual($"Foo{Environment.NewLine}Some long text{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(singleFile));
             }
         }
 
@@ -262,11 +262,11 @@
 
                 var first = files[0];
                 Assert.AreEqual("nsb_log_2010-10-01_0.txt", Path.GetFileName(first));
-                Assert.AreEqual("Foo\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(first));
+                Assert.AreEqual($"Foo{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(first));
 
                 var second = files[1];
                 Assert.AreEqual("nsb_log_2010-10-02_0.txt", Path.GetFileName(second));
-                Assert.AreEqual("Bar\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(second));
+                Assert.AreEqual($"Bar{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(second));
             }
         }
 
@@ -348,15 +348,15 @@
 
                 var first = files[0];
                 Assert.AreEqual("nsb_log_2010-10-01_2.txt", Path.GetFileName(first));
-                Assert.AreEqual("Long text2\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(first));
+                Assert.AreEqual($"Long text2{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(first));
 
                 var second = files[1];
                 Assert.AreEqual("nsb_log_2010-10-01_3.txt", Path.GetFileName(second));
-                Assert.AreEqual("Long text3\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(second));
+                Assert.AreEqual($"Long text3{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(second));
 
                 var third = files[2];
                 Assert.AreEqual("nsb_log_2010-10-01_4.txt", Path.GetFileName(third));
-                Assert.AreEqual("Long text4\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(third));
+                Assert.AreEqual($"Long text4{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(third));
             }
         }
 
@@ -383,15 +383,15 @@
 
                 var first = files[0];
                 Assert.AreEqual("nsb_log_2010-10-03_0.txt", Path.GetFileName(first));
-                Assert.AreEqual("Foo3\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(first));
+                Assert.AreEqual($"Foo3{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(first));
 
                 var second = files[1];
                 Assert.AreEqual("nsb_log_2010-10-04_0.txt", Path.GetFileName(second));
-                Assert.AreEqual("Foo4\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(second));
+                Assert.AreEqual($"Foo4{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(second));
 
                 var third = files[2];
                 Assert.AreEqual("nsb_log_2010-10-05_0.txt", Path.GetFileName(third));
-                Assert.AreEqual("Foo5\r\n", NonLockingFileReader.ReadAllTextWithoutLocking(third));
+                Assert.AreEqual($"Foo5{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(third));
             }
         }
 

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -7,6 +7,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NoWarn>$(NoWarn);NU1701</NoWarn>
     <Optimize>False</Optimize>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Core.Tests/Pipeline/PipelineTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/PipelineTests.cs
@@ -22,6 +22,11 @@
         [Test]
         public async Task ShouldExecutePipeline()
         {
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                Assert.Ignore("ApprovalTests only works on Windows");
+            }
+
             var stringWriter = new StringWriter();
 
             var pipelineModifications = new PipelineModifications();
@@ -45,6 +50,11 @@
         [Test]
         public async Task ShouldNotCacheContext()
         {
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                Assert.Ignore("ApprovalTests only works on Windows");
+            }
+
             var stringWriter = new StringWriter();
 
             var pipelineModifications = new PipelineModifications();
@@ -79,6 +89,11 @@
         [Test]
         public void ShouldCreateCachedExecutionPlan()
         {
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                Assert.Ignore("ApprovalTests only works on Windows");
+            }
+
             var stringWriter = new StringWriter();
 
             var behaviors = new IBehavior[]

--- a/src/NServiceBus.Core.Tests/Sagas/When_saga_has_multiple_correlated_properties.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/When_saga_has_multiple_correlated_properties.cs
@@ -13,6 +13,11 @@ namespace NServiceBus.Core.Tests.Sagas.TypeBasedSagas
         [Test]
         public void Should_throw()
         {
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                Assert.Ignore("ApprovalTests only works on Windows");
+            }
+
             var exception = Assert.Throws<Exception>(() => SagaMetadata.Create(typeof(SagaWithMultipleCorrelatedProperties), new List<Type>(), new Conventions()));
             Approvals.Verify(exception.Message);
         }

--- a/src/NServiceBus.Core.Tests/StandardsTests.cs
+++ b/src/NServiceBus.Core.Tests/StandardsTests.cs
@@ -52,7 +52,7 @@
                     x.Namespace != "NServiceBus").ToList();
             if (types.Count > 0)
             {
-                Assert.IsEmpty(types, "Non public types should have 'NServiceBus' namespace\r\n" + string.Join(Environment.NewLine, types.Select(x => x.FullName)));
+                Assert.IsEmpty(types, $"Non public types should have 'NServiceBus' namespace{Environment.NewLine}{string.Join(Environment.NewLine, types.Select(x => x.FullName))}");
             }
         }
 

--- a/src/NServiceBus.Core.Tests/StructConventionsTests.ApproveStructsWhichDontFollowStructGuidelines.approved.txt
+++ b/src/NServiceBus.Core.Tests/StructConventionsTests.ApproveStructsWhichDontFollowStructGuidelines.approved.txt
@@ -13,4 +13,5 @@ In all other cases, you should define your types as classes.
 NServiceBus.LogicalAddress violates the following rules:
    - The following fields are reference types, which are potentially mutable:
       - Field <EndpointInstance>k__BackingField of type NServiceBus.Routing.EndpointInstance is a reference type.
+   - The size cannot be determined because there are fields that are reference types.
 

--- a/src/NServiceBus.Core.Tests/StructConventionsTests.cs
+++ b/src/NServiceBus.Core.Tests/StructConventionsTests.cs
@@ -30,34 +30,46 @@ In all other cases, you should define your types as classes.
 ");
 
             var assembly = typeof(Endpoint).Assembly;
+
             foreach (var type in assembly.GetTypes().OrderBy(t => t.FullName))
             {
-                if (!type.IsValueType || type.IsEnum || type.IsSpecialName|| type.Namespace == null || !type.Namespace.StartsWith("NServiceBus") || type.FullName.Contains("__")) continue;
+                if (!type.IsValueType || type.IsEnum || type.IsSpecialName || type.Namespace == null || !type.Namespace.StartsWith("NServiceBus") || type.FullName.Contains("__"))
+                {
+                    continue;
+                }
 
                 var violatedRules = new List<string> { $"{type.FullName} violates the following rules:" };
 
-                InspectSizeOfStruct(type, violatedRules);
-                InspectWhetherStructViolatesMutabilityRules(type, violatedRules);
+                InspectWhetherStructContainsPublicFields(type, violatedRules);
+                InspectWhetherStructContainsWritableProperties(type, violatedRules);
+                var containsRefereneceTypes = InspectWhetherStructContainsReferenceTypes(type, violatedRules);
 
-                if (violatedRules.Count <= 1) continue;
+                if (containsRefereneceTypes)
+                {
+                    violatedRules.Add("   - The size cannot be determined because there are fields that are reference types.");
+                }
+                else
+                {
+                    InspectSizeOfStruct(type, violatedRules);
+                }
+
+                if (violatedRules.Count <= 1)
+                {
+                    continue;
+                }
+
                 foreach (var violatedRule in violatedRules)
                 {
                     approvalBuilder.AppendLine(violatedRule);
                 }
+
                 approvalBuilder.AppendLine();
             }
 
             Approvals.Verify(approvalBuilder.ToString());
         }
 
-        static void InspectWhetherStructViolatesMutabilityRules(Type type, List<string> violatedRules)
-        {
-            InspectWhetherStructContainsReferenceTypes(type, violatedRules);
-            InspectWhetherStructContainsPublicFields(type, violatedRules);
-            InspectWhetherStructContainsWritableProperties(type, violatedRules);
-        }
-
-        static void InspectWhetherStructContainsReferenceTypes(Type type, List<string> violatedRules)
+        static bool InspectWhetherStructContainsReferenceTypes(Type type, List<string> violatedRules)
         {
             var mutabilityRules = new List<string> { "   - The following fields are reference types, which are potentially mutable:" };
 
@@ -76,11 +88,17 @@ In all other cases, you should define your types as classes.
                 }
             }
 
-            if(mutabilityRules.Count > 1)
+            if (mutabilityRules.Count > 1)
+            {
                 violatedRules.AddRange(mutabilityRules);
+
+                return true;
+            }
+
+            return false;
         }
 
-        static void InspectWhetherStructContainsPublicFields(Type type, List<string> violatedRules)
+        static bool InspectWhetherStructContainsPublicFields(Type type, List<string> violatedRules)
         {
             var mutabilityRules = new List<string> { "   - The following fields are public, so the type is not immutable:" };
 
@@ -95,10 +113,16 @@ In all other cases, you should define your types as classes.
             }
 
             if (mutabilityRules.Count > 1)
+            {
                 violatedRules.AddRange(mutabilityRules);
+
+                return true;
+            }
+
+            return false;
         }
 
-        static void InspectWhetherStructContainsWritableProperties(Type type, List<string> violatedRules)
+        static bool InspectWhetherStructContainsWritableProperties(Type type, List<string> violatedRules)
         {
             var mutabilityRules = new List<string> { "   - The following properties can be written to, so the type is not immutable:" };
 
@@ -113,17 +137,24 @@ In all other cases, you should define your types as classes.
             }
 
             if (mutabilityRules.Count > 1)
+            {
                 violatedRules.AddRange(mutabilityRules);
+
+                return true;
+            }
+
+            return false;
         }
 
         static void InspectSizeOfStruct(Type type, List<string> violatedRules)
         {
             try
             {
-                var sizeOf = Marshal.SizeOf(type);
-                if (IsLargerThanSixteenBytes(sizeOf))
+                var size = Marshal.SizeOf(type);
+
+                if (IsLargerThanSixteenBytes(size))
                 {
-                    violatedRules.Add($"   - The size is {sizeOf} bytes, which exceeds the recommended maximum of 16 bytes.");
+                    violatedRules.Add($"   - The size is {size} bytes, which exceeds the recommended maximum of 16 bytes.");
                 }
             }
             catch (Exception)
@@ -132,9 +163,6 @@ In all other cases, you should define your types as classes.
             }
         }
 
-        static bool IsLargerThanSixteenBytes(int sizeOf)
-        {
-            return sizeOf > 16;
-        }
+        static bool IsLargerThanSixteenBytes(int size) => size > 16;
     }
 }

--- a/src/NServiceBus.Core.Tests/StructConventionsTests.cs
+++ b/src/NServiceBus.Core.Tests/StructConventionsTests.cs
@@ -15,6 +15,11 @@ namespace NServiceBus.Core.Tests
         [Test]
         public void ApproveStructsWhichDontFollowStructGuidelines()
         {
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                Assert.Ignore("ApprovalTests only works on Windows");
+            }
+
             var approvalBuilder = new StringBuilder();
             approvalBuilder.AppendLine(@"-------------------------------------------------- REMEMBER --------------------------------------------------
 CONSIDER defining a struct instead of a class if instances of the type are small and commonly short-lived or are commonly embedded in other objects.

--- a/src/NServiceBus.Core.Tests/Transports/Learning/HeaderSerializerTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/Learning/HeaderSerializerTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Core.Tests.Transports.Learning
 {
+    using System;
     using System.Collections.Generic;
     using ApprovalTests;
     using NUnit.Framework;
@@ -9,6 +10,11 @@
         [Test]
         public void Can_round_trip_headers()
         {
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                Assert.Ignore("ApprovalTests only works on Windows");
+            }
+
             var input = new Dictionary<string, string>
             {
                 {

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
@@ -90,7 +90,8 @@
 
             return publicKeyToken;
         }
-
+#pragma warning disable PC001
         SHA1CryptoServiceProvider provider = new SHA1CryptoServiceProvider();
+#pragma warning restore PC001
     }
 }

--- a/src/NServiceBus.Core/Hosting/HostInformation.cs
+++ b/src/NServiceBus.Core/Hosting/HostInformation.cs
@@ -19,7 +19,9 @@ namespace NServiceBus.Hosting
             : this(hostId, displayName, new Dictionary<string, string>
             {
                 {"Machine", RuntimeEnvironment.MachineName},
+#pragma warning disable PC001
                 {"ProcessID", Process.GetCurrentProcess().Id.ToString()},
+#pragma warning restore PC001
                 {"UserName", Environment.UserName}
             })
         {

--- a/src/NServiceBus.Core/Hosting/HostInformationFeature.cs
+++ b/src/NServiceBus.Core/Hosting/HostInformationFeature.cs
@@ -23,7 +23,9 @@
                 s.SetDefault("NServiceBus.HostInformation.Properties", new Dictionary<string, string>
                 {
                     {"Machine", RuntimeEnvironment.MachineName},
+#pragma warning disable PC001
                     {"ProcessID", Process.GetCurrentProcess().Id.ToString()},
+#pragma warning restore PC001
                     {"UserName", Environment.UserName},
                     {"PathToExecutable", fullPathToStartingExe}
                 });

--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -4,7 +4,6 @@ namespace NServiceBus
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
-    using System.Security.Principal;
     using System.Threading.Tasks;
     using Features;
     using Installation;
@@ -173,10 +172,19 @@ namespace NServiceBus
 
         string GetInstallationUserName()
         {
-            string username;
-            return settings.TryGet("Installers.UserName", out username)
-                ? username
-                : WindowsIdentity.GetCurrent().Name;
+            if (!settings.TryGet("Installers.UserName", out string userName))
+            {
+                if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                {
+                    userName = $"{Environment.UserDomainName}\\{Environment.UserName}";
+                }
+                else
+                {
+                    userName = Environment.UserName;
+                }
+            }
+
+            return userName;
         }
 
         void EnsureTransportConfigured()

--- a/src/NServiceBus.Core/Licensing/LicenseSources.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseSources.cs
@@ -26,23 +26,26 @@ namespace NServiceBus
             sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"NServiceBus\License.xml")));
             sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"License\License.xml")));
 
-            sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\ParticularSoftware"));
-            sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\ParticularSoftware"));
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\ParticularSoftware"));
+                sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\ParticularSoftware"));
 
-            sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\ParticularSoftware\NServiceBus"));
-            sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\ParticularSoftware\NServiceBus"));
+                sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\ParticularSoftware\NServiceBus"));
+                sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\ParticularSoftware\NServiceBus"));
 
-            sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\NServiceBus\4.3"));
-            sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\NServiceBus\4.3"));
+                sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\NServiceBus\4.3"));
+                sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\NServiceBus\4.3"));
 
-            sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\NServiceBus\4.2"));
-            sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\NServiceBus\4.2"));
+                sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\NServiceBus\4.2"));
+                sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\NServiceBus\4.2"));
 
-            sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\NServiceBus\4.1"));
-            sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\NServiceBus\4.1"));
+                sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\NServiceBus\4.1"));
+                sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\NServiceBus\4.1"));
 
-            sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\NServiceBus\4.0"));
-            sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\NServiceBus\4.0"));
+                sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\NServiceBus\4.0"));
+                sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\NServiceBus\4.0"));
+            }
 
             return sources.ToArray();
         }

--- a/src/NServiceBus.Core/Licensing/LicenseSources.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseSources.cs
@@ -23,8 +23,8 @@ namespace NServiceBus
 
             sources.Add(new LicenseSourceConfigFile());
 
-            sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"NServiceBus\License.xml")));
-            sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"License\License.xml")));
+            sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "NServiceBus", "License.xml")));
+            sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "License", "License.xml")));
 
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
             {

--- a/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Outbox/InMemoryOutboxPersistence.cs
@@ -47,8 +47,10 @@
 
             protected override Task OnStop(IMessageSession session)
             {
+#pragma warning disable PC001
                 using (var waitHandle = new ManualResetEvent(false))
                 {
+#pragma warning restore PC001
                     cleanupTimer.Dispose(waitHandle);
 
                     // TODO: Use async synchronization primitive

--- a/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
@@ -51,10 +51,10 @@
                 var unicastAddressTag = operation.AddressTag as UnicastAddressTag;
                 if (unicastAddressTag != null)
                 {
-                    sb.AppendFormat("Destination: {0}\n", unicastAddressTag.Destination);
+                    sb.AppendFormat("Destination: {0}" + Environment.NewLine, unicastAddressTag.Destination);
                 }
 
-                sb.AppendFormat("Message headers:\n{0}", string.Join(", ", operation.Message.Headers.Select(h => h.Key + ":" + h.Value).ToArray()));
+                sb.AppendFormat("Message headers:" + Environment.NewLine + "{0}", string.Join(", ", operation.Message.Headers.Select(h => h.Key + ":" + h.Value).ToArray()));
             }
             log.Debug(sb.ToString());
         }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/SerializeMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/SerializeMessageConnector.cs
@@ -21,7 +21,7 @@ namespace NServiceBus
         {
             if (log.IsDebugEnabled)
             {
-                log.DebugFormat("Serializing message '{0}' with id '{1}', ToString() of the message yields: {2} \n",
+                log.DebugFormat("Serializing message '{0}' with id '{1}', ToString() of the message yields: {2} " + Environment.NewLine,
                     context.Message.MessageType != null ? context.Message.MessageType.AssemblyQualifiedName : "unknown",
                     context.MessageId, context.Message.Instance);
             }

--- a/src/NServiceBus.Core/Utils/DeterministicGuid.cs
+++ b/src/NServiceBus.Core/Utils/DeterministicGuid.cs
@@ -9,7 +9,9 @@
         public static Guid Create(params object[] data)
         {
             // use MD5 hash to get a 16-byte hash of the string
+#pragma warning disable PC001
             using (var provider = new MD5CryptoServiceProvider())
+#pragma warning restore PC001
             {
                 var inputBytes = Encoding.Default.GetBytes(string.Concat(data));
                 var hashBytes = provider.ComputeHash(inputBytes);

--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This includes the changes needed to avoid anything that is platform-specific. Most of the changes are self-explanatory, for example dealing with path separator and line ending differences.

There are a few that could benefit from some more detail:

#### Marshal.SizeOf

The problem with the StructConventionsTest was that for the `LogicalAddress` struct, instead of showing a size, it instead had an error like `Type cannot be marshaled as an unmanaged structure; no meaningful size or offset can be computed`. On windows, calling `Marshal.SizeOf` on a struct with a reference field works fine, but not on other platforms. I found https://github.com/dotnet/corefx/issues/20442 describing the exact problem, and that it's by design that it doesn't work, because a reference field marshals as `IUnknown`, which is a windows-specific COM interface. So, on other platforms it throws instead. I adjusted the test to skip the size check if the struct has a reference field and indicate that it was skipped.

On a side note, the use of `Marshal.SizeOf` isn't really correct for how we're trying to use it in the test. What we really want here is the managed size of the struct, but the CLR specifically doesn't allow you to find that out. So instead, we're determining the unmanaged size of the struct if we were going to marshal it to native code. However, that size isn't guaranteed to be the same as the size in managed memory!

#### CopyLocalLockFileAssemblies

At first, I ran into a problem where `dotnet test` could not find any tests, but that was because of the differences in the locations of the NuGet cache between machines and the fact that we can't build on non-windows currently. Setting the `CopyLocalLockFileAssemblies` property works around this by making sure all the dependencies are in the build output folder instead of needing to be loaded from the cache.

#### ApprovalTests

The tests that rely on the ApprovalTests library were failing with an error about COM not being supported, but that turned out to be because of our [chosen reporters](https://github.com/Particular/NServiceBus/blob/develop/src/NServiceBus.Core.Tests/ApprovalTestConfig.cs). After switching to the NUnit reporter, I was still seeing failures because ApprovalTests couldn't find the `*.approved.txt` files. Looking into the ApprovalTests code, it uses some stack-walking code to try and figure out the location of the file. That doesn't seem to be working properly on linux, so the tests fail.

I looked around for another approval tests library, and found https://github.com/droyad/Assent. After building locally to deal with the lack of strong-naming in the official package, I found that I was running into the same problem: it couldn't find the `*.approved.txt` files. Instead of stack-walking, it uses the `CallerFilePath` attribute to get the file name, but this path is baked in at compile-time... so since we aren't building on linux, the paths are all wrong and it still can't find them! 😢 

Ultimately, I decided to make the tests `Assert.Ignore` if they're running on a non-windows platform for now. If we can get to a point where we can actually build on linux, then we should take another look at Assent. 

---
With these changes, I can now successfully run all tests on linux locally. 🎉 
