### PR TITLE
Splitting feature setup into configuration and activation phase

### DIFF
--- a/src/NServiceBus.Core.Tests/Features/FeatureDefaultsTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDefaultsTests.cs
@@ -54,7 +54,8 @@
             featureSettings.Add(featureThatIsEnabledByAnother);
             featureSettings.Add(new FeatureThatEnablesAnother());
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             Assert.True(featureThatIsEnabledByAnother.DefaultCalled, "FeatureThatIsEnabledByAnother wasn't activated");
         }
@@ -86,7 +87,8 @@
             featureSettings.Add(level2);
             featureSettings.Add(level1);
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             Assert.True(level1.IsActive, "Activate1 wasn't activated");
             Assert.True(level2.IsActive, "Activate2 wasn't activated");
@@ -118,7 +120,8 @@
 
             settings.EnableFeatureByDefault<MyFeature1>();
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             Assert.True(dependingFeature.IsActive);
 
@@ -156,7 +159,8 @@
             settings.EnableFeatureByDefault<MyFeature2>();
             settings.EnableFeatureByDefault<MyFeature3>();
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             Assert.True(dependingFeature.IsActive);
 
@@ -188,7 +192,8 @@
             featureSettings.Add(level2);
             featureSettings.Add(level1);
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             Assert.True(level1.IsActive, "Level1 wasn't activated");
             Assert.True(level2.IsActive, "Level2 wasn't activated");

--- a/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
@@ -59,7 +59,8 @@
             featureSettings.Add(dependingFeature);
             Array.ForEach(setup.AvailableFeatures, featureSettings.Add);
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             Assert.AreEqual(setup.ShouldBeActive, dependingFeature.IsActive);
         }
@@ -86,7 +87,8 @@
 
             settings.EnableFeatureByDefault<MyFeature1>();
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             Assert.True(dependingFeature.IsActive);
 
@@ -115,7 +117,8 @@
 
             settings.EnableFeatureByDefault<MyFeature2>();
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             Assert.True(dependingFeature.IsActive);
             Assert.IsInstanceOf<MyFeature2>(order.First(), "Upstream dependencies should be activated first");
@@ -141,7 +144,8 @@
             featureSettings.Add(dependingFeature);
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             Assert.False(dependingFeature.IsActive);
             Assert.IsEmpty(order);
@@ -181,7 +185,8 @@
             settings.EnableFeatureByDefault<MyFeature2>();
             settings.EnableFeatureByDefault<MyFeature3>();
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             Assert.True(dependingFeature.IsActive);
 
@@ -217,7 +222,8 @@
             featureSettings.Add(level2);
             featureSettings.Add(level1);
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
 
             Assert.True(level1.IsActive, "Level1 wasn't activated");
@@ -250,7 +256,11 @@
             featureSettings.Add(level1);
             featureSettings.Add(level2);
 
-            Assert.Throws<ArgumentException>(() => featureSettings.SetupFeatures(null, null, null));
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var features = featureSettings.ConfigureFeatures();
+                featureSettings.SetupFeatures(features, null, null, null);
+            });
         }
 
         public class Level1 : TestFeature

--- a/src/NServiceBus.Core.Tests/Features/FeatureDifferingOnlyByNamespaceTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDifferingOnlyByNamespaceTests.cs
@@ -31,7 +31,8 @@
 
             settings.EnableFeatureByDefault<NamespaceA.MyFeature>();
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             Assert.True(dependingFeature.IsActive);
 

--- a/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
@@ -28,7 +28,8 @@
             featureSettings.Add(featureWithTrueCondition);
             featureSettings.Add(featureWithFalseCondition);
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             Assert.True(featureWithTrueCondition.IsActive);
             Assert.False(featureWithFalseCondition.IsActive);
@@ -41,7 +42,8 @@
         {
             featureSettings.Add(new MyFeatureWithDefaults());
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             Assert.True(settings.HasSetting("Test1"));
         }
