### PR TITLE
Mark all fields in behaviors as readonly

### DIFF
--- a/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
@@ -26,6 +26,6 @@
             await this.Fork(auditContext).ConfigureAwait(false);
         }
 
-        string auditAddress;
+        readonly string auditAddress;
     }
 }

--- a/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
+++ b/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
@@ -55,6 +55,6 @@ namespace NServiceBus
             context.Headers[Headers.ConversationId] = conversationIdStrategy(context);
         }
 
-        Func<IOutgoingLogicalMessageContext, string> conversationIdStrategy;
+        readonly Func<IOutgoingLogicalMessageContext, string> conversationIdStrategy;
     }
 }

--- a/src/NServiceBus.Core/DataBus/DataBusReceiveBehavior.cs
+++ b/src/NServiceBus.Core/DataBus/DataBusReceiveBehavior.cs
@@ -61,9 +61,9 @@
             await next(context).ConfigureAwait(false);
         }
 
-        Conventions conventions;
-        IDataBus dataBus;
-        IDataBusSerializer dataBusSerializer;
+        readonly Conventions conventions;
+        readonly IDataBus dataBus;
+        readonly IDataBusSerializer dataBusSerializer;
 
         public class Registration : RegisterStep
         {

--- a/src/NServiceBus.Core/DataBus/DataBusSendBehavior.cs
+++ b/src/NServiceBus.Core/DataBus/DataBusSendBehavior.cs
@@ -79,9 +79,9 @@
             await next(context).ConfigureAwait(false);
         }
 
-        Conventions conventions;
-        IDataBus dataBus;
-        IDataBusSerializer dataBusSerializer;
+        readonly Conventions conventions;
+        readonly IDataBus dataBus;
+        readonly IDataBusSerializer dataBusSerializer;
 
         public class Registration : RegisterStep
         {

--- a/src/NServiceBus.Core/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehavior.cs
@@ -63,6 +63,6 @@ namespace NServiceBus
             return false;
         }
 
-        string timeoutManagerAddress;
+        readonly string timeoutManagerAddress;
     }
 }

--- a/src/NServiceBus.Core/Forwarding/InvokeForwardingPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Forwarding/InvokeForwardingPipelineBehavior.cs
@@ -25,6 +25,6 @@
             await this.Fork(forwardingContext).ConfigureAwait(false);
         }
 
-        string forwardingAddress;
+        readonly string forwardingAddress;
     }
 }

--- a/src/NServiceBus.Core/Hosting/AddHostInfoHeadersBehavior.cs
+++ b/src/NServiceBus.Core/Hosting/AddHostInfoHeadersBehavior.cs
@@ -23,7 +23,7 @@
             return next(context);
         }
 
-        string endpoint;
-        HostInformation hostInformation;
+        readonly string endpoint;
+        readonly HostInformation hostInformation;
     }
 }

--- a/src/NServiceBus.Core/Hosting/AuditHostInformationBehavior.cs
+++ b/src/NServiceBus.Core/Hosting/AuditHostInformationBehavior.cs
@@ -25,8 +25,7 @@
             return next(context);
         }
 
-        string endpoint;
-
-        HostInformation hostInfo;
+        readonly string endpoint;
+        readonly HostInformation hostInfo;
     }
 }

--- a/src/NServiceBus.Core/Licensing/AuditInvalidLicenseBehavior.cs
+++ b/src/NServiceBus.Core/Licensing/AuditInvalidLicenseBehavior.cs
@@ -20,6 +20,6 @@
             }
         }
 
-        static ILog Log = LogManager.GetLogger<AuditInvalidLicenseBehavior>();
+        static readonly ILog Log = LogManager.GetLogger<AuditInvalidLicenseBehavior>();
     }
 }

--- a/src/NServiceBus.Core/Licensing/LogErrorOnInvalidLicenseBehavior.cs
+++ b/src/NServiceBus.Core/Licensing/LogErrorOnInvalidLicenseBehavior.cs
@@ -14,6 +14,6 @@ namespace NServiceBus
             return next(context);
         }
 
-        static ILog Log = LogManager.GetLogger<LogErrorOnInvalidLicenseBehavior>();
+        static readonly ILog Log = LogManager.GetLogger<LogErrorOnInvalidLicenseBehavior>();
     }
 }

