### PR TITLE
Target .NET Standard 2.0 instead

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
+++ b/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
     <OutputPath>..\..\binaries\</OutputPath>

--- a/src/NServiceBus.Core/Licensing/Browser.cs
+++ b/src/NServiceBus.Core/Licensing/Browser.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP2_0
+﻿#if NETSTANDARD2_0
 namespace NServiceBus
 {
     using System.Diagnostics;

--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/ConcreteProxyCreator.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/ConcreteProxyCreator.cs
@@ -55,7 +55,7 @@ namespace NServiceBus
                     Type.EmptyTypes);
 
                 var getIL = getMethodBuilder.GetILGenerator();
-                // For an instance property, argument zero is the instance. Load the 
+                // For an instance property, argument zero is the instance. Load the
                 // instance, then load the private field and return, leaving the
                 // field value on the stack.
                 getIL.Emit(OpCodes.Ldarg_0);
@@ -81,15 +81,15 @@ namespace NServiceBus
                 setIL.Emit(OpCodes.Stfld, fieldBuilder);
                 setIL.Emit(OpCodes.Ret);
 
-                // Last, map the "get" and "set" accessor methods to the 
-                // PropertyBuilder. The property is now complete. 
+                // Last, map the "get" and "set" accessor methods to the
+                // PropertyBuilder. The property is now complete.
                 propBuilder.SetGetMethod(getMethodBuilder);
                 propBuilder.SetSetMethod(setMethodBuilder);
             }
 
             typeBuilder.AddInterfaceImplementation(type);
 
-            return typeBuilder.CreateType();
+            return typeBuilder.CreateTypeInfo().AsType();
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <RootNamespace>NServiceBus</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
@@ -36,9 +36,12 @@
     <PackageReference Include="System.ValueTuple" Version="4.4.0-preview2-25405-01" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.CSharp" Version="4.4.0-preview2-25405-01" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.4.0-preview2-25405-01" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0-preview2-25405-01" />
+    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="4.4.0-preview2-25405-01" />
   </ItemGroup>
 

--- a/src/NServiceBus.Core/ObjectBuilder/LightInject/LightInject.g.cs
+++ b/src/NServiceBus.Core/ObjectBuilder/LightInject/LightInject.g.cs
@@ -31,7 +31,7 @@
 #define NET45
 #endif
 
-#if NETCOREAPP2_0
+#if NETSTANDARD2_0
 #define NETSTANDARD16
 #endif
 

--- a/src/NServiceBus.Testing.Fakes/NServiceBus.Testing.Fakes.csproj
+++ b/src/NServiceBus.Testing.Fakes/NServiceBus.Testing.Fakes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <RootNamespace>NServiceBus.Testing</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
This is all that has to change for us to target .NET Standard instead of .NET Core.

Once #4882 is merged we should be able to drop the Microsoft.CSharp reference as well.