### PR TITLE
Simplify AssemblyValidator by using AssemblyName

### DIFF
--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
@@ -1,47 +1,27 @@
 ﻿namespace NServiceBus
 {
     using System;
-    using System.IO;
-    using System.Reflection.Metadata;
-    using System.Reflection.PortableExecutable;
-    using System.Security.Cryptography;
+    using System.Reflection;
 
     class AssemblyValidator
     {
         public (bool shouldLoad, string reason) ValidateAssemblyFile(string assemblyPath)
         {
-            using (var stream = File.OpenRead(assemblyPath))
-            using (var file = new PEReader(stream))
+            try
             {
-                var hasMetadata = false;
+                var token = AssemblyName.GetAssemblyName(assemblyPath).GetPublicKeyToken();
 
-                try
+                if (IsRuntimeAssembly(token))
                 {
-                    hasMetadata = file.HasMetadata;
+                    return (false, "File is a .NET runtime assembly.");
                 }
-                catch (BadImageFormatException) { }
-
-                if (!hasMetadata)
-                {
-                    return (false, "File is not a .NET assembly.");
-                }
-
-                var reader = file.GetMetadataReader();
-                var assemblyDefinition = reader.GetAssemblyDefinition();
-
-                if (!assemblyDefinition.PublicKey.IsNil)
-                {
-                    var publicKey = reader.GetBlobBytes(assemblyDefinition.PublicKey);
-                    var publicKeyToken = GetPublicKeyToken(publicKey);
-
-                    if (IsRuntimeAssembly(publicKeyToken))
-                    {
-                        return (false, "File is a .NET runtime assembly.");
-                    }
-                }
-
-                return (true, "File is a .NET assembly.");
             }
+            catch (BadImageFormatException)
+            {
+                return (false, "File is not a .NET assembly.");
+            }
+
+            return (true, "File is a .NET assembly.");
         }
 
         public static bool IsRuntimeAssembly(byte[] publicKeyToken)
@@ -77,21 +57,5 @@
 
             return false;
         }
-
-        byte[] GetPublicKeyToken(byte[] publicKey)
-        {
-            var hash = provider.ComputeHash(publicKey);
-            var publicKeyToken = new byte[8];
-
-            for (var i = 0; i < 8; i++)
-            {
-                publicKeyToken[i] = hash[hash.Length - (i + 1)];
-            }
-
-            return publicKeyToken;
-        }
-#pragma warning disable PC001
-        SHA1CryptoServiceProvider provider = new SHA1CryptoServiceProvider();
-#pragma warning restore PC001
     }
 }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="Obsolete.Fody" Version="4.2.2" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Licensing.Sources" Version="1.0.0-alpha0001" PrivateAssets="All" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0-preview2-25405-01" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This simplifies the `AssemblyValidator` logic by using `AssemblyName` to get the public key token instead of using the System.Reflection.Metadata package.

