### PR TITLE
When using the explicit registration API only the last registered mutator is invoked

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Mutators/When_defining_outgoing_message_mutators.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Mutators/When_defining_outgoing_message_mutators.cs
@@ -33,16 +33,15 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer,Context>((config, context) =>
-                {
-                    config.RegisterMessageMutator(new TransportMutator(context));
-                    config.RegisterMessageMutator(new OtherTransportMutator(context));
-                    config.RegisterMessageMutator(new MessageMutator(context));
-                });
+                EndpointSetup<DefaultServer, Context>((config, context) =>
+                 {
+                     config.RegisterMessageMutator(new TransportMutator(context));
+                     config.RegisterMessageMutator(new OtherTransportMutator(context));
+                     config.RegisterMessageMutator(new MessageMutator(context));
+                 });
             }
 
-            class TransportMutator :
-                IMutateOutgoingTransportMessages
+            class TransportMutator : IMutateOutgoingTransportMessages
             {
                 public TransportMutator(Context testContext)
                 {
@@ -58,8 +57,7 @@
                 Context testContext;
             }
 
-            class OtherTransportMutator :
-              IMutateOutgoingTransportMessages
+            class OtherTransportMutator : IMutateOutgoingTransportMessages
             {
                 public OtherTransportMutator(Context testContext)
                 {
@@ -74,7 +72,6 @@
 
                 Context testContext;
             }
-
 
             class MessageMutator : IMutateOutgoingMessages
             {
@@ -109,7 +106,6 @@
                 Context testContext;
             }
         }
-
 
         public class Message : ICommand
         {

--- a/src/NServiceBus.AcceptanceTests/Core/Mutators/When_defining_outgoing_message_mutators.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Mutators/When_defining_outgoing_message_mutators.cs
@@ -17,6 +17,7 @@
                 .Run();
 
             Assert.True(context.TransportMutatorCalled);
+            Assert.True(context.OtherTransportMutatorCalled);
             Assert.True(context.MessageMutatorCalled);
         }
 
@@ -24,6 +25,7 @@
         {
             public bool MessageProcessed { get; set; }
             public bool TransportMutatorCalled { get; set; }
+            public bool OtherTransportMutatorCalled { get; set; }
             public bool MessageMutatorCalled { get; set; }
         }
 
@@ -34,6 +36,7 @@
                 EndpointSetup<DefaultServer,Context>((config, context) =>
                 {
                     config.RegisterMessageMutator(new TransportMutator(context));
+                    config.RegisterMessageMutator(new OtherTransportMutator(context));
                     config.RegisterMessageMutator(new MessageMutator(context));
                 });
             }
@@ -54,6 +57,24 @@
 
                 Context testContext;
             }
