### PR TITLE
Exclude test convention enforcement for shipped tests

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/SelfVerification/ConventionEnforcementTests.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/SelfVerification/ConventionEnforcementTests.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests
+﻿namespace NServiceBus.AcceptanceTests.Core.SelfVerification
 {
     using System;
     using System.Linq;

--- a/src/NServiceBus.AcceptanceTests/Core/SelfVerification/When_running_saga_tests.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/SelfVerification/When_running_saga_tests.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.SelfVerification
+﻿namespace NServiceBus.AcceptanceTests.Core.SelfVerification
 {
     using System;
     using System.Collections.Generic;

--- a/src/NServiceBus.AcceptanceTests/Core/SelfVerification/When_using_custom_components.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/SelfVerification/When_using_custom_components.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.SelfVerification
+﻿namespace NServiceBus.AcceptanceTests.Core.SelfVerification
 {
     using System.Threading;
     using System.Threading.Tasks;


### PR DESCRIPTION
Since it causes issues for downstreams.

Eg. raven and nhibernate needs to exclude them https://github.com/Particular/NServiceBus.NHibernate/pull/317/files#diff-099b6f6bdfd884ef1a6672dfe730b45aR19

Talked to @timbussmann and we concluded that none of the tests where relevant for downstreams since failure to comply with them would just blow up the specific test. We only need this to avoid having the core ship bad tests.
