### PR TITLE
remove release filter on reporter config

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalTestConfig.cs
+++ b/src/NServiceBus.Core.Tests/ApprovalTestConfig.cs
@@ -1,6 +1,2 @@
 ﻿using ApprovalTests.Reporters;
-#if(DEBUG)
 [assembly: UseReporter(typeof(DiffReporter), typeof(AllFailingTestsClipboardReporter))]
-#else
-[assembly: UseReporter(typeof(DiffReporter))]
-#endif


### PR DESCRIPTION
this was to work around a bug in an earlier version on approval tests. and is no longer reauired