### PR TITLE
Improve license warnings

### DIFF
--- a/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
+++ b/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
@@ -27,7 +27,7 @@
             licenseManager.LogExpiringLicenseWarning(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
-            Assert.AreEqual("Please extend your trial or purchase a license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
+            Assert.AreEqual("Trial license expiring soon. Please extend your trial or purchase a license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
             Assert.AreEqual(LogLevel.Warn, logger.Logs.Single().Item2);
         }
 
@@ -62,7 +62,7 @@
             licenseManager.LogExpiredLicenseError(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
-            Assert.AreEqual("Please extend your trial or purchase a license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
+            Assert.AreEqual("Trial license expired. Please extend your trial or purchase a license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
             Assert.AreEqual(LogLevel.Error, logger.Logs.Single().Item2);
         }
 
@@ -82,7 +82,7 @@
             licenseManager.LogExpiringLicenseWarning(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
-            Assert.AreEqual("Please extend your license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
+            Assert.AreEqual("Platform license expiring soon. Please extend your license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
             Assert.AreEqual(LogLevel.Warn, logger.Logs.Single().Item2);
         }
 
@@ -117,7 +117,7 @@
             licenseManager.LogExpiredLicenseError(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
-            Assert.AreEqual("Please extend your license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
+            Assert.AreEqual("Platform license expired. Please extend your license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
             Assert.AreEqual(LogLevel.Error, logger.Logs.Single().Item2);
         }
 
@@ -137,7 +137,7 @@
             licenseManager.LogExpiringLicenseWarning(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
-            Assert.AreEqual("Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.", logger.Logs.Single().Item1);
+            Assert.AreEqual("Upgrade protection expiring soon. Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.", logger.Logs.Single().Item1);
             Assert.AreEqual(LogLevel.Warn, logger.Logs.Single().Item2);
         }
 
@@ -172,7 +172,7 @@
             licenseManager.LogExpiredLicenseError(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
-            Assert.AreEqual("Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.", logger.Logs.Single().Item1);
+            Assert.AreEqual("Upgrade protection expired. Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.", logger.Logs.Single().Item1);
             Assert.AreEqual(LogLevel.Error, logger.Logs.Single().Item2);
         }
 

--- a/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
+++ b/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
@@ -25,7 +25,7 @@
                 LicenseType = "trial"
             };
 
-            licenseManager.LogLicenseWarnings(license, logger, false);
+            licenseManager.LogExpiringLicenseWarning(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
             Assert.AreEqual("Please extend your trial or purchase a license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
@@ -45,7 +45,7 @@
                 LicenseType = "trial"
             };
 
-            licenseManager.LogLicenseWarnings(license, logger, false);
+            licenseManager.LogExpiringLicenseWarning(license, logger);
 
             Assert.AreEqual(0, logger.Logs.Count);
         }
@@ -62,7 +62,7 @@
                 LicenseType = "trial"
             };
 
-            licenseManager.LogLicenseWarnings(license, logger, true);
+            licenseManager.LogExpiredLicenseError(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
             Assert.AreEqual("Please extend your trial or purchase a license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
@@ -83,7 +83,7 @@
                 LicenseType = "not-trial"
             };
 
-            licenseManager.LogLicenseWarnings(license, logger, false);
+            licenseManager.LogExpiringLicenseWarning(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
             Assert.AreEqual("Please extend your license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
@@ -103,7 +103,7 @@
                 LicenseType = "not-trial"
             };
 
-            licenseManager.LogLicenseWarnings(license, logger, false);
+            licenseManager.LogExpiringLicenseWarning(license, logger);
 
             Assert.AreEqual(0, logger.Logs.Count);
         }
@@ -120,7 +120,7 @@
                 LicenseType = "not-trial"
             };
 
-            licenseManager.LogLicenseWarnings(license, logger, true);
+            licenseManager.LogExpiredLicenseError(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
             Assert.AreEqual("Please extend your license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
@@ -141,7 +141,7 @@
                 LicenseType = "not-trial"
             };
 
-            licenseManager.LogLicenseWarnings(license, logger, false);
+            licenseManager.LogExpiringLicenseWarning(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
             Assert.AreEqual("Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.", logger.Logs.Single().Item1);
@@ -161,7 +161,7 @@
                 LicenseType = "not-trial"
             };
 
-            licenseManager.LogLicenseWarnings(license, logger, false);
+            licenseManager.LogExpiringLicenseWarning(license, logger);
 
             Assert.AreEqual(0, logger.Logs.Count);
         }
@@ -178,7 +178,7 @@
                 LicenseType = "not-trial"
             };
 
-            licenseManager.LogLicenseWarnings(license, logger, true);
+            licenseManager.LogExpiredLicenseError(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
             Assert.AreEqual("Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.", logger.Logs.Single().Item1);

--- a/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
+++ b/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
@@ -27,8 +27,8 @@
             licenseManager.LogExpiringLicenseWarning(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
-            Assert.AreEqual("Trial license expiring soon. Please extend your trial or purchase a license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
-            Assert.AreEqual(LogLevel.Warn, logger.Logs.Single().Item2);
+            Assert.AreEqual("Trial license expiring soon. Please extend your trial or purchase a license to continue using the Particular Service Platform.", logger.Logs.Single().message);
+            Assert.AreEqual(LogLevel.Warn, logger.Logs.Single().level);
         }
 
         [TestCase("2012-12-12", "2012-12-16")]
@@ -62,8 +62,8 @@
             licenseManager.LogExpiredLicenseError(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
-            Assert.AreEqual("Trial license expired. Please extend your trial or purchase a license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
-            Assert.AreEqual(LogLevel.Error, logger.Logs.Single().Item2);
+            Assert.AreEqual("Trial license expired. Please extend your trial or purchase a license to continue using the Particular Service Platform.", logger.Logs.Single().message);
+            Assert.AreEqual(LogLevel.Error, logger.Logs.Single().level);
         }
 
         [TestCase("2012-12-12", "2012-12-13")]
@@ -82,8 +82,8 @@
             licenseManager.LogExpiringLicenseWarning(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
-            Assert.AreEqual("Platform license expiring soon. Please extend your license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
-            Assert.AreEqual(LogLevel.Warn, logger.Logs.Single().Item2);
+            Assert.AreEqual("Platform license expiring soon. Please extend your license to continue using the Particular Service Platform.", logger.Logs.Single().message);
+            Assert.AreEqual(LogLevel.Warn, logger.Logs.Single().level);
         }
 
         [TestCase("2012-12-12", "2012-12-16")]
@@ -117,8 +117,8 @@
             licenseManager.LogExpiredLicenseError(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
-            Assert.AreEqual("Platform license expired. Please extend your license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
-            Assert.AreEqual(LogLevel.Error, logger.Logs.Single().Item2);
+            Assert.AreEqual("Platform license expired. Please extend your license to continue using the Particular Service Platform.", logger.Logs.Single().message);
+            Assert.AreEqual(LogLevel.Error, logger.Logs.Single().level);
         }
 
         [TestCase("2012-12-12", "2012-12-13")]
@@ -137,8 +137,8 @@
             licenseManager.LogExpiringLicenseWarning(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
-            Assert.AreEqual("Upgrade protection expiring soon. Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.", logger.Logs.Single().Item1);
-            Assert.AreEqual(LogLevel.Warn, logger.Logs.Single().Item2);
+            Assert.AreEqual("Upgrade protection expiring soon. Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.", logger.Logs.Single().message);
+            Assert.AreEqual(LogLevel.Warn, logger.Logs.Single().level);
         }
 
         [TestCase("2012-12-12", "2012-12-16")]
@@ -172,8 +172,8 @@
             licenseManager.LogExpiredLicenseError(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
-            Assert.AreEqual("Upgrade protection expired. Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.", logger.Logs.Single().Item1);
-            Assert.AreEqual(LogLevel.Error, logger.Logs.Single().Item2);
+            Assert.AreEqual("Upgrade protection expired. Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.", logger.Logs.Single().message);
+            Assert.AreEqual(LogLevel.Error, logger.Logs.Single().level);
         }
 
         static DateTime ParseUtcDateTimeString(string dateTimeString)
@@ -266,10 +266,10 @@
 
             void Log(string message, LogLevel level)
             {
-                Logs.Add(new Tuple<string, LogLevel>(message, level));
+                Logs.Add((message, level));
             }
 
-            public List<Tuple<string, LogLevel>> Logs { get; } = new List<Tuple<string, LogLevel>>();
+            public List<(string message, LogLevel level)> Logs { get; } = new List<(string, LogLevel)>();
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
+++ b/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
@@ -16,8 +16,7 @@
         [TestCase("2012-12-12", "2012-12-15")]
         public void ShouldWarnAboutExpiringTrialLicense(string currentDate, string expirationDate)
         {
-            var licenseManager = new LicenseManager();
-            licenseManager.todayUtc = () => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+            var licenseManager = new LicenseManager(() => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
             var logger = new TestableLogger();
             var license = new License
             {
@@ -36,8 +35,7 @@
         [TestCase("2012-12-12", "2012-12-17")]
         public void ShouldNotWarnAboutExpiringTrialLicenseWhenMoreThanThreeDaysAway(string currentDate, string expirationDate)
         {
-            var licenseManager = new LicenseManager();
-            licenseManager.todayUtc = () => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+            var licenseManager = new LicenseManager(() => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
             var logger = new TestableLogger();
             var license = new License
             {
@@ -53,8 +51,7 @@
         [Test]
         public void ShouldLogErrorAboutExpiredTrialLicense()
         {
-            var licenseManager = new LicenseManager();
-            licenseManager.todayUtc = () => new DateTime(2012, 12, 12);
+            var licenseManager = new LicenseManager(() => new DateTime(2012, 12, 12));
             var logger = new TestableLogger();
             var license = new License
             {
@@ -74,8 +71,7 @@
         [TestCase("2012-12-12", "2012-12-15")]
         public void ShouldWarnAboutExpiringSubscriptionLicense(string currentDate, string expirationDate)
         {
-            var licenseManager = new LicenseManager();
-            licenseManager.todayUtc = () => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+            var licenseManager = new LicenseManager(() => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
             var logger = new TestableLogger();
             var license = new License
             {
@@ -94,8 +90,7 @@
         [TestCase("2012-12-12", "2012-12-17")]
         public void ShouldNotWarnAboutExpiringLicenseWhenMoreThanThreeDaysAway(string currentDate, string expirationDate)
         {
-            var licenseManager = new LicenseManager();
-            licenseManager.todayUtc = () => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+            var licenseManager = new LicenseManager(() => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
             var logger = new TestableLogger();
             var license = new License
             {
@@ -111,8 +106,7 @@
         [Test]
         public void ShouldLogErrorAboutExpiredLicense()
         {
-            var licenseManager = new LicenseManager();
-            licenseManager.todayUtc = () => new DateTime(2012, 12, 12);
+            var licenseManager = new LicenseManager(() => new DateTime(2012, 12, 12));
             var logger = new TestableLogger();
             var license = new License
             {
@@ -132,8 +126,7 @@
         [TestCase("2012-12-12", "2012-12-15")]
         public void ShouldWarnAboutExpiringUpgradeProtection(string currentDate, string expirationDate)
         {
-            var licenseManager = new LicenseManager();
-            licenseManager.todayUtc = () => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+            var licenseManager = new LicenseManager(() => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
             var logger = new TestableLogger();
             var license = new License
             {
@@ -152,8 +145,7 @@
         [TestCase("2012-12-12", "2012-12-17")]
         public void ShouldNotWarnAboutExpiringUpgradeProtectionWhenMoreThanThreeDaysAway(string currentDate, string expirationDate)
         {
-            var licenseManager = new LicenseManager();
-            licenseManager.todayUtc = () => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+            var licenseManager = new LicenseManager(() => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
             var logger = new TestableLogger();
             var license = new License
             {
@@ -169,8 +161,7 @@
         [Test]
         public void ShouldLogErrorAboutExpiredUpgradeProtection()
         {
-            var licenseManager = new LicenseManager();
-            licenseManager.todayUtc = () => new DateTime(2012, 12, 12);
+            var licenseManager = new LicenseManager(() => new DateTime(2012, 12, 12));
             var logger = new TestableLogger();
             var license = new License
             {

--- a/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
+++ b/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
@@ -20,9 +20,9 @@
             Assert.AreEqual(0, logger.Logs.Count);
         }
 
-        [TestCase(LicenseStatus.InvalidDueExpiredTrial, LogLevel.Error, "Trial license expired. Please extend your trial or purchase a license to continue using the Particular Service Platform.")]
-        [TestCase(LicenseStatus.InvalidDueExpiredSubscription, LogLevel.Error, "Platform license expired. Please extend your license to continue using the Particular Service Platform.")]
-        [TestCase(LicenseStatus.InvalidDueExpiredUpgradeProtection, LogLevel.Error, "Upgrade protection expired. Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.")]
+        [TestCase(LicenseStatus.InvalidDueToExpiredTrial, LogLevel.Error, "Trial license expired. Please extend your trial or purchase a license to continue using the Particular Service Platform.")]
+        [TestCase(LicenseStatus.InvalidDueToExpiredSubscription, LogLevel.Error, "Platform license expired. Please extend your license to continue using the Particular Service Platform.")]
+        [TestCase(LicenseStatus.InvalidDueToExpiredUpgradeProtection, LogLevel.Error, "Upgrade protection expired. Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.")]
         [TestCase(LicenseStatus.ValidWithExpiringTrial, LogLevel.Warn, "Trial license expiring soon. Please extend your trial or purchase a license to continue using the Particular Service Platform.")]
         [TestCase(LicenseStatus.ValidWithExpiringSubscription, LogLevel.Warn, "Platform license expiring soon. Please extend your license to continue using the Particular Service Platform.")]
         [TestCase(LicenseStatus.ValidWithExpiringUpgradeProtection, LogLevel.Warn, "Upgrade protection expiring soon. Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.")]

--- a/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
+++ b/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
@@ -1,0 +1,279 @@
+﻿namespace NServiceBus.Core.Tests.Licensing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using NServiceBus.Logging;
+    using NUnit.Framework;
+    using Particular.Licensing;
+
+    [TestFixture]
+    public class LicenseManagerTests
+    {
+        [TestCase("2012-12-12", "2012-12-13")]
+        [TestCase("2012-12-12", "2012-12-14")]
+        [TestCase("2012-12-12", "2012-12-15")]
+        public void ShouldWarnAboutExpiringTrialLicense(string currentDate, string expirationDate)
+        {
+            var licenseManager = new LicenseManager();
+            licenseManager.todayUtc = () => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+            var logger = new TestableLogger();
+            var license = new License
+            {
+                ExpirationDate = DateTime.ParseExact(expirationDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                LicenseType = "trial"
+            };
+
+            licenseManager.LogLicenseWarnings(license, logger, false);
+
+            Assert.AreEqual(1, logger.Logs.Count);
+            Assert.AreEqual("Please extend your trial or purchase a license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
+            Assert.AreEqual(LogLevel.Warn, logger.Logs.Single().Item2);
+        }
+
+        [TestCase("2012-12-12", "2012-12-16")]
+        [TestCase("2012-12-12", "2012-12-17")]
+        public void ShouldNotWarnAboutExpiringTrialLicenseWhenMoreThanThreeDaysAway(string currentDate, string expirationDate)
+        {
+            var licenseManager = new LicenseManager();
+            licenseManager.todayUtc = () => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+            var logger = new TestableLogger();
+            var license = new License
+            {
+                ExpirationDate = DateTime.ParseExact(expirationDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                LicenseType = "trial"
+            };
+
+            licenseManager.LogLicenseWarnings(license, logger, false);
+
+            Assert.AreEqual(0, logger.Logs.Count);
+        }
+
+        [Test]
+        public void ShouldLogErrorAboutExpiredTrialLicense()
+        {
+            var licenseManager = new LicenseManager();
+            licenseManager.todayUtc = () => new DateTime(2012, 12, 12);
+            var logger = new TestableLogger();
+            var license = new License
+            {
+                ExpirationDate = new DateTime(2010, 10, 10),
+                LicenseType = "trial"
+            };
+
+            licenseManager.LogLicenseWarnings(license, logger, true);
+
+            Assert.AreEqual(1, logger.Logs.Count);
+            Assert.AreEqual("Please extend your trial or purchase a license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
+            Assert.AreEqual(LogLevel.Error, logger.Logs.Single().Item2);
+        }
+
+        [TestCase("2012-12-12", "2012-12-13")]
+        [TestCase("2012-12-12", "2012-12-14")]
+        [TestCase("2012-12-12", "2012-12-15")]
+        public void ShouldWarnAboutExpiringSubscriptionLicense(string currentDate, string expirationDate)
+        {
+            var licenseManager = new LicenseManager();
+            licenseManager.todayUtc = () => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+            var logger = new TestableLogger();
+            var license = new License
+            {
+                ExpirationDate = DateTime.ParseExact(expirationDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                LicenseType = "not-trial"
+            };
+
+            licenseManager.LogLicenseWarnings(license, logger, false);
+
+            Assert.AreEqual(1, logger.Logs.Count);
+            Assert.AreEqual("Please extend your license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
+            Assert.AreEqual(LogLevel.Warn, logger.Logs.Single().Item2);
+        }
+
+        [TestCase("2012-12-12", "2012-12-16")]
+        [TestCase("2012-12-12", "2012-12-17")]
+        public void ShouldNotWarnAboutExpiringLicenseWhenMoreThanThreeDaysAway(string currentDate, string expirationDate)
+        {
+            var licenseManager = new LicenseManager();
+            licenseManager.todayUtc = () => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+            var logger = new TestableLogger();
+            var license = new License
+            {
+                ExpirationDate = DateTime.ParseExact(expirationDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                LicenseType = "not-trial"
+            };
+
+            licenseManager.LogLicenseWarnings(license, logger, false);
+
+            Assert.AreEqual(0, logger.Logs.Count);
+        }
+
+        [Test]
+        public void ShouldLogErrorAboutExpiredLicense()
+        {
+            var licenseManager = new LicenseManager();
+            licenseManager.todayUtc = () => new DateTime(2012, 12, 12);
+            var logger = new TestableLogger();
+            var license = new License
+            {
+                ExpirationDate = new DateTime(2010, 10, 10),
+                LicenseType = "not-trial"
+            };
+
+            licenseManager.LogLicenseWarnings(license, logger, true);
+
+            Assert.AreEqual(1, logger.Logs.Count);
+            Assert.AreEqual("Please extend your license to continue using the Particular Service Platform.", logger.Logs.Single().Item1);
+            Assert.AreEqual(LogLevel.Error, logger.Logs.Single().Item2);
+        }
+
+        [TestCase("2012-12-12", "2012-12-13")]
+        [TestCase("2012-12-12", "2012-12-14")]
+        [TestCase("2012-12-12", "2012-12-15")]
+        public void ShouldWarnAboutExpiringUpgradeProtection(string currentDate, string expirationDate)
+        {
+            var licenseManager = new LicenseManager();
+            licenseManager.todayUtc = () => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+            var logger = new TestableLogger();
+            var license = new License
+            {
+                UpgradeProtectionExpiration = DateTime.ParseExact(expirationDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                LicenseType = "not-trial"
+            };
+
+            licenseManager.LogLicenseWarnings(license, logger, false);
+
+            Assert.AreEqual(1, logger.Logs.Count);
+            Assert.AreEqual("Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.", logger.Logs.Single().Item1);
+            Assert.AreEqual(LogLevel.Warn, logger.Logs.Single().Item2);
+        }
+
+        [TestCase("2012-12-12", "2012-12-16")]
+        [TestCase("2012-12-12", "2012-12-17")]
+        public void ShouldNotWarnAboutExpiringUpgradeProtectionWhenMoreThanThreeDaysAway(string currentDate, string expirationDate)
+        {
+            var licenseManager = new LicenseManager();
+            licenseManager.todayUtc = () => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
+            var logger = new TestableLogger();
+            var license = new License
+            {
+                UpgradeProtectionExpiration = DateTime.ParseExact(expirationDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                LicenseType = "not-trial"
+            };
+
+            licenseManager.LogLicenseWarnings(license, logger, false);
+
+            Assert.AreEqual(0, logger.Logs.Count);
+        }
+
+        [Test]
+        public void ShouldLogErrorAboutExpiredUpgradeProtection()
+        {
+            var licenseManager = new LicenseManager();
+            licenseManager.todayUtc = () => new DateTime(2012, 12, 12);
+            var logger = new TestableLogger();
+            var license = new License
+            {
+                UpgradeProtectionExpiration = new DateTime(2010, 10, 10),
+                LicenseType = "not-trial"
+            };
+
+            licenseManager.LogLicenseWarnings(license, logger, true);
+
+            Assert.AreEqual(1, logger.Logs.Count);
+            Assert.AreEqual("Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.", logger.Logs.Single().Item1);
+            Assert.AreEqual(LogLevel.Error, logger.Logs.Single().Item2);
+        }
+
+        class TestableLogger : ILog
+        {
+            public bool IsDebugEnabled => true;
+            public bool IsInfoEnabled => true;
+            public bool IsWarnEnabled => true;
+            public bool IsErrorEnabled => true;
+            public bool IsFatalEnabled => true;
+
+            public void Debug(string message)
+            {
+                Log(message, LogLevel.Debug);
+            }
+
+            public void Debug(string message, Exception exception)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void DebugFormat(string format, params object[] args)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Info(string message)
+            {
+                Log(message, LogLevel.Info);
+            }
+
+            public void Info(string message, Exception exception)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void InfoFormat(string format, params object[] args)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Warn(string message)
+            {
+                Log(message, LogLevel.Warn);
+            }
+
+            public void Warn(string message, Exception exception)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void WarnFormat(string format, params object[] args)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Error(string message)
+            {
+                Log(message, LogLevel.Error);
+            }
+
+            public void Error(string message, Exception exception)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void ErrorFormat(string format, params object[] args)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Fatal(string message)
+            {
+                Log(message, LogLevel.Fatal);
+            }
+
+            public void Fatal(string message, Exception exception)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void FatalFormat(string format, params object[] args)
+            {
+                throw new NotImplementedException();
+            }
+
+            void Log(string message, LogLevel level)
+            {
+                Logs.Add(new Tuple<string, LogLevel>(message, level));
+            }
+
+            public List<Tuple<string, LogLevel>> Logs { get; } = new List<Tuple<string, LogLevel>>();
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
+++ b/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
@@ -24,7 +24,7 @@
                 LicenseType = "trial"
             };
 
-            licenseManager.LogExpiringLicenseWarning(license, logger);
+            licenseManager.LogWarningIfLicenseIsAboutToExpire(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
             Assert.AreEqual("Trial license expiring soon. Please extend your trial or purchase a license to continue using the Particular Service Platform.", logger.Logs.Single().message);
@@ -43,7 +43,7 @@
                 LicenseType = "trial"
             };
 
-            licenseManager.LogExpiringLicenseWarning(license, logger);
+            licenseManager.LogWarningIfLicenseIsAboutToExpire(license, logger);
 
             Assert.AreEqual(0, logger.Logs.Count);
         }
@@ -79,7 +79,7 @@
                 LicenseType = "not-trial"
             };
 
-            licenseManager.LogExpiringLicenseWarning(license, logger);
+            licenseManager.LogWarningIfLicenseIsAboutToExpire(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
             Assert.AreEqual("Platform license expiring soon. Please extend your license to continue using the Particular Service Platform.", logger.Logs.Single().message);
@@ -98,7 +98,7 @@
                 LicenseType = "not-trial"
             };
 
-            licenseManager.LogExpiringLicenseWarning(license, logger);
+            licenseManager.LogWarningIfLicenseIsAboutToExpire(license, logger);
 
             Assert.AreEqual(0, logger.Logs.Count);
         }
@@ -134,7 +134,7 @@
                 LicenseType = "not-trial"
             };
 
-            licenseManager.LogExpiringLicenseWarning(license, logger);
+            licenseManager.LogWarningIfLicenseIsAboutToExpire(license, logger);
 
             Assert.AreEqual(1, logger.Logs.Count);
             Assert.AreEqual("Upgrade protection expiring soon. Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.", logger.Logs.Single().message);
@@ -153,7 +153,7 @@
                 LicenseType = "not-trial"
             };
 
-            licenseManager.LogExpiringLicenseWarning(license, logger);
+            licenseManager.LogWarningIfLicenseIsAboutToExpire(license, logger);
 
             Assert.AreEqual(0, logger.Logs.Count);
         }

--- a/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
+++ b/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
@@ -16,11 +16,11 @@
         [TestCase("2012-12-12", "2012-12-15")]
         public void ShouldWarnAboutExpiringTrialLicense(string currentDate, string expirationDate)
         {
-            var licenseManager = new LicenseManager(() => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+            var licenseManager = new LicenseManager(() => ParseUtcDateTimeString(currentDate));
             var logger = new TestableLogger();
             var license = new License
             {
-                ExpirationDate = DateTime.ParseExact(expirationDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                ExpirationDate = ParseUtcDateTimeString(expirationDate),
                 LicenseType = "trial"
             };
 
@@ -35,11 +35,11 @@
         [TestCase("2012-12-12", "2012-12-17")]
         public void ShouldNotWarnAboutExpiringTrialLicenseWhenMoreThanThreeDaysAway(string currentDate, string expirationDate)
         {
-            var licenseManager = new LicenseManager(() => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+            var licenseManager = new LicenseManager(() => ParseUtcDateTimeString(currentDate));
             var logger = new TestableLogger();
             var license = new License
             {
-                ExpirationDate = DateTime.ParseExact(expirationDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                ExpirationDate = ParseUtcDateTimeString(expirationDate),
                 LicenseType = "trial"
             };
 
@@ -71,11 +71,11 @@
         [TestCase("2012-12-12", "2012-12-15")]
         public void ShouldWarnAboutExpiringSubscriptionLicense(string currentDate, string expirationDate)
         {
-            var licenseManager = new LicenseManager(() => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+            var licenseManager = new LicenseManager(() => ParseUtcDateTimeString(currentDate));
             var logger = new TestableLogger();
             var license = new License
             {
-                ExpirationDate = DateTime.ParseExact(expirationDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                ExpirationDate = ParseUtcDateTimeString(expirationDate),
                 LicenseType = "not-trial"
             };
 
@@ -90,11 +90,11 @@
         [TestCase("2012-12-12", "2012-12-17")]
         public void ShouldNotWarnAboutExpiringLicenseWhenMoreThanThreeDaysAway(string currentDate, string expirationDate)
         {
-            var licenseManager = new LicenseManager(() => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+            var licenseManager = new LicenseManager(() => ParseUtcDateTimeString(currentDate));
             var logger = new TestableLogger();
             var license = new License
             {
-                ExpirationDate = DateTime.ParseExact(expirationDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                ExpirationDate = ParseUtcDateTimeString(expirationDate),
                 LicenseType = "not-trial"
             };
 
@@ -126,11 +126,11 @@
         [TestCase("2012-12-12", "2012-12-15")]
         public void ShouldWarnAboutExpiringUpgradeProtection(string currentDate, string expirationDate)
         {
-            var licenseManager = new LicenseManager(() => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+            var licenseManager = new LicenseManager(() => ParseUtcDateTimeString(currentDate));
             var logger = new TestableLogger();
             var license = new License
             {
-                UpgradeProtectionExpiration = DateTime.ParseExact(expirationDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                UpgradeProtectionExpiration = ParseUtcDateTimeString(expirationDate),
                 LicenseType = "not-trial"
             };
 
@@ -145,11 +145,11 @@
         [TestCase("2012-12-12", "2012-12-17")]
         public void ShouldNotWarnAboutExpiringUpgradeProtectionWhenMoreThanThreeDaysAway(string currentDate, string expirationDate)
         {
-            var licenseManager = new LicenseManager(() => DateTime.ParseExact(currentDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal));
+            var licenseManager = new LicenseManager(() => ParseUtcDateTimeString(currentDate));
             var logger = new TestableLogger();
             var license = new License
             {
-                UpgradeProtectionExpiration = DateTime.ParseExact(expirationDate, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal),
+                UpgradeProtectionExpiration = ParseUtcDateTimeString(expirationDate),
                 LicenseType = "not-trial"
             };
 
@@ -174,6 +174,11 @@
             Assert.AreEqual(1, logger.Logs.Count);
             Assert.AreEqual("Upgrade protection expired. Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.", logger.Logs.Single().Item1);
             Assert.AreEqual(LogLevel.Error, logger.Logs.Single().Item2);
+        }
+
+        static DateTime ParseUtcDateTimeString(string dateTimeString)
+        {
+            return DateTime.ParseExact(dateTimeString, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal);
         }
 
         class TestableLogger : ILog

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="NUnit.ApplicationDomain" Version="11.1.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -14,8 +14,12 @@ namespace NServiceBus
 
     class LicenseManager
     {
-        internal Func<DateTime> todayUtc = () => DateTime.Today;
         internal bool HasLicenseExpired => result?.HasExpired ?? true;
+
+        public LicenseManager(Func<DateTime> utcDateTimeProvider)
+        {
+            this.utcDateTimeProvider = utcDateTimeProvider;
+        }
 
         internal void InitializeLicense(string licenseText, string licenseFilePath)
         {
@@ -59,12 +63,12 @@ namespace NServiceBus
         {
             if (activeLicense.UpgradeProtectionExpiration.HasValue)
             {
-                if (activeLicense.UpgradeProtectionExpiration.Value.Subtract(ExpirationWarningThreshold) <= todayUtc())
+                if (activeLicense.UpgradeProtectionExpiration.Value.Subtract(ExpirationWarningThreshold) <= utcDateTimeProvider().Date)
                 {
                     logger.Warn("Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.");
                 }
             }
-            else if (activeLicense.ExpirationDate?.Subtract(ExpirationWarningThreshold) <= todayUtc())
+            else if (activeLicense.ExpirationDate?.Subtract(ExpirationWarningThreshold) <= utcDateTimeProvider().Date)
             {
                 if (activeLicense.IsTrialLicense)
                 {
@@ -185,6 +189,7 @@ namespace NServiceBus
 #endif
 
         ActiveLicenseFindResult result;
+        readonly Func<DateTime> utcDateTimeProvider;
 
         static ILog Logger = LogManager.GetLogger(typeof(LicenseManager));
         static readonly bool debugLoggingEnabled = Logger.IsDebugEnabled;

--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -2,15 +2,14 @@ namespace NServiceBus
 {
     using System;
     using System.Diagnostics;
+#if NETSTANDARD
+    using System.Runtime.InteropServices;
+#endif
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Logging;
     using Particular.Licensing;
-#if NETSTANDARD
-    using System.Runtime.InteropServices;
-
-#endif
 
     class LicenseManager
     {
@@ -28,6 +27,7 @@ namespace NServiceBus
             result = ActiveLicense.Find("NServiceBus", licenseSources);
 
             LogFindResults(result);
+
             if (result.HasExpired)
             {
                 LogExpiredLicenseError(result.License, Logger);

--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -47,15 +47,15 @@ namespace NServiceBus
         {
             if (activeLicense.UpgradeProtectionExpiration.HasValue)
             {
-                logger.Error("Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.");
+                logger.Error("Upgrade protection expired. Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.");
             }
             else if (activeLicense.IsTrialLicense)
             {
-                logger.Error("Please extend your trial or purchase a license to continue using the Particular Service Platform.");
+                logger.Error("Trial license expired. Please extend your trial or purchase a license to continue using the Particular Service Platform.");
             }
             else
             {
-                logger.Error("Please extend your license to continue using the Particular Service Platform.");
+                logger.Error("Platform license expired. Please extend your license to continue using the Particular Service Platform.");
             }
         }
 
@@ -65,18 +65,18 @@ namespace NServiceBus
             {
                 if (activeLicense.UpgradeProtectionExpiration.Value.Subtract(ExpirationWarningThreshold) <= utcDateTimeProvider().Date)
                 {
-                    logger.Warn("Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.");
+                    logger.Warn("Upgrade protection expiring soon. Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.");
                 }
             }
             else if (activeLicense.ExpirationDate?.Subtract(ExpirationWarningThreshold) <= utcDateTimeProvider().Date)
             {
                 if (activeLicense.IsTrialLicense)
                 {
-                    logger.Warn("Please extend your trial or purchase a license to continue using the Particular Service Platform.");
+                    logger.Warn("Trial license expiring soon. Please extend your trial or purchase a license to continue using the Particular Service Platform.");
                 }
                 else
                 {
-                    logger.Warn("Please extend your license to continue using the Particular Service Platform.");
+                    logger.Warn("Platform license expiring soon. Please extend your license to continue using the Particular Service Platform.");
                 }
             }
         }

--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -15,9 +15,9 @@ namespace NServiceBus
     {
         internal bool HasLicenseExpired => result?.HasExpired ?? true;
 
-        public LicenseManager(Func<DateTime> utcDateTimeProvider)
+        public LicenseManager(Func<DateTime> utcDateProvider)
         {
-            this.utcDateTimeProvider = utcDateTimeProvider;
+            this.utcDateProvider = utcDateProvider;
         }
 
         internal void InitializeLicense(string licenseText, string licenseFilePath)
@@ -63,12 +63,12 @@ namespace NServiceBus
         {
             if (activeLicense.UpgradeProtectionExpiration.HasValue)
             {
-                if (activeLicense.UpgradeProtectionExpiration.Value.Subtract(ExpirationWarningThreshold) <= utcDateTimeProvider().Date)
+                if (activeLicense.UpgradeProtectionExpiration.Value.Subtract(ExpirationWarningThreshold) <= utcDateProvider().Date)
                 {
                     logger.Warn("Upgrade protection expiring soon. Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.");
                 }
             }
-            else if (activeLicense.ExpirationDate?.Subtract(ExpirationWarningThreshold) <= utcDateTimeProvider().Date)
+            else if (activeLicense.ExpirationDate?.Subtract(ExpirationWarningThreshold) <= utcDateProvider().Date)
             {
                 if (activeLicense.IsTrialLicense)
                 {
@@ -85,7 +85,7 @@ namespace NServiceBus
         {
             var report = new StringBuilder();
 
-            if (debugLoggingEnabled)
+            if (DebugLoggingEnabled)
             {
                 report.AppendLine("Looking for license in the following locations:");
 
@@ -189,10 +189,10 @@ namespace NServiceBus
 #endif
 
         ActiveLicenseFindResult result;
-        readonly Func<DateTime> utcDateTimeProvider;
+        readonly Func<DateTime> utcDateProvider;
 
-        static ILog Logger = LogManager.GetLogger(typeof(LicenseManager));
-        static readonly bool debugLoggingEnabled = Logger.IsDebugEnabled;
+        static readonly ILog Logger = LogManager.GetLogger(typeof(LicenseManager));
+        static readonly bool DebugLoggingEnabled = Logger.IsDebugEnabled;
         static readonly TimeSpan ExpirationWarningThreshold = TimeSpan.FromDays(3);
     }
 }

--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -188,6 +188,5 @@ namespace NServiceBus
 
         static readonly ILog Logger = LogManager.GetLogger(typeof(LicenseManager));
         static readonly bool DebugLoggingEnabled = Logger.IsDebugEnabled;
-        static readonly TimeSpan ExpirationWarningThreshold = TimeSpan.FromDays(10);
     }
 }

--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -59,12 +59,12 @@ namespace NServiceBus
         {
             if (activeLicense.UpgradeProtectionExpiration.HasValue)
             {
-                if (activeLicense.UpgradeProtectionExpiration.Value.AddDays(-3) <= todayUtc())
+                if (activeLicense.UpgradeProtectionExpiration.Value.Subtract(ExpirationWarningThreshold) <= todayUtc())
                 {
                     logger.Warn("Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.");
                 }
             }
-            else if (activeLicense.ExpirationDate?.AddDays(-3) <= todayUtc())
+            else if (activeLicense.ExpirationDate?.Subtract(ExpirationWarningThreshold) <= todayUtc())
             {
                 if (activeLicense.IsTrialLicense)
                 {
@@ -188,5 +188,6 @@ namespace NServiceBus
 
         static ILog Logger = LogManager.GetLogger(typeof(LicenseManager));
         static readonly bool debugLoggingEnabled = Logger.IsDebugEnabled;
+        static readonly TimeSpan ExpirationWarningThreshold = TimeSpan.FromDays(3);
     }
 }

--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -34,7 +34,7 @@ namespace NServiceBus
             }
             else
             {
-                LogExpiringLicenseWarning(result.License, Logger);
+                LogWarningIfLicenseIsAboutToExpire(result.License, Logger);
             }
 
             if (result.HasExpired && result.License.IsTrialLicense)
@@ -59,7 +59,7 @@ namespace NServiceBus
             }
         }
 
-        internal void LogExpiringLicenseWarning(License activeLicense, ILog logger)
+        internal void LogWarningIfLicenseIsAboutToExpire(License activeLicense, ILog logger)
         {
             if (activeLicense.UpgradeProtectionExpiration.HasValue)
             {

--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -13,7 +13,7 @@ namespace NServiceBus
 
     class LicenseManager
     {
-        internal bool HasLicenseExpired => result?.HasExpired ?? true;
+        internal bool HasLicenseExpired => result?.License.HasExpired() ?? true;
 
         public LicenseManager(Func<DateTime> utcDateProvider)
         {
@@ -31,7 +31,7 @@ namespace NServiceBus
             var licenseStatus = result.License.GetLicenseStatus();
             LogLicenseStatus(licenseStatus, Logger);
 
-            if (licenseStatus == LicenseStatus.InvalidDueExpiredTrial)
+            if (licenseStatus == LicenseStatus.InvalidDueToExpiredTrial)
             {
                 OpenTrialExtensionPage();
             }
@@ -55,13 +55,13 @@ namespace NServiceBus
                 case LicenseStatus.ValidWithExpiringUpgradeProtection:
                     logger.Warn("Upgrade protection expiring soon. Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.");
                     break;
-                case LicenseStatus.InvalidDueExpiredTrial:
+                case LicenseStatus.InvalidDueToExpiredTrial:
                     logger.Error("Trial license expired. Please extend your trial or purchase a license to continue using the Particular Service Platform.");
                     break;
-                case LicenseStatus.InvalidDueExpiredSubscription:
+                case LicenseStatus.InvalidDueToExpiredSubscription:
                     logger.Error("Platform license expired. Please extend your license to continue using the Particular Service Platform.");
                     break;
-                case LicenseStatus.InvalidDueExpiredUpgradeProtection:
+                case LicenseStatus.InvalidDueToExpiredUpgradeProtection:
                     logger.Error("Upgrade protection expired. Please extend your upgrade protection so that we can continue to provide you with support and new versions of the Particular Service Platform.");
                     break;
             }

--- a/src/NServiceBus.Core/Licensing/LicenseReminder.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseReminder.cs
@@ -18,7 +18,7 @@ namespace NServiceBus.Features
         {
             try
             {
-                var licenseManager = new LicenseManager(() => DateTime.UtcNow);
+                var licenseManager = new LicenseManager();
                 licenseManager.InitializeLicense(context.Settings.Get<string>(LicenseTextSettingsKey), context.Settings.Get<string>(LicenseFilePathSettingsKey));
 
                 if (!licenseManager.HasLicenseExpired)

--- a/src/NServiceBus.Core/Licensing/LicenseReminder.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseReminder.cs
@@ -18,7 +18,7 @@ namespace NServiceBus.Features
         {
             try
             {
-                var licenseManager = new LicenseManager();
+                var licenseManager = new LicenseManager(() => DateTime.UtcNow);
                 licenseManager.InitializeLicense(context.Settings.Get<string>(LicenseTextSettingsKey), context.Settings.Get<string>(LicenseFilePathSettingsKey));
 
                 if (!licenseManager.HasLicenseExpired)

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="SimpleJson" Version="0.38.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.4.1" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="2.0.1" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="2.0.2-has-expired0001" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.2.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="SimpleJson" Version="0.38.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="4.4.1" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="2.0.2-has-expired0001" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.2.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
log better messages when the license expired and start warning about expiring licenses a few days before the expiration date.