### PR TITLE
Fix queue creation logic

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeQueueCreator.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeQueueCreator.cs
@@ -1,13 +1,22 @@
 namespace NServiceBus.AcceptanceTests.Core.FakeTransport
 {
+    using System;
     using System.Threading.Tasks;
     using Transport;
 
     class FakeQueueCreator : ICreateQueues
     {
+        public FakeQueueCreator(Action action = null)
+        {
+            this.action = action;
+        }
+
         public Task CreateQueueIfNecessary(QueueBindings queueBindings, string identity)
         {
+            action?.Invoke();
             return Task.FromResult(0);
         }
+
+        Action action;
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeQueueCreator.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeQueueCreator.cs
@@ -6,17 +6,17 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport
 
     class FakeQueueCreator : ICreateQueues
     {
-        public FakeQueueCreator(Action action = null)
+        public FakeQueueCreator(Action onQueueCreation = null)
         {
-            this.action = action;
+            this.onQueueCreation = onQueueCreation;
         }
 
         public Task CreateQueueIfNecessary(QueueBindings queueBindings, string identity)
         {
-            action?.Invoke();
+            onQueueCreation?.Invoke();
             return Task.FromResult(0);
         }
 
-        Action action;
+        Action onQueueCreation;
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
@@ -44,7 +44,7 @@
 
         public override TransportReceiveInfrastructure ConfigureReceiveInfrastructure()
         {
-            return new TransportReceiveInfrastructure(() => new FakeReceiver(settings.GetOrDefault<bool>("FakeTransport.ThrowCritical"), settings.GetOrDefault<bool>("FakeTransport.ThrowOnPumpStop"), settings.GetOrDefault<Exception>()), () => new FakeQueueCreator(), () => Task.FromResult(StartupCheckResult.Success));
+            return new TransportReceiveInfrastructure(() => new FakeReceiver(settings.GetOrDefault<bool>("FakeTransport.ThrowCritical"), settings.GetOrDefault<bool>("FakeTransport.ThrowOnPumpStop"), settings.GetOrDefault<Exception>()), () => new FakeQueueCreator(settings.GetOrDefault<Action>("FakeTransport.QueueCreatorAction")), () => Task.FromResult(StartupCheckResult.Success));
         }
 
         public override async Task Stop()

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportSettingsExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportSettingsExtensions.cs
@@ -28,5 +28,12 @@
 
             return transportExtensions;
         }
+
+        public static TransportExtensions<FakeTransport> WhenQueuesCreated(this TransportExtensions<FakeTransport> transportExtensions, Action action)
+        {
+            transportExtensions.GetSettings().Set("FakeTransport.QueueCreatorAction", action);
+
+            return transportExtensions;
+        }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Core/Installers/When_creating_queues.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Installers/When_creating_queues.cs
@@ -1,0 +1,105 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Installers
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Configuration.AdvancedExtensibility;
+    using EndpointTemplates;
+    using FakeTransport;
+    using NUnit.Framework;
+
+    public class When_creating_queues : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_not_create_queues_when_queue_creation_disabled_and_installers_disabled()
+        {
+            var context = await Scenario.Define<Context>(c =>
+                {
+                    c.DoNotCreateQueues = true;
+                    c.EnableInstallers = false;
+                })
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsFalse(context.QueuesCreated);
+        }
+
+        [Test]
+        public async Task Should_not_create_queues_when_queue_creation_disabled_and_installers_enabled()
+        {
+            var context = await Scenario.Define<Context>(c =>
+                {
+                    c.DoNotCreateQueues = true;
+                    c.EnableInstallers = true;
+                })
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsFalse(context.QueuesCreated);
+        }
+
+        [Test]
+        public async Task Should_not_create_queues_when_queue_creation_enabled_and_installers_disabled()
+        {
+            var context = await Scenario.Define<Context>(c =>
+                {
+                    c.DoNotCreateQueues = false;
+                    c.EnableInstallers = false;
+                })
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsFalse(context.QueuesCreated);
+        }
+
+        [Test]
+        public async Task Should_create_queues_when_queue_creation_enabled_and_installers_enabled()
+        {
+            var context = await Scenario.Define<Context>(c =>
+                {
+                    c.DoNotCreateQueues = false;
+                    c.EnableInstallers = true;
+                })
+                .WithEndpoint<Endpoint>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.QueuesCreated);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool DoNotCreateQueues { get; set; }
+            public bool EnableInstallers { get; set; }
+            public bool QueuesCreated { get; set; }
+        }
+
+        class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer, Context>((c, t) =>
+                {
+                    c.UseTransport<FakeTransport>()
+                        .WhenQueuesCreated(() =>
+                        {
+                            t.QueuesCreated = true;
+                        });
+
+                    if (t.DoNotCreateQueues)
+                    {
+                        c.DoNotCreateQueues();
+                    }
+                    
+                    if (!t.EnableInstallers)
+                    {
+                        // DefaultServer always calls EnableInstaller. We need to reverse it.
+                        c.GetSettings().Set("Installers.Enable", false);
+                    }
+                });
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/Installers/When_installers_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Installers/When_installers_enabled.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.Installers
+﻿namespace NServiceBus.AcceptanceTests.Core.Installers
 {
     using System.Threading.Tasks;
     using AcceptanceTesting;

--- a/src/NServiceBus.AcceptanceTests/Core/Installers/When_installers_not_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Installers/When_installers_not_enabled.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.Installers
+﻿namespace NServiceBus.AcceptanceTests.Core.Installers
 {
     using System.Threading.Tasks;
     using AcceptanceTesting;


### PR DESCRIPTION
Create queues only when installer are enabled and queue creation has not been explicitly disabled.

Resolve #5023 