### PR TITLE
[SPIKE]New explicit host API

### DIFF
--- a/src/HostDemo/App.config
+++ b/src/HostDemo/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+    </startup>
+</configuration>

--- a/src/HostDemo/HostDemo.csproj
+++ b/src/HostDemo/HostDemo.csproj
@@ -1,0 +1,58 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9A705C9B-9912-4A73-B03F-3E9024DADE4A}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>HostDemo</RootNamespace>
+    <AssemblyName>HostDemo</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NServiceBus.Core\NServiceBus.Core.csproj">
+      <Project>{1bc5ac12-6b4a-4770-b7b1-1a62bee86a90}</Project>
+      <Name>NServiceBus.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/HostDemo/Program.cs
+++ b/src/HostDemo/Program.cs
@@ -5,6 +5,7 @@
     using System.Reflection;
     using System.Threading.Tasks;
     using NServiceBus;
+    using NServiceBus.Unicast.Subscriptions;
 
     class Program
     {
@@ -20,10 +21,11 @@
             var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
 
             endpointConfiguration.UseTransport<LearningTransport>();
-
+            
             var hostInstance = await Host.Start(hostConfiguration, endpointConfiguration);
 
-            await hostInstance.Endpoint.SendLocal(new MyMessage());
+            await hostInstance.EndpointInstance.SendLocal(new MyMessage());
+
             Console.ReadKey();
 
             await hostInstance.Stop();

--- a/src/HostDemo/Program.cs
+++ b/src/HostDemo/Program.cs
@@ -1,0 +1,66 @@
+﻿namespace HostDemo
+{
+    using System;
+    using System.IO;
+    using System.Reflection;
+    using System.Threading.Tasks;
+    using NServiceBus;
+
+    class Program
+    {
+        static void Main()
+        {
+            AsyncMain().GetAwaiter().GetResult();
+        }
+
+        static async Task AsyncMain()
+        {
+            var hostConfiguration = ConsoleHostBuilder.Build();
+
+            var endpointConfiguration = new EndpointConfiguration("MyEndpoint");
+
+            endpointConfiguration.UseTransport<LearningTransport>();
+
+            var hostInstance = await Host.Start(hostConfiguration, endpointConfiguration);
+
+            await hostInstance.Endpoint.SendLocal(new MyMessage());
+            Console.ReadKey();
+
+            await hostInstance.Stop();
+        }
+    }
+
+    class MyMessageHandler : IHandleMessages<MyMessage>
+    {
+        public Task Handle(MyMessage message, IMessageHandlerContext context)
+        {
+            Console.Out.WriteLine("yay!");
+
+            Console.Out.WriteLine("This message came from: " + context.MessageHeaders["OriginatingHost"]);
+
+            return Task.CompletedTask;
+        }
+    }
+
+    class MyMessage : IMessage
+    {
+    }
+
+    //Example host => this would be in a different asm/nuget
+    class ConsoleHostBuilder
+    {
+        public static HostConfiguration Build()
+        {
+            var entryAsm = Assembly.GetEntryAssembly();
+            var diagnosticsBasePath = Path.Combine(Directory.GetParent(entryAsm.Location).FullName, ".diagnostics");
+
+            //TODO: We can set up logging here to `X` but we need to expose a better api for the log manager first
+
+            return new HostConfiguration(entryAsm.GetName().Name, diagnosticsBasePath, context =>
+            {
+                Console.Out.WriteLine("Bummer: " + context.Exception.Message);
+                return Task.CompletedTask;
+            });
+        }
+    }
+}

--- a/src/HostDemo/Properties/AssemblyInfo.cs
+++ b/src/HostDemo/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("HostDemo")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("HostDemo")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("9a705c9b-9912-4a73-b03f-3e9024dade4a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/NServiceBus.Core/HostConfiguration.cs
+++ b/src/NServiceBus.Core/HostConfiguration.cs
@@ -45,7 +45,7 @@ namespace NServiceBus
 
 
             //the host should use extension points as much as possible to enrich messages etc. Eg. the Audit and Error enrichers should be move here eventually
-            endpointConfiguration.Pipeline.Register(b => new AddOriginatingHostHeaders(hostId), "Add hostid on outgoing messages");
+            endpointConfiguration.Pipeline.Register(b => new AddOriginatingHostIdHeaders(hostId), "Add hostid on outgoing messages");
 
             endpoints.Add(endpointConfiguration);
          
@@ -58,11 +58,11 @@ namespace NServiceBus
         List<EndpointConfiguration> endpoints = new List<EndpointConfiguration>();
     }
 
-    class AddOriginatingHostHeaders : Behavior<IOutgoingPhysicalMessageContext>
+    class AddOriginatingHostIdHeaders : Behavior<IOutgoingPhysicalMessageContext>
     {
         string hostId;
 
-        public AddOriginatingHostHeaders(string hostId)
+        public AddOriginatingHostIdHeaders(string hostId)
         {
             this.hostId = hostId;
         }
@@ -115,24 +115,24 @@ namespace NServiceBus
     /// </summary>
     public class HostInstance
     {
-        internal HostInstance(IEndpointInstance endpoint)
+        internal HostInstance(IEndpointInstance endpointInstance)
         {
-            this.endpoint = endpoint;
+            this.endpointInstance = endpointInstance;
         }
 
         /// <summary>
         /// 
         /// </summary>
-        public IEndpointInstance Endpoint => endpoint;
+        public IEndpointInstance EndpointInstance => endpointInstance;
 
         /// <summary>
         /// </summary>
         /// <returns></returns>
         public Task Stop()
         {
-            return endpoint.Stop();
+            return endpointInstance.Stop();
         }
 
-        IEndpointInstance endpoint;
+        IEndpointInstance endpointInstance;
     }
 }

--- a/src/NServiceBus.Core/HostConfiguration.cs
+++ b/src/NServiceBus.Core/HostConfiguration.cs
@@ -1,0 +1,138 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Pipeline;
+
+    /// <summary>
+    /// </summary>
+    public class HostConfiguration
+    {
+        /// <summary>
+        /// </summary>
+        /// <param name="hostId"></param>
+        /// <param name="diagnosticsBasePath"></param>
+        /// <param name="onCriticalErrorAction"></param>
+        public HostConfiguration(string hostId,string diagnosticsBasePath, Func<ICriticalErrorContext, Task> onCriticalErrorAction)
+        {
+            this.hostId = hostId;
+            this.diagnosticsBasePath = diagnosticsBasePath;
+            this.onCriticalErrorAction = onCriticalErrorAction;
+        }
+
+        internal StartableHost Build(EndpointConfiguration endpointConfiguration)
+        {
+            //guid sucks here, we should use a string instead in the future
+            if (Guid.TryParse(hostId, out var guidHostId))
+            {
+                guidHostId = DeterministicGuid.Create(hostId);
+            }
+
+            var hostInfo = endpointConfiguration.UniquelyIdentifyRunningInstance();
+
+            hostInfo.UsingCustomIdentifier(guidHostId);
+
+            endpointConfiguration.DefineCriticalErrorAction(async context =>
+            {
+                //Update status and stuff
+
+                //do what the user wants
+                await onCriticalErrorAction(context).ConfigureAwait(false);
+
+                //other actions
+            });
+
+
+            //the host should use extension points as much as possible to enrich messages etc. Eg. the Audit and Error enrichers should be move here eventually
+            endpointConfiguration.Pipeline.Register(b => new AddOriginatingHostHeaders(hostId), "Add hostid on outgoing messages");
+
+            endpoints.Add(endpointConfiguration);
+         
+            return new StartableHost(endpointConfiguration.Build());
+        }
+        
+        string hostId;
+        string diagnosticsBasePath;//logging, dumps of config settings , etc would go here. We would also expose this to downstreams so they can write stuff in here
+        Func<ICriticalErrorContext, Task> onCriticalErrorAction;
+        List<EndpointConfiguration> endpoints = new List<EndpointConfiguration>();
+    }
+
+    class AddOriginatingHostHeaders : Behavior<IOutgoingPhysicalMessageContext>
+    {
+        string hostId;
+
+        public AddOriginatingHostHeaders(string hostId)
+        {
+            this.hostId = hostId;
+        }
+
+        public override Task Invoke(IOutgoingPhysicalMessageContext context, Func<Task> next)
+        {
+            context.Headers["OriginatingHost"] = hostId;
+
+            return next();
+        }
+    }
+
+    /// <summary>
+    /// </summary>
+    public static class Host
+    {
+        /// <summary>
+        /// </summary>
+        /// <param name="configuration"></param>
+        /// <param name="endpointConfiguration"></param>
+        /// <returns></returns>
+        public static async Task<HostInstance> Start(HostConfiguration configuration, EndpointConfiguration endpointConfiguration)
+        {
+            var startable = configuration.Build(endpointConfiguration);
+
+
+            return await startable.Start().ConfigureAwait(false);
+        }
+    }
+
+    class StartableHost
+    {
+        public StartableHost(InitializableEndpoint endpoint)
+        {
+            this.endpoint = endpoint;
+        }
+
+        public async Task<HostInstance> Start()
+        {
+            var startable = await endpoint.Initialize().ConfigureAwait(false);
+            var instance = await startable.Start().ConfigureAwait(false);
+
+            return new HostInstance(instance);
+        }
+
+        InitializableEndpoint endpoint;
+    }
+
+    /// <summary>
+    /// </summary>
+    public class HostInstance
+    {
+        internal HostInstance(IEndpointInstance endpoint)
+        {
+            this.endpoint = endpoint;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public IEndpointInstance Endpoint => endpoint;
+
+        /// <summary>
+        /// </summary>
+        /// <returns></returns>
+        public Task Stop()
+        {
+            return endpoint.Stop();
+        }
+
+        IEndpointInstance endpoint;
+    }
+}

--- a/src/NServiceBus.sln
+++ b/src/NServiceBus.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.3
+VisualStudioVersion = 15.0.26730.15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{2904B75F-8F07-4C07-BABC-BC42533B3E75}"
 EndProject
@@ -25,6 +25,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HostDemo", "HostDemo\HostDemo.csproj", "{9A705C9B-9912-4A73-B03F-3E9024DADE4A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -60,6 +62,10 @@ Global
 		{65578230-EF42-43A6-A943-624F2DF01E66}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{65578230-EF42-43A6-A943-624F2DF01E66}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{65578230-EF42-43A6-A943-624F2DF01E66}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9A705C9B-9912-4A73-B03F-3E9024DADE4A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9A705C9B-9912-4A73-B03F-3E9024DADE4A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9A705C9B-9912-4A73-B03F-3E9024DADE4A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9A705C9B-9912-4A73-B03F-3E9024DADE4A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
We're starting to see the need to configuring hosting related thing more explicitly so this spike aims to show a proposed way forward.

This allows us to:

* Make things that should be mandatory from a host perspective mandatory
* Start to move host related things from the endpoint config to this new api. HostId, CriticalError action, logging etc etc
* Provide sensible host related defaults, the demo contains a `ConsoleHostBuilder` but you can imaging similar builders for WindowsServices, IIS, Azure WebRoles, ServiceFabric etc etc
* Hook new functionality in against this new `HostConfiguration` API
* Start to add this in a minor since there is no breaking changes, we can also obsolete existing API's with WARN to start to move users towards this
* Pull existing code related to hosting out and use extension points instead, this spike shows how to enrich outgoing messages with the HostId of the host. We can similarly use the error and audit pipelines to enrich those message with `HostId` instead of "hardcoding" it like we do today. 

[This is how it would look like](https://github.com/Particular/NServiceBus/pull/4952/files#diff-52f25ae2be41a7526b38fa320c87e3e8R17)


Not in scope:

We've talked about a `BusConfiguration` concept that would cover things like Transport, Serializer etc => settings that needs to be synced across endpoints. This is not included since IMO its not really related to this.