### PR TITLE
Use concurrent collections to avoid race conditions in acceptance test

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_subscribing_to_scaled_out_publisher.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_subscribing_to_scaled_out_publisher.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Routing.MessageDrivenSubscriptions
 {
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using AcceptanceTesting;
@@ -31,7 +32,7 @@
 
         class Context : ScenarioContext
         {
-            public List<string> PublisherReceivedSubscription { get; } = new List<string>();
+            public ConcurrentBag<string> PublisherReceivedSubscription { get; } = new ConcurrentBag<string>();
         }
 
         class ScaledOutPublisher : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_unsubscribing_to_scaled_out_publisher.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_unsubscribing_to_scaled_out_publisher.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Routing.MessageDrivenSubscriptions
 {
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using AcceptanceTesting;
@@ -31,7 +32,7 @@
 
         class Context : ScenarioContext
         {
-            public List<string> PublisherReceivedUnsubscribeMessage { get; } = new List<string>();
+            public ConcurrentBag<string> PublisherReceivedUnsubscribeMessage { get; } = new ConcurrentBag<string>();
         }
 
         class ScaledOutPublisher : EndpointConfigurationBuilder


### PR DESCRIPTION
fixes https://github.com/Particular/NServiceBus/issues/5178 by using concurrent collections instead of a regular list (which can be modified by the different scaled-out instances in parallel and therefore fail the test)