### PR TITLE
DirectoryBasedTransaction should retry directory move

### DIFF
--- a/src/NServiceBus.Core/Transports/Learning/AsyncDirectory.cs
+++ b/src/NServiceBus.Core/Transports/Learning/AsyncDirectory.cs
@@ -1,0 +1,31 @@
+namespace NServiceBus
+{
+    using System.IO;
+    using System.Threading.Tasks;
+
+    static class AsyncDirectory
+    {
+        public static async Task Move(string sourcePath, string targetPath)
+        {
+            var count = 0;
+            while (count <= 10)
+            {
+                try
+                {
+                    Directory.Move(sourcePath, targetPath);
+                    return;
+                }
+                catch (IOException)
+                {
+                    if (count == 10)
+                    {
+                        throw;
+                    }
+                }
+
+                await Task.Delay(100).ConfigureAwait(false);
+                count++;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -25,12 +25,10 @@ namespace NServiceBus
             return AsyncFile.Move(incomingFilePath, FileToProcess);
         }
 
-        public Task Commit()
+        public async Task Commit()
         {
-            Directory.Move(transactionDir, commitDir);
+            await AsyncDirectory.Move(transactionDir, commitDir).ConfigureAwait(false);
             committed = true;
-
-            return TaskEx.CompletedTask;
         }
 
         public void Rollback()


### PR DESCRIPTION
It is possible that a file handle is still open although the file APIs already returned, in such a case Directory.Move would fail

Found this issue while trying to run the Monitoring demo on the learning transport