### PR TITLE
Add audit diagnostics section

### DIFF
--- a/src/NServiceBus.Core/Audit/Audit.cs
+++ b/src/NServiceBus.Core/Audit/Audit.cs
@@ -29,6 +29,12 @@
             context.Pipeline.Register("AuditProcessedMessage", new InvokeAuditPipelineBehavior(auditConfig.Address), "Execute the audit pipeline");
 
             context.Settings.Get<QueueBindings>().BindSending(auditConfig.Address);
+
+            context.Settings.AddStartupDiagnosticsSection("Audit", new
+            {
+                AuditQueue = auditConfig.Address,
+                AuditTTBR = auditConfig.TimeToBeReceived?.ToString("g") ?? "-"
+            });
         }
     }
 }


### PR DESCRIPTION
Adds an audit diagnostics section when an audit queue has been configured.

e.g.

    "Audit": {
		"AuditQueue": "test",
		"AuditTTBR": "42:0:00:00"
	},