### PR TITLE
Ensure test fails on diagnostic exceptions

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
@@ -16,7 +16,10 @@
         {
             // TestContext.CurrentContext.Test.ID is stable across test runs, 
             // therefore we need to clear existing diagnostics file to avoid asserting on a stale file
-            Directory.Delete(basePath, true);
+            if (Directory.Exists(basePath))
+            {
+                Directory.Delete(basePath, true);
+            }
 
             await Scenario.Define<Context>()
                 .WithEndpoint<MyEndpoint>()

--- a/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
@@ -14,6 +14,10 @@
         [Test]
         public async Task Should_emit_config_diagnostics()
         {
+            // TestContext.CurrentContext.Test.ID is stable across test runs, 
+            // therefore we need to clear existing diagnostics file to avoid asserting on a stale file
+            Directory.Delete(basePath, true);
+
             await Scenario.Define<Context>()
                 .WithEndpoint<MyEndpoint>()
                 .Done(c => c.EndpointsStarted)


### PR DESCRIPTION
The tests writes the diagnostics file at `static string basePath = Path.Combine(TestContext.CurrentContext.TestDirectory, TestContext.CurrentContext.Test.ID);`. The test.id is consistent across test runs, which means that there is a very high chance that a json config file already exists there. This wouldn't be an issue in the happy path as we're overwriting the file, but if the serialization/writing of the json file fails for some reason, the test still succeeds because:
* we swallow exceptions when writing the diagnostics file
* the assert only checks the presence of a file

Deleting files before running the tests allows to have the file around for manual inspection after a successful test.