### PR TITLE
Remove msmq obsolete messages

### DIFF
--- a/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.ApproveNServiceBus.approved.txt
@@ -314,15 +314,6 @@ namespace NServiceBus
             where T : NServiceBus.Features.Feature { }
         public static void EnableFeature(this NServiceBus.EndpointConfiguration config, System.Type featureType) { }
     }
-    [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Wi" +
-        "ll be removed in version 8.0.0.", true)]
-    public class static EndpointInstanceExtensions
-    {
-        [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Th" +
-            "e member currently throws a NotImplementedException. Will be removed in version " +
-            "8.0.0.", true)]
-        public static NServiceBus.Routing.EndpointInstance AtMachine(this NServiceBus.Routing.EndpointInstance instance, string machineName) { }
-    }
     public class static ErrorQueueSettings
     {
         public const string SettingsKey = "errorQueue";
@@ -544,23 +535,6 @@ namespace NServiceBus
         public static void DisableInstallers(this NServiceBus.EndpointConfiguration config) { }
         public static void EnableInstallers(this NServiceBus.EndpointConfiguration config, string username = null) { }
     }
-    [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Wi" +
-        "ll be removed in version 8.0.0.", true)]
-    public class InstanceMappingFileSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
-    {
-        [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Th" +
-            "e member currently throws a NotImplementedException. Will be removed in version " +
-            "8.0.0.", true)]
-        public InstanceMappingFileSettings(NServiceBus.Settings.SettingsHolder settings) { }
-        [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Th" +
-            "e member currently throws a NotImplementedException. Will be removed in version " +
-            "8.0.0.", true)]
-        public NServiceBus.InstanceMappingFileSettings FilePath(string filePath) { }
-        [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Th" +
-            "e member currently throws a NotImplementedException. Will be removed in version " +
-            "8.0.0.", true)]
-        public NServiceBus.InstanceMappingFileSettings RefreshInterval(System.TimeSpan refreshInterval) { }
-    }
     public interface IPipelineContext : NServiceBus.Extensibility.IExtendable
     {
         System.Threading.Tasks.Task Publish(object message, NServiceBus.PublishOptions options);
@@ -677,49 +651,6 @@ namespace NServiceBus
     public sealed class MoveToError : NServiceBus.RecoverabilityAction
     {
         public string ErrorQueue { get; }
-    }
-    [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Wi" +
-        "ll be removed in version 8.0.0.", true)]
-    public class static MsmqConfigurationExtensions
-    {
-        [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Th" +
-            "e member currently throws a NotImplementedException. Will be removed in version " +
-            "8.0.0.", true)]
-        public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> ApplyLabelToMessages(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> transportExtensions, System.Func<System.Collections.Generic.IReadOnlyDictionary<string, string>, string> labelGenerator) { }
-        [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Th" +
-            "e member currently throws a NotImplementedException. Will be removed in version " +
-            "8.0.0.", true)]
-        public static NServiceBus.InstanceMappingFileSettings InstanceMappingFile(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config) { }
-        [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Th" +
-            "e member currently throws a NotImplementedException. Will be removed in version " +
-            "8.0.0.", true)]
-        public static void SetMessageDistributionStrategy(this NServiceBus.RoutingSettings<NServiceBus.MsmqTransport> config, NServiceBus.Routing.DistributionStrategy distributionStrategy) { }
-        [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Th" +
-            "e member currently throws a NotImplementedException. Will be removed in version " +
-            "8.0.0.", true)]
-        public static NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> TransactionScopeOptions(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> transportExtensions, System.Nullable<System.TimeSpan> timeout = null, System.Nullable<System.Transactions.IsolationLevel> isolationLevel = null) { }
-        [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Th" +
-            "e member currently throws a NotImplementedException. Will be removed in version " +
-            "8.0.0.", true)]
-        public static void UseDeadLetterQueueForMessagesWithTimeToBeReceived(this NServiceBus.TransportExtensions<NServiceBus.MsmqTransport> config) { }
-    }
-    [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Wi" +
-        "ll be removed in version 8.0.0.", true)]
-    public class MsmqTransport : NServiceBus.Transport.TransportDefinition, NServiceBus.Routing.IMessageDrivenSubscriptionTransport
-    {
-        public MsmqTransport() { }
-        [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Th" +
-            "e member currently throws a NotImplementedException. Will be removed in version " +
-            "8.0.0.", true)]
-        public override string ExampleConnectionStringForErrorMessage { get; }
-        [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Th" +
-            "e member currently throws a NotImplementedException. Will be removed in version " +
-            "8.0.0.", true)]
-        public override bool RequiresConnectionString { get; }
-        [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Th" +
-            "e member currently throws a NotImplementedException. Will be removed in version " +
-            "8.0.0.", true)]
-        public override NServiceBus.Transport.TransportInfrastructure Initialize(NServiceBus.Settings.SettingsHolder settings, string connectionString) { }
     }
     public class NonDurableDelivery : NServiceBus.DeliveryConstraints.DeliveryConstraint
     {
@@ -1603,12 +1534,6 @@ namespace NServiceBus.Features
     {
         protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
-    [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Wi" +
-        "ll be removed in version 8.0.0.", true)]
-    public class MsmqSubscriptionPersistence
-    {
-        public MsmqSubscriptionPersistence() { }
-    }
     public class Outbox : NServiceBus.Features.Feature
     {
         protected internal override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
@@ -1946,24 +1871,6 @@ namespace NServiceBus.Persistence
         public sealed class Timeouts : NServiceBus.Persistence.StorageType { }
     }
     public interface SynchronizedStorageSession { }
-}
-namespace NServiceBus.Persistence.Legacy
-{
-    [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Wi" +
-        "ll be removed in version 8.0.0.", true)]
-    public class MsmqPersistence : NServiceBus.Persistence.PersistenceDefinition
-    {
-        public MsmqPersistence() { }
-    }
-    [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Wi" +
-        "ll be removed in version 8.0.0.", true)]
-    public class static MsmqSubscriptionStorageConfigurationExtensions
-    {
-        [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Th" +
-            "e member currently throws a NotImplementedException. Will be removed in version " +
-            "8.0.0.", true)]
-        public static void SubscriptionQueue(this NServiceBus.PersistenceExtensions<NServiceBus.Persistence.Legacy.MsmqPersistence> persistenceExtensions, string queue) { }
-    }
 }
 namespace NServiceBus.Pipeline
 {
@@ -2709,17 +2616,6 @@ namespace NServiceBus.Transport
         public string Destination { get; }
         public NServiceBus.Transport.OutgoingMessage Message { get; }
         public NServiceBus.Transport.DispatchConsistency RequiredDispatchConsistency { get; }
-    }
-}
-namespace NServiceBus.Transport.Msmq
-{
-    [System.ObsoleteAttribute("Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq. Wi" +
-        "ll be removed in version 8.0.0.", true)]
-    public class HeaderInfo
-    {
-        public HeaderInfo() { }
-        public string Key { get; set; }
-        public string Value { get; set; }
     }
 }
 namespace NServiceBus.Unicast

