### PR TITLE
Clean up license sources

### DIFF
--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -58,6 +58,20 @@ namespace NServiceBus
 
                 Logger.Info(report.ToString());
             }
+
+#if REGISTRYLICENSESOURCE
+            if (result.Location.StartsWith("HKEY_"))
+            {
+                Logger.Warn("Reading license information from the registry has been deprecated and will be removed in version 8.0. See the documentation for more details.");
+            }
+#endif
+
+#if APPCONFIGLICENSESOURCE
+            if (result.Location.StartsWith("app config"))
+            {
+                Logger.Warn("Reading license information from the app config file has been deprecated and will be removed in version 8.0. See the documentation for more details.");
+            }
+#endif
         }
 
         void OpenTrialExtensionPage()

--- a/src/NServiceBus.Core/Licensing/LicenseSources.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseSources.cs
@@ -30,21 +30,6 @@ namespace NServiceBus
             {
                 sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\ParticularSoftware"));
                 sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\ParticularSoftware"));
-
-                sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\ParticularSoftware\NServiceBus"));
-                sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\ParticularSoftware\NServiceBus"));
-
-                sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\NServiceBus\4.3"));
-                sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\NServiceBus\4.3"));
-
-                sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\NServiceBus\4.2"));
-                sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\NServiceBus\4.2"));
-
-                sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\NServiceBus\4.1"));
-                sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\NServiceBus\4.1"));
-
-                sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\NServiceBus\4.0"));
-                sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\NServiceBus\4.0"));
             }
 
             return sources.ToArray();

--- a/src/NServiceBus.Core/Licensing/LicenseSources.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseSources.cs
@@ -21,7 +21,8 @@ namespace NServiceBus
                 sources.Add(new LicenseSourceFilePath(licenseFilePath));
             }
 
-            sources.Add(new LicenseSourceConfigFile());
+            sources.Add(new LicenseSourceAppConfigLicenseSetting());
+            sources.Add(new LicenseSourceAppConfigLicensePathSetting());
 
             sources.Add(new LicenseSourceFilePath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ParticularSoftware", "license.xml")));
             sources.Add(new LicenseSourceFilePath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "ParticularSoftware", "license.xml")));

--- a/src/NServiceBus.Core/Licensing/LicenseSources.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseSources.cs
@@ -24,11 +24,9 @@ namespace NServiceBus
             sources.Add(new LicenseSourceAppConfigLicenseSetting());
             sources.Add(new LicenseSourceAppConfigLicensePathSetting());
 
-            sources.Add(new LicenseSourceFilePath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ParticularSoftware", "license.xml")));
             sources.Add(new LicenseSourceFilePath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "ParticularSoftware", "license.xml")));
-
-            sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "NServiceBus", "License.xml")));
-            sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "License", "License.xml")));
+            sources.Add(new LicenseSourceFilePath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ParticularSoftware", "license.xml")));
+            sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "license.xml")));
 
             if (Environment.OSVersion.Platform == PlatformID.Win32NT)
             {

--- a/src/NServiceBus.Core/Licensing/LicenseSources.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseSources.cs
@@ -1,15 +1,12 @@
 namespace NServiceBus
 {
-    using System;
-    using System.Collections.Generic;
-    using System.IO;
     using Particular.Licensing;
 
     static class LicenseSources
     {
         public static LicenseSource[] GetLicenseSources(string licenseText, string licenseFilePath)
         {
-            var sources = new List<LicenseSource>();
+            var sources = LicenseSource.GetStandardLicenseSources();
 
             if (licenseText != null)
             {
@@ -21,12 +18,10 @@ namespace NServiceBus
                 sources.Add(new LicenseSourceFilePath(licenseFilePath));
             }
 
+#if APPCONFIGLICENSESOURCE
             sources.Add(new LicenseSourceAppConfigLicenseSetting());
             sources.Add(new LicenseSourceAppConfigLicensePathSetting());
-
-            sources.Add(new LicenseSourceFilePath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "ParticularSoftware", "license.xml")));
-            sources.Add(new LicenseSourceFilePath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ParticularSoftware", "license.xml")));
-            sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "license.xml")));
+#endif
 
             return sources.ToArray();
         }

--- a/src/NServiceBus.Core/Licensing/LicenseSources.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseSources.cs
@@ -23,6 +23,9 @@ namespace NServiceBus
 
             sources.Add(new LicenseSourceConfigFile());
 
+            sources.Add(new LicenseSourceFilePath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ParticularSoftware", "license.xml")));
+            sources.Add(new LicenseSourceFilePath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData), "ParticularSoftware", "license.xml")));
+
             sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "NServiceBus", "License.xml")));
             sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "License", "License.xml")));
 

--- a/src/NServiceBus.Core/Licensing/LicenseSources.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseSources.cs
@@ -28,12 +28,6 @@ namespace NServiceBus
             sources.Add(new LicenseSourceFilePath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ParticularSoftware", "license.xml")));
             sources.Add(new LicenseSourceFilePath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "license.xml")));
 
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-            {
-                sources.Add(new LicenseSourceHKCURegKey(@"SOFTWARE\ParticularSoftware"));
-                sources.Add(new LicenseSourceHKLMRegKey(@"SOFTWARE\ParticularSoftware"));
-            }
-
             return sources.ToArray();
         }
     }

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <RootNamespace>NServiceBus</RootNamespace>
-    <DefineConstants>$(DefineConstants);REGISTRYLICENSESOURCE</DefineConstants>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
     <OutputPath>..\..\binaries\</OutputPath>
@@ -37,7 +36,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0-preview2-25405-01" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0-preview2-25405-01" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <RootNamespace>NServiceBus</RootNamespace>
+    <DefineConstants>$(DefineConstants);REGISTRYLICENSESOURCE</DefineConstants>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
     <OutputPath>..\..\binaries\</OutputPath>
@@ -11,7 +12,6 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Security" />
     <Reference Include="System.Transactions" />
@@ -24,7 +24,7 @@
     <PackageReference Include="SimpleJson" Version="0.38.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.2.4" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="1.0.0-alpha0001" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="1.0.0-alpha0002" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
@@ -37,7 +37,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.CSharp" Version="4.4.0-preview2-25405-01" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0-preview2-25405-01" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0-preview2-25405-01" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -10,6 +10,10 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net452'">
+    <DefineConstants>$(DefineConstants);REGISTRYLICENSESOURCE;APPCONFIGLICENSESOURCE</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Security" />
@@ -23,7 +27,7 @@
     <PackageReference Include="SimpleJson" Version="0.38.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.2.4" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="1.0.0-alpha0002" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="1.0.0-alpha0003" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This cleans up the old, undocumented registry locations, and adds new machine-level and user-level file locations.

It also cleans up the two different per-project locations and has a single location that doesn't need a subfolder.

This also brings in the latest licensing package, which makes the registry license sources completely optional. 

I think there's a case to be made for now being the time to drop the registry license locations altogether. 

If we can agree on doing that, then I can add that to this PR.

CC @DavidBoike @adamralph 