### PR TITLE
Only fail test on StackOverflowExceptions

### DIFF
--- a/src/NServiceBus.ContainerTests/When_building_components.cs
+++ b/src/NServiceBus.ContainerTests/When_building_components.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.ContainerTests
 {
+    using System;
     using NServiceBus;
     using ObjectBuilder.Common;
     using NUnit.Framework;
@@ -98,10 +99,17 @@ namespace NServiceBus.ContainerTests
         [Test]
         public void Resolving_recursive_types_does_not_stack_overflow()
         {
-            using (var builder = TestContainerBuilder.ConstructBuilder())
+            try
             {
-                InitializeBuilder(builder);
-                builder.Build(typeof(RecursiveComponent));
+                using (var builder = TestContainerBuilder.ConstructBuilder())
+                {
+                    InitializeBuilder(builder);
+                    builder.Build(typeof(RecursiveComponent));
+                }
+            }
+            catch (Exception)
+            {
+                // this can't be a StackOverflowException as they can't be caught
             }
         }
 


### PR DESCRIPTION
This test is supposed to ensure that recursive types do not cause our DI adapters to run into SO exceptions. However, any exception will cause this test to fail.

Running this test against Autofac throws the following exception:
> Autofac.Core.DependencyResolutionException : Circular component dependency detected

which will fail the test as well. I'm not sure the Autofac behavior is correct this way but at least it's not a stack overflow exception which is what this test is looking for.

It's also interesting to note that depending on the exact type of configuration, multiple contains throw exceptions due to detected circular dependencies.

thoguhts @WilliamBZA @Particular/nservicebus-maintainers ?