### PR TITLE
Stop using DI to access the message mapper

### DIFF
--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingPublishContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingPublishContextTests.cs
@@ -13,7 +13,7 @@
             var options = new PublishOptions();
             options.Context.Set("someKey", "someValue");
 
-            var testee = new OutgoingPublishContext(message, "message-id", options.OutgoingHeaders, options.Context, new RootContext(null, null, null));
+            var testee = new OutgoingPublishContext(message, "message-id", options.OutgoingHeaders, options.Context, new RootContext(null, null, null, null));
             testee.Extensions.Set("someKey", "updatedValue");
             testee.Extensions.Set("anotherKey", "anotherValue");
             options.Context.TryGet("someKey", out string value);
@@ -32,7 +32,7 @@
             var options = new PublishOptions();
             options.Context.Set("someKey", "someValue");
 
-            var parentContext = new RootContext(null,null,null);
+            var parentContext = new RootContext(null, null, null, null);
 
             new OutgoingPublishContext(message, "message-id", options.OutgoingHeaders, options.Context, parentContext);
 

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingReplyContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingReplyContextTests.cs
@@ -13,7 +13,7 @@
             var options = new ReplyOptions();
             options.Context.Set("someKey", "someValue");
 
-            var testee = new OutgoingReplyContext(message, "message-id", options.OutgoingHeaders, options.Context, new RootContext(null, null, null));
+            var testee = new OutgoingReplyContext(message, "message-id", options.OutgoingHeaders, options.Context, new RootContext(null, null, null, null));
             testee.Extensions.Set("someKey", "updatedValue");
             testee.Extensions.Set("anotherKey", "anotherValue");
 
@@ -33,7 +33,7 @@
             var options = new ReplyOptions();
             options.Context.Set("someKey", "someValue");
 
-            var parentContext = new RootContext(null, null, null);
+            var parentContext = new RootContext(null, null, null, null);
 
             new OutgoingReplyContext(message, "message-id", options.OutgoingHeaders, options.Context, parentContext);
 

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingSendContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingSendContextTests.cs
@@ -13,7 +13,7 @@
             var options = new SendOptions();
             options.Context.Set("someKey", "someValue");
 
-            var testee = new OutgoingSendContext(message, "message-id", options.OutgoingHeaders, options.Context, new RootContext(null, null, null));
+            var testee = new OutgoingSendContext(message, "message-id", options.OutgoingHeaders, options.Context, new RootContext(null, null, null, null));
             testee.Extensions.Set("someKey", "updatedValue");
             testee.Extensions.Set("anotherKey", "anotherValue");
             options.Context.TryGet("someKey", out string value);
@@ -32,7 +32,7 @@
             var options = new SendOptions();
             options.Context.Set("someKey", "someValue");
 
-            var parentContext = new RootContext(null, null, null);
+            var parentContext = new RootContext(null, null, null, null);
 
             new OutgoingSendContext(message, "message-id", options.OutgoingHeaders, options.Context, parentContext);
 

