### PR TITLE
Add TransportSendInfrastructure.PreStartupCheck to test

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
@@ -79,7 +79,12 @@
         {
             settings.Get<FakeTransport.StartUpSequence>().Add($"{nameof(TransportInfrastructure)}.{nameof(ConfigureSendInfrastructure)}");
 
-            return new TransportSendInfrastructure(() => new FakeDispatcher(), () => Task.FromResult(StartupCheckResult.Success));
+            return new TransportSendInfrastructure(() => new FakeDispatcher(),
+                () =>
+                {
+                    settings.Get<FakeTransport.StartUpSequence>().Add($"{nameof(TransportSendInfrastructure)}.PreStartupCheck");
+                    return Task.FromResult(StartupCheckResult.Success);
+                });
         }
 
         public override TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure()

--- a/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_initializing_transport.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_initializing_transport.cs
@@ -27,6 +27,7 @@
                 $"{nameof(TransportInfrastructure)}.{nameof(TransportInfrastructure.Start)}",
                 $"{nameof(TransportInfrastructure)}.{nameof(TransportInfrastructure.ConfigureSendInfrastructure)}",
                 $"{nameof(IPushMessages)}.{nameof(IPushMessages.Init)}",
+                $"{nameof(TransportSendInfrastructure)}.PreStartupCheck",
                 $"{nameof(IPushMessages)}.{nameof(IPushMessages.Start)}",
                 $"{nameof(IPushMessages)}.{nameof(IPushMessages.Stop)}",
                 $"{nameof(TransportInfrastructure)}.{nameof(TransportInfrastructure.Stop)}",
@@ -42,12 +43,13 @@
                 .Run();
 
             CollectionAssert.AreEqual(new List<string>
-                {
-                    $"{nameof(TransportDefinition)}.{nameof(TransportDefinition.Initialize)}",
-                    $"{nameof(TransportInfrastructure)}.{nameof(TransportInfrastructure.Start)}",
-                    $"{nameof(TransportInfrastructure)}.{nameof(TransportInfrastructure.ConfigureSendInfrastructure)}",
-                    $"{nameof(TransportInfrastructure)}.{nameof(TransportInfrastructure.Stop)}",
-                }, context.StartUpSequence);
+            {
+                $"{nameof(TransportDefinition)}.{nameof(TransportDefinition.Initialize)}",
+                $"{nameof(TransportInfrastructure)}.{nameof(TransportInfrastructure.Start)}",
+                $"{nameof(TransportInfrastructure)}.{nameof(TransportInfrastructure.ConfigureSendInfrastructure)}",
+                $"{nameof(TransportSendInfrastructure)}.PreStartupCheck",
+                $"{nameof(TransportInfrastructure)}.{nameof(TransportInfrastructure.Stop)}",
+            }, context.StartUpSequence);
         }
 
         class Context : ScenarioContext


### PR DESCRIPTION
Looking at #5032, I noticed the TransportSendInfrastructure PreStartupCheck was left out.

While I think this demonstrates that we're currently calling this in a really weird place in the sequence, I think it make sense to include it in the test so we can observe the change when/if we improve it.