### PR TITLE
SimpleJson fails with DateTime used as Dictionary key

### DIFF
--- a/src/NServiceBus.Core.Tests/Serializers/SimpleJsonTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/SimpleJsonTests.cs
@@ -129,12 +129,12 @@
         }
 
         [Test]
-        public void TestDateTimeIntDictionary()
+        public void TestDateTimeDictionaryKeys()
         {
             var date1 = new DateTime(2018, 1, 1);
             var date2 = new DateTime(2017, 1, 1);
 
-            var input = new Dictionary<DateTime, int>()
+            var input = new Dictionary<DateTime, int>
             {
                 {date1, 1},
                 {date2, 2}
@@ -145,6 +145,64 @@
             Assert.AreEqual(2, result.Count);
             Assert.AreEqual(1, result[date1]);
             Assert.AreEqual(2, result[date2]);
+        }
+
+        [Test]
+        public void TestDateTimeOffsetDictionaryKeys()
+        {
+            var date1 = new DateTimeOffset(new DateTime(2018, 1, 1), TimeSpan.FromHours(4));
+            var date2 = new DateTimeOffset(new DateTime(2017, 1, 1), TimeSpan.FromHours(-2));
+
+            var input = new Dictionary<DateTimeOffset, int>
+            {
+                {date1, 1},
+                {date2, 2}
+            };
+            var json = SimpleJson.SerializeObject(input);
+            var result = SimpleJson.DeserializeObject<Dictionary<DateTimeOffset, int>>(json);
+
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(1, result[date1]);
+            Assert.AreEqual(2, result[date2]);
+        }
+
+        [Test]
+        public void TestGuidDictionaryKeys()
+        {
+            var guid1 = Guid.NewGuid();
+            var guid2 = Guid.NewGuid();
+
+            var input = new Dictionary<Guid, int>
+            {
+                {guid1, 1},
+                {guid2, 2}
+            };
+            var json = SimpleJson.SerializeObject(input);
+            var result = SimpleJson.DeserializeObject<Dictionary<Guid, int>>(json);
+
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(1, result[guid1]);
+            Assert.AreEqual(2, result[guid2]);
+        }
+
+        [Test]
+        [Ignore("not supported")]
+        public void TestEnumDictionaryKeys()
+        {
+            var enum1 = SampleEnum.EnumValue2;
+            var enum2 = SampleEnum.EnumValue3;
+
+            var input = new Dictionary<SampleEnum, int>
+            {
+                {enum1, 1},
+                {enum2, 2}
+            };
+            var json = SimpleJson.SerializeObject(input);
+            var result = SimpleJson.DeserializeObject<Dictionary<SampleEnum, int>>(json);
+
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(1, result[enum1]);
+            Assert.AreEqual(2, result[enum2]);
         }
 
         [Test]
@@ -268,5 +326,10 @@
 
     class CustomDictionary : Dictionary<int, int>
     {
+    }
+
+    enum SampleEnum
+    {
+        EnumValue1, EnumValue2, EnumValue3
     }
 }

--- a/src/NServiceBus.Core.Tests/Serializers/SimpleJsonTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/SimpleJsonTests.cs
@@ -129,6 +129,25 @@
         }
 
         [Test]
+        public void TestDateTimeIntDictionary()
+        {
+            var date1 = new DateTime(2018, 1, 1);
+            var date2 = new DateTime(2017, 1, 1);
+
+            var input = new Dictionary<DateTime, int>()
+            {
+                {date1, 1},
+                {date2, 2}
+            };
+            var json = SimpleJson.SerializeObject(input);
+            var result = SimpleJson.DeserializeObject<Dictionary<DateTime, int>>(json);
+
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual(1, result[date1]);
+            Assert.AreEqual(2, result[date2]);
+        }
+
+        [Test]
         public void TestPocoClass()
         {
             var input = new SamplePoco

--- a/src/NServiceBus.Core/Serializers/SimpleJson/SimpleJson.g.cs
+++ b/src/NServiceBus.Core/Serializers/SimpleJson/SimpleJson.g.cs
@@ -1067,7 +1067,10 @@ namespace SimpleJson
                 if (stringKey != null)
                     SerializeString(stringKey, builder);
                 else
-                    SerializeString(key.ToString(), builder);
+                {
+                    jsonSerializerStrategy.TrySerializeNonPrimitiveObject(key, out var serializedKey);
+                    SerializeString((serializedKey as string) ?? key.ToString(), builder);
+                }
                 builder.Append(":");
                 if (!SerializeValue(jsonSerializerStrategy, value, builder))
                     return false;

--- a/src/NServiceBus.Core/Serializers/SimpleJson/SimpleJson.g.cs
+++ b/src/NServiceBus.Core/Serializers/SimpleJson/SimpleJson.g.cs
@@ -1068,8 +1068,22 @@ namespace SimpleJson
                     SerializeString(stringKey, builder);
                 else
                 {
-                    jsonSerializerStrategy.TrySerializeNonPrimitiveObject(key, out var serializedKey);
-                    SerializeString((serializedKey as string) ?? key.ToString(), builder);
+//                    alternative approach:
+//                    jsonSerializerStrategy.TrySerializeNonPrimitiveObject(key, out var keyValue);
+//                    SerializeString((keyValue as string) ?? key.ToString(), builder);
+
+                    switch (key)
+                    {
+                        case DateTime d:
+                            SerializeString(d.ToString("O", CultureInfo.InvariantCulture), builder);
+                            break;
+                        case DateTimeOffset d:
+                            SerializeString(d.ToString("O", CultureInfo.InvariantCulture), builder);
+                            break;
+                        default:
+                            SerializeString(key.ToString(), builder);
+                            break;
+                    }
                 }
                 builder.Append(":");
                 if (!SerializeValue(jsonSerializerStrategy, value, builder))


### PR DESCRIPTION
Even after the changes @timbussmann made in #5131, it there are some other cases that aren't handled that I think we might want to support.

Currently, if a dictionary key isn't a string, `ToString` is called on it, and then it's serialized as a string:
https://github.com/Particular/NServiceBus/blob/f347ae2026e654a4154555d710d945a20fff9c14/src/NServiceBus.Core/Serializers/SimpleJson/SimpleJson.g.cs#L1070

This breaks things like `DateTime` since it's not serialized to the correct format. I would think this almost always the wrong thing to do, since most types are not going to produce a valid string from calling `ToString' on it.