### PR TITLE
When using the explicit registration API only the last registered mutator is invoked

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Mutators/When_defining_outgoing_message_mutators.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Mutators/When_defining_outgoing_message_mutators.cs
@@ -42,8 +42,7 @@
                 });
             }
 
-            class TransportMutator :
-                IMutateOutgoingTransportMessages
+            class TransportMutator : IMutateOutgoingTransportMessages
             {
                 public TransportMutator(Context testContext)
                 {
@@ -59,8 +58,7 @@
                 Context testContext;
             }
 
-            class OtherTransportMutator :
-              IMutateOutgoingTransportMessages
+            class OtherTransportMutator : IMutateOutgoingTransportMessages
             {
                 public OtherTransportMutator(Context testContext)
                 {
@@ -75,7 +73,6 @@
 
                 Context testContext;
             }
-
 
             class MessageMutator : IMutateOutgoingMessages
             {
@@ -110,7 +107,6 @@
                 Context testContext;
             }
         }
-
 
         public class Message : ICommand
         {

--- a/src/NServiceBus.AcceptanceTests/Core/Mutators/When_defining_outgoing_message_mutators.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Mutators/When_defining_outgoing_message_mutators.cs
@@ -17,6 +17,7 @@
                 .Run();
 
             Assert.True(context.TransportMutatorCalled);
+            Assert.True(context.OtherTransportMutatorCalled);
             Assert.True(context.MessageMutatorCalled);
         }
 
@@ -24,6 +25,7 @@
         {
             public bool MessageProcessed { get; set; }
             public bool TransportMutatorCalled { get; set; }
+            public bool OtherTransportMutatorCalled { get; set; }
             public bool MessageMutatorCalled { get; set; }
         }
 
@@ -35,6 +37,7 @@
                 {
                     var scenarioContext = (Context)r.ScenarioContext;
                     c.RegisterMessageMutator(new TransportMutator(scenarioContext));
+                    c.RegisterMessageMutator(new OtherTransportMutator(context));
                     c.RegisterMessageMutator(new MessageMutator(scenarioContext));
                 });
             }
@@ -55,6 +58,24 @@
 
                 Context testContext;
             }
