### PR TITLE
Use .txt ending on the diagnostics file

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
@@ -27,7 +27,7 @@
                 .Run();
 
             var endpointName = Conventions.EndpointNamingConvention(typeof(MyEndpoint));
-            var startupDiagnoticsFileName = $"{endpointName}-configuration.json";
+            var startupDiagnoticsFileName = $"{endpointName}-configuration.txt";
 
             var pathToFile = Path.Combine(basePath, startupDiagnoticsFileName);
             Assert.True(File.Exists(pathToFile));

--- a/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnostics.cs
+++ b/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnostics.cs
@@ -49,7 +49,7 @@
 
             // Once we have the proper hosting model in place we can skip the endpoint name since the host would
             // know how to handle multi hosting but for now we do this so that multi-hosting users will get a file per endpoint
-            var startupDiagnosticsFileName = $"{endpointName}-configuration.json";
+            var startupDiagnosticsFileName = $"{endpointName}-configuration.txt";
             var startupDiagnosticsFilePath = Path.Combine(diagnosticsRootPath, startupDiagnosticsFileName);
 
             return data => AsyncFile.WriteText(startupDiagnosticsFilePath, data);


### PR DESCRIPTION
Since that allows us to change to XML if needed (due to pretty printing issues with simplejson) and it better conveys the fact that we don't promise anything around the format