### PR TITLE
Add test to confirm recursive types can be built

### DIFF
--- a/src/NServiceBus.ContainerTests/When_building_components.cs
+++ b/src/NServiceBus.ContainerTests/When_building_components.cs
@@ -95,6 +95,16 @@ namespace NServiceBus.ContainerTests
             }
         }
 
+        [Test]
+        public void Resolving_recursive_types_does_not_stack_overflow()
+        {
+            using (var builder = TestContainerBuilder.ConstructBuilder())
+            {
+                InitializeBuilder(builder);
+                builder.Build(typeof(RecursiveComponent));
+            }
+        }
+
         void InitializeBuilder(IContainer container)
         {
             container.Configure(typeof(SingletonComponent), DependencyLifecycle.SingleInstance);
@@ -103,6 +113,12 @@ namespace NServiceBus.ContainerTests
             container.Configure(() => new SingletonLambdaComponent(), DependencyLifecycle.SingleInstance);
             container.Configure(() => new SingleCallLambdaComponent(), DependencyLifecycle.InstancePerCall);
             container.Configure(() => new LambdaComponentUoW(), DependencyLifecycle.InstancePerUnitOfWork);
+            container.Configure(() => new RecursiveComponent(), DependencyLifecycle.SingleInstance);
+        }
+
+        public class RecursiveComponent
+        {
+            public RecursiveComponent Instance { get; set; }
         }
 
         public class SingletonComponent


### PR DESCRIPTION
As a result of https://discuss.particular.net/t/system-outofmemoryexception-with-iconfigurecomponents-and-dp/856 it is clear that containers need to be able to build recursive types. This test makes sure that all containers will allow this behavior (Unity currently does not).