### PR TITLE
Avoid querying semantic model when possible

### DIFF
--- a/src/NServiceBus.Core.Analyzer.Tests/AwaitOrCaptureTasksAnalyzerTests.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests/AwaitOrCaptureTasksAnalyzerTests.cs
@@ -186,6 +186,16 @@ public class Program
         session.Send(message).ConfigureAwait(false);
     }
 }")]
+        [TestCase(
+            @"using NServiceBus;
+using System.Threading.Tasks;
+public class Program
+{
+    public void Handle(object message, IMessageSession session)
+    {
+        Task.Run(() => {});
+    }
+}")]
         public async Task NoDiagnosticIsReported(string source) => await Verify(source);
 
         protected override DiagnosticAnalyzer GetAnalyzer() => new AwaitOrCaptureTasksAnalyzer();

--- a/src/NServiceBus.Core.Analyzer.Tests/AwaitOrCaptureTasksAnalyzerTests.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests/AwaitOrCaptureTasksAnalyzerTests.cs
@@ -52,7 +52,7 @@ namespace NServiceBus.Core.Analyzer.Tests
         // Endpoint
         [TestCase("EndpointConfiguration", "Endpoint.Create(obj);")]
         [TestCase("EndpointConfiguration", "Endpoint.Start(obj);")]
-        
+
         // IStartableEndpoint
         [TestCase("IStartableEndpoint", "obj.Start();")]
 

--- a/src/NServiceBus.Core.Analyzer/AwaitOrCaptureTasksAnalyzer.cs
+++ b/src/NServiceBus.Core.Analyzer/AwaitOrCaptureTasksAnalyzer.cs
@@ -39,10 +39,10 @@ namespace NServiceBus.Core.Analyzer
             "NServiceBus.IMessageSessionExtensions.Publish",
             "NServiceBus.IMessageSessionExtensions.Subscribe",
             "NServiceBus.IMessageSessionExtensions.Unsubscribe",
-            
+
             "NServiceBus.Saga.RequestTimeout",
             "NServiceBus.Saga.ReplyToOriginator",
-            
+
             "NServiceBus.Endpoint.Create",
             "NServiceBus.Endpoint.Start",
             "NServiceBus.IStartableEndpoint.Start",
@@ -69,8 +69,8 @@ namespace NServiceBus.Core.Analyzer
 
             foreach (var syntaxToken in call.Expression?.DescendantTokens() ?? Enumerable.Empty<SyntaxToken>())
             {
-                if (syntaxToken.Kind() == SyntaxKind.IdentifierToken 
-                    && methodNames.Contains(syntaxToken.Text) 
+                if (syntaxToken.Kind() == SyntaxKind.IdentifierToken
+                    && methodNames.Contains(syntaxToken.Text)
                     && IsNServiceBusApi())
                 {
                     context.ReportDiagnostic(Diagnostic.Create(diagnostic, call.GetLocation(), call.ToString()));


### PR DESCRIPTION
switching to the semantic model is clearly the most expensive operation in the analyzer. Therefore we should try to avoid using the semantic model whenever possible. This PR introduces a pre-check to check the invoked methods for a match with one of the method names from our APIs (e.g. `Send` `Publish` `Stop` etc.) before looking at the full semantic version of the invoked method.

This speeds up invocations for code which doesn't use an NServiceBus API (e.g. the added `Task.Run` test):
before:
![image](https://user-images.githubusercontent.com/3524870/40503581-d5a4d190-5f8e-11e8-9e0b-fc8587b03e50.png)
after:
![image](https://user-images.githubusercontent.com/3524870/40503598-e6c56264-5f8e-11e8-9296-8a92dcec033c.png)

for actual analyzer hits, this change as barely any impact:
before:
![image](https://user-images.githubusercontent.com/3524870/40503731-63b352c2-5f8f-11e8-92f9-2610ebf465df.png)
after:
![image](https://user-images.githubusercontent.com/3524870/40503835-ad98ef5a-5f8f-11e8-9c8b-4d93bfe91329.png)
