### PR TITLE
Add header manipulation transport tests

### DIFF
--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -284,6 +284,9 @@
                 transaction.ClearPendingOutgoingOperations();
                 var processingFailures = retryCounts.AddOrUpdate(messageId, id => 1, (id, currentCount) => currentCount + 1);
 
+                headers = HeaderSerializer.Deserialize(message);
+                headers.Remove(LearningTransportHeaders.TimeToBeReceived);
+
                 var errorContext = new ErrorContext(exception, headers, messageId, body, transportTransaction, processingFailures);
 
                 // the transport tests assume that all transports use a circuit breaker to be resilient against exceptions

--- a/src/NServiceBus.TransportTests/When_modifying_incoming_headers.cs
+++ b/src/NServiceBus.TransportTests/When_modifying_incoming_headers.cs
@@ -1,0 +1,110 @@
+﻿namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using Transport;
+
+    public class When_modifying_incoming_headers : NServiceBusTransportTest
+    {
+        [TestCase(TransportTransactionMode.ReceiveOnly)]
+        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
+        [TestCase(TransportTransactionMode.TransactionScope)]
+        public async Task Should_roll_back_header_modifications_between_processing_attempts(TransportTransactionMode transactionMode)
+        {
+            var messageRetries = new TaskCompletionSource<MessageContext>();
+            var firstInvocation = true;
+
+            await StartPump(context =>
+                {
+                    if (firstInvocation)
+                    {
+                        context.Headers["test-header"] = "modified";
+                        firstInvocation = false;
+                        throw new Exception();
+                    }
+
+                    messageRetries.SetResult(context);
+                    return Task.FromResult(0);
+                },
+                context => Task.FromResult(ErrorHandleResult.RetryRequired),
+                transactionMode);
+
+            await SendMessage(InputQueueName, new Dictionary<string, string>
+            {
+                {"test-header", "original"}
+            });
+
+            var retriedMessage = await messageRetries.Task;
+
+            Assert.AreEqual("original", retriedMessage.Headers["test-header"]);
+        }
+
+        [TestCase(TransportTransactionMode.None)]
+        [TestCase(TransportTransactionMode.ReceiveOnly)]
+        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
+        [TestCase(TransportTransactionMode.TransactionScope)]
+        public async Task Should_roll_back_header_modifications_before_handling_error(TransportTransactionMode transactionMode)
+        {
+            var errorHandled = new TaskCompletionSource<ErrorContext>();
+
+            await StartPump(context =>
+                {
+                    context.Headers["test-header"] = "modified";
+                    throw new Exception();
+                },
+                context =>
+                {
+                    errorHandled.SetResult(context);
+                    return Task.FromResult(ErrorHandleResult.Handled);
+                },
+                transactionMode);
+
+            await SendMessage(InputQueueName, new Dictionary<string, string>
+            {
+                {"test-header", "original"}
+            });
+
+            var errorContext = await errorHandled.Task;
+
+            Assert.AreEqual("original", errorContext.Message.Headers["test-header"]);
+        }
+
+        [TestCase(TransportTransactionMode.ReceiveOnly)]
+        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
+        [TestCase(TransportTransactionMode.TransactionScope)]
+        public async Task Should_roll_back_header_modifications_made_while_handling_error(TransportTransactionMode transactionMode)
+        {
+            var messageRetries = new TaskCompletionSource<MessageContext>();
+            var firstInvocation = true;
+
+            await StartPump(context =>
+                {
+                    if (firstInvocation)
+                    {
+                        firstInvocation = false;
+                        throw new Exception();
+                    }
+
+                    messageRetries.SetResult(context);
+                    return Task.FromResult(0);
+                },
+                context =>
+                {
+                    context.Message.Headers["test-header"] = "modified";
+                    return Task.FromResult(ErrorHandleResult.RetryRequired);
+                },
+                transactionMode);
+
+            await SendMessage(InputQueueName, new Dictionary<string, string>
+            {
+                {"test-header", "original"}
+            });
+
+            var retriedMessage = await messageRetries.Task;
+
+            Assert.AreEqual("original", retriedMessage.Headers["test-header"]);
+        }
+    }
+}


### PR DESCRIPTION
As part of fixing the header manipulation issues in the RabbitMQ transport, https://github.com/Particular/NServiceBus.RabbitMQ/pull/532 added transport tests to verify the correct behavior.

These tests should actually be in Core instead so all transports can be tested.