### PR TITLE
Add default constructor to DataBusProperty

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -192,6 +192,7 @@ namespace NServiceBus
     public class DataBusProperty<T> : NServiceBus.IDataBusProperty, System.Runtime.Serialization.ISerializable
         where T :  class
     {
+        public DataBusProperty() { }
         public DataBusProperty(T value) { }
         protected DataBusProperty(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public bool HasValue { get; set; }

--- a/src/NServiceBus.Core/DataBus/DataBusProperty.cs
+++ b/src/NServiceBus.Core/DataBus/DataBusProperty.cs
@@ -12,6 +12,13 @@
     public class DataBusProperty<T> : IDataBusProperty, ISerializable where T : class
     {
         /// <summary>
+        /// initializes a <see cref="DataBusProperty{T}" /> with no value set.
+        /// </summary>
+        public DataBusProperty() : this(null)
+        {
+        }
+
+        /// <summary>
         /// initializes a <see cref="DataBusProperty{T}" /> with the <paramref name="value" />.
         /// </summary>
         /// <param name="value">The value to initialize with.</param>


### PR DESCRIPTION
fixes https://github.com/Particular/NServiceBus/issues/4805

@SimonCropp since you mentioned this behavior breaking certain serializers, do you have a sample to verify this PR does solve the issue?