### PR TITLE
Write output to TestContext instead to the console

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
+++ b/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="SourceLink.Create.GitHub" Version="2.1.2" PrivateAssets="All" />
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.1.2" />
   </ItemGroup>

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -5,6 +5,7 @@ namespace NServiceBus.AcceptanceTesting
     using System.Diagnostics;
     using System.Threading.Tasks;
     using Logging;
+    using NUnit.Framework;
     using Support;
 
     public class ScenarioWithContext<TContext> : IScenarioWithEndpointBehavior<TContext> where TContext : ScenarioContext, new()
@@ -46,7 +47,7 @@ namespace NServiceBus.AcceptanceTesting
             await runDescriptor.RaiseOnTestCompleted(runSummary);
 
             DisplayRunResult(runSummary);
-            Console.WriteLine("Total time for testrun: {0}", sw.Elapsed);
+            TestContext.WriteLine("Total time for testrun: {0}", sw.Elapsed);
 
             if (runSummary.Result.Failed)
             {
@@ -88,11 +89,11 @@ namespace NServiceBus.AcceptanceTesting
 
         void PrintLog(TContext scenarioContext)
         {
-            Console.WriteLine($"Log entries (log level: {scenarioContext.LogLevel}):");
-            Console.WriteLine("------------------------------------------------------");
+            TestContext.WriteLine($"Log entries (log level: {scenarioContext.LogLevel}):");
+            TestContext.WriteLine("------------------------------------------------------");
             foreach (var logEntry in scenarioContext.Logs)
             {
-                Console.WriteLine($"{logEntry.Level}: {logEntry.Message}");
+                TestContext.WriteLine($"{logEntry.Level}: {logEntry.Message}");
             }
         }
 
@@ -101,48 +102,48 @@ namespace NServiceBus.AcceptanceTesting
             var runDescriptor = summary.RunDescriptor;
             var runResult = summary.Result;
 
-            Console.WriteLine("------------------------------------------------------");
-            Console.WriteLine("Test summary:");
-            Console.WriteLine();
+            TestContext.WriteLine("------------------------------------------------------");
+            TestContext.WriteLine("Test summary:");
+            TestContext.WriteLine();
 
             PrintSettings(runDescriptor.Settings);
 
-            Console.WriteLine();
-            Console.WriteLine("Endpoints:");
+            TestContext.WriteLine();
+            TestContext.WriteLine("Endpoints:");
 
             foreach (var endpoint in runResult.ActiveEndpoints)
             {
-                Console.WriteLine("     - {0}", endpoint);
+                TestContext.WriteLine("     - {0}", endpoint);
             }
 
             if (runResult.Failed)
             {
-                Console.WriteLine("Test failed: {0}", runResult.Exception.SourceException);
+                TestContext.WriteLine("Test failed: {0}", runResult.Exception.SourceException);
             }
             else
             {
-                Console.WriteLine("Result: Successful - Duration: {0}", runResult.TotalTime);
+                TestContext.WriteLine("Result: Successful - Duration: {0}", runResult.TotalTime);
             }
 
             //dump trace and context regardless since asserts outside the should could still fail the test
-            Console.WriteLine();
-            Console.WriteLine("Context:");
+            TestContext.WriteLine();
+            TestContext.WriteLine("Context:");
 
             foreach (var prop in runResult.ScenarioContext.GetType().GetProperties())
             {
-                Console.WriteLine("{0} = {1}", prop.Name, prop.GetValue(runResult.ScenarioContext, null));
+                TestContext.WriteLine("{0} = {1}", prop.Name, prop.GetValue(runResult.ScenarioContext, null));
             }
         }
 
         static void PrintSettings(IEnumerable<KeyValuePair<string, object>> settings)
         {
-            Console.WriteLine();
-            Console.WriteLine("Using settings:");
+            TestContext.WriteLine();
+            TestContext.WriteLine("Using settings:");
             foreach (var pair in settings)
             {
-                Console.WriteLine("   {0}: {1}", pair.Key, pair.Value);
+                TestContext.WriteLine("   {0}: {1}", pair.Key, pair.Value);
             }
-            Console.WriteLine();
+            TestContext.WriteLine();
         }
 
         List<IComponentBehavior> behaviors = new List<IComponentBehavior>();

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointBehavior.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointBehavior.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Customization;
+    using NUnit.Framework;
 
     public class EndpointBehavior : IComponentBehavior
     {
@@ -38,7 +39,7 @@
             }
             catch (Exception)
             {
-                Console.WriteLine($"Endpoint {runner.Name} failed to initialize");
+                TestContext.WriteLine($"Endpoint {runner.Name} failed to initialize");
                 throw;
             }
             return runner;

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -9,16 +9,18 @@
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
+    using NUnit.Framework;
 
     public class ScenarioRunner
     {
         public static async Task<RunSummary> Run(RunDescriptor runDescriptor, List<IComponentBehavior> behaviorDescriptors, Func<ScenarioContext, bool> done)
         {
-            Console.WriteLine("Started test @ {0}", DateTime.Now.ToString(CultureInfo.InvariantCulture));
+            TestContext.WriteLine("current context: " + runDescriptor.ScenarioContext.GetType().FullName);
+            TestContext.WriteLine("Started test @ {0}", DateTime.Now.ToString(CultureInfo.InvariantCulture));
 
             var runResult = await PerformTestRun(behaviorDescriptors, runDescriptor, done).ConfigureAwait(false);
 
-            Console.WriteLine("Finished test @ {0}", DateTime.Now.ToString(CultureInfo.InvariantCulture));
+            TestContext.WriteLine("Finished test @ {0}", DateTime.Now.ToString(CultureInfo.InvariantCulture));
 
             return new RunSummary
             {
@@ -134,7 +136,7 @@
             catch (Exception)
             {
                 cts.Cancel();
-                Console.WriteLine($"Endpoint {component.Name} failed to start.");
+                TestContext.WriteLine($"Endpoint {component.Name} failed to start.");
                 throw;
             }
         }
@@ -156,7 +158,7 @@
             catch (Exception)
             {
                 cts.Cancel();
-                Console.WriteLine($"Whens for endpoint {component.Name} failed to execute.");
+                TestContext.WriteLine($"Whens for endpoint {component.Name} failed to execute.");
                 throw;
             }
         }
@@ -167,17 +169,17 @@
             return endpoints.Select(async endpoint =>
             {
                 await Task.Yield(); // ensure all endpoints are stopped even if a synchronous implementation throws
-                Console.WriteLine("Stopping endpoint: {0}", endpoint.Name);
+                TestContext.WriteLine("Stopping endpoint: {0}", endpoint.Name);
                 var stopwatch = Stopwatch.StartNew();
                 try
                 {
                     await endpoint.Stop().ConfigureAwait(false);
                     stopwatch.Stop();
-                    Console.WriteLine("Endpoint: {0} stopped ({1}s)", endpoint.Name, stopwatch.Elapsed);
+                    TestContext.WriteLine("Endpoint: {0} stopped ({1}s)", endpoint.Name, stopwatch.Elapsed);
                 }
                 catch (Exception)
                 {
-                    Console.WriteLine($"Endpoint {endpoint.Name} failed to stop.");
+                    TestContext.WriteLine($"Endpoint {endpoint.Name} failed to stop.");
                     throw;
                 }
             }).Timebox(stopTimeout, $"Stopping endpoints took longer than {stopTimeout.TotalMinutes} minutes.");
@@ -193,7 +195,7 @@
             }
             catch (Exception e)
             {
-                Console.WriteLine(e);
+                TestContext.WriteLine(e);
                 throw;
             }
         }

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/EndpointCustomizationConfigurationExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/EndpointCustomizationConfigurationExtensions.cs
@@ -13,14 +13,20 @@
         {
             var assemblies = new AssemblyScanner().GetScannableAssemblies();
 
-            var types = assemblies.Assemblies
+            var assembliesToScan = assemblies.Assemblies
                 //exclude all test types by default
                 .Where(a =>
                 {
+                    if (a.FullName.Contains("NServiceBus.AcceptanceTesting"))
+                    {
+                        return true;
+                    }
+
                     var references = a.GetReferencedAssemblies();
 
                     return references.All(an => an.Name != "nunit.framework");
-                })
+                });
+            var types = assembliesToScan
                 .SelectMany(a => a.GetTypes());
 
             types = types.Union(GetNestedTypeRecursive(endpointConfiguration.BuilderType.DeclaringType, endpointConfiguration.BuilderType));

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/EndpointCustomizationConfigurationExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/EndpointCustomizationConfigurationExtensions.cs
@@ -14,18 +14,8 @@
             var assemblies = new AssemblyScanner().GetScannableAssemblies();
 
             var assembliesToScan = assemblies.Assemblies
