### PR TITLE
Fix proxy message updates

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Persistence\InMemory\When_completing_a_saga_with_no_defined_unique_property.cs" />
     <Compile Include="Persistence\InMemory\When_updating_a_saga_with_no_defined_unique_property.cs" />
     <Compile Include="Persistence\PersistenceStartupTests.cs" />
+    <Compile Include="Pipeline\Outgoing\OutgoingLogicalMessageContextTests.cs" />
     <Compile Include="Routing\SubscribeContextTests.cs" />
     <Compile Include="Routing\UnsubscribeContextTests.cs" />
     <Compile Include="Pipeline\PipelineTests.cs" />

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingLogicalMessageContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingLogicalMessageContextTests.cs
@@ -1,0 +1,65 @@
+﻿namespace NServiceBus.Core.Tests.Pipeline.Outgoing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using MessageInterfaces.MessageMapper.Reflection;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class OutgoingLogicalMessageContextTests
+    {
+        [Test]
+        public void Updating_the_message_proxy_instance_with_a_new_property_value_should_retain_the_original_interface_type()
+        {
+            var mapper = new MessageMapper();
+            var message = mapper.CreateInstance<IMyMessage>(m => m.Id = Guid.NewGuid());
+
+            var context = new OutgoingLogicalMessageContext("message1234", new Dictionary<string, string>(), new OutgoingLogicalMessage(typeof(IMyMessage), message), null, null);
+
+            var newMessageId = Guid.NewGuid();
+            var newMessage = context.Message.Instance;
+            newMessage.GetType().InvokeMember("Id",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.SetProperty,
+                Type.DefaultBinder, newMessage, new object[]
+                {
+                    newMessageId
+                });
+
+            context.UpdateMessage(newMessage);
+
+            Assert.AreEqual(typeof(IMyMessage), context.Message.MessageType);
+            Assert.AreEqual(newMessageId, ((IMyMessage)context.Message.Instance).Id);
+        }
+
+        [Test]
+        public void Updating_the_message_to_a_new_type_should_update_the_MessageType()
+        {
+            var mapper = new MessageMapper();
+            var message = mapper.CreateInstance<IMyMessage>(m => m.Id = Guid.NewGuid());
+
+            var context = new OutgoingLogicalMessageContext("message1234", new Dictionary<string, string>(), new OutgoingLogicalMessage(typeof(IMyMessage), message), null, null);
+
+            var differentMessage = new MyDifferentMessage
+            {
+                Id = Guid.NewGuid()
+            };
+
+            context.UpdateMessage(differentMessage);
+
+            Assert.AreEqual(typeof(MyDifferentMessage), context.Message.MessageType);
+        }
+
+        class MyDifferentMessage
+        {
+            public Guid Id { get; set; }
+        }
+
+        //public required for proxy magic to happen
+        public interface IMyMessage
+        {
+            Guid Id { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingLogicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingLogicalMessageContext.cs
@@ -21,8 +21,11 @@
         public void UpdateMessage(object newInstance)
         {
             Guard.AgainstNull(nameof(newInstance), newInstance);
-
-            Message = new OutgoingLogicalMessage(newInstance.GetType(), newInstance);
+            
+            if (Message.Instance != newInstance)
+            {
+                Message = new OutgoingLogicalMessage(newInstance.GetType(), newInstance);
+            }
         }
     }
 }


### PR DESCRIPTION
This fixes #4860 where updating a message (that is a dynamic proxy type of an interface) in the outgoing pipeline will see the `MessageType` get updated to the proxy'd type. That will cause the message to fail during outbound serialization.