### PR TITLE
Update development tooling

### DIFF
--- a/packaging/nuget/nservicebus.acceptancetests.nuspec
+++ b/packaging/nuget/nservicebus.acceptancetests.nuspec
@@ -17,7 +17,7 @@
     <dependencies>
       <dependency id="NServiceBus" version="$version$" />
       <dependency id="NServiceBus.AcceptanceTesting" version="$version$" />
-      <dependency id="NUnit" version="[3.6.1, 4.0.0)" />
+      <dependency id="NUnit" version="[3.11.0, 4.0.0)" />
     </dependencies>
   <frameworkAssemblies>
     <frameworkAssembly assemblyName="Microsoft.CSharp" targetFramework="net452" />

--- a/packaging/nuget/nservicebus.containertests.nuspec
+++ b/packaging/nuget/nservicebus.containertests.nuspec
@@ -16,7 +16,7 @@
     <tags>nservicebus servicebus msmq cqrs publish subscribe</tags>
     <dependencies>
       <dependency id="NServiceBus" version="$version$" />
-  	  <dependency id="NUnit" version="[3.6.1, 4.0.0)" />
+  	  <dependency id="NUnit" version="[3.11.0, 4.0.0)" />
     </dependencies>
   </metadata>
   <files>

--- a/packaging/nuget/nservicebus.transporttests.nuspec
+++ b/packaging/nuget/nservicebus.transporttests.nuspec
@@ -16,7 +16,7 @@
     <tags>$tags$</tags>
     <dependencies>
       <dependency id="NServiceBus" version="$version$" />
-      <dependency id="NUnit" version="[3.6.1, 4.0.0)" />
+      <dependency id="NUnit" version="[3.11.0, 4.0.0)" />
     </dependencies>
   <frameworkAssemblies>
     <frameworkAssembly assemblyName="System.Transactions" targetFramework="net452" />

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <Import Project="..\packages\Particular.CodeRules.0.2.0\build\Particular.CodeRules.props" Condition="Exists('..\packages\Particular.CodeRules.0.2.0\build\Particular.CodeRules.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -43,8 +45,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -390,6 +392,8 @@
     <Error Condition="!Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets'))" />
     <Error Condition="!Exists('..\packages\Particular.CodeRules.0.2.0\build\Particular.CodeRules.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Particular.CodeRules.0.2.0\build\Particular.CodeRules.props'))" />
     <Error Condition="!Exists('..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.11.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
   <Import Project="..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" />
   <Import Project="..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets" Condition="Exists('..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets')" />

--- a/src/NServiceBus.AcceptanceTests/packages.config
+++ b/src/NServiceBus.AcceptanceTests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="GitVersionTask" version="3.6.5" targetFramework="net452" developmentDependency="true" />
   <package id="NuGetPackager" version="0.6.5" targetFramework="net452" developmentDependency="true" />
-  <package id="NUnit" version="3.6.1" targetFramework="net452" />
+  <package id="NUnit" version="3.11.0" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="3.12.0" targetFramework="net452" />
   <package id="Particular.CodeRules" version="0.2.0" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
+++ b/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -40,8 +42,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -76,6 +78,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets'))" />
     <Error Condition="!Exists('..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.11.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
   <Import Project="..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" />
   <Import Project="..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets" Condition="Exists('..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets')" />

--- a/src/NServiceBus.ContainerTests/packages.config
+++ b/src/NServiceBus.ContainerTests/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="GitVersionTask" version="3.6.5" targetFramework="net452" developmentDependency="true" />
   <package id="NuGetPackager" version="0.6.5" targetFramework="net452" developmentDependency="true" />
-  <package id="NUnit" version="3.6.1" targetFramework="net452" />
+  <package id="NUnit" version="3.11.0" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="3.12.0" targetFramework="net452" />
 </packages>

--- a/src/NServiceBus.Core.Tests.x86/NServiceBus.Core.x86.Tests.csproj
+++ b/src/NServiceBus.Core.Tests.x86/NServiceBus.Core.x86.Tests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -13,6 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,8 +43,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -70,4 +74,11 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.11.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
 </Project>

--- a/src/NServiceBus.Core.Tests.x86/packages.config
+++ b/src/NServiceBus.Core.Tests.x86/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.6.1" targetFramework="net452" />
+  <package id="NUnit" version="3.11.0" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="3.12.0" targetFramework="net452" />
 </packages>

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.cs
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.cs
@@ -1,7 +1,5 @@
 ﻿namespace NServiceBus.Core.Tests.API
 {
-    using System;
-    using System.Linq;
     using System.Runtime.CompilerServices;
     using NUnit.Framework;
     using PublicApiGenerator;
@@ -13,20 +11,8 @@
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void ApproveNServiceBus()
         {
-            var publicApi = Filter(ApiGenerator.GeneratePublicApi(typeof(Endpoint).Assembly));
+            var publicApi = ApiGenerator.GeneratePublicApi(typeof(Endpoint).Assembly);
             TestApprover.Verify(publicApi);
         }
-
-        string Filter(string text)
-        {
-            return string.Join(Environment.NewLine, text.Split(new[]
-            {
-                Environment.NewLine
-            }, StringSplitOptions.RemoveEmptyEntries)
-                .Where(l => !l.StartsWith("[assembly: ReleaseDateAttribute("))
-                .Where(l => !string.IsNullOrWhiteSpace(l))
-                );
-        }
-
     }
 }

