### PR TITLE
Use version-agnostic define constants

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/AsyncLocal.cs
+++ b/src/NServiceBus.AcceptanceTesting/AsyncLocal.cs
@@ -1,4 +1,4 @@
-﻿#if NET452
+﻿#if NETFRAMEWORK
 namespace System.Threading
 {
     using Runtime.Remoting.Messaging;

--- a/src/NServiceBus.AcceptanceTests/NServiceBusAcceptanceTest.cs
+++ b/src/NServiceBus.AcceptanceTests/NServiceBusAcceptanceTest.cs
@@ -15,7 +15,7 @@ namespace NServiceBus.AcceptanceTests
         [SetUp]
         public void SetUp()
         {
-#if !NETCOREAPP2_0
+#if NETFRAMEWORK
             // Hack: prevents SerializationException ... Type 'x' in assembly 'y' is not marked as serializable.
             // https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/mitigation-deserialization-of-objects-across-app-domains
             System.Configuration.ConfigurationManager.GetSection("X");

--- a/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_dtc_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_dtc_enabled.cs
@@ -21,7 +21,7 @@
             Assert.False(context.CanEnlistPromotable, "There should exists a DTC tx");
         }
 
-#if !NETCOREAPP2_0
+#if NETFRAMEWORK
         [Test]
         public void Basic_assumptions_promotable_should_fail_if_durable_already_exists()
         {

--- a/src/NServiceBus.Core.Analyzer.Tests/Helpers/DiagnosticVerifier.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests/Helpers/DiagnosticVerifier.cs
@@ -117,7 +117,7 @@ namespace NServiceBus.Core.Analyzer.Tests.Helpers
                 .AddMetadataReference(projectId, TestLib)
                 .AddMetadataReference(projectId, NServiceBusReference);
 
-#if NETCOREAPP2_0
+#if NETCOREAPP
             var netstandard = MetadataReference.CreateFromFile(System.Reflection.Assembly.Load("netstandard").Location);
             var systemTasks = MetadataReference.CreateFromFile(System.Reflection.Assembly.Load("System.Threading.Tasks").Location);
             var systemRuntime = MetadataReference.CreateFromFile(System.Reflection.Assembly.Load("System.Runtime").Location);

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.cs
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.cs
@@ -7,7 +7,7 @@
     [TestFixture]
     public class APIApprovals
     {
-#if NET452
+#if NETFRAMEWORK
         [Test]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void ApproveNServiceBus__NET452()
@@ -17,7 +17,7 @@
         }
 #endif
 
-#if NETCOREAPP2_0
+#if NETCOREAPP
         [Test]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void ApproveNServiceBus__NETSTANDARD2_0()

--- a/src/NServiceBus.Core.Tests/ApprovalTestConfig.cs
+++ b/src/NServiceBus.Core.Tests/ApprovalTestConfig.cs
@@ -1,5 +1,5 @@
 ﻿using ApprovalTests.Reporters;
-#if NET452
+#if NETFRAMEWORK
 [assembly: UseReporter(typeof(DiffReporter), typeof(AllFailingTestsClipboardReporter))]
 #else
 [assembly: UseReporter(typeof(NUnitReporter))]

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
@@ -1,5 +1,5 @@
 ﻿
-#if NET452
+#if NETFRAMEWORK
 namespace NServiceBus.Core.Tests.AssemblyScanner
 {
     using System;

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_InMemory_and_an_escalated_DTC_transaction.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/When_persisting_a_saga_with_InMemory_and_an_escalated_DTC_transaction.cs
@@ -1,4 +1,4 @@
-﻿#if NET452
+﻿#if NETFRAMEWORK
 namespace NServiceBus.SagaPersisters.InMemory.Tests
 {
     using System;

--- a/src/NServiceBus.Core.Tests/Serializers/XML/SerializingNullableTypesTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/SerializingNullableTypesTests.cs
@@ -70,18 +70,12 @@ namespace NServiceBus.Serializers.XML.Test
                 var reader = new StreamReader(stream);
                 var xml = reader.ReadToEnd();
 
-#if NETFRAMEWORK
-                var birthDate = "1950-04-25T00:00:00";
-#else
-                var birthDate = "1950-04-25T00:00:00.0000000";
-#endif
-
-                var expected = XDocument.Parse($@"<?xml version=""1.0""?>
+                var expected = XDocument.Parse(@"<?xml version=""1.0""?>
 <MessageWithNullable xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns=""http://tempuri.net/NServiceBus.Serializers.XML.Test"">
    <FirstName>FirstName</FirstName>
    <LastName>LastName</LastName>
    <EmailAddress>EmailAddress</EmailAddress>
-   <BirthDate>{birthDate}</BirthDate>
+   <BirthDate>1950-04-25T00:00:00</BirthDate>
 </MessageWithNullable>
 ");
                 var actual = XDocument.Parse(xml);

--- a/src/NServiceBus.Core.Tests/Serializers/XML/SerializingNullableTypesTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/SerializingNullableTypesTests.cs
@@ -6,7 +6,6 @@ namespace NServiceBus.Serializers.XML.Test
     using System.Xml.Linq;
     using NUnit.Framework;
 
-    
     public class MessageWithNullable : IMessage
     {
         public string FirstName { get; set; }
@@ -71,7 +70,7 @@ namespace NServiceBus.Serializers.XML.Test
                 var reader = new StreamReader(stream);
                 var xml = reader.ReadToEnd();
 
-#if NET452
+#if NETFRAMEWORK
                 var birthDate = "1950-04-25T00:00:00";
 #else
                 var birthDate = "1950-04-25T00:00:00.0000000";

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
@@ -1,10 +1,10 @@
 ﻿namespace NServiceBus
 {
     using System;
-#if NET452
+#if NETFRAMEWORK
     using System.Reflection;
 #endif
-#if NETSTANDARD2_0
+#if NETSTANDARD
     using System.IO;
     using System.Reflection.Metadata;
     using System.Reflection.PortableExecutable;
@@ -13,7 +13,7 @@
 
     class AssemblyValidator
     {
-#if NET452
+#if NETFRAMEWORK
         public void ValidateAssemblyFile(string assemblyPath, out bool shouldLoad, out string reason)
         {
             try
@@ -39,7 +39,7 @@
         }
 #endif
 
-#if NETSTANDARD2_0
+#if NETSTANDARD
         public void ValidateAssemblyFile(string assemblyPath, out bool shouldLoad, out string reason)
         {
             using (var stream = File.OpenRead(assemblyPath))

--- a/src/NServiceBus.Core/Licensing/Browser.cs
+++ b/src/NServiceBus.Core/Licensing/Browser.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETSTANDARD
 namespace NServiceBus
 {
     using System.Diagnostics;

--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -2,7 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Diagnostics;
-#if NETSTANDARD2_0
+#if NETSTANDARD
     using System.Runtime.InteropServices;
 #endif
     using System.Text;
@@ -120,7 +120,7 @@ namespace NServiceBus
             }
         }
 
-#if NETSTANDARD2_0
+#if NETSTANDARD
         string GetPlatformCode()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/NServiceBus.Core/Unicast/Transport/Config/TransportExtensions.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/Config/TransportExtensions.cs
@@ -28,7 +28,7 @@ namespace NServiceBus
             return this;
         }
 
-#if NET452
+#if NETFRAMEWORK
         /// <summary>
         /// Configures the transport to use the connection string with the given name.
         /// </summary>
@@ -44,7 +44,7 @@ namespace NServiceBus
         }
 #endif
 
-#if NETSTANDARD2_0
+#if NETSTANDARD
         /// <summary>
         /// Configures the transport to use the connection string with the given name.
         /// </summary>
@@ -101,7 +101,7 @@ namespace NServiceBus
             return this;
         }
 
-#if NET452
+#if NETFRAMEWORK
         /// <summary>
         /// Configures the transport to use the connection string with the given name.
         /// </summary>
@@ -118,7 +118,7 @@ namespace NServiceBus
         }
 #endif
 
-#if NETSTANDARD2_0
+#if NETSTANDARD
         /// <summary>
         /// Configures the transport to use the connection string with the given name.
         /// </summary>

--- a/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/TransportConnectionString.cs
@@ -3,7 +3,7 @@
     using System;
     using Transport;
 
-#if NET452
+#if NETFRAMEWORK
     sealed class TransportConnectionString
     {
         TransportConnectionString()
@@ -69,7 +69,7 @@ or
     }
 #endif
 
-#if NETSTANDARD2_0
+#if NETSTANDARD
     sealed class TransportConnectionString
     {
         TransportConnectionString()

--- a/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWork.cs
+++ b/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWork.cs
@@ -53,7 +53,7 @@
             {
                 //default is always 10 minutes
                 var maxTimeout = TimeSpan.FromMinutes(10);
-#if NET452
+#if NETFRAMEWORK
                 var systemTransactionsGroup = System.Configuration.ConfigurationManager.OpenMachineConfiguration()
                     .GetSectionGroup("system.transactions");
 


### PR DESCRIPTION
These version-agnostic automatic define constants have been added to the SDK recently, I believe as part of the .NET Core 2.1 SDK.

This ensures that these continue to work as expected even when the actual TFMs change.