### PR TITLE
Done delegate should accept outContextType

### DIFF
--- a/src/NServiceBus.Core/Pipeline/PipelineExecutionExtensions.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineExecutionExtensions.cs
@@ -53,11 +53,8 @@
 
                 if (i == behaviorCount)
                 {
-                    if (currentBehavior is IPipelineTerminator)
-                    {
-                        inContextType = typeof(PipelineTerminator<>.ITerminatingContext).MakeGenericType(inContextType);
-                    }
-                    var doneDelegate = CreateDoneDelegate(inContextType, i);
+                    var outContextType = genericArguments[1];
+                    var doneDelegate = CreateDoneDelegate(outContextType, i);
                     lambdaExpression = CreateBehaviorCallDelegate(currentBehavior, methodInfo, inContextParameter, doneDelegate, expressions);
                     continue;
                 }


### PR DESCRIPTION
While reading through the code (demonstrated by @danielmarbach at Techorama), I was wondering if it isn't more logical to create a done delegate that takes an instance of `outContextType` instead. Unit- and acceptance tests seem to be happy.