--- a/src/NServiceBus.Core.Tests/App.config
+++ b/src/NServiceBus.Core.Tests/App.config
@@ -36,7 +36,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="nunit.framework" publicKeyToken="2638cd05610744eb" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.6.1.0" newVersion="3.6.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.11.0.0" newVersion="3.11.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/NServiceBus.Core.Tests/App_Packages/PublicApiGenerator.8.0.1/ApiGenerator.cs
+++ b/src/NServiceBus.Core.Tests/App_Packages/PublicApiGenerator.8.0.1/ApiGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.CodeDom;
 using System.CodeDom.Compiler;
 using System.Collections.Generic;
@@ -19,32 +19,55 @@ namespace PublicApiGenerator
 {
     public static class ApiGenerator
     {
-        public static string GeneratePublicApi(Assembly assemby, Type[] includeTypes = null, bool shouldIncludeAssemblyAttributes = true)
+        static readonly string[] defaultWhitelistedNamespacePrefixes = new string[0];
+
+        public static string GeneratePublicApi(Assembly assembly, Type[] includeTypes = null, bool shouldIncludeAssemblyAttributes = true, string[] whitelistedNamespacePrefixes = null, string[] excludeAttributes = null)
         {
-            var assemblyResolver = new DefaultAssemblyResolver();
-            var assemblyPath = assemby.Location;
-            assemblyResolver.AddSearchDirectory(Path.GetDirectoryName(assemblyPath));
+            var attributesToExclude = excludeAttributes == null
+                ? SkipAttributeNames
+                : new HashSet<string>(excludeAttributes.Union(SkipAttributeNames));
 
-            var readSymbols = File.Exists(Path.ChangeExtension(assemblyPath, ".pdb"));
-            var asm = AssemblyDefinition.ReadAssembly(assemblyPath, new ReaderParameters(ReadingMode.Deferred)
+            using (var assemblyResolver = new DefaultAssemblyResolver())
             {
-                ReadSymbols = readSymbols,
-                AssemblyResolver = assemblyResolver,
-            });
+                var assemblyPath = assembly.Location;
+                assemblyResolver.AddSearchDirectory(Path.GetDirectoryName(assemblyPath));
+                assemblyResolver.AddSearchDirectory(AppDomain.CurrentDomain.BaseDirectory);
 
-            return CreatePublicApiForAssembly(asm, tr => includeTypes == null || includeTypes.Any(t => t.FullName == tr.FullName && t.Assembly.FullName == tr.Module.Assembly.FullName), shouldIncludeAssemblyAttributes);
+                var readSymbols = File.Exists(Path.ChangeExtension(assemblyPath, ".pdb"));
+                using (var asm = AssemblyDefinition.ReadAssembly(assemblyPath, new ReaderParameters(ReadingMode.Deferred)
+                {
+                    ReadSymbols = readSymbols,
+                    AssemblyResolver = assemblyResolver
+                }))
+                {
+                    var publicApiForAssembly = CreatePublicApiForAssembly(asm, tr => includeTypes == null || includeTypes.Any(t => t.FullName == tr.FullName && t.Assembly.FullName == tr.Module.Assembly.FullName),
+                        shouldIncludeAssemblyAttributes, whitelistedNamespacePrefixes ?? defaultWhitelistedNamespacePrefixes, attributesToExclude);
+                    return RemoveUnnecessaryWhiteSpace(publicApiForAssembly);
+                }
+            }
+        }
+
+        static string RemoveUnnecessaryWhiteSpace(string publicApi)
+        {
+            return string.Join(Environment.NewLine, publicApi.Split(new[]
+                {
+                    Environment.NewLine
+                }, StringSplitOptions.RemoveEmptyEntries)
+                .Where(l => !string.IsNullOrWhiteSpace(l))
+            );
         }
 
         // TODO: Assembly references?
         // TODO: Better handle namespaces - using statements? - requires non-qualified type names
-        static string CreatePublicApiForAssembly(AssemblyDefinition assembly, Func<TypeDefinition, bool> shouldIncludeType, bool shouldIncludeAssemblyAttributes)
+        static string CreatePublicApiForAssembly(AssemblyDefinition assembly, Func<TypeDefinition, bool> shouldIncludeType, bool shouldIncludeAssemblyAttributes, string[] whitelistedNamespacePrefixes, HashSet<string> excludeAttributes)
         {
             var publicApiBuilder = new StringBuilder();
             var cgo = new CodeGeneratorOptions
             {
                 BracingStyle = "C",
                 BlankLinesBetweenMembers = false,
-                VerbatimOrder = false
+                VerbatimOrder = false,
+                IndentString = "    "
             };
 
             using (var provider = new CSharpCodeProvider())
@@ -52,7 +75,7 @@ namespace PublicApiGenerator
                 var compileUnit = new CodeCompileUnit();
                 if (shouldIncludeAssemblyAttributes && assembly.HasCustomAttributes)
                 {
-                    PopulateCustomAttributes(assembly, compileUnit.AssemblyCustomAttributes);
+                    PopulateCustomAttributes(assembly, compileUnit.AssemblyCustomAttributes, excludeAttributes);
                 }
 
                 var publicTypes = assembly.Modules.SelectMany(m => m.GetTypes())
@@ -68,7 +91,7 @@ namespace PublicApiGenerator
                         compileUnit.Namespaces.Add(@namespace);
                     }
 
-                    var typeDeclaration = CreateTypeDeclaration(publicType);
+                    var typeDeclaration = CreateTypeDeclaration(publicType, whitelistedNamespacePrefixes, excludeAttributes);
                     @namespace.Types.Add(typeDeclaration);
                 }
 
