### PR TITLE
Fix autosubscribe acceptance test by checking for the correct log level

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_excluding_event_type_from_autosubscribe.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_excluding_event_type_from_autosubscribe.cs
@@ -25,7 +25,7 @@
             Assert.AreEqual(1, ctx.EventsSubscribedTo.Count);
             Assert.AreEqual(typeof(EventToSubscribeTo), ctx.EventsSubscribedTo[0]);
 
-            CollectionAssert.IsEmpty(ctx.Logs.Where(l => l.LoggerName == typeof(AutoSubscribe).FullName && l.Level == LogLevel.Warn));
+            CollectionAssert.IsEmpty(ctx.Logs.Where(l => l.LoggerName == typeof(AutoSubscribe).FullName && l.Level == LogLevel.Error));
         }
 
         class Context : ScenarioContext


### PR DESCRIPTION
the test wasn't adjusted to the changes of logging errors instead of warnings.