### PR TITLE
Cleanup routing component

### DIFF
--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -174,12 +174,7 @@ namespace NServiceBus
 
         RoutingComponent InitializeRouting(TransportInfrastructure transportInfrastructure, ReceiveConfiguration receiveConfiguration)
         {
-            // use GetOrCreate to use of instances already created during EndpointConfiguration.
-            var routing = new RoutingComponent(
-                settings.GetOrCreate<UnicastRoutingTable>(),
-                settings.GetOrCreate<DistributionPolicy>(),
-                settings.GetOrCreate<EndpointInstances>(),
-                settings.GetOrCreate<Publishers>());
+            var routing = new RoutingComponent(settings);
 
             routing.Initialize(settings, transportInfrastructure.ToTransportAddress, pipelineComponent.PipelineSettings, receiveConfiguration);
 

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -82,16 +82,16 @@ namespace NServiceBus
 
             var receiveConfiguration = BuildReceiveConfiguration(transportInfrastructure);
 
-            var routing = new RoutingComponent(settings);
+            var routingComponent = new RoutingComponent(settings);
 
-            routing.Initialize(transportInfrastructure, pipelineComponent.PipelineSettings, receiveConfiguration);
+            routingComponent.Initialize(transportInfrastructure, pipelineComponent, receiveConfiguration);
 
             var messageMapper = new MessageMapper();
             settings.Set<IMessageMapper>(messageMapper);
 
             pipelineComponent.AddRootContextItem<IMessageMapper>(messageMapper);
 
-            var featureStats = featureActivator.SetupFeatures(containerComponent.ContainerConfiguration, pipelineComponent.PipelineSettings, routing, receiveConfiguration);
+            var featureStats = featureActivator.SetupFeatures(containerComponent.ContainerConfiguration, pipelineComponent.PipelineSettings, routingComponent, receiveConfiguration);
             settings.AddStartupDiagnosticsSection("Features", featureStats);
 
             pipelineComponent.RegisterBehaviorsInContainer(containerComponent.ContainerConfiguration);

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -84,7 +84,7 @@ namespace NServiceBus
 
             var routing = new RoutingComponent(settings);
 
-            routing.Initialize(transportInfrastructure.ToTransportAddress, pipelineComponent.PipelineSettings, receiveConfiguration);
+            routing.Initialize(transportInfrastructure, pipelineComponent.PipelineSettings, receiveConfiguration);
 
             var messageMapper = new MessageMapper();
             settings.Set<IMessageMapper>(messageMapper);

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -176,7 +176,7 @@ namespace NServiceBus
         {
             var routing = new RoutingComponent(settings);
 
-            routing.Initialize(settings, transportInfrastructure.ToTransportAddress, pipelineComponent.PipelineSettings, receiveConfiguration);
+            routing.Initialize(transportInfrastructure.ToTransportAddress, pipelineComponent.PipelineSettings, receiveConfiguration);
 
             return routing;
         }

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -82,7 +82,9 @@ namespace NServiceBus
 
             var receiveConfiguration = BuildReceiveConfiguration(transportInfrastructure);
 
-            var routing = InitializeRouting(transportInfrastructure, receiveConfiguration);
+            var routing = new RoutingComponent(settings);
+
+            routing.Initialize(transportInfrastructure.ToTransportAddress, pipelineComponent.PipelineSettings, receiveConfiguration);
 
             var messageMapper = new MessageMapper();
             settings.Set<IMessageMapper>(messageMapper);
@@ -170,15 +172,6 @@ namespace NServiceBus
             }
 
             return userName;
-        }
-
-        RoutingComponent InitializeRouting(TransportInfrastructure transportInfrastructure, ReceiveConfiguration receiveConfiguration)
-        {
-            var routing = new RoutingComponent(settings);
-
-            routing.Initialize(transportInfrastructure.ToTransportAddress, pipelineComponent.PipelineSettings, receiveConfiguration);
-
-            return routing;
         }
 
         TransportInfrastructure InitializeTransportComponent()

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -11,8 +11,6 @@ namespace NServiceBus
     using MessageInterfaces;
     using MessageInterfaces.MessageMapper.Reflection;
     using ObjectBuilder;
