### PR TITLE
SubscriberReturnAddress can be case sensitive since it is changed according to the transports address translation rules

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/SubscriptionBehavior.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/SubscriptionBehavior.cs
@@ -25,6 +25,11 @@
                     context.Message.Headers.TryGetValue(Headers.ReplyToAddress, out returnAddress);
                 }
 
+                if (!context.Message.Headers.TryGetValue(Headers.SubscriberEndpoint, out var endpointName))
+                {
+                    endpointName = string.Empty;
+                }
+
                 var intent = (MessageIntentEnum)Enum.Parse(typeof(MessageIntentEnum), context.Message.Headers[Headers.MessageIntent], true);
                 if (intent != intentToHandle)
                 {
@@ -34,7 +39,8 @@
                 action(new SubscriptionEventArgs
                 {
                     MessageType = subscriptionMessageType,
-                    SubscriberReturnAddress = returnAddress
+                    SubscriberReturnAddress = returnAddress,
+                    SubscriberEndpoint = endpointName
                 }, scenarioContext);
             }
         }

--- a/src/NServiceBus.AcceptanceTesting/Support/SubscriptionEventArgs.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/SubscriptionEventArgs.cs
@@ -3,6 +3,11 @@
     public class SubscriptionEventArgs
     {
         /// <summary>
+        /// The name of the subscriber endpoint.
+        /// </summary>
+        public string SubscriberEndpoint { get; set; }
+        
+        /// <summary>
         /// The address of the subscriber.
         /// </summary>
         public string SubscriberReturnAddress { get; set; }

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_unsubscribing_from_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_unsubscribing_from_event.cs
@@ -60,19 +60,19 @@
                 {
                     c.OnEndpointSubscribed<Context>((args, ctx) =>
                     {
-                        if (args.SubscriberReturnAddress.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber1))))
+                        if (args.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber1))))
                         {
                             ctx.Subscriber1Subscribed = true;
                         }
 
-                        if (args.SubscriberReturnAddress.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber2))))
+                        if (args.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber2))))
                         {
                             ctx.Subscriber2Subscribed = true;
                         }
                     });
                     c.OnEndpointUnsubscribed<Context>((args, ctx) =>
                     {
-                        if (args.SubscriberReturnAddress.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber2))))
+                        if (args.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber2))))
                         {
                             ctx.Subscriber2Unsubscribed = true;
                         }

--- a/src/NServiceBus.AcceptanceTests/Routing/When_base_event_from_2_publishers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_base_event_from_2_publishers.cs
@@ -5,6 +5,7 @@
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
+    using Conventions = AcceptanceTesting.Customization.Conventions;
 
     public class When_base_event_from_2_publishers : NServiceBusAcceptanceTest
     {
@@ -50,8 +51,8 @@
             {
                 EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
                 {
-                    context.AddTrace("Publisher1 SubscriberReturnAddress=" + s.SubscriberReturnAddress);
-                    if (s.SubscriberReturnAddress.Contains("Subscriber1"))
+                    context.AddTrace($"{Conventions.EndpointNamingConvention(typeof(Publisher1))} SubscriberEndpoint={s.SubscriberEndpoint}");
+                    if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber1))))
                     {
                         context.SubscribedToPublisher1 = true;
                     }
@@ -65,9 +66,9 @@
             {
                 EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
                 {
-                    context.AddTrace("Publisher2 SubscriberReturnAddress=" + s.SubscriberReturnAddress);
+                    context.AddTrace($"{Conventions.EndpointNamingConvention(typeof(Publisher2))} SubscriberEndpoint={s.SubscriberEndpoint}");
 
-                    if (s.SubscriberReturnAddress.Contains("Subscriber1"))
+                    if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber1))))
                     {
                         context.SubscribedToPublisher2 = true;
                     }
