### PR TITLE
[WIP] Spike xml interface serialization fix

### DIFF
--- a/src/NServiceBus.Core.Tests/Serializers/XML/SerializerTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/SerializerTests.cs
@@ -1158,8 +1158,49 @@ namespace NServiceBus.Serializers.XML.Test
             Assert.AreEqual(message.Value, ((SerializedPair)messageDeserialized[0]).Value);
         }
 
+        [Test]
+        public void Interface_Message_with_no_setter()
+        {
+            var serializer = SerializerFactory.Create<MesssageImplementingMessageWithGetterOnlyProperty>();
+            using (var stream = new MemoryStream())
+            {
+                serializer.Serialize(new MesssageImplementingMessageWithGetterOnlyProperty(){Property = new Blabla(){Property = "Hello World"}}, stream);
+                stream.Position = 0;
+                var reader = new StreamReader(stream);
+                // ReSharper disable once UnusedVariable
+                var xml = reader.ReadToEnd();
+                stream.Position = 0;
+                var result = serializer.Deserialize(stream, new[]
+                {
+                    typeof(IMessageWithGetterOnlyProperty)
+                }).Single() as IMessageWithGetterOnlyProperty;
+
+                Assert.IsNull(result.Property.Property);
+            }
+        }
+
         int number = 1;
         int numberOfIterations = 100;
+    }
+
+    public interface IMessageWithGetterOnlyProperty
+    {
+        InterfacePropertyType Property { get; set; }
+    }
+
+    public interface InterfacePropertyType
+    {
+        string Property { get; }
+    }
+
+    public class Blabla : InterfacePropertyType
+    {
+        public string Property { get; set; }
+    }
+
+    public class MesssageImplementingMessageWithGetterOnlyProperty : IMessageWithGetterOnlyProperty
+    {
+        public InterfacePropertyType Property { get; set; }
     }
 
     public class SerializedPair

--- a/src/NServiceBus.Core.Tests/Serializers/XML/SerializerTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/SerializerTests.cs
@@ -1164,7 +1164,7 @@ namespace NServiceBus.Serializers.XML.Test
             var serializer = SerializerFactory.Create<MesssageImplementingMessageWithGetterOnlyProperty>();
             using (var stream = new MemoryStream())
             {
-                serializer.Serialize(new MesssageImplementingMessageWithGetterOnlyProperty(){Property = new Blabla(){Property = "Hello World"}}, stream);
+                serializer.Serialize(new MesssageImplementingMessageWithGetterOnlyProperty(){Property = new ConcretePropertyType(){Property = "Hello World"}}, stream);
                 stream.Position = 0;
                 var reader = new StreamReader(stream);
                 // ReSharper disable once UnusedVariable
@@ -1185,22 +1185,22 @@ namespace NServiceBus.Serializers.XML.Test
 
     public interface IMessageWithGetterOnlyProperty
     {
-        InterfacePropertyType Property { get; set; }
+        IInterfacePropertyType Property { get; set; }
     }
 
-    public interface InterfacePropertyType
+    public interface IInterfacePropertyType
     {
         string Property { get; }
     }
 
-    public class Blabla : InterfacePropertyType
+    public class ConcretePropertyType : IInterfacePropertyType
     {
         public string Property { get; set; }
     }
 
     public class MesssageImplementingMessageWithGetterOnlyProperty : IMessageWithGetterOnlyProperty
     {
-        public InterfacePropertyType Property { get; set; }
+        public IInterfacePropertyType Property { get; set; }
     }
 
     public class SerializedPair

--- a/src/NServiceBus.Core/Serializers/XML/XmlDeserialization.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlDeserialization.cs
@@ -491,6 +491,7 @@
                 {
                     if (n.ChildNodes[0] is XmlWhitespace)
                     {
+                        // this is where the deserialization fails when trying to deserialize a interface property wihtout values
                         return Activator.CreateInstance(type);
                     }
 

--- a/src/NServiceBus.Core/Serializers/XML/XmlSerialization.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlSerialization.cs
@@ -151,13 +151,14 @@
                 return;
             }
 
+            var tx = obj.GetType();
             if (!cache.typeToProperties.TryGetValue(t, out var properties))
             {
                 cache.InitType(t);
                 cache.typeToProperties.TryGetValue(t, out properties);
             }
 
-            foreach (var prop in properties)
+            foreach (var prop in tx.GetProperties())
             {
                 if (IsIndexedProperty(prop))
                 {

--- a/src/NServiceBus.Core/Serializers/XML/XmlSerializerCache.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlSerializerCache.cs
@@ -136,6 +136,7 @@ namespace NServiceBus
 
             foreach (var prop in t.GetProperties())
             {
+                // this prevents the property to be listed in the cache
                 if (!prop.CanWrite && !isKeyValuePair)
                 {
                     continue;


### PR DESCRIPTION
based on this discourse topic: https://discuss.particular.net/t/xml-serialization-not-working-for-interfaces/117 I was wondering why the serialized message actually doesn't contain any values for the interface-property. The easy solution is indeed to just add a public setter and everything works fine again, but I had the feeling that this shouldn't be related to the serialization. The issue is:
* read-only property values are not serialized into the xml
* trying to deserialize this message will throw a super unhelpful message because the deserializer tries to create an instance of the interface.

Turns out the current serialization logic checks the xml serializer cache for all the properties which should be written to the xml. Properties with no setter will be skipped though. This makes sense when deserializing. I'm not 100% whether sticking to the same logic when serializing is the right way, as it will result in the read-only properties not being written into the message.

A little code change in this wasp nest does change the behavior to write all properties into the xml. The deserialization isn't affected. All tests seem to pass with this behavior (obviously we still can't deserialize the message, but it won't fail with an exception anymore).

The goal of this "spike" is to figure out what (if at all) we should do about this? I'm quite skeptical about changing the xml serializer code, as it's quite risky, especially since 

* Should nservicebus be able to deserialize the message without throwing an exception?
* Should nservicebus serialize the read-only property values into the xml?
* Should we document these limitations (more of a rhetoric question)?

sidenote: I tested the behavior of read-only properties on non-interface types, and in that case the value won't be serialized into the message but the deserialization of the message doesn't fail and the message is passed to it's handlers.