### PR TITLE
Make TestApprover immune to shadow copying

### DIFF
--- a/src/NServiceBus.Core.Tests/TestApprover.cs
+++ b/src/NServiceBus.Core.Tests/TestApprover.cs
@@ -3,6 +3,7 @@
     using System.IO;
     using ApprovalTests;
     using ApprovalTests.Namers;
+    using NUnit.Framework;
 
     static class TestApprover
     {
@@ -15,17 +16,7 @@
 
         class ApprovalNamer : UnitTestFrameworkNamer
         {
-            public ApprovalNamer()
-            {
-                var assemblyPath = GetType().Assembly.Location;
-                var assemblyDir = Path.GetDirectoryName(assemblyPath);
-
-                sourcePath = Path.Combine(assemblyDir, "..", "..", "..", "ApprovalFiles");
-            }
-
-            public override string SourcePath => sourcePath;
-
-            readonly string sourcePath;
+            public override string SourcePath { get; } = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "ApprovalFiles");
         }
     }
 }


### PR DESCRIPTION
This uses `TestContext.CurrentContext.TestDirectory` to find the correct folder, and it will still be correct even when the test assembly has been shadow copied.