### PR TITLE
Ensure ColoredConsoleLogger doesn't crash process when terminal is lost

### DIFF
--- a/src/NServiceBus.Core/Logging/ColoredConsoleLogger.cs
+++ b/src/NServiceBus.Core/Logging/ColoredConsoleLogger.cs
@@ -25,10 +25,11 @@
             {
                 Console.ForegroundColor = GetColor(logLevel);
                 Console.WriteLine(message);
-            }
-            finally
-            {
                 Console.ResetColor();
+            }
+            catch (IOException)
+            {
+                logToConsole = false;
             }
         }
 


### PR DESCRIPTION
This change ensures that when running on linux as a background job, if the terminal is closed, the process won't crash from an unhandled `IOException` bubbling up from `ColoredConsoleLogger`.