### PR TITLE
ReceiveComponent cleanup

### DIFF
--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -59,8 +59,6 @@ namespace NServiceBus.Features
                 ActivateFeature(feature, enabledFeatures, container, pipelineSettings, routing, receiveConfiguration);
             }
 
-            settings.PreventChanges();
-
             return features.Select(t => t.Diagnostics).ToArray();
         }
 

--- a/src/NServiceBus.Core/InitializableEndpoint.cs
+++ b/src/NServiceBus.Core/InitializableEndpoint.cs
@@ -56,6 +56,7 @@ namespace NServiceBus
             settings.Set<IMessageMapper>(messageMapper);
 
             var featureStats = featureActivator.SetupFeatures(container, pipelineSettings, routing, receiveConfiguration);
+            settings.PreventChanges();
             settings.AddStartupDiagnosticsSection("Features", featureStats);
 
             pipelineConfiguration.RegisterBehaviorsInContainer(container);
@@ -72,7 +73,6 @@ namespace NServiceBus
             var receiveComponent = CreateReceiveComponent(receiveConfiguration, transportInfrastructure, queueBindings, eventAggregator, mainPipelineExecutor);
 
             var shouldRunInstallers = settings.GetOrDefault<bool>("Installers.Enable");
-
             if (shouldRunInstallers)
             {
                 var username = GetInstallationUserName();

--- a/src/NServiceBus.Core/Receiving/IReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/IReceiveComponent.cs
@@ -1,0 +1,14 @@
+namespace NServiceBus
+{
+    using System.Threading.Tasks;
+    using Transport;
+
+    interface IReceiveComponent
+    {
+        Task CreateQueuesIfNecessary(QueueBindings queueBindings, string username);
+        Task Initialize();
+        void Start();
+        Task Stop();
+        Task PerformPreStartupChecks();
+    }
+}

--- a/src/NServiceBus.Core/Receiving/IdleReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/IdleReceiveComponent.cs
@@ -1,0 +1,32 @@
+namespace NServiceBus
+{
+    using System.Threading.Tasks;
+    using Transport;
+
+    class IdleReceiveComponent : IReceiveComponent
+    {
+        public Task CreateQueuesIfNecessary(QueueBindings queueBindings, string username)
+        {
+            return TaskEx.CompletedTask;
+        }
+
+        public Task Initialize()
+        {
+            return TaskEx.CompletedTask;
+        }
+
+        public void Start()
+        {
+        }
+
+        public Task Stop()
+        {
+            return TaskEx.CompletedTask;
+        }
+
+        public Task PerformPreStartupChecks()
+        {
+            return TaskEx.CompletedTask;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -8,7 +8,7 @@ namespace NServiceBus
     using ObjectBuilder;
     using Transport;
 
-    class ReceiveComponent
+    class ReceiveComponent : IReceiveComponent
     {
         public ReceiveComponent(ReceiveConfiguration configuration,
             TransportReceiveInfrastructure receiveInfrastructure,
@@ -29,11 +29,6 @@ namespace NServiceBus
 
         public void BindQueues(QueueBindings queueBindings)
         {
-            if (IsSendOnly)
-            {
-                return;
-            }
-
             queueBindings.BindReceiving(configuration.LocalAddress);
 
             if (configuration.InstanceSpecificQueue != null)
@@ -49,11 +44,6 @@ namespace NServiceBus
 
         public async Task Initialize()
         {
-            if (IsSendOnly)
-            {
-                return;
-            }
-
             if (configuration.PurgeOnStartup)
             {
                 Logger.Warn("All queues owned by the endpoint will be purged on startup.");
@@ -105,11 +95,6 @@ namespace NServiceBus
 
         public Task CreateQueuesIfNecessary(QueueBindings queueBindings, string username)
         {
-            if (IsSendOnly)
-            {
-                return TaskEx.CompletedTask;
-            }
-
             var queueCreator = receiveInfrastructure.QueueCreatorFactory();
 
             return queueCreator.CreateQueueIfNecessary(queueBindings, username);
@@ -117,11 +102,6 @@ namespace NServiceBus
 
         public async Task PerformPreStartupChecks()
         {
-            if (IsSendOnly)
-            {
-                return;
-            }
-
             var result = await receiveInfrastructure.PreStartupCheck().ConfigureAwait(false);
 
             if (!result.Succeeded)
@@ -129,8 +109,6 @@ namespace NServiceBus
                 throw new Exception($"Pre start-up check failed: {result.ErrorMessage}");
             }
         }
-
-        bool IsSendOnly => configuration == null;
 
         void AddReceivers()
         {

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -5,32 +5,26 @@ namespace NServiceBus
     using System.Linq;
     using System.Threading.Tasks;
     using Logging;
-    using MessageInterfaces;
     using ObjectBuilder;
-    using Pipeline;
     using Transport;
 
     class ReceiveComponent
     {
         public ReceiveComponent(ReceiveConfiguration configuration,
             TransportReceiveInfrastructure receiveInfrastructure,
-            IPipelineCache pipelineCache,
-            PipelineConfiguration pipelineConfiguration,
             IEventAggregator eventAggregator,
             IBuilder builder,
             CriticalError criticalError,
             string errorQueue,
-            IMessageMapper messageMapper)
+            IPipelineExecutor mainPipelineExecutor)
         {
             this.configuration = configuration;
             this.receiveInfrastructure = receiveInfrastructure;
-            this.pipelineCache = pipelineCache;
-            this.pipelineConfiguration = pipelineConfiguration;
             this.eventAggregator = eventAggregator;
             this.builder = builder;
             this.criticalError = criticalError;
             this.errorQueue = errorQueue;
-            this.messageMapper = messageMapper;
+            this.mainPipelineExecutor = mainPipelineExecutor;
         }
 
         public void BindQueues(QueueBindings queueBindings)
@@ -59,9 +53,6 @@ namespace NServiceBus
             {
                 return;
             }
-
-            var mainPipeline = new Pipeline<ITransportReceiveContext>(builder, pipelineConfiguration.Modifications);
-            mainPipelineExecutor = new MainPipelineExecutor(builder, eventAggregator, pipelineCache, mainPipeline, messageMapper);
 
             if (configuration.PurgeOnStartup)
             {
@@ -178,14 +169,11 @@ namespace NServiceBus
         ReceiveConfiguration configuration;
         List<TransportReceiver> receivers = new List<TransportReceiver>();
         TransportReceiveInfrastructure receiveInfrastructure;
-        IPipelineCache pipelineCache;
-        PipelineConfiguration pipelineConfiguration;
         IPipelineExecutor mainPipelineExecutor;
         IEventAggregator eventAggregator;
         IBuilder builder;
         CriticalError criticalError;
         string errorQueue;
-        IMessageMapper messageMapper;
 
         const string MainReceiverId = "Main";
 

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -10,7 +10,7 @@ namespace NServiceBus
 
     class StartableEndpoint : IStartableEndpoint
     {
-        public StartableEndpoint(SettingsHolder settings, IBuilder builder, FeatureActivator featureActivator, TransportInfrastructure transportInfrastructure, ReceiveComponent receiveComponent, CriticalError criticalError, IMessageSession messageSession)
+        public StartableEndpoint(SettingsHolder settings, IBuilder builder, FeatureActivator featureActivator, TransportInfrastructure transportInfrastructure, IReceiveComponent receiveComponent, CriticalError criticalError, IMessageSession messageSession)
         {
             this.criticalError = criticalError;
             this.settings = settings;
@@ -55,7 +55,7 @@ namespace NServiceBus
         FeatureActivator featureActivator;
         SettingsHolder settings;
         TransportInfrastructure transportInfrastructure;
-        ReceiveComponent receiveComponent;
+        IReceiveComponent receiveComponent;
         CriticalError criticalError;
     }
 }

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -11,7 +11,7 @@ namespace NServiceBus
 
     class RunningEndpointInstance : IEndpointInstance
     {
-        public RunningEndpointInstance(SettingsHolder settings, IBuilder builder, ReceiveComponent receiveComponent, FeatureRunner featureRunner, IMessageSession messageSession, TransportInfrastructure transportInfrastructure)
+        public RunningEndpointInstance(SettingsHolder settings, IBuilder builder, IReceiveComponent receiveComponent, FeatureRunner featureRunner, IMessageSession messageSession, TransportInfrastructure transportInfrastructure)
         {
             this.settings = settings;
             this.builder = builder;
@@ -92,7 +92,7 @@ namespace NServiceBus
         }
 
         IBuilder builder;
-        ReceiveComponent receiveComponent;
+        IReceiveComponent receiveComponent;
         FeatureRunner featureRunner;
         IMessageSession messageSession;
         TransportInfrastructure transportInfrastructure;


### PR DESCRIPTION
Some small changes around the ReceiveComponent. With the ideas of being able to disable the message pump it might makes more sense to split the existing implementation into a idle, inactive receivecomponent which can also be used when running in send-only mode instead of having all the `if(readonly)` checks.