+
+            class OtherTransportMutator :
+              IMutateOutgoingTransportMessages
+            {
+                public OtherTransportMutator(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task MutateOutgoing(MutateOutgoingTransportMessageContext context)
+                {
+                    testContext.OtherTransportMutatorCalled = true;
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+
 
             class MessageMutator : IMutateOutgoingMessages
             {

--- a/src/NServiceBus.AcceptanceTests/Core/Mutators/When_defining_outgoing_message_mutators.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Mutators/When_defining_outgoing_message_mutators.cs
@@ -37,7 +37,7 @@
                 {
                     var scenarioContext = (Context)r.ScenarioContext;
                     c.RegisterMessageMutator(new TransportMutator(scenarioContext));
-                    c.RegisterMessageMutator(new OtherTransportMutator(context));
+                    c.RegisterMessageMutator(new OtherTransportMutator(scenarioContext));
                     c.RegisterMessageMutator(new MessageMutator(scenarioContext));
                 });
             }

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -252,7 +252,7 @@
     <Compile Include="Serialization\When_wrapping_is_not_skipped.cs" />
     <Compile Include="Serialization\When_xml_serializer_used_with_unobtrusive_mode.cs" />
     <Compile Include="Routing\NativePublishSubscribe\When_multi_subscribing_to_a_polymorphic_event.cs" />
-    <Compile Include="Routing\MessageDrivenSubscriptions\When_using_autosubscribe_with_missing_routing_information.cs" />
+    <Compile Include="Routing\MessageDrivenSubscriptions\When_autosubscribe_with_missing_routing_information.cs" />
     <Compile Include="Routing\MessageDrivenSubscriptions\When_publishing_to_scaled_out_subscribers.cs" />
     <Compile Include="Routing\NativePublishSubscribe\When_publishing_to_scaled_out_subscribers.cs" />
     <Compile Include="Routing\When_replying_to_a_message_sent_to_specific_instance.cs" />

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_autosubscribe_with_missing_routing_information.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_autosubscribe_with_missing_routing_information.cs
@@ -7,7 +7,7 @@
     using System.Linq;
     using System.Threading.Tasks;
 
-    public class When_using_autosubscribe_with_missing_routing_information : NServiceBusAcceptanceTest
+    public class When_autosubscribe_with_missing_routing_information : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_log_events_with_missing_routes()

--- a/src/NServiceBus.Core.Tests/MessageMutators/MutatorRegistrationExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageMutators/MutatorRegistrationExtensionsTests.cs
@@ -31,6 +31,41 @@
             Assert.DoesNotThrow(() => endpointConfiguration.RegisterMessageMutator(messageMutator));
         }
 
+        [TestCase(typeof(IncomingMessageMutator))]
+        [TestCase(typeof(IncomingTransportMessageMutator))]
+        [TestCase(typeof(OutgoingMessageMutator))]
+        [TestCase(typeof(OutgoingTransportMessageMutator))]
+        public void Should_only_invoke_instances_once_even_if_registered_multiple_times(Type mutatorType)
+        {
+            var endpointConfiguration = new EndpointConfiguration("test");
+            var messageMutator = Activator.CreateInstance(mutatorType);
+
+            endpointConfiguration.RegisterMessageMutator(messageMutator);
+            endpointConfiguration.RegisterMessageMutator(messageMutator);
+
+            var registry = endpointConfiguration.Settings.Get<NServiceBus.Features.Mutators.RegisteredMutators>();
+            
+            if (mutatorType == typeof(IncomingMessageMutator))
+            {
+                Assert.AreEqual(1, registry.IncomingMessage.Count);
+            }
+
+            if (mutatorType == typeof(IncomingTransportMessageMutator))
+            {
+                Assert.AreEqual(1, registry.IncomingTransportMessage.Count);
+            }
+
+            if (mutatorType == typeof(OutgoingMessageMutator))
+            {
+                Assert.AreEqual(1, registry.OutgoingMessage.Count);
+            }
+
+            if (mutatorType == typeof(OutgoingTransportMessageMutator))
+            {
+                Assert.AreEqual(1, registry.OutgoingTransportMessage.Count);
+            }
+        }
+
         [Test]
         public void Should_not_throw_when_registering_mutator_implementing_multiple_mutator_interfaces()
         {

--- a/src/NServiceBus.Core/MessageMutators/MutateInstanceMessage/MutateIncomingMessageBehavior.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateInstanceMessage/MutateIncomingMessageBehavior.cs
@@ -1,12 +1,18 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using MessageMutator;
     using Pipeline;
 
     class MutateIncomingMessageBehavior : IBehavior<IIncomingLogicalMessageContext, IIncomingLogicalMessageContext>
     {
+        public MutateIncomingMessageBehavior(HashSet<IMutateIncomingMessages> mutators)
+        {
+            this.mutators = mutators;
+        }
+
         public Task Invoke(IIncomingLogicalMessageContext context, Func<IIncomingLogicalMessageContext, Task> next)
         {
             if (hasIncomingMessageMutators)
@@ -25,7 +31,17 @@
             var mutatorContext = new MutateIncomingMessageContext(current, context.Headers);
 
             var hasMutators = false;
+
             foreach (var mutator in context.Builder.BuildAll<IMutateIncomingMessages>())
+            {
+                hasMutators = true;
+
+                await mutator.MutateIncoming(mutatorContext)
+                    .ThrowIfNull()
+                    .ConfigureAwait(false);
+            }
+
+            foreach (var mutator in mutators)
             {
                 hasMutators = true;
 
@@ -45,5 +61,6 @@
         }
 
         volatile bool hasIncomingMessageMutators = true;
+        HashSet<IMutateIncomingMessages> mutators;
     }
 }

--- a/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
@@ -1,12 +1,18 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using MessageMutator;
     using Pipeline;
 
     class MutateIncomingTransportMessageBehavior : IBehavior<IIncomingPhysicalMessageContext, IIncomingPhysicalMessageContext>
     {
+        public MutateIncomingTransportMessageBehavior(HashSet<IMutateIncomingTransportMessages> mutators)
+        {
+            this.mutators = mutators;
+        }
+
         public Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
         {
             if (hasIncomingTransportMessageMutators)
@@ -19,11 +25,21 @@
 
         async Task InvokeIncomingTransportMessagesMutators(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
         {
-            var mutators = context.Builder.BuildAll<IMutateIncomingTransportMessages>();
+            var mutatorsRegisteredInDI = context.Builder.BuildAll<IMutateIncomingTransportMessages>();
             var transportMessage = context.Message;
             var mutatorContext = new MutateIncomingTransportMessageContext(transportMessage.Body, transportMessage.Headers);
 
             var hasMutators = false;
+
+            foreach (var mutator in mutatorsRegisteredInDI)
+            {
+                hasMutators = true;
+
+                await mutator.MutateIncoming(mutatorContext)
+                    .ThrowIfNull()
+                    .ConfigureAwait(false);
+            }
+
             foreach (var mutator in mutators)
             {
                 hasMutators = true;
@@ -44,5 +60,6 @@
         }
 
         volatile bool hasIncomingTransportMessageMutators = true;
+        HashSet<IMutateIncomingTransportMessages> mutators;
     }
 }

--- a/src/NServiceBus.Core/MessageMutators/Mutators.cs
+++ b/src/NServiceBus.Core/MessageMutators/Mutators.cs
@@ -1,5 +1,8 @@
 ﻿namespace NServiceBus.Features
 {
+    using MessageMutator;
+    using System.Collections.Generic;
+
     class Mutators : Feature
     {
         public Mutators()
@@ -9,11 +12,21 @@
 
         protected internal override void Setup(FeatureConfigurationContext context)
         {
-            context.Pipeline.Register("MutateIncomingTransportMessage", new MutateIncomingTransportMessageBehavior(), "Executes IMutateIncomingTransportMessages");
-            context.Pipeline.Register("MutateIncomingMessages", new MutateIncomingMessageBehavior(), "Executes IMutateIncomingMessages");
+            var registry = context.Settings.GetOrDefault<RegisteredMutators>() ?? new RegisteredMutators();
 
-            context.Pipeline.Register("MutateOutgoingMessages", new MutateOutgoingMessageBehavior(), "Executes IMutateOutgoingMessages");
-            context.Pipeline.Register("MutateOutgoingTransportMessage", new MutateOutgoingTransportMessageBehavior(), "Executes IMutateOutgoingTransportMessages");
+            context.Pipeline.Register("MutateIncomingTransportMessage", b => new MutateIncomingTransportMessageBehavior(registry.IncomingTransportMessage), "Executes IMutateIncomingTransportMessages");
+            context.Pipeline.Register("MutateIncomingMessages", new MutateIncomingMessageBehavior(registry.IncomingMessage), "Executes IMutateIncomingMessages");
+
+            context.Pipeline.Register("MutateOutgoingMessages", new MutateOutgoingMessageBehavior(registry.OutgoingMessage), "Executes IMutateOutgoingMessages");
+            context.Pipeline.Register("MutateOutgoingTransportMessage", new MutateOutgoingTransportMessageBehavior(registry.OutgoingTransportMessage), "Executes IMutateOutgoingTransportMessages");
+        }
+
+        public class RegisteredMutators
+        {
+            public readonly HashSet<IMutateIncomingMessages> IncomingMessage = new HashSet<IMutateIncomingMessages>();
+            public readonly HashSet<IMutateOutgoingMessages> OutgoingMessage = new HashSet<IMutateOutgoingMessages>();
+            public readonly HashSet<IMutateIncomingTransportMessages> IncomingTransportMessage = new HashSet<IMutateIncomingTransportMessages>();
+            public readonly HashSet<IMutateOutgoingTransportMessages> OutgoingTransportMessage = new HashSet<IMutateOutgoingTransportMessages>();
         }
     }
 }

--- a/src/NServiceBus.Core/MessageMutators/Mutators.cs
+++ b/src/NServiceBus.Core/MessageMutators/Mutators.cs
@@ -14,9 +14,8 @@
         {
             var registry = context.Settings.GetOrDefault<RegisteredMutators>() ?? new RegisteredMutators();
 
-            context.Pipeline.Register("MutateIncomingTransportMessage", b => new MutateIncomingTransportMessageBehavior(registry.IncomingTransportMessage), "Executes IMutateIncomingTransportMessages");
+            context.Pipeline.Register("MutateIncomingTransportMessage", new MutateIncomingTransportMessageBehavior(registry.IncomingTransportMessage), "Executes IMutateIncomingTransportMessages");
             context.Pipeline.Register("MutateIncomingMessages", new MutateIncomingMessageBehavior(registry.IncomingMessage), "Executes IMutateIncomingMessages");
-
             context.Pipeline.Register("MutateOutgoingMessages", new MutateOutgoingMessageBehavior(registry.OutgoingMessage), "Executes IMutateOutgoingMessages");
             context.Pipeline.Register("MutateOutgoingTransportMessage", new MutateOutgoingTransportMessageBehavior(registry.OutgoingTransportMessage), "Executes IMutateOutgoingTransportMessages");
         }


### PR DESCRIPTION
## Who's affected

Any user registering more than one message mutator [of the same kind](https://docs.particular.net/nservicebus/pipeline/message-mutators) using the [`EndpointConfiguration.RegisterMessageMutator(myMutator)` API](https://docs.particular.net/nservicebus/pipeline/message-mutators#registering-a-mutator) and is not using [the builtin container, Autofac or StructureMap as their DI container.](https://docs.particular.net/nservicebus/dependency-injection/#supported-containers)

## Symptoms

Only the last registered mutator of each kind is invoked.

## Workaround

Use the following syntax to workaround the issue by manually register the mutators:

```
endpointConfiguration.RegisterComponents(r => {
            r.ConfigureComponent<FooMessageMutator>(DependencyLifecycle.SingleInstance);
            r.ConfigureComponent<BarMessageMutator>(DependencyLifecycle.SingleInstance);
        });
```

See https://github.com/Particular/NServiceBus/issues/5263 for more details.