@@ -97,9 +120,9 @@ namespace PublicApiGenerator
             return (t.IsPublic || t.IsNestedPublic || t.IsNestedFamily) && !IsCompilerGenerated(t);
         }
 
-        static bool ShouldIncludeMember(IMemberDefinition m)
+        static bool ShouldIncludeMember(IMemberDefinition m, string[] whitelistedNamespacePrefixes)
         {
-            return !IsCompilerGenerated(m) && !IsDotNetTypeMember(m) && !(m is FieldDefinition);
+            return !IsCompilerGenerated(m) && !IsDotNetTypeMember(m, whitelistedNamespacePrefixes) && !(m is FieldDefinition);
         }
 
         static bool IsCompilerGenerated(IMemberDefinition m)
@@ -107,34 +130,38 @@ namespace PublicApiGenerator
             return m.CustomAttributes.Any(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.CompilerGeneratedAttribute");
         }
 
-        static bool IsDotNetTypeMember(IMemberDefinition m)
+        static bool IsDotNetTypeMember(IMemberDefinition m, string[] whitelistedNamespacePrefixes)
         {
-            if (m.DeclaringType == null || m.DeclaringType.FullName == null)
+            if (m.DeclaringType?.FullName == null)
                 return false;
-            return m.DeclaringType.FullName.StartsWith("System") || m.DeclaringType.FullName.StartsWith("Microsoft");
+
+            return (m.DeclaringType.FullName.StartsWith("System") || m.DeclaringType.FullName.StartsWith("Microsoft"))
+                && !whitelistedNamespacePrefixes.Any(prefix => m.DeclaringType.FullName.StartsWith(prefix));
         }
 
-        static void AddMemberToTypeDeclaration(CodeTypeDeclaration typeDeclaration, IMemberDefinition memberInfo)
+        static void AddMemberToTypeDeclaration(CodeTypeDeclaration typeDeclaration,
+            IMemberDefinition memberInfo,
+            HashSet<string> excludeAttributes)
         {
             var methodDefinition = memberInfo as MethodDefinition;
             if (methodDefinition != null)
             {
                 if (methodDefinition.IsConstructor)
-                    AddCtorToTypeDeclaration(typeDeclaration, methodDefinition);
+                    AddCtorToTypeDeclaration(typeDeclaration, methodDefinition, excludeAttributes);
                 else
-                    AddMethodToTypeDeclaration(typeDeclaration, methodDefinition);
+                    AddMethodToTypeDeclaration(typeDeclaration, methodDefinition, excludeAttributes);
             }
             else if (memberInfo is PropertyDefinition)
             {
-                AddPropertyToTypeDeclaration(typeDeclaration, (PropertyDefinition) memberInfo);
+                AddPropertyToTypeDeclaration(typeDeclaration, (PropertyDefinition) memberInfo, excludeAttributes);
             }
             else if (memberInfo is EventDefinition)
             {
-                typeDeclaration.Members.Add(GenerateEvent((EventDefinition)memberInfo));
+                typeDeclaration.Members.Add(GenerateEvent((EventDefinition)memberInfo, excludeAttributes));
             }
             else if (memberInfo is FieldDefinition)
             {
-                AddFieldToTypeDeclaration(typeDeclaration, (FieldDefinition) memberInfo);
+                AddFieldToTypeDeclaration(typeDeclaration, (FieldDefinition) memberInfo, excludeAttributes);
             }
         }
 
@@ -161,12 +188,12 @@ namespace PublicApiGenerator
             return gennedClass;
         }
 
