### PR TITLE
Start and stop transport infrastructure on transport tests

### DIFF
--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -74,6 +74,7 @@
             ErrorQueueName = $"{InputQueueName}.error";
 
             transportSettings.Set("NServiceBus.Routing.EndpointName", InputQueueName);
+            transportSettings.Set<StartupDiagnosticEntries>(new StartupDiagnosticEntries());
 
             var queueBindings = new QueueBindings();
             queueBindings.BindReceiving(InputQueueName);

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -62,6 +62,7 @@
         {
             testCancellationTokenSource?.Dispose();
             MessagePump?.Stop().GetAwaiter().GetResult();
+            TransportInfrastructure.Stop().GetAwaiter().GetResult();
             Configurer?.Cleanup().GetAwaiter().GetResult();
 
             transportSettings.Clear();
@@ -101,6 +102,8 @@
             var queueCreator = ReceiveInfrastructure.QueueCreatorFactory();
             var userName = GetUserName();
             await queueCreator.CreateQueueIfNecessary(queueBindings, userName);
+
+            await TransportInfrastructure.Start();
 
             var pushSettings = new PushSettings(InputQueueName, ErrorQueueName, configuration.PurgeInputQueueOnStartup, transactionMode);
             await MessagePump.Init(

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -25,6 +25,8 @@
 
             //when using [TestCase] NUnit will reuse the same test instance so we need to make sure that the message pump is a fresh one
             MessagePump = null;
+            TransportInfrastructure = null;
+            Configurer = null;
             testCancellationTokenSource = null;
         }
 

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -77,7 +77,7 @@
             ErrorQueueName = $"{InputQueueName}.error";
 
             transportSettings.Set("NServiceBus.Routing.EndpointName", InputQueueName);
-            transportSettings.Set<StartupDiagnosticEntries>(new StartupDiagnosticEntries());
+            transportSettings.Set(new StartupDiagnosticEntries());
 
             var queueBindings = new QueueBindings();
             queueBindings.BindReceiving(InputQueueName);

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -25,6 +25,7 @@
 
             //when using [TestCase] NUnit will reuse the same test instance so we need to make sure that the message pump is a fresh one
             MessagePump = null;
+            testCancellationTokenSource = null;
         }
 
         static IConfigureTransportInfrastructure CreateConfigurer()

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -62,7 +62,7 @@
         {
             testCancellationTokenSource?.Dispose();
             MessagePump?.Stop().GetAwaiter().GetResult();
-            TransportInfrastructure.Stop().GetAwaiter().GetResult();
+            TransportInfrastructure?.Stop().GetAwaiter().GetResult();
             Configurer?.Cleanup().GetAwaiter().GetResult();
 
             transportSettings.Clear();


### PR DESCRIPTION
fixes https://github.com/Particular/NServiceBus/issues/5099

ensure to start & stop the transport infrastructure at the right moment. I put it between creating the queues (https://github.com/Particular/NServiceBus/blob/develop/src/NServiceBus.Core/InitializableEndpoint.cs#L75) and initializing the receivers (https://github.com/Particular/NServiceBus/blob/develop/src/NServiceBus.Core/StartableEndpoint.cs#L32)

See https://github.com/Particular/NServiceBus/blob/develop/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs#L46 for the shutdown sequence

tested against:
* [x] MSMQ
* [x] RabbitMQ
* [x] ASB
* [x] ASQ
* [x] SQL
* [ ] SQS