### PR TITLE
Emit persistence diagnostics

### DIFF
--- a/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnostics.cs
+++ b/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnostics.cs
@@ -64,7 +64,9 @@
             {
                 try
                 {
-                    var data = SimpleJson.SerializeObject(settings.Get<StartupDiagnosticEntries>().Entries.ToDictionary(e => e.Name, e => e.Data));
+                    var data = SimpleJson.SerializeObject(settings.Get<StartupDiagnosticEntries>().Entries
+                        .OrderBy(e=>e.Name)
+                        .ToDictionary(e => e.Name, e => e.Data));
 
                     await diagnosticsWriter.Write(data).ConfigureAwait(false);
                 }

--- a/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnostics.cs
+++ b/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnostics.cs
@@ -65,7 +65,7 @@
                 try
                 {
                     var data = SimpleJson.SerializeObject(settings.Get<StartupDiagnosticEntries>().Entries
-                        .OrderBy(e=>e.Name)
+                        .OrderBy(e => e.Name)
                         .ToDictionary(e => e.Name, e => e.Data));
 
                     await diagnosticsWriter.Write(data).ConfigureAwait(false);

--- a/src/NServiceBus.Core/Persistence/PersistenceStartup.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceStartup.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using Logging;
     using Persistence;
     using Settings;


### PR DESCRIPTION
 Outputs:

```
"Persistence":{
   "Sagas":{
      "Type":"NServiceBus.LearningPersistence",
      "Version":"7.0.0"
   },
   "Timeouts":{
      "Type":"NServiceBus.InMemoryPersistence",
      "Version":"7.0.0"
   },
   "Subscriptions":{
      "Type":"NServiceBus.InMemoryPersistence",
      "Version":"7.0.0"
   }
}
```

Note that the selected storage for each storage type is listed but we have no way of knowing if they are actually used. Talking to @timbussmann we decided to live with this for now until we redo the "persistence" concept.

This also orders the section by Name ASC