### PR TITLE
Log when learning transport starts to poll

### DIFF
--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -136,6 +136,8 @@
 
         async Task InnerProcessMessages()
         {
+            log.Debug($"Started polling for new messages in {messagePumpBasePath}");
+
             while (!cancellationToken.IsCancellationRequested)
             {
                 var filesFound = false;


### PR DESCRIPTION
This is to help us figure out why the TTBR test (and I suspect others) are sometimes slow.

This causes the TTBR test fail now and then since its time sensitive