### PR TITLE
Update Particular.Licensing.Sources to 1.0.0

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="SimpleJson" Version="0.38.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.2.4" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="1.0.0-alpha0004" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The 1.0.0 version of the package contains some fixes around the usage of `GetFolderPath` to find license file locations.