### PR TITLE
Explicitly specify receiving diagnostic properties

### DIFF
--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -166,7 +166,23 @@ namespace NServiceBus
 
             if (receiveConfiguration != null)
             {
-                settings.AddStartupDiagnosticsSection("Receiving", receiveConfiguration);
+                settings.AddStartupDiagnosticsSection("Receiving", new
+                {
+                    receiveConfiguration.LocalAddress,
+                    receiveConfiguration.InstanceSpecificQueue,
+                    receiveConfiguration.LogicalAddress,
+                    receiveConfiguration.PurgeOnStartup,
+                    receiveConfiguration.QueueNameBase,
+                    TransactionMode = receiveConfiguration.TransactionMode.ToString("G"),
+                    receiveConfiguration.PushRuntimeSettings.MaxConcurrency,
+                    Satellites = receiveConfiguration.SatelliteDefinitions.Select(s => new
+                    {
+                        s.Name,
+                        s.ReceiveAddress,
+                        TransactionMode = s.RequiredTransportTransactionMode.ToString("G"),
+                        s.RuntimeSettings.MaxConcurrency
+                    }).ToArray()
+                });
             }
 
             return receiveComponent;


### PR DESCRIPTION
fixes https://github.com/Particular/NServiceBus/issues/5061

currently targeting develop. I suggest to release this as beta11.

This went past all tests because we're using the learning transport locally which doesn't use satellites. I wonder how we can test this to avoid such an issue in the future?