### PR TITLE
Tweak wording of error message

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/When_overriding_local_address.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_overriding_local_address.cs
@@ -38,7 +38,7 @@
                .Done(c => c.EndpointsStarted)
                .Run());
 
-            StringAssert.Contains("send only", ex.Message);
+            StringAssert.Contains("send-only", ex.Message);
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.Core/Receiving/ReceiveConfigurationBuilder.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveConfigurationBuilder.cs
@@ -15,7 +15,7 @@ namespace NServiceBus
             {
                 if (settings.HasExplicitValue(ReceiveSettingsExtensions.CustomLocalAddressKey))
                 {
-                    throw new Exception($"Overriding local address using `{nameof(ReceiveSettingsExtensions.OverrideLocalAddress)}(myCustomAddress)` is not supported for send only endpoints.");
+                    throw new Exception($"Specifying a base name for the input queue using `{nameof(ReceiveSettingsExtensions.OverrideLocalAddress)}(baseInputQueueName)` is not supported for send-only endpoints.");
                 }
                 return null;
             }


### PR DESCRIPTION
Followup to #5045. This tweaks the wording of the error message and changes "send only" to "send-only" to be consistent.

