### PR TITLE
Change to unix-compatible environment variable name

### DIFF
--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -29,7 +29,7 @@
 
         static IConfigureTransportInfrastructure CreateConfigurer()
         {
-            var transportToUse = EnvironmentHelper.GetEnvironmentVariable("Transport.UseSpecific");
+            var transportToUse = EnvironmentHelper.GetEnvironmentVariable("Transport_UseSpecific");
 
             if (string.IsNullOrWhiteSpace(transportToUse))
             {


### PR DESCRIPTION
We need to stop using `.` in environment variable names because `.` is not a valid character for them on linux and macOS.