### PR TITLE
Async done condition for ATT framework

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -82,6 +82,11 @@ namespace NServiceBus.AcceptanceTesting
 
         public IScenarioWithEndpointBehavior<TContext> Done(Func<TContext, bool> func)
         {
+            return Done(ctx => Task.FromResult(func(ctx)));
+        }
+        
+        public IScenarioWithEndpointBehavior<TContext> Done(Func<TContext, Task<bool>> func)
+        {
             done = c => func((TContext)c);
 
             return this;
@@ -148,6 +153,6 @@ namespace NServiceBus.AcceptanceTesting
 
         List<IComponentBehavior> behaviors = new List<IComponentBehavior>();
         Action<TContext> contextInitializer;
-        Func<ScenarioContext, bool> done = context => true;
+        Func<ScenarioContext, Task<bool>> done = context => TaskEx.TrueTask;
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -12,13 +12,7 @@
     using NUnit.Framework;
 
     public class ScenarioRunner
-    {
-        // remove in v8
-        public static Task<RunSummary> Run(RunDescriptor runDescriptor, List<IComponentBehavior> behaviorDescriptors, Func<ScenarioContext, bool> done)
-        {
-            return Run(runDescriptor, behaviorDescriptors, ctx => Task.FromResult(done(ctx)));
-        }
-        
+    {       
         public static async Task<RunSummary> Run(RunDescriptor runDescriptor, List<IComponentBehavior> behaviorDescriptors, Func<ScenarioContext, Task<bool>> done)
         {
             TestContext.WriteLine("current context: " + runDescriptor.ScenarioContext.GetType().FullName);

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -13,7 +13,13 @@
 
     public class ScenarioRunner
     {
-        public static async Task<RunSummary> Run(RunDescriptor runDescriptor, List<IComponentBehavior> behaviorDescriptors, Func<ScenarioContext, bool> done)
+        // remove in v8
+        public static Task<RunSummary> Run(RunDescriptor runDescriptor, List<IComponentBehavior> behaviorDescriptors, Func<ScenarioContext, bool> done)
+        {
+            return Run(runDescriptor, behaviorDescriptors, ctx => Task.FromResult(done(ctx)));
+        }
+        
+        public static async Task<RunSummary> Run(RunDescriptor runDescriptor, List<IComponentBehavior> behaviorDescriptors, Func<ScenarioContext, Task<bool>> done)
         {
             TestContext.WriteLine("current context: " + runDescriptor.ScenarioContext.GetType().FullName);
             TestContext.WriteLine("Started test @ {0}", DateTime.Now.ToString(CultureInfo.InvariantCulture));
@@ -30,7 +36,7 @@
             };
         }
 
-        static async Task<RunResult> PerformTestRun(List<IComponentBehavior> behaviorDescriptors, RunDescriptor runDescriptor, Func<ScenarioContext, bool> done)
+        static async Task<RunResult> PerformTestRun(List<IComponentBehavior> behaviorDescriptors, RunDescriptor runDescriptor, Func<ScenarioContext, Task<bool>> done)
         {
             var runResult = new RunResult
             {
@@ -62,7 +68,7 @@
         }
 
 
-        static async Task PerformScenarios(RunDescriptor runDescriptor, ComponentRunner[] runners, Func<bool> done)
+        static async Task PerformScenarios(RunDescriptor runDescriptor, ComponentRunner[] runners, Func<Task<bool>> done)
         {
             using (var cts = new CancellationTokenSource())
             {
@@ -75,7 +81,7 @@
 
                     var startTime = DateTime.UtcNow;
                     var maxTime = runDescriptor.Settings.TestExecutionTimeout ?? TimeSpan.FromSeconds(90);
-                    while (!done() && !cts.Token.IsCancellationRequested)
+                    while (!await done().ConfigureAwait(false) && !cts.Token.IsCancellationRequested)
                     {
                         if (!Debugger.IsAttached)
                         {

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -12,7 +12,7 @@
     using NUnit.Framework;
 
     public class ScenarioRunner
-    {       
+    {
         public static async Task<RunSummary> Run(RunDescriptor runDescriptor, List<IComponentBehavior> behaviorDescriptors, Func<ScenarioContext, Task<bool>> done)
         {
             TestContext.WriteLine("current context: " + runDescriptor.ScenarioContext.GetType().FullName);


### PR DESCRIPTION
ServiceControl requires an async done condition because it needs to fetch the context from the http APIs. This allows us to remove the custom component hack that we had to write to enable this.