### PR TITLE
MSMQ Transport results in unnecessary IO when reading from empty queues due to very short timeout value

### DIFF
--- a/src/NServiceBus.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureEndpointMsmqTransport.cs
@@ -19,8 +19,11 @@ public class ConfigureEndpointMsmqTransport : IConfigureEndpointTestExecution
         var connectionString =
             EnvironmentHelper.GetEnvironmentVariable($"{nameof(MsmqTransport)}.ConnectionString")
             ?? DefaultConnectionString;
-        var transportConfig = configuration.UseTransport<MsmqTransport>();
 
+        configuration.GetSettings().Set("NServiceBus.Transport.Msmq.MessageEnumeratorTimeout", TimeSpan.FromMilliseconds(10));
+
+        var transportConfig = configuration.UseTransport<MsmqTransport>();
+        
         transportConfig.ConnectionString(connectionString);
 
         var routingConfig = transportConfig.Routing();

--- a/src/NServiceBus.Core.Tests/Msmq/MsmqMessagePumpTests.cs
+++ b/src/NServiceBus.Core.Tests/Msmq/MsmqMessagePumpTests.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.Core.Tests.Msmq
         [Test]
         public void ShouldThrowIfConfiguredToReceiveFromRemoteQueue()
         {
-            var messagePump = new MessagePump(mode => null);
+            var messagePump = new MessagePump(mode => null, TimeSpan.Zero);
             var pushSettings = new PushSettings("queue@remote", "error", false, TransportTransactionMode.None);
 
             var exception = Assert.Throws<Exception>(() =>

--- a/src/NServiceBus.Core/Licensing/GenerateReleaseDate.targets
+++ b/src/NServiceBus.Core/Licensing/GenerateReleaseDate.targets
@@ -29,9 +29,9 @@
 
   </UsingTask>
 
-  <Target Name="GenerateReleaseDate" DependsOnTargets="GetVersion" BeforeTargets="CoreCompile">
+  <Target Name="GenerateReleaseDate" DependsOnTargets="GetVersion" BeforeTargets="CoreCompile" Condition=" '$(GetVersion)' == 'true' ">
 
-    <Exec Command="git show --format=%%cI $(GitVersion_Major).$(GitVersion_Minor).0" WorkingDirectory="$(MSBuildProjectDirectory)" ConsoleToMSBuild="true" Condition="$(GitVersion_Patch) != 0">
+    <Exec Command="git show -s --format=%%cI $(GitVersion_Major).$(GitVersion_Minor).0^^{commit}" WorkingDirectory="$(MSBuildProjectDirectory)" ConsoleToMSBuild="true" Condition="$(GitVersion_Patch) != 0">
       <Output TaskParameter="ConsoleOutput" PropertyName="CurrentMinorCommitDateAndTime" />
     </Exec>
 
@@ -41,6 +41,7 @@
 
     <ItemGroup>
       <Compile Include="$(GeneratedReleaseDateFilePath)" />
+      <FileWrites Include="$(GeneratedReleaseDateFilePath)" />
     </ItemGroup>
 
   </Target>

--- a/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MessagePump.cs
@@ -13,9 +13,10 @@ namespace NServiceBus
 
     class MessagePump : IPushMessages, IDisposable
     {
-        public MessagePump(Func<TransportTransactionMode, ReceiveStrategy> receiveStrategyFactory)
+        public MessagePump(Func<TransportTransactionMode, ReceiveStrategy> receiveStrategyFactory, TimeSpan messageEnumeratorTimeout)
         {
             this.receiveStrategyFactory = receiveStrategyFactory;
+            this.messageEnumeratorTimeout = messageEnumeratorTimeout;
         }
 
         public void Dispose()
@@ -126,7 +127,7 @@ namespace NServiceBus
                     try
                     {
                         //note: .Peek will throw an ex if no message is available. It also turns out that .MoveNext is faster since message isn't read
-                        if (!enumerator.MoveNext(TimeSpan.FromMilliseconds(10)))
+                        if (!enumerator.MoveNext(messageEnumeratorTimeout))
                         {
                             continue;
                         }
@@ -222,6 +223,7 @@ namespace NServiceBus
         RepeatedFailuresOverTimeCircuitBreaker peekCircuitBreaker;
         RepeatedFailuresOverTimeCircuitBreaker receiveCircuitBreaker;
         Func<TransportTransactionMode, ReceiveStrategy> receiveStrategyFactory;
+        TimeSpan messageEnumeratorTimeout;
         ConcurrentDictionary<Task, Task> runningReceiveTasks;
 
         static ILog Logger = LogManager.GetLogger<MessagePump>();

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqSettings.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqSettings.cs
@@ -11,6 +11,7 @@ namespace NServiceBus
             UseConnectionCache = true;
             UseTransactionalQueues = true;
             TimeToReachQueue = Message.InfiniteTimeout;
+            MessageEnumeratorTimeout = TimeSpan.FromSeconds(1); //with a 1s timeout a graceful shutdown will take on average 500ms which is acceptable
         }
 
         public bool UseDeadLetterQueue { get; set; }
@@ -24,5 +25,7 @@ namespace NServiceBus
         public TimeSpan TimeToReachQueue { get; set; }
 
         public bool UseDeadLetterQueueForMessagesWithTimeToBeReceived { get; set; }
+
+        public TimeSpan MessageEnumeratorTimeout { get; set; }
     }
 }

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransport.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransport.cs
@@ -40,8 +40,13 @@ namespace NServiceBus
 
             var msmqSettings = connectionString != null ? new MsmqConnectionStringBuilder(connectionString)
                 .RetrieveSettings() : new MsmqSettings();
-
+            
             msmqSettings.UseDeadLetterQueueForMessagesWithTimeToBeReceived = settings.GetOrDefault<bool>(UseDeadLetterQueueForMessagesWithTimeToBeReceived);
+
+            if (settings.TryGet<TimeSpan>("NServiceBus.Transport.Msmq.MessageEnumeratorTimeout", out var messageEnumeratorTimeout))
+            {
+                msmqSettings.MessageEnumeratorTimeout = messageEnumeratorTimeout;
+            }
 
             settings.Set<MsmqSettings>(msmqSettings);
 

--- a/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Msmq/MsmqTransportInfrastructure.cs
@@ -90,7 +90,7 @@ namespace NServiceBus
             var msmqSettings = settings.Get<MsmqSettings>();
 
             return new TransportReceiveInfrastructure(
-                () => new MessagePump(guarantee => SelectReceiveStrategy(guarantee, scopeOptions.TransactionOptions)),
+                () => new MessagePump(guarantee => SelectReceiveStrategy(guarantee, scopeOptions.TransactionOptions), msmqSettings.MessageEnumeratorTimeout),
                 () => new MsmqQueueCreator(msmqSettings.UseTransactionalQueues),
                 () =>
                 {

--- a/src/NServiceBus.Msmq.AcceptanceTests/BasicServer.cs
+++ b/src/NServiceBus.Msmq.AcceptanceTests/BasicServer.cs
@@ -34,7 +34,8 @@ namespace NServiceBus.AcceptanceTests.EndpointTemplates
             configuration.CustomConfigurationSource(configSource);
             configuration.EnableInstallers();
 
-         
+            configuration.GetSettings().Set("NServiceBus.Transport.Msmq.MessageEnumeratorTimeout", TimeSpan.FromMilliseconds(10));
+
             var transportConfig = configuration.UseTransport<MsmqTransport>();
             var routingConfig = transportConfig.Routing();
 

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -184,7 +184,11 @@
         protected virtual TransportInfrastructure CreateTransportInfrastructure()
         {
             var msmqTransportDefinition = new MsmqTransport();
-            return msmqTransportDefinition.Initialize(new SettingsHolder(), "");
+            var settings = new SettingsHolder();
+
+            settings.Set("NServiceBus.Transport.Msmq.MessageEnumeratorTimeout", TimeSpan.FromMilliseconds(10));
+
+            return msmqTransportDefinition.Initialize(settings, "");
         }
 
         protected void RequireDeliveryConstraint<T>() where T : DeliveryConstraint


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus/issues/5349

Adding a new setting for passing the MessageEnumeratorTimeout
The default value will be 1 second instead of 10 milliseconds
This new setting will be available as part of the connection string.