### PR TITLE
Expose MessageId on DelayedRetryMessage

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -1461,10 +1461,15 @@ namespace NServiceBus.Faults
 {
     public class DelayedRetryMessage
     {
+        public DelayedRetryMessage(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, System.Exception exception, int retryAttempt) { }
+        [System.ObsoleteAttribute("Use `DelayedRetryMessage(string messageId, Dictionary<string, string> headers, by" +
+            "te[] body, Exception exception, int retryAttempt)` instead. Will be removed in v" +
+            "ersion 8.0.0.", true)]
         public DelayedRetryMessage(System.Collections.Generic.Dictionary<string, string> headers, byte[] body, System.Exception exception, int retryAttempt) { }
         public byte[] Body { get; }
         public System.Exception Exception { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
+        public string MessageId { get; }
         public int RetryAttempt { get; }
     }
     public class ErrorsNotifications

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -1463,10 +1463,15 @@ namespace NServiceBus.Faults
 {
     public class DelayedRetryMessage
     {
+        public DelayedRetryMessage(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, System.Exception exception, int retryAttempt) { }
+        [System.ObsoleteAttribute("Use `DelayedRetryMessage(string messageId, Dictionary<string, string> headers, by" +
+            "te[] body, Exception exception, int retryAttempt)` instead. Will be removed in v" +
+            "ersion 8.0.0.", true)]
         public DelayedRetryMessage(System.Collections.Generic.Dictionary<string, string> headers, byte[] body, System.Exception exception, int retryAttempt) { }
         public byte[] Body { get; }
         public System.Exception Exception { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
+        public string MessageId { get; }
         public int RetryAttempt { get; }
     }
     public class ErrorsNotifications

--- a/src/NServiceBus.Core/Recoverability/DelayedRetries/DelayedRetryMessage.cs
+++ b/src/NServiceBus.Core/Recoverability/DelayedRetries/DelayedRetryMessage.cs
@@ -11,17 +11,41 @@ namespace NServiceBus.Faults
         /// <summary>
         /// Creates a new instance of <see cref="DelayedRetryMessage" />.
         /// </summary>
+        /// <param name="messageId">The id of the message.</param>
         /// <param name="headers">Message headers.</param>
         /// <param name="body">Message body.</param>
         /// <param name="exception">Exception thrown.</param>
         /// <param name="retryAttempt">Number of retry attempt.</param>
+        public DelayedRetryMessage(string messageId, Dictionary<string, string> headers, byte[] body, Exception exception, int retryAttempt)
+        {
+            Headers = headers;
+            Body = body;
+            Exception = exception;
+            RetryAttempt = retryAttempt;
+            MessageId = messageId;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="DelayedRetryMessage" />.
+        /// </summary>
+        /// <param name="headers">Message headers.</param>
+        /// <param name="body">Message body.</param>
+        /// <param name="exception">Exception thrown.</param>
+        /// <param name="retryAttempt">Number of retry attempt.</param>
+        [ObsoleteEx(RemoveInVersion = "8.0", ReplacementTypeOrMember = "DelayedRetryMessage(string messageId, Dictionary<string, string> headers, byte[] body, Exception exception, int retryAttempt)")]
         public DelayedRetryMessage(Dictionary<string, string> headers, byte[] body, Exception exception, int retryAttempt)
         {
             Headers = headers;
             Body = body;
             Exception = exception;
             RetryAttempt = retryAttempt;
+            MessageId = headers[NServiceBus.Headers.MessageId]; // safe because IncomingMessage has already set that header
         }
+
+        /// <summary>
+        /// Id of the failed message.
+        /// </summary>
+        public string MessageId { get; }
 
         /// <summary>
         /// Gets the message headers.

--- a/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
@@ -45,6 +45,7 @@ namespace NServiceBus.Faults
         internal void InvokeMessageHasBeenSentToDelayedRetries(int delayedRetryAttempt, IncomingMessage message, Exception exception)
         {
             MessageHasBeenSentToDelayedRetries?.Invoke(this, new DelayedRetryMessage(
+                message.MessageId,
                 new Dictionary<string, string>(message.Headers),
                 CopyOfBody(message.Body),
                 exception,


### PR DESCRIPTION
Based on https://discuss.particular.net/t/faults-delayedretrymessage/1244

Seemed like a low hanging fruit.

I currently went for obsolete with warn of the existing constructor. Happy to discuss the pros and cons