### PR TITLE
Make MessageHandlerRegistry configurable

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_providing_custom_handler_registry.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_providing_custom_handler_registry.cs
@@ -17,16 +17,16 @@
                 .WithEndpoint<EndpointWithRegularHandler>(e => e
                     .When(ctx => ctx.SendLocal(new SomeCommand()))
                     .When(ctx => ctx.Publish(new SomeEvent()))) // verify autosubscribe picks up the handlers too
-                .Done(c => c.RegularCommandHandlerInvoked 
+                .Done(c => c.RegularCommandHandlerInvoked
                            && c.ManuallyRegisteredCommandHandlerInvoked
                            && c.RegularEventHandlerInvoked
-                           && c.ManuallyRegisteredEventHandlerInoked)
+                           && c.ManuallyRegisteredEventHandlerInvoked)
                 .Run(TimeSpan.FromSeconds(10));
 
             Assert.IsTrue(context.RegularCommandHandlerInvoked);
             Assert.IsTrue(context.ManuallyRegisteredCommandHandlerInvoked);
             Assert.IsTrue(context.RegularEventHandlerInvoked);
-            Assert.IsTrue(context.ManuallyRegisteredEventHandlerInoked);
+            Assert.IsTrue(context.ManuallyRegisteredEventHandlerInvoked);
         }
 
         class Context : ScenarioContext
@@ -34,7 +34,7 @@
             public bool RegularCommandHandlerInvoked { get; set; }
             public bool ManuallyRegisteredCommandHandlerInvoked { get; set; }
             public bool RegularEventHandlerInvoked { get; set; }
-            public bool ManuallyRegisteredEventHandlerInoked { get; set; }
+            public bool ManuallyRegisteredEventHandlerInvoked { get; set; }
         }
 
         class EndpointWithRegularHandler : EndpointConfigurationBuilder
@@ -93,7 +93,7 @@
 
             public Task Handle(SomeEvent message, IMessageHandlerContext context)
             {
-                testContext.ManuallyRegisteredEventHandlerInoked = true;
+                testContext.ManuallyRegisteredEventHandlerInvoked = true;
                 return Task.FromResult(0);
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_providing_custom_handler_registry.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_providing_custom_handler_registry.cs
@@ -13,6 +13,8 @@
         [Test]
         public async Task Should_invoke_manually_registered_handlers()
         {
+            Requires.NativePubSubSupport();
+
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithRegularHandler>(e => e
                     .When(ctx => ctx.SendLocal(new SomeCommand()))

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_providing_custom_handler_registry.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_providing_custom_handler_registry.cs
@@ -98,11 +98,11 @@
             }
         }
 
-        class SomeCommand : ICommand
+        public class SomeCommand : ICommand
         {
         }
 
-        class SomeEvent : IEvent
+        public class SomeEvent : IEvent
         {
         }
     }

--- a/src/NServiceBus.Core/Unicast/Config/RegisterHandlersInOrder.cs
+++ b/src/NServiceBus.Core/Unicast/Config/RegisterHandlersInOrder.cs
@@ -43,7 +43,7 @@ namespace NServiceBus.Features
 
         static void ConfigureMessageHandlersIn(FeatureConfigurationContext context, IEnumerable<Type> types)
         {
-            var handlerRegistry = new MessageHandlerRegistry();
+            var handlerRegistry = context.Settings.GetOrDefault<MessageHandlerRegistry>() ?? new MessageHandlerRegistry();
 
             foreach (var t in types.Where(IsMessageHandler))
             {


### PR DESCRIPTION
This change allows a `MessageHandlerRegistry` (public class) to be configured in the settings. I think there is currently no way to access the message handler in order to register your own handlers otherwise. At the point where the handler registry can be resolved via DI, some important points like autosubscribe have already made use of the registry, so it would be to late to add handlers once it's resolvable from the container.
This "non-public" change can open the doors for some ideas like delegate based message handlers.