### PR TITLE
Enabling installers cause endpoints to fail during startup when the container used is immutable

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingContainer/AcceptanceTestingContainer.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingContainer/AcceptanceTestingContainer.cs
@@ -1,0 +1,78 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using ObjectBuilder.Common;
+
+    /// <summary>
+    /// Container that enforces registration immutability once the first instance has been resolved.
+    /// </summary>
+    public class AcceptanceTestingContainer : IContainer
+    {
+        public AcceptanceTestingContainer()
+        {
+            builder = new LightInjectObjectBuilder();
+        }
+
+        public void Dispose()
+        {
+            builder.Dispose();
+        }
+
+        public object Build(Type typeToBuild)
+        {
+            locked = true;
+            return builder.Build(typeToBuild);
+        }
+
+        public IContainer BuildChildContainer()
+        {
+            return builder.BuildChildContainer();
+        }
+
+        public IEnumerable<object> BuildAll(Type typeToBuild)
+        {
+            locked = true;
+            return builder.BuildAll(typeToBuild);
+        }
+
+        public void Configure(Type component, DependencyLifecycle dependencyLifecycle)
+        {
+            ThrowIfLocked();
+            builder.Configure(component, dependencyLifecycle);
+        }
+
+        public void Configure<T>(Func<T> component, DependencyLifecycle dependencyLifecycle)
+        {
+            ThrowIfLocked();
+            builder.Configure(component, dependencyLifecycle);
+        }
+
+        public void RegisterSingleton(Type lookupType, object instance)
+        {
+            ThrowIfLocked();
+            builder.RegisterSingleton(lookupType, instance);
+        }
+
+        public bool HasComponent(Type componentType)
+        {
+            return builder.HasComponent(componentType);
+        }
+
+        public void Release(object instance)
+        {
+            builder.Release(instance);
+        }
+
+        void ThrowIfLocked()
+        {
+            if (locked)
+            {
+                throw new InvalidOperationException("Can't register components after the container has been used to resolve instances");
+            }
+        }
+
+        LightInjectObjectBuilder builder;
+        bool locked;
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
@@ -30,6 +30,7 @@
             configuration.TypesToIncludeInScan(typesToInclude);
             configuration.EnableInstallers();
 
+            configuration.UseContainer(new AcceptanceTestingContainer());
             configuration.DisableFeature<TimeoutManager>();
 
             var recoverability = configuration.Recoverability();

--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -150,13 +150,12 @@ namespace NServiceBus
             IPipelineCache pipelineCache,
             EventAggregator eventAggregator)
         {
-            var mainPipeline = new Pipeline<ITransportReceiveContext>(builder, pipelineConfiguration.Modifications);
-            var mainPipelineExecutor = new MainPipelineExecutor(builder, eventAggregator, pipelineCache, mainPipeline);
             var errorQueue = settings.ErrorQueueAddress();
 
             var receiveComponent = new ReceiveComponent(receiveConfiguration,
                 receiveConfiguration != null ? transportInfrastructure.ConfigureReceiveInfrastructure() : null, //don't create the receive infrastructure for send-only endpoints
-                mainPipelineExecutor,
+                pipelineCache,
+                pipelineConfiguration,
                 eventAggregator,
                 builder,
                 criticalError,

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -6,13 +6,15 @@ namespace NServiceBus
     using System.Threading.Tasks;
     using Logging;
     using ObjectBuilder;
+    using Pipeline;
     using Transport;
 
     class ReceiveComponent
     {
         public ReceiveComponent(ReceiveConfiguration configuration,
             TransportReceiveInfrastructure receiveInfrastructure,
-            IPipelineExecutor mainPipelineExecutor,
+            IPipelineCache pipelineCache,
+            PipelineConfiguration pipelineConfiguration,
             IEventAggregator eventAggregator,
             IBuilder builder,
             CriticalError criticalError,
@@ -20,7 +22,8 @@ namespace NServiceBus
         {
             this.configuration = configuration;
             this.receiveInfrastructure = receiveInfrastructure;
-            this.mainPipelineExecutor = mainPipelineExecutor;
+            this.pipelineCache = pipelineCache;
+            this.pipelineConfiguration = pipelineConfiguration;
             this.eventAggregator = eventAggregator;
             this.builder = builder;
             this.criticalError = criticalError;
@@ -53,6 +56,9 @@ namespace NServiceBus
             {
                 return;
             }
+
+            var mainPipeline = new Pipeline<ITransportReceiveContext>(builder, pipelineConfiguration.Modifications);
+            mainPipelineExecutor = new MainPipelineExecutor(builder, eventAggregator, pipelineCache, mainPipeline);
 
             if (configuration.PurgeOnStartup)
             {
@@ -169,6 +175,8 @@ namespace NServiceBus
         ReceiveConfiguration configuration;
         List<TransportReceiver> receivers = new List<TransportReceiver>();
         TransportReceiveInfrastructure receiveInfrastructure;
+        IPipelineCache pipelineCache;
+        PipelineConfiguration pipelineConfiguration;
         IPipelineExecutor mainPipelineExecutor;
         IEventAggregator eventAggregator;
         IBuilder builder;


### PR DESCRIPTION
## Who's affected
Users configuring a container that is immutable after first resolve like Spring.net and SimpleInjector.

## Symptoms
Endpoint fails to start with an exception that container registrations can't be altered after first resolve.

## Details

Backport of https://github.com/Particular/NServiceBus/pull/5304