--- a/src/NServiceBus.Core/obsoletes.cs
+++ b/src/NServiceBus.Core/obsoletes.cs
@@ -11,7 +11,6 @@ namespace NServiceBus
     using System.Reflection;
     using System.Runtime.Serialization;
     using System.Text;
-    using System.Transactions;
     using Config.ConfigurationSource;
     using MessageInterfaces;
     using Pipeline;
@@ -372,137 +371,6 @@ namespace NServiceBus
             set { throw new NotImplementedException(); }
         }
     }
-
-    [ObsoleteEx(
-        Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-        RemoveInVersion = "8",
-        TreatAsErrorFromVersion = "7")]
-    public static class EndpointInstanceExtensions
-    {
-        [ObsoleteEx(
-            Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-            RemoveInVersion = "8",
-            TreatAsErrorFromVersion = "7")]
-        public static Routing.EndpointInstance AtMachine(this Routing.EndpointInstance instance, string machineName)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
-    [ObsoleteEx(
-        Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-        RemoveInVersion = "8",
-        TreatAsErrorFromVersion = "7")]
-    public class InstanceMappingFileSettings : Configuration.AdvancedExtensibility.ExposeSettings 
-    {
-        [ObsoleteEx(
-            Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-            RemoveInVersion = "8",
-            TreatAsErrorFromVersion = "7")]
-        public InstanceMappingFileSettings(SettingsHolder settings) : base(settings)
-        {
-            throw new NotImplementedException();
-        }
-
-        [ObsoleteEx(
-            Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-            RemoveInVersion = "8",
-            TreatAsErrorFromVersion = "7")]
-        public InstanceMappingFileSettings FilePath(string filePath)
-        {
-            throw new NotImplementedException();
-        }
-
-        [ObsoleteEx(
-            Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-            RemoveInVersion = "8",
-            TreatAsErrorFromVersion = "7")]
-        public InstanceMappingFileSettings RefreshInterval(TimeSpan refreshInterval)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
-    [ObsoleteEx(
-        Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-        RemoveInVersion = "8",
-        TreatAsErrorFromVersion = "7")]
-    public class MsmqTransport : Transport.TransportDefinition, Routing.IMessageDrivenSubscriptionTransport
-    {
-        [ObsoleteEx(
-            Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-            RemoveInVersion = "8",
-            TreatAsErrorFromVersion = "7")]
-        public override string ExampleConnectionStringForErrorMessage => throw new NotImplementedException();
-
-        [ObsoleteEx(
-            Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-            RemoveInVersion = "8",
-            TreatAsErrorFromVersion = "7")]
-        public override bool RequiresConnectionString => throw new NotImplementedException();
-
-        [ObsoleteEx(
-            Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-            RemoveInVersion = "8",
-            TreatAsErrorFromVersion = "7")]
-        public override Transport.TransportInfrastructure Initialize(SettingsHolder settings, string connectionString)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
-    [ObsoleteEx(
-        Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-        RemoveInVersion = "8",
-        TreatAsErrorFromVersion = "7")]
-    public static class MsmqConfigurationExtensions
-    {
-        [ObsoleteEx(
-            Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-            RemoveInVersion = "8",
-            TreatAsErrorFromVersion = "7")]
-        public static TransportExtensions<MsmqTransport> ApplyLabelToMessages(this TransportExtensions<MsmqTransport> transportExtensions, Func<IReadOnlyDictionary<string, string>, string> labelGenerator)
-        {
-            throw new NotImplementedException();
-        }
-
-        [ObsoleteEx(
-            Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-            RemoveInVersion = "8",
-            TreatAsErrorFromVersion = "7")]
-        public static InstanceMappingFileSettings InstanceMappingFile(this RoutingSettings<MsmqTransport> config)
-        {
-            throw new NotImplementedException();
-        }
-
-        [ObsoleteEx(
-            Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-            RemoveInVersion = "8",
-            TreatAsErrorFromVersion = "7")]
-        public static void SetMessageDistributionStrategy(this RoutingSettings<MsmqTransport> config, Routing.DistributionStrategy distributionStrategy)
-        {
-            throw new NotImplementedException();
-        }
-
-        [ObsoleteEx(
-            Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-            RemoveInVersion = "8",
-            TreatAsErrorFromVersion = "7")]
-        public static TransportExtensions<MsmqTransport> TransactionScopeOptions(this TransportExtensions<MsmqTransport> transportExtensions, TimeSpan? timeout = null, IsolationLevel? isolationLevel = null)
-        {
-            throw new NotImplementedException();
-        }
-
-        [ObsoleteEx(
-            Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-            RemoveInVersion = "8",
-            TreatAsErrorFromVersion = "7")]
-        public static void UseDeadLetterQueueForMessagesWithTimeToBeReceived(this TransportExtensions<MsmqTransport> config)
-        {
-            throw new NotImplementedException();
-        }
-    }
-
 }
 
 namespace NServiceBus.Config
@@ -1093,11 +961,6 @@ namespace NServiceBus.Features
         TreatAsErrorFromVersion = "7")]
     public class SLAMonitoring { }
 
