### PR TITLE
Make sure File.Move leaves a unlocked file behind

### DIFF
--- a/src/NServiceBus.Core/Transports/Learning/AsyncFile.cs
+++ b/src/NServiceBus.Core/Transports/Learning/AsyncFile.cs
@@ -96,19 +96,21 @@ namespace NServiceBus
             return new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
         }
 
-        public static async Task<bool> Move(string source, string target)
+        public static async Task<bool> Move(string sourcePath, string targetPath)
         {
             try
             {
-                File.Move(source, target);
+                File.Move(sourcePath, targetPath);
             }
             catch (IOException)
             {
                 return false;
             }
 
+            var targetFileInfo = new FileInfo(targetPath);
             var count = 0;
-            while (IsFileLocked(new FileInfo(target)))
+
+            while (IsFileLocked(targetFileInfo))
             {
                 await Task.Delay(100).ConfigureAwait(false);
 
@@ -120,8 +122,7 @@ namespace NServiceBus
                 }
             }
 
-            //seem like File.Move is not atomic at least within the same process so we need this extra check
-            return File.Exists(target);
+            return true;
         }
 
         static bool IsFileLocked(FileInfo file)

--- a/src/NServiceBus.Core/Transports/Learning/AsyncFile.cs
+++ b/src/NServiceBus.Core/Transports/Learning/AsyncFile.cs
@@ -100,17 +100,16 @@ namespace NServiceBus
         {
             try
             {
-                File.Move(sourcePath, targetPath);
+                new FileInfo(sourcePath).MoveTo(targetPath);
             }
             catch (IOException)
             {
                 return false;
             }
 
-            var targetFileInfo = new FileInfo(targetPath);
             var count = 0;
 
-            while (IsFileLocked(targetFileInfo))
+            while (IsFileLocked(targetPath))
             {
                 await Task.Delay(100).ConfigureAwait(false);
 
@@ -125,13 +124,14 @@ namespace NServiceBus
             return true;
         }
 
-        static bool IsFileLocked(FileInfo file)
+        static bool IsFileLocked(string filePath)
         {
-            FileStream stream = null;
-
             try
             {
-                stream = file.Open(FileMode.Open, FileAccess.Read, FileShare.None);
+                using (File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.None))
+                {
+                    //no-op
+                }
             }
             catch (IOException)
             {
@@ -141,16 +141,9 @@ namespace NServiceBus
                 //or does not exist (has already been processed)
                 return true;
             }
-            finally
-            {
-                if (stream != null)
-                    stream.Close();
-            }
 
             //file is not locked
             return false;
         }
-
-
     }
 }

--- a/src/NServiceBus.Core/Transports/Learning/AsyncFile.cs
+++ b/src/NServiceBus.Core/Transports/Learning/AsyncFile.cs
@@ -100,7 +100,7 @@ namespace NServiceBus
         {
             try
             {
-                new FileInfo(sourcePath).MoveTo(targetPath);
+                File.Move(sourcePath, targetPath);
             }
             catch (IOException)
             {

--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -57,7 +57,7 @@ namespace NServiceBus
             return AsyncFile.WriteText(txPath, messageContents);
         }
 
-        public async Task<bool> Complete()
+        public bool Complete()
         {
             if (!committed)
             {
@@ -66,7 +66,7 @@ namespace NServiceBus
 
             while (outgoingFiles.TryDequeue(out var outgoingFile))
             {
-                await AsyncFile.Move(outgoingFile.TxPath, outgoingFile.TargetPath).ConfigureAwait(false);
+                File.Move(outgoingFile.TxPath, outgoingFile.TargetPath);
             }
 
             Directory.Delete(commitDir, true);

--- a/src/NServiceBus.Core/Transports/Learning/ILearningTransportTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/ILearningTransportTransaction.cs
@@ -16,6 +16,6 @@ namespace NServiceBus
 
         Task Enlist(string messagePath, string messageContents);
 
-        Task<bool> Complete();
+        bool Complete();
     }
 }

--- a/src/NServiceBus.Core/Transports/Learning/ILearningTransportTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/ILearningTransportTransaction.cs
@@ -6,7 +6,7 @@ namespace NServiceBus
     {
         string FileToProcess { get; }
 
-        bool BeginTransaction(string incomingFilePath);
+        Task<bool> BeginTransaction(string incomingFilePath);
 
         Task Commit();
 
@@ -16,6 +16,6 @@ namespace NServiceBus
 
         Task Enlist(string messagePath, string messageContents);
 
-        bool Complete();
+        Task<bool> Complete();
     }
 }

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -175,7 +175,7 @@
                     }
 
                     ProcessFile(transaction, nativeMessageId)
-                        .ContinueWith(async t =>
+                        .ContinueWith(t =>
                         {
                             try
                             {
@@ -184,7 +184,7 @@
                                     log.Debug($"Completing processing for {filePath}({transaction.FileToProcess}), exception (if any): {t.Exception}");
                                 }
 
-                                var wasCommitted = await transaction.Complete().ConfigureAwait(false);
+                                var wasCommitted = transaction.Complete();
 
                                 if (wasCommitted)
                                 {

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -157,7 +157,7 @@
                     {
                         transaction = GetTransaction();
 
-                        var ableToLockFile = transaction.BeginTransaction(filePath);
+                        var ableToLockFile = await transaction.BeginTransaction(filePath).ConfigureAwait(false);
 
                         if (!ableToLockFile)
                         {
@@ -175,7 +175,7 @@
                     }
 
                     ProcessFile(transaction, nativeMessageId)
-                        .ContinueWith(t =>
+                        .ContinueWith(async t =>
                         {
                             try
                             {
@@ -184,7 +184,7 @@
                                     log.Debug($"Completing processing for {filePath}({transaction.FileToProcess}), exception (if any): {t.Exception}");
                                 }
 
-                                var wasCommitted = transaction.Complete();
+                                var wasCommitted = await transaction.Complete().ConfigureAwait(false);
 
                                 if (wasCommitted)
                                 {

--- a/src/NServiceBus.Core/Transports/Learning/NoTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/NoTransaction.cs
@@ -29,11 +29,11 @@ namespace NServiceBus
 
         public void ClearPendingOutgoingOperations() { }
 
-        public Task<bool> Complete()
+        public bool Complete()
         {
             Directory.Delete(processingDirectory, true);
 
-            return Task.FromResult(true);
+            return true;
         }
 
         string processingDirectory;


### PR DESCRIPTION
We've seen the acceptance tests fail now and then due to file lock issues. @mikeminutillo ran into this as well while testing the learning transport together with ServiceControl.

This PR makes sure that we don't exit "File.Move" until the file is unlocked.