--- a/src/NServiceBus.Core/Performance/MessageDurability/DetermineMessageDurabilityBehavior.cs
+++ b/src/NServiceBus.Core/Performance/MessageDurability/DetermineMessageDurabilityBehavior.cs
@@ -26,8 +26,7 @@ namespace NServiceBus
             return next(context);
         }
 
-        Func<Type, bool> convention;
-
-        ConcurrentDictionary<Type, bool> durabilityCache;
+        readonly Func<Type, bool> convention;
+        readonly ConcurrentDictionary<Type, bool> durabilityCache;
     }
 }

--- a/src/NServiceBus.Core/Performance/TimeToBeReceived/ApplyTimeToBeReceivedBehavior.cs
+++ b/src/NServiceBus.Core/Performance/TimeToBeReceived/ApplyTimeToBeReceivedBehavior.cs
@@ -24,6 +24,6 @@
             return next(context);
         }
 
-        TimeToBeReceivedMappings timeToBeReceivedMappings;
+        readonly TimeToBeReceivedMappings timeToBeReceivedMappings;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
@@ -136,18 +136,18 @@ namespace NServiceBus
             return existingTypeString.StartsWith("NServiceBus.Scheduling.Messages.ScheduledTask, NServiceBus.Core");
         }
 
-        MessageDeserializerResolver deserializerResolver;
-        LogicalMessageFactory logicalMessageFactory;
-        MessageMetadataRegistry messageMetadataRegistry;
-        MessageMapper mapper;
+        readonly MessageDeserializerResolver deserializerResolver;
+        readonly LogicalMessageFactory logicalMessageFactory;
+        readonly MessageMetadataRegistry messageMetadataRegistry;
+        readonly MessageMapper mapper;
 
-        static LogicalMessage[] NoMessagesFound = new LogicalMessage[0];
+        static readonly LogicalMessage[] NoMessagesFound = new LogicalMessage[0];
 
-        static char[] EnclosedMessageTypeSeparator =
+        static readonly char[] EnclosedMessageTypeSeparator =
         {
             ';'
         };
 
-        static ILog log = LogManager.GetLogger<DeserializeLogicalMessagesConnector>();
+        static readonly ILog log = LogManager.GetLogger<DeserializeLogicalMessagesConnector>();
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
@@ -59,8 +59,6 @@
 
         readonly ISynchronizedStorageAdapter adapter;
         readonly ISynchronizedStorage synchronizedStorage;
-
-
-        MessageHandlerRegistry messageHandlerRegistry;
+        readonly MessageHandlerRegistry messageHandlerRegistry;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageProcessingConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageProcessingConnector.cs
@@ -181,6 +181,6 @@ namespace NServiceBus
             throw new Exception("Could not find routing strategy to deserialize");
         }
 
-        IOutboxStorage outboxStorage;
+        readonly IOutboxStorage outboxStorage;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/ImmediateDispatchTerminator.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/ImmediateDispatchTerminator.cs
@@ -19,6 +19,6 @@
             return dispatcher.Dispatch(new TransportOperations(operations), transaction, context.Extensions);
         }
 
-        IDispatchMessages dispatcher;
+        readonly IDispatchMessages dispatcher;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
@@ -56,7 +56,7 @@
             log.Debug(sb.ToString());
         }
 
-        static ILog log = LogManager.GetLogger<RoutingToDispatchConnector>();
+        static readonly ILog log = LogManager.GetLogger<RoutingToDispatchConnector>();
         static readonly bool isDebugEnabled = log.IsDebugEnabled;
 
         public class State

--- a/src/NServiceBus.Core/Pipeline/Outgoing/SerializeMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/SerializeMessageConnector.cs
@@ -67,9 +67,9 @@ namespace NServiceBus
             return string.Join(";", assemblyQualifiedNames);
         }
 
-        MessageMetadataRegistry messageMetadataRegistry;
-        IMessageSerializer messageSerializer;
+        readonly MessageMetadataRegistry messageMetadataRegistry;
+        readonly IMessageSerializer messageSerializer;
 
-        static ILog log = LogManager.GetLogger<SerializeMessageConnector>();
+        static readonly ILog log = LogManager.GetLogger<SerializeMessageConnector>();
     }
 }

--- a/src/NServiceBus.Core/Routing/ApplyReplyToAddressBehavior.cs
+++ b/src/NServiceBus.Core/Routing/ApplyReplyToAddressBehavior.cs
@@ -53,10 +53,9 @@
             return replyTo;
         }
 
