### PR TITLE
Add acceptance test that tests Saga and Outbox together

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Sagas/When_handling_concurrent_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_handling_concurrent_messages.cs
@@ -8,13 +8,17 @@
     using EndpointTemplates;
     using NUnit.Framework;
 
-    public class When_using_saga_and_outbox : NServiceBusAcceptanceTest
+    public class When_handling_concurrent_messages : NServiceBusAcceptanceTest
     {
-        [Test]
-        public async Task Should_not_overwrite_each_other()
+        [TestCase(false)]
+        [TestCase(true)]
+        public async Task Should_not_overwrite_each_other(bool useOutbox)
         {
-            // The test is still valid if Outbox persistence is not available. Only turn it on if it's offered.
-            var enableOutbox = TestSuiteConstraints.Current.SupportsOutbox;
+            // The true case provides a good test of the combination of Saga and Outbox together.
+            if (useOutbox)
+            {
+                Requires.OutboxPersistence();
+            }
 
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithSagaAndOutbox>(b =>
@@ -22,7 +26,7 @@
                     b.DoNotFailOnErrorMessages();
                     b.CustomConfig(cfg =>
                     {
-                        if (enableOutbox)
+                        if (useOutbox)
                         {
                             cfg.EnableOutbox();
                         }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_saga_and_outbox.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_saga_and_outbox.cs
@@ -1,0 +1,124 @@
+﻿namespace NServiceBus.AcceptanceTests.Sagas
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTests;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_using_saga_and_outbox : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_not_overwrite_each_other()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithSagaAndOutbox>(b =>
+                {
+                    b.DoNotFailOnErrorMessages();
+                    b.CustomConfig(cfg =>
+                    {
+                        cfg.EnableOutbox();
+                        cfg.Recoverability().Immediate(x => x.NumberOfRetries(5));
+                    });
+                    b.When((session, ctx) => session.SendLocal(new StartMsg { OrderId = "12345" }));
+
+                    var timeout = DateTime.UtcNow.AddSeconds(15);
+
+                    b.When(c => DateTime.UtcNow > timeout, (session, ctx) => session.SendLocal(new FinishMsg { OrderId = "12345" }));
+                })
+                .Done(c => c.SagaData != null)
+                .Run();
+
+            Assert.IsNotNull(context.SagaData);
+            Assert.AreEqual(3, context.SagaData.ContinueCount);
+            Assert.Contains(1, context.SagaData.CollectedIndexes);
+            Assert.Contains(2, context.SagaData.CollectedIndexes);
+            Assert.Contains(3, context.SagaData.CollectedIndexes);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public EndpointWithSagaAndOutbox.OrderSagaData SagaData { get; set; }
+        }
+
+        public class EndpointWithSagaAndOutbox : EndpointConfigurationBuilder
+        {
+            public EndpointWithSagaAndOutbox()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class OrderSaga : Saga<OrderSagaData>,
+                IAmStartedByMessages<StartMsg>,
+                IHandleMessages<ContinueMsg>,
+                IHandleMessages<FinishMsg>
+            {
+                Context testContext;
+
+                public OrderSaga(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<OrderSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartMsg>(m => m.OrderId).ToSaga(s => s.OrderId);
+                    mapper.ConfigureMapping<ContinueMsg>(m => m.OrderId).ToSaga(s => s.OrderId);
+                    mapper.ConfigureMapping<FinishMsg>(m => m.OrderId).ToSaga(s => s.OrderId);
+                }
+
+                public async Task Handle(StartMsg message, IMessageHandlerContext context)
+                {
+                    await context.SendLocal(new ContinueMsg { OrderId = message.OrderId, Index = 1 });
+                    await context.SendLocal(new ContinueMsg { OrderId = message.OrderId, Index = 2 });
+                    await context.SendLocal(new ContinueMsg { OrderId = message.OrderId, Index = 3 });
+                }
+
+                public Task Handle(ContinueMsg message, IMessageHandlerContext context)
+                {
+                    this.Data.ContinueCount++;
+                    this.Data.CollectedIndexes.Add(message.Index);
+
+                    if (this.Data.ContinueCount == 3)
+                    {
+                        return context.SendLocal(new FinishMsg { OrderId = message.OrderId });
+                    }
+
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(FinishMsg message, IMessageHandlerContext context)
+                {
+                    this.MarkAsComplete();
+                    testContext.SagaData = this.Data;
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class OrderSagaData : ContainSagaData
+            {
+                public string OrderId { get; set; }
+                public int ContinueCount { get; set; }
+                public List<int> CollectedIndexes { get; set; } = new List<int>();
+            }
+        }
+
+        public class StartMsg : ICommand
+        {
+            public string OrderId { get; set; }
+        }
+
+        public class ContinueMsg : ICommand
+        {
+            public string OrderId { get; set; }
+            public int Index { get; set; }
+        }
+
+        public class FinishMsg : ICommand
+        {
+            public string OrderId { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_saga_and_outbox.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_saga_and_outbox.cs
@@ -13,13 +13,19 @@
         [Test]
         public async Task Should_not_overwrite_each_other()
         {
+            // The test is still valid if Outbox persistence is not available. Only turn it on if it's offered.
+            var enableOutbox = TestSuiteConstraints.Current.SupportsOutbox;
+
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithSagaAndOutbox>(b =>
                 {
                     b.DoNotFailOnErrorMessages();
                     b.CustomConfig(cfg =>
                     {
-                        cfg.EnableOutbox();
+                        if (enableOutbox)
+                        {
+                            cfg.EnableOutbox();
+                        }
                         cfg.Recoverability().Immediate(x => x.NumberOfRetries(5));
                     });
                     b.When((session, ctx) => session.SendLocal(new StartMsg { OrderId = "12345" }));
@@ -99,9 +105,9 @@
 
             public class OrderSagaData : ContainSagaData
             {
-                public string OrderId { get; set; }
-                public int ContinueCount { get; set; }
-                public List<int> CollectedIndexes { get; set; } = new List<int>();
+                public virtual string OrderId { get; set; }
+                public virtual int ContinueCount { get; set; }
+                public virtual List<int> CollectedIndexes { get; set; } = new List<int>();
             }
         }
 


### PR DESCRIPTION
While working on a Raven release, I discovered we don't have an acceptance test that tests a Saga and the Outbox together, nor do we really have one that puts a saga through multiple steps with a possibility of concurrency issue. So I was passing all tests but still having a concurrency issue where successive updates to the saga data were overriding each other. This test covers that case.