-        static CodeTypeDeclaration CreateTypeDeclaration(TypeDefinition publicType)
+        static CodeTypeDeclaration CreateTypeDeclaration(TypeDefinition publicType, string[] whitelistedNamespacePrefixes, HashSet<string> excludeAttributes)
         {
             if (IsDelegate(publicType))
-                return CreateDelegateDeclaration(publicType);
+                return CreateDelegateDeclaration(publicType, excludeAttributes);
 
-            bool @static = false;
+            var @static = false;
             TypeAttributes attributes = 0;
             if (publicType.IsPublic || publicType.IsNestedPublic)
                 attributes |= TypeAttributes.Public;
@@ -188,7 +215,7 @@ namespace PublicApiGenerator
                 name = name.Substring(0, index);
             var declaration = new CodeTypeDeclaration(@static ? "static " + name : name)
             {
-                CustomAttributes = CreateCustomAttributes(publicType),
+                CustomAttributes = CreateCustomAttributes(publicType, excludeAttributes),
                 // TypeAttributes must be specified before the IsXXX as they manipulate TypeAttributes!
                 TypeAttributes = attributes,
                 IsClass = publicType.IsClass,
@@ -213,32 +240,32 @@ namespace PublicApiGenerator
                 else
                     declaration.BaseTypes.Add(CreateCodeTypeReference(publicType.BaseType));
             }
-            foreach(var @interface in publicType.Interfaces.OrderBy(i => i.FullName)
-                .Select(t => new { Reference = t, Definition = t.Resolve() })
+            foreach(var @interface in publicType.Interfaces.OrderBy(i => i.InterfaceType.FullName)
+                .Select(t => new { Reference = t, Definition = t.InterfaceType.Resolve() })
                 .Where(t => ShouldIncludeType(t.Definition))
                 .Select(t => t.Reference))
-                declaration.BaseTypes.Add(CreateCodeTypeReference(@interface));
+                declaration.BaseTypes.Add(CreateCodeTypeReference(@interface.InterfaceType));
 
-            foreach (var memberInfo in publicType.GetMembers().Where(ShouldIncludeMember).OrderBy(m => m.Name))
-                AddMemberToTypeDeclaration(declaration, memberInfo);
+            foreach (var memberInfo in publicType.GetMembers().Where(memberDefinition => ShouldIncludeMember(memberDefinition, whitelistedNamespacePrefixes)).OrderBy(m => m.Name))
+                AddMemberToTypeDeclaration(declaration, memberInfo, excludeAttributes);
 
             // Fields should be in defined order for an enum
             var fields = !publicType.IsEnum
                 ? publicType.Fields.OrderBy(f => f.Name)
                 : (IEnumerable<FieldDefinition>)publicType.Fields;
             foreach (var field in fields)
-                AddMemberToTypeDeclaration(declaration, field);
+                AddMemberToTypeDeclaration(declaration, field, excludeAttributes);
 
             foreach (var nestedType in publicType.NestedTypes.Where(ShouldIncludeType).OrderBy(t => t.FullName))
             {
-                var nestedTypeDeclaration = CreateTypeDeclaration(nestedType);
+                var nestedTypeDeclaration = CreateTypeDeclaration(nestedType, whitelistedNamespacePrefixes, excludeAttributes);
                 declaration.Members.Add(nestedTypeDeclaration);
             }
 
             return declaration;
         }
 
-        static CodeTypeDeclaration CreateDelegateDeclaration(TypeDefinition publicType)
+        static CodeTypeDeclaration CreateDelegateDeclaration(TypeDefinition publicType, HashSet<string> excludeAttributes)
         {
             var invokeMethod = publicType.Methods.Single(m => m.Name == "Invoke");
             var name = publicType.Name;
@@ -248,14 +275,14 @@ namespace PublicApiGenerator
             var declaration = new CodeTypeDelegate(name)
             {
                 Attributes = MemberAttributes.Public,
-                CustomAttributes = CreateCustomAttributes(publicType),
+                CustomAttributes = CreateCustomAttributes(publicType, excludeAttributes),
                 ReturnType = CreateCodeTypeReference(invokeMethod.ReturnType),
             };
 
             // CodeDOM. No support. Return type attributes.
-            PopulateCustomAttributes(invokeMethod.MethodReturnType, declaration.CustomAttributes, type => ModifyCodeTypeReference(type, "return:"));
+            PopulateCustomAttributes(invokeMethod.MethodReturnType, declaration.CustomAttributes, type => ModifyCodeTypeReference(type, "return:"), excludeAttributes);
             PopulateGenericParameters(publicType, declaration.TypeParameters);
-            PopulateMethodParameters(invokeMethod, declaration.Parameters);
+            PopulateMethodParameters(invokeMethod, declaration.Parameters, excludeAttributes);
 
             // Of course, CodeDOM doesn't support generic type parameters for delegates. Of course.
             if (declaration.TypeParameters.Count > 0)
@@ -305,23 +332,27 @@ namespace PublicApiGenerator
             }
         }
 
