### PR TITLE
XML serializer's type initialization is vulnerable to concurrency

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Sagas\SagaModelTests.cs" />
     <Compile Include="Sagas\TypeBasedSagaMetaModelTests.cs" />
     <Compile Include="Serializers\XML\Issue_2796.cs" />
+    <Compile Include="Serializers\XML\XmlSerializerCacheTests.cs" />
     <Compile Include="StandardsTests.cs" />
     <Compile Include="Encryption\ConfigureRijndaelEncryptionServiceTests.cs" />
     <Compile Include="Encryption\RijndaelEncryptionServiceTest.cs" />

--- a/src/NServiceBus.Core.Tests/Serializers/XML/XmlSerializerCacheTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/XmlSerializerCacheTests.cs
@@ -1,0 +1,70 @@
+﻿namespace NServiceBus.Core.Tests.Serializers.XML
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+    using System.Xml.Linq;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class XmlSerializerCacheTests
+    {
+        [Test]
+        public void InitType_ShouldNotInitializeXContainerTypes()
+        {
+            var cache = new XmlSerializerCache();
+
+            cache.InitType(typeof(XElement));
+
+            Assert.IsFalse(cache.typeMembers.ContainsKey(typeof(XElement)));
+        }
+
+        [Test]
+        public void InitType_ShouldNotInfinitelyInitializeRecursiveTypes()
+        {
+            var cache = new XmlSerializerCache();
+
+            cache.InitType(typeof(RecursiveType));
+
+            var members = cache.typeMembers[typeof(RecursiveType)];
+            Assert.AreEqual(typeof(RecursiveType), members.Item1.Single().FieldType);
+            Assert.AreEqual(typeof(RecursiveType), members.Item2[0].PropertyType);
+            Assert.AreEqual(typeof(RecursiveType[]), members.Item2[1].PropertyType);
+        }
+
+        [Test]
+        public void InitType_ShouldHandleConcurrentInitializations()
+        {
+            var cache = new XmlSerializerCache();
+
+            Parallel.For(0, 10, _ =>
+            {
+                cache.InitType(typeof(SimpleType));
+
+                var members = cache.typeMembers[typeof(SimpleType)];
+                Assert.NotNull(members);
+                Assert.AreEqual(nameof(SimpleType.SimpleField), members.Item1.Single().Name);
+                Assert.AreEqual(nameof(SimpleType.SimpleProperty), members.Item2.Single().Name);
+            });
+        }
+    }
+
+    class SimpleType
+    {
+#pragma warning disable 649, 169
+        public string SimpleField;
+#pragma warning restore 649, 169
+
+        public string SimpleProperty { get; set; }
+    }
+
+    class RecursiveType
+    {
+#pragma warning disable 649, 169
+        public RecursiveType RecursiveField;
+#pragma warning restore 649, 169
+
+        public RecursiveType RecursiveProperty { get; set; }
+
+        public RecursiveType[] RecursiveArrayProperty { get; set; }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Serializers/XML/XmlSerializerCacheTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/XmlSerializerCacheTests.cs
@@ -3,6 +3,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using System.Xml.Linq;
+    using NServiceBus.Serializers.XML;
     using NUnit.Framework;
 
     [TestFixture]

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -76,7 +76,9 @@
     <Reference Include="System.Web.Services" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml.Linq">
+      <HintPath>..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Xml.Linq.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Packages\Particular.Licensing\License.cs" />

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -76,9 +76,7 @@
     <Reference Include="System.Web.Services" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq">
-      <HintPath>..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Xml.Linq.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Packages\Particular.Licensing\License.cs" />

--- a/src/NServiceBus.Core/Serializers/XML/Deserializer.cs
+++ b/src/NServiceBus.Core/Serializers/XML/Deserializer.cs
@@ -274,7 +274,14 @@
                     type = Type.GetType("System." + n.Name.Substring(0, n.Name.IndexOf(":")), false, true);
                 }
 
-                var prop = GetProperty(t, n.Name);
+                Tuple<FieldInfo[], PropertyInfo[]> typeMembers;
+                if (!cache.typeMembers.TryGetValue(t, out typeMembers))
+                {
+                    cache.InitType(t);
+                    cache.typeMembers.TryGetValue(t, out typeMembers);
+                }
+
+                var prop = GetProperty(typeMembers?.Item2, n.Name);
                 if (prop != null)
                 {
                     var val = GetPropertyValue(type ?? prop.PropertyType, n);
@@ -286,7 +293,7 @@
                     }
                 }
 
