### PR TITLE
[WIP]Endpoint startup diagnostics

### DIFF
--- a/src/NServiceBus.Core.Tests/DeliveryConstraintContextExtensions/DeliveryConstraintContextExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/DeliveryConstraintContextExtensions/DeliveryConstraintContextExtensionsTests.cs
@@ -5,7 +5,7 @@
     using Extensibility;
     using DelayedDelivery;
     using DeliveryConstraints;
-    using NServiceBus.Features;
+    using Features;
     using NServiceBus.Routing;
     using Settings;
     using Transport;
@@ -22,7 +22,7 @@
             settings.Set<TransportDefinition>(fakeTransportDefinition);
             settings.Set<TransportInfrastructure>(fakeTransportDefinition.Initialize(settings, null));
 
-            var context = new FeatureConfigurationContext(settings, null, null, null);
+            var context = new TestableFeatureConfigurationContext(settings);
             var result = context.Settings.DoesTransportSupportConstraint<DeliveryConstraint>();
             Assert.IsTrue(result);
         }

--- a/src/NServiceBus.Core.Tests/Features/FeatureDefaultsTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDefaultsTests.cs
@@ -36,8 +36,8 @@
             }
         }
 
-        private FeatureActivator featureSettings;
-        private SettingsHolder settings;
+        FeatureActivator featureSettings;
+        SettingsHolder settings;
 
         [SetUp]
         public void Init()
@@ -54,7 +54,7 @@
             featureSettings.Add(featureThatIsEnabledByAnother);
             featureSettings.Add(new FeatureThatEnablesAnother());
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             Assert.True(featureThatIsEnabledByAnother.DefaultCalled, "FeatureThatIsEnabledByAnother wasn't activated");
         }
@@ -86,7 +86,7 @@
             featureSettings.Add(level2);
             featureSettings.Add(level1);
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             Assert.True(level1.IsActive, "Activate1 wasn't activated");
             Assert.True(level2.IsActive, "Activate2 wasn't activated");
@@ -118,7 +118,7 @@
 
             settings.EnableFeatureByDefault<MyFeature1>();
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             Assert.True(dependingFeature.IsActive);
 
@@ -156,7 +156,7 @@
             settings.EnableFeatureByDefault<MyFeature2>();
             settings.EnableFeatureByDefault<MyFeature3>();
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             Assert.True(dependingFeature.IsActive);
 
@@ -188,7 +188,7 @@
             featureSettings.Add(level2);
             featureSettings.Add(level1);
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             Assert.True(level1.IsActive, "Level1 wasn't activated");
             Assert.True(level2.IsActive, "Level2 wasn't activated");
@@ -230,7 +230,7 @@
             public Activate1()
             {
                 EnableByDefault();
-                Defaults(s=>s.EnableFeatureByDefault<Activate2>());
+                Defaults(s => s.EnableFeatureByDefault<Activate2>());
             }
         }
 
@@ -253,17 +253,14 @@
 
         public class MyFeature1 : TestFeature
         {
-
         }
 
         public class MyFeature2 : TestFeature
         {
-
         }
 
         public class MyFeature3 : TestFeature
         {
-
         }
 
         public class DependsOnOne_Feature : TestFeature

--- a/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
@@ -59,7 +59,7 @@
             featureSettings.Add(dependingFeature);
             Array.ForEach(setup.AvailableFeatures, featureSettings.Add);
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             Assert.AreEqual(setup.ShouldBeActive, dependingFeature.IsActive);
         }
@@ -86,7 +86,7 @@
 
             settings.EnableFeatureByDefault<MyFeature1>();
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             Assert.True(dependingFeature.IsActive);
 
@@ -115,7 +115,7 @@
 
             settings.EnableFeatureByDefault<MyFeature2>();
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             Assert.True(dependingFeature.IsActive);
             Assert.IsInstanceOf<MyFeature2>(order.First(), "Upstream dependencies should be activated first");
@@ -141,7 +141,7 @@
             featureSettings.Add(dependingFeature);
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             Assert.False(dependingFeature.IsActive);
             Assert.IsEmpty(order);
