### PR TITLE
Deprecate redundant overloads for Set and SetDefault

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -2403,9 +2403,13 @@ namespace NServiceBus.Settings
         public bool HasSetting(string key) { }
         public bool HasSetting<T>() { }
         public void Set(string key, object value) { }
+        [System.ObsoleteAttribute("Use `Set<T>(T value)` instead. Will be treated as an error from version 8.0.0. Wi" +
+            "ll be removed in version 9.0.0.", false)]
         public void Set<T>(object value) { }
         public void Set<T>(T value) { }
         public void Set<T>(System.Action value) { }
+        [System.ObsoleteAttribute("Use `SetDefault<T>(T value)` instead. Will be treated as an error from version 8." +
+            "0.0. Will be removed in version 9.0.0.", false)]
         public void SetDefault<T>(object value) { }
         public void SetDefault<T>(T value) { }
         public void SetDefault<T>(System.Action value) { }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -2405,9 +2405,13 @@ namespace NServiceBus.Settings
         public bool HasSetting(string key) { }
         public bool HasSetting<T>() { }
         public void Set(string key, object value) { }
+        [System.ObsoleteAttribute("Use `Set<T>(T value)` instead. Will be treated as an error from version 8.0.0. Wi" +
+            "ll be removed in version 9.0.0.", false)]
         public void Set<T>(object value) { }
         public void Set<T>(T value) { }
         public void Set<T>(System.Action value) { }
+        [System.ObsoleteAttribute("Use `SetDefault<T>(T value)` instead. Will be treated as an error from version 8." +
+            "0.0. Will be removed in version 9.0.0.", false)]
         public void SetDefault<T>(object value) { }
         public void SetDefault<T>(T value) { }
         public void SetDefault<T>(System.Action value) { }

--- a/src/NServiceBus.Core/Settings/SettingsHolder.cs
+++ b/src/NServiceBus.Core/Settings/SettingsHolder.cs
@@ -201,6 +201,10 @@ namespace NServiceBus.Settings
         /// </summary>
         /// <typeparam name="T">The type to use as a key for storing the setting.</typeparam>
         /// <param name="value">The setting value.</param>
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "Set<T>(T value)",
+            TreatAsErrorFromVersion = "8.0",
+            RemoveInVersion = "9.0")]
         public void Set<T>(object value)
         {
             Set(typeof(T).FullName, value);
@@ -231,6 +235,11 @@ namespace NServiceBus.Settings
         /// </summary>
         /// <typeparam name="T">The type to use as a key for storing the setting.</typeparam>
         /// <param name="value">The setting value.</param>
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "SetDefault<T>(T value)",
+            TreatAsErrorFromVersion = "8.0",
+            RemoveInVersion = "9.0")]
+
         public void SetDefault<T>(object value)
         {
             SetDefault(typeof(T).FullName, value);


### PR DESCRIPTION
Connects to #5228 

Deprecates `Set<T>(object)` and `SetDefault<T>(object)` in favour of generic versions added in #5228.