### PR TITLE
Guard against exceptions in Learning transport that can happen due to competing consumer starting

### DIFF
--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -101,27 +101,28 @@ namespace NServiceBus
         {
             var pendingDir = new DirectoryInfo(transactionDir);
 
-            //only need to move the incoming file
-            foreach (var file in pendingDir.EnumerateFiles(TxtFileExtension))
-            {
-                var destFileName = Path.Combine(basePath, file.Name);
-                try
-                {
-                    File.Move(file.FullName, destFileName);
-                }
-                catch (IOException e)
-                {
-                    log.Debug($"Unable to move pending transaction from '{file.FullName}' to '{destFileName}'. Pending transaction is assumed to be recovered by a competing consumer.", e);
-                }
-            }
-
             try
             {
+                //only need to move the incoming file
+                foreach (var file in pendingDir.EnumerateFiles(TxtFileExtension))
+                {
+                    var destFileName = Path.Combine(basePath, file.Name);
+                    try
+                    {
+                        File.Move(file.FullName, destFileName);
+                    }
+                    catch (IOException e)
+                    {
+                        log.Debug($"Unable to move pending transaction from '{file.FullName}' to '{destFileName}'. Pending transaction is assumed to be recovered by a competing consumer.", e);
+                    }
+                }
+
+
                 pendingDir.Delete(true);
             }
             catch (IOException e)
             {
-                log.Debug($"Unable to delete pending transaction directory '{pendingDir.FullName}'.", e);
+                log.Debug($"Unable to recover pedning transaction '{pendingDir.FullName}'.", e);
             }
         }
 

--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -104,10 +104,25 @@ namespace NServiceBus
             //only need to move the incoming file
             foreach (var file in pendingDir.EnumerateFiles(TxtFileExtension))
             {
-                File.Move(file.FullName, Path.Combine(basePath, file.Name));
+                var destFileName = Path.Combine(basePath, file.Name);
+                try
+                {
+                    File.Move(file.FullName, destFileName);
+                }
+                catch (IOException e)
+                {
+                    log.Debug($"Unable to move pending transaction from '{file.FullName}' to '{destFileName}'. Pending transaction is assumed to be recovered by a competing consumer.", e);
+                }
             }
 
-            pendingDir.Delete(true);
+            try
+            {
+                pendingDir.Delete(true);
+            }
+            catch (IOException e)
+            {
+                log.Debug($"Unable to delete pending transaction directory '{pendingDir.FullName}'.", e);
+            }
         }
 
         void RecoverCommitted()
@@ -118,10 +133,25 @@ namespace NServiceBus
             // but its good enough for now since duplicates is a possibility anyway
             foreach (var file in committedDir.EnumerateFiles(TxtFileExtension))
             {
-                File.Move(file.FullName, Path.Combine(basePath, file.Name));
+                var destFileName = Path.Combine(basePath, file.Name);
+                try
+                {
+                    File.Move(file.FullName, destFileName);
+                }
+                catch (IOException e)
+                {
+                    log.Debug($"Unable to move committed transaction from '{file.FullName}' to '{destFileName}'. Committed transaction is assumed to be recovered by a competing consumer.", e);
+                }
             }
 
-            committedDir.Delete(true);
+            try
+            {
+                committedDir.Delete(true);
+            }
+            catch (IOException e)
+            {
+                log.Debug($"Unable to delete committed transaction directory '{committedDir.FullName}'.", e);
+            }
         }
 
         string basePath;

--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -123,7 +123,7 @@ namespace NServiceBus
             }
             catch (Exception e)
             {
-                log.Debug($"Unable to recover pedning transaction '{pendingDir.FullName}'.", e);
+                log.Debug($"Unable to recover pending transaction '{pendingDir.FullName}'.", e);
             }
         }
 
@@ -131,28 +131,28 @@ namespace NServiceBus
         {
             var committedDir = new DirectoryInfo(commitDir);
 
-            //for now just rollback the completed ones as well. We could consider making this smarter in the future
-            // but its good enough for now since duplicates is a possibility anyway
-            foreach (var file in committedDir.EnumerateFiles(TxtFileExtension))
-            {
-                var destFileName = Path.Combine(basePath, file.Name);
-                try
-                {
-                    File.Move(file.FullName, destFileName);
-                }
-                catch (Exception e)
-                {
-                    log.Debug($"Unable to move committed transaction from '{file.FullName}' to '{destFileName}'. Committed transaction is assumed to be recovered by a competing consumer.", e);
-                }
-            }
-
             try
             {
+                //for now just rollback the completed ones as well. We could consider making this smarter in the future
+                // but its good enough for now since duplicates is a possibility anyway
+                foreach (var file in committedDir.EnumerateFiles(TxtFileExtension))
+                {
+                    var destFileName = Path.Combine(basePath, file.Name);
+                    try
+                    {
+                        File.Move(file.FullName, destFileName);
+                    }
+                    catch (Exception e)
+                    {
+                        log.Debug($"Unable to move committed transaction from '{file.FullName}' to '{destFileName}'. Committed transaction is assumed to be recovered by a competing consumer.", e);
+                    }
+                }
+
                 committedDir.Delete(true);
             }
             catch (Exception e)
             {
-                log.Debug($"Unable to delete committed transaction directory '{committedDir.FullName}'.", e);
+                log.Debug($"Unable to recover committed transaction '{committedDir.FullName}'.", e);
             }
         }
 

