### PR TITLE
remove applicative header comments

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus__NET452.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus__NET452.approved.txt
@@ -374,6 +374,8 @@ namespace NServiceBus
         public const string DestinationSites = "NServiceBus.DestinationSites";
         public const string EnclosedMessageTypes = "NServiceBus.EnclosedMessageTypes";
         public const string HasLicenseExpired = "$.diagnostics.license.expired";
+        [System.ObsoleteAttribute("Not intended for public usage. Will be treated as an error from version 8.0.0. Wi" +
+            "ll be removed in version 8.0.0.", false)]
         public const string HeaderName = "Header";
         public const string HostDisplayName = "$.diagnostics.hostdisplayname";
         public const string HostId = "$.diagnostics.hostid";

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus__NET452.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus__NET452.approved.txt
@@ -375,7 +375,7 @@ namespace NServiceBus
         public const string EnclosedMessageTypes = "NServiceBus.EnclosedMessageTypes";
         public const string HasLicenseExpired = "$.diagnostics.license.expired";
         [System.ObsoleteAttribute("Not intended for public usage. Will be treated as an error from version 8.0.0. Wi" +
-            "ll be removed in version 8.0.0.", false)]
+            "ll be removed in version 9.0.0.", false)]
         public const string HeaderName = "Header";
         public const string HostDisplayName = "$.diagnostics.hostdisplayname";
         public const string HostId = "$.diagnostics.hostid";

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus__NETSTANDARD2_0.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus__NETSTANDARD2_0.approved.txt
@@ -374,6 +374,8 @@ namespace NServiceBus
         public const string DestinationSites = "NServiceBus.DestinationSites";
         public const string EnclosedMessageTypes = "NServiceBus.EnclosedMessageTypes";
         public const string HasLicenseExpired = "$.diagnostics.license.expired";
+        [System.ObsoleteAttribute("Not intended for public usage. Will be treated as an error from version 8.0.0. Wi" +
+            "ll be removed in version 9.0.0.", false)]
         public const string HeaderName = "Header";
         public const string HostDisplayName = "$.diagnostics.hostdisplayname";
         public const string HostId = "$.diagnostics.hostid";

--- a/src/NServiceBus.Core/Headers.cs
+++ b/src/NServiceBus.Core/Headers.cs
@@ -55,7 +55,7 @@
         /// Prefix included on the wire when sending applicative headers.
         /// </summary>
         [ObsoleteEx(
-            RemoveInVersion = "8.0", 
+            RemoveInVersion = "9.0", 
             TreatAsErrorFromVersion = "8.0",
             Message = "Not intended for public usage.")]
         public const string HeaderName = "Header";

--- a/src/NServiceBus.Core/Headers.cs
+++ b/src/NServiceBus.Core/Headers.cs
@@ -54,6 +54,10 @@
         /// <summary>
         /// Prefix included on the wire when sending applicative headers.
         /// </summary>
+        [ObsoleteEx(
+            RemoveInVersion = "8.0", 
+            TreatAsErrorFromVersion = "8.0",
+            Message = "Not intended for public usage.")]
         public const string HeaderName = "Header";
 
         /// <summary>

--- a/src/NServiceBus.Core/Headers.cs
+++ b/src/NServiceBus.Core/Headers.cs
@@ -17,26 +17,22 @@
 
         /// <summary>
         /// Header for specifying to which queue behind the http gateway should the message be delivered.
-        /// This header is considered an applicative header.
         /// </summary>
         public const string RouteTo = "NServiceBus.Header.RouteTo";
 
         /// <summary>
         /// Header for specifying to which sites the gateway should send the message. For multiple
-        /// sites a comma separated list can be used
-        /// This header is considered an applicative header.
+        /// sites a comma separated list can be used.
         /// </summary>
         public const string DestinationSites = "NServiceBus.DestinationSites";
 
         /// <summary>
         /// Header for specifying the key for the site where this message originated.
-        /// This header is considered an applicative header.
         /// </summary>
         public const string OriginatingSite = "NServiceBus.OriginatingSite";
 
         /// <summary>
         /// Header containing the id of the saga instance the sent the message
-        /// This header is considered an applicative header.
         /// </summary>
         public const string SagaId = "NServiceBus.SagaId";
 

--- a/src/NServiceBus.Core/Headers.cs
+++ b/src/NServiceBus.Core/Headers.cs
@@ -32,7 +32,7 @@
         public const string OriginatingSite = "NServiceBus.OriginatingSite";
 
         /// <summary>
-        /// Header containing the id of the saga instance the sent the message
+        /// Header containing the id of the saga instance the sent the message.
         /// </summary>
         public const string SagaId = "NServiceBus.SagaId";
 

--- a/src/NServiceBus.Core/Headers.cs
+++ b/src/NServiceBus.Core/Headers.cs
@@ -22,7 +22,7 @@
 
         /// <summary>
         /// Header for specifying to which sites the gateway should send the message. For multiple
-        /// sites a comma separated list can be used.
+        /// sites, a comma separated list can be used.
         /// </summary>
         public const string DestinationSites = "NServiceBus.DestinationSites";
 


### PR DESCRIPTION
seems the applicate headers concept seems to come from the Gateway as the `HeaderName` property is only used by the gateway as a prefix.

We have no internal usage of the obsoleted header in core, so we should be able to move it to the gateway, I don't think this is supposed to by used by users directly.

based on this doco feedback: https://github.com/Particular/docs.particular.net/issues/3752