### PR TITLE
Fix namespace of test

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Outbox/When_clearing_saga_timeouts.cs
+++ b/src/NServiceBus.AcceptanceTests/Outbox/When_clearing_saga_timeouts.cs
@@ -8,7 +8,7 @@
     using Features;
     using NServiceBus;
     using NServiceBus.Outbox;
-    using NServiceBus.Persistence;
+    using Persistence;
     using NUnit.Framework;
 
     public class When_clearing_saga_timeouts : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Outbox/When_clearing_saga_timeouts.cs
+++ b/src/NServiceBus.AcceptanceTests/Outbox/When_clearing_saga_timeouts.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AcceptanceTests.Core.Outbox
+﻿namespace NServiceBus.AcceptanceTests.Outbox
 {
     using System;
     using System.Threading.Tasks;


### PR DESCRIPTION
The test is in the main folder, not the Core folder, so it shouldn't have the Core namespace.