--- a/src/NServiceBus.Core.Tests/Routing/RoutingToDispatchConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingToDispatchConnectorTests.cs
@@ -84,7 +84,7 @@
         static IOutgoingSendContext CreateContext(SendOptions options, bool fromHandler)
         {
             var message = new MyMessage();
-            var context = new OutgoingSendContext(new OutgoingLogicalMessage(message.GetType(), message), options.UserDefinedMessageId ?? Guid.NewGuid().ToString(), options.OutgoingHeaders, options.Context, new RootContext(null, null, null));
+            var context = new OutgoingSendContext(new OutgoingLogicalMessage(message.GetType(), message), options.UserDefinedMessageId ?? Guid.NewGuid().ToString(), options.OutgoingHeaders, options.Context, new RootContext(null, null, null, null));
             if (fromHandler)
             {
                 context.Extensions.Set(new PendingTransportOperations());

--- a/src/NServiceBus.Core.Tests/Routing/SubscribeContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SubscribeContextTests.cs
@@ -12,7 +12,7 @@
             var context = new ContextBag();
             context.Set("someKey", "someValue");
 
-            var testee = new SubscribeContext(new RootContext(null, null, null), typeof(object), context);
+            var testee = new SubscribeContext(new RootContext(null, null, null, null), typeof(object), context);
             testee.Extensions.Set("someKey", "updatedValue");
             testee.Extensions.Set("anotherKey", "anotherValue");
             context.TryGet("someKey", out string value);
@@ -30,7 +30,7 @@
             var context = new ContextBag();
             context.Set("someKey", "someValue");
 
-            var parentContext = new RootContext(null, null, null);
+            var parentContext = new RootContext(null, null, null, null);
 
             new SubscribeContext(parentContext, typeof(object), context);
 

--- a/src/NServiceBus.Core.Tests/Routing/UnsubscribeContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnsubscribeContextTests.cs
@@ -12,7 +12,7 @@
             var context = new ContextBag();
             context.Set("someKey", "someValue");
 
-            var testee = new UnsubscribeContext(new RootContext(null, null, null), typeof(object), context);
+            var testee = new UnsubscribeContext(new RootContext(null, null, null, null), typeof(object), context);
             testee.Extensions.Set("someKey", "updatedValue");
             testee.Extensions.Set("anotherKey", "anotherValue");
             context.TryGet("someKey", out string value);
@@ -30,7 +30,7 @@
             var context = new ContextBag();
             context.Set("someKey", "someValue");
 
-            var parentContext = new RootContext(null, null, null);
+            var parentContext = new RootContext(null, null, null, null);
 
             new UnsubscribeContext(parentContext, typeof(object), context);
 

--- a/src/NServiceBus.Core.Tests/Unicast/MessageOperationsTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/MessageOperationsTests.cs
@@ -222,7 +222,8 @@
             pipelineCache.RegisterPipeline(pipeline);
 
             var context = new TestableMessageHandlerContext();
-            context.Builder.Register<IMessageMapper>(() => new MessageMapper());
+
+            context.Extensions.Set<IMessageMapper>(new MessageMapper());
             context.Extensions.Set<IPipelineCache>(pipelineCache);
 
             return context;

--- a/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
@@ -21,7 +21,7 @@
                 new FakeBuilder(),
                 null,
                 new FeatureRunner(new FeatureActivator(new SettingsHolder())),
-                new MessageSession(new RootContext(null, null, null)), new FakeTransportInfrastructure());
+                new MessageSession(new RootContext(null, null, null, null)), new FakeTransportInfrastructure());
 
             await testee.Stop();
 

--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -66,7 +66,7 @@ namespace NServiceBus
             var eventAggregator = new EventAggregator(settings.Get<NotificationSubscriptions>());
             var pipelineCache = new PipelineCache(builder, settings);
             var queueBindings = settings.Get<QueueBindings>();
-          
+
             var receiveComponent = CreateReceiveComponent(receiveConfiguration, transportInfrastructure, queueBindings, pipelineCache, eventAggregator, messageMapper);
 
             var shouldRunInstallers = settings.GetOrDefault<bool>("Installers.Enable");

--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -52,8 +52,8 @@ namespace NServiceBus
             var receiveConfiguration = BuildReceiveConfiguration(transportInfrastructure);
 
             var routing = InitializeRouting(transportInfrastructure, receiveConfiguration);
-            var messageMapper = new MessageMapper();
 
+            var messageMapper = new MessageMapper();
             settings.Set<IMessageMapper>(messageMapper);
 
             var featureStats = featureActivator.SetupFeatures(container, pipelineSettings, routing, receiveConfiguration);
@@ -91,6 +91,7 @@ namespace NServiceBus
                     NServiceBusVersion = GitFlowVersion.MajorMinorPatch
                 }
             );
+
             var messageSession = new MessageSession(new RootContext(builder, pipelineCache, eventAggregator, messageMapper));
 
             return new StartableEndpoint(settings, builder, featureActivator, transportInfrastructure, receiveComponent, criticalError, messageSession);

--- a/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/DeserializeLogicalMessagesConnector.cs
@@ -7,14 +7,14 @@ namespace NServiceBus
     using System.Linq;
     using System.Threading.Tasks;
     using Logging;
