### PR TITLE
Add wait to timeout poller

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -237,6 +237,7 @@
     <Compile Include="Serializers\XML\Using_Infer_Type_With_Non_Nested_Class.cs" />
     <Compile Include="Timeout\FakeMessageSender.cs" />
     <Compile Include="Timeout\InMemoryTimeoutPersisterTests.cs" />
+    <Compile Include="Timeout\TimeoutMessageReceiverTests.cs" />
     <Compile Include="Timeout\When_fetching_timeouts_from_storage.cs" />
     <Compile Include="Timeout\InMemoryTimeoutPersisterThreadTests.cs" />
     <Compile Include="Timeout\When_pooling_timeouts.cs" />

--- a/src/NServiceBus.Core.Tests/Timeout/TimeoutMessageReceiverTests.cs
+++ b/src/NServiceBus.Core.Tests/Timeout/TimeoutMessageReceiverTests.cs
@@ -1,0 +1,151 @@
+﻿namespace NServiceBus.Core.Tests.Timeout
+{
+    using System;
+    using System.Collections.Generic;
+    using NServiceBus.InMemory.TimeoutPersister;
+    using NServiceBus.ObjectBuilder;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Settings;
+    using NServiceBus.Timeout.Core;
+    using NServiceBus.Timeout.Hosting.Windows;
+    using NServiceBus.Transports;
+    using NServiceBus.Unicast;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class TimeoutMessageReceiverTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            startSlice = DateTime.UtcNow.AddYears(-10);
+
+            timeouts = new InMemoryTimeoutPersister(() => currentTime);
+
+            sender = new TestableMessageSender();
+
+            receiver = new TimeoutPersisterReceiver(() => currentTime)
+            {
+                MessageSender = sender,
+                TimeoutsPersister = timeouts,
+                DispatcherAddress = new Address("test", String.Empty),
+                CriticalError = new CriticalError((msg, ex) => { }, new Configure(new SettingsHolder(), new FuncBuilder(), new List<Action<IConfigureComponents>>(), new PipelineSettings(null)))
+            };
+        }
+
+        [Test]
+        public void Sends_no_messages_when_no_timeouts_registered()
+        {
+            receiver.SpinOnce(startSlice);
+            Assert.AreEqual(0, sender.MessagesSent, "Messages Sent");
+        }
+
+        [Test]
+        public void Returns_to_normal_poll_cycle_after_dispatching_a_pushed_timeout()
+        {
+            receiver.SpinOnce(startSlice);
+
+            var nextRetrieval = receiver.NextRetrieval;
+            
+            RegisterNewTimeout(nextRetrieval - HalfOfDefaultInMemoryPersisterSleep);
+
+            currentTime = receiver.NextRetrieval;
+
+            receiver.SpinOnce(startSlice);
+
+            Assert.AreEqual(1, sender.MessagesSent,"Messages Sent");
+            Assert.AreEqual((currentTime + EmptyResultsNextTimeToRunQuerySpan), receiver.NextRetrieval, "Next Retrieval");
+        }
+
+        [Test]
+        public void Returns_to_normal_poll_cycle_after_dispatching_a_non_pushed_timeout()
+        {
+            var nextRetrieval = receiver.NextRetrieval;
+            var timeout1 = nextRetrieval.Subtract(HalfOfDefaultInMemoryPersisterSleep);
+
+            // ReSharper disable once PossibleLossOfFraction
+            var timeout2 = timeout1.Add(TimeSpan.FromMilliseconds(HalfOfDefaultInMemoryPersisterSleep.Milliseconds / 2));
+
+            RegisterNewTimeout(timeout1);
+            RegisterNewTimeout(timeout2, false);
+
+            currentTime = timeout2;
+            receiver.SpinOnce(startSlice);
+
+            Assert.AreEqual(2, sender.MessagesSent, "Messages Sent");
+            Assert.AreEqual(currentTime + EmptyResultsNextTimeToRunQuerySpan, receiver.NextRetrieval, "Next Retrieval");
+        }
+
+        [Test]
+        public void Poll_with_same_start_slice_from_last_failed_dispatch()
+        {
+            RegisterNewTimeout(currentTime.Subtract(TimeSpan.FromMinutes(5)));
+
+            var dispatchCalls = 0;
+            var transportOperations = new List<TransportMessage>();
+
+            sender.SendAction = m =>
+            {
+                if (++dispatchCalls == 1)
+                {
+                    // fail first dispatch
+                    throw new Exception("transport error");
+                }
+
+                // succeed second dispatch
+                transportOperations.Add(m);
+            };
+
+            try
+            {
+                receiver.SpinOnce(startSlice);
+            }
+            catch (Exception)
+            {
+                // ignore. An exception will cause another polling attempt.
+            }
+
+            receiver.SpinOnce(startSlice);
+
+            Assert.AreEqual(1, transportOperations.Count);
+        }
+
+        void RegisterNewTimeout(DateTime newTimeout, bool withNotification = true)
+        {
+            var newTimeoutData = new TimeoutData
+            {
+                Time = newTimeout
+            };
+            timeouts.Add(newTimeoutData);
+
+            if (withNotification)
+            {
+                receiver.TimeoutsManagerOnTimeoutPushed(newTimeoutData);
+            }
+        }
+
+        DateTime currentTime = DateTime.UtcNow;
+        private TimeoutPersisterReceiver receiver;
+        private TestableMessageSender sender;
+        InMemoryTimeoutPersister timeouts;
+
+        static TimeSpan EmptyResultsNextTimeToRunQuerySpan = TimeSpan.FromMinutes(1);
+        TimeSpan HalfOfDefaultInMemoryPersisterSleep = TimeSpan.FromMilliseconds(EmptyResultsNextTimeToRunQuerySpan.TotalMilliseconds / 2);
+        private DateTime startSlice;
+
+        class TestableMessageSender : ISendMessages
+        {
+            private volatile int messagesSent;
+
+            public int MessagesSent => messagesSent;
+
+            public Action<TransportMessage> SendAction { private get; set; } = msg => { };
+
+            public void Send(TransportMessage message, SendOptions sendOptions)
+            {
+                messagesSent++;
+                SendAction(message);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/TimeoutPersister/InMemoryTimeoutPersister.cs
@@ -10,10 +10,20 @@ namespace NServiceBus.InMemory.TimeoutPersister
     {
         List<TimeoutData> storage = new List<TimeoutData>();
         ReaderWriterLockSlim readerWriterLock = new ReaderWriterLockSlim();
+        Func<DateTime> currentTime = () => DateTime.UtcNow;
+
+        public InMemoryTimeoutPersister()
+        {            
+        }
+
+        public InMemoryTimeoutPersister(Func<DateTime> currentTimeProvider)
+        {
+            currentTime = currentTimeProvider;
+        }
 
         public IEnumerable<Tuple<string, DateTime>> GetNextChunk(DateTime startSlice, out DateTime nextTimeToRunQuery)
         {
-            var now = DateTime.UtcNow;
+            var now = currentTime();
             nextTimeToRunQuery = DateTime.MaxValue;
 
             var tuples = new List<Tuple<string, DateTime>>();

--- a/src/NServiceBus.Core/Timeout/Hosting/Windows/TimeoutPersisterReceiver.cs
+++ b/src/NServiceBus.Core/Timeout/Hosting/Windows/TimeoutPersisterReceiver.cs
@@ -112,18 +112,17 @@ namespace NServiceBus.Timeout.Hosting.Windows
                     }
 
                     timeoutPushed = false;
+
+                    // we cap the next retrieval to max 1 minute this will make sure that we trip the circuit breaker if we
+                    // loose connectivity to our storage. This will also make sure that timeouts added (during migration) direct to storage
+                    // will be picked up after at most 1 minute
+                    var maxNextRetrieval = DateTime.UtcNow + TimeSpan.FromMinutes(1);
+
+                    if (nextRetrieval > maxNextRetrieval)
+                    {
+                        nextRetrieval = maxNextRetrieval;
+                    }
                 }
-
-                // we cap the next retrieval to max 1 minute this will make sure that we trip the circuit breaker if we
-                // loose connectivity to our storage. This will also make sure that timeouts added (during migration) direct to storage
-                // will be picked up after at most 1 minute
-                var maxNextRetrieval = DateTime.UtcNow + TimeSpan.FromMinutes(1);
-
-                if (nextRetrieval > maxNextRetrieval)
-                {
-                    nextRetrieval = maxNextRetrieval;
-                }
-
                 Logger.DebugFormat("Polling next retrieval is at {0}.", nextRetrieval.ToLocalTime());
                 circuitBreaker.Success();
             }

--- a/src/NServiceBus.Core/Timeout/Hosting/Windows/TimeoutPersisterReceiver.cs
+++ b/src/NServiceBus.Core/Timeout/Hosting/Windows/TimeoutPersisterReceiver.cs
@@ -19,6 +19,16 @@ namespace NServiceBus.Timeout.Hosting.Windows
         public CriticalError CriticalError { get; set; }
         public Address DispatcherAddress { get; set; }
         public TimeSpan TimeToWaitBeforeTriggeringCriticalError { get; set; }
+        internal DateTime NextRetrieval { get; private set; } = DateTime.UtcNow;
+
+        public TimeoutPersisterReceiver()
+        {            
+        }
+
+        public TimeoutPersisterReceiver(Func<DateTime> currentTimeProvider)
+        {
+            currentTime = currentTimeProvider;
+        }
 
         public void Dispose()
         {
@@ -72,47 +82,53 @@ namespace NServiceBus.Timeout.Hosting.Windows
         {
             var cancellationToken = (CancellationToken)obj;
 
-            var startSlice = DateTime.UtcNow.AddYears(-10);
+            var startSlice = currentTime().AddYears(-10);
 
             resetEvent.Reset();
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                if (nextRetrieval > DateTime.UtcNow)
-                {
-                    Thread.Sleep(SecondsToSleepBetweenPolls * 1000);
-                    continue;
-                }
-
-                Logger.DebugFormat("Polling for timeouts at {0}.", DateTime.Now);
-
-                DateTime nextExpiredTimeout;
-                var timeoutDatas = TimeoutsPersister.GetNextChunk(startSlice, out nextExpiredTimeout);
-
-                foreach (var timeoutData in timeoutDatas)
-                {
-                    if (startSlice < timeoutData.Item2)
-                    {
-                        startSlice = timeoutData.Item2;
-                    }
-
-                    MessageSender.Send(CreateTransportMessage(timeoutData.Item1), new SendOptions(DispatcherAddress));
-                }
-
-                lock (lockObject)
-                {
-                    // we cap the next retrieval to max 1 minute this will make sure that we trip the circuit breaker if we
-                    // loose connectivity to our storage. This will also make sure that timeouts added (during migration) direct to storage
-                    // will be picked up after at most 1 minute
-                    var maxNextRetrieval = DateTime.UtcNow + TimeSpan.FromMinutes(1);
-
-                    nextRetrieval = nextExpiredTimeout > maxNextRetrieval ? maxNextRetrieval : nextExpiredTimeout;
-                }
-                Logger.DebugFormat("Polling next retrieval is at {0}.", nextRetrieval.ToLocalTime());
+                startSlice = SpinOnce(startSlice);
                 circuitBreaker.Success();
             }
 
             resetEvent.Set();
+        }
+
+        internal DateTime SpinOnce(DateTime startSlice)
+        {
+            if (NextRetrieval > currentTime())
+            {
+                Thread.Sleep(SecondsToSleepBetweenPolls * 1000);
+                return startSlice;
+            }
+
+            Logger.DebugFormat("Polling for timeouts at {0}.", DateTime.Now);
+
+            DateTime nextExpiredTimeout;
+            var timeoutDatas = TimeoutsPersister.GetNextChunk(startSlice, out nextExpiredTimeout);
+
+            foreach (var timeoutData in timeoutDatas)
+            {
+                if (startSlice < timeoutData.Item2)
+                {
+                    startSlice = timeoutData.Item2;
+                }
+
+                MessageSender.Send(CreateTransportMessage(timeoutData.Item1), new SendOptions(DispatcherAddress));
+            }
+
+            lock (lockObject)
+            {
+                // we cap the next retrieval to max 1 minute this will make sure that we trip the circuit breaker if we
+                // loose connectivity to our storage. This will also make sure that timeouts added (during migration) direct to storage
+                // will be picked up after at most 1 minute
+                var maxNextRetrieval = currentTime() + TimeSpan.FromMinutes(1);
+
+                NextRetrieval = nextExpiredTimeout > maxNextRetrieval ? maxNextRetrieval : nextExpiredTimeout;
+            }
+            Logger.DebugFormat("Polling next retrieval is at {0}.", NextRetrieval.ToLocalTime());
+            return startSlice;
         }
 
         static TransportMessage CreateTransportMessage(string timeoutId)
@@ -126,13 +142,13 @@ namespace NServiceBus.Timeout.Hosting.Windows
             return transportMessage;
         }
 
-        void TimeoutsManagerOnTimeoutPushed(TimeoutData timeoutData)
+        internal void TimeoutsManagerOnTimeoutPushed(TimeoutData timeoutData)
         {
             lock (lockObject)
             {
-                if (nextRetrieval > timeoutData.Time)
+                if (NextRetrieval > timeoutData.Time)
                 {
-                    nextRetrieval = timeoutData.Time;
+                    NextRetrieval = timeoutData.Time;
                 }
             }
         }
@@ -142,8 +158,8 @@ namespace NServiceBus.Timeout.Hosting.Windows
         RepeatedFailuresOverTimeCircuitBreaker circuitBreaker;
 
         readonly object lockObject = new object();
-        ManualResetEvent resetEvent = new ManualResetEvent(true);
-        DateTime nextRetrieval = DateTime.UtcNow;
+        ManualResetEvent resetEvent = new ManualResetEvent(true);        
         CancellationTokenSource tokenSource;
+        private Func<DateTime> currentTime = () => DateTime.UtcNow;
     }
 }


### PR DESCRIPTION
Connects to https://github.com/Particular/PlatformDevelopment/issues/1388

Update the timeout polling in v5 to act more like v6 by introducing a wait between polls.