-    using Routing;
-    using Routing.MessageDrivenSubscriptions;
     using Settings;
     using Transport;
     using Unicast.Messages;

--- a/src/NServiceBus.Core/Routing/RoutingComponent.cs
+++ b/src/NServiceBus.Core/Routing/RoutingComponent.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus
 {
-    using System;
     using System.Collections.Generic;
     using Features;
     using NServiceBus.Transport;
@@ -33,7 +32,7 @@ namespace NServiceBus
 
         public bool EnforceBestPractices { get; private set; }
 
-        public void Initialize(TransportInfrastructure transportInfrastructure, PipelineSettings pipelineSettings, ReceiveConfiguration receiveConfiguration)
+        public void Initialize(TransportInfrastructure transportInfrastructure, PipelineComponent pipelineComponent, ReceiveConfiguration receiveConfiguration)
         {
             var conventions = settings.Get<Conventions>();
             var configuredUnicastRoutes = settings.GetOrDefault<ConfiguredUnicastRoutes>();
@@ -47,6 +46,8 @@ namespace NServiceBus
             }
 
             configuredUnicastRoutes?.Apply(UnicastRoutingTable, conventions);
+
+            var pipelineSettings = pipelineComponent.PipelineSettings;
 
             pipelineSettings.Register(b =>
             {

--- a/src/NServiceBus.Core/Routing/RoutingComponent.cs
+++ b/src/NServiceBus.Core/Routing/RoutingComponent.cs
@@ -2,7 +2,7 @@ namespace NServiceBus
 {
     using System.Collections.Generic;
     using Features;
-    using NServiceBus.Transport;
+    using Transport;
     using Pipeline;
     using Routing;
     using Routing.MessageDrivenSubscriptions;

--- a/src/NServiceBus.Core/Routing/RoutingComponent.cs
+++ b/src/NServiceBus.Core/Routing/RoutingComponent.cs
@@ -14,12 +14,13 @@ namespace NServiceBus
 
         public RoutingComponent(SettingsHolder settings)
         {
+            this.settings = settings;
+
             // use GetOrCreate to use of instances already created during EndpointConfiguration.
             UnicastRoutingTable = settings.GetOrCreate<UnicastRoutingTable>();
             DistributionPolicy = settings.GetOrCreate<DistributionPolicy>();
             EndpointInstances = settings.GetOrCreate<EndpointInstances>();
             Publishers = settings.GetOrCreate<Publishers>();
-            this.settings = settings;
         }
 
         public UnicastRoutingTable UnicastRoutingTable { get; }

--- a/src/NServiceBus.Core/Routing/RoutingComponent.cs
+++ b/src/NServiceBus.Core/Routing/RoutingComponent.cs
@@ -11,7 +11,7 @@ namespace NServiceBus
     class RoutingComponent
     {
         public const string EnforceBestPracticesSettingsKey = "NServiceBus.Routing.EnforceBestPractices";
-
+        
         public RoutingComponent(SettingsHolder settings)
         {
             // use GetOrCreate to use of instances already created during EndpointConfiguration.
@@ -19,6 +19,7 @@ namespace NServiceBus
             DistributionPolicy = settings.GetOrCreate<DistributionPolicy>();
             EndpointInstances = settings.GetOrCreate<EndpointInstances>();
             Publishers = settings.GetOrCreate<Publishers>();
+            this.settings = settings;
         }
 
         public UnicastRoutingTable UnicastRoutingTable { get; }
@@ -31,7 +32,7 @@ namespace NServiceBus
 
         public bool EnforceBestPractices { get; private set; }
 
-        public void Initialize(ReadOnlySettings settings, Func<LogicalAddress, string> toTransportAddress, PipelineSettings pipelineSettings, ReceiveConfiguration receiveConfiguration)
+        public void Initialize(Func<LogicalAddress, string> toTransportAddress, PipelineSettings pipelineSettings, ReceiveConfiguration receiveConfiguration)
         {
             var conventions = settings.Get<Conventions>();
             var configuredUnicastRoutes = settings.GetOrDefault<ConfiguredUnicastRoutes>();
@@ -101,5 +102,7 @@ namespace NServiceBus
                 new EnforceUnsubscribeBestPracticesBehavior(validations),
                 "Enforces unsubscribe messaging best practices");
         }
+
+        SettingsHolder settings;
     }
 }

--- a/src/NServiceBus.Core/Routing/RoutingComponent.cs
+++ b/src/NServiceBus.Core/Routing/RoutingComponent.cs
@@ -3,6 +3,7 @@ namespace NServiceBus
     using System;
     using System.Collections.Generic;
     using Features;
+    using NServiceBus.Transport;
     using Pipeline;
     using Routing;
     using Routing.MessageDrivenSubscriptions;
@@ -11,7 +12,7 @@ namespace NServiceBus
     class RoutingComponent
     {
         public const string EnforceBestPracticesSettingsKey = "NServiceBus.Routing.EnforceBestPractices";
-        
+
         public RoutingComponent(SettingsHolder settings)
         {
             // use GetOrCreate to use of instances already created during EndpointConfiguration.
@@ -32,7 +33,7 @@ namespace NServiceBus
 
         public bool EnforceBestPractices { get; private set; }
 
-        public void Initialize(Func<LogicalAddress, string> toTransportAddress, PipelineSettings pipelineSettings, ReceiveConfiguration receiveConfiguration)
+        public void Initialize(TransportInfrastructure transportInfrastructure, PipelineSettings pipelineSettings, ReceiveConfiguration receiveConfiguration)
         {
             var conventions = settings.Get<Conventions>();
             var configuredUnicastRoutes = settings.GetOrDefault<ConfiguredUnicastRoutes>();
@@ -49,7 +50,7 @@ namespace NServiceBus
 
             pipelineSettings.Register(b =>
             {
-                var router = new UnicastSendRouter(receiveConfiguration == null, receiveConfiguration?.QueueNameBase, receiveConfiguration?.InstanceSpecificQueue, DistributionPolicy, UnicastRoutingTable, EndpointInstances, i => toTransportAddress(LogicalAddress.CreateRemoteAddress(i)));
+                var router = new UnicastSendRouter(receiveConfiguration == null, receiveConfiguration?.QueueNameBase, receiveConfiguration?.InstanceSpecificQueue, DistributionPolicy, UnicastRoutingTable, EndpointInstances, i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)));
                 return new UnicastSendRouterConnector(router);
             }, "Determines how the message being sent should be routed");
 

--- a/src/NServiceBus.Core/Routing/RoutingComponent.cs
+++ b/src/NServiceBus.Core/Routing/RoutingComponent.cs
@@ -12,12 +12,13 @@ namespace NServiceBus
     {
         public const string EnforceBestPracticesSettingsKey = "NServiceBus.Routing.EnforceBestPractices";
 
-        public RoutingComponent(UnicastRoutingTable unicastRoutingTable, DistributionPolicy distributionPolicy, EndpointInstances endpointInstances, Publishers publishers)
+        public RoutingComponent(SettingsHolder settings)
         {
-            UnicastRoutingTable = unicastRoutingTable;
-            DistributionPolicy = distributionPolicy;
-            EndpointInstances = endpointInstances;
-            Publishers = publishers;
+            // use GetOrCreate to use of instances already created during EndpointConfiguration.
+            UnicastRoutingTable = settings.GetOrCreate<UnicastRoutingTable>();
+            DistributionPolicy = settings.GetOrCreate<DistributionPolicy>();
+            EndpointInstances = settings.GetOrCreate<EndpointInstances>();
+            Publishers = settings.GetOrCreate<Publishers>();
         }
 
         public UnicastRoutingTable UnicastRoutingTable { get; }


### PR DESCRIPTION
Moved all routing code into the routing component and aligned the `Initalize` method with the others on that sense that they take in the "component" that it depends on.