### PR TITLE
Avoid array allocation in writing log

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
+++ b/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
@@ -28,6 +28,24 @@
             Log(fullMessage, LogLevel.Debug);
         }
 
+        public void DebugFormat(string format, object argument1)
+        {
+            var fullMessage = string.Format(format, argument1);
+            Log(fullMessage, LogLevel.Debug);
+        }
+
+        public void DebugFormat(string format, object argument1, object argument2)
+        {
+            var fullMessage = string.Format(format, argument1, argument2);
+            Log(fullMessage, LogLevel.Debug);
+        }
+
+        public void DebugFormat(string format, object argument1, object argument2, object argument3)
+        {
+            var fullMessage = string.Format(format, argument1, argument2, argument3);
+            Log(fullMessage, LogLevel.Debug);
+        }
+
         public void DebugFormat(string format, params object[] args)
         {
             var fullMessage = string.Format(format, args);
@@ -42,6 +60,24 @@
         public void Info(string message, Exception exception)
         {
             var fullMessage = $"{message} {exception}";
+            Log(fullMessage, LogLevel.Info);
+        }
+
+        public void InfoFormat(string format, object argument1)
+        {
+            var fullMessage = string.Format(format, argument1);
+            Log(fullMessage, LogLevel.Info);
+        }
+
+        public void InfoFormat(string format, object argument1, object argument2)
+        {
+            var fullMessage = string.Format(format, argument1, argument2);
+            Log(fullMessage, LogLevel.Info);
+        }
+
+        public void InfoFormat(string format, object argument1, object argument2, object argument3)
+        {
+            var fullMessage = string.Format(format, argument1, argument2, argument3);
             Log(fullMessage, LogLevel.Info);
         }
 
@@ -62,6 +98,24 @@
             Log(fullMessage, LogLevel.Warn);
         }
 
+        public void WarnFormat(string format, object argument1)
+        {
+            var fullMessage = string.Format(format, argument1);
+            Log(fullMessage, LogLevel.Warn);
+        }
+
+        public void WarnFormat(string format, object argument1, object argument2)
+        {
+            var fullMessage = string.Format(format, argument1, argument2);
+            Log(fullMessage, LogLevel.Warn);
+        }
+
+        public void WarnFormat(string format, object argument1, object argument2, object argument3)
+        {
+            var fullMessage = string.Format(format, argument1, argument2, argument3);
+            Log(fullMessage, LogLevel.Warn);
+        }
+
         public void WarnFormat(string format, params object[] args)
         {
             var fullMessage = string.Format(format, args);
@@ -79,6 +133,24 @@
             Log(fullMessage, LogLevel.Error);
         }
 