@@ -52,7 +54,8 @@
             featureSettings.Add(new MyFeatureWithDefaultsNotActive());
             featureSettings.Add(new MyFeatureWithDefaultsNotActiveDueToUnsatisfiedPrerequisite());
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             Assert.False(settings.HasSetting("Test1"));
             Assert.False(settings.HasSetting("Test2"));

--- a/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
@@ -25,7 +25,8 @@
 
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             await featureSettings.StartFeatures(null, null);
             await featureSettings.StopFeatures(null);
@@ -41,7 +42,8 @@
 
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             await featureSettings.StartFeatures(null, null);
             await featureSettings.StopFeatures(null);
@@ -57,7 +59,8 @@
             featureSettings.Add(feature1);
             featureSettings.Add(feature2);
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             Assert.ThrowsAsync<InvalidOperationException>(async () => await featureSettings.StartFeatures(null, null));
 
@@ -73,7 +76,8 @@
             featureSettings.Add(feature1);
             featureSettings.Add(feature2);
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             await featureSettings.StartFeatures(null, null);
 
@@ -88,7 +92,8 @@
             var feature = new FeatureWithStartupTaskThatThrows(throwOnStart: false, throwOnStop: true);
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(null, null, null);
+            var features = featureSettings.ConfigureFeatures();
+            featureSettings.SetupFeatures(features, null, null, null);
 
             await featureSettings.StartFeatures(null, null);
 

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -36,7 +36,7 @@ namespace NServiceBus.Features
             }));
         }
 
-        public FeaturesReport SetupFeatures(IConfigureComponents container, PipelineSettings pipelineSettings, RoutingComponent routing)
+        public List<FeatureInfo> ConfigureFeatures()
         {
             // featuresToActivate is enumerated twice because after setting defaults some new features might got activated.
             var sourceFeatures = Sort(features);
@@ -53,13 +53,16 @@ namespace NServiceBus.Features
                 enabledFeatures.Add(featureToActivate);
                 featureToActivate.Feature.ConfigureDefaults(settings);
             }
-
-            foreach (var feature in enabledFeatures)
-            {
-                ActivateFeature(feature, enabledFeatures, container, pipelineSettings, routing);
-            }
-
             settings.PreventChanges();
+            return enabledFeatures;
+        }
+
+        public FeaturesReport SetupFeatures(List<FeatureInfo> enableFeatures, IConfigureComponents container, PipelineSettings pipelineSettings, RoutingComponent routing)
+        {
+            foreach (var feature in enableFeatures)
+            {
+                ActivateFeature(feature, enableFeatures, container, pipelineSettings, routing);
+            }
 
             return new FeaturesReport(features.Select(t => t.Diagnostics).ToList());
         }
@@ -212,7 +215,7 @@ namespace NServiceBus.Features
         List<FeatureInfo> features = new List<FeatureInfo>();
         SettingsHolder settings;
 
-        class FeatureInfo
+        internal class FeatureInfo
         {
             public FeatureInfo(Feature feature, FeatureDiagnosticData diagnostics)
             {

--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -53,9 +53,12 @@ namespace NServiceBus
                 settings.GetOrCreate<DistributionPolicy>(),
                 settings.GetOrCreate<EndpointInstances>(),
                 settings.GetOrCreate<Publishers>());
+
+            var enabledFeatures = featureActivator.ConfigureFeatures();
+
             routing.Initialize(settings, transportInfrastructure, pipelineSettings);
 
-            var featureStats = featureActivator.SetupFeatures(container, pipelineSettings, routing);
+            var featureStats = featureActivator.SetupFeatures(enabledFeatures, container, pipelineSettings, routing);
 
             pipelineConfiguration.RegisterBehaviorsInContainer(container);
 


### PR DESCRIPTION
@andreasohlund and I were discussing a few ATT related questions when we discovered that the settings are not locked before the features are activated. Although the FeatureConfigurationContext exposes ReadonlySettings this would allow a feature to modify the settings. I guess if someone does it then that one has to be punished ;)

- Splitting feature setup into configuration and activation phase
- Configuration phase locks the settings

Sending this in to show what should be done. Not saying it necessarily needs to go into this version