### PR TITLE
Update GitVersion yml

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -2,6 +2,6 @@ assembly-versioning-scheme: Major
 next-version: 7.0
 branches:
   develop:
-    tag: alpharelease
-  release:
     tag: beta
+  release:
+    tag: rc


### PR DESCRIPTION
Moving beta creation back to develop in a previous commit missed updating the `GitVertion.yml` file to reflect that `develop` should be beta and `release-*` should be rc