### PR TITLE
Use a TryGet style API for conversation ids instead

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -151,11 +151,6 @@ namespace NServiceBus
         public NServiceBus.ConventionsBuilder DefiningEventsAs(System.Func<System.Type, bool> definesEventType) { }
         public NServiceBus.ConventionsBuilder DefiningMessagesAs(System.Func<System.Type, bool> definesMessageType) { }
     }
-    public class ConversationIdGeneratorContext
-    {
-        public ConversationIdGeneratorContext(NServiceBus.Pipeline.OutgoingLogicalMessage message) { }
-        public NServiceBus.Pipeline.OutgoingLogicalMessage Message { get; }
-    }
     [System.ObsoleteAttribute("Setting a custom correlation ID is no longer supported. Will be removed in versio" +
         "n 8.0.0.", true)]
     public class static CorrelationContextExtensions
@@ -194,6 +189,12 @@ namespace NServiceBus
             "ll be removed in version 8.0.0.", true)]
         public static void EnableCriticalTimePerformanceCounter(this NServiceBus.EndpointConfiguration config) { }
     }
+    public class CustomConversationIdContext
+    {
+        public CustomConversationIdContext(NServiceBus.Pipeline.OutgoingLogicalMessage message) { }
+        public NServiceBus.Pipeline.OutgoingLogicalMessage Message { get; }
+    }
+    public delegate bool CustomConversationIdDelegate(NServiceBus.CustomConversationIdContext context, out string customConverationId);
     public class DataBusProperty<T> : NServiceBus.IDataBusProperty, System.Runtime.Serialization.ISerializable
         where T :  class
     {
@@ -622,7 +623,7 @@ namespace NServiceBus
     }
     public class static MessageCausationConfigurationExtensions
     {
-        public static void CustomConversationIdGenerator(this NServiceBus.EndpointConfiguration endpointConfiguration, System.Func<NServiceBus.ConversationIdGeneratorContext, string> customGenerator) { }
+        public static void CustomConversationId(this NServiceBus.EndpointConfiguration endpointConfiguration, NServiceBus.CustomConversationIdDelegate customConversationIdDelegate) { }
     }
     public class MessageDeserializationException : System.Runtime.Serialization.SerializationException
     {

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -194,7 +194,6 @@ namespace NServiceBus
         public CustomConversationIdContext(NServiceBus.Pipeline.OutgoingLogicalMessage message) { }
         public NServiceBus.Pipeline.OutgoingLogicalMessage Message { get; }
     }
-    public delegate bool CustomConversationIdDelegate(NServiceBus.CustomConversationIdContext context, out string customConverationId);
     public class DataBusProperty<T> : NServiceBus.IDataBusProperty, System.Runtime.Serialization.ISerializable
         where T :  class
     {
@@ -623,7 +622,7 @@ namespace NServiceBus
     }
     public class static MessageCausationConfigurationExtensions
     {
-        public static void CustomConversationId(this NServiceBus.EndpointConfiguration endpointConfiguration, NServiceBus.CustomConversationIdDelegate customConversationIdDelegate) { }
+        public static void CustomConversationId(this NServiceBus.EndpointConfiguration endpointConfiguration, NServiceBus.TryGetConversationIdDelegate tryGetConversationIdDelegate) { }
     }
     public class MessageDeserializationException : System.Runtime.Serialization.SerializationException
     {
@@ -974,6 +973,7 @@ namespace NServiceBus
         SendsAtomicWithReceive = 2,
         TransactionScope = 3,
     }
+    public delegate bool TryGetConversationIdDelegate(NServiceBus.CustomConversationIdContext context, out string customConverationId);
     public class UnitOfWorkSettings
     {
         public NServiceBus.UnitOfWorkSettings WrapHandlersInATransactionScope(System.Nullable<System.TimeSpan> timeout = null, System.Nullable<System.Transactions.IsolationLevel> isolationLevel = null) { }

--- a/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
+++ b/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
@@ -53,24 +53,27 @@ namespace NServiceBus
             }
 
             string conversationId;
+            bool userProvidedId;
 
             try
             {
-                if (customConversationIdDelegate(new CustomConversationIdContext(context.Message), out conversationId))
-                {
-                    if (string.IsNullOrEmpty(conversationId))
-                    {
-                        throw new Exception("Null or empty conversation ID's are not allowed.");
-                    }
-                }
-                else
-                {
-                    conversationId = CombGuid.Generate().ToString();
-                }
+                userProvidedId = customConversationIdDelegate(new CustomConversationIdContext(context.Message), out conversationId);
             }
             catch (Exception exception)
             {
                 throw new Exception($"Failed to execute CustomConversationId delegate. This configuration option was defined using {nameof(EndpointConfiguration)}.{nameof(MessageCausationConfigurationExtensions.CustomConversationId)}.", exception);
+            }
+
+            if (userProvidedId)
+            {
+                if (string.IsNullOrEmpty(conversationId))
+                {
+                    throw new Exception("Null or empty conversation ID's are not allowed.");
+                }
+            }
+            else
+            {
+                conversationId = CombGuid.Generate().ToString();
             }
 
             context.Headers[Headers.ConversationId] = conversationId;

