### PR TITLE
Teach assembly scanner to find assemblies referenced from NuGet packages

### DIFF
--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -89,6 +89,21 @@ namespace NServiceBus.Hosting.Helpers
                 }
             }
 
+            var platformAssembliesString = (string)AppDomain.CurrentDomain.GetData("TRUSTED_PLATFORM_ASSEMBLIES");
+
+            if (platformAssembliesString != null)
+            {
+                var platformAssemblies = platformAssembliesString.Split(Path.PathSeparator);
+
+                foreach (var platformAssembly in platformAssemblies)
+                {
+                    if (TryLoadScannableAssembly(platformAssembly, results, out var assembly))
+                    {
+                        assemblies.Add(assembly);
+                    }
+                }
+            }
+
             foreach (var assembly in assemblies)
             {
                 if (ScanAssembly(assembly, processed))

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
@@ -60,6 +60,11 @@
                 return true;
             }
 
+            if (tokenString == "adb9793829ddae60")
+            {
+                return true;
+            }
+
             return false;
         }
     }

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
@@ -1,10 +1,19 @@
 ﻿namespace NServiceBus
 {
     using System;
+#if NET452
     using System.Reflection;
+#endif
+#if NETSTANDARD2_0
+    using System.IO;
+    using System.Reflection.Metadata;
+    using System.Reflection.PortableExecutable;
+    using System.Security.Cryptography;
+#endif
 
     class AssemblyValidator
     {
+#if NET452
         public void ValidateAssemblyFile(string assemblyPath, out bool shouldLoad, out string reason)
         {
             try
@@ -28,6 +37,66 @@
             shouldLoad = true;
             reason = "File is a .NET assembly.";
         }
+#endif
+
+#if NETSTANDARD2_0
+        public void ValidateAssemblyFile(string assemblyPath, out bool shouldLoad, out string reason)
+        {
+            using (var stream = File.OpenRead(assemblyPath))
+            using (var file = new PEReader(stream))
+            {
+                var hasMetadata = false;
+
+                try
+                {
+                    hasMetadata = file.HasMetadata;
+                }
+                catch (BadImageFormatException) { }
+
+                if (!hasMetadata)
+                {
+                    shouldLoad = false;
+                    reason = "File is not a .NET assembly.";
+                    return;
+                }
+
+                var reader = file.GetMetadataReader();
+                var assemblyDefinition = reader.GetAssemblyDefinition();
+
+                if (!assemblyDefinition.PublicKey.IsNil)
+                {
+                    var publicKey = reader.GetBlobBytes(assemblyDefinition.PublicKey);
+                    var publicKeyToken = GetPublicKeyToken(publicKey);
+
+                    if (IsRuntimeAssembly(publicKeyToken))
+                    {
+                        shouldLoad = false;
+                        reason = "File is a .NET runtime assembly.";
+                        return;
+                    }
+                }
+
+                shouldLoad = true;
+                reason = "File is a .NET assembly.";
+            }
+        }
+
+        static byte[] GetPublicKeyToken(byte[] publicKey)
+        {
+            using (var sha1 = SHA1.Create())
+            {
+                var hash = sha1.ComputeHash(publicKey);
+                var publicKeyToken = new byte[8];
+
+                for (var i = 0; i < 8; i++)
+                {
+                    publicKeyToken[i] = hash[hash.Length - (i + 1)];
+                }
+
+                return publicKeyToken;
+            }
+        }
+#endif
 
         public static bool IsRuntimeAssembly(byte[] publicKeyToken)
         {

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -37,6 +37,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="4.4.0" />
   </ItemGroup>
 


### PR DESCRIPTION
I was looking at how Mono.Cecil was getting access to assemblies in NuGet packages to load them properly, and I discovered `AppDomain.CurrentDomain.GetData("TRUSTED_PLATFORM_ASSEMBLIES")`. When this is called from a .NET Core application, you get something like the following:
```
C:\ConsoleApp47\ConsoleApp47\bin\Debug\netcoreapp2.0\ConsoleApp47.dll
C:\Users\Brandon\.nuget\packages\libgit2sharp\0.25.0-preview-0033\lib\netstandard1.3\LibGit2Sharp.dll
C:\Users\Brandon\.nuget\packages\nservicebus\7.0.0-beta0008\lib\netstandard2.0\NServiceBus.Core.dll
C:\Program Files\dotnet\store\x64\netcoreapp2.0\newtonsoft.json\10.0.1\lib\netstandard1.3\Newtonsoft.Json.dll
C:\Program Files\dotnet\store\x64\netcoreapp2.0\system.security.cryptography.xml\4.4.0\lib\netstandard2.0\System.Security.Cryptography.Xml.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\Microsoft.CSharp.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\Microsoft.VisualBasic.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\Microsoft.Win32.Primitives.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\Microsoft.Win32.Registry.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\SOS.NETCore.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\System.AppContext.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\System.Buffers.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\System.Collections.Concurrent.dll

...

C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\System.Windows.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\System.Xml.Linq.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\System.Xml.ReaderWriter.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\System.Xml.Serialization.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\System.Xml.XDocument.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\System.Xml.XPath.XDocument.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\System.Xml.XPath.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\System.Xml.XmlDocument.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\System.Xml.XmlSerializer.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\System.Xml.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\System.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\WindowsBase.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\mscorlib.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\netstandard.dll
C:\Program Files\dotnet\shared\Microsoft.NETCore.App\2.0.3\System.Private.CoreLib.dll
```

So the actual resolved path of all the assemblies, including the ones that come from NuGet packages!

I've modified the AssemblyScanner to use this, so it will be able to pick up any dependencies from packages during development as well as when an app has been published.

I've currently targeted this PR against develop, but I think this is important enough that we'll probably want to retarget this to the release branch instead.