### PR TITLE
Adjust license source ordering

### DIFF
--- a/src/NServiceBus.Core/Licensing/LicenseSources.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseSources.cs
@@ -1,12 +1,13 @@
 namespace NServiceBus
 {
+    using System.Collections.Generic;
     using Particular.Licensing;
 
     static class LicenseSources
     {
         public static LicenseSource[] GetLicenseSources(string licenseText, string licenseFilePath)
         {
-            var sources = LicenseSource.GetStandardLicenseSources();
+            var sources = new List<LicenseSource>();
 
             if (licenseText != null)
             {
@@ -17,6 +18,10 @@ namespace NServiceBus
             {
                 sources.Add(new LicenseSourceFilePath(licenseFilePath));
             }
+
+            var standardSources = LicenseSource.GetStandardLicenseSources();
+
+            sources.AddRange(standardSources);
 
 #if APPCONFIGLICENSESOURCE
             sources.Add(new LicenseSourceAppConfigLicenseSetting());

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="SimpleJson" Version="0.38.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.2.4" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="1.0.0-alpha0003" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="1.0.0-alpha0004" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This ensures that if the same license is found in more than one location (where same means the same expiration date) then we prefer the API-provided licenses over the convention-based locations.

The package update made a minor tweak the ordering of the file locations to make the precedence order be per-project, per-user, machine-global,

There's an argument to be had that the app config license sources should also come before the standard sources, but if we moved those, then we'd get into the situation mentioned in https://github.com/Particular/NServiceBus/pull/4882#discussion_r132151055 where we'd pick the app config license over the file license and log a warning.