-        static CodeAttributeDeclarationCollection CreateCustomAttributes(ICustomAttributeProvider type)
+        static CodeAttributeDeclarationCollection CreateCustomAttributes(ICustomAttributeProvider type,
+            HashSet<string> excludeAttributes)
         {
             var attributes = new CodeAttributeDeclarationCollection();
-            PopulateCustomAttributes(type, attributes);
+            PopulateCustomAttributes(type, attributes, excludeAttributes);
             return attributes;
         }
 
         static void PopulateCustomAttributes(ICustomAttributeProvider type,
-            CodeAttributeDeclarationCollection attributes)
+            CodeAttributeDeclarationCollection attributes,
+            HashSet<string> excludeAttributes)
         {
-            PopulateCustomAttributes(type, attributes, ctr => ctr);
+            PopulateCustomAttributes(type, attributes, ctr => ctr, excludeAttributes);
         }
 
         static void PopulateCustomAttributes(ICustomAttributeProvider type,
-            CodeAttributeDeclarationCollection attributes, Func<CodeTypeReference, CodeTypeReference> codeTypeModifier)
+            CodeAttributeDeclarationCollection attributes,
+            Func<CodeTypeReference, CodeTypeReference> codeTypeModifier,
+            HashSet<string> excludeAttributes)
         {
-            foreach (var customAttribute in type.CustomAttributes.Where(ShouldIncludeAttribute).OrderBy(a => a.AttributeType.FullName).ThenBy(a => ConvertAttrbuteToCode(codeTypeModifier, a)))
+            foreach (var customAttribute in type.CustomAttributes.Where(t => ShouldIncludeAttribute(t, excludeAttributes)).OrderBy(a => a.AttributeType.FullName).ThenBy(a => ConvertAttributeToCode(codeTypeModifier, a)))
             {
                 var attribute = GenerateCodeAttributeDeclaration(codeTypeModifier, customAttribute);
                 attributes.Add(attribute);
@@ -347,7 +378,7 @@ namespace PublicApiGenerator
         }
 
         // Litee: This method is used for additional sorting of custom attributes when multiple values are allowed
-        static object ConvertAttrbuteToCode(Func<CodeTypeReference, CodeTypeReference> codeTypeModifier, CustomAttribute customAttribute)
+        static object ConvertAttributeToCode(Func<CodeTypeReference, CodeTypeReference> codeTypeModifier, CustomAttribute customAttribute)
         {
             using (var provider = new CSharpCodeProvider())
             {
@@ -379,6 +410,7 @@ namespace PublicApiGenerator
             "System.Runtime.CompilerServices.CompilationRelaxationsAttribute",
             "System.Runtime.CompilerServices.ExtensionAttribute",
             "System.Runtime.CompilerServices.RuntimeCompatibilityAttribute",
+            "System.Runtime.CompilerServices.IteratorStateMachineAttribute",
             "System.Reflection.DefaultMemberAttribute",
             "System.Diagnostics.DebuggableAttribute",
             "System.Diagnostics.DebuggerNonUserCodeAttribute",
@@ -394,10 +426,10 @@ namespace PublicApiGenerator
             "System.Reflection.AssemblyTrademarkAttribute"
         };
 
-        static bool ShouldIncludeAttribute(CustomAttribute attribute)
+        static bool ShouldIncludeAttribute(CustomAttribute attribute, HashSet<string> excludeAttributes)
         {
             var attributeTypeDefinition = attribute.AttributeType.Resolve();
-            return !SkipAttributeNames.Contains(attribute.AttributeType.FullName) && attributeTypeDefinition.IsPublic;
+            return attributeTypeDefinition != null && !excludeAttributes.Contains(attribute.AttributeType.FullName) && attributeTypeDefinition.IsPublic;
         }
 
         static CodeExpression CreateInitialiserExpression(CustomAttributeArgument attributeArgument)
@@ -462,39 +494,74 @@ namespace PublicApiGenerator
             return new CodePrimitiveExpression(value);
         }
 
-        static void AddCtorToTypeDeclaration(CodeTypeDeclaration typeDeclaration, MethodDefinition member)
+        static void AddCtorToTypeDeclaration(CodeTypeDeclaration typeDeclaration, MethodDefinition member, HashSet<string> excludeAttributes)
         {
             if (member.IsAssembly || member.IsPrivate)
                 return;
 
             var method = new CodeConstructor
             {
-                CustomAttributes = CreateCustomAttributes(member),
+                CustomAttributes = CreateCustomAttributes(member, excludeAttributes),
                 Name = member.Name,
                 Attributes = GetMethodAttributes(member)
             };
-            PopulateMethodParameters(member, method.Parameters);
+            PopulateMethodParameters(member, method.Parameters, excludeAttributes);
 
             typeDeclaration.Members.Add(method);
         }
 
-        static void AddMethodToTypeDeclaration(CodeTypeDeclaration typeDeclaration, MethodDefinition member)
+        static readonly IDictionary<string, string> OperatorNameMap = new Dictionary<string, string>
         {
-            if (member.IsAssembly || member.IsPrivate || member.IsSpecialName)
-                return;
+            { "op_Addition", "+" },
+            { "op_UnaryPlus", "+" },
+            { "op_Subtraction", "-" },
+            { "op_UnaryNegation", "-" },
+            { "op_Multiply", "*" },
+            { "op_Division", "/" },
+            { "op_Modulus", "%" },
+            { "op_Increment", "++" },
+            { "op_Decrement", "--" },
+            { "op_OnesComplement", "~" },
+            { "op_LogicalNot", "!" },
+            { "op_BitwiseAnd", "&" },
+            { "op_BitwiseOr", "|" },
+            { "op_ExclusiveOr", "^" },
+            { "op_LeftShift", "<<" },
+            { "op_RightShift", ">>" },
+            { "op_Equality", "==" },
+            { "op_Inequality", "!=" },
+            { "op_GreaterThan", ">" },
+            { "op_GreaterThanOrEqual", ">=" },
+            { "op_LessThan", "<" },
+            { "op_LessThanOrEqual", "<=" }
+        };
+
+        static void AddMethodToTypeDeclaration(CodeTypeDeclaration typeDeclaration, MethodDefinition member, HashSet<string> excludeAttributes)
+        {
+            if (member.IsAssembly || member.IsPrivate) return;
+
+            if (member.IsSpecialName && !member.Name.StartsWith("op_")) return;
+
+            var memberName = member.Name;
+            // ReSharper disable once InlineOutVariableDeclaration
+            string mappedMemberName;
+            if (OperatorNameMap.TryGetValue(memberName, out mappedMemberName))
+            {
+                memberName = mappedMemberName;
+            }
 
             var returnType = CreateCodeTypeReference(member.ReturnType);
 
             var method = new CodeMemberMethod
             {
-                Name = member.Name,
+                Name = memberName,
                 Attributes = GetMethodAttributes(member),
-                CustomAttributes = CreateCustomAttributes(member),
+                CustomAttributes = CreateCustomAttributes(member, excludeAttributes),
                 ReturnType = returnType,
             };
-            PopulateCustomAttributes(member.MethodReturnType, method.ReturnTypeCustomAttributes);
+            PopulateCustomAttributes(member.MethodReturnType, method.ReturnTypeCustomAttributes, excludeAttributes);
             PopulateGenericParameters(member, method.TypeParameters);
-            PopulateMethodParameters(member, method.Parameters, IsExtensionMethod(member));
+            PopulateMethodParameters(member, method.Parameters, excludeAttributes, IsExtensionMethod(member));
 
             typeDeclaration.Members.Add(method);
         }
@@ -505,7 +572,9 @@ namespace PublicApiGenerator
         }
 
         static void PopulateMethodParameters(IMethodSignature member,
-            CodeParameterDeclarationExpressionCollection parameters, bool isExtension = false)
+            CodeParameterDeclarationExpressionCollection parameters,
+            HashSet<string> excludeAttributes,
+            bool isExtension = false)
         {
             foreach (var parameter in member.Parameters)
             {
@@ -533,7 +602,7 @@ namespace PublicApiGenerator
                 var expression = new CodeParameterDeclarationExpression(type, name)
                 {
                     Direction = direction,
-                    CustomAttributes = CreateCustomAttributes(parameter)
+                    CustomAttributes = CreateCustomAttributes(parameter, excludeAttributes)
                 };
                 parameters.Add(expression);
             }
@@ -584,7 +653,7 @@ namespace PublicApiGenerator
             if (typeDefinition.IsInterface)
             {
                 var interfaceMethods = from @interfaceReference in typeDefinition.Interfaces
-                    let interfaceDefinition = @interfaceReference.Resolve()
+                    let interfaceDefinition = @interfaceReference.InterfaceType.Resolve()
                     where interfaceDefinition != null
                     select interfaceDefinition.Methods;
 
@@ -609,7 +678,7 @@ namespace PublicApiGenerator
             }
         }
 