@@ -181,7 +181,7 @@
             settings.EnableFeatureByDefault<MyFeature2>();
             settings.EnableFeatureByDefault<MyFeature3>();
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             Assert.True(dependingFeature.IsActive);
 
@@ -217,7 +217,7 @@
             featureSettings.Add(level2);
             featureSettings.Add(level1);
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
 
             Assert.True(level1.IsActive, "Level1 wasn't activated");
@@ -250,7 +250,7 @@
             featureSettings.Add(level1);
             featureSettings.Add(level2);
 
-            Assert.Throws<ArgumentException>(() => featureSettings.SetupFeatures(null, null, null));
+            Assert.Throws<ArgumentException>(() => featureSettings.SetupFeaturesForTest());
         }
 
         public class Level1 : TestFeature

--- a/src/NServiceBus.Core.Tests/Features/FeatureDifferingOnlyByNamespaceTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDifferingOnlyByNamespaceTests.cs
@@ -31,7 +31,7 @@
 
             settings.EnableFeatureByDefault<NamespaceA.MyFeature>();
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             Assert.True(dependingFeature.IsActive);
 

--- a/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
@@ -28,7 +28,7 @@
             featureSettings.Add(featureWithTrueCondition);
             featureSettings.Add(featureWithFalseCondition);
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             Assert.True(featureWithTrueCondition.IsActive);
             Assert.False(featureWithFalseCondition.IsActive);
@@ -41,7 +41,7 @@
         {
             featureSettings.Add(new MyFeatureWithDefaults());
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             Assert.True(settings.HasSetting("Test1"));
         }
@@ -52,7 +52,7 @@
             featureSettings.Add(new MyFeatureWithDefaultsNotActive());
             featureSettings.Add(new MyFeatureWithDefaultsNotActiveDueToUnsatisfiedPrerequisite());
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             Assert.False(settings.HasSetting("Test1"));
             Assert.False(settings.HasSetting("Test2"));

--- a/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
@@ -25,7 +25,7 @@
 
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             await featureSettings.StartFeatures(null, null);
             await featureSettings.StopFeatures(null);
@@ -41,7 +41,7 @@
 
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             await featureSettings.StartFeatures(null, null);
             await featureSettings.StopFeatures(null);
@@ -57,7 +57,7 @@
             featureSettings.Add(feature1);
             featureSettings.Add(feature2);
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             Assert.ThrowsAsync<InvalidOperationException>(async () => await featureSettings.StartFeatures(null, null));
 
@@ -73,7 +73,7 @@
             featureSettings.Add(feature1);
             featureSettings.Add(feature2);
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             await featureSettings.StartFeatures(null, null);
 
@@ -88,7 +88,7 @@
             var feature = new FeatureWithStartupTaskThatThrows(throwOnStart: false, throwOnStop: true);
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(null, null, null);
+            featureSettings.SetupFeaturesForTest();
 
             await featureSettings.StartFeatures(null, null);
 