+        public void ErrorFormat(string format, object argument1)
+        {
+            var fullMessage = string.Format(format, argument1);
+            Log(fullMessage, LogLevel.Error);
+        }
+
+        public void ErrorFormat(string format, object argument1, object argument2)
+        {
+            var fullMessage = string.Format(format, argument1, argument2);
+            Log(fullMessage, LogLevel.Error);
+        }
+
+        public void ErrorFormat(string format, object argument1, object argument2, object argument3)
+        {
+            var fullMessage = string.Format(format, argument1, argument2, argument3);
+            Log(fullMessage, LogLevel.Error);
+        }
+
         public void ErrorFormat(string format, params object[] args)
         {
             var fullMessage = string.Format(format, args);
@@ -93,6 +165,24 @@
         public void Fatal(string message, Exception exception)
         {
             var fullMessage = $"{message} {exception}";
+            Log(fullMessage, LogLevel.Fatal);
+        }
+
+        public void FatalFormat(string format, object argument1)
+        {
+            var fullMessage = string.Format(format, argument1);
+            Log(fullMessage, LogLevel.Fatal);
+        }
+
+        public void FatalFormat(string format, object argument1, object argument2)
+        {
+            var fullMessage = string.Format(format, argument1, argument2);
+            Log(fullMessage, LogLevel.Fatal);
+        }
+
+        public void FatalFormat(string format, object argument1, object argument2, object argument3)
+        {
+            var fullMessage = string.Format(format, argument1, argument2, argument3);
             Log(fullMessage, LogLevel.Fatal);
         }
 

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1687,18 +1687,33 @@ namespace NServiceBus.Logging
         bool IsWarnEnabled { get; }
         void Debug(string message);
         void Debug(string message, System.Exception exception);
+        void DebugFormat(string format, object argument1);
+        void DebugFormat(string format, object argument1, object argument2);
+        void DebugFormat(string format, object argument1, object argument2, object argument3);
         void DebugFormat(string format, params object[] args);
         void Error(string message);
         void Error(string message, System.Exception exception);
+        void ErrorFormat(string format, object argument1);
+        void ErrorFormat(string format, object argument1, object argument2);
+        void ErrorFormat(string format, object argument1, object argument2, object argument3);
         void ErrorFormat(string format, params object[] args);
         void Fatal(string message);
         void Fatal(string message, System.Exception exception);
+        void FatalFormat(string format, object argument1);
+        void FatalFormat(string format, object argument1, object argument2);
+        void FatalFormat(string format, object argument1, object argument2, object argument3);
         void FatalFormat(string format, params object[] args);
         void Info(string message);
         void Info(string message, System.Exception exception);
+        void InfoFormat(string format, object argument1);
+        void InfoFormat(string format, object argument1, object argument2);
+        void InfoFormat(string format, object argument1, object argument2, object argument3);
         void InfoFormat(string format, params object[] args);
         void Warn(string message);
         void Warn(string message, System.Exception exception);
+        void WarnFormat(string format, object argument1);
+        void WarnFormat(string format, object argument1, object argument2);
+        void WarnFormat(string format, object argument1, object argument2, object argument3);
         void WarnFormat(string format, params object[] args);
     }
     public interface ILoggerFactory

--- a/src/NServiceBus.Core/Logging/DefaultLog.cs
+++ b/src/NServiceBus.Core/Logging/DefaultLog.cs
@@ -27,6 +27,21 @@ namespace NServiceBus
             defaultLoggerFactory.Write(name, LogLevel.Debug, message + Environment.NewLine + exception);
         }
 
+        public void DebugFormat(string format, object argument1)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Debug, string.Format(format, argument1));
+        }
+
+        public void DebugFormat(string format, object argument1, object argument2)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Debug, string.Format(format, argument1, argument2));
+        }
+
+        public void DebugFormat(string format, object argument1, object argument2, object argument3)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Debug, string.Format(format, argument1, argument2, argument3));
+        }
+
         public void DebugFormat(string format, params object[] args)
         {
             defaultLoggerFactory.Write(name, LogLevel.Debug, string.Format(format, args));
@@ -40,6 +55,21 @@ namespace NServiceBus
         public void Info(string message, Exception exception)
         {
             defaultLoggerFactory.Write(name, LogLevel.Info, message + Environment.NewLine + exception);
+        }
+
+        public void InfoFormat(string format, object argument1)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Info, string.Format(format, argument1));
+        }
+
+        public void InfoFormat(string format, object argument1, object argument2)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Info, string.Format(format, argument1, argument2));
+        }
+
+        public void InfoFormat(string format, object argument1, object argument2, object argument3)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Info, string.Format(format, argument1, argument2, argument3));
         }
 
         public void InfoFormat(string format, params object[] args)
@@ -57,6 +87,21 @@ namespace NServiceBus
             defaultLoggerFactory.Write(name, LogLevel.Warn, message + Environment.NewLine + exception);
         }
 
+        public void WarnFormat(string format, object argument1)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Warn, string.Format(format, argument1));
+        }
+
+        public void WarnFormat(string format, object argument1, object argument2)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Warn, string.Format(format, argument1, argument2));
+        }
+
+        public void WarnFormat(string format, object argument1, object argument2, object argument3)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Warn, string.Format(format, argument1, argument2, argument3));
+        }
+
         public void WarnFormat(string format, params object[] args)
         {
             defaultLoggerFactory.Write(name, LogLevel.Warn, string.Format(format, args));
@@ -72,6 +117,21 @@ namespace NServiceBus
             defaultLoggerFactory.Write(name, LogLevel.Error, message + Environment.NewLine + exception);
         }
 
