### PR TITLE
Add new transport configuration API

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -1034,6 +1034,8 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<T> UseTransport<T>(this NServiceBus.EndpointConfiguration endpointConfiguration)
             where T : NServiceBus.Transport.TransportDefinition, new () { }
         public static NServiceBus.TransportExtensions UseTransport(this NServiceBus.EndpointConfiguration endpointConfiguration, System.Type transportDefinitionType) { }
+        public static NServiceBus.TransportExtensions<T> UseTransport<T>(this NServiceBus.EndpointConfiguration endpointConfiguration, T transportDefinition)
+            where T : NServiceBus.Transport.TransportDefinition { }
     }
     [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
         "ssageProperty\' package. Use `NServiceBus.Encryption.MessageProperty.EncryptedStr" +

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -1036,6 +1036,8 @@ namespace NServiceBus
         public static NServiceBus.TransportExtensions<T> UseTransport<T>(this NServiceBus.EndpointConfiguration endpointConfiguration)
             where T : NServiceBus.Transport.TransportDefinition, new () { }
         public static NServiceBus.TransportExtensions UseTransport(this NServiceBus.EndpointConfiguration endpointConfiguration, System.Type transportDefinitionType) { }
+        public static NServiceBus.TransportExtensions<T> UseTransport<T>(this NServiceBus.EndpointConfiguration endpointConfiguration, T transportDefinition)
+            where T : NServiceBus.Transport.TransportDefinition { }
     }
     [System.ObsoleteAttribute("Message property encryption is released as a dedicated \'NServiceBus.Encryption.Me" +
         "ssageProperty\' package. Use `NServiceBus.Encryption.MessageProperty.EncryptedStr" +

--- a/src/NServiceBus.Core/Unicast/Transport/Config/UseTransportExtensions.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/Config/UseTransportExtensions.cs
@@ -15,7 +15,7 @@ namespace NServiceBus
         {
             Guard.AgainstNull(nameof(endpointConfiguration), endpointConfiguration);
             var type = typeof(TransportExtensions<>).MakeGenericType(typeof(T));
-            var extension = (TransportExtensions<T>) Activator.CreateInstance(type, endpointConfiguration.Settings);
+            var extension = (TransportExtensions<T>)Activator.CreateInstance(type, endpointConfiguration.Settings);
 
             var transportDefinition = new T();
             ConfigureTransport(endpointConfiguration, transportDefinition);
@@ -34,6 +34,16 @@ namespace NServiceBus
             var transportDefinition = transportDefinitionType.Construct<TransportDefinition>();
             ConfigureTransport(endpointConfiguration, transportDefinition);
             return new TransportExtensions(endpointConfiguration.Settings);
+        }
+
+        /// <summary>
+        /// Configures NServiceBus to use the given transport.
+        /// </summary>
+        public static TransportExtensions<T> UseTransport<T>(this EndpointConfiguration endpointConfiguration, T transportDefinition) where T : TransportDefinition
+        {
+            Guard.AgainstNull(nameof(endpointConfiguration), endpointConfiguration);
+            ConfigureTransport(endpointConfiguration, transportDefinition);
+            return new TransportExtensions<T>(endpointConfiguration.Settings);
         }
 
         static void ConfigureTransport(EndpointConfiguration endpointConfiguration, TransportDefinition transportDefinition)


### PR DESCRIPTION
adds a new transport configuration API which allows passing in an existing instance of a `TransportDefinition`. Currently this isn't possible and the existing API will always create a new instance of the given transport definition type (also adding a `new()` constraint which is only coming from the API).

being able to pass in an existing object would allow for easier transport configuration in some cases which won't require the APIs to rely that heavily on generic parameters* and it would also allow to add transport specific configuration APIs to the specific `TransportDefinition` class.

* this is mostly related to cases where some API spans the endpoint configuration to provide a better situational API. Without this change, the transport configuration will "leak" to the upper API as generic parameter instead of being able to make it a regular parameter.