-        static void AddPropertyToTypeDeclaration(CodeTypeDeclaration typeDeclaration, PropertyDefinition member)
+        static void AddPropertyToTypeDeclaration(CodeTypeDeclaration typeDeclaration, PropertyDefinition member, HashSet<string> excludeAttributes)
         {
             var getterAttributes = member.GetMethod != null ? GetMethodAttributes(member.GetMethod) : 0;
             var setterAttributes = member.SetMethod != null ? GetMethodAttributes(member.SetMethod) : 0;
@@ -628,7 +697,7 @@ namespace PublicApiGenerator
                 Name = member.Name,
                 Type = propertyType,
                 Attributes = propertyAttributes,
-                CustomAttributes = CreateCustomAttributes(member),
+                CustomAttributes = CreateCustomAttributes(member, excludeAttributes),
                 HasGet = member.GetMethod != null && HasVisiblePropertyMethod(getterAttributes),
                 HasSet = member.SetMethod != null && HasVisiblePropertyMethod(setterAttributes)
             };
@@ -637,11 +706,11 @@ namespace PublicApiGenerator
             // attributes on getters or setters
             if (member.GetMethod != null && member.GetMethod.HasCustomAttributes)
             {
-                PopulateCustomAttributes(member.GetMethod, property.CustomAttributes, type => ModifyCodeTypeReference(type, "get:"));
+                PopulateCustomAttributes(member.GetMethod, property.CustomAttributes, type => ModifyCodeTypeReference(type, "get:"), excludeAttributes);
             }
             if (member.SetMethod != null && member.SetMethod.HasCustomAttributes)
             {
-                PopulateCustomAttributes(member.SetMethod, property.CustomAttributes, type => ModifyCodeTypeReference(type, "set:"));
+                PopulateCustomAttributes(member.SetMethod, property.CustomAttributes, type => ModifyCodeTypeReference(type, "set:"), excludeAttributes);
             }
 
             foreach (var parameter in member.Parameters)
@@ -695,20 +764,20 @@ namespace PublicApiGenerator
                    access == MemberAttributes.FamilyOrAssembly;
         }
 
-        static CodeTypeMember GenerateEvent(EventDefinition eventDefinition)
+        static CodeTypeMember GenerateEvent(EventDefinition eventDefinition, HashSet<string> excludeAttributes)
         {
             var @event = new CodeMemberEvent
             {
                 Name = eventDefinition.Name,
                 Attributes = MemberAttributes.Public | MemberAttributes.Final,
-                CustomAttributes = CreateCustomAttributes(eventDefinition),
+                CustomAttributes = CreateCustomAttributes(eventDefinition, excludeAttributes),
                 Type = CreateCodeTypeReference(eventDefinition.EventType)
             };
 
             return @event;
         }
 
-        static void AddFieldToTypeDeclaration(CodeTypeDeclaration typeDeclaration, FieldDefinition memberInfo)
+        static void AddFieldToTypeDeclaration(CodeTypeDeclaration typeDeclaration, FieldDefinition memberInfo, HashSet<string> excludeAttributes)
         {
             if (memberInfo.IsPrivate || memberInfo.IsAssembly || memberInfo.IsSpecialName)
                 return;
@@ -730,7 +799,7 @@ namespace PublicApiGenerator
             var field = new CodeMemberField(codeTypeReference, memberInfo.Name)
             {
                 Attributes = attributes,
-                CustomAttributes = CreateCustomAttributes(memberInfo)
+                CustomAttributes = CreateCustomAttributes(memberInfo, excludeAttributes)
             };
 
             if (memberInfo.HasConstant)

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -847,6 +847,8 @@ namespace NServiceBus
         public static NServiceBus.LogicalAddress CreateRemoteAddress(NServiceBus.Routing.EndpointInstance endpointInstance) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
+        public static bool ==(NServiceBus.LogicalAddress left, NServiceBus.LogicalAddress right) { }
+        public static bool !=(NServiceBus.LogicalAddress left, NServiceBus.LogicalAddress right) { }
         public override string ToString() { }
     }
     public class MessageDeserializationException : System.Runtime.Serialization.SerializationException
