### PR TITLE
Learning transport throws exceptions when there are competing consumers

### DIFF
--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus
 {
+    using System;
     using System.Collections.Concurrent;
     using System.IO;
     using System.Threading.Tasks;
@@ -113,7 +114,7 @@ namespace NServiceBus
                     {
                         File.Move(file.FullName, destFileName);
                     }
-                    catch (IOException e)
+                    catch (Exception e)
                     {
                         log.Debug($"Unable to move pending transaction from '{file.FullName}' to '{destFileName}'. Pending transaction is assumed to be recovered by a competing consumer.", e);
                     }
@@ -122,7 +123,7 @@ namespace NServiceBus
 
                 pendingDir.Delete(true);
             }
-            catch (IOException e)
+            catch (Exception e)
             {
                 log.Debug($"Unable to recover pedning transaction '{pendingDir.FullName}'.", e);
             }
@@ -141,7 +142,7 @@ namespace NServiceBus
                 {
                     File.Move(file.FullName, destFileName);
                 }
-                catch (IOException e)
+                catch (Exception e)
                 {
                     log.Debug($"Unable to move committed transaction from '{file.FullName}' to '{destFileName}'. Committed transaction is assumed to be recovered by a competing consumer.", e);
                 }
@@ -151,7 +152,7 @@ namespace NServiceBus
             {
                 committedDir.Delete(true);
             }
-            catch (IOException e)
+            catch (Exception e)
             {
                 log.Debug($"Unable to delete committed transaction directory '{committedDir.FullName}'.", e);
             }

--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -106,10 +106,25 @@ namespace NServiceBus
             //only need to move the incoming file
             foreach (var file in pendingDir.EnumerateFiles(TxtFileExtension))
             {
-                File.Move(file.FullName, Path.Combine(basePath, file.Name));
+                var destFileName = Path.Combine(basePath, file.Name);
+                try
+                {
+                    File.Move(file.FullName, destFileName);
+                }
+                catch (IOException e)
+                {
+                    log.Debug($"Unable to move pending transaction from '{file.FullName}' to '{destFileName}'. Pending transaction is assumed to be recovered by a competing consumer.", e);
+                }
             }
 
-            pendingDir.Delete(true);
+            try
+            {
+                pendingDir.Delete(true);
+            }
+            catch (IOException e)
+            {
+                log.Debug($"Unable to delete pending transaction directory '{pendingDir.FullName}'.", e);
+            }
         }
 
         void RecoverCommitted()
@@ -120,10 +135,25 @@ namespace NServiceBus
             // but its good enough for now since duplicates is a possibility anyway
             foreach (var file in committedDir.EnumerateFiles(TxtFileExtension))
             {
-                File.Move(file.FullName, Path.Combine(basePath, file.Name));
+                var destFileName = Path.Combine(basePath, file.Name);
+                try
+                {
+                    File.Move(file.FullName, destFileName);
+                }
+                catch (IOException e)
+                {
+                    log.Debug($"Unable to move committed transaction from '{file.FullName}' to '{destFileName}'. Committed transaction is assumed to be recovered by a competing consumer.", e);
+                }
             }
 
-            committedDir.Delete(true);
+            try
+            {
+                committedDir.Delete(true);
+            }
+            catch (IOException e)
+            {
+                log.Debug($"Unable to delete committed transaction directory '{committedDir.FullName}'.", e);
+            }
         }
 
         string basePath;

--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -125,7 +125,7 @@ namespace NServiceBus
             }
             catch (Exception e)
             {
-                log.Debug($"Unable to recover pedning transaction '{pendingDir.FullName}'.", e);
+                log.Debug($"Unable to recover pending transaction '{pendingDir.FullName}'.", e);
             }
         }
 