-    using MessageInterfaces.MessageMapper.Reflection;
+    using MessageInterfaces;
     using Pipeline;
     using Transport;
     using Unicast.Messages;
 
     class DeserializeLogicalMessagesConnector : StageConnector<IIncomingPhysicalMessageContext, IIncomingLogicalMessageContext>
     {
-        public DeserializeLogicalMessagesConnector(MessageDeserializerResolver deserializerResolver, LogicalMessageFactory logicalMessageFactory, MessageMetadataRegistry messageMetadataRegistry, MessageMapper mapper)
+        public DeserializeLogicalMessagesConnector(MessageDeserializerResolver deserializerResolver, LogicalMessageFactory logicalMessageFactory, MessageMetadataRegistry messageMetadataRegistry, IMessageMapper mapper)
         {
             this.deserializerResolver = deserializerResolver;
             this.logicalMessageFactory = logicalMessageFactory;
@@ -140,7 +140,7 @@ namespace NServiceBus
         readonly MessageDeserializerResolver deserializerResolver;
         readonly LogicalMessageFactory logicalMessageFactory;
         readonly MessageMetadataRegistry messageMetadataRegistry;
-        readonly MessageMapper mapper;
+        readonly IMessageMapper mapper;
 
         static readonly LogicalMessage[] NoMessagesFound = new LogicalMessage[0];
 

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -2,18 +2,20 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
+    using MessageInterfaces;
     using ObjectBuilder;
     using Pipeline;
     using Transport;
 
     class MainPipelineExecutor : IPipelineExecutor
     {
-        public MainPipelineExecutor(IBuilder builder, IEventAggregator eventAggregator, IPipelineCache pipelineCache, IPipeline<ITransportReceiveContext> mainPipeline)
+        public MainPipelineExecutor(IBuilder builder, IEventAggregator eventAggregator, IPipelineCache pipelineCache, IPipeline<ITransportReceiveContext> mainPipeline, IMessageMapper messageMapper)
         {
             this.mainPipeline = mainPipeline;
             this.pipelineCache = pipelineCache;
             this.builder = builder;
             this.eventAggregator = eventAggregator;
+            this.messageMapper = messageMapper;
         }
 
         public async Task Invoke(MessageContext messageContext)
@@ -22,7 +24,7 @@ namespace NServiceBus
 
             using (var childBuilder = builder.CreateChildBuilder())
             {
-                var rootContext = new RootContext(childBuilder, pipelineCache, eventAggregator);
+                var rootContext = new RootContext(childBuilder, pipelineCache, eventAggregator, messageMapper);
 
                 var message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.Body);
                 var context = new TransportReceiveContext(message, messageContext.TransportTransaction, messageContext.ReceiveCancellationTokenSource, rootContext);
@@ -35,6 +37,7 @@ namespace NServiceBus
             }
         }
 
+        IMessageMapper messageMapper;
         IEventAggregator eventAggregator;
         IBuilder builder;
         IPipelineCache pipelineCache;

--- a/src/NServiceBus.Core/Pipeline/RootContext.cs
+++ b/src/NServiceBus.Core/Pipeline/RootContext.cs
@@ -1,14 +1,16 @@
 namespace NServiceBus
 {
+    using MessageInterfaces;
     using ObjectBuilder;
 
     class RootContext : BehaviorContext
     {
-        public RootContext(IBuilder builder, IPipelineCache pipelineCache, IEventAggregator eventAggregator) : base(null)
+        public RootContext(IBuilder builder, IPipelineCache pipelineCache, IEventAggregator eventAggregator, IMessageMapper messageMapper) : base(null)
         {
             Set(builder);
             Set(pipelineCache);
             Set(eventAggregator);
+            Set(messageMapper);
         }
     }
 }

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -5,6 +5,7 @@ namespace NServiceBus
     using System.Linq;
     using System.Threading.Tasks;
     using Logging;
+    using MessageInterfaces;
     using ObjectBuilder;
     using Pipeline;
     using Transport;
@@ -18,7 +19,8 @@ namespace NServiceBus
             IEventAggregator eventAggregator,
             IBuilder builder,
             CriticalError criticalError,
-            string errorQueue)
+            string errorQueue,
+            IMessageMapper messageMapper)
         {
             this.configuration = configuration;
             this.receiveInfrastructure = receiveInfrastructure;
@@ -28,6 +30,7 @@ namespace NServiceBus
             this.builder = builder;
             this.criticalError = criticalError;
             this.errorQueue = errorQueue;
+            this.messageMapper = messageMapper;
         }
 
         public void BindQueues(QueueBindings queueBindings)
@@ -58,7 +61,7 @@ namespace NServiceBus
             }
 
             var mainPipeline = new Pipeline<ITransportReceiveContext>(builder, pipelineConfiguration.Modifications);
