### PR TITLE
[WIP]Sending pre-created interface message fails

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_routing_interface_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_routing_interface_message.cs
@@ -1,0 +1,70 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Routing
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using AcceptanceTesting.Customization;
+    using NUnit.Framework;
+
+    public class When_routing_interface_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_route_correctly()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(c => c.When(b => b.SendLocal(new StartMessage())))
+                .Done(c => c.GotTheMessage)
+                .Run();
+
+            Assert.True(context.GotTheMessage);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotTheMessage { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>((c, r) =>
+                {
+                    var routing = c.ConfigureTransport().Routing();
+                    routing.RouteToEndpoint(typeof(IMyMessage), typeof(Endpoint));
+                });
+            }
+
+            public class StartMessageHandler : IHandleMessages<StartMessage>
+            {
+                public IMessageCreator MessageCreator { get; set; }
+
+                public Task Handle(StartMessage message, IMessageHandlerContext context)
+                {
+                    var interfaceMessage = MessageCreator.CreateInstance<IMyMessage>();
+                    return context.Send(interfaceMessage);
+                }
+            }
+
+            public class IMyMessageHandler : IHandleMessages<IMyMessage>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(IMyMessage message, IMessageHandlerContext context)
+                {
+                    Context.GotTheMessage = true;
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class StartMessage : IMessage
+        {
+        }
+
+        public interface IMyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_pre_created_interface.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_pre_created_interface.cs
@@ -1,0 +1,115 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+    using Conventions = AcceptanceTesting.Customization.Conventions;
+
+    public class When_publishing_pre_created_interface : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_receive_event()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(b =>
+                    b.When(c => c.Subscribed, (session, ctx) => session.SendLocal(new StartMessage())))
+                .WithEndpoint<Subscriber>(b => b.When(async (session, ctx) =>
+                {
+                    await session.Subscribe<MyEvent>();
+                    if (ctx.HasNativePubSubSupport)
+                    {
+                        ctx.Subscribed = true;
+                    }
+                }))
+                .Done(c => c.GotTheEvent)
+                .Run();
+
+            Assert.True(context.GotTheEvent);
+            //Assert.AreEqual(typeof(MyEvent), context.EventTypePassedToRouting);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotTheEvent { get; set; }
+            public bool Subscribed { get; set; }
+            public Type EventTypePassedToRouting { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(c =>
+                {
+                    c.Pipeline.Register("EventTypeSpy", new EventTypeSpy((Context)ScenarioContext), "EventTypeSpy");
+                    c.OnEndpointSubscribed<Context>((s, context) =>
+                    {
+                        if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber))))
+                        {
+                            context.Subscribed = true;
+                        }
+                    });
+                });
+            }
+
+            public class StartMessageHandler : IHandleMessages<StartMessage>
+            {
+                public IMessageCreator MessageCreator { get; set; }
+
+                public Task Handle(StartMessage message, IMessageHandlerContext context)
+                {
+                    return context.Publish(MessageCreator.CreateInstance<MyEvent>());
+                }
+            }
+
+            class EventTypeSpy : IBehavior<IOutgoingLogicalMessageContext, IOutgoingLogicalMessageContext>
+            {
+                public EventTypeSpy(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Invoke(IOutgoingLogicalMessageContext context, Func<IOutgoingLogicalMessageContext, Task> next)
+                {
+                    testContext.EventTypePassedToRouting = context.Message.MessageType;
+                    return next(context);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                    {
+                        c.DisableFeature<AutoSubscribe>();
+                    },
+                    metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyEvent @event, IMessageHandlerContext context)
+                {
+                    Context.GotTheEvent = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+        public class StartMessage : IMessage
+        {
+        }
+        public interface MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_pre_created_interface.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_pre_created_interface.cs
@@ -29,7 +29,7 @@
                 .Run();
 
             Assert.True(context.GotTheEvent);
-            //Assert.AreEqual(typeof(MyEvent), context.EventTypePassedToRouting);
+            Assert.AreEqual(typeof(MyEvent), context.EventTypePassedToRouting);
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.Core/Unicast/MessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperations.cs
@@ -17,7 +17,10 @@ namespace NServiceBus
 
         public static Task Publish(IBehaviorContext context, object message, PublishOptions options)
         {
-            return Publish(context, message.GetType(), message, options);
+            var mapper = context.Builder.Build<IMessageMapper>();
+            var messageType = mapper.GetMappedTypeFor(message.GetType());
+
+            return Publish(context, messageType, message, options);
         }
 
         static Task Publish(IBehaviorContext context, Type messageType, object message, PublishOptions options)

--- a/src/NServiceBus.Core/Unicast/MessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperations.cs
@@ -76,7 +76,10 @@ namespace NServiceBus
 
         public static Task Send(IBehaviorContext context, object message, SendOptions options)
         {
-            return SendMessage(context, message.GetType(), message, options);
+            var mapper = context.Builder.Build<IMessageMapper>();
+            var messageType = mapper.GetMappedTypeFor(message.GetType());
+
+            return SendMessage(context, messageType, message, options);
         }
 
         static Task SendMessage(this IBehaviorContext context, Type messageType, object message, SendOptions options)


### PR DESCRIPTION
I have a customer upgrading from v5 to v7 and in v7 we only provide a `Send<T>` overload that take an action to create interface messages. This means that if you use the plain send to send the message routing will fail since we're looking for the route that matches `.GetType` which gives the autogenerated `impl` class.

This PR shows a repro and results in:


```
No destination specified for message: NServiceBus.AcceptanceTests.Core.Routing.When_routing_interface_message\\+IMyMessage__impl
```

One could argue that the user should change their code to use the mentioned action overload but since we still expose the message creator it feels wrong that it doesn't work?