### PR TITLE
Always try to get a connection string

### DIFF
--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -44,14 +44,7 @@ namespace NServiceBus
 
             EnsureTransportConfigured();
             var transportDefinition = settings.Get<TransportDefinition>();
-
-            string connectionString = null;
-
-            if (transportDefinition.RequiresConnectionString)
-            {
-                connectionString = settings.Get<TransportConnectionString>().GetConnectionStringOrRaiseError(transportDefinition);
-            }
-
+            var connectionString = settings.Get<TransportConnectionString>().GetConnectionStringOrRaiseError(transportDefinition);
             var transportInfrastructure = transportDefinition.Initialize(settings, connectionString);
             settings.Set<TransportInfrastructure>(transportInfrastructure);
 

--- a/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
@@ -41,7 +41,7 @@
         {
             var connectionString = GetValue();
 
-            if (connectionString == null)
+            if (connectionString == null && transportDefinition.RequiresConnectionString)
             {
                 throw new InvalidOperationException(string.Format(message, transportDefinition.GetType().Name, transportDefinition.ExampleConnectionStringForErrorMessage));
             }
@@ -88,7 +88,7 @@ or
         {
             var connectionString = GetValue();
 
-            if (connectionString == null)
+            if (connectionString == null && transportDefinition.RequiresConnectionString)
             {
                 throw new InvalidOperationException(string.Format(message, transportDefinition.GetType().Name, transportDefinition.ExampleConnectionStringForErrorMessage));
             }


### PR DESCRIPTION
A transport connection string will once again always be looked for, even when it's not mandatory.

Fixes #4961 