+        public void ErrorFormat(string format, object argument1)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Error, string.Format(format, argument1));
+        }
+
+        public void ErrorFormat(string format, object argument1, object argument2)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Error, string.Format(format, argument1, argument2));
+        }
+
+        public void ErrorFormat(string format, object argument1, object argument2, object argument3)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Error, string.Format(format, argument1, argument2, argument3));
+        }
+
         public void ErrorFormat(string format, params object[] args)
         {
             defaultLoggerFactory.Write(name, LogLevel.Error, string.Format(format, args));
@@ -85,6 +145,21 @@ namespace NServiceBus
         public void Fatal(string message, Exception exception)
         {
             defaultLoggerFactory.Write(name, LogLevel.Fatal, message + Environment.NewLine + exception);
+        }
+
+        public void FatalFormat(string format, object argument1)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Fatal, string.Format(format, argument1));
+        }
+
+        public void FatalFormat(string format, object argument1, object argument2)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Fatal, string.Format(format, argument1, argument2));
+        }
+
+        public void FatalFormat(string format, object argument1, object argument2, object argument3)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Fatal, string.Format(format, argument1, argument2, argument3));
         }
 
         public void FatalFormat(string format, params object[] args)

--- a/src/NServiceBus.Core/Logging/ILog.cs
+++ b/src/NServiceBus.Core/Logging/ILog.cs
@@ -47,7 +47,34 @@ namespace NServiceBus.Logging
 
         /// <summary>
         /// Writes the message at the <see cref="LogLevel.Debug" /> level using the specified <paramref name="format" /> provider
-        /// and format <paramref name="args" />.
+        /// and arguments.
+        /// </summary>
+        /// <param name="format">A string containing format items.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        void DebugFormat(string format, object argument1);
+
+        /// <summary>
+        /// Writes the message at the <see cref="LogLevel.Debug" /> level using the specified <paramref name="format" /> provider
+        /// and arguments.
+        /// </summary>
+        /// <param name="format">A string containing format items.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        void DebugFormat(string format, object argument1, object argument2);
+
+        /// <summary>
+        /// Writes the message at the <see cref="LogLevel.Debug" /> level using the specified <paramref name="format" /> provider
+        /// and arguments.
+        /// </summary>
+        /// <param name="format">A string containing format items.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        /// <param name="argument3">The third argument to format.</param>
+        void DebugFormat(string format, object argument1, object argument2, object argument3);
+
+        /// <summary>
+        /// Writes the message at the <see cref="LogLevel.Debug" /> level using the specified <paramref name="format" /> provider
+        /// and arguments.
         /// </summary>
         /// <param name="format">A string containing format items.</param>
         /// <param name="args">Arguments to format.</param>
@@ -68,7 +95,34 @@ namespace NServiceBus.Logging
 
         /// <summary>
         /// Writes the message at the <see cref="LogLevel.Info" /> level using the specified <paramref name="format" /> provider
-        /// and format <paramref name="args" />.
+        /// and arguments.
+        /// </summary>
+        /// <param name="format">A string containing format items.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        void InfoFormat(string format, object argument1);
+
+        /// <summary>
+        /// Writes the message at the <see cref="LogLevel.Info" /> level using the specified <paramref name="format" /> provider
+        /// and arguments.
+        /// </summary>
+        /// <param name="format">A string containing format items.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        void InfoFormat(string format, object argument1, object argument2);
+
+        /// <summary>
+        /// Writes the message at the <see cref="LogLevel.Info" /> level using the specified <paramref name="format" /> provider
+        /// and arguments.
+        /// </summary>
+        /// <param name="format">A string containing format items.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        /// <param name="argument3">The third argument to format.</param>
+        void InfoFormat(string format, object argument1, object argument2, object argument3);
+
+        /// <summary>
+        /// Writes the message at the <see cref="LogLevel.Info" /> level using the specified <paramref name="format" /> provider
+        /// and arguments.
         /// </summary>
         /// <param name="format">A string containing format items.</param>
         /// <param name="args">Arguments to format.</param>