-            mainPipelineExecutor = new MainPipelineExecutor(builder, eventAggregator, pipelineCache, mainPipeline);
+            mainPipelineExecutor = new MainPipelineExecutor(builder, eventAggregator, pipelineCache, mainPipeline, messageMapper);
 
             if (configuration.PurgeOnStartup)
             {
@@ -182,6 +185,7 @@ namespace NServiceBus
         IBuilder builder;
         CriticalError criticalError;
         string errorQueue;
+        IMessageMapper messageMapper;
 
         const string MainReceiverId = "Main";
 

--- a/src/NServiceBus.Core/Serialization/SerializationFeature.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationFeature.cs
@@ -6,7 +6,6 @@
     using Features;
     using Logging;
     using MessageInterfaces;
-    using MessageInterfaces.MessageMapper.Reflection;
     using Pipeline;
     using Serialization;
     using Settings;

--- a/src/NServiceBus.Core/Serialization/SerializationFeature.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationFeature.cs
@@ -21,7 +21,7 @@
 
         protected internal sealed override void Setup(FeatureConfigurationContext context)
         {
-            var mapper = new MessageMapper();
+            var mapper = context.Settings.Get<IMessageMapper>();
             var settings = context.Settings;
             var messageMetadataRegistry = settings.Get<MessageMetadataRegistry>();
             mapper.Initialize(messageMetadataRegistry.GetAllMessages().Select(m => m.MessageType));

--- a/src/NServiceBus.Core/Unicast/MessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperations.cs
@@ -11,13 +11,13 @@ namespace NServiceBus
     {
         public static Task Publish<T>(IBehaviorContext context, Action<T> messageConstructor, PublishOptions options)
         {
-            var mapper = context.Builder.Build<IMessageMapper>();
+            var mapper = context.Extensions.Get<IMessageMapper>();
             return Publish(context, typeof(T), mapper.CreateInstance(messageConstructor), options);
         }
 
         public static Task Publish(IBehaviorContext context, object message, PublishOptions options)
         {
-            var mapper = context.Builder.Build<IMessageMapper>();
+            var mapper = context.Extensions.Get<IMessageMapper>();
             var messageType = mapper.GetMappedTypeFor(message.GetType());
 
             return Publish(context, messageType, message, options);
@@ -72,14 +72,15 @@ namespace NServiceBus
 
         public static Task Send<T>(IBehaviorContext context, Action<T> messageConstructor, SendOptions options)
         {
-            var mapper = context.Builder.Build<IMessageMapper>();
+            var mapper = context.Extensions.Get<IMessageMapper>();
 
             return SendMessage(context, typeof(T), mapper.CreateInstance(messageConstructor), options);
         }
 
         public static Task Send(IBehaviorContext context, object message, SendOptions options)
         {
-            var mapper = context.Builder.Build<IMessageMapper>();
+            var mapper = context.Extensions.Get<IMessageMapper>();
+
             var messageType = mapper.GetMappedTypeFor(message.GetType());
 
             return SendMessage(context, messageType, message, options);
@@ -120,7 +121,7 @@ namespace NServiceBus
 
         public static Task Reply<T>(IBehaviorContext context, Action<T> messageConstructor, ReplyOptions options)
         {
-            var mapper = context.Builder.Build<IMessageMapper>();
+            var mapper = context.Extensions.Get<IMessageMapper>();
 
             return ReplyMessage(context, typeof(T), mapper.CreateInstance(messageConstructor), options);
         }

--- a/src/NServiceBus.Core/Unicast/MessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperations.cs
@@ -12,6 +12,7 @@ namespace NServiceBus
         public static Task Publish<T>(IBehaviorContext context, Action<T> messageConstructor, PublishOptions options)
         {
             var mapper = context.Extensions.Get<IMessageMapper>();
+
             return Publish(context, typeof(T), mapper.CreateInstance(messageConstructor), options);
         }
 
@@ -80,7 +81,6 @@ namespace NServiceBus
         public static Task Send(IBehaviorContext context, object message, SendOptions options)
         {
             var mapper = context.Extensions.Get<IMessageMapper>();
-
             var messageType = mapper.GetMappedTypeFor(message.GetType());
 
             return SendMessage(context, messageType, message, options);


### PR DESCRIPTION
This would eliminate the need to use the builder to access it.

Would we be fine with adding this to the patch or would we want this to go against develop only?