### PR TITLE
Remove ConfigurationErrorsException usage

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_using_timeout_greater_than_machine_max.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_using_timeout_greater_than_machine_max.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Core.UnitOfWork.TransactionScope
 {
     using System;
-    using System.Configuration;
     using AcceptanceTesting;
     using EndpointTemplates;
     using NUnit.Framework;
@@ -11,7 +10,7 @@
         [Test]
         public void Should_blow_up()
         {
-            var exception = Assert.ThrowsAsync<ConfigurationErrorsException>(async () =>
+            var exception = Assert.ThrowsAsync<Exception>(async () =>
             {
                 await Scenario.Define<ScenarioContext>()
                     .WithEndpoint<ScopeEndpoint>()

--- a/src/NServiceBus.Core.Tests/Settings/SettingsHolderTests.cs
+++ b/src/NServiceBus.Core.Tests/Settings/SettingsHolderTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Settings
 {
     using System;
-    using System.Configuration;
     using System.Linq;
     using NUnit.Framework;
 
@@ -63,7 +62,7 @@
 
             settings.PreventChanges();
 
-            Assert.Throws<ConfigurationErrorsException>(() => settings.Merge(mergeFrom));
+            Assert.Throws<Exception>(() => settings.Merge(mergeFrom));
         }
 
         class SomeDisposable : IDisposable

--- a/src/NServiceBus.Core/Settings/SettingsHolder.cs
+++ b/src/NServiceBus.Core/Settings/SettingsHolder.cs
@@ -3,7 +3,6 @@ namespace NServiceBus.Settings
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Configuration;
 
     /// <summary>
     /// Setting container.
@@ -285,7 +284,7 @@ namespace NServiceBus.Settings
         {
             if (locked)
             {
-                throw new ConfigurationErrorsException("Unable to merge settings. The settings has been locked for modifications. Move any configuration code earlier in the configuration pipeline");
+                throw new Exception("Unable to merge settings. The settings has been locked for modifications. Move any configuration code earlier in the configuration pipeline");
             }
         }
 
@@ -293,7 +292,7 @@ namespace NServiceBus.Settings
         {
             if (locked)
             {
-                throw new ConfigurationErrorsException($"Unable to set the value for key: {key}. The settings has been locked for modifications. Move any configuration code earlier in the configuration pipeline");
+                throw new Exception($"Unable to set the value for key: {key}. The settings has been locked for modifications. Move any configuration code earlier in the configuration pipeline");
             }
         }
 

--- a/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWork.cs
+++ b/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWork.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Features
 {
     using System;
-    using System.Configuration;
     using System.Transactions;
     using ConsistencyGuarantees;
 
@@ -30,7 +29,7 @@
 
                     if (requestedTimeout.Value > maxTimeout)
                     {
-                        throw new ConfigurationErrorsException(
+                        throw new Exception(
                             "Timeout requested is longer than the maximum value for this machine. Override using the maxTimeout setting of the system.transactions section in machine.config");
                     }
 
@@ -56,7 +55,7 @@
                 //default is always 10 minutes
                 var maxTimeout = TimeSpan.FromMinutes(10);
 #if NET452
-                var systemTransactionsGroup = ConfigurationManager.OpenMachineConfiguration()
+                var systemTransactionsGroup = System.Configuration.ConfigurationManager.OpenMachineConfiguration()
                     .GetSectionGroup("system.transactions");
 
                 var machineSettings = systemTransactionsGroup?.Sections.Get("machineSettings") as System.Transactions.Configuration.MachineSettingsSection;


### PR DESCRIPTION
This gets us one step closer to having no dependency on `System.Configuration`/`System.Configuration.ConfigurationManager`.

Replaces #4887

docs PR: https://github.com/Particular/docs.particular.net/pull/3043