### PR TITLE
Update Particular.Licensing.Sources to 2.0.0

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="SimpleJson" Version="0.38.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.3.2" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="2.0.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
The 2.0.0 version of the package includes a fix to make sure the license file can be found properly when running in a Windows container.

It also improves license verification to avoid thrown unnecessary exceptions.