### PR TITLE
Implement discard action for recoverability policy

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -754,7 +754,6 @@ namespace NServiceBus
     {
         protected internal RecoverabilityAction() { }
         public static NServiceBus.DelayedRetry DelayedRetry(System.TimeSpan timeSpan) { }
-        public static NServiceBus.Discard Discard() { }
         public static NServiceBus.Discard Discard(string reason) { }
         public static NServiceBus.ImmediateRetry ImmediateRetry() { }
         public static NServiceBus.MoveToError MoveToError(string errorQueue) { }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -256,6 +256,10 @@ namespace NServiceBus
         public static void CustomDiagnosticsWriter(this NServiceBus.EndpointConfiguration config, System.Func<string, System.Threading.Tasks.Task> customDiagnosticsWriter) { }
         public static void SetDiagnosticsPath(this NServiceBus.EndpointConfiguration config, string path) { }
     }
+    public sealed class Discard : NServiceBus.RecoverabilityAction
+    {
+        public string Reason { get; }
+    }
     public class DistributionPolicy : NServiceBus.IDistributionPolicy
     {
         public DistributionPolicy() { }
@@ -750,6 +754,7 @@ namespace NServiceBus
     {
         protected internal RecoverabilityAction() { }
         public static NServiceBus.DelayedRetry DelayedRetry(System.TimeSpan timeSpan) { }
+        public static NServiceBus.Discard Discard(string reason = null) { }
         public static NServiceBus.ImmediateRetry ImmediateRetry() { }
         public static NServiceBus.MoveToError MoveToError(string errorQueue) { }
     }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -754,7 +754,8 @@ namespace NServiceBus
     {
         protected internal RecoverabilityAction() { }
         public static NServiceBus.DelayedRetry DelayedRetry(System.TimeSpan timeSpan) { }
-        public static NServiceBus.Discard Discard(string reason = null) { }
+        public static NServiceBus.Discard Discard() { }
+        public static NServiceBus.Discard Discard(string reason) { }
         public static NServiceBus.ImmediateRetry ImmediateRetry() { }
         public static NServiceBus.MoveToError MoveToError(string errorQueue) { }
     }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -754,7 +754,6 @@ namespace NServiceBus
     {
         protected internal RecoverabilityAction() { }
         public static NServiceBus.DelayedRetry DelayedRetry(System.TimeSpan timeSpan) { }
-        public static NServiceBus.Discard Discard() { }
         public static NServiceBus.Discard Discard(string reason) { }
         public static NServiceBus.ImmediateRetry ImmediateRetry() { }
         public static NServiceBus.MoveToError MoveToError(string errorQueue) { }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -256,6 +256,10 @@ namespace NServiceBus
         public static void CustomDiagnosticsWriter(this NServiceBus.EndpointConfiguration config, System.Func<string, System.Threading.Tasks.Task> customDiagnosticsWriter) { }
         public static void SetDiagnosticsPath(this NServiceBus.EndpointConfiguration config, string path) { }
     }
+    public sealed class Discard : NServiceBus.RecoverabilityAction
+    {
+        public string Reason { get; }
+    }
     public class DistributionPolicy : NServiceBus.IDistributionPolicy
     {
         public DistributionPolicy() { }
@@ -750,6 +754,7 @@ namespace NServiceBus
     {
         protected internal RecoverabilityAction() { }
         public static NServiceBus.DelayedRetry DelayedRetry(System.TimeSpan timeSpan) { }
+        public static NServiceBus.Discard Discard(string reason = null) { }
         public static NServiceBus.ImmediateRetry ImmediateRetry() { }
         public static NServiceBus.MoveToError MoveToError(string errorQueue) { }
     }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -754,7 +754,8 @@ namespace NServiceBus
     {
         protected internal RecoverabilityAction() { }
         public static NServiceBus.DelayedRetry DelayedRetry(System.TimeSpan timeSpan) { }
-        public static NServiceBus.Discard Discard(string reason = null) { }
+        public static NServiceBus.Discard Discard() { }
+        public static NServiceBus.Discard Discard(string reason) { }
         public static NServiceBus.ImmediateRetry ImmediateRetry() { }
         public static NServiceBus.MoveToError MoveToError(string errorQueue) { }
     }

--- a/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
@@ -135,7 +135,7 @@
         public async Task When_discard_action_returned_should_discard_message()
         {
             var recoverabilityExecutor = CreateExecutor(
-                RetryPolicy.Discard());
+                RetryPolicy.Discard("not needed anymore"));
             var errorContext = CreateErrorContext(messageId: "message-id");
 
             var result = await recoverabilityExecutor.Invoke(errorContext);
@@ -232,11 +232,11 @@
                 }).Invoke;
             }
             
