### PR TITLE
Make the outbox honor message durability

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="Basic\When_using_callback_to_get_message.cs" />
     <Compile Include="Encryption\When_using_Rijndael_without_incoming_key_identifier.cs" />
     <Compile Include="HostInformation\When_feature_overrides_hostid.cs" />
+    <Compile Include="NonDTC\When_sending_a_durable_message.cs" />
     <Compile Include="NonDTC\When_sending_a_message_with_a_ttbr.cs" />
     <Compile Include="PerfMon\CriticalTime\When_deferring_a_message.cs" />
     <Compile Include="PubSub\When_publishing_from_sendonly.cs" />

--- a/src/NServiceBus.AcceptanceTests/NonDTC/When_sending_a_durable_message.cs
+++ b/src/NServiceBus.AcceptanceTests/NonDTC/When_sending_a_durable_message.cs
@@ -1,0 +1,124 @@
+﻿namespace NServiceBus.AcceptanceTests.NonDTC
+{
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NServiceBus.Configuration.AdvanceExtensibility;
+    using NServiceBus.Features;
+    using NServiceBus.ObjectBuilder;
+    using NServiceBus.Transports;
+    using NServiceBus.Unicast;
+    using NUnit.Framework;
+
+    public class When_sending_a_durable_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_honor_it()
+        {
+            var context = new Context();
+
+            Scenario.Define(context)
+                .WithEndpoint<Endpoint>(b => b.Given((bus, c) => bus.SendLocal(new StartMessage())))
+                .Done(c => c.WasCalled)
+                .Run();
+
+            Assert.True(context.WasSentDurable);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool WasCalled { get; set; }
+            public bool WasSentDurable { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(
+                    b =>
+                    {
+                        b.GetSettings().Set("DisableOutboxTransportCheck", true);
+                        b.EnableOutbox();
+                    });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyDurableMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(MyDurableMessage message)
+                {
+                    Context.WasCalled = true;
+                }
+            }
+
+            public class StartMessageHandler : IHandleMessages<StartMessage>
+            {
+                public Context Context { get; set; }
+
+                public IBus Bus { get; set; }
+
+                public void Handle(StartMessage message)
+                {
+                    Bus.SendLocal(new MyDurableMessage());
+                }
+            }
+
+            public class DispatcherInterceptor : Feature
+            {
+                public DispatcherInterceptor()
+                {
+                    EnableByDefault();
+                    DependsOn<MsmqTransportConfigurator>();
+                }
+
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                    var originalDispatcher = EndpointConfiguration.builder.Build<ISendMessages>();
+                    var ctx = EndpointConfiguration.builder.Build<Context>();
+                    context.Container.ConfigureComponent(() => new SenderWrapper(originalDispatcher, ctx), DependencyLifecycle.SingleInstance);
+                }
+            }
+
+            public class EndpointConfiguration : IWantToRunBeforeConfigurationIsFinalized
+            {
+                public static IBuilder builder;
+
+                public void Run(Configure config)
+                {
+                    builder = config.Builder;
+                }
+            }
+
+
+            class SenderWrapper : ISendMessages
+            {
+                public SenderWrapper(ISendMessages wrappedSender, Context context)
+                {
+                    this.wrappedSender = wrappedSender;
+                    this.context = context;
+                }
+
+                public void Send(TransportMessage message, SendOptions sendOptions)
+                {
+                    context.WasSentDurable = message.Recoverable;
+
+                    wrappedSender.Send(message, sendOptions);
+                }
+
+                Context context;
+                ISendMessages wrappedSender;
+            }
+        }
+
+        public class MyDurableMessage : IMessage
+        {
+        }
+
+        public class StartMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core/Outbox/OutboxDeduplicationBehavior.cs
+++ b/src/NServiceBus.Core/Outbox/OutboxDeduplicationBehavior.cs
@@ -62,7 +62,8 @@
 
                 var message = new TransportMessage(transportOperation.MessageId, transportOperation.Headers)
                 {
-                    Body = transportOperation.Body
+                    Body = transportOperation.Body,
+                    Recoverable = !transportOperation.Options.ContainsKey("NonDurable")
                 };
 
                 string ttbr;

--- a/src/NServiceBus.Core/Outbox/OutboxSendBehavior.cs
+++ b/src/NServiceBus.Core/Outbox/OutboxSendBehavior.cs
@@ -23,6 +23,11 @@ namespace NServiceBus
                     options["TimeToBeReceived"] = context.OutgoingMessage.TimeToBeReceived.ToString();
                 }
 
+                if (!context.OutgoingMessage.Recoverable)
+                {
+                    options["NonDurable"] = bool.TrueString;
+                }
+
                 currentOutboxMessage.TransportOperations.Add(transportOperation);
             }
             else

--- a/src/NServiceBus.sln.DotSettings
+++ b/src/NServiceBus.sln.DotSettings
@@ -582,6 +582,7 @@ II.2.12 &lt;HandlesEvent /&gt;&#xD;
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsParsFormattingSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsWrapperSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>
 	
 	


### PR DESCRIPTION
fixes https://github.com/Particular/NServiceBus/issues/5074

I took the same approach as v6 and above using  a `NonDurable` flag. Since the presense of the flag means non durable there is no migration effort since existing users won't have the flag in storage and we'll default to durable messages.

For users with non durable messages the ones that are in flight will be marked as durable but I'd say we can live with that?