### PR TITLE
Clean up GenerateImplementationFor error messages

### DIFF
--- a/src/NServiceBus.Core.Tests/MessageMapper/MessageMapperTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageMapper/MessageMapperTests.cs
@@ -86,7 +86,17 @@
         {
             var mapper = new MessageMapper();
 
-            Assert.Throws<Exception>(() => mapper.Initialize(new[] { typeof(InterfaceMessageWithIllegalInterfaceProperty) }));
+            var ex = Assert.Throws<Exception>(() => mapper.Initialize(new[] { typeof(InterfaceMessageWithIllegalInterfaceProperty) }));
+            StringAssert.Contains($"Cannot generate a concrete implementation for '{nameof(IIllegalProperty)}' because it contains methods. Ensure that all interfaces used as messages do not contain methods.", ex.Message);
+        }
+
+        [Test]
+        public void Should_fail_for_non_public_interface_message()
+        {
+            var mapper = new MessageMapper();
+
+            var ex = Assert.Throws<Exception>(() => mapper.Initialize(new[] { typeof(IPrivateInterfaceMessage) }));
+            StringAssert.Contains($"Cannot generate a concrete implementation for '{typeof(IPrivateInterfaceMessage).FullName}' because it is not public. Ensure that all interfaces used as messages are public.", ex.Message);
         }
 
         [Test]
@@ -174,6 +184,11 @@
 
             //this is not supported by our mapper
             void SomeMethod();
+        }
+
+        interface IPrivateInterfaceMessage
+        {
+            string SomeValue { get; set; }
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/MessageMapper/MessageMapperTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageMapper/MessageMapperTests.cs
@@ -87,7 +87,7 @@
             var mapper = new MessageMapper();
 
             var ex = Assert.Throws<Exception>(() => mapper.Initialize(new[] { typeof(InterfaceMessageWithIllegalInterfaceProperty) }));
-            StringAssert.Contains($"Cannot generate a concrete implementation for '{nameof(IIllegalProperty)}' because it contains methods. Ensure that all interfaces used as messages do not contain methods.", ex.Message);
+            StringAssert.Contains($"Cannot generate a concrete implementation for '{typeof(IIllegalProperty).FullName}' because it contains methods. Ensure that all interfaces used as messages do not contain methods.", ex.Message);
         }
 
         [Test]

--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
@@ -223,7 +223,7 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
 
             if (interfaceType.GetMethods().Any(mi => !(mi.IsSpecialName && (mi.Name.StartsWith("set_") || mi.Name.StartsWith("get_")))))
             {
-                throw new Exception($"Cannot generate a concrete implementation for '{interfaceType.Name}' because it contains methods. Ensure that all interfaces used as messages do not contain methods.");
+                throw new Exception($"Cannot generate a concrete implementation for '{interfaceType}' because it contains methods. Ensure that all interfaces used as messages do not contain methods.");
             }
             var mapped = concreteProxyCreator.CreateTypeFrom(interfaceType);
             interfaceToConcreteTypeMapping[interfaceType.TypeHandle] = mapped.TypeHandle;

--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/MessageMapper.cs
@@ -218,12 +218,12 @@ namespace NServiceBus.MessageInterfaces.MessageMapper.Reflection
         {
             if (!interfaceType.IsVisible)
             {
-                throw new Exception($"Can only generate a concrete implementation for '{interfaceType}' if '{interfaceType}' is public.");
+                throw new Exception($"Cannot generate a concrete implementation for '{interfaceType}' because it is not public. Ensure that all interfaces used as messages are public.");
             }
 
             if (interfaceType.GetMethods().Any(mi => !(mi.IsSpecialName && (mi.Name.StartsWith("set_") || mi.Name.StartsWith("get_")))))
             {
-                throw new Exception($"Can only generate a concrete implementation for '{interfaceType.Name}' because the interface contains methods. Ensure interface messages do not contain methods.");
+                throw new Exception($"Cannot generate a concrete implementation for '{interfaceType.Name}' because it contains methods. Ensure that all interfaces used as messages do not contain methods.");
             }
             var mapped = concreteProxyCreator.CreateTypeFrom(interfaceType);
             interfaceToConcreteTypeMapping[interfaceType.TypeHandle] = mapped.TypeHandle;


### PR DESCRIPTION
After seeing https://discuss.particular.net/t/exception-when-starting-endpoint/1052, I took a look the `MessageMapper`, and it looks like the "Can only" portion of the second exception was incorrectly copied from the first one.

I went ahead and reworded both of them for clarity.