### PR TITLE
Make sure transports invoke critical error if recoverability fails

### DIFF
--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -294,7 +294,7 @@
                 }
                 catch (Exception ex)
                 {
-                    criticalError.Raise($"Failed to execute recoverability policy for message `{messageContext.MessageId}`", ex);
+                    criticalError.Raise($"Failed to execute recoverability policy for message with native ID: `{messageContext.MessageId}`", ex);
                     actionToTake = ErrorHandleResult.RetryRequired;
                 }
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -286,8 +286,6 @@
 
                 var errorContext = new ErrorContext(exception, headers, messageId, body, transportTransaction, processingFailures);
 
-                // the transport tests assume that all transports use a circuit breaker to be resilient against exceptions
-                // in onError. Since we don't need that robustness, we just retry onError once should it fail.
                 ErrorHandleResult actionToTake;
                 try
                 {
@@ -296,7 +294,7 @@
                 }
                 catch (Exception ex)
                 {
-                    criticalError.Raise($"Failed to execute recoverability actions for message `{messageContext.MessageId}`", ex);
+                    criticalError.Raise($"Failed to execute recoverability strategy for message `{messageContext.MessageId}`", ex);
                     actionToTake = ErrorHandleResult.RetryRequired;
                 }
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -294,7 +294,7 @@
                 }
                 catch (Exception ex)
                 {
-                    criticalError.Raise($"Failed to execute recoverability strategy for message `{messageContext.MessageId}`", ex);
+                    criticalError.Raise($"Failed to execute recoverability policy for message `{messageContext.MessageId}`", ex);
                     actionToTake = ErrorHandleResult.RetryRequired;
                 }
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -294,10 +294,10 @@
                     actionToTake = await onError(errorContext)
                         .ConfigureAwait(false);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
-                    actionToTake = await onError(errorContext)
-                        .ConfigureAwait(false);
+                    criticalError.Raise($"Failed to execute recoverability actions for message `{messageContext.MessageId}`", ex);
+                    actionToTake = ErrorHandleResult.RetryRequired;
                 }
 
                 if (actionToTake == ErrorHandleResult.RetryRequired)

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -21,7 +21,8 @@
         {
             testId = Guid.NewGuid().ToString();
 
-            LogManager.UseFactory(new TransportTestLoggerFactory());
+            LogFactory = new TransportTestLoggerFactory();
+            LogManager.UseFactory(LogFactory);
 
             //when using [TestCase] NUnit will reuse the same test instance so we need to make sure that the message pump is a fresh one
             MessagePump = null;
@@ -235,6 +236,7 @@
 
         protected string InputQueueName;
         protected string ErrorQueueName;
+        protected TransportTestLoggerFactory LogFactory;
 
         string testId;
 

--- a/src/NServiceBus.TransportTests/TransportTestLoggerFactory.cs
+++ b/src/NServiceBus.TransportTests/TransportTestLoggerFactory.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.TransportTests
 {
     using System;
+    using System.Collections.Generic;
     using Logging;
     using NUnit.Framework;
 
@@ -8,21 +9,28 @@
     {
         public ILog GetLogger(Type type)
         {
-            return this.GetLogger(type.FullName);
+            return GetLogger(type.FullName);
         }
 
         public ILog GetLogger(string name)
         {
-            return new TransportTestLogger(name);
+            return new TransportTestLogger(name, LogItems);
+        }
+
+        public List<LogItem> LogItems { get; } = new List<LogItem>();
+
+        public class LogItem
+        {
+            public LogLevel Level;
+            public string Message;
         }
 
         class TransportTestLogger : ILog
         {
-            string name;
-
-            public TransportTestLogger(string name)
+            public TransportTestLogger(string name, List<LogItem> logItems)
             {
                 this.name = name;
+                this.logItems = logItems;
             }
 
             public bool IsDebugEnabled { get; } = true;
@@ -108,8 +116,17 @@
 
             void Log(LogLevel level, string message)
             {
+                logItems.Add(new LogItem
+                {
+                    Level = level,
+                    Message = message
+                });
+
                 TestContext.WriteLine($"{DateTime.Now:T} {level} {name}: {message}");
             }
+
+            string name;
+            List<LogItem> logItems;
         }
     }
 }

--- a/src/NServiceBus.TransportTests/TransportTestLoggerFactory.cs
+++ b/src/NServiceBus.TransportTests/TransportTestLoggerFactory.cs
@@ -22,6 +22,7 @@
         public class LogItem
         {
             public LogLevel Level;
+            // ReSharper disable once NotAccessedField.Global
             public string Message;
         }
 

--- a/src/NServiceBus.TransportTests/When_on_error_throws.cs
+++ b/src/NServiceBus.TransportTests/When_on_error_throws.cs
@@ -58,7 +58,7 @@
 
             Assert.AreEqual("Simulated exception", errorContext.Exception.Message, "Should retry the message");
             Assert.True(criticalErrorCalled, "Should invoke critical error");
-            StringAssert.Contains(nativeMessageId, criticalErrorMessage, "Should include the native message id in the critical error message");
+            Assert.AreEqual($"Failed to execute recoverability policy for message with native ID: `{nativeMessageId}`",criticalErrorMessage);
             Assert.False(LogFactory.LogItems.Any(item => item.Level > LogLevel.Info));
        }
     }

--- a/src/NServiceBus.TransportTests/When_on_error_throws.cs
+++ b/src/NServiceBus.TransportTests/When_on_error_throws.cs
@@ -1,7 +1,9 @@
 ﻿namespace NServiceBus.TransportTests
 {
     using System;
+    using System.Linq;
     using System.Threading.Tasks;
+    using Logging;
     using NUnit.Framework;
     using Transport;
 
@@ -57,6 +59,7 @@
             Assert.AreEqual("Simulated exception", errorContext.Exception.Message, "Should retry the message");
             Assert.True(criticalErrorCalled, "Should invoke critical error");
             StringAssert.Contains(nativeMessageId, criticalErrorMessage, "Should include the native message id in the critical error message");
+            Assert.False(LogFactory.LogItems.Any(item => item.Level > LogLevel.Info));
        }
     }
 }


### PR DESCRIPTION
- [x] Check critical error is called
- [x] Make sure that message is retried
- [x] Make sure native transport id is included in failure message
- [x] Make sure no extra logs above WARN is done
- [x] Agree and potentially verify the format of the failure message
- [ ] Verify that test exposes issues on all downstreams
  - [x] MSMQ @andreasohlund 
  - [ ] ASB
  - [ ] ASQ
  - [x] SQL @andreasohlund 
  - [ ] Rabbit @boblangley 
  - [x] SQS @andreasohlund 