### PR TITLE
Add recoverability diagnostics section

### DIFF
--- a/src/NServiceBus.Core/Recoverability/Recoverability.cs
+++ b/src/NServiceBus.Core/Recoverability/Recoverability.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using ConsistencyGuarantees;
     using DelayedDelivery;
     using DeliveryConstraints;
@@ -37,6 +38,27 @@
             var errorQueue = context.Settings.ErrorQueueAddress();
             context.Settings.Get<QueueBindings>().BindSending(errorQueue);
 
+            var transactionsOn = context.Settings.GetRequiredTransactionModeForReceives() != TransportTransactionMode.None;
+            var delayedRetryConfig = GetDelayedRetryConfig(context.Settings, transactionsOn);
+            var delayedRetriesAvailable = transactionsOn
+                                          && (context.Settings.DoesTransportSupportConstraint<DelayedDeliveryConstraint>() || context.Settings.Get<TimeoutManagerAddressConfiguration>().TransportAddress != null);
+
+
+            var immediateRetryConfig = GetImmediateRetryConfig(context.Settings, transactionsOn);
+            var immediateRetriesAvailable = transactionsOn;
+
+            var failedConfig = new FailedConfig(errorQueue, context.Settings.UnrecoverableExceptions());
+
+            var recoverabilityConfig = new RecoverabilityConfig(immediateRetryConfig, delayedRetryConfig, failedConfig);
+            context.Settings.AddStartupDiagnosticsSection("Recoverability", new
+            {
+                ImmediateRetries = recoverabilityConfig.Immediate.MaxNumberOfRetries,
+                DelayedRetries = recoverabilityConfig.Delayed.MaxNumberOfRetries,
+                DelayedRetriesTimeIncrease = recoverabilityConfig.Delayed.TimeIncrease.ToString("g"),
+                ErrorQueue = recoverabilityConfig.Failed.ErrorQueue,
+                UnrecoverableExceptions = recoverabilityConfig.Failed.UnrecoverableExceptionTypes.Select(t => t.FullName).ToArray()
+            });
+
             context.Container.ConfigureComponent(b =>
             {
                 Func<string, MoveToErrorsExecutor> moveToErrorsExecutorFactory = localAddress =>
@@ -55,12 +77,7 @@
 
                     return new MoveToErrorsExecutor(b.Build<IDispatchMessages>(), staticFaultMetadata, headerCustomizations);
                 };
-
-                var transactionsOn = context.Settings.GetRequiredTransactionModeForReceives() != TransportTransactionMode.None;
-                var delayedRetryConfig = GetDelayedRetryConfig(context.Settings, transactionsOn);
-                var delayedRetriesAvailable = transactionsOn
-                                              && (context.Settings.DoesTransportSupportConstraint<DelayedDeliveryConstraint>() || context.Settings.Get<TimeoutManagerAddressConfiguration>().TransportAddress != null);
-
+                
                 Func<string, DelayedRetryExecutor> delayedRetryExecutorFactory = localAddress =>
                 {
                     if (delayedRetriesAvailable)
@@ -76,19 +93,14 @@
                     return null;
                 };
 
-                var immediateRetryConfig = GetImmediateRetryConfig(context.Settings, transactionsOn);
-                var immediateRetriesAvailable = transactionsOn;
-
                 if (!context.Settings.TryGet(PolicyOverride, out Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> policy))
                 {
                     policy = DefaultRecoverabilityPolicy.Invoke;
                 }
 
-                var failedConfig = new FailedConfig(errorQueue, context.Settings.UnrecoverableExceptions());
-
                 return new RecoverabilityExecutorFactory(
                     policy,
-                    new RecoverabilityConfig(immediateRetryConfig, delayedRetryConfig, failedConfig),
+                    recoverabilityConfig,
                     delayedRetryExecutorFactory,
                     moveToErrorsExecutorFactory,
                     immediateRetriesAvailable,

--- a/src/NServiceBus.Core/Recoverability/Recoverability.cs
+++ b/src/NServiceBus.Core/Recoverability/Recoverability.cs
@@ -50,12 +50,13 @@
             var failedConfig = new FailedConfig(errorQueue, context.Settings.UnrecoverableExceptions());
 
             var recoverabilityConfig = new RecoverabilityConfig(immediateRetryConfig, delayedRetryConfig, failedConfig);
+
             context.Settings.AddStartupDiagnosticsSection("Recoverability", new
             {
                 ImmediateRetries = recoverabilityConfig.Immediate.MaxNumberOfRetries,
                 DelayedRetries = recoverabilityConfig.Delayed.MaxNumberOfRetries,
                 DelayedRetriesTimeIncrease = recoverabilityConfig.Delayed.TimeIncrease.ToString("g"),
-                ErrorQueue = recoverabilityConfig.Failed.ErrorQueue,
+                recoverabilityConfig.Failed.ErrorQueue,
                 UnrecoverableExceptions = recoverabilityConfig.Failed.UnrecoverableExceptionTypes.Select(t => t.FullName).ToArray()
             });
 
@@ -77,7 +78,7 @@
 
                     return new MoveToErrorsExecutor(b.Build<IDispatchMessages>(), staticFaultMetadata, headerCustomizations);
                 };
-                
+
                 Func<string, DelayedRetryExecutor> delayedRetryExecutorFactory = localAddress =>
                 {
                     if (delayedRetriesAvailable)


### PR DESCRIPTION
Sets the immediate/delayed retry and error queue settings on the diagnostics file.

Note that due to the changes in the feature, there is a slight change in time when we resolve the settings. But as it's not intended to set those values somehow in feature setups (and we don't provide any API to do so), I don't see this as an issue.

Sample output:

	"Recoverability": {
		"ImmediateRetries": 0,
		"DelayedRetries": 0,
		"DelayedRetriesTimeIncrease": "0:00:10",
		"ErrorQueue": "error",
		"UnrecoverableExceptions": ["NServiceBus.MessageDeserializationException"]
	}