### PR TITLE
Expose the diagnostics entries

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -919,6 +919,17 @@ namespace NServiceBus
             "ll be removed in version 8.0.0.", true)]
         public static void EnableSLAPerformanceCounter(this NServiceBus.EndpointConfiguration config) { }
     }
+    public class StartupDiagnosticEntries
+    {
+        public StartupDiagnosticEntries() { }
+        public void Add(string sectionName, object section) { }
+        public class StartupDiagnosticEntry
+        {
+            public StartupDiagnosticEntry() { }
+            public object Data { get; set; }
+            public string Name { get; set; }
+        }
+    }
     public class static StaticHeadersConfigExtensions
     {
         public static void AddHeaderToAllOutgoingMessages(this NServiceBus.EndpointConfiguration config, string key, string value) { }

--- a/src/NServiceBus.Core/Hosting/StartupDiagnostics/StartupDiagnosticEntries.cs
+++ b/src/NServiceBus.Core/Hosting/StartupDiagnostics/StartupDiagnosticEntries.cs
@@ -2,8 +2,14 @@
 {
     using System.Collections.Generic;
 
-    class StartupDiagnosticEntries
+    /// <summary>
+    /// Holds diagnostics entries to be written at startup.
+    /// </summary>
+    public class StartupDiagnosticEntries
     {
+        /// <summary>
+        /// Adds a new section to the diagnostics.
+        /// </summary>
         public void Add(string sectionName, object section)
         {
             entries.Add(new StartupDiagnosticEntry
@@ -15,10 +21,20 @@
 
         internal List<StartupDiagnosticEntry> entries = new List<StartupDiagnosticEntry>();
 
+        /// <summary>
+        /// A diagnostics section.
+        /// </summary>
         public class StartupDiagnosticEntry
         {
-            public string Name;
-            public object Data;
+            /// <summary>
+            /// The section name.
+            /// </summary>
+            public string Name { get; set; }
+
+            /// <summary>
+            /// The actual diagnostics data.
+            /// </summary>
+            public object Data { get; set; }
         }
     }
 }


### PR DESCRIPTION
We need to let downstreams like NSB.Raw set it to avoid transports etc to blow up.

Closes https://github.com/Particular/NServiceBus/issues/5064