### PR TITLE
Enable data contract support

### DIFF
--- a/src/NServiceBus.Core/Serializers/SimpleJson/SimpleJson.g.cs
+++ b/src/NServiceBus.Core/Serializers/SimpleJson/SimpleJson.g.cs
@@ -29,7 +29,7 @@
 #define SIMPLE_JSON_DYNAMIC
 
 // NOTE: uncomment the following line to enable DataContract support.
-//#define SIMPLE_JSON_DATACONTRACT
+#define SIMPLE_JSON_DATACONTRACT
 
 // NOTE: uncomment the following line to enable IReadOnlyCollection<T> and IReadOnlyList<T> support.
 #define SIMPLE_JSON_READONLY_COLLECTIONS


### PR DESCRIPTION
We are using SimpleJson to serialize objects that are passed to the diagnostic sections. The problem is that when you want to pass in an object but one member should not be serialized you have to now wrap every property into an anonymous object. By enabling DataContract support one can simple add

```
public class Section
{
   public string Serialized { get;set;}
   [IgnoreDataMember]
   public string NotSerialized { get;set;}
}
```

and then serialize this object instead of doing

`AddDiagnostics...("Section", new { section.Serialized }); // doesn't look problematic but imagine you have an existing things with dozens of properties`