-                //exclude all test types by default
-                .Where(a =>
-                {
-                    if (a.FullName.Contains("NServiceBus.AcceptanceTesting"))
-                    {
-                        return true;
-                    }
-
-                    var references = a.GetReferencedAssemblies();
-
-                    return references.All(an => an.Name != "nunit.framework");
-                });
+                //exclude acceptance tests by default
+                .Where(a => !a.FullName.Contains("NServiceBus.AcceptanceTests"));
             var types = assembliesToScan
                 .SelectMany(a => a.GetTypes());
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -251,11 +251,12 @@
                 //file.move preserves create time
                 var sentTime = File.GetCreationTimeUtc(transaction.FileToProcess);
 
-                if (sentTime + ttbr < DateTime.UtcNow)
+                var utcNow = DateTime.UtcNow;
+                if (sentTime + ttbr < utcNow)
                 {
                     await transaction.Commit()
                         .ConfigureAwait(false);
-                    log.InfoFormat("Dropping message '{0}' as the specified TimeToBeReceived of '{1}' expired since sending the message at '{2:O}'", messageId, ttbrString, sentTime);
+                    log.InfoFormat("Dropping message '{0}' as the specified TimeToBeReceived of '{1}' expired since sending the message at '{2:O}'. Current UTC time is '{3:O}'", messageId, ttbrString, sentTime, utcNow);
                     return;
                 }
             }


### PR DESCRIPTION
As we're running tests in parallel, it probably makes more sense to write to the testcontex instead to the console directly.

this has the disadvantage that we have to tie the testing framework to nunit, but afaik, we're using nunit everywhere as of now and we would have to find a better way to enable other testing frameworks instead as the problem is the same on other testing frameworks.

Note: this currently doesn't really seem to change behavior, as TestContext.Write has a bug: https://github.com/nunit/nunit3-vs-adapter/issues/368