--- a/src/NServiceBus.Core.Tests/Features/FeatureTestExtensions.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureTestExtensions.cs
@@ -1,0 +1,12 @@
+﻿namespace NServiceBus.Core.Tests.Features
+{
+    using NServiceBus.Features;
+
+    static class FeatureTestExtensions
+    {
+        public static void SetupFeaturesForTest(this FeatureActivator activator)
+        {
+            activator.SetupFeatures(null, null, null, null);
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Features/TestableFeatureConfigurationContext.cs
+++ b/src/NServiceBus.Core.Tests/Features/TestableFeatureConfigurationContext.cs
@@ -1,0 +1,16 @@
+﻿namespace NServiceBus.Core.Tests.Features
+{
+    using NServiceBus.Features;
+    using NServiceBus.Pipeline;
+    using ObjectBuilder;
+    using Settings;
+
+    class TestableFeatureConfigurationContext : FeatureConfigurationContext
+    {
+        public TestableFeatureConfigurationContext(ReadOnlySettings settings = null, IConfigureComponents container = null, PipelineSettings pipelineSettings = null, RoutingComponent routing = null, EndpointInfo endpointInfo = null) :
+            base(settings, container, pipelineSettings, routing, endpointInfo)
+        {
+
+        }
+    }
+}

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
@@ -18,7 +18,7 @@
             Defaults(s => s.SetDefault("TimeToWaitBeforeTriggeringCriticalErrorForTimeoutPersisterReceiver", TimeToWaitBeforeTriggeringCriticalError));
             EnableByDefault();
 
-            Prerequisite(context => !context.Settings.Get<EndpointComponent>().IsSendOnly, "Send only endpoints can't use the timeoutmanager since it requires receive capabilities");
+            Prerequisite(context => !context.Endpoint.IsSendOnly, "Send only endpoints can't use the timeoutmanager since it requires receive capabilities");
             Prerequisite(context => !HasAlternateTimeoutManagerBeenConfigured(context.Settings), "A user configured timeoutmanager address has been found and this endpoint will send timeouts to that endpoint");
             Prerequisite(c => !c.Settings.DoesTransportSupportConstraint<DelayedDeliveryConstraint>(), "The selected transport supports delayed delivery natively");
         }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
@@ -18,7 +18,7 @@
             Defaults(s => s.SetDefault("TimeToWaitBeforeTriggeringCriticalErrorForTimeoutPersisterReceiver", TimeToWaitBeforeTriggeringCriticalError));
             EnableByDefault();
 
-            Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"), "Send only endpoints can't use the timeoutmanager since it requires receive capabilities");
+            Prerequisite(context => !context.Settings.Get<EndpointComponent>().IsSendOnly, "Send only endpoints can't use the timeoutmanager since it requires receive capabilities");
             Prerequisite(context => !HasAlternateTimeoutManagerBeenConfigured(context.Settings), "A user configured timeoutmanager address has been found and this endpoint will send timeouts to that endpoint");
             Prerequisite(c => !c.Settings.DoesTransportSupportConstraint<DelayedDeliveryConstraint>(), "The selected transport supports delayed delivery natively");
         }

--- a/src/NServiceBus.Core/EndpointComponent.cs
+++ b/src/NServiceBus.Core/EndpointComponent.cs
@@ -1,0 +1,18 @@
+namespace NServiceBus
+{
+    using Settings;
+
+    class EndpointComponent
+    {
+        public EndpointComponent(ReadOnlySettings settings)
+        {
+            Name = settings.Get<string>("NServiceBus.Routing.EndpointName");
+            IsSendOnly = settings.GetOrDefault<bool>("Endpoint.SendOnly");
+            InstanceDiscriminator = settings.GetOrDefault<string>("EndpointInstanceDiscriminator");
+        }
+
+        public string Name { get; }
+        public bool IsSendOnly { get; }
+        public string InstanceDiscriminator { get; }
+    }
+}

--- a/src/NServiceBus.Core/EndpointInfo.cs
+++ b/src/NServiceBus.Core/EndpointInfo.cs
@@ -6,13 +6,15 @@ namespace NServiceBus
     {
         public EndpointInfo(ReadOnlySettings settings)
         {
-            Name = settings.Get<string>("NServiceBus.Routing.EndpointName");
-            IsSendOnly = settings.GetOrDefault<bool>("Endpoint.SendOnly");
-            InstanceDiscriminator = settings.GetOrDefault<string>("EndpointInstanceDiscriminator");
+            this.settings = settings;
         }
 
-        public string Name { get; }
-        public bool IsSendOnly { get; }
-        public string InstanceDiscriminator { get; }
+        public string Name => settings.Get<string>("NServiceBus.Routing.EndpointName");
+
+        public bool IsSendOnly => settings.GetOrDefault<bool>("Endpoint.SendOnly");
+
+        public string InstanceDiscriminator => settings.GetOrDefault<string>("EndpointInstanceDiscriminator");
+
+        ReadOnlySettings settings;
     }
 }

