### PR TITLE
Select destination using transport agnostic criteria

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/When_extending_command_routing.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_extending_command_routing.cs
@@ -70,7 +70,8 @@
 
                 public override string SelectDestination(DistributionContext context)
                 {
-                    return context.ReceiverAddresses.First(x => x.Contains("XYZ"));
+                    var address = context.ToTransportAddress(new EndpointInstance(ReceiverEndpoint, "XYZ"));
+                    return context.ReceiverAddresses.First(x => x == address);
                 }
             }
         }


### PR DESCRIPTION
ASQ had a bug fixed, which was causing transport address not to be returned in correct form (lower case). This ATT is not taking into consideration transport specific nuances, and it shouldn't. What it should do, is use an a transport translated address in the criteria.

This will unblock https://github.com/Particular/NServiceBus.Persistence.AzureStorage/issues/170 and https://github.com/Particular/NServiceBus.AzureStorageQueues/issues/273