### PR TITLE
Connection string tweaks

### DIFF
--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -44,7 +44,14 @@ namespace NServiceBus
 
             EnsureTransportConfigured();
             var transportDefinition = settings.Get<TransportDefinition>();
-            var connectionString = settings.Get<TransportConnectionString>().GetConnectionStringOrRaiseError(transportDefinition);
+
+            string connectionString = null;
+
+            if (transportDefinition.RequiresConnectionString)
+            {
+                connectionString = settings.Get<TransportConnectionString>().GetConnectionStringOrRaiseError(transportDefinition);
+            }
+
             var transportInfrastructure = transportDefinition.Initialize(settings, connectionString);
             settings.Set<TransportInfrastructure>(transportInfrastructure);
 

--- a/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
@@ -41,10 +41,12 @@
         public string GetConnectionStringOrRaiseError(TransportDefinition transportDefinition)
         {
             var connectionString = GetValue();
-            if (connectionString == null && transportDefinition.RequiresConnectionString)
+
+            if (connectionString == null)
             {
                 throw new InvalidOperationException(string.Format(Message, transportDefinition.GetType().Name, transportDefinition.ExampleConnectionStringForErrorMessage));
             }
+
             return connectionString;
         }
 
@@ -87,10 +89,12 @@ or
         public string GetConnectionStringOrRaiseError(TransportDefinition transportDefinition)
         {
             var connectionString = GetValue();
-            if (connectionString == null && transportDefinition.RequiresConnectionString)
+
+            if (connectionString == null)
             {
                 throw new InvalidOperationException(string.Format(Message, transportDefinition.GetType().Name, transportDefinition.ExampleConnectionStringForErrorMessage));
             }
+
             return connectionString;
         }
 

--- a/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
@@ -43,7 +43,7 @@
 
             if (connectionString == null)
             {
-                throw new InvalidOperationException(string.Format(Message, transportDefinition.GetType().Name, transportDefinition.ExampleConnectionStringForErrorMessage));
+                throw new InvalidOperationException(string.Format(message, transportDefinition.GetType().Name, transportDefinition.ExampleConnectionStringForErrorMessage));
             }
 
             return connectionString;
@@ -53,19 +53,18 @@
 
         Func<string> GetValue;
 
-        const string Message =
-@"Transport connection string has not been explicitly configured via 'ConnectionString' method and no default connection was found in the app.config or web.config file for the {0} Transport.
+        const string message =
+@"Transport connection string has not been explicitly configured via 'ConnectionString' method, and no connection string was found in the app.config or web.config file.
 
-To run NServiceBus with {0} Transport you need to specify the database connectionstring.
 Here are examples of what is required:
+
+  endpointConfig.UseTransport<{0}>().ConnectionString(""{1}"");
+
+or
 
   <connectionStrings>
     <add name=""NServiceBus/Transport"" connectionString=""{1}"" />
   </connectionStrings>
-
-or
-
-  busConfig.UseTransport<{0}>().ConnectionString(""{1}"");
 ";
     }
 #endif

--- a/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
@@ -24,9 +24,12 @@
 
         static string ReadConnectionStringFromAppConfig(string connectionStringName)
         {
-            Log.Warn("Using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to EndpointConfiguration.UseTransport().ConnectionString(connectionString).");
-
             var connectionStringSettings = System.Configuration.ConfigurationManager.ConnectionStrings[connectionStringName];
+
+            if (connectionStringSettings?.ConnectionString != null)
+            {
+                Log.WarnFormat("A connection string named '{0}' was found. Using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to EndpointConfiguration.UseTransport().ConnectionString(connectionString).", connectionStringName);
+            }
 
             return connectionStringSettings?.ConnectionString;
         }

--- a/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
@@ -92,7 +92,7 @@ or
 
             if (connectionString == null)
             {
-                throw new InvalidOperationException(string.Format(Message, transportDefinition.GetType().Name, transportDefinition.ExampleConnectionStringForErrorMessage));
+                throw new InvalidOperationException(string.Format(message, transportDefinition.GetType().Name, transportDefinition.ExampleConnectionStringForErrorMessage));
             }
 
             return connectionString;
@@ -100,7 +100,7 @@ or
 
         Func<string> GetValue;
 
-        const string Message = "Transport connection string has not been explicitly configured via 'ConnectionString' method.";
+        const string message = "Transport connection string has not been explicitly configured via 'ConnectionString' method. Here is an example of what is required: endpointConfig.UseTransport<{0}>().ConnectionString(\"{1}\");";
     }
 #endif
 }

--- a/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
@@ -4,7 +4,6 @@
     using Transport;
 
 #if NET452
-    using Logging;
     sealed class TransportConnectionString
     {
         TransportConnectionString()
@@ -28,7 +27,7 @@
 
             if (connectionStringSettings?.ConnectionString != null)
             {
-                Log.WarnFormat("A connection string named '{0}' was found. Using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to EndpointConfiguration.UseTransport().ConnectionString(connectionString).", connectionStringName);
+                logger.WarnFormat("A connection string named '{0}' was found. Using named connection strings is discouraged. Instead, load the connection string in your code and pass the value to EndpointConfiguration.UseTransport().ConnectionString(connectionString).", connectionStringName);
             }
 
             return connectionStringSettings?.ConnectionString;
@@ -50,7 +49,7 @@
             return connectionString;
         }
 
-        static ILog Log => LogManager.GetLogger<TransportExtensions>();
+        static Logging.ILog logger = Logging.LogManager.GetLogger<TransportExtensions>();
 
         Func<string> GetValue;
 


### PR DESCRIPTION
This makes a few improvements to the transport connection string settings. We now don't try to get a connection string at all if one is not required.

The warning about using a connection string from app.config only shows up if there is actually a named connection string in the file. Otherwise, you'll just get the exception about not having a connection string.

I added the example connection string to the netstandard2.0 version of the message as well.

The net452 error message also got some improvements.