### PR TITLE
Always process messages that have handlers regardless of conventions

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Conventions/When_receiving_non_matching_message_with_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Conventions/When_receiving_non_matching_message_with_handler.cs
@@ -1,0 +1,64 @@
+namespace NServiceBus.AcceptanceTests.Core.Conventions
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_receiving_non_matching_message_with_handler : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_process_message()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(c => c.When(s => s.Send(new NonMatchingMessageWithHandler())))
+                .WithEndpoint<Receiver>()
+                .Done(c => c.GotTheMessage)
+                .Run();
+
+            Assert.True(context.GotTheMessage);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotTheMessage { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.ConfigureTransport().Routing().RouteToEndpoint(typeof(NonMatchingMessageWithHandler), typeof(Receiver));
+                });
+            }
+        }
+
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(c => { c.Conventions().DefiningMessagesAs(t => false); });
+
+            }
+
+            class MyHandler : IHandleMessages<NonMatchingMessageWithHandler>
+            {
+                public Context TestContext { get; set; }
+
+                public Task Handle(NonMatchingMessageWithHandler message, IMessageHandlerContext context)
+                {
+                    TestContext.GotTheMessage = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class NonMatchingMessageWithHandler : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/Conventions/When_receiving_non_matching_message_with_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Conventions/When_receiving_non_matching_message_with_handler.cs
@@ -36,13 +36,11 @@ namespace NServiceBus.AcceptanceTests.Core.Conventions
             }
         }
 