@@ -1399,6 +1401,8 @@ namespace NServiceBus
             "removed in version 8.0.0.", false)]
         public string Value { get; set; }
         public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public static string op_Implicit(NServiceBus.WireEncryptedString s) { }
+        public static NServiceBus.WireEncryptedString op_Implicit(string s) { }
     }
     public class static XmlSerializationExtensions
     {
@@ -2799,6 +2803,8 @@ namespace NServiceBus.Routing
         public System.Collections.Generic.IReadOnlyDictionary<string, string> Properties { get; }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
+        public static bool ==(NServiceBus.Routing.EndpointInstance left, NServiceBus.Routing.EndpointInstance right) { }
+        public static bool !=(NServiceBus.Routing.EndpointInstance left, NServiceBus.Routing.EndpointInstance right) { }
         public NServiceBus.Routing.EndpointInstance SetProperty(string key, string value) { }
         public override string ToString() { }
     }
@@ -3770,6 +3776,8 @@ namespace NServiceBus.Unicast.Subscriptions
         public bool Equals(NServiceBus.Unicast.Subscriptions.MessageType other) { }
         public override bool Equals(object obj) { }
         public override int GetHashCode() { }
+        public static bool ==(NServiceBus.Unicast.Subscriptions.MessageType left, NServiceBus.Unicast.Subscriptions.MessageType right) { }
+        public static bool !=(NServiceBus.Unicast.Subscriptions.MessageType left, NServiceBus.Unicast.Subscriptions.MessageType right) { }
         public override string ToString() { }
     }
     [System.ObsoleteAttribute("No longer used, safe to remove. Will be removed in version 7.0.0.", true)]