--- a/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
+++ b/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
@@ -7,9 +7,9 @@ namespace NServiceBus
 
     class AttachCausationHeadersBehavior : IBehavior<IOutgoingLogicalMessageContext, IOutgoingLogicalMessageContext>
     {
-        public AttachCausationHeadersBehavior(CustomConversationIdDelegate customConversationIdDelegate)
+        public AttachCausationHeadersBehavior(TryGetConversationIdDelegate tryGetConversationIdDelegate)
         {
-            this.customConversationIdDelegate = customConversationIdDelegate;
+            this.tryGetConversationIdDelegate = tryGetConversationIdDelegate;
         }
 
         public Task Invoke(IOutgoingLogicalMessageContext context, Func<IOutgoingLogicalMessageContext, Task> next)
@@ -57,7 +57,7 @@ namespace NServiceBus
 
             try
             {
-                userProvidedId = customConversationIdDelegate(new CustomConversationIdContext(context.Message), out conversationId);
+                userProvidedId = tryGetConversationIdDelegate(new CustomConversationIdContext(context.Message), out conversationId);
             }
             catch (Exception exception)
             {
@@ -79,6 +79,6 @@ namespace NServiceBus
             context.Headers[Headers.ConversationId] = conversationId;
         }
 
-        CustomConversationIdDelegate customConversationIdDelegate;
+        TryGetConversationIdDelegate tryGetConversationIdDelegate;
     }
 }

--- a/src/NServiceBus.Core/Causation/CustomConversationIdContext.cs
+++ b/src/NServiceBus.Core/Causation/CustomConversationIdContext.cs
@@ -5,12 +5,12 @@
     /// <summary>
     /// Provides context when generating message conversation ID's.
     /// </summary>
-    public class ConversationIdGeneratorContext
+    public class CustomConversationIdContext
     {
         /// <summary>
         /// Creates a new context.
         /// </summary>
-        public ConversationIdGeneratorContext(OutgoingLogicalMessage message)
+        public CustomConversationIdContext(OutgoingLogicalMessage message)
         {
             Guard.AgainstNull(nameof(message), message);
 

--- a/src/NServiceBus.Core/Causation/MessageCausation.cs
+++ b/src/NServiceBus.Core/Causation/MessageCausation.cs
@@ -14,9 +14,9 @@
             context.Pipeline.Register("AttachCausationHeaders", new AttachCausationHeadersBehavior(newIdGenerator), "Adds related to and conversation id headers to outgoing messages");
         }
 
-        static CustomConversationIdDelegate GetIdGenerator(FeatureConfigurationContext context)
+        static TryGetConversationIdDelegate GetIdGenerator(FeatureConfigurationContext context)
         {
-            if (context.Settings.TryGet<CustomConversationIdDelegate>(out var idGenerator))
+            if (context.Settings.TryGet<TryGetConversationIdDelegate>(out var idGenerator))
             {
                 return idGenerator;
             }

--- a/src/NServiceBus.Core/Causation/MessageCausation.cs
+++ b/src/NServiceBus.Core/Causation/MessageCausation.cs
@@ -1,7 +1,5 @@
 ﻿namespace NServiceBus.Features
 {
-    using System;
-
     class MessageCausation : Feature
     {
         public MessageCausation()
@@ -16,24 +14,18 @@
             context.Pipeline.Register("AttachCausationHeaders", new AttachCausationHeadersBehavior(newIdGenerator), "Adds related to and conversation id headers to outgoing messages");
         }
 
-        static Func<ConversationIdGeneratorContext, string> GetIdGenerator(FeatureConfigurationContext context)
+        static CustomConversationIdDelegate GetIdGenerator(FeatureConfigurationContext context)
         {
-            var settings = context.Settings;
-            if (settings.TryGet<Func<ConversationIdGeneratorContext, string>>(MessageCausationConfigurationExtensions.CustomConversationIdGeneratorKey, out var idGenerator))
+            if (context.Settings.TryGet<CustomConversationIdDelegate>(out var idGenerator))
             {
-                return generatorContext =>
-                {
-                    try
-                    {
-                        return idGenerator(generatorContext);
-                    }
-                    catch (Exception exception)
-                    {
-                        throw new Exception($"Failed to execute CustomConversationIdGenerator. This configuration option was defined using {nameof(EndpointConfiguration)}.{nameof(MessageCausationConfigurationExtensions.CustomConversationIdGenerator)}.", exception);
-                    }
-                };
+                return idGenerator;
             }
-            return _ => CombGuid.Generate().ToString();
+
+            return (CustomConversationIdContext _, out string id) =>
+            {
+                id = null;
+                return false;
+            };
         }
     }
 }

--- a/src/NServiceBus.Core/Causation/MessageCausationConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Causation/MessageCausationConfigurationExtensions.cs
@@ -9,13 +9,13 @@
         /// Allows customization of conversation ID's for individual messages. Use this to provide domain specific conversation ID's.
         /// </summary>
         /// <param name="endpointConfiguration">The configuration object being extended.</param>
-        /// <param name="customConversationIdDelegate">The delegate that will determine the conversation id.</param>
-        public static void CustomConversationId(this EndpointConfiguration endpointConfiguration, CustomConversationIdDelegate customConversationIdDelegate)
+        /// <param name="tryGetConversationIdDelegate">The delegate that will try to determine the conversation id. If not possible a generated COMB guid will be used.</param>
+        public static void CustomConversationId(this EndpointConfiguration endpointConfiguration, TryGetConversationIdDelegate tryGetConversationIdDelegate)
         {
             Guard.AgainstNull(nameof(endpointConfiguration), endpointConfiguration);
-            Guard.AgainstNull(nameof(customConversationIdDelegate), customConversationIdDelegate);
+            Guard.AgainstNull(nameof(tryGetConversationIdDelegate), tryGetConversationIdDelegate);
 
-            endpointConfiguration.Settings.Set<CustomConversationIdDelegate>(customConversationIdDelegate);
+            endpointConfiguration.Settings.Set<TryGetConversationIdDelegate>(tryGetConversationIdDelegate);
         }
     }
 
