### PR TITLE
Work around reference assembly packaging issue

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -10,6 +10,11 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
+  <!--Workaround for https://github.com/dotnet/sdk/issues/1469 -->
+  <PropertyGroup>
+    <DisableLockFileFrameworks>true</DisableLockFileFrameworks>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(TargetFramework)' == 'net452'">
     <DefineConstants>$(DefineConstants);REGISTRYLICENSESOURCE;APPCONFIGLICENSESOURCE</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
While testing a preview3 daily SDK release, I noticed that while the problem of there being too many reference assemblies listed in the package, there was now an issue where some were missing. I filed https://github.com/dotnet/sdk/issues/1469 and discovered that there is a workaround for now until the underlying issue is solved.