### PR TITLE
[WIP]Throw if structs are used as message contracts

### DIFF
--- a/src/NServiceBus.Core.Tests/Unicast/Messages/DefaultMessageRegistryTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/Messages/DefaultMessageRegistryTests.cs
@@ -20,6 +20,13 @@
             }
 
             [Test]
+            public void Should_throw_if_structs_matches_the_message_conventions()
+            {
+                var defaultMessageRegistry = new MessageMetadataRegistry(new Conventions().IsMessageType);
+                Assert.Throws<Exception>(() => defaultMessageRegistry.RegisterMessageTypesFoundIn(new List<Type> { typeof(MyStruct) }));
+            }
+
+            [Test]
             public void Should_return_metadata_for_a_mapped_type()
             {
                 var defaultMessageRegistry = new MessageMetadataRegistry(type => type == typeof(int));
@@ -75,6 +82,10 @@
 
             }
 
+            struct MyStruct : IMessage
+            {
+
+            }
         }
     }
 }

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -131,6 +131,11 @@
 
         MessageMetadata RegisterMessageType(Type messageType)
         {
+            if (messageType.IsValueType)
+            {
+                throw new Exception($"Structs are not supported as message types, please change {messageType} to a `class`");
+            }
+
             //get the parent types
             var parentMessages = GetParentTypes(messageType)
                 .Where(t => isMessageType(t))


### PR DESCRIPTION
As discovered in https://github.com/Particular/docs.particular.net/pull/4350#discussion_r279357020 we fail with a null ref if a user tried to define a message contract using a struct. This PR throws a nicer Exception at startup.

### WIP
I'm on the fence if we can actually do this in a minor since, in theory, you could use a custom convention that currently matches a struct that happens to be in your message assembly but you don't use it. In those cases we would now be starting to throw?