### PR TITLE
Update ApprovalTests reporter for .NET Core

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalTestConfig.cs
+++ b/src/NServiceBus.Core.Tests/ApprovalTestConfig.cs
@@ -2,5 +2,5 @@
 #if NET452
 [assembly: UseReporter(typeof(DiffReporter), typeof(AllFailingTestsClipboardReporter))]
 #else
-[assembly: UseReporter(typeof(DiffReporter))]
+[assembly: UseReporter(typeof(NUnitReporter))]
 #endif


### PR DESCRIPTION
When ApprovalTests is trying to report that it found a problem with the approval file, `DiffReporter` fails with an exception about not being able to load System.Drawing when the test is being run locally on .NET Core.

This can be avoided by switching to `NUnitReporter` reporter instead. The test will now fail with an actual Assert error message. It does mean that it won't pop up a diff window in that case, but the received approval file is created as usual.