### PR TITLE
Add test for building lists of objects

### DIFF
--- a/src/NServiceBus.ContainerTests/When_building_components.cs
+++ b/src/NServiceBus.ContainerTests/When_building_components.cs
@@ -85,6 +85,16 @@ namespace NServiceBus.ContainerTests
             }
         }
 
+        [Test]
+        public void Resolving_all_components_of_unregistered_types_should_give_empty_list()
+        {
+            using (var builder = TestContainerBuilder.ConstructBuilder())
+            {
+                InitializeBuilder(builder);
+                Assert.IsEmpty(builder.BuildAll(typeof(UnregisteredComponent)));
+            }
+        }
+
         void InitializeBuilder(IContainer container)
         {
             container.Configure(typeof(SingletonComponent), DependencyLifecycle.SingleInstance);


### PR DESCRIPTION
Adds an additional test for verifying container behavior.

The test verifies that when building all items of a type that the result is an empty array in the event that no types have been registered.  This bug was discovered as a result of https://github.com/Particular/NServiceBus.Persistence.Sql/issues/128. The behavior is different between Ninject and other containers so this verifies uniformity.