### PR TITLE
Log license warnings with the license manager

### DIFF
--- a/src/NServiceBus.Core/Licensing/LogErrorOnInvalidLicenseBehavior.cs
+++ b/src/NServiceBus.Core/Licensing/LogErrorOnInvalidLicenseBehavior.cs
@@ -14,6 +14,6 @@ namespace NServiceBus
             return next(context);
         }
 
-        static readonly ILog Log = LogManager.GetLogger<LogErrorOnInvalidLicenseBehavior>();
+        static readonly ILog Log = LogManager.GetLogger<LicenseManager>();
     }
 }


### PR DESCRIPTION
I found it a bit weird that we're logging a highly visible message from the specific behavior's logger. I'd prefer to not see the behavior as the logger but something like "LicenseManager" or just "Licensing". Thoughts?

example:
![image](https://user-images.githubusercontent.com/3524870/33206157-a3e754f2-d109-11e7-9d9e-03533e24498d.png)
