### PR TITLE
Partial requires

### DIFF
--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/Requires.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/Requires.cs
@@ -2,7 +2,8 @@
 {
     using NUnit.Framework;
 
-    static class Requires
+    // ReSharper disable once PartialTypeWithSinglePart
+    static partial class Requires
     {
         public static void DtcSupport()
         {


### PR DESCRIPTION
At the moment when a transport wants to define additional requires steps it needs to come up with its own name for the requires file. This is what we did it ASB

```
    public static class TestRequires
    {
        public static void ForwardingToplogy()
        {
            if (!TestSuiteConstraints.Current.IsForwardingTopology)
            {
                Assert.Ignore("Ignoring this test because it requires the forwarding topology to be configured.");
            }
        }

        public static void EndpointOrientedToplogy()
        {
            if (!TestSuiteConstraints.Current.IsEndpointOrientedTopology)
            {
                Assert.Ignore("Ignoring this test because it requires the endpoint oriented topology to be configured.");
            }
        }
    }
```

TestSuiteConstraints is already partial and can be extended customized. Would be nice if Requires could be as well. So that we can add those 'guards' to the requires file