-                var field = GetField(t, n.Name);
+                var field = GetField(typeMembers?.Item1, n.Name);
                 if (field != null)
                 {
                     var val = GetPropertyValue(type ?? field.FieldType, n);
@@ -301,11 +308,8 @@
             return result;
         }
 
-        FieldInfo GetField(Type t, string name)
+        FieldInfo GetField(FieldInfo[] fields, string name)
         {
-            IEnumerable<FieldInfo> fields;
-            cache.typeToFields.TryGetValue(t, out fields);
-
             if (fields == null)
             {
                 return null;
@@ -592,11 +596,8 @@
             return GetObjectOfTypeFromNode(type, n);
         }
 
-        PropertyInfo GetProperty(Type t, string name)
+        PropertyInfo GetProperty(PropertyInfo[] props, string name)
         {
-            IEnumerable<PropertyInfo> props;
-            cache.typeToProperties.TryGetValue(t, out props);
-
             if (props == null)
             {
                 return null;

--- a/src/NServiceBus.Core/Serializers/XML/Deserializer.cs
+++ b/src/NServiceBus.Core/Serializers/XML/Deserializer.cs
@@ -275,11 +275,7 @@
                 }
 
                 Tuple<FieldInfo[], PropertyInfo[]> typeMembers;
-                if (!cache.typeMembers.TryGetValue(t, out typeMembers))
-                {
-                    cache.InitType(t);
-                    cache.typeMembers.TryGetValue(t, out typeMembers);
-                }
+                cache.typeMembers.TryGetValue(t, out typeMembers);
 
                 var prop = GetProperty(typeMembers?.Item2, n.Name);
                 if (prop != null)

--- a/src/NServiceBus.Core/Serializers/XML/Serializer.cs
+++ b/src/NServiceBus.Core/Serializers/XML/Serializer.cs
@@ -372,13 +372,14 @@
                 return;
             }
 
-            IEnumerable<PropertyInfo> properties;
-            if (!cache.typeToProperties.TryGetValue(t, out properties))
+            Tuple<FieldInfo[], PropertyInfo[]> members;
+            if (!cache.typeMembers.TryGetValue(t, out members))
             {
-                throw new InvalidOperationException(string.Format("Type {0} was not registered in the serializer. Check that it appears in the list of configured assemblies/types to scan.", t.FullName));
+                cache.InitType(t);
+                members = cache.typeMembers[t];
             }
 
-            foreach (var prop in properties)
+            foreach (var prop in members.Item2)
             {
                 if (IsIndexedProperty(prop))
                 {
@@ -387,7 +388,7 @@
                 WriteEntry(prop.Name, prop.PropertyType, DelegateFactory.CreateGet(prop).Invoke(obj), builder);
             }
 
-            foreach (var field in cache.typeToFields[t])
+            foreach (var field in members.Item1)
             {
                 WriteEntry(field.Name, field.FieldType, DelegateFactory.CreateGet(field).Invoke(obj), builder);
             }

--- a/src/NServiceBus.Core/Serializers/XML/Serializer.cs
+++ b/src/NServiceBus.Core/Serializers/XML/Serializer.cs
@@ -375,8 +375,7 @@
             Tuple<FieldInfo[], PropertyInfo[]> members;
             if (!cache.typeMembers.TryGetValue(t, out members))
             {
-                cache.InitType(t);
-                members = cache.typeMembers[t];
+                throw new InvalidOperationException(string.Format("Type {0} was not registered in the serializer. Check that it appears in the list of configured assemblies/types to scan.", t.FullName));
             }
 
             foreach (var prop in members.Item2)

--- a/src/NServiceBus.Core/Serializers/XML/XmlSerializerCache.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlSerializerCache.cs
@@ -1,20 +1,36 @@
-namespace NServiceBus.Serializers.XML
+namespace NServiceBus
 {
     using System;
     using System.Collections;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
     using System.Xml.Linq;
     using System.Xml.Serialization;
-    using NServiceBus.Logging;
+    using Logging;
     using NServiceBus.Utils.Reflection;
 
     class XmlSerializerCache
     {
         public void InitType(Type t)
         {
-            logger.Debug("Initializing type: " + t.AssemblyQualifiedName);
+            logger.Debug($"Initializing type: {t.AssemblyQualifiedName}");
+
+            lock (lockObject)
+            {
+                InitTypeInternal(t);
+            }
+        }
+
+        void InitTypeInternal(Type t)
+        {
+            if (typesBeingInitialized.Contains(t))
+            {
+                return;
+            }
+
+            typesBeingInitialized.Add(t);
 
             if (t.IsSimpleType())
             {
@@ -23,8 +39,6 @@ namespace NServiceBus.Serializers.XML
 
             if (typeof(XContainer).IsAssignableFrom(t))
             {
-                typesBeingInitialized.Add(t);
-
                 return;
             }
 
@@ -37,7 +51,7 @@ namespace NServiceBus.Serializers.XML
 
                 foreach (var g in t.GetGenericArguments())
                 {
-                    InitType(g);
+                    InitTypeInternal(g);
                 }
 
                 //Handle dictionaries - initialize relevant KeyValuePair<T,K> types.
@@ -51,7 +65,7 @@ namespace NServiceBus.Serializers.XML
 
                     if (typeof(IEnumerable<>).MakeGenericType(arr[0]).IsAssignableFrom(t))
                     {
-                        InitType(arr[0]);
+                        InitTypeInternal(arr[0]);
                     }
                 }
 
@@ -90,14 +104,14 @@ namespace NServiceBus.Serializers.XML
             var args = t.GetGenericArguments();
             if (args.Length == 2)
             {
-                isKeyValuePair = (typeof(KeyValuePair<,>).MakeGenericType(args[0], args[1]) == t);
+                isKeyValuePair = typeof(KeyValuePair<,>).MakeGenericType(args[0], args[1]) == t;
             }
 
             if (args.Length == 1 && args[0].IsValueType)
             {
                 if (args[0].GetGenericArguments().Any() || typeof(Nullable<>).MakeGenericType(args[0]) == t)
                 {
-                    InitType(args[0]);
+                    InitTypeInternal(args[0]);
 
                     if (!args[0].GetGenericArguments().Any())
                     {
@@ -106,47 +120,28 @@ namespace NServiceBus.Serializers.XML
                 }
             }
 
-            //already in the process of initializing this type (prevents infinite recursion).
-            if (typesBeingInitialized.Contains(t))
+            if (typeMembers.ContainsKey(t))
             {
                 return;
             }
 
-            typesBeingInitialized.Add(t);
-
             var props = GetAllPropertiesForType(t, isKeyValuePair);
-            typeToProperties[t] = props;
-            var fields = GetAllFieldsForType(t);
-            typeToFields[t] = fields;
-
             foreach (var p in props)
             {
-                logger.Debug("Handling property: " + p.Name);
-
-                DelegateFactory.CreateGet(p);
-                if (!isKeyValuePair)
-                {
-                    DelegateFactory.CreateSet(p);
-                }
-
-                InitType(p.PropertyType);
+                InitTypeInternal(p.PropertyType);
             }
 
+            var fields = GetAllFieldsForType(t);
             foreach (var f in fields)
             {
-                logger.Debug("Handling field: " + f.Name);
-
-                DelegateFactory.CreateGet(f);
-                if (!isKeyValuePair)
-                {
-                    DelegateFactory.CreateSet(f);
-                }
-
-                InitType(f.FieldType);
+                InitTypeInternal(f.FieldType);
             }
+
+            // make the type only available once all properties & fields have been initialzed
+            typeMembers[t] = new Tuple<FieldInfo[], PropertyInfo[]>(fields, props);
         }
 
-        IEnumerable<PropertyInfo> GetAllPropertiesForType(Type t, bool isKeyValuePair)
+        PropertyInfo[] GetAllPropertiesForType(Type t, bool isKeyValuePair)
         {
             var result = new List<PropertyInfo>();
 
@@ -164,7 +159,7 @@ namespace NServiceBus.Serializers.XML
 
                 if (typeof(IList) == prop.PropertyType)
                 {
-                    throw new NotSupportedException("IList is not a supported property type for serialization, use List instead. Type: " + t.FullName + " Property: " + prop.Name);
+                    throw new NotSupportedException($"IList is not a supported property type for serialization, use List instead. Type: {t.FullName} Property: {prop.Name}");
                 }
 
                 var args = prop.PropertyType.GetGenericArguments();
@@ -173,11 +168,11 @@ namespace NServiceBus.Serializers.XML
                 {
                     if (typeof(IList<>).MakeGenericType(args) == prop.PropertyType)
                     {
-                        throw new NotSupportedException("IList<T> is not a supported property type for serialization, use List<T> instead. Type: " + t.FullName + " Property: " + prop.Name);
+                        throw new NotSupportedException($"IList<T> is not a supported property type for serialization, use List<T> instead. Type: {t.FullName} Property: {prop.Name}");
                     }
                     if (typeof(ISet<>).MakeGenericType(args) == prop.PropertyType)
                     {
-                        throw new NotSupportedException("ISet<T> is not a supported property type for serialization, use HashSet<T> instead. Type: " + t.FullName + " Property: " + prop.Name);
+                        throw new NotSupportedException($"ISet<T> is not a supported property type for serialization, use HashSet<T> instead. Type: {t.FullName} Property: {prop.Name}");
                     }
                 }
 
@@ -185,12 +180,12 @@ namespace NServiceBus.Serializers.XML
                 {
                     if (typeof(IDictionary<,>).MakeGenericType(args[0], args[1]) == prop.PropertyType)
                     {
-                        throw new NotSupportedException("IDictionary<T, K> is not a supported property type for serialization, use Dictionary<T,K> instead. Type: " + t.FullName + " Property: " + prop.Name + ". Consider using a concrete Dictionary<T, K> instead, where T and K cannot be of type 'System.Object'");
+                        throw new NotSupportedException($"IDictionary<T, K> is not a supported property type for serialization, use Dictionary<T,K> instead. Type: {t.FullName} Property: {prop.Name}. Consider using a concrete Dictionary<T, K> instead, where T and K cannot be of type 'System.Object'");
                     }
 
                     if (args[0].FullName == "System.Object" || args[1].FullName == "System.Object")
                     {
-                        throw new NotSupportedException("Dictionary<T, K> is not a supported when Key or Value is of Type System.Object. Type: " + t.FullName + " Property: " + prop.Name + ". Consider using a concrete Dictionary<T, K> where T and K are not of type 'System.Object'");
+                        throw new NotSupportedException($"Dictionary<T, K> is not a supported when Key or Value is of Type System.Object. Type: {t.FullName} Property: {prop.Name}. Consider using a concrete Dictionary<T, K> where T and K are not of type 'System.Object'");
                     }
                 }
 
@@ -205,19 +200,22 @@ namespace NServiceBus.Serializers.XML
                 }
             }
 
-            return result.Distinct();
+            return result.Distinct().ToArray();
         }
 
-        IEnumerable<FieldInfo> GetAllFieldsForType(Type t)
+        FieldInfo[] GetAllFieldsForType(Type t)
         {
             return t.GetFields(BindingFlags.FlattenHierarchy | BindingFlags.Instance | BindingFlags.Public);
         }
 
-        public readonly Dictionary<Type, IEnumerable<FieldInfo>> typeToFields = new Dictionary<Type, IEnumerable<FieldInfo>>();
-        public readonly Dictionary<Type, IEnumerable<PropertyInfo>> typeToProperties = new Dictionary<Type, IEnumerable<PropertyInfo>>();
-        readonly List<Type> typesBeingInitialized = new List<Type>();
-        public readonly Dictionary<Type, Type> typesToCreateForArrays = new Dictionary<Type, Type>();
-        public readonly Dictionary<Type, Type> typesToCreateForEnumerables = new Dictionary<Type, Type>();
+        readonly object lockObject = new object();
+
+        ConcurrentBag<Type> typesBeingInitialized = new ConcurrentBag<Type>();
+
+        public ConcurrentDictionary<Type, Type> typesToCreateForArrays = new ConcurrentDictionary<Type, Type>();
+        public ConcurrentDictionary<Type, Type> typesToCreateForEnumerables = new ConcurrentDictionary<Type, Type>();
+
+        public ConcurrentDictionary<Type, Tuple<FieldInfo[], PropertyInfo[]>> typeMembers = new ConcurrentDictionary<Type, Tuple<FieldInfo[], PropertyInfo[]>>();
 
         static ILog logger = LogManager.GetLogger<XmlSerializerCache>();
     }

--- a/src/NServiceBus.Core/Serializers/XML/XmlSerializerCache.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlSerializerCache.cs
@@ -1,4 +1,4 @@
-namespace NServiceBus
+namespace NServiceBus.Serializers.XML
 {
     using System;
     using System.Collections;


### PR DESCRIPTION
This PR backports XmlSerializer #5166 fix to version 5.

I did the backporting manually, please review it carefully.