### PR TITLE
Replace URL in init.ps1

### DIFF
--- a/packaging/nuget/tools/init.ps1
+++ b/packaging/nuget/tools/init.ps1
@@ -37,7 +37,7 @@ $jobScriptBlock = {
         # Post Version to particular.net
         $wc = New-Object System.Net.WebClient 
         try {
-            $url = 'https://particular.net/api/ReportFirstTimeInstall'
+            $url = 'https://api.particular.net/googleanalytics/reportfirsttimeinstall'
             $postData  = New-Object System.Collections.Specialized.NameValueCollection
             $postData.Add("version", $packageversion)
             $wc.UseDefaultCredentials = $true


### PR DESCRIPTION
Related to a reconfiguration in the website. The POST will continue to be reverse-proxied as necessary on the public website for all old versions of the package we cannot change, but this will be the canonical URL going forward.