### PR TITLE
Interface messages created with IMessageCreator can't be routed

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_replying_with_pre_created_interface.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_replying_with_pre_created_interface.cs
@@ -1,0 +1,85 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Routing
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    public class When_replying_with_pre_created_interface : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_route_to_sender()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(c => c.When(b => b.SendLocal(new MyRequest())))
+                .Done(c => c.GotTheReply)
+                .Run();
+
+            Assert.True(context.GotTheReply);
+            Assert.AreEqual(typeof(IMyReply), context.MessageTypeInPipeline);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotTheReply { get; set; }
+            public Type MessageTypeInPipeline { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(c => c.Pipeline.Register("MessageTypeSpy", new MessageTypeSpy((Context)ScenarioContext), "MessageTypeSpy"));
+            }
+
+            public class StartMessageHandler : IHandleMessages<MyRequest>
+            {
+                public IMessageCreator MessageCreator { get; set; }
+
+                public Task Handle(MyRequest message, IMessageHandlerContext context)
+                {
+                    var interfaceMessage = MessageCreator.CreateInstance<IMyReply>();
+                    return context.Reply(interfaceMessage);
+                }
+            }
+
+            public class IMyMessageHandler : IHandleMessages<IMyReply>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(IMyReply message, IMessageHandlerContext context)
+                {
+                    Context.GotTheReply = true;
+
+                    return Task.FromResult(0);
+                }
+            }
+
+            class MessageTypeSpy : IBehavior<IOutgoingLogicalMessageContext, IOutgoingLogicalMessageContext>
+            {
+                public MessageTypeSpy(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Invoke(IOutgoingLogicalMessageContext context, Func<IOutgoingLogicalMessageContext, Task> next)
+                {
+                    testContext.MessageTypeInPipeline = context.Message.MessageType;
+                    return next(context);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class MyRequest : IMessage
+        {
+        }
+
+        public interface IMyReply : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_routing_interface_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_routing_interface_message.cs
@@ -9,7 +9,7 @@
     public class When_routing_interface_message : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_route_correctly()
+        public async Task Should_use_interface_types_route()
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(c => c.When(b => b.SendLocal(new StartMessage())))

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_routing_interface_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_routing_interface_message.cs
@@ -1,0 +1,70 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Routing
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using AcceptanceTesting.Customization;
+    using NUnit.Framework;
+
+    public class When_routing_interface_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_route_correctly()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(c => c.When(b => b.SendLocal(new StartMessage())))
+                .Done(c => c.GotTheMessage)
+                .Run();
+
+            Assert.True(context.GotTheMessage);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotTheMessage { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>((c, r) =>
+                {
+                    var routing = c.ConfigureTransport().Routing();
+                    routing.RouteToEndpoint(typeof(IMyMessage), typeof(Endpoint));
+                });
+            }
+
+            public class StartMessageHandler : IHandleMessages<StartMessage>
+            {
+                public IMessageCreator MessageCreator { get; set; }
+
+                public Task Handle(StartMessage message, IMessageHandlerContext context)
+                {
+                    var interfaceMessage = MessageCreator.CreateInstance<IMyMessage>();
+                    return context.Send(interfaceMessage);
+                }
+            }
+
+            public class IMyMessageHandler : IHandleMessages<IMyMessage>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(IMyMessage message, IMessageHandlerContext context)
+                {
+                    Context.GotTheMessage = true;
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class StartMessage : IMessage
+        {
+        }
+
+        public interface IMyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_pre_created_interface.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_pre_created_interface.cs
@@ -1,0 +1,115 @@
+﻿namespace NServiceBus.AcceptanceTests.Routing
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+    using Conventions = AcceptanceTesting.Customization.Conventions;
+
+    public class When_publishing_pre_created_interface : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_receive_event()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Publisher>(b =>
+                    b.When(c => c.Subscribed, (session, ctx) => session.SendLocal(new StartMessage())))
+                .WithEndpoint<Subscriber>(b => b.When(async (session, ctx) =>
+                {
+                    await session.Subscribe<MyEvent>();
+                    if (ctx.HasNativePubSubSupport)
+                    {
+                        ctx.Subscribed = true;
+                    }
+                }))
+                .Done(c => c.GotTheEvent)
+                .Run();
+
+            Assert.True(context.GotTheEvent);
+            Assert.AreEqual(typeof(MyEvent), context.EventTypePassedToRouting);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool GotTheEvent { get; set; }
+            public bool Subscribed { get; set; }
+            public Type EventTypePassedToRouting { get; set; }
+        }
+
+        public class Publisher : EndpointConfigurationBuilder
+        {
+            public Publisher()
+            {
+                EndpointSetup<DefaultPublisher>(c =>
+                {
+                    c.Pipeline.Register("EventTypeSpy", new EventTypeSpy((Context)ScenarioContext), "EventTypeSpy");
+                    c.OnEndpointSubscribed<Context>((s, context) =>
+                    {
+                        if (s.SubscriberEndpoint.Contains(Conventions.EndpointNamingConvention(typeof(Subscriber))))
+                        {
+                            context.Subscribed = true;
+                        }
+                    });
+                });
+            }
+
+            public class StartMessageHandler : IHandleMessages<StartMessage>
+            {
+                public IMessageCreator MessageCreator { get; set; }
+
+                public Task Handle(StartMessage message, IMessageHandlerContext context)
+                {
+                    return context.Publish(MessageCreator.CreateInstance<MyEvent>());
+                }
+            }
+
+            class EventTypeSpy : IBehavior<IOutgoingLogicalMessageContext, IOutgoingLogicalMessageContext>
+            {
+                public EventTypeSpy(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Invoke(IOutgoingLogicalMessageContext context, Func<IOutgoingLogicalMessageContext, Task> next)
+                {
+                    testContext.EventTypePassedToRouting = context.Message.MessageType;
+                    return next(context);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                    {
+                        c.DisableFeature<AutoSubscribe>();
+                    },
+                    metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
+            }
+
+            public class MyEventHandler : IHandleMessages<MyEvent>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MyEvent @event, IMessageHandlerContext context)
+                {
+                    Context.GotTheEvent = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+        public class StartMessage : IMessage
+        {
+        }
+        public interface MyEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_pre_created_interface.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_pre_created_interface.cs
@@ -12,7 +12,7 @@
     public class When_publishing_pre_created_interface : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_receive_event()
+        public async Task Should_publish_event_to_interface_type_subscribers()
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<Publisher>(b =>

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingPublishContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingPublishContextTests.cs
@@ -13,7 +13,7 @@
             var options = new PublishOptions();
             options.Context.Set("someKey", "someValue");
 
-            var testee = new OutgoingPublishContext(message, "message-id", options.OutgoingHeaders, options.Context, new RootContext(null, null, null));
+            var testee = new OutgoingPublishContext(message, "message-id", options.OutgoingHeaders, options.Context, new RootContext(null, null, null, null));
             testee.Extensions.Set("someKey", "updatedValue");
             testee.Extensions.Set("anotherKey", "anotherValue");
             options.Context.TryGet("someKey", out string value);
@@ -32,7 +32,7 @@
             var options = new PublishOptions();
             options.Context.Set("someKey", "someValue");
 
-            var parentContext = new RootContext(null,null,null);
+            var parentContext = new RootContext(null, null, null, null);
 
             new OutgoingPublishContext(message, "message-id", options.OutgoingHeaders, options.Context, parentContext);
 

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingReplyContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingReplyContextTests.cs
@@ -13,7 +13,7 @@
             var options = new ReplyOptions();
             options.Context.Set("someKey", "someValue");
 
-            var testee = new OutgoingReplyContext(message, "message-id", options.OutgoingHeaders, options.Context, new RootContext(null, null, null));
+            var testee = new OutgoingReplyContext(message, "message-id", options.OutgoingHeaders, options.Context, new RootContext(null, null, null, null));
             testee.Extensions.Set("someKey", "updatedValue");
             testee.Extensions.Set("anotherKey", "anotherValue");
 
@@ -33,7 +33,7 @@
             var options = new ReplyOptions();
             options.Context.Set("someKey", "someValue");
 
-            var parentContext = new RootContext(null, null, null);
+            var parentContext = new RootContext(null, null, null, null);
 
             new OutgoingReplyContext(message, "message-id", options.OutgoingHeaders, options.Context, parentContext);
 

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingSendContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingSendContextTests.cs
@@ -13,7 +13,7 @@
             var options = new SendOptions();
             options.Context.Set("someKey", "someValue");
 
-            var testee = new OutgoingSendContext(message, "message-id", options.OutgoingHeaders, options.Context, new RootContext(null, null, null));
+            var testee = new OutgoingSendContext(message, "message-id", options.OutgoingHeaders, options.Context, new RootContext(null, null, null, null));
             testee.Extensions.Set("someKey", "updatedValue");
             testee.Extensions.Set("anotherKey", "anotherValue");
             options.Context.TryGet("someKey", out string value);
@@ -32,7 +32,7 @@
             var options = new SendOptions();
             options.Context.Set("someKey", "someValue");
 
-            var parentContext = new RootContext(null, null, null);
+            var parentContext = new RootContext(null, null, null, null);
 
             new OutgoingSendContext(message, "message-id", options.OutgoingHeaders, options.Context, parentContext);
 

--- a/src/NServiceBus.Core.Tests/Routing/RoutingToDispatchConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingToDispatchConnectorTests.cs
@@ -84,7 +84,7 @@
         static IOutgoingSendContext CreateContext(SendOptions options, bool fromHandler)
         {
             var message = new MyMessage();
-            var context = new OutgoingSendContext(new OutgoingLogicalMessage(message.GetType(), message), options.UserDefinedMessageId ?? Guid.NewGuid().ToString(), options.OutgoingHeaders, options.Context, new RootContext(null, null, null));
+            var context = new OutgoingSendContext(new OutgoingLogicalMessage(message.GetType(), message), options.UserDefinedMessageId ?? Guid.NewGuid().ToString(), options.OutgoingHeaders, options.Context, new RootContext(null, null, null, null));
             if (fromHandler)
             {
                 context.Extensions.Set(new PendingTransportOperations());

--- a/src/NServiceBus.Core.Tests/Routing/SubscribeContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SubscribeContextTests.cs
@@ -12,7 +12,7 @@
             var context = new ContextBag();
             context.Set("someKey", "someValue");
 
-            var testee = new SubscribeContext(new RootContext(null, null, null), typeof(object), context);
+            var testee = new SubscribeContext(new RootContext(null, null, null, null), typeof(object), context);
             testee.Extensions.Set("someKey", "updatedValue");
             testee.Extensions.Set("anotherKey", "anotherValue");
             context.TryGet("someKey", out string value);
@@ -30,7 +30,7 @@
             var context = new ContextBag();
             context.Set("someKey", "someValue");
 
-            var parentContext = new RootContext(null, null, null);
+            var parentContext = new RootContext(null, null, null, null);
 
             new SubscribeContext(parentContext, typeof(object), context);
 

--- a/src/NServiceBus.Core.Tests/Routing/UnsubscribeContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnsubscribeContextTests.cs
@@ -12,7 +12,7 @@
             var context = new ContextBag();
             context.Set("someKey", "someValue");
 
-            var testee = new UnsubscribeContext(new RootContext(null, null, null), typeof(object), context);
+            var testee = new UnsubscribeContext(new RootContext(null, null, null, null), typeof(object), context);
             testee.Extensions.Set("someKey", "updatedValue");
             testee.Extensions.Set("anotherKey", "anotherValue");
             context.TryGet("someKey", out string value);
@@ -30,7 +30,7 @@
             var context = new ContextBag();
             context.Set("someKey", "someValue");
 
-            var parentContext = new RootContext(null, null, null);
+            var parentContext = new RootContext(null, null, null, null);
 
             new UnsubscribeContext(parentContext, typeof(object), context);
 

--- a/src/NServiceBus.Core.Tests/Unicast/MessageOperationsTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/MessageOperationsTests.cs
@@ -222,7 +222,8 @@
             pipelineCache.RegisterPipeline(pipeline);
 
             var context = new TestableMessageHandlerContext();
-            context.Builder.Register<IMessageMapper>(() => new MessageMapper());
+
+            context.Extensions.Set<IMessageMapper>(new MessageMapper());
             context.Extensions.Set<IPipelineCache>(pipelineCache);
 
             return context;

--- a/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
@@ -21,7 +21,7 @@
                 new FakeBuilder(),
                 null,
                 new FeatureRunner(new FeatureActivator(new SettingsHolder())),
-                new MessageSession(new RootContext(null, null, null)), new FakeTransportInfrastructure());
+                new MessageSession(new RootContext(null, null, null, null)), new FakeTransportInfrastructure());
 
             await testee.Stop();
 

--- a/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
@@ -7,14 +7,14 @@ namespace NServiceBus
     using System.Linq;
     using System.Threading.Tasks;
     using Logging;
-    using MessageInterfaces.MessageMapper.Reflection;
+    using MessageInterfaces;
     using Pipeline;
     using Transport;
     using Unicast.Messages;
 
     class DeserializeLogicalMessagesConnector : StageConnector<IIncomingPhysicalMessageContext, IIncomingLogicalMessageContext>
     {
-        public DeserializeLogicalMessagesConnector(MessageDeserializerResolver deserializerResolver, LogicalMessageFactory logicalMessageFactory, MessageMetadataRegistry messageMetadataRegistry, MessageMapper mapper)
+        public DeserializeLogicalMessagesConnector(MessageDeserializerResolver deserializerResolver, LogicalMessageFactory logicalMessageFactory, MessageMetadataRegistry messageMetadataRegistry, IMessageMapper mapper)
         {
             this.deserializerResolver = deserializerResolver;
             this.logicalMessageFactory = logicalMessageFactory;
@@ -140,7 +140,7 @@ namespace NServiceBus
         readonly MessageDeserializerResolver deserializerResolver;
         readonly LogicalMessageFactory logicalMessageFactory;
         readonly MessageMetadataRegistry messageMetadataRegistry;
-        readonly MessageMapper mapper;
+        readonly IMessageMapper mapper;
 
         static readonly LogicalMessage[] NoMessagesFound = new LogicalMessage[0];
 

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -2,18 +2,20 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
+    using MessageInterfaces;
     using ObjectBuilder;
     using Pipeline;
     using Transport;
 
     class MainPipelineExecutor : IPipelineExecutor
     {
-        public MainPipelineExecutor(IBuilder builder, IEventAggregator eventAggregator, IPipelineCache pipelineCache, IPipeline<ITransportReceiveContext> mainPipeline)
+        public MainPipelineExecutor(IBuilder builder, IEventAggregator eventAggregator, IPipelineCache pipelineCache, IPipeline<ITransportReceiveContext> mainPipeline, IMessageMapper messageMapper)
         {
             this.mainPipeline = mainPipeline;
             this.pipelineCache = pipelineCache;
             this.builder = builder;
             this.eventAggregator = eventAggregator;
+            this.messageMapper = messageMapper;
         }
 
         public async Task Invoke(MessageContext messageContext)
@@ -22,7 +24,7 @@ namespace NServiceBus
 
             using (var childBuilder = builder.CreateChildBuilder())
             {
-                var rootContext = new RootContext(childBuilder, pipelineCache, eventAggregator);
+                var rootContext = new RootContext(childBuilder, pipelineCache, eventAggregator, messageMapper);
 
                 var message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.Body);
                 var context = new TransportReceiveContext(message, messageContext.TransportTransaction, messageContext.ReceiveCancellationTokenSource, rootContext);
@@ -35,6 +37,7 @@ namespace NServiceBus
             }
         }
 
+        IMessageMapper messageMapper;
         IEventAggregator eventAggregator;
         IBuilder builder;
         IPipelineCache pipelineCache;

--- a/src/NServiceBus.Core/Pipeline/RootContext.cs
+++ b/src/NServiceBus.Core/Pipeline/RootContext.cs
@@ -1,14 +1,16 @@
 namespace NServiceBus
 {
+    using MessageInterfaces;
     using ObjectBuilder;
 
     class RootContext : BehaviorContext
     {
-        public RootContext(IBuilder builder, IPipelineCache pipelineCache, IEventAggregator eventAggregator) : base(null)
+        public RootContext(IBuilder builder, IPipelineCache pipelineCache, IEventAggregator eventAggregator, IMessageMapper messageMapper) : base(null)
         {
             Set(builder);
             Set(pipelineCache);
             Set(eventAggregator);
+            Set(messageMapper);
         }
     }
 }

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -5,6 +5,7 @@ namespace NServiceBus
     using System.Linq;
     using System.Threading.Tasks;
     using Logging;
+    using MessageInterfaces;
     using ObjectBuilder;
     using Pipeline;
     using Transport;
@@ -18,7 +19,8 @@ namespace NServiceBus
             IEventAggregator eventAggregator,
             IBuilder builder,
             CriticalError criticalError,
-            string errorQueue)
+            string errorQueue,
+            IMessageMapper messageMapper)
         {
             this.configuration = configuration;
             this.receiveInfrastructure = receiveInfrastructure;
@@ -28,6 +30,7 @@ namespace NServiceBus
             this.builder = builder;
             this.criticalError = criticalError;
             this.errorQueue = errorQueue;
+            this.messageMapper = messageMapper;
         }
 
         public void BindQueues(QueueBindings queueBindings)
@@ -58,7 +61,7 @@ namespace NServiceBus
             }
 
             var mainPipeline = new Pipeline<ITransportReceiveContext>(builder, pipelineConfiguration.Modifications);
-            mainPipelineExecutor = new MainPipelineExecutor(builder, eventAggregator, pipelineCache, mainPipeline);
+            mainPipelineExecutor = new MainPipelineExecutor(builder, eventAggregator, pipelineCache, mainPipeline, messageMapper);
 
             if (configuration.PurgeOnStartup)
             {
@@ -182,6 +185,7 @@ namespace NServiceBus
         IBuilder builder;
         CriticalError criticalError;
         string errorQueue;
+        IMessageMapper messageMapper;
 
         const string MainReceiverId = "Main";
 

--- a/src/NServiceBus.Core/Serialization/SerializationFeature.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationFeature.cs
@@ -6,7 +6,6 @@
     using Features;
     using Logging;
     using MessageInterfaces;
-    using MessageInterfaces.MessageMapper.Reflection;
     using Pipeline;
     using Serialization;
     using Settings;
@@ -21,7 +20,7 @@
 
         protected internal sealed override void Setup(FeatureConfigurationContext context)
         {
-            var mapper = new MessageMapper();
+            var mapper = context.Settings.Get<IMessageMapper>();
             var settings = context.Settings;
             var messageMetadataRegistry = settings.Get<MessageMetadataRegistry>();
             mapper.Initialize(messageMetadataRegistry.GetAllMessages().Select(m => m.MessageType));

--- a/src/NServiceBus.Core/Unicast/MessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperations.cs
@@ -116,7 +116,10 @@ namespace NServiceBus
 
         public static Task Reply(IBehaviorContext context, object message, ReplyOptions options)
         {
-            return ReplyMessage(context, message.GetType(), message, options);
+            var mapper = context.Extensions.Get<IMessageMapper>();
+            var messageType = mapper.GetMappedTypeFor(message.GetType());
+
+            return ReplyMessage(context, messageType, message, options);
         }
 
         public static Task Reply<T>(IBehaviorContext context, Action<T> messageConstructor, ReplyOptions options)

--- a/src/NServiceBus.Core/Unicast/MessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperations.cs
@@ -17,7 +17,10 @@ namespace NServiceBus
 
         public static Task Publish(IBehaviorContext context, object message, PublishOptions options)
         {
-            return Publish(context, message.GetType(), message, options);
+            var mapper = context.Builder.Build<IMessageMapper>();
+            var messageType = mapper.GetMappedTypeFor(message.GetType());
+
+            return Publish(context, messageType, message, options);
         }
 
         static Task Publish(IBehaviorContext context, Type messageType, object message, PublishOptions options)
@@ -76,7 +79,10 @@ namespace NServiceBus
 
         public static Task Send(IBehaviorContext context, object message, SendOptions options)
         {
-            return SendMessage(context, message.GetType(), message, options);
+            var mapper = context.Builder.Build<IMessageMapper>();
+            var messageType = mapper.GetMappedTypeFor(message.GetType());
+
+            return SendMessage(context, messageType, message, options);
         }
 
         static Task SendMessage(this IBehaviorContext context, Type messageType, object message, SendOptions options)

--- a/src/NServiceBus.Core/Unicast/MessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperations.cs
@@ -11,13 +11,14 @@ namespace NServiceBus
     {
         public static Task Publish<T>(IBehaviorContext context, Action<T> messageConstructor, PublishOptions options)
         {
-            var mapper = context.Builder.Build<IMessageMapper>();
+            var mapper = context.Extensions.Get<IMessageMapper>();
+
             return Publish(context, typeof(T), mapper.CreateInstance(messageConstructor), options);
         }
 
         public static Task Publish(IBehaviorContext context, object message, PublishOptions options)
         {
-            var mapper = context.Builder.Build<IMessageMapper>();
+            var mapper = context.Extensions.Get<IMessageMapper>();
             var messageType = mapper.GetMappedTypeFor(message.GetType());
 
             return Publish(context, messageType, message, options);
@@ -72,14 +73,14 @@ namespace NServiceBus
 
         public static Task Send<T>(IBehaviorContext context, Action<T> messageConstructor, SendOptions options)
         {
-            var mapper = context.Builder.Build<IMessageMapper>();
+            var mapper = context.Extensions.Get<IMessageMapper>();
 
             return SendMessage(context, typeof(T), mapper.CreateInstance(messageConstructor), options);
         }
 
         public static Task Send(IBehaviorContext context, object message, SendOptions options)
         {
-            var mapper = context.Builder.Build<IMessageMapper>();
+            var mapper = context.Extensions.Get<IMessageMapper>();
             var messageType = mapper.GetMappedTypeFor(message.GetType());
 
             return SendMessage(context, messageType, message, options);
@@ -120,7 +121,7 @@ namespace NServiceBus
 
         public static Task Reply<T>(IBehaviorContext context, Action<T> messageConstructor, ReplyOptions options)
         {
-            var mapper = context.Builder.Build<IMessageMapper>();
+            var mapper = context.Extensions.Get<IMessageMapper>();
 
             return ReplyMessage(context, typeof(T), mapper.CreateInstance(messageConstructor), options);
         }


### PR DESCRIPTION
Interface messages created using `IMessageCreator` can't be routed since they message type resolves to the `{message-type}__impl` type generated by NServiceBus.

## Who's affected

Users that defines messages using interfaces and creates them using the `IMessageCreator` API.

## Symptoms

Send operations fail with an exception that no route can be found for `message-type`.