### PR TITLE
Update for NetStandard inspections

### DIFF
--- a/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
@@ -1,10 +1,10 @@
 ﻿namespace NServiceBus
 {
     using System;
-    using Logging;
     using Transport;
 
 #if NET452
+    using Logging;
     sealed class TransportConnectionString
     {
         TransportConnectionString()


### PR DESCRIPTION
This fixes one inspection that is visible in VS and is related to a NetStandard2_0 `#if`.