### PR TITLE
Update ApprovalTests to 3.0.14

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ApprovalTests" Version="3.0.13" NoWarn="NU1701" />
-    <PackageReference Include="ApprovalUtilities" Version="3.0.13" NoWarn="NU1701" />
+    <PackageReference Include="ApprovalTests" Version="3.0.14" NoWarn="NU1701" />
+    <PackageReference Include="ApprovalUtilities" Version="3.0.14" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0-beta7" />
     <PackageReference Include="NuDoq" Version="1.2.5" NoWarn="NU1701" />

--- a/src/NServiceBus.Core.Tests/TestApprover.cs
+++ b/src/NServiceBus.Core.Tests/TestApprover.cs
@@ -2,7 +2,8 @@
 {
     using System.IO;
     using ApprovalTests;
-    using ApprovalTests.Namers;
+    using ApprovalTests.Core;
+    using ApprovalTests.Namers.StackTraceParsers;
     using NUnit.Framework;
 
     static class TestApprover
@@ -14,9 +15,20 @@
             Approvals.Verify(writer, namer, Approvals.GetReporter());
         }
 
-        class ApprovalNamer : UnitTestFrameworkNamer
+        class ApprovalNamer : IApprovalNamer
         {
-            public override string SourcePath { get; } = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "ApprovalFiles");
+            public ApprovalNamer()
+            {
+                Approvals.SetCaller();
+                stackTraceParser = new StackTraceParser();
+                stackTraceParser.Parse(Approvals.CurrentCaller.StackTrace);
+            }
+
+            public string Name => stackTraceParser.ApprovalName;
+
+            public string SourcePath { get; } = Path.Combine(TestContext.CurrentContext.TestDirectory, "..", "..", "..", "ApprovalFiles");
+
+            readonly StackTraceParser stackTraceParser;
         }
     }
 }


### PR DESCRIPTION
The new release of ApprovalTests removed the `virtual` keywords from their `UnitTestFrameworkNamer` class, so I had to adjust `ApprovalNamer` to account for that.