### PR TITLE
add UnrecoverableException

### DIFF
--- a/src/NServiceBus.Core/Recoverability/Recoverability.cs
+++ b/src/NServiceBus.Core/Recoverability/Recoverability.cs
@@ -29,6 +29,7 @@
                 settings.SetDefault(NumberOfImmediateRetries, 5);
                 settings.SetDefault(FaultHeaderCustomization, new Action<Dictionary<string, string>>(headers => { }));
                 settings.AddUnrecoverableException(typeof(MessageDeserializationException));
+                settings.AddUnrecoverableException(typeof(UnrecoverableException));
             });
         }
 

--- a/src/NServiceBus.Core/Recoverability/UnrecoverableException.cs
+++ b/src/NServiceBus.Core/Recoverability/UnrecoverableException.cs
@@ -1,0 +1,33 @@
+namespace NServiceBus
+{
+    using System;
+
+    /// <summary>
+    /// Used to throw an exception cannot be handled by recoverability.
+    /// Added by default to <see cref="RecoverabilitySettings.AddUnrecoverableException"/>.
+    /// </summary>
+    [Serializable]
+    public class UnrecoverableException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="UnrecoverableException" />.
+        /// </summary>
+        public UnrecoverableException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="UnrecoverableException" />.
+        /// </summary>
+        public UnrecoverableException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="UnrecoverableException" />.
+        /// </summary>
+        public UnrecoverableException(string message, Exception inner) : base(message, inner)
+        {
+        }
+    }
+}


### PR DESCRIPTION
In several projects now i have had scenarios where a case is hit that cannot be handled by retries. In each of these the exception type is usually irrelevant, it is the message that usually is important. So in each of these projects i have had to add a custom `UnrecoverableException` and add it to `AddUnrecoverableException`. It would be nice if this was supported OOTB by NSB