+
+            class OtherTransportMutator :
+              IMutateOutgoingTransportMessages
+            {
+                public OtherTransportMutator(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task MutateOutgoing(MutateOutgoingTransportMessageContext context)
+                {
+                    testContext.OtherTransportMutatorCalled = true;
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+
 
             class MessageMutator : IMutateOutgoingMessages
             {

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_autosubscribe_with_missing_publisher_information.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_autosubscribe_with_missing_publisher_information.cs
@@ -5,7 +5,7 @@
     using EndpointTemplates;
     using NUnit.Framework;
 
-    public class When_using_autosubscribe_with_missing_publisher_information : NServiceBusAcceptanceTest
+    public class When_autosubscribe_with_missing_publisher_information : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_skip_events_with_missing_routes()

--- a/src/NServiceBus.Core.Tests/MessageMutators/MutatorRegistrationExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageMutators/MutatorRegistrationExtensionsTests.cs
@@ -31,6 +31,41 @@
             Assert.DoesNotThrow(() => endpointConfiguration.RegisterMessageMutator(messageMutator));
         }
 
+        [TestCase(typeof(IncomingMessageMutator))]
+        [TestCase(typeof(IncomingTransportMessageMutator))]
+        [TestCase(typeof(OutgoingMessageMutator))]
+        [TestCase(typeof(OutgoingTransportMessageMutator))]
+        public void Should_only_invoke_instances_once_even_if_registered_multiple_times(Type mutatorType)
+        {
+            var endpointConfiguration = new EndpointConfiguration("test");
+            var messageMutator = Activator.CreateInstance(mutatorType);
+
+            endpointConfiguration.RegisterMessageMutator(messageMutator);
+            endpointConfiguration.RegisterMessageMutator(messageMutator);
+
+            var registry = endpointConfiguration.Settings.Get<NServiceBus.Features.Mutators.RegisteredMutators>();
+            
+            if (mutatorType == typeof(IncomingMessageMutator))
+            {
+                Assert.AreEqual(1, registry.IncomingMessage.Count);
+            }
+
+            if (mutatorType == typeof(IncomingTransportMessageMutator))
+            {
+                Assert.AreEqual(1, registry.IncomingTransportMessage.Count);
+            }
+
+            if (mutatorType == typeof(OutgoingMessageMutator))
+            {
+                Assert.AreEqual(1, registry.OutgoingMessage.Count);
+            }
+
+            if (mutatorType == typeof(OutgoingTransportMessageMutator))
+            {
+                Assert.AreEqual(1, registry.OutgoingTransportMessage.Count);
+            }
+        }
+
         [Test]
         public void Should_not_throw_when_registering_mutator_implementing_multiple_mutator_interfaces()
         {

--- a/src/NServiceBus.Core.Tests/Serializers/XML/SerializingNullableTypesTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/SerializingNullableTypesTests.cs
@@ -71,18 +71,12 @@ namespace NServiceBus.Serializers.XML.Test
                 var reader = new StreamReader(stream);
                 var xml = reader.ReadToEnd();
 
-#if NET452
-                var birthDate = "1950-04-25T00:00:00";
-#else
-                var birthDate = "1950-04-25T00:00:00.0000000";
-#endif
-
-                var expected = XDocument.Parse($@"<?xml version=""1.0""?>
+                var expected = XDocument.Parse(@"<?xml version=""1.0""?>
 <MessageWithNullable xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns=""http://tempuri.net/NServiceBus.Serializers.XML.Test"">
    <FirstName>FirstName</FirstName>
    <LastName>LastName</LastName>
    <EmailAddress>EmailAddress</EmailAddress>
-   <BirthDate>{birthDate}</BirthDate>
+   <BirthDate>1950-04-25T00:00:00</BirthDate>
 </MessageWithNullable>
 ");
                 var actual = XDocument.Parse(xml);

--- a/src/NServiceBus.Core/MessageMutators/MutateInstanceMessage/MutateIncomingMessageBehavior.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateInstanceMessage/MutateIncomingMessageBehavior.cs
@@ -1,12 +1,18 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using MessageMutator;
     using Pipeline;
 
     class MutateIncomingMessageBehavior : IBehavior<IIncomingLogicalMessageContext, IIncomingLogicalMessageContext>
     {
+        public MutateIncomingMessageBehavior(HashSet<IMutateIncomingMessages> mutators)
+        {
+            this.mutators = mutators;
+        }
+
         public Task Invoke(IIncomingLogicalMessageContext context, Func<IIncomingLogicalMessageContext, Task> next)
         {
             if (hasIncomingMessageMutators)
@@ -25,7 +31,17 @@
             var mutatorContext = new MutateIncomingMessageContext(current, context.Headers);
 
             var hasMutators = false;
+
             foreach (var mutator in context.Builder.BuildAll<IMutateIncomingMessages>())
+            {
+                hasMutators = true;
+
+                await mutator.MutateIncoming(mutatorContext)
+                    .ThrowIfNull()
+                    .ConfigureAwait(false);
+            }
+
+            foreach (var mutator in mutators)
             {
                 hasMutators = true;
 
@@ -45,5 +61,6 @@
         }
 
         volatile bool hasIncomingMessageMutators = true;
+        HashSet<IMutateIncomingMessages> mutators;
     }
 }

--- a/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
@@ -1,12 +1,18 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using MessageMutator;
     using Pipeline;
 
     class MutateIncomingTransportMessageBehavior : IBehavior<IIncomingPhysicalMessageContext, IIncomingPhysicalMessageContext>
     {
+        public MutateIncomingTransportMessageBehavior(HashSet<IMutateIncomingTransportMessages> mutators)
+        {
+            this.mutators = mutators;
+        }
+
         public Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
         {
             if (hasIncomingTransportMessageMutators)
@@ -19,11 +25,21 @@
 
         async Task InvokeIncomingTransportMessagesMutators(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
         {
-            var mutators = context.Builder.BuildAll<IMutateIncomingTransportMessages>();
+            var mutatorsRegisteredInDI = context.Builder.BuildAll<IMutateIncomingTransportMessages>();
             var transportMessage = context.Message;
             var mutatorContext = new MutateIncomingTransportMessageContext(transportMessage.Body, transportMessage.Headers);
 
             var hasMutators = false;
+
+            foreach (var mutator in mutatorsRegisteredInDI)
+            {
+                hasMutators = true;
+
+                await mutator.MutateIncoming(mutatorContext)
+                    .ThrowIfNull()
+                    .ConfigureAwait(false);
+            }
+
             foreach (var mutator in mutators)
             {
                 hasMutators = true;
@@ -44,5 +60,6 @@
         }
 
         volatile bool hasIncomingTransportMessageMutators = true;
+        HashSet<IMutateIncomingTransportMessages> mutators;
     }
 }

--- a/src/NServiceBus.Core/MessageMutators/Mutators.cs
+++ b/src/NServiceBus.Core/MessageMutators/Mutators.cs
@@ -1,5 +1,8 @@
 ﻿namespace NServiceBus.Features
 {
+    using MessageMutator;
+    using System.Collections.Generic;
+
     class Mutators : Feature
     {
         public Mutators()
@@ -9,11 +12,21 @@
 
         protected internal override void Setup(FeatureConfigurationContext context)
         {
-            context.Pipeline.Register("MutateIncomingTransportMessage", new MutateIncomingTransportMessageBehavior(), "Executes IMutateIncomingTransportMessages");
-            context.Pipeline.Register("MutateIncomingMessages", new MutateIncomingMessageBehavior(), "Executes IMutateIncomingMessages");
+            var registry = context.Settings.GetOrDefault<RegisteredMutators>() ?? new RegisteredMutators();
 
-            context.Pipeline.Register("MutateOutgoingMessages", new MutateOutgoingMessageBehavior(), "Executes IMutateOutgoingMessages");
-            context.Pipeline.Register("MutateOutgoingTransportMessage", new MutateOutgoingTransportMessageBehavior(), "Executes IMutateOutgoingTransportMessages");
+            context.Pipeline.Register("MutateIncomingTransportMessage", b => new MutateIncomingTransportMessageBehavior(registry.IncomingTransportMessage), "Executes IMutateIncomingTransportMessages");
+            context.Pipeline.Register("MutateIncomingMessages", new MutateIncomingMessageBehavior(registry.IncomingMessage), "Executes IMutateIncomingMessages");
+
+            context.Pipeline.Register("MutateOutgoingMessages", new MutateOutgoingMessageBehavior(registry.OutgoingMessage), "Executes IMutateOutgoingMessages");
+            context.Pipeline.Register("MutateOutgoingTransportMessage", new MutateOutgoingTransportMessageBehavior(registry.OutgoingTransportMessage), "Executes IMutateOutgoingTransportMessages");
+        }
+
+        public class RegisteredMutators
+        {
+            public readonly HashSet<IMutateIncomingMessages> IncomingMessage = new HashSet<IMutateIncomingMessages>();
+            public readonly HashSet<IMutateOutgoingMessages> OutgoingMessage = new HashSet<IMutateOutgoingMessages>();
+            public readonly HashSet<IMutateIncomingTransportMessages> IncomingTransportMessage = new HashSet<IMutateIncomingTransportMessages>();
+            public readonly HashSet<IMutateOutgoingTransportMessages> OutgoingTransportMessage = new HashSet<IMutateOutgoingTransportMessages>();
         }
     }
 }

--- a/src/NServiceBus.Core/MessageMutators/Mutators.cs
+++ b/src/NServiceBus.Core/MessageMutators/Mutators.cs
@@ -14,9 +14,8 @@
         {
             var registry = context.Settings.GetOrDefault<RegisteredMutators>() ?? new RegisteredMutators();
 
-            context.Pipeline.Register("MutateIncomingTransportMessage", b => new MutateIncomingTransportMessageBehavior(registry.IncomingTransportMessage), "Executes IMutateIncomingTransportMessages");
+            context.Pipeline.Register("MutateIncomingTransportMessage", new MutateIncomingTransportMessageBehavior(registry.IncomingTransportMessage), "Executes IMutateIncomingTransportMessages");
             context.Pipeline.Register("MutateIncomingMessages", new MutateIncomingMessageBehavior(registry.IncomingMessage), "Executes IMutateIncomingMessages");
-
             context.Pipeline.Register("MutateOutgoingMessages", new MutateOutgoingMessageBehavior(registry.OutgoingMessage), "Executes IMutateOutgoingMessages");
             context.Pipeline.Register("MutateOutgoingTransportMessage", new MutateOutgoingTransportMessageBehavior(registry.OutgoingTransportMessage), "Executes IMutateOutgoingTransportMessages");
         }


### PR DESCRIPTION
## Who's affected

Any user registering more than one message mutator [of the same kind](https://docs.particular.net/nservicebus/pipeline/message-mutators) using the [`EndpointConfiguration.RegisterMessageMutator(myMutator)` API](https://docs.particular.net/nservicebus/pipeline/message-mutators#registering-a-mutator) and is not using [Autofac or StructureMap as their DI container.](https://docs.particular.net/nservicebus/dependency-injection/#supported-containers)

## Symptoms

Only the last registered mutator of each kind is invoked.

## Workaround

Use the following syntax to workaround the issue by manually register the mutators:

```
endpointConfiguration.RegisterComponents(r => {
            r.ConfigureComponent<FooMessageMutator>(DependencyLifecycle.SingleInstance);
            r.ConfigureComponent<BarMessageMutator>(DependencyLifecycle.SingleInstance);
        });
```

See https://github.com/Particular/NServiceBus/issues/5263 for more details.