@@ -25,5 +25,5 @@
     /// <param name="context">Context for the conversation id generation.</param>
     /// <param name="customConverationId">The custom conversation id to be used for this message.</param>
     /// <returns>`true` if the returned conversation id should be used, `false` otherwise.</returns>
-    public delegate bool CustomConversationIdDelegate(CustomConversationIdContext context, out string customConverationId);
+    public delegate bool TryGetConversationIdDelegate(CustomConversationIdContext context, out string customConverationId);
 }

--- a/src/NServiceBus.Core/Causation/MessageCausationConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Causation/MessageCausationConfigurationExtensions.cs
@@ -1,25 +1,29 @@
 ﻿namespace NServiceBus
 {
-    using System;
-
     /// <summary>
     /// Provides configuration option for message causation.
     /// </summary>
     public static class MessageCausationConfigurationExtensions
     {
         /// <summary>
-        /// Overrides the default conversation id generator where messages are assigned a COMB-Guid as conversation id. Use this to provide domain specific conversation ID's.
+        /// Allows customization of conversation ID's for individual messages. Use this to provide domain specific conversation ID's.
         /// </summary>
         /// <param name="endpointConfiguration">The configuration object being extended.</param>
-        /// <param name="customGenerator">The custom conversation id convention.</param>
-        public static void CustomConversationIdGenerator(this EndpointConfiguration endpointConfiguration, Func<ConversationIdGeneratorContext, string> customGenerator)
+        /// <param name="customConversationIdDelegate">The delegate that will determine the conversation id.</param>
+        public static void CustomConversationId(this EndpointConfiguration endpointConfiguration, CustomConversationIdDelegate customConversationIdDelegate)
         {
             Guard.AgainstNull(nameof(endpointConfiguration), endpointConfiguration);
-            Guard.AgainstNull(nameof(customGenerator), customGenerator);
+            Guard.AgainstNull(nameof(customConversationIdDelegate), customConversationIdDelegate);
 
-            endpointConfiguration.Settings.Set(CustomConversationIdGeneratorKey, customGenerator);
+            endpointConfiguration.Settings.Set<CustomConversationIdDelegate>(customConversationIdDelegate);
         }
-
-        internal static string CustomConversationIdGeneratorKey = "MessageCausation.CustomConversationIdGenerator";
     }
+
+    /// <summary>
+    /// Allows customization of conversation ID's for individual messages. Return false to use the default COMB-Guid strategy.
+    /// </summary>
+    /// <param name="context">Context for the conversation id generation.</param>
+    /// <param name="customConverationId">The custom conversation id to be used for this message.</param>
+    /// <returns>`true` if the returned conversation id should be used, `false` otherwise.</returns>
+    public delegate bool CustomConversationIdDelegate(CustomConversationIdContext context, out string customConverationId);
 }


### PR DESCRIPTION
After talking to @SimonCropp I realized that the use case for custom conversation ids is not to override the whole thing but rather override certain messages. This API should convey this usage better.

@SimonCropp @weralabaj what do you think?

Relates to #4992