@@ -93,11 +94,11 @@
 
                 public Task Handle(BaseEvent message, IMessageHandlerContext context)
                 {
-                    if (message.GetType().FullName.Contains("DerivedEvent1"))
+                    if (message.GetType().FullName.Contains(nameof(DerivedEvent1)))
                     {
                         Context.GotTheEventFromPublisher1 = true;
                     }
-                    if (message.GetType().FullName.Contains("DerivedEvent2"))
+                    if (message.GetType().FullName.Contains(nameof(DerivedEvent1)))
                     {
                         Context.GotTheEventFromPublisher2 = true;
                     }

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing.cs
@@ -6,6 +6,7 @@
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
+    using Conventions = AcceptanceTesting.Customization.Conventions;
 
     public class When_publishing : NServiceBusAcceptanceTest
     {
@@ -100,15 +101,17 @@
                 {
                     b.OnEndpointSubscribed<Context>((s, context) =>
                     {
-                        if (s.SubscriberReturnAddress.Contains("Subscriber1"))
+                        var subscriber1 = Conventions.EndpointNamingConvention(typeof(Subscriber1));
+                        if (s.SubscriberEndpoint.Contains(subscriber1))
                         {
                             context.Subscriber1Subscribed = true;
-                            context.AddTrace("Subscriber1 is now subscribed");
+                            context.AddTrace($"{subscriber1} is now subscribed");
                         }
 
-                        if (s.SubscriberReturnAddress.Contains("Subscriber2"))
+                        var subscriber2 = Conventions.EndpointNamingConvention(typeof(Subscriber2));
+                        if (s.SubscriberEndpoint.Contains(subscriber2))
                         {
-                            context.AddTrace("Subscriber2 is now subscribed");
+                            context.AddTrace($"{subscriber2} is now subscribed");
                             context.Subscriber2Subscribed = true;
                         }
                     });
@@ -123,8 +126,10 @@
             {
                 EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
                 {
-                    if (s.SubscriberReturnAddress.Contains("Subscriber3"))
+                    var subscriber3 = Conventions.EndpointNamingConvention(typeof(Subscriber3));
+                    if (s.SubscriberEndpoint.Contains(subscriber3))
                     {
+                        context.AddTrace($"{subscriber3} is now subscribed");
                         context.Subscriber3Subscribed = true;
                     }
                 }));

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
@@ -6,6 +6,7 @@
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
+    using Conventions = AcceptanceTesting.Customization.Conventions;
 
     public class When_publishing_an_event_implementing_two_unrelated_interfaces : NServiceBusAcceptanceTest
     {
@@ -57,7 +58,7 @@
                 {
                     b.OnEndpointSubscribed<Context>((s, context) =>
                     {
-                        if (s.SubscriberReturnAddress.Contains("Subscriber"))
+                        if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber))))
                         {
                             if (s.MessageType == typeof(IEventA).AssemblyQualifiedName)
                             {

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface.cs
@@ -7,6 +7,7 @@
     using Features;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
+    using Conventions = AcceptanceTesting.Customization.Conventions;
 
     public class When_publishing_an_interface : NServiceBusAcceptanceTest
     {
@@ -47,7 +48,7 @@
                     c.Pipeline.Register("EventTypeSpy", new EventTypeSpy((Context)ScenarioContext), "EventTypeSpy");
                     c.OnEndpointSubscribed<Context>((s, context) =>
                     {
-                        if (s.SubscriberReturnAddress.Contains("Subscriber"))
+                        if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber))))
                         {
                             context.Subscribed = true;
                         }

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface_with_unobtrusive.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface_with_unobtrusive.cs
@@ -7,6 +7,7 @@
     using Features;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
+    using Conventions = AcceptanceTesting.Customization.Conventions;
 
     public class When_publishing_an_interface_with_unobtrusive : NServiceBusAcceptanceTest
     {
@@ -48,7 +49,7 @@
                     c.Pipeline.Register("EventTypeSpy", typeof(EventTypeSpy), "EventTypeSpy");
                     c.OnEndpointSubscribed<Context>((s, context) =>
                     {
-                        if (s.SubscriberReturnAddress.Contains("Subscriber"))
+                        if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber))))
                         {
                             context.Subscribed = true;
                         }

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_using_base_type.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_using_base_type.cs
@@ -6,6 +6,7 @@
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
+    using Conventions = AcceptanceTesting.Customization.Conventions;
 
     public class When_publishing_using_base_type : NServiceBusAcceptanceTest
     {
@@ -47,7 +48,7 @@
             {
                 EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
                 {
-                    if (s.SubscriberReturnAddress.Contains("Subscriber1"))
+                    if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber1))))
                     {
                         context.Subscriber1Subscribed = true;
                     }

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_with_overridden_local_address.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_with_overridden_local_address.cs
@@ -8,7 +8,7 @@
 
     public class When_publishing_with_overridden_local_address : NServiceBusAcceptanceTest
     {
-        [Test, Explicit("This test fails against RabbitMQ")]
+        [Test]
         public async Task Should_be_delivered_to_all_subscribers()
         {
             var context = await Scenario.Define<Context>()
@@ -57,6 +57,7 @@
                 EndpointSetup<DefaultServer>(builder =>
                 {
                     builder.DisableFeature<AutoSubscribe>();
+                    builder.OverrideLocalAddress("myinputqueue");
                 },
                 metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
             }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_base_event_from_other_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_base_event_from_other_saga.cs
@@ -46,7 +46,7 @@
             {
                 EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<SagaContext>((s, context) =>
                 {
-                    context.AddTrace("Subscription received for " + s.SubscriberReturnAddress);
+                    context.AddTrace($"Subscription received for {s.SubscriberEndpoint}");
                     context.IsEventSubscriptionReceived = true;
                 }));
             }

--- a/src/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
+++ b/src/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
@@ -5,6 +5,7 @@
     using EndpointTemplates;
     using Features;
     using NUnit.Framework;
+    using Conventions = AcceptanceTesting.Customization.Conventions;
 
     public class When_multiple_versions_of_a_message_is_published : NServiceBusAcceptanceTest
     {
@@ -61,12 +62,12 @@
             {
                 EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
                 {
-                    if (s.SubscriberReturnAddress.Contains("V1Subscriber"))
+                    if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(V1Subscriber))))
                     {
                         context.V1Subscribed = true;
                     }
 
-                    if (s.SubscriberReturnAddress.Contains("V2Subscriber"))
+                    if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(V2Subscriber))))
                     {
                         context.V2Subscribed = true;
                     }


### PR DESCRIPTION
While fixing https://github.com/Particular/NServiceBus.AzureStorageQueues/issues/261 we detected that the build started suddenly failing. All tests that used

```
if (s.SubscriberReturnAddress.Contains("Subscriber1"))
```

where subjected to this since ASQ ToTransportAddress lower-cases all queues. Using the `SubscriberReturnAddress `is not a safe way to check whether an endpoint is subscriber with message driven pubsub. This was never detected in the core because the learning transport has native pubsub.

This PR introduces `SubscriberEndpoint `alongside with `SubscriberReturnAddress` since there is one test that still requires `SubscriberReturnAddress`. See more details in the inline comments