### PR TITLE
Remove app config connection string API

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBusAcceptanceTest.cs
+++ b/src/NServiceBus.AcceptanceTests/NServiceBusAcceptanceTest.cs
@@ -15,9 +15,12 @@ namespace NServiceBus.AcceptanceTests
         [SetUp]
         public void SetUp()
         {
+#if NET452
             // Hack: prevents SerializationException ... Type 'x' in assembly 'y' is not marked as serializable.
             // https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/mitigation-deserialization-of-objects-across-app-domains
             System.Configuration.ConfigurationManager.GetSection("X");
+#endif
+
             Conventions.EndpointNamingConvention = t =>
             {
                 var classAndEndpoint = t.FullName.Split('.').Last();

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -932,6 +932,7 @@ namespace NServiceBus
         public TransportExtensions(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.TransportExtensions ConnectionString(string connectionString) { }
         public NServiceBus.TransportExtensions ConnectionString(System.Func<string> connectionString) { }
+        [System.ObsoleteAttribute(@"Directly using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to TransportExtensions.ConnectionString(connectionString). Use `TransportExtensions.ConnectionString(connectionString)` instead. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
         public NServiceBus.TransportExtensions ConnectionStringName(string name) { }
         public NServiceBus.TransportExtensions Transactions(NServiceBus.TransportTransactionMode transportTransactionMode) { }
     }
@@ -941,6 +942,7 @@ namespace NServiceBus
         public TransportExtensions(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.TransportExtensions<T> ConnectionString(string connectionString) { }
         public NServiceBus.TransportExtensions<T> ConnectionString(System.Func<string> connectionString) { }
+        [System.ObsoleteAttribute(@"Directly using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to TransportExtensions<T>.ConnectionString(connectionString). Use `TransportExtensions<T>.ConnectionString(connectionString)` instead. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
         public NServiceBus.TransportExtensions<T> ConnectionStringName(string name) { }
         public NServiceBus.TransportExtensions<T> Transactions(NServiceBus.TransportTransactionMode transportTransactionMode) { }
     }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -932,7 +932,7 @@ namespace NServiceBus
         public TransportExtensions(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.TransportExtensions ConnectionString(string connectionString) { }
         public NServiceBus.TransportExtensions ConnectionString(System.Func<string> connectionString) { }
-        [System.ObsoleteAttribute(@"Directly using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to TransportExtensions.ConnectionString(connectionString). Use `TransportExtensions.ConnectionString(connectionString)` instead. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
+        [System.ObsoleteAttribute(@"Using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to EndpointConfiguration.UseTransport().ConnectionString(connectionString). Use `TransportExtensions.ConnectionString(connectionString)` instead. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
         public NServiceBus.TransportExtensions ConnectionStringName(string name) { }
         public NServiceBus.TransportExtensions Transactions(NServiceBus.TransportTransactionMode transportTransactionMode) { }
     }
@@ -942,7 +942,7 @@ namespace NServiceBus
         public TransportExtensions(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.TransportExtensions<T> ConnectionString(string connectionString) { }
         public NServiceBus.TransportExtensions<T> ConnectionString(System.Func<string> connectionString) { }
-        [System.ObsoleteAttribute(@"Directly using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to TransportExtensions<T>.ConnectionString(connectionString). Use `TransportExtensions<T>.ConnectionString(connectionString)` instead. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
+        [System.ObsoleteAttribute(@"Using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to EndpointConfiguration.UseTransport().ConnectionString(connectionString). Use `TransportExtensions<T>.ConnectionString(connectionString)` instead. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
         public NServiceBus.TransportExtensions<T> ConnectionStringName(string name) { }
         public NServiceBus.TransportExtensions<T> Transactions(NServiceBus.TransportTransactionMode transportTransactionMode) { }
     }

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <Reference Include="System.Configuration" />
     <Reference Include="System.Transactions" />
   </ItemGroup>
 

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -45,7 +45,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.4.0" />
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="4.4.0" />

--- a/src/NServiceBus.Core/Unicast/Transport/Config/TransportExtensions.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/Config/TransportExtensions.cs
@@ -2,7 +2,6 @@ namespace NServiceBus
 {
     using System;
     using Configuration.AdvancedExtensibility;
-    using Logging;
     using Settings;
     using Transport;
 
@@ -34,14 +33,13 @@ namespace NServiceBus
         /// Configures the transport to use the connection string with the given name.
         /// </summary>
         [ObsoleteEx(
-        Message = "Directly using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to TransportExtensions<T>.ConnectionString(connectionString)",
+        Message = "Using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to EndpointConfiguration.UseTransport().ConnectionString(connectionString).",
             ReplacementTypeOrMember = "TransportExtensions<T>.ConnectionString(connectionString)",
             TreatAsErrorFromVersion = "8.0",
             RemoveInVersion = "9.0")]
         public new TransportExtensions<T> ConnectionStringName(string name)
         {
             base.ConnectionStringName(name);
-            Log.Info("Directly using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to TransportExtensions<T>.ConnectionString(connectionString)");
             return this;
         }
 #endif
@@ -51,7 +49,7 @@ namespace NServiceBus
         /// Configures the transport to use the connection string with the given name.
         /// </summary>
         [ObsoleteEx(
-            Message = "The ability to used named connection strings has been removed. Instead, load the connection string in your code and pass the value to TransportExtensions<T>.ConnectionString(connectionString)",
+            Message = "Loading named connection strings is no longer supported",
             ReplacementTypeOrMember = "TransportExtensions<T>.ConnectionString(connectionString)",
             TreatAsErrorFromVersion = "7.0",
             RemoveInVersion = "8.0")]
@@ -84,8 +82,6 @@ namespace NServiceBus
     /// </summary>
     public class TransportExtensions : ExposeSettings
     {
-        internal static ILog Log => LogManager.GetLogger<TransportExtensions>();
-
         /// <summary>
         /// Initializes a new instance of <see cref="TransportExtensions" />.
         /// </summary>
@@ -110,7 +106,7 @@ namespace NServiceBus
         /// Configures the transport to use the connection string with the given name.
         /// </summary>
         [ObsoleteEx(
-            Message = "Directly using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to TransportExtensions.ConnectionString(connectionString)",
+            Message = "Using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to EndpointConfiguration.UseTransport().ConnectionString(connectionString).",
             ReplacementTypeOrMember = "TransportExtensions.ConnectionString(connectionString)",
             TreatAsErrorFromVersion = "8.0",
             RemoveInVersion = "9.0")]
@@ -118,7 +114,6 @@ namespace NServiceBus
         {
             Guard.AgainstNullAndEmpty(nameof(name), name);
             Settings.Set<TransportConnectionString>(new TransportConnectionString(name));
-            Log.Info("Directly using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to TransportExtensions.ConnectionString(connectionString)");
             return this;
         }
 #endif

--- a/src/NServiceBus.Core/Unicast/Transport/Config/TransportExtensions.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/Config/TransportExtensions.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using Configuration.AdvancedExtensibility;
+    using Logging;
     using Settings;
     using Transport;
 
@@ -32,13 +33,33 @@ namespace NServiceBus
         /// <summary>
         /// Configures the transport to use the connection string with the given name.
         /// </summary>
+        [ObsoleteEx(
+        Message = "Directly using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to TransportExtensions<T>.ConnectionString(connectionString)",
+            ReplacementTypeOrMember = "TransportExtensions<T>.ConnectionString(connectionString)",
+            TreatAsErrorFromVersion = "8.0",
+            RemoveInVersion = "9.0")]
         public new TransportExtensions<T> ConnectionStringName(string name)
         {
             base.ConnectionStringName(name);
+            Log.Info("Directly using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to TransportExtensions<T>.ConnectionString(connectionString)");
             return this;
         }
 #endif
 
+#if NETSTANDARD2_0
+        /// <summary>
+        /// Configures the transport to use the connection string with the given name.
+        /// </summary>
+        [ObsoleteEx(
+            Message = "The ability to used named connection strings has been removed. Instead, load the connection string in your code and pass the value to TransportExtensions<T>.ConnectionString(connectionString)",
+            ReplacementTypeOrMember = "TransportExtensions<T>.ConnectionString(connectionString)",
+            TreatAsErrorFromVersion = "7.0",
+            RemoveInVersion = "8.0")]
+        public new TransportExtensions<T> ConnectionStringName(string name)
+        {
+            throw new NotImplementedException();
+        }
+#endif
         /// <summary>
         /// Configures the transport to use the given func as the connection string.
         /// </summary>
@@ -63,6 +84,8 @@ namespace NServiceBus
     /// </summary>
     public class TransportExtensions : ExposeSettings
     {
+        internal static ILog Log => LogManager.GetLogger<TransportExtensions>();
+
         /// <summary>
         /// Initializes a new instance of <see cref="TransportExtensions" />.
         /// </summary>
@@ -86,11 +109,32 @@ namespace NServiceBus
         /// <summary>
         /// Configures the transport to use the connection string with the given name.
         /// </summary>
+        [ObsoleteEx(
+            Message = "Directly using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to TransportExtensions.ConnectionString(connectionString)",
+            ReplacementTypeOrMember = "TransportExtensions.ConnectionString(connectionString)",
+            TreatAsErrorFromVersion = "8.0",
+            RemoveInVersion = "9.0")]
         public TransportExtensions ConnectionStringName(string name)
         {
             Guard.AgainstNullAndEmpty(nameof(name), name);
             Settings.Set<TransportConnectionString>(new TransportConnectionString(name));
+            Log.Info("Directly using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to TransportExtensions.ConnectionString(connectionString)");
             return this;
+        }
+#endif
+
+#if NETSTANDARD2_0
+        /// <summary>
+        /// Configures the transport to use the connection string with the given name.
+        /// </summary>
+        [ObsoleteEx(
+        Message = "The ability to used named connection strings has been removed. Instead, load the connection string in your code and pass the value to TransportExtensions.ConnectionString(connectionString)",
+        ReplacementTypeOrMember = "TransportExtensions.ConnectionString(connectionString)",
+        TreatAsErrorFromVersion = "7.0",
+        RemoveInVersion = "8.0")]
+        public TransportExtensions ConnectionStringName(string name)
+        {
+            throw new NotImplementedException();
         }
 #endif
 

--- a/src/NServiceBus.Core/Unicast/Transport/Config/TransportExtensions.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/Config/TransportExtensions.cs
@@ -28,6 +28,7 @@ namespace NServiceBus
             return this;
         }
 
+#if NET452
         /// <summary>
         /// Configures the transport to use the connection string with the given name.
         /// </summary>
@@ -36,6 +37,7 @@ namespace NServiceBus
             base.ConnectionStringName(name);
             return this;
         }
+#endif
 
         /// <summary>
         /// Configures the transport to use the given func as the connection string.
@@ -80,6 +82,7 @@ namespace NServiceBus
             return this;
         }
 
+#if NET452
         /// <summary>
         /// Configures the transport to use the connection string with the given name.
         /// </summary>
@@ -89,6 +92,7 @@ namespace NServiceBus
             Settings.Set<TransportConnectionString>(new TransportConnectionString(name));
             return this;
         }
+#endif
 
         /// <summary>
         /// Configures the transport to use the given func as the connection string.

--- a/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
@@ -1,17 +1,15 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using Logging;
     using Transport;
 
+#if NET452
     sealed class TransportConnectionString
     {
         TransportConnectionString()
         {
-#if NET452
             GetValue = () => ReadConnectionStringFromAppConfig(DefaultConnectionStringName);
-#else
-            GetValue = () => null;
-#endif
         }
 
         public TransportConnectionString(Func<string> func)
@@ -19,7 +17,6 @@
             GetValue = func;
         }
 
-#if NET452
         public TransportConnectionString(string name)
         {
             GetValue = () => ReadConnectionStringFromAppConfig(name);
@@ -27,13 +24,60 @@
 
         static string ReadConnectionStringFromAppConfig(string connectionStringName)
         {
+            Log.Warn("Using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to EndpointConfiguration.UseTransport().ConnectionString(connectionString).");
+
             var connectionStringSettings = System.Configuration.ConfigurationManager.ConnectionStrings[connectionStringName];
 
             return connectionStringSettings?.ConnectionString;
         }
 
         const string DefaultConnectionStringName = "NServiceBus/Transport";
+
+        public static TransportConnectionString Default => new TransportConnectionString();
+
+        public string GetConnectionStringOrRaiseError(TransportDefinition transportDefinition)
+        {
+            var connectionString = GetValue();
+            if (connectionString == null && transportDefinition.RequiresConnectionString)
+            {
+                throw new InvalidOperationException(string.Format(Message, transportDefinition.GetType().Name, transportDefinition.ExampleConnectionStringForErrorMessage));
+            }
+            return connectionString;
+        }
+
+        static ILog Log => LogManager.GetLogger<TransportExtensions>();
+
+        Func<string> GetValue;
+
+        const string Message =
+@"Transport connection string has not been explicitly configured via 'ConnectionString' method and no default connection was found in the app.config or web.config file for the {0} Transport.
+
+To run NServiceBus with {0} Transport you need to specify the database connectionstring.
+Here are examples of what is required:
+
+  <connectionStrings>
+    <add name=""NServiceBus/Transport"" connectionString=""{1}"" />
+  </connectionStrings>
+
+or
+
+  busConfig.UseTransport<{0}>().ConnectionString(""{1}"");
+";
+    }
 #endif
+
+#if NETSTANDARD2_0
+    sealed class TransportConnectionString
+    {
+        TransportConnectionString()
+        {
+            GetValue = () => null;
+        }
+
+        public TransportConnectionString(Func<string> func)
+        {
+            GetValue = func;
+        }
 
         public static TransportConnectionString Default => new TransportConnectionString();
 
@@ -49,23 +93,7 @@
 
         Func<string> GetValue;
 
-#if NET452
-        const string Message =
-   @"Transport connection string has not been explicitly configured via ConnectionString method and no default connection has been was found in the app.config or web.config file for the {0} Transport.
-
-To run NServiceBus with {0} Transport you need to specify the database connectionstring.
-Here are examples of what is required:
-
-  <connectionStrings>
-    <add name=""NServiceBus/Transport"" connectionString=""{1}"" />
-  </connectionStrings>
-
-or
-
-  busConfig.UseTransport<{0}>().ConnectionString(""{1}"");
-";
-#else
-        const string Message = "Transport connection string has not been explicitly configured via ConnectionString method.";
-#endif
+        const string Message = "Transport connection string has not been explicitly configured via 'ConnectionString' method.";
     }
+#endif
 }


### PR DESCRIPTION
This is currently branched on top of #4882, so this needs to be rebased to develop after #4882 is merged.

This is an approach to removing the last dependency on the `System.Configuration.ConfigurationManager` package. At the moment, the `ConnectionStringName` API has been removed from the netstandard2.0 target, which would be the first place where we have public API difference between the two targets. If we're OK with this approach, we could go ahead and add an obsolete for the API that would be specific to the netstandard2.0 target as well.

Alternatively, we could just stop supporting this on net452 also, and then the API would be the same for both targets.

Thoughts?