-            public static Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> Discard()
+            public static Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> Discard(string reason)
             {
                 return new RetryPolicy(new[]
                 {
-                    new Discard(), 
+                    new Discard(reason), 
                 }).Invoke;
             }
 

--- a/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
@@ -130,7 +130,21 @@
             Assert.AreEqual(1, eventAggregator.NotificationsRaised.Count);
             Assert.AreEqual("message-id", failure.Message.MessageId);
         }
+        
+        [Test]
+        public async Task When_discard_action_returned_should_discard_message()
+        {
+            var recoverabilityExecutor = CreateExecutor(
+                RetryPolicy.Discard());
+            var errorContext = CreateErrorContext(messageId: "message-id");
 
+            var result = await recoverabilityExecutor.Invoke(errorContext);
+
+            Assert.AreEqual(ErrorHandleResult.Handled, result);
+            Assert.AreEqual(0, eventAggregator.NotificationsRaised.Count);
+        }
+
+        [Test]
         public async Task When_moving_to_custom_error_queue_custom_error_queue_address_should_be_set_on_notification()
         {
             var customErrorQueueAddress = "custom-error-queue";
@@ -215,6 +229,14 @@
                 return new RetryPolicy(new[]
                 {
                     new UnsupportedAction()
+                }).Invoke;
+            }
+            
+            public static Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> Discard()
+            {
+                return new RetryPolicy(new[]
+                {
+                    new Discard(), 
                 }).Invoke;
             }
 

--- a/src/NServiceBus.Core/Recoverability/Discard.cs
+++ b/src/NServiceBus.Core/Recoverability/Discard.cs
@@ -1,0 +1,18 @@
+namespace NServiceBus
+{
+    /// <summary>
+    /// Indicates recoverability is required to discard/ignore the current message.
+    /// </summary>
+    public sealed class Discard : RecoverabilityAction
+    {
+        internal Discard(string reason = null)
+        {
+            Reason = reason;
+        }
+
+        /// <summary>
+        /// The reason why a message was discarded.
+        /// </summary>
+        public string Reason { get; }
+    }
+}

--- a/src/NServiceBus.Core/Recoverability/Discard.cs
+++ b/src/NServiceBus.Core/Recoverability/Discard.cs
@@ -5,7 +5,7 @@ namespace NServiceBus
     /// </summary>
     public sealed class Discard : RecoverabilityAction
     {
-        internal Discard(string reason = null)
+        internal Discard(string reason)
         {
             Reason = reason;
         }

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityAction.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityAction.cs
@@ -45,7 +45,17 @@ namespace NServiceBus
             Guard.AgainstNullAndEmpty(nameof(errorQueue), errorQueue);
             return new MoveToError(errorQueue);
         }
+        
+        /// <summary>
+        /// Creates a discard recoverability action.
+        /// </summary>
+        /// <returns>Discard action.</returns>
+        public static Discard Discard(string reason = null)
+        {
+            return string.IsNullOrEmpty(reason) ? CachedDiscard : new Discard(reason);
+        }
 
         static ImmediateRetry CachedImmediateRetry = new ImmediateRetry();
+        static Discard CachedDiscard = new Discard();
     }
 }

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityAction.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityAction.cs
@@ -50,7 +50,14 @@ namespace NServiceBus
         /// Creates a discard recoverability action.
         /// </summary>
         /// <returns>Discard action.</returns>
-        public static Discard Discard(string reason = null)
+        public static Discard Discard() => Discard(null);
+        
+        /// <summary>
+        /// Creates a discard recoverability action.
+        /// </summary>
+        /// <param name="reason">The reason why the message was discarded</param>
+        /// <returns>Discard action.</returns>
+        public static Discard Discard(string reason)
         {
             return string.IsNullOrEmpty(reason) ? CachedDiscard : new Discard(reason);
         }

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityAction.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityAction.cs
@@ -53,6 +53,7 @@ namespace NServiceBus
         /// <returns>Discard action.</returns>
         public static Discard Discard(string reason)
         {
+            Guard.AgainstNullAndEmpty(nameof(reason), reason);
             return new Discard(reason);
         }
 

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityAction.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityAction.cs
@@ -55,7 +55,7 @@ namespace NServiceBus
         /// <summary>
         /// Creates a discard recoverability action.
         /// </summary>
