### PR TITLE
Remove SettingsHolder.Set with Action overload

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -2411,7 +2411,6 @@ namespace NServiceBus.Settings
             "ll be removed in version 9.0.0.", false)]
         public void Set<T>(object value) { }
         public void Set<T>(T value) { }
-        public void Set<T>(System.Action value) { }
         [System.ObsoleteAttribute("Use `SetDefault<T>(T value)` instead. Will be treated as an error from version 8." +
             "0.0. Will be removed in version 9.0.0.", false)]
         public void SetDefault<T>(object value) { }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -2413,7 +2413,6 @@ namespace NServiceBus.Settings
             "ll be removed in version 9.0.0.", false)]
         public void Set<T>(object value) { }
         public void Set<T>(T value) { }
-        public void Set<T>(System.Action value) { }
         [System.ObsoleteAttribute("Use `SetDefault<T>(T value)` instead. Will be treated as an error from version 8." +
             "0.0. Will be removed in version 9.0.0.", false)]
         public void SetDefault<T>(object value) { }

--- a/src/NServiceBus.Core/Settings/SettingsHolder.cs
+++ b/src/NServiceBus.Core/Settings/SettingsHolder.cs
@@ -221,16 +221,6 @@ namespace NServiceBus.Settings
         }
 
         /// <summary>
-        /// Sets the given value, key is type fullname.
-        /// </summary>
-        /// <typeparam name="T">The type.</typeparam>
-        /// <param name="value">Action to store.</param>
-        public void Set<T>(Action value)
-        {
-            Set(typeof(T).FullName, value);
-        }
-
-        /// <summary>
         /// Sets the default setting value.
         /// </summary>
         /// <typeparam name="T">The type to use as a key for storing the setting.</typeparam>


### PR DESCRIPTION
```
public void Set<T>(System.Action value) { }
```

creates an ambiguous reference because it clashes with

```
public void Set<T>(T value) { }
```

```
Severity    Code    Description    Project    File    Line    Suppression State
Error    CS0411    The type arguments for method 'SettingsHolder.Set<T>(object)' cannot be inferred from the usage. Try specifying the type arguments explicitly.    NServiceBus.AzureServiceBus.Tests    C:\p\NServiceBus.AzureServiceBus\src\Tests\Receiving\When_receiving_brokeredmessages_from_queues.cs    22    Active
```

Probably introduced as part of https://github.com/Particular/NServiceBus/pull/5228 so it should only affect 7.1.

The Action overload should be covered and can be inferred by the compiler by using 


```
void Set<T>(System.Action value)
```