@@ -89,7 +143,34 @@ namespace NServiceBus.Logging
 
         /// <summary>
         /// Writes the message at the <see cref="LogLevel.Warn" /> level using the specified <paramref name="format" /> provider
-        /// and format <paramref name="args" />.
+        /// and arguments.
+        /// </summary>
+        /// <param name="format">A string containing format items.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        void WarnFormat(string format, object argument1);
+
+        /// <summary>
+        /// Writes the message at the <see cref="LogLevel.Warn" /> level using the specified <paramref name="format" /> provider
+        /// and arguments.
+        /// </summary>
+        /// <param name="format">A string containing format items.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        void WarnFormat(string format, object argument1, object argument2);
+
+        /// <summary>
+        /// Writes the message at the <see cref="LogLevel.Warn" /> level using the specified <paramref name="format" /> provider
+        /// and arguments.
+        /// </summary>
+        /// <param name="format">A string containing format items.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        /// <param name="argument3">The third argument to format.</param>
+        void WarnFormat(string format, object argument1, object argument2, object argument3);
+
+        /// <summary>
+        /// Writes the message at the <see cref="LogLevel.Warn" /> level using the specified <paramref name="format" /> provider
+        /// and arguments.
         /// </summary>
         /// <param name="format">A string containing format items.</param>
         /// <param name="args">Arguments to format.</param>
@@ -110,7 +191,34 @@ namespace NServiceBus.Logging
 
         /// <summary>
         /// Writes the message at the <see cref="LogLevel.Error" /> level using the specified <paramref name="format" /> provider
-        /// and format <paramref name="args" />.
+        /// and arguments.
+        /// </summary>
+        /// <param name="format">A string containing format items.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        void ErrorFormat(string format, object argument1);
+
+        /// <summary>
+        /// Writes the message at the <see cref="LogLevel.Error" /> level using the specified <paramref name="format" /> provider
+        /// and arguments.
+        /// </summary>
+        /// <param name="format">A string containing format items.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        void ErrorFormat(string format, object argument1, object argument2);
+
+        /// <summary>
+        /// Writes the message at the <see cref="LogLevel.Error" /> level using the specified <paramref name="format" /> provider
+        /// and arguments.
+        /// </summary>
+        /// <param name="format">A string containing format items.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        /// <param name="argument3">The third argument to format.</param>
+        void ErrorFormat(string format, object argument1, object argument2, object argument3);
+
+        /// <summary>
+        /// Writes the message at the <see cref="LogLevel.Error" /> level using the specified <paramref name="format" /> provider
+        /// and arguments.
         /// </summary>
         /// <param name="format">A string containing format items.</param>
         /// <param name="args">Arguments to format.</param>
@@ -131,7 +239,34 @@ namespace NServiceBus.Logging
 
         /// <summary>
         /// Writes the message at the <see cref="LogLevel.Fatal" /> level using the specified <paramref name="format" /> provider
-        /// and format <paramref name="args" />.
+        /// and arguments.
+        /// </summary>
+        /// <param name="format">A string containing format items.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        void FatalFormat(string format, object argument1);
+
+        /// <summary>
+        /// Writes the message at the <see cref="LogLevel.Fatal" /> level using the specified <paramref name="format" /> provider
+        /// and arguments.
+        /// </summary>
+        /// <param name="format">A string containing format items.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        void FatalFormat(string format, object argument1, object argument2);
+
+        /// <summary>
+        /// Writes the message at the <see cref="LogLevel.Fatal" /> level using the specified <paramref name="format" /> provider
+        /// and arguments.
+        /// </summary>
+        /// <param name="format">A string containing format items.</param>
+        /// <param name="argument1">The first argument to format.</param>
+        /// <param name="argument2">The second argument to format.</param>
+        /// <param name="argument3">The third argument to format.</param>
+        void FatalFormat(string format, object argument1, object argument2, object argument3);
+
+        /// <summary>
+        /// Writes the message at the <see cref="LogLevel.Fatal" /> level using the specified <paramref name="format" /> provider
+        /// and arguments.
         /// </summary>
         /// <param name="format">A string containing format items.</param>
         /// <param name="args">Arguments to format.</param>