-        /// <param name="reason">The reason why the message was discarded</param>
+        /// <param name="reason">The reason why the message was discarded.</param>
         /// <returns>Discard action.</returns>
         public static Discard Discard(string reason)
         {

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityAction.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityAction.cs
@@ -45,13 +45,7 @@ namespace NServiceBus
             Guard.AgainstNullAndEmpty(nameof(errorQueue), errorQueue);
             return new MoveToError(errorQueue);
         }
-        
-        /// <summary>
-        /// Creates a discard recoverability action.
-        /// </summary>
-        /// <returns>Discard action.</returns>
-        public static Discard Discard() => Discard(null);
-        
+
         /// <summary>
         /// Creates a discard recoverability action.
         /// </summary>
@@ -59,10 +53,9 @@ namespace NServiceBus
         /// <returns>Discard action.</returns>
         public static Discard Discard(string reason)
         {
-            return string.IsNullOrEmpty(reason) ? CachedDiscard : new Discard(reason);
+            return new Discard(reason);
         }
 
         static ImmediateRetry CachedImmediateRetry = new ImmediateRetry();
-        static Discard CachedDiscard = new Discard();
     }
 }

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
@@ -24,6 +24,12 @@
         {
             var recoveryAction = recoverabilityPolicy(configuration, errorContext);
 
+            if (recoveryAction is Discard discard)
+            {
+                Logger.Info($"Message with id '{errorContext.Message.MessageId}' discarded.{(string.IsNullOrEmpty(discard.Reason) ? string.Empty : $" Reason: {discard.Reason}")}", errorContext.Exception);
+                return HandledTask;
+            }
+
             // When we can't do immediate retries and policy did not honor MaxNumberOfRetries for ImmediateRetries
             if (recoveryAction is ImmediateRetry && !immediateRetriesAvailable)
             {
@@ -119,6 +125,7 @@
         bool immediateRetriesAvailable;
         bool delayedRetriesAvailable;
 
+        static Task<ErrorHandleResult> HandledTask = Task.FromResult(ErrorHandleResult.Handled);
         static ILog Logger = LogManager.GetLogger<RecoverabilityExecutor>();
         RecoverabilityConfig configuration;
     }

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
@@ -26,7 +26,7 @@
 
             if (recoveryAction is Discard discard)
             {
-                Logger.Info($"Message with id '{errorContext.Message.MessageId}' discarded.{(string.IsNullOrEmpty(discard.Reason) ? string.Empty : $" Reason: {discard.Reason}")}", errorContext.Exception);
+                Logger.Info($"Discarding message with id '{errorContext.Message.MessageId}'. (string.IsNullOrEmpty(discard.Reason) ? string.Empty : $" Reason: {discard.Reason}")}", errorContext.Exception);
                 return HandledTask;
             }
 

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
@@ -26,7 +26,7 @@
 
             if (recoveryAction is Discard discard)
             {
-                Logger.Info($"Discarding message with id '{errorContext.Message.MessageId}'. (string.IsNullOrEmpty(discard.Reason) ? string.Empty : $" Reason: {discard.Reason}")}", errorContext.Exception);
+                Logger.Info($"Discarding message with id '{errorContext.Message.MessageId}'.{(string.IsNullOrEmpty(discard.Reason) ? string.Empty : $" Reason: {discard.Reason}")}", errorContext.Exception);
                 return HandledTask;
             }
 

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
@@ -26,7 +26,7 @@
 
             if (recoveryAction is Discard discard)
             {
-                Logger.Info($"Discarding message with id '{errorContext.Message.MessageId}'.{(string.IsNullOrEmpty(discard.Reason) ? string.Empty : $" Reason: {discard.Reason}")}", errorContext.Exception);
+                Logger.Info($"Discarding message with id '{errorContext.Message.MessageId}'. Reason: {discard.Reason}", errorContext.Exception);
                 return HandledTask;
             }
 


### PR DESCRIPTION
On a live chat today a user had the following requirement

They have certain types of messages that they want to retry a few times and after they failed a certain number of times they want to ignore/discard the message. We first started exploring whether it is possible to implement this scenario with the recoverability policy but found out it is not possible. 

Trying to implement that with behaviors in the pipeline becomes really cumbersome because you are essentially faced with reimplementing parts of the recoverability seam inside behaviors. Especially the counting of how many times a message has failed can become very brittle.

This demonstrates that a discard action in the recoverability seam would be easy to add in a non-breaking way and could provide good benefit to some of our customers.

There is a workaround that we came up with for the customer. You can currently implement a `MoveToError` action and move it to a queue that exists (but not the error queue) and then have a no-op handler on that queue or from time to time purge that queue. But that requires you to deploy an additional endpoint that listens on that queue or have a dedicated purge this queue job that runs from time to time (plus obviously the unnecessary additional infrastructure resources that are required). 