--- a/src/NServiceBus.Core/EndpointInfo.cs
+++ b/src/NServiceBus.Core/EndpointInfo.cs
@@ -2,9 +2,9 @@ namespace NServiceBus
 {
     using Settings;
 
-    class EndpointComponent
+    class EndpointInfo
     {
-        public EndpointComponent(ReadOnlySettings settings)
+        public EndpointInfo(ReadOnlySettings settings)
         {
             Name = settings.Get<string>("NServiceBus.Routing.EndpointName");
             IsSendOnly = settings.GetOrDefault<bool>("Endpoint.SendOnly");

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -36,7 +36,7 @@ namespace NServiceBus.Features
             }));
         }
 
-        public FeatureDiagnosticData[] SetupFeatures(IConfigureComponents container, PipelineSettings pipelineSettings, RoutingComponent routing)
+        public FeatureDiagnosticData[] SetupFeatures(IConfigureComponents container, PipelineSettings pipelineSettings, RoutingComponent routing, EndpointInfo endpointInfo)
         {
             // featuresToActivate is enumerated twice because after setting defaults some new features might got activated.
             var sourceFeatures = Sort(features);
@@ -56,7 +56,7 @@ namespace NServiceBus.Features
 
             foreach (var feature in enabledFeatures)
             {
-                ActivateFeature(feature, enabledFeatures, container, pipelineSettings, routing);
+                ActivateFeature(feature, enabledFeatures, container, pipelineSettings, routing, endpointInfo);
             }
 
             settings.PreventChanges();
@@ -160,7 +160,7 @@ namespace NServiceBus.Features
             return false;
         }
 