@@ -133,28 +133,28 @@ namespace NServiceBus
         {
             var committedDir = new DirectoryInfo(commitDir);
 
-            //for now just rollback the completed ones as well. We could consider making this smarter in the future
-            // but its good enough for now since duplicates is a possibility anyway
-            foreach (var file in committedDir.EnumerateFiles(TxtFileExtension))
-            {
-                var destFileName = Path.Combine(basePath, file.Name);
-                try
-                {
-                    File.Move(file.FullName, destFileName);
-                }
-                catch (Exception e)
-                {
-                    log.Debug($"Unable to move committed transaction from '{file.FullName}' to '{destFileName}'. Committed transaction is assumed to be recovered by a competing consumer.", e);
-                }
-            }
-
             try
             {
+                //for now just rollback the completed ones as well. We could consider making this smarter in the future
+                // but its good enough for now since duplicates is a possibility anyway
+                foreach (var file in committedDir.EnumerateFiles(TxtFileExtension))
+                {
+                    var destFileName = Path.Combine(basePath, file.Name);
+                    try
+                    {
+                        File.Move(file.FullName, destFileName);
+                    }
+                    catch (Exception e)
+                    {
+                        log.Debug($"Unable to move committed transaction from '{file.FullName}' to '{destFileName}'. Committed transaction is assumed to be recovered by a competing consumer.", e);
+                    }
+                }
+
                 committedDir.Delete(true);
             }
             catch (Exception e)
             {
-                log.Debug($"Unable to delete committed transaction directory '{committedDir.FullName}'.", e);
+                log.Debug($"Unable to recover committed transaction '{committedDir.FullName}'.", e);
             }
         }
 

--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -103,27 +103,28 @@ namespace NServiceBus
         {
             var pendingDir = new DirectoryInfo(transactionDir);
 
-            //only need to move the incoming file
-            foreach (var file in pendingDir.EnumerateFiles(TxtFileExtension))
-            {
-                var destFileName = Path.Combine(basePath, file.Name);
-                try
-                {
-                    File.Move(file.FullName, destFileName);
-                }
-                catch (IOException e)
-                {
-                    log.Debug($"Unable to move pending transaction from '{file.FullName}' to '{destFileName}'. Pending transaction is assumed to be recovered by a competing consumer.", e);
-                }
-            }
-
             try
             {
+                //only need to move the incoming file
+                foreach (var file in pendingDir.EnumerateFiles(TxtFileExtension))
+                {
+                    var destFileName = Path.Combine(basePath, file.Name);
+                    try
+                    {
+                        File.Move(file.FullName, destFileName);
+                    }
+                    catch (IOException e)
+                    {
+                        log.Debug($"Unable to move pending transaction from '{file.FullName}' to '{destFileName}'. Pending transaction is assumed to be recovered by a competing consumer.", e);
+                    }
+                }
+
+
                 pendingDir.Delete(true);
             }
             catch (IOException e)
             {
-                log.Debug($"Unable to delete pending transaction directory '{pendingDir.FullName}'.", e);
+                log.Debug($"Unable to recover pedning transaction '{pendingDir.FullName}'.", e);
             }
         }
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -91,9 +91,18 @@
             }
             else
             {
-                if (Directory.Exists(pendingTransactionDir))
+                if (!Directory.Exists(pendingTransactionDir))
+                {
+                    return;
+                }
+
+                try
                 {
                     Directory.Delete(pendingTransactionDir, true);
+                }
+                catch (IOException e)
+                {
+                    log.Debug($"Unable to delete pending transaction directory '{pendingTransactionDir}'.", e);
                 }
             }
         }

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -210,6 +210,11 @@
             }
             finally
             {
+                if (log.IsDebugEnabled)
+                {
+                    log.Debug($"Completing processing for {filePath}({transaction.FileToProcess}).");
+                }
+
                 try
                 {
                     var wasCommitted = transaction.Complete();

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -100,7 +100,7 @@
                 {
                     Directory.Delete(pendingTransactionDir, true);
                 }
-                catch (IOException e)
+                catch (Exception e)
                 {
                     log.Debug($"Unable to delete pending transaction directory '{pendingTransactionDir}'.", e);
                 }


### PR DESCRIPTION
While working on https://github.com/Particular/MonitoringDemo/pull/51 to let the monitoring demo run on the learning transport, several problems were encountered:

- https://github.com/Particular/NServiceBus/pull/5299#issue-233877697
- https://github.com/Particular/NServiceBus/pull/5299#issuecomment-442411526
- https://github.com/Particular/NServiceBus/pull/5299#issuecomment-444073957

This PR fixes these problems by guarding against the exceptions that can be thrown.
It also prevents a critical error from being raised for a case that can actually be recovered from instead.