### PR TITLE
Add UniformSession API to analyzer

### DIFF
--- a/src/NServiceBus.Core.Analyzer.Tests/Helpers/DiagnosticVerifier.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests/Helpers/DiagnosticVerifier.cs
@@ -11,6 +11,7 @@ namespace NServiceBus.Core.Analyzer.Tests.Helpers
     using Microsoft.CodeAnalysis.Diagnostics;
     using Microsoft.CodeAnalysis.Text;
     using NUnit.Framework;
+    using UniformSession;
 
     /// <summary>
     /// Base type for tests for DiagnosticAnalyzers
@@ -22,6 +23,7 @@ namespace NServiceBus.Core.Analyzer.Tests.Helpers
         static readonly MetadataReference CSharpSymbolsReference = MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
         static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
         static readonly MetadataReference NServiceBusReference = MetadataReference.CreateFromFile(typeof(EndpointConfiguration).Assembly.Location);
+        static readonly MetadataReference TestLib = MetadataReference.CreateFromFile(typeof(IUniformSession).Assembly.Location);
 
         /// <summary>
         /// Get the analyzer being tested.
@@ -139,6 +141,7 @@ namespace NServiceBus.Core.Analyzer.Tests.Helpers
                 .AddMetadataReference(projectId, SystemCoreReference)
                 .AddMetadataReference(projectId, CSharpSymbolsReference)
                 .AddMetadataReference(projectId, CodeAnalysisReference)
+                .AddMetadataReference(projectId, TestLib)
                 .AddMetadataReference(projectId, NServiceBusReference);
 
 #if NETCOREAPP2_0

--- a/src/NServiceBus.Core.Analyzer.Tests/UniformSessionStubs/IUniformSession.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests/UniformSessionStubs/IUniformSession.cs
@@ -1,0 +1,42 @@
+﻿
+namespace NServiceBus.UniformSession
+{
+    using System;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// A uniform session which unifies the common operations of message session and handler context.
+    /// </summary>
+    public interface IUniformSession
+    {
+        /// <summary>
+        /// Sends the provided message.
+        /// </summary>
+        /// <param name="message">The message to send.</param>
+        /// <param name="options">The options for the send.</param>
+        Task Send(object message, SendOptions options);
+
+        /// <summary>
+        /// Instantiates a message of type T and sends it.
+        /// </summary>
+        /// <typeparam name="T">The type of message, usually an interface.</typeparam>
+        /// <param name="messageConstructor">An action which initializes properties of the message.</param>
+        /// <param name="options">The options for the send.</param>
+        Task Send<T>(Action<T> messageConstructor, SendOptions options);
+
+        /// <summary>
+        /// Publish the message to subscribers.
+        /// </summary>
+        /// <param name="message">The message to publish.</param>
+        /// <param name="options">The options for the publish.</param>
+        Task Publish(object message, PublishOptions options);
+
+        /// <summary>
+        /// Instantiates a message of type T and publishes it.
+        /// </summary>
+        /// <typeparam name="T">The type of message, usually an interface.</typeparam>
+        /// <param name="messageConstructor">An action which initializes properties of the message.</param>
+        /// <param name="publishOptions">Specific options for this event.</param>
+        Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions);
+    }
+}

