### PR TITLE
[WIP] Add TimeoutManager migration mode

### DIFF
--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
@@ -19,7 +19,7 @@
 
             Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"), "Send only endpoints can't use the timeoutmanager since it requires receive capabilities");
             Prerequisite(context => !HasAlternateTimeoutManagerBeenConfigured(context.Settings), "A user configured timeoutmanager address has been found and this endpoint will send timeouts to that endpoint");
-            Prerequisite(c => !c.Settings.DoesTransportSupportConstraint<DelayedDeliveryConstraint>(), "The selected transport supports delayed delivery natively");
+            Prerequisite(c => !c.Settings.DoesTransportSupportConstraint<DelayedDeliveryConstraint>() || IsMigrationModeEnabled(c.Settings), "The selected transport supports delayed delivery natively");
         }
 
         /// <summary>
@@ -102,6 +102,11 @@
         static bool HasAlternateTimeoutManagerBeenConfigured(ReadOnlySettings settings)
         {
             return settings.Get<TimeoutManagerAddressConfiguration>().TransportAddress != null;
+        }
+
+        static bool IsMigrationModeEnabled(ReadOnlySettings settings)
+        {
+            return settings.TryGet("NServiceBus.TimeoutManager.EnableMigrationMode", out bool enabled) && enabled;
         }
 
         static RecoverabilityAction RecoverabilityPolicy(RecoverabilityConfig config, ErrorContext errorContext)


### PR DESCRIPTION
adds an ability to keep the timeout manager enabled even when the transport supports delayed delivery natively. This will cause the timeout queues to continue to work, while the delayed delivery feature itself still uses the native delaying mechanism.

this approach has the downside, that completed sagas will not cancel the timeouts anymore (which is only done for timeout manager delays, not for native ones), potentially causing timeouts to arrive during migration. Since native delay mechanism don't support timeout cancellation, that shouldn't really be an issue anyway though?

Todo:
* [ ] Test with transports supporting migration to native delayed delivery
* [ ] public API
