### PR TITLE
Add message diagnostics

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
@@ -47,10 +47,5 @@
                    .EnableStartupDiagnostics();
             }
         }
-
-        class MyMessage : IMessage
-        {
-
-        }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
@@ -47,5 +47,10 @@
                    .EnableStartupDiagnostics();
             }
         }
+
+        class MyMessage : IMessage
+        {
+
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/ConventionsTests.cs
+++ b/src/NServiceBus.Core.Tests/ConventionsTests.cs
@@ -5,7 +5,7 @@
     [TestFixture]
     public class ConventionsTests
     {
-      
+
         [Test]
         public void IsMessageType_should_return_false_for_unknown_type()
         {
@@ -81,14 +81,13 @@
                 Assert.IsFalse(conventions.IsCommandType(typeof(Conventions)));
             }
 
-        
+
             [Test]
             public void IsMessageType_should_return_false_for_NServiceBus_types()
             {
-                var conventions = new Conventions
-                {
-                    IsMessageTypeAction = t => t.Assembly == typeof(Conventions).Assembly
-                };
+                var conventions = new Conventions();
+
+                conventions.DefineMessageTypeConvention(t => t.Assembly == typeof(Conventions).Assembly);
                 Assert.IsFalse(conventions.IsMessageType(typeof(Conventions)));
             }
 
@@ -124,11 +123,9 @@
             [Test]
             public void IsMessageType_should_return_true_for_matching_type()
             {
-                var conventions = new Conventions
-                {
-                    IsMessageTypeAction = t => t.Assembly == typeof(Conventions).Assembly ||
-                                               t == typeof(MyConventionMessage)
-                };
+                var conventions = new Conventions();
+
+                conventions.DefineMessageTypeConvention(t => t.Assembly == typeof(Conventions).Assembly || t == typeof(MyConventionMessage));
                 Assert.IsTrue(conventions.IsMessageType(typeof(MyConventionMessage)));
             }
 

--- a/src/NServiceBus.Core.Tests/ConventionsTests.cs
+++ b/src/NServiceBus.Core.Tests/ConventionsTests.cs
@@ -5,7 +5,6 @@
     [TestFixture]
     public class ConventionsTests
     {
-
         [Test]
         public void IsMessageType_should_return_false_for_unknown_type()
         {
@@ -67,7 +66,6 @@
 
         }
 
-
         [TestFixture]
         public class When_using_a_greedy_convention_that_overlaps_with_NServiceBus
         {
@@ -80,7 +78,6 @@
                 };
                 Assert.IsFalse(conventions.IsCommandType(typeof(Conventions)));
             }
-
 
             [Test]
             public void IsMessageType_should_return_false_for_NServiceBus_types()

--- a/src/NServiceBus.Core.Tests/MessageConventionSpecs.cs
+++ b/src/NServiceBus.Core.Tests/MessageConventionSpecs.cs
@@ -9,15 +9,13 @@
         public void Should_cache_the_message_convention()
         {
             var timesCalled = 0;
-            conventions = new Conventions
-            {
-                IsMessageTypeAction = t =>
-                {
-                    timesCalled++;
-                    return false;
-                }
-            };
+            conventions = new Conventions();
 
+            conventions.DefineMessageTypeConvention(t =>
+            {
+                timesCalled++;
+                return false;
+            });
             conventions.IsMessageType(GetType());
             Assert.AreEqual(1, timesCalled);
 

--- a/src/NServiceBus.Core.Tests/Pipeline/Incoming/SerializeMessageConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Incoming/SerializeMessageConnectorTests.cs
@@ -16,7 +16,7 @@
         [Test]
         public async Task Should_set_content_type_header()
         {
-            var registry = new MessageMetadataRegistry(new Conventions());
+            var registry = new MessageMetadataRegistry(new Conventions().IsMessageType);
 
             registry.RegisterMessageTypesFoundIn(new List<Type>
             {

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterConnectorTests.cs
@@ -65,7 +65,7 @@
 
         static UnicastSendRouterConnector InitializeBehavior(FakeRouter router = null)
         {
-            var metadataRegistry = new MessageMetadataRegistry(new Conventions());
+            var metadataRegistry = new MessageMetadataRegistry(new Conventions().IsMessageType);
             metadataRegistry.RegisterMessageTypesFoundIn(new List<Type>
             {
                 typeof(MyMessage),

--- a/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
@@ -102,7 +102,7 @@
         [SetUp]
         public void Setup()
         {
-            metadataRegistry = new MessageMetadataRegistry(new Conventions());
+            metadataRegistry = new MessageMetadataRegistry(_ => true);
             endpointInstances = new EndpointInstances();
             subscriptionStorage = new FakeSubscriptionStorage();
             router = new UnicastPublishRouter(
@@ -113,7 +113,7 @@
 
         class FakeSubscriptionStorage : ISubscriptionStorage
         {
-            public List<Subscriber> Subscribers { get; }= new List<Subscriber>();
+            public List<Subscriber> Subscribers { get; } = new List<Subscriber>();
             public Task Subscribe(Subscriber subscriber, MessageType messageType, ContextBag context)
             {
                 throw new NotImplementedException();

--- a/src/NServiceBus.Core.Tests/Unicast/Messages/DefaultMessageRegistryTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/Messages/DefaultMessageRegistryTests.cs
@@ -15,17 +15,14 @@
             [Test]
             public void Should_throw_an_exception_for_a_unmapped_type()
             {
-                var defaultMessageRegistry = new MessageMetadataRegistry(new Conventions());
+                var defaultMessageRegistry = new MessageMetadataRegistry(_ => false);
                 Assert.Throws<Exception>(() => defaultMessageRegistry.GetMessageMetadata(typeof(int)));
             }
 
             [Test]
             public void Should_return_metadata_for_a_mapped_type()
             {
-                var conventions = new Conventions();
-                conventions.IsMessageTypeAction = type => type == typeof(int);
-
-                var defaultMessageRegistry = new MessageMetadataRegistry(conventions);
+                var defaultMessageRegistry = new MessageMetadataRegistry(type => type == typeof(int));
                 defaultMessageRegistry.RegisterMessageTypesFoundIn(new List<Type> { typeof(int) });
 
                 var messageMetadata = defaultMessageRegistry.GetMessageMetadata(typeof(int));
@@ -38,7 +35,7 @@
             [Test]
             public void Should_return_the_correct_parent_hierarchy()
             {
-                var defaultMessageRegistry = new MessageMetadataRegistry(new Conventions());
+                var defaultMessageRegistry = new MessageMetadataRegistry(new Conventions().IsMessageType);
 
                 defaultMessageRegistry.RegisterMessageTypesFoundIn(new List<Type> { typeof(MyEvent) });
                 var messageMetadata = defaultMessageRegistry.GetMessageMetadata(typeof(MyEvent));

--- a/src/NServiceBus.Core/ConventionsBuilder.cs
+++ b/src/NServiceBus.Core/ConventionsBuilder.cs
@@ -24,7 +24,7 @@ namespace NServiceBus
         public ConventionsBuilder DefiningMessagesAs(Func<Type, bool> definesMessageType)
         {
             Guard.AgainstNull(nameof(definesMessageType), definesMessageType);
-            Conventions.IsMessageTypeAction = definesMessageType;
+            Conventions.DefineMessageTypeConvention(definesMessageType);
             return this;
         }
 

--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -166,11 +166,11 @@ namespace NServiceBus
 
             var foundMessages = messageMetadataRegistry.GetAllMessages().ToList();
 
-            Settings.AddStartupDiagnosticsSection("Messages",new
+            Settings.AddStartupDiagnosticsSection("Messages", new
             {
                 CustomConventionUsed = conventions.CustomMessageTypeConventionUsed,
                 NumberOfMessagesFoundAtStartup = foundMessages.Count,
-                Messages = foundMessages.Select(m=>m.MessageType.FullName)
+                Messages = foundMessages.Select(m => m.MessageType.FullName)
             });
         }
 

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -11,9 +11,9 @@
     /// </summary>
     public class MessageMetadataRegistry
     {
-        internal MessageMetadataRegistry(Conventions conventions)
+        internal MessageMetadataRegistry(Func<Type, bool> isMessageType)
         {
-            this.conventions = conventions;
+            this.isMessageType = isMessageType;
         }
 
         /// <summary>
@@ -107,11 +107,11 @@
 
         MessageMetadata RegisterMessageType(Type messageType)
         {
-            if (conventions.IsMessageType(messageType))
+            if (isMessageType(messageType))
             {
                 //get the parent types
                 var parentMessages = GetParentTypes(messageType)
-                    .Where(t => conventions.IsMessageType(t))
+                    .Where(t => isMessageType(t))
                     .OrderByDescending(PlaceInMessageHierarchy);
 
                 var metadata = new MessageMetadata(messageType, new[]
@@ -161,7 +161,7 @@
             }
         }
 
-        Conventions conventions;
+        Func<Type, bool> isMessageType;
         ConcurrentDictionary<RuntimeTypeHandle, MessageMetadata> messages = new ConcurrentDictionary<RuntimeTypeHandle, MessageMetadata>();
         ConcurrentDictionary<string, Type> cachedTypes = new ConcurrentDictionary<string, Type>();
 


### PR DESCRIPTION
Outputs:

```
"Messages":{
   "CustomConventionUsed":false,
   "NumberOfMessagesFoundAtStartup":1,
   "Messages":[
      "NServiceBus.AcceptanceTests.Core.Hosting.When_endpoint_starts+MyMessage"
   ]
}

```

Made a few changes to the message metadata registry to capture if a custom convention was used our not