### PR TITLE
Retain order when deduplicating message types

### DIFF
--- a/src/NServiceBus.Core/Pipeline/Outgoing/SerializeMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/SerializeMessageConnector.cs
@@ -3,7 +3,6 @@ namespace NServiceBus
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
     using System.Threading.Tasks;
     using Logging;
     using Pipeline;
@@ -53,7 +52,7 @@ namespace NServiceBus
         {
             var metadata = messageMetadataRegistry.GetMessageMetadata(messageType);
 
-            var assemblyQualifiedNames = new List<string>();
+            var assemblyQualifiedNames = new List<string>(metadata.MessageHierarchy.Length);
             foreach (var type in metadata.MessageHierarchy)
             {
                 var typeAssemblyQualifiedName = type.AssemblyQualifiedName;

--- a/src/NServiceBus.Core/Pipeline/Outgoing/SerializeMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/SerializeMessageConnector.cs
@@ -3,6 +3,7 @@ namespace NServiceBus
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Threading.Tasks;
     using Logging;
     using Pipeline;
@@ -52,10 +53,16 @@ namespace NServiceBus
         {
             var metadata = messageMetadataRegistry.GetMessageMetadata(messageType);
 
-            var assemblyQualifiedNames = new HashSet<string>();
+            var assemblyQualifiedNames = new List<string>();
             foreach (var type in metadata.MessageHierarchy)
             {
-                assemblyQualifiedNames.Add(type.AssemblyQualifiedName);
+                var typeAssemblyQualifiedName = type.AssemblyQualifiedName;
+                if (assemblyQualifiedNames.Contains(typeAssemblyQualifiedName))
+                {
+                    continue;
+                }
+
+                assemblyQualifiedNames.Add(typeAssemblyQualifiedName);
             }
 
             return string.Join(";", assemblyQualifiedNames);


### PR DESCRIPTION
fixes https://github.com/Particular/NServiceBus/issues/4794

Decided to not remove the deduplication code altogether at this point as the current behavior is quite hard to follow for certain edge cases related to complex inheritance chains.