### PR TITLE
Copy headers because they are exposed on the scenario context which lives longer than the endpoint

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/FailTestOnErrorMessageFeature.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/FailTestOnErrorMessageFeature.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using Faults;
@@ -28,12 +29,12 @@
                     context.Settings.EndpointName(),
                     new[]
                     {
-                        new FailedMessage(m.Message.MessageId, m.Message.Headers, m.Message.Body, m.Exception, m.ErrorQueue)
+                        new FailedMessage(m.Message.MessageId, new Dictionary<string, string>(m.Message.Headers), m.Message.Body, m.Exception, m.ErrorQueue)
                     },
                     (i, failed) =>
                     {
                         var result = failed.ToList();
-                        result.Add(new FailedMessage(m.Message.MessageId, m.Message.Headers, m.Message.Body, m.Exception, m.ErrorQueue));
+                        result.Add(new FailedMessage(m.Message.MessageId, new Dictionary<string, string>(m.Message.Headers), m.Message.Body, m.Exception, m.ErrorQueue));
                         return result;
                     });
 

--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_reusing_sendoptions_with_delay.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/TimeoutManager/When_reusing_sendoptions_with_delay.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -60,7 +61,7 @@
 
                 public Task Handle(DelayedMessage message, IMessageHandlerContext context)
                 {
-                    testContext.IncomingMessageHeaders.Add(context.MessageHeaders);
+                    testContext.IncomingMessageHeaders.Add(context.MessageHeaders.ToDictionary(x => x.Key, x => x.Value));
                     return Task.FromResult(0);
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_message_is_audited.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
@@ -72,7 +73,7 @@
 
                 public Task Handle(MessageToBeAudited message, IMessageHandlerContext context)
                 {
-                    testContext.Headers = context.MessageHeaders;
+                    testContext.Headers = context.MessageHeaders.ToDictionary(x => x.Key, x => x.Value);
                     testContext.IsMessageHandledByTheAuditEndpoint = true;
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_message_is_faulted.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_message_is_faulted.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
@@ -120,7 +121,7 @@
                 public Task Handle(MessageThatFails message, IMessageHandlerContext context)
                 {
                     testContext.TimeSentOnTheFailingMessageWhenItWasHandled = DateTimeExtensions.ToUtcDateTime(context.MessageHeaders[Headers.TimeSent]);
-                    testContext.FaultHeaders = context.MessageHeaders;
+                    testContext.FaultHeaders = context.MessageHeaders.ToDictionary(x => x.Key, x => x.Value);
                     testContext.IsMessageHandledByTheFaultEndpoint = true;
 
                     return Task.FromResult(0);

--- a/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_sending_ensure_proper_headers.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_sending_ensure_proper_headers.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
@@ -68,7 +69,7 @@
                     return Task.FromResult(0);
                 }
 
-                TestContext.ReceivedHeaders = context.MessageHeaders;
+                TestContext.ReceivedHeaders = context.MessageHeaders.ToDictionary(x => x.Key, x => x.Value);
                 TestContext.WasCalled = true;
 
                 return Task.FromResult(0);

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_message_is_moved_to_error_queue_with_header_customizations.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_message_is_moved_to_error_queue_with_header_customizations.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.AcceptanceTests.Core.Recoverability
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
@@ -80,7 +81,7 @@ namespace NServiceBus.AcceptanceTests.Core.Recoverability
                 {
                     if (initiatingMessage.Id == TestContext.TestRunId)
                     {
-                        TestContext.Headers = context.MessageHeaders;
+                        TestContext.Headers = context.MessageHeaders.ToDictionary(x => x.Key, x => x.Value);
                         TestContext.MessageMovedToErrorQueue = true;
                     }
 

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_using_special_characters_in_headers.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_using_special_characters_in_headers.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -69,7 +70,7 @@
 
                 public Task Handle(DelayedMessage message, IMessageHandlerContext context)
                 {
-                    testContext.ReceivedMessageHeaders = context.MessageHeaders;
+                    testContext.ReceivedMessageHeaders = context.MessageHeaders.ToDictionary(x => x.Key, x => x.Value);
                     return Task.FromResult(0);
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/Forwarding/When_forwarding_is_configured_for_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Forwarding/When_forwarding_is_configured_for_endpoint.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Forwarding
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -42,7 +43,7 @@
 
                 public Task Handle(MessageToForward message, IMessageHandlerContext context)
                 {
-                    Context.ForwardedHeaders = context.MessageHeaders;
+                    Context.ForwardedHeaders = context.MessageHeaders.ToDictionary(x => x.Key, x => x.Value);
                     Context.GotForwardedMessage = true;
                     return Task.FromResult(0);
                 }
@@ -62,7 +63,7 @@
 
                 public Task Handle(MessageToForward message, IMessageHandlerContext context)
                 {
-                    Context.ReceivedHeaders = context.MessageHeaders;
+                    Context.ReceivedHeaders = context.MessageHeaders.ToDictionary(x => x.Key, x => x.Value);
                     return Task.FromResult(0);
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/Forwarding/When_requesting_message_to_be_forwarded.cs
+++ b/src/NServiceBus.AcceptanceTests/Forwarding/When_requesting_message_to_be_forwarded.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Forwarding
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -62,7 +63,7 @@
 
                 public Task Handle(MessageToForward message, IMessageHandlerContext context)
                 {
-                    Context.ReceivedHeaders = context.MessageHeaders;
+                    Context.ReceivedHeaders = context.MessageHeaders.ToDictionary(x => x.Key, x => x.Value);
                     return context.ForwardCurrentMessageTo("message_forward_receiver");
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_empty_id_header.cs
+++ b/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_empty_id_header.cs
@@ -54,7 +54,7 @@
                 public Task Handle(Message message, IMessageHandlerContext context)
                 {
                     TestContext.MessageId = context.MessageId;
-                    TestContext.Headers = context.MessageHeaders;
+                    TestContext.Headers = context.MessageHeaders.ToDictionary(x => x.Key, x => x.Value);
                     TestContext.MessageReceived = true;
 
                     return Task.FromResult(0);

--- a/src/NServiceBus.AcceptanceTests/Outbox/When_headers_contain_special_characters.cs
+++ b/src/NServiceBus.AcceptanceTests/Outbox/When_headers_contain_special_characters.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -99,7 +100,7 @@
                 public Task Handle(SendOrderAcknowledgement message, IMessageHandlerContext context)
                 {
                     Context.MessageReceived = true;
-                    Context.UnicodeHeaders = context.MessageHeaders;
+                    Context.UnicodeHeaders = context.MessageHeaders.ToDictionary(x => x.Key, x => x.Value);
                     return Task.FromResult(0);
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/Pipeline/When_sending_to_another_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Pipeline/When_sending_to_another_endpoint.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
@@ -85,7 +86,7 @@
                     TestContext.MyMessageId = context.MessageId;
                     TestContext.MyHeader = context.MessageHeaders["MyHeader"];
 
-                    TestContext.ReceivedHeaders = context.MessageHeaders;
+                    TestContext.ReceivedHeaders = context.MessageHeaders.ToDictionary(x => x.Key, x => x.Value);
 
                     TestContext.WasCalled = true;
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_using_special_characters_in_headers.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_using_special_characters_in_headers.cs
@@ -81,7 +81,7 @@
                 {
                     if (context.MessageHeaders.TryGetValue(Headers.DelayedRetries, out _))
                     {
-                        testContext.ReceivedMessageHeaders = context.MessageHeaders;
+                        testContext.ReceivedMessageHeaders = context.MessageHeaders.ToDictionary(x => x.Key, x => x.Value);
                         return Task.FromResult(0);
                     }
 


### PR DESCRIPTION
Some acceptance tests as well as the `FailTestOnErrorMessageFeature` do not make a copy of the headers. The headers are added to the scenario context which outlives the message handling lifetime as well as the endpoint lifetime. By doing that the core does not allow the transport to optimize for header dictionary reuse. More context available at 

https://github.com/Particular/NServiceBus.AmazonSQS/pull/277