### PR TITLE
SimpleJson usage cleanup

### DIFF
--- a/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
@@ -207,7 +207,6 @@ namespace NServiceBus
             readonly IContainSagaData data;
             static ConcurrentDictionary<Type, bool> canBeShallowCopiedCache = new ConcurrentDictionary<Type, bool>();
             static Func<IContainSagaData, IContainSagaData> shallowCopy;
-            static readonly EnumAwareStrategy serializationStrategy = new EnumAwareStrategy();
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaStorageFile.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaStorageFile.cs
@@ -68,7 +68,7 @@ namespace NServiceBus
         public Task Write(IContainSagaData sagaData)
         {
             fileStream.Position = 0;
-            var json = SimpleJson.SerializeObject(sagaData, serializationStrategy);
+            var json = SimpleJson.SerializeObject(sagaData, EnumAwareStrategy.Instance);
             return streamWriter.WriteAsync(json);
         }
 
@@ -81,7 +81,7 @@ namespace NServiceBus
         public async Task<TSagaData> Read<TSagaData>() where TSagaData : class, IContainSagaData
         {
             var json = await streamReader.ReadToEndAsync().ConfigureAwait(false);
-            return SimpleJson.DeserializeObject<TSagaData>(json, serializationStrategy);
+            return SimpleJson.DeserializeObject<TSagaData>(json, EnumAwareStrategy.Instance);
         }
 
         FileStream fileStream;
@@ -91,6 +91,5 @@ namespace NServiceBus
 
         const int DefaultBufferSize = 4096;
         static Task<SagaStorageFile> noSagaFoundResult = Task.FromResult<SagaStorageFile>(null);
-        static readonly EnumAwareStrategy serializationStrategy = new EnumAwareStrategy();
     }
 }

--- a/src/NServiceBus.Core/Serializers/SimpleJson/EnumAwareStrategy.cs
+++ b/src/NServiceBus.Core/Serializers/SimpleJson/EnumAwareStrategy.cs
@@ -7,6 +7,8 @@
     // https://github.com/facebook-csharp-sdk/simple-json/issues/15
     class EnumAwareStrategy : PocoJsonSerializerStrategy
     {
+        EnumAwareStrategy() {}
+
         protected override object SerializeEnum(Enum p)
         {
             return p.ToString();
@@ -34,5 +36,8 @@
 
             return base.DeserializeObject(value, type);
         }
+
+        static EnumAwareStrategy enumAwareStrategy;
+        public static EnumAwareStrategy Instance => enumAwareStrategy ?? (enumAwareStrategy = new EnumAwareStrategy());
     }
 }


### PR DESCRIPTION
Inheritors of PocoSerializationStrategy need to be singletons because of the reflection caches. Made the EnumAwareStrategy a singleton and the constructor private to avoid having multiple instances around in core. Found an unused field in the InMemorySagaPersister