-        string instanceSpecificQueue;
-
-        string sharedQueue;
-        string configuredReturnAddress;
+        readonly string instanceSpecificQueue;
+        readonly string sharedQueue;
+        readonly string configuredReturnAddress;
 
         public class State
         {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -75,13 +75,12 @@
             }
         }
 
-        IDispatchMessages dispatcher;
-        string subscriberAddress;
-        string subscriberEndpoint;
+        readonly IDispatchMessages dispatcher;
+        readonly string subscriberAddress;
+        readonly string subscriberEndpoint;
+        readonly SubscriptionRouter subscriptionRouter;
 
-        SubscriptionRouter subscriptionRouter;
-
-        static ILog Logger = LogManager.GetLogger<MessageDrivenSubscribeTerminator>();
+        static readonly ILog Logger = LogManager.GetLogger<MessageDrivenSubscribeTerminator>();
 
         public class Settings
         {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -76,12 +76,11 @@
         }
 
         readonly string endpoint;
-        IDispatchMessages dispatcher;
-        string replyToAddress;
+        readonly IDispatchMessages dispatcher;
+        readonly string replyToAddress;
+        readonly SubscriptionRouter subscriptionRouter;
 
-        SubscriptionRouter subscriptionRouter;
-
-        static ILog Logger = LogManager.GetLogger<MessageDrivenUnsubscribeTerminator>();
+        static readonly ILog Logger = LogManager.GetLogger<MessageDrivenUnsubscribeTerminator>();
 
         public class Settings
         {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionReceiverBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionReceiverBehavior.cs
@@ -92,11 +92,10 @@
             return value;
         }
 
-        Func<IIncomingPhysicalMessageContext, bool> authorizer;
+        readonly Func<IIncomingPhysicalMessageContext, bool> authorizer;
+        readonly ISubscriptionStorage subscriptionStorage;
 
-        ISubscriptionStorage subscriptionStorage;
-
-        static ILog Logger = LogManager.GetLogger<SubscriptionReceiverBehavior>();
+        static readonly ILog Logger = LogManager.GetLogger<SubscriptionReceiverBehavior>();
 
         public class Registration : RegisterStep
         {

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforcePublishBestPracticesBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforcePublishBestPracticesBehavior.cs
@@ -21,6 +21,6 @@
             return next(context);
         }
 
-        Validations validations;
+        readonly Validations validations;
     }
 }

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceReplyBestPracticesBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceReplyBestPracticesBehavior.cs
@@ -21,6 +21,6 @@ namespace NServiceBus
             return next(context);
         }
 
-        Validations validations;
+        readonly Validations validations;
     }
 }

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceSendBestPracticesBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceSendBestPracticesBehavior.cs
@@ -21,6 +21,6 @@
             return next(context);
         }
 
-        Validations validations;
+        readonly Validations validations;
     }
 }

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceSubscribeBestPracticesBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceSubscribeBestPracticesBehavior.cs
@@ -21,6 +21,6 @@ namespace NServiceBus
             return next(context);
         }
 
-        Validations validations;
+        readonly Validations validations;
     }
 }

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceUnsubscribeBestPracticesBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceUnsubscribeBestPracticesBehavior.cs
@@ -21,6 +21,6 @@ namespace NServiceBus
             return next(context);
         }
 
-        Validations validations;
+        readonly Validations validations;
     }
 }

--- a/src/NServiceBus.Core/Routing/NativeSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/NativeSubscribeTerminator.cs
@@ -16,6 +16,6 @@ namespace NServiceBus
             return subscriptionManager.Subscribe(context.EventType, context.Extensions);
         }
 
-        IManageSubscriptions subscriptionManager;
+        readonly IManageSubscriptions subscriptionManager;
     }
 }

--- a/src/NServiceBus.Core/Routing/NativeUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/NativeUnsubscribeTerminator.cs
@@ -16,6 +16,6 @@ namespace NServiceBus
             return subscriptionManager.Unsubscribe(context.EventType, context.Extensions);
         }
 
-        IManageSubscriptions subscriptionManager;
+        readonly IManageSubscriptions subscriptionManager;
     }
 }

--- a/src/NServiceBus.Core/Routing/Routers/UnicastPublishRouterConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/UnicastPublishRouterConnector.cs
@@ -44,7 +44,7 @@ namespace NServiceBus
             return addressLabels.ToList();
         }
 
