### PR TITLE
[WIP] Async analyzer testing

### DIFF
--- a/src/NServiceBus.Core.Analyzer.Tests/AwaitOrCaptureTasksAnalyzerTests.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests/AwaitOrCaptureTasksAnalyzerTests.cs
@@ -186,6 +186,16 @@ public class Program
         session.Send(message).ConfigureAwait(false);
     }
 }")]
+        [TestCase(
+            @"using NServiceBus;
+using System.Threading.Tasks;
+public class Program
+{
+    public void SendSync(object message, IMessageSession session)
+    {
+        Task.Run(_ => {});
+    }
+}", Description = "should only warn on NServiceBus APIs")]
         public async Task NoDiagnosticIsReported(string source) => await Verify(source);
 
         protected override DiagnosticAnalyzer GetAnalyzer() => new AwaitOrCaptureTasksAnalyzer();

--- a/src/NServiceBus.Core.Analyzer/AwaitOrCaptureTasksAnalyzer.cs
+++ b/src/NServiceBus.Core.Analyzer/AwaitOrCaptureTasksAnalyzer.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace NServiceBus.Core.Analyzer
 {
+    /// Roslyn analyzer which is raising errors for missing await statments on asynchronous NServiceBus APIs.
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class AwaitOrCaptureTasksAnalyzer : DiagnosticAnalyzer
     {
@@ -49,8 +50,10 @@ namespace NServiceBus.Core.Analyzer
 
             "NServiceBus.RequestResponseExtensions.Request");
 
+        /// <inheritdoc />
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(diagnostic);
 
+        /// <inheritdoc />
         public override void Initialize(AnalysisContext context) => context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
 
         void Analyze(SyntaxNodeAnalysisContext context)

--- a/src/NServiceBus.Core.Analyzer/AwaitOrCaptureTasksAnalyzer.cs
+++ b/src/NServiceBus.Core.Analyzer/AwaitOrCaptureTasksAnalyzer.cs
@@ -45,7 +45,9 @@ namespace NServiceBus.Core.Analyzer
             "NServiceBus.Endpoint.Create",
             "NServiceBus.Endpoint.Start",
             "NServiceBus.IStartableEndpoint.Start",
-            "NServiceBus.IEndpointInstance.Stop");
+            "NServiceBus.IEndpointInstance.Stop",
+
+            "NServiceBus.RequestResponseExtensions.Request`1");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(diagnostic);
 

--- a/src/NServiceBus.Core.Analyzer/AwaitOrCaptureTasksAnalyzer.cs
+++ b/src/NServiceBus.Core.Analyzer/AwaitOrCaptureTasksAnalyzer.cs
@@ -47,7 +47,7 @@ namespace NServiceBus.Core.Analyzer
             "NServiceBus.IStartableEndpoint.Start",
             "NServiceBus.IEndpointInstance.Stop",
 
-            "NServiceBus.RequestResponseExtensions.Request`1");
+            "NServiceBus.RequestResponseExtensions.Request");
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(diagnostic);
 

--- a/src/NServiceBus.Core.Analyzer/NServiceBus.Core.Analyzer.csproj
+++ b/src/NServiceBus.Core.Analyzer/NServiceBus.Core.Analyzer.csproj
@@ -7,6 +7,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.2.2" />
+    <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
   </ItemGroup>
+
+  <PropertyGroup>
+    <PackageId>NServiceBus.Testing.Analyzer</PackageId>
+    <Description>Contains the NServiceBus.Core.Analyzer for testing purposes.</Description>
+  </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
While the analyzer can test for callback APIs (and other APIs coming from dedicated packages) directly, we cannot write unit tests for them directly as the test project needs a working reference to the dll containing the API so it can resolve the semantic model correctly.

As proposed by @bording, we can create a dedicated package containing the analyzer dll as a regular library. The library can be referenced by callbacks/uniform session/other packages to write unit tests in their repository, e.g. https://github.com/Particular/NServiceBus.Callbacks/pull/97