### PR TITLE
speed up some tests

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_dispatch_fails_on_removal_SendsAtomicWithReceive.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_dispatch_fails_on_removal_SendsAtomicWithReceive.cs
@@ -8,9 +8,9 @@
     using Features;
     using NServiceBus.Persistence;
     using NServiceBus.Pipeline;
+    using NServiceBus.Timeout.Core;
     using NUnit.Framework;
-    using Timeout.Core;
-
+    
     class When_dispatch_fails_on_removal_SendsAtomicWithReceive : NServiceBusAcceptanceTest
     {
         [Test]

--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_dispatch_fails_on_removal_TXScopes.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_dispatch_fails_on_removal_TXScopes.cs
@@ -9,8 +9,8 @@
     using NServiceBus;
     using NServiceBus.Persistence;
     using NServiceBus.Pipeline;
+    using NServiceBus.Timeout.Core;
     using NUnit.Framework;
-    using Timeout.Core;
     using Conventions = AcceptanceTesting.Customization.Conventions;
 
     public class When_dispatch_fails_on_removal_TXScopes : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_timeout_dispatch_fails.cs
@@ -9,8 +9,8 @@
     using NServiceBus;
     using NServiceBus.Persistence;
     using NServiceBus.Pipeline;
+    using NServiceBus.Timeout.Core;
     using NUnit.Framework;
-    using Timeout.Core;
     using Conventions = AcceptanceTesting.Customization.Conventions;
 
     public class When_timeout_dispatch_fails : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_timeout_storage_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_timeout_storage_fails.cs
@@ -8,9 +8,9 @@
     using Features;
     using NServiceBus;
     using NServiceBus.Persistence;
+    using NServiceBus.Timeout.Core;
     using NUnit.Framework;
-    using Timeout.Core;
-
+    
     public class When_timeout_storage_fails : NServiceBusAcceptanceTest
     {
         [Test]

--- a/src/NServiceBus.AcceptanceTests/Core/Timeout/CyclingOutageTimeoutPersister.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Timeout/CyclingOutageTimeoutPersister.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.Timeouts
+﻿namespace NServiceBus.AcceptanceTests.Core.Timeout
 {
     using System;
     using System.Collections.Concurrent;
@@ -6,7 +6,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using Extensibility;
-    using Timeout.Core;
+    using NServiceBus.Timeout.Core;
 
     /// <summary>
     /// This class mocks outages for timeout storage.

--- a/src/NServiceBus.AcceptanceTests/Core/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.Timeouts
+﻿namespace NServiceBus.AcceptanceTests.Core.Timeout
 {
     using System;
     using System.Threading.Tasks;
@@ -6,8 +6,8 @@
     using Configuration.AdvancedExtensibility;
     using EndpointTemplates;
     using Features;
+    using NServiceBus.Persistence;
     using NUnit.Framework;
-    using Persistence;
 
     class When_timeout_storage_is_unavailable_temporarily : NServiceBusAcceptanceTest
     {

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_using_special_characters_in_headers.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_using_special_characters_in_headers.cs
@@ -32,7 +32,7 @@
                     {
                         var options = new SendOptions();
                         options.RouteToThisEndpoint();
-                        options.DelayDeliveryWith(TimeSpan.FromSeconds(3));
+                        options.DelayDeliveryWith(TimeSpan.FromMilliseconds(100));
                         foreach (var specialHeader in specialHeaders)
                         {
                             options.SetHeader(specialHeader.Key, specialHeader.Value);

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_message_is_deferred_by_delayed_retries_using_dtc.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_message_is_deferred_by_delayed_retries_using_dtc.cs
@@ -50,7 +50,7 @@
                     recoverability.Delayed(settings =>
                     {
                         settings.NumberOfRetries(3);
-                        settings.TimeIncrease(TimeSpan.FromSeconds(1));
+                        settings.TimeIncrease(TimeSpan.FromMilliseconds(10));
                     });
                 });
             }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_using_special_characters_in_headers.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_using_special_characters_in_headers.cs
@@ -33,7 +33,7 @@
                     {
                         var options = new SendOptions();
                         options.RouteToThisEndpoint();
-                        options.DelayDeliveryWith(TimeSpan.FromSeconds(3));
+                        options.DelayDeliveryWith(TimeSpan.FromMilliseconds(100));
                         foreach (var specialHeader in specialHeaders)
                         {
                             options.SetHeader(specialHeader.Key, specialHeader.Value);

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_share_timeout_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_share_timeout_messages.cs
@@ -80,7 +80,7 @@
 
                 public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
                 {
-                    return RequestTimeout<MySagaTimeout>(context, TimeSpan.FromSeconds(10));
+                    return RequestTimeout<MySagaTimeout>(context, TimeSpan.FromMilliseconds(100));
                 }
 
                 public Task Timeout(MySagaTimeout state, IMessageHandlerContext context)

--- a/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired.cs
+++ b/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired.cs
@@ -37,7 +37,7 @@
             protected override async Task OnStart(IMessageSession session)
             {
                 await session.SendLocal(new MyMessage());
-                await Task.Delay(TimeSpan.FromSeconds(5));
+                await Task.Delay(TimeSpan.FromMilliseconds(200));
             }
 
             protected override Task OnStop(IMessageSession session)
@@ -65,7 +65,7 @@
             }
         }
 
-        [TimeToBeReceived("00:00:02")]
+        [TimeToBeReceived("00:00:0.200")]
         public class MyMessage : IMessage
         {
         }

--- a/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired.cs
+++ b/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired.cs
@@ -37,7 +37,7 @@
             protected override async Task OnStart(IMessageSession session)
             {
                 await session.SendLocal(new MyMessage());
-                await Task.Delay(TimeSpan.FromMilliseconds(200));
+                await Task.Delay(TimeSpan.FromMilliseconds(300));
             }
 
             protected override Task OnStop(IMessageSession session)

--- a/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired_convention.cs
+++ b/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired_convention.cs
@@ -37,7 +37,7 @@
             protected override async Task OnStart(IMessageSession session)
             {
                 await session.SendLocal(new MyMessage());
-                await Task.Delay(TimeSpan.FromSeconds(5));
+                await Task.Delay(TimeSpan.FromMilliseconds(500));
             }
 
             protected override Task OnStop(IMessageSession session)
@@ -57,7 +57,7 @@
                     {
                         if (messageType == typeof(MyMessage))
                         {
-                            return TimeSpan.FromSeconds(2);
+                            return TimeSpan.FromMilliseconds(100);
                         }
                         return TimeSpan.MaxValue;
                     });

--- a/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_not_expired.cs
+++ b/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_not_expired.cs
@@ -46,7 +46,6 @@
             }
         }
 
-        
         [TimeToBeReceived("00:00:10")]
         public class MyMessage : IMessage
         {

--- a/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_used_with_unobtrusive_mode.cs
+++ b/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_used_with_unobtrusive_mode.cs
@@ -59,7 +59,7 @@
                     {
                         if (messageType == typeof(MyCommand))
                         {
-                            return TimeSpan.FromSeconds(2);
+                            return TimeSpan.FromMilliseconds(100);
                         }
                         return TimeSpan.MaxValue;
                     });
@@ -81,7 +81,7 @@
         {
             protected override Task OnStart(IMessageSession session)
             {
-                return Task.Delay(TimeSpan.FromSeconds(5));
+                return Task.Delay(TimeSpan.FromSeconds(1));
             }
 
             protected override Task OnStop(IMessageSession session)

--- a/src/NServiceBus.AcceptanceTests/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
+++ b/src/NServiceBus.AcceptanceTests/Timeout/When_timeout_storage_is_unavailable_temporarily.cs
@@ -27,10 +27,10 @@
         [Test]
         public async Task Endpoint_should_not_shutdown()
         {
-            var stopTime = DateTime.UtcNow.AddSeconds(6);
+            var stopTime = DateTime.UtcNow.AddSeconds(2);
 
             var testContext =
-                await Scenario.Define<TimeoutTestContext>(c => { c.SecondsToWait = 3; })
+                await Scenario.Define<TimeoutTestContext>(c => { c.SecondsToWait = 1; })
                     .WithEndpoint<Endpoint>(b =>
                     {
                         b.CustomConfig((busConfig, context) =>
@@ -64,7 +64,7 @@
             {
                 EndpointSetup<DefaultServer>(config =>
                 {
-                    config.GetSettings().Set("TimeToWaitBeforeTriggeringCriticalErrorForTimeoutPersisterReceiver", TimeSpan.FromSeconds(7));
+                    config.GetSettings().Set("TimeToWaitBeforeTriggeringCriticalErrorForTimeoutPersisterReceiver", TimeSpan.FromSeconds(3));
                     config.EnableFeature<TimeoutManager>();
                     config.UsePersistence<CustomTimeoutPersister, StorageType.Timeouts>();
                 });


### PR DESCRIPTION
in testing shaves 20-30 secs of an acc test run. 

given sql persistence runs them 4 times (sql server core+net, mysql, oracle), it will speed up sql CI cc @Particular/sqlpersistence-maintainers 