-        DistributionPolicy distributionPolicy;
-        IUnicastPublishRouter unicastPublishRouter;
+        readonly DistributionPolicy distributionPolicy;
+        readonly IUnicastPublishRouter unicastPublishRouter;
     }
 }

--- a/src/NServiceBus.Core/Routing/Routers/UnicastSendRouterConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/UnicastSendRouterConnector.cs
@@ -28,6 +28,6 @@ namespace NServiceBus
             }
         }
 
-        UnicastSendRouter unicastSendRouter;
+        readonly UnicastSendRouter unicastSendRouter;
     }
 }

--- a/src/NServiceBus.Core/Sagas/AttachSagaDetailsToOutGoingMessageBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/AttachSagaDetailsToOutGoingMessageBehavior.cs
@@ -19,7 +19,6 @@
             return next(context);
         }
 
-
         static bool HasBeenFound(ActiveSagaInstance saga)
         {
             return !saga.NotFound;

--- a/src/NServiceBus.Core/Sagas/InvokeSagaNotFoundBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/InvokeSagaNotFoundBehavior.cs
@@ -33,6 +33,6 @@ namespace NServiceBus
             }
         }
 
-        static ILog logger = LogManager.GetLogger<InvokeSagaNotFoundBehavior>();
+        static readonly ILog logger = LogManager.GetLogger<InvokeSagaNotFoundBehavior>();
     }
 }

--- a/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
@@ -45,7 +45,6 @@
                 return;
             }
 
-
             var currentSagaMetadata = sagaMetadataCollection.Find(context.MessageHandler.Instance.GetType());
 
             if (context.Headers.TryGetValue(Headers.SagaType, out var targetSagaTypeString) && context.Headers.TryGetValue(Headers.SagaId, out var targetSagaId))
@@ -321,13 +320,12 @@
         }
 
         IInvokeHandlerContext currentContext;
-        SagaMetadataCollection sagaMetadataCollection;
+        readonly SagaMetadataCollection sagaMetadataCollection;
+        readonly ISagaPersister sagaPersister;
+        readonly ICancelDeferredMessages timeoutCancellation;
+        readonly ISagaIdGenerator sagaIdGenerator;
 
-        ISagaPersister sagaPersister;
-        ICancelDeferredMessages timeoutCancellation;
-
-        static Task<IContainSagaData> DefaultSagaDataCompletedTask = Task.FromResult(default(IContainSagaData));
-        static ILog logger = LogManager.GetLogger<SagaPersistenceBehavior>();
-        ISagaIdGenerator sagaIdGenerator;
+        static readonly Task<IContainSagaData> DefaultSagaDataCompletedTask = Task.FromResult(default(IContainSagaData));
+        static readonly ILog logger = LogManager.GetLogger<SagaPersistenceBehavior>();
     }
 }

--- a/src/NServiceBus.Core/Scheduling/ScheduleBehavior.cs
+++ b/src/NServiceBus.Core/Scheduling/ScheduleBehavior.cs
@@ -20,7 +20,7 @@ namespace NServiceBus
             return next(context);
         }
 
-        DefaultScheduler scheduler;
+        readonly DefaultScheduler scheduler;
 
         public class State
         {

--- a/src/NServiceBus.Core/StaticHeaders/ApplyStaticHeadersBehavior.cs
+++ b/src/NServiceBus.Core/StaticHeaders/ApplyStaticHeadersBehavior.cs
@@ -21,6 +21,6 @@ namespace NServiceBus
             return next(context);
         }
 
-        CurrentStaticHeaders currentStaticHeaders;
+        readonly CurrentStaticHeaders currentStaticHeaders;
     }
 }

--- a/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWorkBehavior.cs
+++ b/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWorkBehavior.cs
@@ -27,6 +27,6 @@
             }
         }
 
-        TransactionOptions transactionOptions;
+        readonly TransactionOptions transactionOptions;
     }
 }


### PR DESCRIPTION
As a follow up action of #5082 I checked our other behaviors for fields vulnerable to race conditions. I marked all fields as readonly to avoid accidental sets during a behavior invocation.

Note: this PR does not contain the fix of #5082, so there is one field in SagaPersistenceBehavior which isn't readonly. We can either fix it right away in this PR too or wait till the fix comes back into develop from the release branch.