-    [ObsoleteEx(
-        Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-        RemoveInVersion = "8",
-        TreatAsErrorFromVersion = "7")]
-    public class MsmqSubscriptionPersistence {}
 }
 
 namespace NServiceBus.Routing.Legacy
@@ -1147,47 +1010,6 @@ namespace NServiceBus.Transport
         {
             get { throw new NotImplementedException(); }
             set { throw new NotImplementedException(); }
-        }
-    }
-}
-
-namespace NServiceBus.Transport.Msmq
-{
-    
-    [ObsoleteEx(
-        Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-        RemoveInVersion = "8",
-        TreatAsErrorFromVersion = "7")]
-    public class HeaderInfo
-    {
-        public string Key { get; set; }
-        public string Value { get; set; }
-    }
-}
-
-namespace NServiceBus.Persistence.Legacy
-{
-    using System;
-
-    [ObsoleteEx(
-        Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-        RemoveInVersion = "8",
-        TreatAsErrorFromVersion = "7")]
-    public class MsmqPersistence : PersistenceDefinition { }
-
-    [ObsoleteEx(
-        Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-        RemoveInVersion = "8",
-        TreatAsErrorFromVersion = "7")]
-    public static class MsmqSubscriptionStorageConfigurationExtensions
-    {
-        [ObsoleteEx(
-            Message = "Msmq support has been moved to a separate package: NServiceBus.Transport.Msmq",
-            RemoveInVersion = "8",
-            TreatAsErrorFromVersion = "7")]
-        public static void SubscriptionQueue(this PersistenceExtensions<MsmqPersistence> persistenceExtensions, string queue)
-        {
-            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
Can't have the types in both core and in new msmq package unfortunately. Causes "type found in both assemblies bla blah" errors for users.