### PR TITLE
Remove assumption about temp folder on Windows

### DIFF
--- a/src/NServiceBus.AcceptanceTests/ConfigureEndpointLearningTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureEndpointLearningTransport.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using System.Threading.Tasks;
 using NServiceBus;
@@ -22,19 +21,7 @@ public class ConfigureEndpointLearningTransport : IConfigureEndpointTestExecutio
     {
         var testRunId = TestContext.CurrentContext.Test.ID;
 
-        string tempDir;
-
-        if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-        {
-            //can't use bin dir since that will be too long on the build agents
-            tempDir = @"c:\temp";
-        }
-        else
-        {
-            tempDir = Path.GetTempPath();
-        }
-
-        storageDir = Path.Combine(tempDir, testRunId);
+        storageDir = Path.Combine(Path.GetTempPath(), testRunId);
 
         //we want the tests to be exposed to concurrency
         configuration.LimitMessageProcessingConcurrencyTo(PushRuntimeSettings.Default.MaxConcurrency);


### PR DESCRIPTION
`c:\temp` is not a given. Chaning to `Path.GetTempFolder()` for consistency.

E.g.: on my system there's no `c:\temp` folder.