--- a/src/NServiceBus.Core.Tests/ArgumentExceptionTests.cs
+++ b/src/NServiceBus.Core.Tests/ArgumentExceptionTests.cs
@@ -136,16 +136,20 @@
 
         static void WriteMethod(MethodDefinition method, TextWriter writer)
         {
-            writer.WriteLine($"\r\n{method.DeclaringType.Name}.{method.Name}");
+            writer.WriteLine($"{Environment.NewLine}{method.DeclaringType.Name}.{method.Name}");
+
+            var mapping = method.DebugInformation.GetSequencePointMapping();
+
             var instruction = method.Body.Instructions.FirstOrDefault(x =>
             {
-                return x.SequencePoint != null &&
+                return mapping.TryGetValue(x, out var sequencePoint) &&
                        // ignore hidden sequence points
-                       x.SequencePoint.StartLine != 0xfeefee;
+                       sequencePoint.StartLine != 0xfeefee;
             });
+
             if (instruction != null)
             {
-                var point = instruction.SequencePoint;
+                var point = mapping[instruction];
                 writer.WriteLine($"{point.Document.Url.Replace(@"\", "/")}:{point.StartLine}");
             }
         }

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScannerTests.cs
@@ -70,7 +70,7 @@
         {
             var circularDirectory = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestDlls\circular");
             var classLibB = Path.Combine(circularDirectory, "ClassLibraryB.dll");
-          
+
             // Put ClassLibraryB.dll in CurrentDomain.BaseDirectory so it resolves correctly
             var tempClassLibB = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ClassLibraryB.dll");
 
@@ -421,10 +421,15 @@ class InterfaceMessageHandler : IHandleMessages<IBaseEvent>
 
                 if (fakeIdentity)
                 {
-                    var reader = AssemblyDefinition.ReadAssembly(FilePath);
-                    reader.Name.Name = nameWithoutExtension;
-                    reader.MainModule.Name = nameWithoutExtension;
-                    reader.Write(FilePath);
+                    using (var assemblyDefinition = AssemblyDefinition.ReadAssembly(FilePath, new ReaderParameters
+                    {
+                        ReadWrite = true
+                    }))
+                    {
+                        assemblyDefinition.Name.Name = nameWithoutExtension;
+                        assemblyDefinition.MainModule.Name = nameWithoutExtension;
+                        assemblyDefinition.Write();
+                    }
                 }
 
                 Assembly = result.CompiledAssembly;

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqExtensionsTests.cs
@@ -13,7 +13,7 @@
         string path;
         MessageQueue queue;
 
-        [TestFixtureSetUp]
+        [OneTimeSetUp]
         public void Setup()
         {
             var queueName = "permissionsTest";
@@ -24,7 +24,7 @@
             queue = new MessageQueue(path);
         }
 
-        [TestFixtureTearDown]
+        [OneTimeTearDown]
         public void Teardown()
         {
             queue.Dispose();

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -15,7 +17,8 @@
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
-    <NuGetPackageImportStamp>27189a06</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -76,11 +79,11 @@
     <Reference Include="NuDoq">
       <HintPath>..\packages\NuDoq.1.2.5\lib\net35\NuDoq.dll</HintPath>
     </Reference>
-    <Reference Include="NUnit.ApplicationDomain, Version=10.0.0.0, Culture=neutral, PublicKeyToken=afbd8211e0c40e2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.ApplicationDomain.10.2.0\lib\net40\NUnit.ApplicationDomain.dll</HintPath>
+    <Reference Include="NUnit.ApplicationDomain, Version=11.0.0.0, Culture=neutral, PublicKeyToken=afbd8211e0c40e2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.ApplicationDomain.11.1.0\lib\net40\NUnit.ApplicationDomain.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -420,4 +423,11 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.11.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
 </Project>

--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -60,21 +60,17 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Mono.Cecil, Version=0.10.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.1\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Mdb, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.10.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.1\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Pdb, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.10.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.1\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil.Rocks, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\packages\Mono.Cecil.0.9.6.4\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.10.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.1\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
     <Reference Include="NuDoq">
       <HintPath>..\packages\NuDoq.1.2.5\lib\net35\NuDoq.dll</HintPath>
@@ -103,7 +99,7 @@
   <ItemGroup>
     <Compile Include="API\APIApprovals.cs" />
     <Compile Include="ApprovalTestConfig.cs" />
-    <Compile Include="App_Packages\PublicApiGenerator.6.0.0\ApiGenerator.cs" />
+    <Compile Include="App_Packages\PublicApiGenerator.8.0.1\ApiGenerator.cs" />
     <Compile Include="AssemblyScanner\AssemblyScannerTests.cs" />
     <Compile Include="AssemblyScanner\When_checking_image_type.cs" />
     <Compile Include="AssemblyScanner\When_directory_with_no_reference_dlls_is_scanned.cs" />

--- a/src/NServiceBus.Core.Tests/Persistence/PersistenceExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/PersistenceExtensionsTests.cs
@@ -13,7 +13,7 @@
         {
             // ReSharper disable once ObjectCreationAsStatement
             var ex = Assert.Throws<Exception>(() => new PersistenceExtensions(typeof(PartialPersistence), new SettingsHolder(), typeof(StorageType.Timeouts)));
-            Assert.That(ex.Message, Is.StringStarting("PartialPersistence does not support storage type Timeouts."));
+            Assert.That(ex.Message, Does.StartWith("PartialPersistence does not support storage type Timeouts."));
         }
 
         public class PartialPersistence : PersistenceDefinition

--- a/src/NServiceBus.Core.Tests/packages.config
+++ b/src/NServiceBus.Core.Tests/packages.config
@@ -4,7 +4,8 @@
   <package id="ApprovalUtilities" version="3.0.13" targetFramework="net452" />
   <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net452" />
   <package id="NuDoq" version="1.2.5" targetFramework="net45" />
-  <package id="NUnit" version="3.6.1" targetFramework="net452" />
-  <package id="NUnit.ApplicationDomain" version="10.2.0" targetFramework="net452" />
+  <package id="NUnit" version="3.11.0" targetFramework="net452" />
+  <package id="NUnit.ApplicationDomain" version="11.1.0" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="3.12.0" targetFramework="net452" />
   <package id="PublicApiGenerator" version="6.0.0" targetFramework="net452" />
 </packages>

--- a/src/NServiceBus.Core.Tests/packages.config
+++ b/src/NServiceBus.Core.Tests/packages.config
@@ -2,10 +2,10 @@
 <packages>
   <package id="ApprovalTests" version="3.0.13" targetFramework="net452" />
   <package id="ApprovalUtilities" version="3.0.13" targetFramework="net452" />
-  <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net452" />
+  <package id="Mono.Cecil" version="0.10.1" targetFramework="net452" />
   <package id="NuDoq" version="1.2.5" targetFramework="net45" />
   <package id="NUnit" version="3.11.0" targetFramework="net452" />
   <package id="NUnit.ApplicationDomain" version="11.1.0" targetFramework="net452" />
   <package id="NUnit3TestAdapter" version="3.12.0" targetFramework="net452" />
-  <package id="PublicApiGenerator" version="6.0.0" targetFramework="net452" />
+  <package id="PublicApiGenerator" version="8.0.1" targetFramework="net452" />
 </packages>

--- a/src/NServiceBus.Msmq.AcceptanceTests/NServiceBus.Msmq.AcceptanceTests.csproj
+++ b/src/NServiceBus.Msmq.AcceptanceTests/NServiceBus.Msmq.AcceptanceTests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -11,6 +13,8 @@
     <AssemblyName>NServiceBus.Msmq.AcceptanceTests</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,8 +36,8 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -116,6 +120,13 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.11.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/NServiceBus.Msmq.AcceptanceTests/packages.config
+++ b/src/NServiceBus.Msmq.AcceptanceTests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit" version="3.6.1" targetFramework="net46" />
+  <package id="NUnit" version="3.11.0" targetFramework="net46" />
+  <package id="NUnit3TestAdapter" version="3.12.0" targetFramework="net46" />
 </packages>

--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props')" />
+  <Import Project="..\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -33,8 +35,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -85,6 +87,8 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets'))" />
     <Error Condition="!Exists('..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets'))" />
+    <Error Condition="!Exists('..\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.11.0\build\NUnit.props'))" />
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.12.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
   <Import Project="..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" />
   <Import Project="..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets" Condition="Exists('..\packages\NuGetPackager.0.6.5\build\NuGetPackager.targets')" />

--- a/src/NServiceBus.TransportTests/packages.config
+++ b/src/NServiceBus.TransportTests/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="GitVersionTask" version="3.6.5" targetFramework="net452" developmentDependency="true" />
   <package id="NuGetPackager" version="0.6.5" targetFramework="net452" developmentDependency="true" />
-  <package id="NUnit" version="3.6.1" targetFramework="net452" />
+  <package id="NUnit" version="3.11.0" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="3.12.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
This updates development tooling on the `support-6.4` branch.

This doesn't switch to Particular.Approvals because it has a Json.NET 12 dependency, which conflicts with the 8.0 dependency in core in this branch. However, this branch is using the `TestApprover` predecessor of Particular.Approvals, so that is good enough to allow approval tests to work on TeamCity properly.

Note: It is okay for this to be squashed.