-
         public class Receiver : EndpointConfigurationBuilder
         {
             public Receiver()
             {
-                EndpointSetup<DefaultServer>(c => { c.Conventions().DefiningMessagesAs(t => false); });
-
+                EndpointSetup<DefaultServer>(c => c.Conventions().DefiningMessagesAs(t => false));
             }
 
             class MyHandler : IHandleMessages<NonMatchingMessageWithHandler>

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -1,4 +1,4 @@
-﻿[assembly: System.CLSCompliantAttribute(true)]
+[assembly: System.CLSCompliantAttribute(true)]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"NServiceBus.AcceptanceTesting, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"NServiceBus.Core.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001007f16e21368ff041183fab592d9e8ed37e7be355e93323147a1d29983d6e591b04282e4da0c9e18bd901e112c0033925eb7d7872c2f1706655891c5c9d57297994f707d16ee9a8f40d978f064ee1ffc73c0db3f4712691b23bf596f75130f4ec978cf78757ec034625a5f27e6bb50c618931ea49f6f628fd74271c32959efb1c5")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute(@"NServiceBus.Hosting.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92")]
@@ -2685,6 +2685,7 @@ namespace NServiceBus.Unicast
     }
     public class MessageHandlerRegistry
     {
+        public MessageHandlerRegistry() { }
         public void Clear() { }
         public System.Collections.Generic.List<NServiceBus.Pipeline.MessageHandler> GetHandlersFor(System.Type messageType) { }
         public System.Collections.Generic.IEnumerable<System.Type> GetMessageTypes() { }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -2687,6 +2687,7 @@ namespace NServiceBus.Unicast
     }
     public class MessageHandlerRegistry
     {
+        public MessageHandlerRegistry() { }
         public void Clear() { }
         public System.Collections.Generic.List<NServiceBus.Pipeline.MessageHandler> GetHandlersFor(System.Type messageType) { }
         public System.Collections.Generic.IEnumerable<System.Type> GetMessageTypes() { }

--- a/src/NServiceBus.Core.Tests/Handlers/MessageHandlerRegistryTests.cs
+++ b/src/NServiceBus.Core.Tests/Handlers/MessageHandlerRegistryTests.cs
@@ -18,7 +18,7 @@
         [TestCase(typeof(SagaWithIllegalDep))]
         public void ShouldThrowIfUserTriesToBypassTheHandlerContext(Type handlerType)
         {
-            var registry = new MessageHandlerRegistry(new Conventions());
+            var registry = new MessageHandlerRegistry();
 
             Assert.Throws<Exception>(() => registry.RegisterHandler(handlerType));
         }
@@ -26,7 +26,7 @@
         [Test]
         public async Task ShouldIndicateWhetherAHandlerIsATimeoutHandler()
         {
-            var registry = new MessageHandlerRegistry(new Conventions());
+            var registry = new MessageHandlerRegistry();
 
             registry.RegisterHandler(typeof(SagaWithTimeoutOfMessage));
 

--- a/src/NServiceBus.Core.Tests/Unicast/HandlerInvocationCache.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/HandlerInvocationCache.cs
@@ -15,7 +15,7 @@
         [Test]
         public async Task RunNew()
         {
-            var cache = new MessageHandlerRegistry(new Conventions());
+            var cache = new MessageHandlerRegistry();
             cache.RegisterHandler(typeof(StubMessageHandler));
             cache.RegisterHandler(typeof(StubTimeoutHandler));
             var stubMessage = new StubMessage();
@@ -67,7 +67,7 @@
         [Test]
         public async Task Should_invoke_handle_method()
         {
-            var cache = new MessageHandlerRegistry(new Conventions());
+            var cache = new MessageHandlerRegistry();
             cache.RegisterHandler(typeof(StubHandler));
 
             var handler = cache.GetCachedHandlerForMessage<StubMessage>();
@@ -80,7 +80,7 @@
         [Test]
         public async Task Should_have_passed_through_correct_message()
         {
-            var cache = new MessageHandlerRegistry(new Conventions());
+            var cache = new MessageHandlerRegistry();
             cache.RegisterHandler(typeof(StubHandler));
 
             var handler = cache.GetCachedHandlerForMessage<StubMessage>();
@@ -94,7 +94,7 @@
         [Test]
         public async Task Should_have_passed_through_correct_context()
         {
-            var cache = new MessageHandlerRegistry(new Conventions());
+            var cache = new MessageHandlerRegistry();
             cache.RegisterHandler(typeof(StubHandler));
 
             var handler = cache.GetCachedHandlerForMessage<StubMessage>();
@@ -130,7 +130,7 @@
         [Test]
         public async Task Should_invoke_timeout_method()
         {
-            var cache = new MessageHandlerRegistry(new Conventions());
+            var cache = new MessageHandlerRegistry();
             cache.RegisterHandler(typeof(StubHandler));
 
             var handler = cache.GetCachedHandlerForMessage<StubTimeoutState>();
@@ -143,7 +143,7 @@
         [Test]
         public async Task Should_have_passed_through_correct_state()
         {
-            var cache = new MessageHandlerRegistry(new Conventions());
+            var cache = new MessageHandlerRegistry();
             cache.RegisterHandler(typeof(StubHandler));
 
             var stubState = new StubTimeoutState();
@@ -157,7 +157,7 @@
         [Test]
         public async Task Should_have_passed_through_correct_context()
         {
-            var cache = new MessageHandlerRegistry(new Conventions());
+            var cache = new MessageHandlerRegistry();
             cache.RegisterHandler(typeof(StubHandler));
 
             var handler = cache.GetCachedHandlerForMessage<StubTimeoutState>();

--- a/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/LoadHandlersBehaviorTests.cs
@@ -11,7 +11,7 @@
         [Test]
         public void Should_throw_when_there_are_no_registered_message_handlers()
         {
-            var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(new Conventions()), new InMemorySynchronizedStorage(), new InMemoryTransactionalSynchronizedStorageAdapter());
+            var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(), new InMemorySynchronizedStorage(), new InMemoryTransactionalSynchronizedStorageAdapter());
 
             var context = new TestableIncomingLogicalMessageContext();
 

--- a/src/NServiceBus.Core/Unicast/Config/RegisterHandlersInOrder.cs
+++ b/src/NServiceBus.Core/Unicast/Config/RegisterHandlersInOrder.cs
@@ -43,7 +43,7 @@ namespace NServiceBus.Features
 
         static void ConfigureMessageHandlersIn(FeatureConfigurationContext context, IEnumerable<Type> types)
         {
-            var handlerRegistry = new MessageHandlerRegistry(context.Settings.Get<Conventions>());
+            var handlerRegistry = new MessageHandlerRegistry();
 
             foreach (var t in types.Where(IsMessageHandler))
             {

--- a/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
@@ -13,11 +13,6 @@
     /// </summary>
     public class MessageHandlerRegistry
     {
-        internal MessageHandlerRegistry(Conventions conventions)
-        {
-            this.conventions = conventions;
-        }
-
         /// <summary>
         /// Gets the list of handlers <see cref="Type" />s for the given
         /// <paramref name="messageType" />.
@@ -56,7 +51,6 @@
             return (from messagesBeingHandled in handlerAndMessagesHandledByHandlerCache.Values
                 from typeHandled in messagesBeingHandled
                 let messageType = typeHandled.MessageType
-                where conventions.IsMessageType(messageType)
                 select messageType).Distinct();
         }
 
@@ -177,7 +171,6 @@
             }
         }
 
-        readonly Conventions conventions;
         readonly Dictionary<Type, List<DelegateHolder>> handlerAndMessagesHandledByHandlerCache = new Dictionary<Type, List<DelegateHolder>>();
         static ILog Log = LogManager.GetLogger<MessageHandlerRegistry>();
 

--- a/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
@@ -179,7 +179,6 @@
 
         readonly Conventions conventions;
         readonly Dictionary<Type, List<DelegateHolder>> handlerAndMessagesHandledByHandlerCache = new Dictionary<Type, List<DelegateHolder>>();
-        static List<MessageHandler> noMessageHandlers = new List<MessageHandler>(0);
         static ILog Log = LogManager.GetLogger<MessageHandlerRegistry>();
 
         class DelegateHolder

--- a/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
@@ -26,10 +26,6 @@
         public List<MessageHandler> GetHandlersFor(Type messageType)
         {
             Guard.AgainstNull(nameof(messageType), messageType);
-            if (!conventions.IsMessageType(messageType))
-            {
-                return noMessageHandlers;
-            }
 
             var messageHandlers = new List<MessageHandler>();
             // ReSharper disable once LoopCanBeConvertedToQuery


### PR DESCRIPTION
To avoid messages going to the error queue when there are issues with [conventions](https://docs.particular.net/nservicebus/messaging/messages-events-commands) we should process messages if there are handlers for it regardless of conventions.