### PR TITLE
Support custom logger for acceptance tests

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Scenario.cs
+++ b/src/NServiceBus.AcceptanceTesting/Scenario.cs
@@ -1,10 +1,13 @@
 ﻿namespace NServiceBus.AcceptanceTesting
 {
     using System;
+    using Logging;
     using Support;
 
     public class Scenario
     {
+        public static Func<ScenarioContext, ILoggerFactory> GetLoggerFactory = _ => new ContextAppenderFactory();
+
         public static IScenarioWithEndpointBehavior<T> Define<T>() where T : ScenarioContext, new()
         {
             return new ScenarioWithContext<T>(c => { });

--- a/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
@@ -34,14 +34,9 @@
 
         public ConcurrentQueue<LogItem> Logs = new ConcurrentQueue<LogItem>();
 
-        internal LogLevel LogLevel { get; set; } = LogLevel.Debug;
+        public LogLevel LogLevel { get; set; } = LogLevel.Debug;
 
         internal ConcurrentDictionary<string, bool> UnfinishedFailedMessages = new ConcurrentDictionary<string, bool>();
-
-        public void SetLogLevel(LogLevel level)
-        {
-            LogLevel = level;
-        }
 
         static readonly AsyncLocal<ScenarioContext> asyncContext = new AsyncLocal<ScenarioContext>();
 

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -36,7 +36,7 @@ namespace NServiceBus.AcceptanceTesting
 
             ScenarioContext.Current = scenarioContext;
 
-            LogManager.UseFactory(new ContextAppenderFactory());
+            LogManager.UseFactory(Scenario.GetLoggerFactory(scenarioContext));
 
             var sw = new Stopwatch();
 

--- a/src/NServiceBus.AcceptanceTests/NServiceBusAcceptanceTest.cs
+++ b/src/NServiceBus.AcceptanceTests/NServiceBusAcceptanceTest.cs
@@ -20,7 +20,6 @@ namespace NServiceBus.AcceptanceTests
             // https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/mitigation-deserialization-of-objects-across-app-domains
             System.Configuration.ConfigurationManager.GetSection("X");
 #endif
-
             Conventions.EndpointNamingConvention = t =>
             {
                 var classAndEndpoint = t.FullName.Split('.').Last();


### PR DESCRIPTION
It seems that certain downstreams (e.g. ASB) have issues with the async-local usage to track the current context which is used for logging. If downstreams run code which for some reason looses the logical call context, it will result in null-ref exceptions when trying to write to the log.

We need the asynclocal approach to run tests in parallel though.

It would be possible to allow downstreams to provide their custom logger factory, so that they can switch to use statics which works as long as tests aren't run in parallel. With the changes in the code, ASB can for example provide a custom logger like this:

```
namespace NServiceBus.AcceptanceTests
{
    public partial class NServiceBusAcceptanceTest
    {
        [OneTimeSetUp]
        public void OneTimeSetup()
        {
            Scenario.GetLoggerFactory = ctx => new StaticLoggerFactory(ctx);
        }
    }
}
```

ping @andreasohlund @yvesgoeleven 