--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus
 {
+    using System;
     using System.Collections.Concurrent;
     using System.IO;
     using System.Threading.Tasks;
@@ -111,7 +112,7 @@ namespace NServiceBus
                     {
                         File.Move(file.FullName, destFileName);
                     }
-                    catch (IOException e)
+                    catch (Exception e)
                     {
                         log.Debug($"Unable to move pending transaction from '{file.FullName}' to '{destFileName}'. Pending transaction is assumed to be recovered by a competing consumer.", e);
                     }
@@ -120,7 +121,7 @@ namespace NServiceBus
 
                 pendingDir.Delete(true);
             }
-            catch (IOException e)
+            catch (Exception e)
             {
                 log.Debug($"Unable to recover pedning transaction '{pendingDir.FullName}'.", e);
             }
@@ -139,7 +140,7 @@ namespace NServiceBus
                 {
                     File.Move(file.FullName, destFileName);
                 }
-                catch (IOException e)
+                catch (Exception e)
                 {
                     log.Debug($"Unable to move committed transaction from '{file.FullName}' to '{destFileName}'. Committed transaction is assumed to be recovered by a competing consumer.", e);
                 }
@@ -149,7 +150,7 @@ namespace NServiceBus
             {
                 committedDir.Delete(true);
             }
-            catch (IOException e)
+            catch (Exception e)
             {
                 log.Debug($"Unable to delete committed transaction directory '{committedDir.FullName}'.", e);
             }

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -91,9 +91,18 @@
             }
             else
             {
-                if (Directory.Exists(pendingTransactionDir))
+                if (!Directory.Exists(pendingTransactionDir))
+                {
+                    return;
+                }
+
+                try
                 {
                     Directory.Delete(pendingTransactionDir, true);
+                }
+                catch (IOException e)
+                {
+                    log.Debug($"Unable to delete pending transaction directory '{pendingTransactionDir}'.", e);
                 }
             }
         }

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -210,6 +210,11 @@
             }
             finally
             {
+                if (log.IsDebugEnabled)
+                {
+                    log.Debug($"Completing processing for {filePath}({transaction.FileToProcess}).");
+                }
+
                 try
                 {
                     var wasCommitted = transaction.Complete();

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -100,7 +100,7 @@
                 {
                     Directory.Delete(pendingTransactionDir, true);
                 }
-                catch (IOException e)
+                catch (Exception e)
                 {
                     log.Debug($"Unable to delete pending transaction directory '{pendingTransactionDir}'.", e);
                 }


### PR DESCRIPTION
While migrating the monitoring demo to the learning transport we found that in some scenarios with competing consumers the endpoint might fail to start with the following exception

```
Unhandled Exception: System.IO.IOException: The process cannot access the file '432e0ce9-851b-46cb-b156-16d390325ff9.metadata.out' because it is being used by another process.
  at System.IO.Directory.DeleteHelper(String fullPath, String userPath, Boolean recursive, Boolean throwOnTopLevelDirectoryNotFound, WIN32_FIND_DATA& data)
  at System.IO.Directory.Delete(String fullPath, String userPath, Boolean recursive, Boolean checkHost)
  at NServiceBus.DirectoryBasedTransaction.RecoverPartiallyCompletedTransactions(String basePath, String pendingDirName, String committedDirName)
  at NServiceBus.LearningTransportMessagePump.Start(PushRuntimeSettings limitations)
  at NServiceBus.TransportReceiver.Start()
  at NServiceBus.ReceiveComponent.Start()
  at NServiceBus.StartableEndpoint.<Start>d__1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
  at NServiceBus.Endpoint.<Start>d__1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
  at Sales.Program.<Main>d__0.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
  at Sales.Program.<Main>(String[] args)
```

After doing short investigation it looks that `LearningTransport` does not consider competing consumers during start-up when it [cleans](https://github.com/Particular/NServiceBus/blob/develop/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs#L105) the unfinished transactions. What is probably happening is that he running endpoint has an opened transaction that is consider by new starting instance as unfished pending. In such case the new one tries to clean the transaction and delete message folder which fails as it is locked by other instance.

https://github.com/Particular/MonitoringDemo/pull/51#issuecomment-441996185