### PR TITLE
Autosubscribe warnings

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_excluding_event_type_from_autosubscribe.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_excluding_event_type_from_autosubscribe.cs
@@ -1,0 +1,104 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.AutomaticSubscriptions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using Logging;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_excluding_event_type_from_autosubscribe : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_not_subscribe_excluded_events()
+        {
+            var ctx = await Scenario.Define<Context>()
+                .WithEndpoint<Subscriber>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.AreEqual(1, ctx.EventsSubscribedTo.Count);
+            Assert.AreEqual(typeof(EventToSubscribeTo), ctx.EventsSubscribedTo[0]);
+
+            CollectionAssert.IsEmpty(ctx.Logs.Where(l => l.LoggerName == typeof(AutoSubscribe).FullName && l.Level == LogLevel.Warn));
+        }
+
+        class Context : ScenarioContext
+        {
+            public Context()
+            {
+                EventsSubscribedTo = new List<Type>();
+            }
+
+            public List<Type> EventsSubscribedTo { get; }
+        }
+
+        class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.Pipeline.Register("SubscriptionSpy", new SubscriptionSpy((Context)ScenarioContext), "Spies on subscriptions made");
+                    c.AutoSubscribe().DisableFor<EventToExclude>();
+                    c.AutoSubscribe().DisableFor(typeof(EventWithNoPublisher));
+                },
+                    metadata =>
+                    {
+                        metadata.RegisterPublisherFor<EventToSubscribeTo>(typeof(Subscriber));
+                        metadata.RegisterPublisherFor<EventToExclude>(typeof(Subscriber));
+                    });
+            }
+
+            class SubscriptionSpy : IBehavior<ISubscribeContext, ISubscribeContext>
+            {
+                public SubscriptionSpy(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public async Task Invoke(ISubscribeContext context, Func<ISubscribeContext, Task> next)
+                {
+                    await next(context).ConfigureAwait(false);
+
+                    testContext.EventsSubscribedTo.Add(context.EventType);
+                }
+
+                Context testContext;
+            }
+
+            class MyMessageHandler : IHandleMessages<EventToSubscribeTo>
+            {
+                public Task Handle(EventToSubscribeTo message, IMessageHandlerContext context)
+                {
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class EventMessageHandler : IHandleMessages<EventToExclude>
+            {
+                public Task Handle(EventToExclude message, IMessageHandlerContext context)
+                {
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class MyEventWithNoRoutingHandler : IHandleMessages<EventWithNoPublisher>
+            {
+                public Task Handle(EventWithNoPublisher message, IMessageHandlerContext context)
+                {
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class EventToSubscribeTo : IEvent { }
+        public class EventToExclude : IEvent { }
+        public class EventWithNoPublisher : IEvent { }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/CoreTestSuiteConstraints.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/CoreTestSuiteConstraints.cs
@@ -6,10 +6,10 @@
     {
         public bool SupportsDtc => false;
         public bool SupportsCrossQueueTransactions => true;
-        public bool SupportsNativePubSub => true;
+        public bool SupportsNativePubSub => false;
         public bool SupportsNativeDeferral => true;
         public bool SupportsOutbox => false;
-        public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureEndpointLearningTransport();
+        public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureEndpointAcceptanceTestingTransport(SupportsNativePubSub, SupportsNativeDeferral);
         public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointLearningPersistence();
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Core/CoreTestSuiteConstraints.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/CoreTestSuiteConstraints.cs
@@ -6,10 +6,10 @@
     {
         public bool SupportsDtc => false;
         public bool SupportsCrossQueueTransactions => true;
-        public bool SupportsNativePubSub => false;
+        public bool SupportsNativePubSub => true;
         public bool SupportsNativeDeferral => true;
         public bool SupportsOutbox => false;
-        public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureEndpointAcceptanceTestingTransport(SupportsNativePubSub, SupportsNativeDeferral);
+        public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureEndpointLearningTransport();
         public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointLearningPersistence();
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_using_autosubscribe_with_missing_publisher_information.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_using_autosubscribe_with_missing_publisher_information.cs
@@ -23,7 +23,7 @@
             Assert.True(context.EndpointsStarted, "because it should not prevent endpoint startup");
 
             var log = context.Logs.Single(l => l.Message.Contains($"AutoSubscribe was unable to subscribe to event '{typeof(MyEvent).FullName}': No publisher address could be found for message type '{typeof(MyEvent).FullName}'."));
-            Assert.AreEqual(LogLevel.Warn, log.Level);
+            Assert.AreEqual(LogLevel.Error, log.Level);
             Assert.AreEqual(typeof(AutoSubscribe).FullName, log.LoggerName);
         }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_using_autosubscribe_with_missing_publisher_information.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_using_autosubscribe_with_missing_publisher_information.cs
@@ -4,6 +4,8 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
+    using Features;
+    using Logging;
     using NUnit.Framework;
 
     public class When_using_autosubscribe_with_missing_publisher_information : NServiceBusAcceptanceTest
@@ -18,9 +20,11 @@
                 .Done(c => c.EndpointsStarted)
                 .Run();
 
-            Assert.True(context.EndpointsStarted);
-            var logs = context.Logs.Where(l =>l.LoggerName == "AutoSubscribe" && l.Message.Contains("MyEvent"));
-            Assert.AreEqual(1, logs.Count());
+            Assert.True(context.EndpointsStarted, "because it should not prevent endpoint startup");
+
+            var log = context.Logs.Single(l => l.Message.Contains($"AutoSubscribe was unable to subscribe to event '{typeof(MyEvent).FullName}'."));
+            Assert.AreEqual(LogLevel.Warn, log.Level);
+            Assert.AreEqual(typeof(AutoSubscribe).FullName, log.LoggerName);
         }
 
         public class Subscriber : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_using_autosubscribe_with_missing_publisher_information.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_using_autosubscribe_with_missing_publisher_information.cs
@@ -22,7 +22,7 @@
 
             Assert.True(context.EndpointsStarted, "because it should not prevent endpoint startup");
 
-            var log = context.Logs.Single(l => l.Message.Contains($"AutoSubscribe was unable to subscribe to event '{typeof(MyEvent).FullName}':"));
+            var log = context.Logs.Single(l => l.Message.Contains($"AutoSubscribe was unable to subscribe to event '{typeof(MyEvent).FullName}': No publisher address could be found for message type '{typeof(MyEvent).FullName}'."));
             Assert.AreEqual(LogLevel.Warn, log.Level);
             Assert.AreEqual(typeof(AutoSubscribe).FullName, log.LoggerName);
         }

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_using_autosubscribe_with_missing_publisher_information.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_using_autosubscribe_with_missing_publisher_information.cs
@@ -22,7 +22,7 @@
 
             Assert.True(context.EndpointsStarted, "because it should not prevent endpoint startup");
 
-            var log = context.Logs.Single(l => l.Message.Contains($"AutoSubscribe was unable to subscribe to event '{typeof(MyEvent).FullName}'."));
+            var log = context.Logs.Single(l => l.Message.Contains($"AutoSubscribe was unable to subscribe to event '{typeof(MyEvent).FullName}':"));
             Assert.AreEqual(LogLevel.Warn, log.Level);
             Assert.AreEqual(typeof(AutoSubscribe).FullName, log.LoggerName);
         }

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_using_autosubscribe_with_missing_publisher_information.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_using_autosubscribe_with_missing_publisher_information.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Routing.MessageDrivenSubscriptions
 {
+    using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -8,7 +9,7 @@
     public class When_using_autosubscribe_with_missing_publisher_information : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_skip_events_with_missing_routes()
+        public async Task Should_log_events_with_missing_routes()
         {
             Requires.MessageDrivenPubSub();
 
@@ -18,6 +19,8 @@
                 .Run();
 
             Assert.True(context.EndpointsStarted);
+            var logs = context.Logs.Where(l =>l.LoggerName == "AutoSubscribe" && l.Message.Contains("MyEvent"));
+            Assert.AreEqual(1, logs.Count());
         }
 
         public class Subscriber : EndpointConfigurationBuilder

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus__NET452.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus__NET452.approved.txt
@@ -1062,6 +1062,8 @@ namespace NServiceBus.AutomaticSubscriptions.Config
 {
     public class AutoSubscribeSettings
     {
+        public NServiceBus.AutomaticSubscriptions.Config.AutoSubscribeSettings DisableFor<T>() { }
+        public NServiceBus.AutomaticSubscriptions.Config.AutoSubscribeSettings DisableFor(System.Type eventType) { }
         public void DoNotAutoSubscribeSagas() { }
     }
 }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus__NETSTANDARD2_0.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus__NETSTANDARD2_0.approved.txt
@@ -1064,6 +1064,8 @@ namespace NServiceBus.AutomaticSubscriptions.Config
 {
     public class AutoSubscribeSettings
     {
+        public NServiceBus.AutomaticSubscriptions.Config.AutoSubscribeSettings DisableFor<T>() { }
+        public NServiceBus.AutomaticSubscriptions.Config.AutoSubscribeSettings DisableFor(System.Type eventType) { }
         public void DoNotAutoSubscribeSagas() { }
     }
 }

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -87,7 +87,7 @@
                 }
                 catch (Exception e) when (!(e is QueueNotFoundException))
                 {
-                    Logger.Warn($"AutoSubscribe was unable to subscribe to event '{eventType.FullName}'.", e);
+                    Logger.Warn($"AutoSubscribe was unable to subscribe to event '{eventType.FullName}': {e.Message}");
                     // swallow exception
                 }
             }

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -66,8 +66,8 @@
                 {
                     var eventType = messagesHandledByThisEndpoint[i];
 
-                    tasks[i] = excludedTypes.Contains(eventType) 
-                        ? TaskEx.CompletedTask 
+                    tasks[i] = excludedTypes.Contains(eventType)
+                        ? TaskEx.CompletedTask
                         : SubscribeToEvent(session, eventType);
                 }
                 return Task.WhenAll(tasks);
@@ -85,7 +85,7 @@
                     await session.Subscribe(eventType).ConfigureAwait(false);
                     Logger.DebugFormat("Auto subscribed to event {0}", eventType);
                 }
-                catch (Exception e ) when (!(e is QueueNotFoundException))
+                catch (Exception e) when (!(e is QueueNotFoundException))
                 {
                     Logger.Warn($"AutoSubscribe was unable to subscribe to event '{eventType.FullName}'.", e);
                     // swallow exception

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -6,6 +6,7 @@
     using System.Threading.Tasks;
     using Logging;
     using Unicast;
+    using Unicast.Queuing;
 
     /// <summary>
     /// Used to configure auto subscriptions.
@@ -79,7 +80,7 @@
                     await session.Subscribe(eventType).ConfigureAwait(false);
                     Logger.DebugFormat("Auto subscribed to event {0}", eventType);
                 }
-                catch (Exception e)
+                catch (Exception e ) when (!(e is QueueNotFoundException))
                 {
                     Logger.Warn($"AutoSubscribe was unable to subscribe to event '{eventType.FullName}'.", e);
                     // swallow exception

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -87,7 +87,7 @@
                 }
                 catch (Exception e) when (!(e is QueueNotFoundException))
                 {
-                    Logger.Warn($"AutoSubscribe was unable to subscribe to event '{eventType.FullName}': {e.Message}");
+                    Logger.Error($"AutoSubscribe was unable to subscribe to event '{eventType.FullName}': {e.Message}");
                     // swallow exception
                 }
             }

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribeSettings.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribeSettings.cs
@@ -22,20 +22,21 @@ namespace NServiceBus.AutomaticSubscriptions.Config
         }
 
         /// <summary>
-        /// todo
+        /// Configure AutoSubscribe to not subscribe automatically to the given event type.
         /// </summary>
         public AutoSubscribeSettings DisableFor<T>()
         {
-            //TODO implement
-            return this;
+            return DisableFor(typeof(T));
         }
 
         /// <summary>
-        /// todo
+        /// Configure AutoSubscribe to not subscribe automatically to the given event type.
         /// </summary>
         public AutoSubscribeSettings DisableFor(Type eventType)
         {
-            //TODO implement
+            Guard.AgainstNull(nameof(eventType), eventType);
+
+            GetSettings().ExcludedTypes.Add(eventType);
             return this;
         }
 

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribeSettings.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribeSettings.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.AutomaticSubscriptions.Config
 {
+    using System;
     using Features;
 
     /// <summary>
@@ -18,6 +19,24 @@ namespace NServiceBus.AutomaticSubscriptions.Config
         public void DoNotAutoSubscribeSagas()
         {
             GetSettings().AutoSubscribeSagas = false;
+        }
+
+        /// <summary>
+        /// todo
+        /// </summary>
+        public AutoSubscribeSettings DisableFor<T>()
+        {
+            //TODO implement
+            return this;
+        }
+
+        /// <summary>
+        /// todo
+        /// </summary>
+        public AutoSubscribeSettings DisableFor(Type eventType)
+        {
+            //TODO implement
+            return this;
         }
 
         AutoSubscribe.SubscribeSettings GetSettings()

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -28,7 +28,7 @@
             var publisherAddresses = subscriptionRouter.GetAddressesForEventType(eventType);
             if (publisherAddresses.Count == 0)
             {
-                throw new Exception($"No publisher address could be found for message type {eventType}. Ensure that a publisher has been configured for the event type and that the configured publisher endpoint has at least one known instance.");
+                throw new Exception($"No publisher address could be found for message type '{eventType}'. Ensure that a publisher has been configured for the event type and that the configured publisher endpoint has at least one known instance.");
             }
 
             var subscribeTasks = new List<Task>(publisherAddresses.Count);

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -28,7 +28,7 @@
             var publisherAddresses = subscriptionRouter.GetAddressesForEventType(eventType);
             if (publisherAddresses.Count == 0)
             {
-                throw new Exception($"No publisher address could be found for message type {eventType}. Ensure the configured publisher endpoint has at least one known instance.");
+                throw new Exception($"No publisher address could be found for message type {eventType}. Ensure that a publisher has been configured for the event type and that the configured publisher endpoint has at least one known instance.");
             }
 
             var subscribeTasks = new List<Task>(publisherAddresses.Count);


### PR DESCRIPTION
log warnings when autosubscribe isn't able to subscribe to an event handled by the endpoint.