### PR TITLE
[Spike] Acceptance testing transport

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransport.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransport.cs
@@ -1,0 +1,48 @@
+﻿namespace NServiceBus
+{
+    using Routing;
+    using Settings;
+    using Transport;
+
+    /// <summary>
+    /// A transport optimized for development and learning use. DO NOT use in production.
+    /// </summary>
+    public class AcceptanceTestingTransport : TransportDefinition, IMessageDrivenSubscriptionTransport
+    {
+        /// <summary>
+        /// Used by implementations to control if a connection string is necessary.
+        /// </summary>
+        public override bool RequiresConnectionString => false;
+
+        /// <summary>
+        /// Gets an example connection string to use when reporting the lack of a configured connection string to the user.
+        /// </summary>
+        public override string ExampleConnectionStringForErrorMessage { get; } = "";
+
+        /// <summary>
+        /// Initializes all the factories and supported features for the transport. This method is called right before all features
+        /// are activated and the settings will be locked down. This means you can use the SettingsHolder both for providing
+        /// default capabilities as well as for initializing the transport's configuration based on those settings (the user cannot
+        /// provide information anymore at this stage).
+        /// </summary>
+        /// <param name="settings">An instance of the current settings.</param>
+        /// <param name="connectionString">The connection string.</param>
+        /// <returns>The supported factories.</returns>
+        public override TransportInfrastructure Initialize(SettingsHolder settings, string connectionString)
+        {
+            Guard.AgainstNull(nameof(settings), settings);
+
+            if (!settings.TryGet<bool>("AcceptanceTestingTransport.UseNativePubSub", out var useNativePubSub))
+            {
+                useNativePubSub = true;
+            }
+
+            if (!settings.TryGet<bool>("AcceptanceTestingTransport.UseNativeDelayedDelivery", out var useNativeDelayedDelivery))
+            {
+                useNativeDelayedDelivery = true;
+            }
+
+            return new AcceptanceTestingTransportInfrastructure(settings, useNativePubSub, useNativeDelayedDelivery);
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransportExtensions.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransportExtensions.cs
@@ -1,0 +1,27 @@
+﻿namespace NServiceBus
+{
+    public static class AcceptanceTestingTransportExtensions
+    {
+        public static TransportExtensions<AcceptanceTestingTransport> UseNativeDelayedDelivery(this TransportExtensions<AcceptanceTestingTransport> config, bool useNativeDelayedDelivery = true)
+        {
+            config.Settings.Set("AcceptanceTestingTransport.UseNativeDelayedDelivery", useNativeDelayedDelivery);
+            return config;
+        }
+
+        public static TransportExtensions<AcceptanceTestingTransport> UseNativePubSub(this TransportExtensions<AcceptanceTestingTransport> config, bool useNativePubSub = true)
+        {
+            config.Settings.Set("AcceptanceTestingTransport.UseNativePubSub", useNativePubSub);
+            return config;
+        }
+
+        public static TransportExtensions<AcceptanceTestingTransport> StorageDirectory(this TransportExtensions<AcceptanceTestingTransport> transportExtensions, string path)
+        {
+            Guard.AgainstNullAndEmpty(nameof(path), path);
+            Guard.AgainstNull(nameof(transportExtensions), transportExtensions);
+            PathChecker.ThrowForBadPath(path, "StorageDirectory");
+
+            transportExtensions.Settings.Set(LearningTransportInfrastructure.StorageLocationKey, path);
+            return transportExtensions;
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransportInfrastructure.cs
@@ -1,0 +1,146 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using DelayedDelivery;
+    using Performance.TimeToBeReceived;
+    using Routing;
+    using Settings;
+    using Transport;
+
+    class AcceptanceTestingTransportInfrastructure : TransportInfrastructure
+    {
+        public AcceptanceTestingTransportInfrastructure(SettingsHolder settings, bool nativePubSub, bool nativeDelayedDelivery)
+        {
+            this.nativePubSub = nativePubSub;
+            this.nativeDelayedDelivery = nativeDelayedDelivery;
+            this.settings = settings;
+
+            if (!settings.TryGet(StorageLocationKey, out storagePath))
+            {
+                var solutionRoot = FindSolutionRoot();
+                storagePath = Path.Combine(solutionRoot, ".learningtransport");
+            }
+
+            settings.SetDefault<MessageProcessingOptimizationExtensions.ConcurrencyLimit>(new MessageProcessingOptimizationExtensions.ConcurrencyLimit
+            {
+                MaxValue = 1
+            });
+
+            var errorQueueAddress = settings.ErrorQueueAddress();
+            PathChecker.ThrowForBadPath(errorQueueAddress, "ErrorQueueAddress");
+        }
+
+        public override IEnumerable<Type> DeliveryConstraints => nativeDelayedDelivery
+            ? new[]
+            {
+                typeof(DiscardIfNotReceivedBefore),
+                typeof(DelayDeliveryWith),
+                typeof(DoNotDeliverBefore)
+            }
+            : new[]
+            {
+                typeof(DiscardIfNotReceivedBefore)
+            };
+
+        public override TransportTransactionMode TransactionMode => TransportTransactionMode.SendsAtomicWithReceive;
+
+        public override OutboundRoutingPolicy OutboundRoutingPolicy => new OutboundRoutingPolicy(
+            OutboundRoutingType.Unicast, 
+            nativePubSub ? OutboundRoutingType.Multicast : OutboundRoutingType.Unicast, 
+            OutboundRoutingType.Unicast);
+
+        string FindSolutionRoot()
+        {
+            var directory = AppDomain.CurrentDomain.BaseDirectory;
+
+            while (true)
+            {
+                if (Directory.EnumerateFiles(directory).Any(file => file.EndsWith(".sln")))
+                {
+                    return directory;
+                }
+
+                var parent = Directory.GetParent(directory);
+
+                if (parent == null)
+                {
+                    // throw for now. if we discover there is an edge then we can fix it in a patch.
+                    throw new Exception("Couldn't find the solution directory for the learning transport. If the endpoint is outside the solution folder structure, make sure to specify a storage directory using the 'EndpointConfiguration.UseTransport<LearningTransport>().StorageDirectory()' API.");
+                }
+
+                directory = parent.FullName;
+            }
+        }
+
+        public override TransportReceiveInfrastructure ConfigureReceiveInfrastructure()
+        {
+            return new TransportReceiveInfrastructure(() => new LearningTransportMessagePump(storagePath), () => new LearningTransportQueueCreator(), () => Task.FromResult(StartupCheckResult.Success));
+        }
+
+        public override TransportSendInfrastructure ConfigureSendInfrastructure()
+        {
+            var maxPayloadSize = settings.GetOrDefault<bool>(NoPayloadSizeRestrictionKey) ? int.MaxValue / 1024 : 64; //64 kB is the max size of the ASQ transport
+
+            return new TransportSendInfrastructure(() => new LearningTransportDispatcher(storagePath, maxPayloadSize), () => Task.FromResult(StartupCheckResult.Success));
+        }
+
+        public override TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure()
+        {
+            if (!nativePubSub)
+            {
+                throw new NotSupportedException();
+            }
+
+            return new TransportSubscriptionInfrastructure(() =>
+            {
+                var endpointName = settings.EndpointName();
+                PathChecker.ThrowForBadPath(endpointName, "endpoint name");
+
+                var localAddress = settings.LocalAddress();
+                PathChecker.ThrowForBadPath(localAddress, "localAddress");
+
+                return new LearningTransportSubscriptionManager(storagePath, endpointName, localAddress);
+            });
+        }
+
+        public override EndpointInstance BindToLocalEndpoint(EndpointInstance instance) => instance;
+
+        public override string ToTransportAddress(LogicalAddress logicalAddress)
+        {
+            var address = logicalAddress.EndpointInstance.Endpoint;
+            PathChecker.ThrowForBadPath(address, "endpoint name");
+
+            var discriminator = logicalAddress.EndpointInstance.Discriminator;
+
+            if (!string.IsNullOrEmpty(discriminator))
+            {
+                PathChecker.ThrowForBadPath(discriminator, "endpoint discriminator");
+
+                address += "-" + discriminator;
+            }
+
+            var qualifier = logicalAddress.Qualifier;
+
+            if (!string.IsNullOrEmpty(qualifier))
+            {
+                PathChecker.ThrowForBadPath(qualifier, "address qualifier");
+
+                address += "-" + qualifier;
+            }
+
+            return address;
+        }
+
+        string storagePath;
+        SettingsHolder settings;
+        bool nativePubSub;
+        readonly bool nativeDelayedDelivery;
+
+        public const string StorageLocationKey = "LearningTransport.StoragePath";
+        public const string NoPayloadSizeRestrictionKey = "LearningTransport.NoPayloadSizeRestrictionKey";
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/ConfigureEndpointLearningTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureEndpointLearningTransport.cs
@@ -39,8 +39,20 @@ public class ConfigureEndpointLearningTransport : IConfigureEndpointTestExecutio
         //we want the tests to be exposed to concurrency
         configuration.LimitMessageProcessingConcurrencyTo(PushRuntimeSettings.Default.MaxConcurrency);
 
-        configuration.UseTransport<LearningTransport>()
-            .StorageDirectory(storageDir);
+        var transportConfig = configuration.UseTransport<AcceptanceTestingTransport>()
+            .StorageDirectory(storageDir)
+            .UseNativePubSub(false)
+            .UseNativeDelayedDelivery(false);
+
+        var routingConfig = transportConfig.Routing();
+
+        foreach (var publisherMetadataPublisher in publisherMetadata.Publishers)
+        {
+            foreach (var @event in publisherMetadataPublisher.Events)
+            {
+                routingConfig.RegisterPublisher(@event, publisherMetadataPublisher.PublisherName);
+            }
+        }
 
         return Task.FromResult(0);
     }

--- a/src/NServiceBus.AcceptanceTests/Core/CoreTestSuiteConstraints.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/CoreTestSuiteConstraints.cs
@@ -6,8 +6,8 @@
     {
         public bool SupportsDtc => false;
         public bool SupportsCrossQueueTransactions => true;
-        public bool SupportsNativePubSub => true;
-        public bool SupportsNativeDeferral => true;
+        public bool SupportsNativePubSub => false;
+        public bool SupportsNativeDeferral => false;
         public bool SupportsOutbox => false;
         public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureEndpointLearningTransport();
         public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointLearningPersistence();

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -35,6 +35,13 @@
             committedTransactionDir = Path.Combine(messagePumpBasePath, CommittedDirName);
 
             purgeOnStartup = settings.PurgeOnStartup;
+            if (purgeOnStartup)
+            {
+                if (Directory.Exists(messagePumpBasePath))
+                {
+                    Directory.Delete(messagePumpBasePath, true);
+                }
+            }
 
             delayedMessagePoller = new DelayedMessagePoller(messagePumpBasePath, delayedDir);
 
@@ -48,14 +55,6 @@
             cancellationTokenSource = new CancellationTokenSource();
 
             cancellationToken = cancellationTokenSource.Token;
-
-            if (purgeOnStartup)
-            {
-                if (Directory.Exists(messagePumpBasePath))
-                {
-                    Directory.Delete(messagePumpBasePath, true);
-                }
-            }
 
             RecoverPendingTransactions();
 


### PR DESCRIPTION
Adds an `AcceptanceTestingTransport ` transport to the acceptance testing projects which is based upon the learning transport but offers some additional configuration options to turn on/off native pubsub and native delayed delivery. This allows downstream persistence packages to specifically test for correct usage of timeout storage and subscription storage.

Note:
I had to move the purging logic earlier within the learning transport pump's code to purge on initialize instead of start as start gets invoked after the feature startup tasks (including autosubscribe) and therefore it will delete subscriptions to itself. This is not an issue when running with native pubsub but something which needs to be this way when using message driven pubsub (and is done the same way in MSMQ and SQL transport afaik).

ping @andreasohlund 