### PR TITLE
Avoid race condition due to async critical error action

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_from_a_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_from_a_handler.cs
@@ -36,7 +36,7 @@
                         });
                     });
                 })
-                .Done(c => c.CriticalErrorsRaised > 0)
+                .Done(c => c.CriticalErrorsRaised > 0 && exceptions.Keys.Count > 0)
                 .Run();
 
             Assert.AreEqual(1, exceptions.Keys.Count);


### PR DESCRIPTION
The critical error action is raised on a dedicated thread using `Task.Run`. @bording noticed this test failing from time to time (on the linux builds) and we believe this might be the reason for the failing test.