--- a/src/NServiceBus.Testing.Fakes/NamedLogger.cs
+++ b/src/NServiceBus.Testing.Fakes/NamedLogger.cs
@@ -27,6 +27,21 @@ namespace NServiceBus.Testing
             defaultLoggerFactory.Write(name, LogLevel.Debug, message + Environment.NewLine + exception);
         }
 
+        public void DebugFormat(string format, object argument1)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Debug, string.Format(format, argument1));
+        }
+
+        public void DebugFormat(string format, object argument1, object argument2)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Debug, string.Format(format, argument1, argument2));
+        }
+
+        public void DebugFormat(string format, object argument1, object argument2, object argument3)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Debug, string.Format(format, argument1, argument2, argument3));
+        }
+
         public void DebugFormat(string format, params object[] args)
         {
             defaultLoggerFactory.Write(name, LogLevel.Debug, string.Format(format, args));
@@ -40,6 +55,21 @@ namespace NServiceBus.Testing
         public void Info(string message, Exception exception)
         {
             defaultLoggerFactory.Write(name, LogLevel.Info, message + Environment.NewLine + exception);
+        }
+
+        public void InfoFormat(string format, object argument1)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Info, string.Format(format, argument1));
+        }
+
+        public void InfoFormat(string format, object argument1, object argument2)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Info, string.Format(format, argument1, argument2));
+        }
+
+        public void InfoFormat(string format, object argument1, object argument2, object argument3)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Info, string.Format(format, argument1, argument2, argument3));
         }
 
         public void InfoFormat(string format, params object[] args)
@@ -57,6 +87,21 @@ namespace NServiceBus.Testing
             defaultLoggerFactory.Write(name, LogLevel.Warn, message + Environment.NewLine + exception);
         }
 
+        public void WarnFormat(string format, object argument1)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Warn, string.Format(format, argument1));
+        }
+
+        public void WarnFormat(string format, object argument1, object argument2)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Warn, string.Format(format, argument1, argument2));
+        }
+
+        public void WarnFormat(string format, object argument1, object argument2, object argument3)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Warn, string.Format(format, argument1, argument2, argument3));
+        }
+
         public void WarnFormat(string format, params object[] args)
         {
             defaultLoggerFactory.Write(name, LogLevel.Warn, string.Format(format, args));
@@ -72,6 +117,21 @@ namespace NServiceBus.Testing
             defaultLoggerFactory.Write(name, LogLevel.Error, message + Environment.NewLine + exception);
         }
 
+        public void ErrorFormat(string format, object argument1)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Error, string.Format(format, argument1));
+        }
+
+        public void ErrorFormat(string format, object argument1, object argument2)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Error, string.Format(format, argument1, argument2));
+        }
+
+        public void ErrorFormat(string format, object argument1, object argument2, object argument3)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Error, string.Format(format, argument1, argument2, argument3));
+        }
+
         public void ErrorFormat(string format, params object[] args)
         {
             defaultLoggerFactory.Write(name, LogLevel.Error, string.Format(format, args));
@@ -85,6 +145,21 @@ namespace NServiceBus.Testing
         public void Fatal(string message, Exception exception)
         {
             defaultLoggerFactory.Write(name, LogLevel.Error, message + Environment.NewLine + exception);
+        }
+
+        public void FatalFormat(string format, object argument1)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Fatal, string.Format(format, argument1));
+        }
+
+        public void FatalFormat(string format, object argument1, object argument2)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Fatal, string.Format(format, argument1, argument2));
+        }
+
+        public void FatalFormat(string format, object argument1, object argument2, object argument3)
+        {
+            defaultLoggerFactory.Write(name, LogLevel.Fatal, string.Format(format, argument1, argument2, argument3));
         }
 
         public void FatalFormat(string format, params object[] args)

