### PR TITLE
Move StorageType to root namespace

### DIFF
--- a/src/NServiceBus.AcceptanceTests/ConfigureEndpointLearningPersistence.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureEndpointLearningPersistence.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
-using NServiceBus.Persistence;
 using NUnit.Framework;
 
 public class ConfigureEndpointLearningPersistence : IConfigureEndpointTestExecution

--- a/src/NServiceBus.AcceptanceTests/Core/Persistence/When_a_persistence_does_not_support_outbox.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Persistence/When_a_persistence_does_not_support_outbox.cs
@@ -3,7 +3,6 @@ namespace NServiceBus.AcceptanceTests.Core.Persistence
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using NServiceBus.Persistence;
     using NUnit.Framework;
 
     public class When_a_persistence_does_not_support_outbox : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Core/Persistence/When_a_persistence_does_not_support_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Persistence/When_a_persistence_does_not_support_saga.cs
@@ -4,7 +4,6 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using NServiceBus.Persistence;
     using NUnit.Framework;
 
     public class When_a_persistence_does_not_support_saga : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Core/Persistence/When_a_persistence_does_not_support_subscriptions.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Persistence/When_a_persistence_does_not_support_subscriptions.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.AcceptanceTests.Core.Persistence
 {
     using AcceptanceTesting;
     using EndpointTemplates;
-    using NServiceBus.Persistence;
     using NUnit.Framework;
 
     public class When_a_persistence_does_not_support_subscriptions : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Core/Persistence/When_a_persistence_does_not_support_timeouts.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Persistence/When_a_persistence_does_not_support_timeouts.cs
@@ -4,7 +4,6 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using Features;
-    using NServiceBus.Persistence;
     using NUnit.Framework;
 
     public class When_a_persistence_does_not_support_timeouts : NServiceBusAcceptanceTest

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -681,7 +681,7 @@ namespace NServiceBus
             where T : NServiceBus.Persistence.PersistenceDefinition { }
         public static NServiceBus.PersistenceExtensions<T, S> UsePersistence<T, S>(this NServiceBus.EndpointConfiguration config)
             where T : NServiceBus.Persistence.PersistenceDefinition
-            where S : NServiceBus.Persistence.StorageType { }
+            where S : NServiceBus.StorageType { }
         public static NServiceBus.PersistenceExtensions UsePersistence(this NServiceBus.EndpointConfiguration config, System.Type definitionType) { }
     }
     public class PersistenceExtensions : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
@@ -696,7 +696,7 @@ namespace NServiceBus
     }
     public class PersistenceExtensions<T, S> : NServiceBus.PersistenceExtensions<T>
         where T : NServiceBus.Persistence.PersistenceDefinition
-        where S : NServiceBus.Persistence.StorageType
+        where S : NServiceBus.StorageType
     {
         public PersistenceExtensions(NServiceBus.Settings.SettingsHolder settings) { }
     }
@@ -900,6 +900,15 @@ namespace NServiceBus
     public class static StaticHeadersConfigExtensions
     {
         public static void AddHeaderToAllOutgoingMessages(this NServiceBus.EndpointConfiguration config, string key, string value) { }
+    }
+    public abstract class StorageType
+    {
+        public override string ToString() { }
+        public sealed class GatewayDeduplication : NServiceBus.StorageType { }
+        public sealed class Outbox : NServiceBus.StorageType { }
+        public sealed class Sagas : NServiceBus.StorageType { }
+        public sealed class Subscriptions : NServiceBus.StorageType { }
+        public sealed class Timeouts : NServiceBus.StorageType { }
     }
     public class SubscribeOptions : NServiceBus.Extensibility.ExtendableOptions
     {
@@ -1858,19 +1867,10 @@ namespace NServiceBus.Persistence
         protected PersistenceDefinition() { }
         protected void Defaults(System.Action<NServiceBus.Settings.SettingsHolder> action) { }
         public bool HasSupportFor<T>()
-            where T : NServiceBus.Persistence.StorageType { }
+            where T : NServiceBus.StorageType { }
         public bool HasSupportFor(System.Type storageType) { }
         protected void Supports<T>(System.Action<NServiceBus.Settings.SettingsHolder> action)
-            where T : NServiceBus.Persistence.StorageType { }
-    }
-    public abstract class StorageType
-    {
-        public override string ToString() { }
-        public sealed class GatewayDeduplication : NServiceBus.Persistence.StorageType { }
-        public sealed class Outbox : NServiceBus.Persistence.StorageType { }
-        public sealed class Sagas : NServiceBus.Persistence.StorageType { }
-        public sealed class Subscriptions : NServiceBus.Persistence.StorageType { }
-        public sealed class Timeouts : NServiceBus.Persistence.StorageType { }
+            where T : NServiceBus.StorageType { }
     }
     public interface SynchronizedStorageSession { }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/PersistenceStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/PersistenceStartupTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Core.Tests.Persistence
 {
-    using NServiceBus.Persistence;
     using NUnit.Framework;
     using Settings;
 

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
@@ -4,7 +4,6 @@
     using ConsistencyGuarantees;
     using DelayedDelivery;
     using DeliveryConstraints;
-    using Persistence;
     using Settings;
     using Timeout.Core;
     using Transport;

--- a/src/NServiceBus.Core/Persistence/StorageType.cs
+++ b/src/NServiceBus.Core/Persistence/StorageType.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.Persistence
+﻿namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;

--- a/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using ConsistencyGuarantees;
-    using Persistence;
 
     /// <summary>
     /// Configure the Outbox.

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Features
 {
     using System;
-    using Persistence;
     using Transport;
     using Unicast.Messages;
     using Unicast.Subscriptions.MessageDrivenSubscriptions;

--- a/src/NServiceBus.Core/Sagas/Sagas.cs
+++ b/src/NServiceBus.Core/Sagas/Sagas.cs
@@ -5,7 +5,6 @@
     using System.Linq;
     using NServiceBus.Sagas;
     using ObjectBuilder;
-    using Persistence;
     using Transport;
 
     /// <summary>


### PR DESCRIPTION
Closes #3921 

There are still types left in the `NServiceBus.Persistence` namespace so users wouldn't notice this since they would have `using NServiceBus` in the same file. Thinking that we don't need to mention this in the upgrade guide?