### PR TITLE
Logging improvements

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
+++ b/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
@@ -6,12 +6,16 @@
 
     class ContextAppender : ILog
     {
+        public ContextAppender(string logger)
+        {
+            this.logger = logger;
+        }
+
         public bool IsDebugEnabled => ScenarioContext.Current.LogLevel <= LogLevel.Debug;
         public bool IsInfoEnabled => ScenarioContext.Current.LogLevel <= LogLevel.Info;
         public bool IsWarnEnabled => ScenarioContext.Current.LogLevel <= LogLevel.Warn;
         public bool IsErrorEnabled => ScenarioContext.Current.LogLevel <= LogLevel.Error;
         public bool IsFatalEnabled => ScenarioContext.Current.LogLevel <= LogLevel.Fatal;
-
 
         public void Debug(string message)
         {
@@ -34,7 +38,6 @@
         {
             Log(message, LogLevel.Info);
         }
-
 
         public void Info(string message, Exception exception)
         {
@@ -99,21 +102,23 @@
             Log(fullMessage, LogLevel.Fatal);
         }
 
-        static void Log(string message, LogLevel messageSeverity)
+        void Log(string message, LogLevel messageSeverity)
         {
             var context = ScenarioContext.Current;
 
             if (context.LogLevel > messageSeverity)
-            {
                 return;
-            }
 
             Trace.WriteLine(message);
             context.Logs.Enqueue(new ScenarioContext.LogItem
             {
+                Endpoint = ScenarioContext.CurrentEndpoint,
+                LoggerName = logger,
                 Level = messageSeverity,
                 Message = message
             });
         }
+
+        string logger;
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/ContextAppenderFactory.cs
+++ b/src/NServiceBus.AcceptanceTesting/ContextAppenderFactory.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.AcceptanceTesting
 
         public ILog GetLogger(string name)
         {
-            return new ContextAppender();
+            return new ContextAppender(name);
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
@@ -9,15 +9,16 @@
 
     public class ScenarioContext
     {
-        public ScenarioContext()
-        {
-            CurrentEndpoint = "<Infrastructure>";
-        }
-
         internal static ScenarioContext Current
         {
             get => asyncContext.Value;
             set => asyncContext.Value = value;
+        }
+
+        internal static string CurrentEndpoint
+        {
+            get => asyncEndpointName.Value;
+            set => asyncEndpointName.Value = value;
         }
 
         public Guid TestRunId { get; } = Guid.NewGuid();
@@ -41,12 +42,6 @@
         public ConcurrentQueue<LogItem> Logs = new ConcurrentQueue<LogItem>();
 
         public LogLevel LogLevel { get; set; } = LogLevel.Debug;
-
-        internal static string CurrentEndpoint
-        {
-            get => asyncEndpointName.Value;
-            set => asyncEndpointName.Value = value;
-        }
 
         internal ConcurrentDictionary<string, bool> UnfinishedFailedMessages = new ConcurrentDictionary<string, bool>();
 

--- a/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioContext.cs
@@ -9,6 +9,11 @@
 
     public class ScenarioContext
     {
+        public ScenarioContext()
+        {
+            CurrentEndpoint = "<Infrastructure>";
+        }
+
         internal static ScenarioContext Current
         {
             get => asyncContext.Value;
@@ -25,6 +30,7 @@
         {
             Logs.Enqueue(new LogItem
             {
+                LoggerName = "Trace",
                 Level = LogLevel.Info,
                 Message = trace
             });
@@ -36,19 +42,24 @@
 
         public LogLevel LogLevel { get; set; } = LogLevel.Debug;
 
+        internal static string CurrentEndpoint
+        {
+            get => asyncEndpointName.Value;
+            set => asyncEndpointName.Value = value;
+        }
+
         internal ConcurrentDictionary<string, bool> UnfinishedFailedMessages = new ConcurrentDictionary<string, bool>();
 
         static readonly AsyncLocal<ScenarioContext> asyncContext = new AsyncLocal<ScenarioContext>();
+        static readonly AsyncLocal<string> asyncEndpointName = new AsyncLocal<string>();
 
         public class LogItem
         {
+            public DateTime Timestamp { get; } = DateTime.Now;
+            public string Endpoint { get; set; }
+            public string LoggerName { get; set; }
             public string Message { get; set; }
             public LogLevel Level { get; set; }
-
-            public override string ToString()
-            {
-                return $"{Level}: {Message}";
-            }
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -94,7 +94,7 @@ namespace NServiceBus.AcceptanceTesting
             TestContext.WriteLine("------------------------------------------------------");
             foreach (var logEntry in scenarioContext.Logs)
             {
-                TestContext.WriteLine($"{logEntry.Timestamp:T} {logEntry.Level} {logEntry.Endpoint}: {logEntry.Message}");
+                TestContext.WriteLine($"{logEntry.Timestamp:T} {logEntry.Level} {logEntry.Endpoint ?? "<unknown>"}: {logEntry.Message}");
             }
         }
 

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -49,7 +49,6 @@ namespace NServiceBus.AcceptanceTesting
             DisplayRunResult(runSummary);
             TestContext.WriteLine("Total time for testrun: {0}", sw.Elapsed);
 
-            PrintLog(scenarioContext);
             if (runSummary.Result.Failed)
             {
                 PrintLog(scenarioContext);

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -49,6 +49,7 @@ namespace NServiceBus.AcceptanceTesting
             DisplayRunResult(runSummary);
             TestContext.WriteLine("Total time for testrun: {0}", sw.Elapsed);
 
+            PrintLog(scenarioContext);
             if (runSummary.Result.Failed)
             {
                 PrintLog(scenarioContext);
@@ -93,7 +94,7 @@ namespace NServiceBus.AcceptanceTesting
             TestContext.WriteLine("------------------------------------------------------");
             foreach (var logEntry in scenarioContext.Logs)
             {
-                TestContext.WriteLine($"{logEntry.Level}: {logEntry.Message}");
+                TestContext.WriteLine($"{logEntry.Timestamp:T} {logEntry.Level} {logEntry.Endpoint}: {logEntry.Message}");
             }
         }
 

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -78,6 +78,7 @@
         {
             try
             {
+                ScenarioContext.CurrentEndpoint = configuration.EndpointName;
                 endpointInstance = await startable.Start().ConfigureAwait(false);
 
                 if (token.IsCancellationRequested)

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -28,6 +28,7 @@
 
         public async Task Initialize(RunDescriptor run, EndpointBehavior endpointBehavior, string endpointName)
         {
+            ScenarioContext.CurrentEndpoint = endpointName;
             try
             {
                 behavior = endpointBehavior;
@@ -76,9 +77,9 @@
 
         public override async Task Start(CancellationToken token)
         {
+            ScenarioContext.CurrentEndpoint = configuration.EndpointName;
             try
             {
-                ScenarioContext.CurrentEndpoint = configuration.EndpointName;
                 endpointInstance = await startable.Start().ConfigureAwait(false);
 
                 if (token.IsCancellationRequested)
@@ -96,6 +97,7 @@
 
         public override async Task ComponentsStarted(CancellationToken token)
         {
+            ScenarioContext.CurrentEndpoint = configuration.EndpointName;
             try
             {
                 if (behavior.Whens.Count != 0)
@@ -149,6 +151,7 @@
 
         public override async Task Stop()
         {
+            ScenarioContext.CurrentEndpoint = configuration.EndpointName;
             try
             {
                 if (endpointInstance != null)
@@ -176,9 +179,6 @@
             }
         }
 
-        public override string Name
-        {
-            get { return configuration.EndpointName; }
-        }
+        public override string Name => configuration.EndpointName;
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -30,8 +30,6 @@
             };
         }
 
-
-
         static async Task<RunResult> PerformTestRun(List<IComponentBehavior> behaviorDescriptors, RunDescriptor runDescriptor, Func<ScenarioContext, bool> done)
         {
             var runResult = new RunResult


### PR DESCRIPTION
relates to https://github.com/Particular/NServiceBus/issues/4925
Add additional information to the log output for acceptance tests:
* the logger name (trivial)
* timestamp (trivial)
* the endpoint name (non-trivial)

sample log produced by this PR:
```
09:22:05 Debug AMessageIsAudited.EndpointWithAuditOn: Finished message a07ddffb-7927-40cd-a4bd-a7df00796af3
09:22:05 Debug AMessageIsAudited.EndpointWithAuditOn: Completing processing for c:\temp\0-1506\AMessageIsAudited.EndpointWithAuditOn\c849c038-0268-4b2f-94f2-e2362c885e69.metadata.txt(c:\temp\0-1506\AMessageIsAudited.EndpointWithAuditOn\.pending\ed1e0efd-3fa2-4a9e-a602-7ac456fd7677\c849c038-0268-4b2f-94f2-e2362c885e69.metadata.txt), exception (if any): 
09:22:05 Debug AMessageIsAudited.AuditSpyEndpoint: Procesing message a07ddffb-7927-40cd-a4bd-a7df00796af3
09:22:05 Debug AMessageIsAudited.AuditSpyEndpoint: Finished message a07ddffb-7927-40cd-a4bd-a7df00796af3
09:22:05 Debug AMessageIsAudited.AuditSpyEndpoint: Completing processing for c:\temp\0-1506\AMessageIsAudited.AuditSpyEndpoint\53594fee-9076-43b5-bff9-b24aed8c36d9.metadata.txt(c:\temp\0-1506\AMessageIsAudited.AuditSpyEndpoint\.pending\07106399-1b4b-42dc-8901-e9482df96f71\53594fee-9076-43b5-bff9-b24aed8c36d9.metadata.txt), exception (if any): 
09:22:05 Info <Infrastructure>: Initiating shutdown.
```
