### PR TITLE
Add missing docs back

### DIFF
--- a/src/NServiceBus.Testing.Fakes/TestableInvokeHandlerContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableInvokeHandlerContext.cs
@@ -34,6 +34,9 @@ namespace NServiceBus.Testing
             throw new NotSupportedException("HandleCurrentMessageLater has been deprecated and will be removed in NServiceBus.Core Version 8.");
         }
 
+        /// <summary>
+        /// Indicates if <see cref="IMessageHandlerContext.HandleCurrentMessageLater" /> has been called.
+        /// </summary>
         public bool HandleCurrentMessageLaterWasCalled => throw new NotSupportedException("HandleCurrentMessageLater has been deprecated and will be removed in NServiceBus.Core Version 8.");
 
         /// <summary>


### PR DESCRIPTION
The properties docs somehow got lost on the PR to deprecate HandleCurrentMessasgeLater. This does cause issues when consuming the testing.fakes package as NServiceBus.Testing does verify the presence of docs on public APIs.