--- a/src/NServiceBus.TransportTests/TransportTestLoggerFactory.cs
+++ b/src/NServiceBus.TransportTests/TransportTestLoggerFactory.cs
@@ -41,6 +41,21 @@
                 Log(LogLevel.Debug, $"{message} {exception}");
             }
 
+            public void DebugFormat(string format, object argument1)
+            {
+                Log(LogLevel.Debug, string.Format(format, argument1));
+            }
+
+            public void DebugFormat(string format, object argument1, object argument2)
+            {
+                Log(LogLevel.Debug, string.Format(format, argument1, argument2));
+            }
+
+            public void DebugFormat(string format, object argument1, object argument2, object argument3)
+            {
+                Log(LogLevel.Debug, string.Format(format, argument1, argument2, argument3));
+            }
+
             public void DebugFormat(string format, params object[] args)
             {
                 Log(LogLevel.Debug, string.Format(format, args));
@@ -54,6 +69,21 @@
             public void Info(string message, Exception exception)
             {
                 Log(LogLevel.Info, $"{message} {exception}");
+            }
+
+            public void InfoFormat(string format, object argument1)
+            {
+                Log(LogLevel.Info, string.Format(format, argument1));
+            }
+
+            public void InfoFormat(string format, object argument1, object argument2)
+            {
+                Log(LogLevel.Info, string.Format(format, argument1, argument2));
+            }
+
+            public void InfoFormat(string format, object argument1, object argument2, object argument3)
+            {
+                Log(LogLevel.Info, string.Format(format, argument1, argument2, argument3));
             }
 
             public void InfoFormat(string format, params object[] args)
@@ -71,6 +101,21 @@
                 Log(LogLevel.Warn, $"{message} {exception}");
             }
 
+            public void WarnFormat(string format, object argument1)
+            {
+                Log(LogLevel.Warn, string.Format(format, argument1));
+            }
+
+            public void WarnFormat(string format, object argument1, object argument2)
+            {
+                Log(LogLevel.Warn, string.Format(format, argument1, argument2));
+            }
+
+            public void WarnFormat(string format, object argument1, object argument2, object argument3)
+            {
+                Log(LogLevel.Warn, string.Format(format, argument1, argument2, argument3));
+            }
+
             public void WarnFormat(string format, params object[] args)
             {
                 Log(LogLevel.Warn, string.Format(format, args));
@@ -86,6 +131,21 @@
                 Log(LogLevel.Error, $"{message} {exception}");
             }
 
+            public void ErrorFormat(string format, object argument1)
+            {
+                Log(LogLevel.Error, string.Format(format, argument1));
+            }
+
+            public void ErrorFormat(string format, object argument1, object argument2)
+            {
+                Log(LogLevel.Error, string.Format(format, argument1, argument2));
+            }
+
+            public void ErrorFormat(string format, object argument1, object argument2, object argument3)
+            {
+                Log(LogLevel.Error, string.Format(format, argument1, argument2, argument3));
+            }
+
             public void ErrorFormat(string format, params object[] args)
             {
                 Log(LogLevel.Error, string.Format(format, args));
@@ -99,6 +159,21 @@
             public void Fatal(string message, Exception exception)
             {
                 Log(LogLevel.Fatal, $"{message} {exception}");
+            }
+
+            public void FatalFormat(string format, object argument1)
+            {
+                Log(LogLevel.Fatal, string.Format(format, argument1));
+            }
+
+            public void FatalFormat(string format, object argument1, object argument2)
+            {
+                Log(LogLevel.Fatal, string.Format(format, argument1, argument2));
+            }
+
+            public void FatalFormat(string format, object argument1, object argument2, object argument3)
+            {
+                Log(LogLevel.Fatal, string.Format(format, argument1, argument2, argument3));
             }
 
             public void FatalFormat(string format, params object[] args)


### PR DESCRIPTION
This change adds additional logging methods to `ILog` to avoid params array allocations in the 1-3 arguments cases by taking advantage of the `String.Format` overloads that also take 1-3 arguments.

These are the changes introduced in #4872 but rebased to latest develop. I had to open a new PR because GH would not let me re-open the previous one.