### PR TITLE
Improve the exception message on how to resolve the issue

### DIFF
--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
@@ -59,7 +59,7 @@
                 if (parent == null)
                 {
                     // throw for now. if we discover there is an edge then we can fix it in a patch.
-                    throw new Exception("Couldn't find the solution directory for the learning transport. If you are running this endpoint outside the solution folder structure, make sure to specify a storage directory using the 'transportConfiguration.StorageDirectory' API.");
+                    throw new Exception("Couldn't find the solution directory for the learning transport. If the endpoint is outside the solution folder structure, make sure to specify a storage directory using the 'EndpointConfiguration.UseTransport<LearningTransport>().StorageDirectory()' API.");
                 }
 
                 directory = parent.FullName;

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
@@ -59,7 +59,7 @@
                 if (parent == null)
                 {
                     // throw for now. if we discover there is an edge then we can fix it in a patch.
-                    throw new Exception("Couldn't find the solution directory for the learning transport.");
+                    throw new Exception("Couldn't find the solution directory for the learning transport. If you are running this endpoint outside the solution folder structure, make sure to specify a storage directory using the 'transportConfiguration.StorageDirectory' API.");
                 }
 
                 directory = parent.FullName;


### PR DESCRIPTION
noticed while testing published endpoints outside of a solution folder structure that the exception message is not super helpful regarding how to resolve it.

Thoughts about the wording?