--- a/src/NServiceBus.Core.Analyzer.Tests/UniformSessionStubs/IUniformSessionExtensions.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests/UniformSessionStubs/IUniformSessionExtensions.cs
@@ -1,0 +1,110 @@
+﻿namespace NServiceBus.UniformSession
+{
+    using System;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Extension methods for <see cref="IUniformSession" />.
+    /// </summary>
+    public static class IUniformSessionExtensions
+    {
+        /// <summary>
+        /// Sends the provided message.
+        /// </summary>
+        /// <param name="session">The instance of <see cref="IUniformSession" /> to use for the action.</param>
+        /// <param name="message">The message to send.</param>
+        public static Task Send(this IUniformSession session, object message)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Instantiates a message of <typeparamref name="T" /> and sends it.
+        /// </summary>
+        /// <typeparam name="T">The type of message, usually an interface.</typeparam>
+        /// <param name="session">The instance of <see cref="IUniformSession" /> to use for the action.</param>
+        /// <param name="messageConstructor">An action which initializes properties of the message.</param>
+        /// <remarks>
+        /// The message will be sent to the destination configured for <typeparamref name="T" />.
+        /// </remarks>
+        public static Task Send<T>(this IUniformSession session, Action<T> messageConstructor)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Sends the message.
+        /// </summary>
+        /// <param name="session">The instance of <see cref="IUniformSession" /> to use for the action.</param>
+        /// <param name="destination">The address of the destination to which the message will be sent.</param>
+        /// <param name="message">The message to send.</param>
+        public static Task Send(this IUniformSession session, string destination, object message)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Instantiates a message of type T and sends it to the given destination.
+        /// </summary>
+        /// <typeparam name="T">The type of message, usually an interface.</typeparam>
+        /// <param name="session">The instance of <see cref="IUniformSession" /> to use for the action.</param>
+        /// <param name="destination">The destination to which the message will be sent.</param>
+        /// <param name="messageConstructor">An action which initializes properties of the message.</param>
+        public static Task Send<T>(this IUniformSession session, string destination, Action<T> messageConstructor)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Sends the message back to the current endpoint.
+        /// </summary>
+        /// <param name="session">Object being extended.</param>
+        /// <param name="message">The message to send.</param>
+        public static Task SendLocal(this IUniformSession session, object message)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Instantiates a message of type T and sends it back to the current endpoint.
+        /// </summary>
+        /// <typeparam name="T">The type of message, usually an interface.</typeparam>
+        /// <param name="session">Object being extended.</param>
+        /// <param name="messageConstructor">An action which initializes properties of the message.</param>
+        public static Task SendLocal<T>(this IUniformSession session, Action<T> messageConstructor)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Publish the message to subscribers.
+        /// </summary>
+        /// <param name="session">The instance of <see cref="IUniformSession" /> to use for the action.</param>
+        /// <param name="message">The message to publish.</param>
+        public static Task Publish(this IUniformSession session, object message)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Publish the message to subscribers.
+        /// </summary>
+        /// <param name="session">The instance of <see cref="IUniformSession" /> to use for the action.</param>
+        /// <typeparam name="T">The message type.</typeparam>
+        public static Task Publish<T>(this IUniformSession session)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Instantiates a message of type T and publishes it.
+        /// </summary>
+        /// <typeparam name="T">The type of message, usually an interface.</typeparam>
+        /// <param name="session">The instance of <see cref="IUniformSession" /> to use for the action.</param>
+        /// <param name="messageConstructor">An action which initializes properties of the message.</param>
+        public static Task Publish<T>(this IUniformSession session, Action<T> messageConstructor)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NServiceBus.Core.Analyzer/AwaitOrCaptureTasksAnalyzer.cs
+++ b/src/NServiceBus.Core.Analyzer/AwaitOrCaptureTasksAnalyzer.cs
@@ -81,7 +81,12 @@ namespace NServiceBus.Core.Analyzer
             "NServiceBus.Endpoint.Create",
             "NServiceBus.Endpoint.Start",
             "NServiceBus.IStartableEndpoint.Start",
-            "NServiceBus.IEndpointInstance.Stop");
+            "NServiceBus.IEndpointInstance.Stop",
+            "NServiceBus.UniformSession.IUniformSession.Send",
+            "NServiceBus.UniformSession.IUniformSession.Publish",
+            "NServiceBus.UniformSession.IUniformSessionExtensions.Send",
+            "NServiceBus.UniformSession.IUniformSessionExtensions.SendLocal",
+            "NServiceBus.UniformSession.IUniformSessionExtensions.Publish");
 
         static readonly ImmutableHashSet<string> methodNames = methods.Select(m => m.Split('.').Last()).ToImmutableHashSet();
     }

--- a/src/NServiceBus.Core.Analyzer/AwaitOrCaptureTasksAnalyzer.cs
+++ b/src/NServiceBus.Core.Analyzer/AwaitOrCaptureTasksAnalyzer.cs
@@ -82,6 +82,8 @@ namespace NServiceBus.Core.Analyzer
             "NServiceBus.Endpoint.Start",
             "NServiceBus.IStartableEndpoint.Start",
             "NServiceBus.IEndpointInstance.Stop",
+
+            // This workaround is only allowed for the UniformSession package. Other downstream packages have to provide their own analyzer instead.
             "NServiceBus.UniformSession.IUniformSession.Send",
             "NServiceBus.UniformSession.IUniformSession.Publish",
             "NServiceBus.UniformSession.IUniformSessionExtensions.Send",


### PR DESCRIPTION
Adds the `IUniformSession` APIs to the analyzer's list of APIs to check.

This PR also contains unit tests for the uniform session API by copying the uniform session API to the test project to allow the semantic model to resolve the full name of the referenced API. Thanks @danielmarbach for that idea.
This approach has the following disadvantage:
* This copy of the API needs to be kept in sync with the actual uniformsession API
* We also need to reference the test library in the workspace which runs the analyzer

we can also remove the testing part again since it was only used to "implement" the changes.