-        bool ActivateFeature(FeatureInfo featureInfo, List<FeatureInfo> featuresToActivate, IConfigureComponents container, PipelineSettings pipelineSettings, RoutingComponent routing)
+        bool ActivateFeature(FeatureInfo featureInfo, List<FeatureInfo> featuresToActivate, IConfigureComponents container, PipelineSettings pipelineSettings, RoutingComponent routing, EndpointInfo endpointInfo)
         {
             if (featureInfo.Feature.IsActive)
             {
@@ -177,14 +177,14 @@ namespace NServiceBus.Features
                 {
                     dependentFeaturesToActivate.Add(dependency);
                 }
-                return dependentFeaturesToActivate.Aggregate(false, (current, f) => current | ActivateFeature(f, featuresToActivate, container, pipelineSettings, routing));
+                return dependentFeaturesToActivate.Aggregate(false, (current, f) => current | ActivateFeature(f, featuresToActivate, container, pipelineSettings, routing, endpointInfo));
             };
             var featureType = featureInfo.Feature.GetType();
             if (featureInfo.Feature.Dependencies.All(dependencyActivator))
             {
                 featureInfo.Diagnostics.DependenciesAreMet = true;
 
-                var context = new FeatureConfigurationContext(settings, container, pipelineSettings, routing);
+                var context = new FeatureConfigurationContext(settings, container, pipelineSettings, routing, endpointInfo);
                 if (!HasAllPrerequisitesSatisfied(featureInfo.Feature, featureInfo.Diagnostics, context))
                 {
                     settings.MarkFeatureAsDeactivated(featureType);

--- a/src/NServiceBus.Core/Features/FeatureConfigurationContext.cs
+++ b/src/NServiceBus.Core/Features/FeatureConfigurationContext.cs
@@ -14,12 +14,13 @@
     /// </summary>
     public partial class FeatureConfigurationContext
     {
-        internal FeatureConfigurationContext(ReadOnlySettings settings, IConfigureComponents container, PipelineSettings pipelineSettings, RoutingComponent routing)
+        internal FeatureConfigurationContext(ReadOnlySettings settings, IConfigureComponents container, PipelineSettings pipelineSettings, RoutingComponent routing, EndpointInfo endpointInfo)
         {
             Settings = settings;
             Container = container;
             Pipeline = pipelineSettings;
             Routing = routing;
+            Endpoint = endpointInfo;
 
             TaskControllers = new List<FeatureStartupTaskController>();
         }
@@ -40,6 +41,8 @@
         public PipelineSettings Pipeline { get; }
 
         internal RoutingComponent Routing { get; }
+
+        internal EndpointInfo Endpoint { get; }
 
         internal List<FeatureStartupTaskController> TaskControllers { get; }
 

--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -41,7 +41,12 @@ namespace NServiceBus
 
             ConfigRunBeforeIsFinalized(concreteTypes);
 
+
             var transportInfrastructure = InitializeTransport();
+            var endpointComponent = new EndpointComponent(settings);
+
+            settings.Set<EndpointComponent>(endpointComponent);
+            settings.AddStartupDiagnosticsSection("Endpoint", endpointComponent);
 
             // use GetOrCreate to use of instances already created during EndpointConfiguration.
             var routing = new RoutingComponent(
@@ -61,7 +66,7 @@ namespace NServiceBus
             var username = GetInstallationUserName();
             TransportReceiveInfrastructure receiveInfrastructure = null;
 
-            if (!settings.Get<bool>("Endpoint.SendOnly"))
+            if (!endpointComponent.IsSendOnly)
             {
                 receiveInfrastructure = transportInfrastructure.ConfigureReceiveInfrastructure();
                 await CreateQueuesIfNecessary(receiveInfrastructure, username).ConfigureAwait(false);

--- a/src/NServiceBus.Core/Recoverability/Recoverability.cs
+++ b/src/NServiceBus.Core/Recoverability/Recoverability.cs
@@ -21,7 +21,7 @@
             EnableByDefault();
             DependsOnOptionally<DelayedDeliveryFeature>();
 
-            Prerequisite(context => !context.Settings.Get<EndpointComponent>().IsSendOnly,
+            Prerequisite(context => !context.Endpoint.IsSendOnly,
                 "Message recoverability is only relevant for endpoints receiving messages.");
             Defaults(settings =>
             {

--- a/src/NServiceBus.Core/Recoverability/Recoverability.cs
+++ b/src/NServiceBus.Core/Recoverability/Recoverability.cs
@@ -21,7 +21,7 @@
             EnableByDefault();
             DependsOnOptionally<DelayedDeliveryFeature>();
 
-            Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"),
+            Prerequisite(context => !context.Settings.Get<EndpointComponent>().IsSendOnly,
                 "Message recoverability is only relevant for endpoints receiving messages.");
             Defaults(settings =>
             {

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -16,7 +16,7 @@
         internal AutoSubscribe()
         {
             EnableByDefault();
-            Prerequisite(context => !context.Settings.Get<EndpointComponent>().IsSendOnly, "Send only endpoints can't autosubscribe.");
+            Prerequisite(context => !context.Endpoint.IsSendOnly, "Send only endpoints can't autosubscribe.");
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -16,7 +16,7 @@
         internal AutoSubscribe()
         {
             EnableByDefault();
-            Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"), "Send only endpoints can't autosubscribe.");
+            Prerequisite(context => !context.Settings.Get<EndpointComponent>().IsSendOnly, "Send only endpoints can't autosubscribe.");
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -32,7 +32,7 @@ namespace NServiceBus.Features
             }
 
             var transportInfrastructure = context.Settings.Get<TransportInfrastructure>();
-            var canReceive = !context.Settings.Get<EndpointComponent>().IsSendOnly;
+            var canReceive = !context.Endpoint.IsSendOnly;
             var conventions = context.Settings.Get<Conventions>();
             var enforceBestPractices = context.Routing.EnforceBestPractices;
 

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -32,7 +32,7 @@ namespace NServiceBus.Features
             }
 
             var transportInfrastructure = context.Settings.Get<TransportInfrastructure>();
-            var canReceive = !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly");
+            var canReceive = !context.Settings.Get<EndpointComponent>().IsSendOnly;
             var conventions = context.Settings.Get<Conventions>();
             var enforceBestPractices = context.Routing.EnforceBestPractices;
 

--- a/src/NServiceBus.Core/Routing/NativePublishSubscribeFeature.cs
+++ b/src/NServiceBus.Core/Routing/NativePublishSubscribeFeature.cs
@@ -13,7 +13,7 @@ namespace NServiceBus.Features
         protected internal override void Setup(FeatureConfigurationContext context)
         {
             var transportInfrastructure = context.Settings.Get<TransportInfrastructure>();
-            var canReceive = !context.Settings.Get<EndpointComponent>().IsSendOnly;
+            var canReceive = !context.Endpoint.IsSendOnly;
 
             context.Pipeline.Register(new MulticastPublishRouterBehavior(), "Determines how the published messages should be routed");
 

--- a/src/NServiceBus.Core/Routing/NativePublishSubscribeFeature.cs
+++ b/src/NServiceBus.Core/Routing/NativePublishSubscribeFeature.cs
@@ -13,7 +13,7 @@ namespace NServiceBus.Features
         protected internal override void Setup(FeatureConfigurationContext context)
         {
             var transportInfrastructure = context.Settings.Get<TransportInfrastructure>();
-            var canReceive = !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly");
+            var canReceive = !context.Settings.Get<EndpointComponent>().IsSendOnly;
 
             context.Pipeline.Register(new MulticastPublishRouterBehavior(), "Determines how the published messages should be routed");
 

--- a/src/NServiceBus.Core/Routing/ReplyAddressFeature.cs
+++ b/src/NServiceBus.Core/Routing/ReplyAddressFeature.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Features
         public ReplyAddressFeature()
         {
             EnableByDefault();
-            Prerequisite(c => !c.Settings.Get<EndpointComponent>().IsSendOnly, "Send-Only endpoints can't receive replies");
+            Prerequisite(c => !c.Endpoint.IsSendOnly, "Send-Only endpoints can't receive replies");
         }
 
         protected internal override void Setup(FeatureConfigurationContext context)

--- a/src/NServiceBus.Core/Routing/ReplyAddressFeature.cs
+++ b/src/NServiceBus.Core/Routing/ReplyAddressFeature.cs
@@ -5,7 +5,7 @@ namespace NServiceBus.Features
         public ReplyAddressFeature()
         {
             EnableByDefault();
-            Prerequisite(c => !c.Settings.GetOrDefault<bool>("Endpoint.SendOnly"), "Send-Only endpoints can't receive replies");
+            Prerequisite(c => !c.Settings.Get<EndpointComponent>().IsSendOnly, "Send-Only endpoints can't receive replies");
         }
 
         protected internal override void Setup(FeatureConfigurationContext context)

--- a/src/NServiceBus.Core/Scheduling/Scheduler.cs
+++ b/src/NServiceBus.Core/Scheduling/Scheduler.cs
@@ -8,7 +8,7 @@ namespace NServiceBus.Features
     {
         internal Scheduler()
         {
-            Prerequisite(c => !c.Settings.GetOrDefault<bool>("Endpoint.SendOnly"), "Scheduler cannot be used from a sendonly endpoint");
+            Prerequisite(c => !c.Settings.Get<EndpointComponent>().IsSendOnly, "Scheduler cannot be used from a sendonly endpoint");
 
             EnableByDefault();
         }

--- a/src/NServiceBus.Core/Scheduling/Scheduler.cs
+++ b/src/NServiceBus.Core/Scheduling/Scheduler.cs
@@ -8,7 +8,7 @@ namespace NServiceBus.Features
     {
         internal Scheduler()
         {
-            Prerequisite(c => !c.Settings.Get<EndpointComponent>().IsSendOnly, "Scheduler cannot be used from a sendonly endpoint");
+            Prerequisite(c => !c.Endpoint.IsSendOnly, "Scheduler cannot be used from a sendonly endpoint");
 
             EnableByDefault();
         }

--- a/src/NServiceBus.Core/SettingsExtensions.cs
+++ b/src/NServiceBus.Core/SettingsExtensions.cs
@@ -24,7 +24,7 @@ namespace NServiceBus
         public static string EndpointName(this ReadOnlySettings settings)
         {
             Guard.AgainstNull(nameof(settings), settings);
-            return settings.Get<EndpointComponent>().Name;
+            return settings.Get<EndpointInfo>().Name;
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/SettingsExtensions.cs
+++ b/src/NServiceBus.Core/SettingsExtensions.cs
@@ -24,7 +24,7 @@ namespace NServiceBus
         public static string EndpointName(this ReadOnlySettings settings)
         {
             Guard.AgainstNull(nameof(settings), settings);
-            return settings.Get<string>("NServiceBus.Routing.EndpointName");
+            return settings.Get<EndpointComponent>().Name;
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -109,7 +109,7 @@ namespace NServiceBus
 
         List<TransportReceiver> CreateReceivers(IPipeline<ITransportReceiveContext> mainPipeline)
         {
-            if (settings.Get<EndpointComponent>().IsSendOnly)
+            if (settings.Get<EndpointInfo>().IsSendOnly)
             {
                 return new List<TransportReceiver>();
             }

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -109,7 +109,7 @@ namespace NServiceBus
 
         List<TransportReceiver> CreateReceivers(IPipeline<ITransportReceiveContext> mainPipeline)
         {
-            if (settings.GetOrDefault<bool>("Endpoint.SendOnly"))
+            if (settings.Get<EndpointComponent>().IsSendOnly)
             {
                 return new List<TransportReceiver>();
             }

--- a/src/NServiceBus.Core/Transports/Receiving.cs
+++ b/src/NServiceBus.Core/Transports/Receiving.cs
@@ -9,11 +9,11 @@ namespace NServiceBus
         internal Receiving()
         {
             EnableByDefault();
-            Prerequisite(c => !c.Settings.GetOrDefault<bool>("Endpoint.SendOnly"), "Endpoint is configured as send-only");
+            Prerequisite(c => !c.Settings.Get<EndpointComponent>().IsSendOnly, "Endpoint is configured as send-only");
             Defaults(s =>
             {
                 var transportInfrastructure = s.Get<TransportInfrastructure>();
-                var discriminator = s.GetOrDefault<string>("EndpointInstanceDiscriminator");
+                var discriminator = s.Get<EndpointComponent>().InstanceDiscriminator;
                 var baseQueueName = s.GetOrDefault<string>("BaseInputQueueName") ?? s.EndpointName();
 
                 var mainInstance = transportInfrastructure.BindToLocalEndpoint(new EndpointInstance(s.EndpointName()));

--- a/src/NServiceBus.Core/Transports/Receiving.cs
+++ b/src/NServiceBus.Core/Transports/Receiving.cs
@@ -9,11 +9,11 @@ namespace NServiceBus
         internal Receiving()
         {
             EnableByDefault();
-            Prerequisite(c => !c.Settings.Get<EndpointComponent>().IsSendOnly, "Endpoint is configured as send-only");
+            Prerequisite(c => !c.Endpoint.IsSendOnly, "Endpoint is configured as send-only");
             Defaults(s =>
             {
                 var transportInfrastructure = s.Get<TransportInfrastructure>();
-                var discriminator = s.Get<EndpointComponent>().InstanceDiscriminator;
+                var discriminator = s.Get<EndpointInfo>().InstanceDiscriminator;
                 var baseQueueName = s.GetOrDefault<string>("BaseInputQueueName") ?? s.EndpointName();
 
                 var mainInstance = transportInfrastructure.BindToLocalEndpoint(new EndpointInstance(s.EndpointName()));


### PR DESCRIPTION
This PR's add endpoint info to diagnostics. It also extracts a `EndpointInfo` "DTO" to get rid of some magical strings.

Adds the following to diagnostics:

```
...
"Endpoint":{
   "Name":"EndpointStarts.MyEndpoint",
   "IsSendOnly":true,
   "InstanceDiscriminator":"instance1"
}
...
```

SideNote: 

I realized that a better api for configuring this in the future would be `class EndpointConfiguration(string endpointName, bool isSendOnly = null, string instanceDiscriminator = null)`