### PR TITLE
Use a factory method for the feature setup context

### DIFF
--- a/src/NServiceBus.Core.Tests/Features/FakeFeatureConfigurationContext.cs
+++ b/src/NServiceBus.Core.Tests/Features/FakeFeatureConfigurationContext.cs
@@ -1,0 +1,11 @@
+﻿namespace NServiceBus.Core.Tests.Features
+{
+    using NServiceBus.Features;
+
+    public class FakeFeatureConfigurationContext : FeatureConfigurationContext
+    {
+        public FakeFeatureConfigurationContext() : base(null, null, null, null, null)
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Features/FeatureDefaultsTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDefaultsTests.cs
@@ -54,7 +54,7 @@
             featureSettings.Add(featureThatIsEnabledByAnother);
             featureSettings.Add(new FeatureThatEnablesAnother());
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             Assert.True(featureThatIsEnabledByAnother.DefaultCalled, "FeatureThatIsEnabledByAnother wasn't activated");
         }
@@ -86,7 +86,7 @@
             featureSettings.Add(level2);
             featureSettings.Add(level1);
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             Assert.True(level1.IsActive, "Activate1 wasn't activated");
             Assert.True(level2.IsActive, "Activate2 wasn't activated");
@@ -118,7 +118,7 @@
 
             settings.EnableFeatureByDefault<MyFeature1>();
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             Assert.True(dependingFeature.IsActive);
 
@@ -156,7 +156,7 @@
             settings.EnableFeatureByDefault<MyFeature2>();
             settings.EnableFeatureByDefault<MyFeature3>();
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             Assert.True(dependingFeature.IsActive);
 
@@ -188,7 +188,7 @@
             featureSettings.Add(level2);
             featureSettings.Add(level1);
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             Assert.True(level1.IsActive, "Level1 wasn't activated");
             Assert.True(level2.IsActive, "Level2 wasn't activated");

--- a/src/NServiceBus.Core.Tests/Features/FeatureDefaultsTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDefaultsTests.cs
@@ -54,7 +54,7 @@
             featureSettings.Add(featureThatIsEnabledByAnother);
             featureSettings.Add(new FeatureThatEnablesAnother());
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             Assert.True(featureThatIsEnabledByAnother.DefaultCalled, "FeatureThatIsEnabledByAnother wasn't activated");
         }
@@ -86,7 +86,7 @@
             featureSettings.Add(level2);
             featureSettings.Add(level1);
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             Assert.True(level1.IsActive, "Activate1 wasn't activated");
             Assert.True(level2.IsActive, "Activate2 wasn't activated");
@@ -118,7 +118,7 @@
 
             settings.EnableFeatureByDefault<MyFeature1>();
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             Assert.True(dependingFeature.IsActive);
 
@@ -156,7 +156,7 @@
             settings.EnableFeatureByDefault<MyFeature2>();
             settings.EnableFeatureByDefault<MyFeature3>();
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             Assert.True(dependingFeature.IsActive);
 
@@ -188,7 +188,7 @@
             featureSettings.Add(level2);
             featureSettings.Add(level1);
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             Assert.True(level1.IsActive, "Level1 wasn't activated");
             Assert.True(level2.IsActive, "Level2 wasn't activated");

--- a/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
@@ -59,7 +59,7 @@
             featureSettings.Add(dependingFeature);
             Array.ForEach(setup.AvailableFeatures, featureSettings.Add);
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             Assert.AreEqual(setup.ShouldBeActive, dependingFeature.IsActive);
         }
@@ -86,7 +86,7 @@
 
             settings.EnableFeatureByDefault<MyFeature1>();
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             Assert.True(dependingFeature.IsActive);
 
@@ -115,7 +115,7 @@
 
             settings.EnableFeatureByDefault<MyFeature2>();
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             Assert.True(dependingFeature.IsActive);
             Assert.IsInstanceOf<MyFeature2>(order.First(), "Upstream dependencies should be activated first");
@@ -141,7 +141,7 @@
             featureSettings.Add(dependingFeature);
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             Assert.False(dependingFeature.IsActive);
             Assert.IsEmpty(order);
@@ -181,7 +181,7 @@
             settings.EnableFeatureByDefault<MyFeature2>();
             settings.EnableFeatureByDefault<MyFeature3>();
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             Assert.True(dependingFeature.IsActive);
 
@@ -217,7 +217,7 @@
             featureSettings.Add(level2);
             featureSettings.Add(level1);
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
 
             Assert.True(level1.IsActive, "Level1 wasn't activated");

--- a/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
@@ -59,7 +59,7 @@
             featureSettings.Add(dependingFeature);
             Array.ForEach(setup.AvailableFeatures, featureSettings.Add);
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             Assert.AreEqual(setup.ShouldBeActive, dependingFeature.IsActive);
         }
@@ -86,7 +86,7 @@
 
             settings.EnableFeatureByDefault<MyFeature1>();
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             Assert.True(dependingFeature.IsActive);
 
@@ -115,7 +115,7 @@
 
             settings.EnableFeatureByDefault<MyFeature2>();
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             Assert.True(dependingFeature.IsActive);
             Assert.IsInstanceOf<MyFeature2>(order.First(), "Upstream dependencies should be activated first");
@@ -141,7 +141,7 @@
             featureSettings.Add(dependingFeature);
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             Assert.False(dependingFeature.IsActive);
             Assert.IsEmpty(order);
@@ -181,7 +181,7 @@
             settings.EnableFeatureByDefault<MyFeature2>();
             settings.EnableFeatureByDefault<MyFeature3>();
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             Assert.True(dependingFeature.IsActive);
 
@@ -217,7 +217,7 @@
             featureSettings.Add(level2);
             featureSettings.Add(level1);
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
 
             Assert.True(level1.IsActive, "Level1 wasn't activated");
@@ -250,7 +250,7 @@
             featureSettings.Add(level1);
             featureSettings.Add(level2);
 
-            Assert.Throws<ArgumentException>(() => featureSettings.SetupFeatures(null, null, null, null));
+            Assert.Throws<ArgumentException>(() => featureSettings.SetupFeatures(null));
         }
 
         public class Level1 : TestFeature

--- a/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
@@ -250,7 +250,7 @@
             featureSettings.Add(level1);
             featureSettings.Add(level2);
 
-            Assert.Throws<ArgumentException>(() => featureSettings.SetupFeatures(null));
+            Assert.Throws<ArgumentException>(() => featureSettings.SetupFeatures(new FakeFeatureConfigurationContext()));
         }
 
         public class Level1 : TestFeature

--- a/src/NServiceBus.Core.Tests/Features/FeatureDifferingOnlyByNamespaceTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDifferingOnlyByNamespaceTests.cs
@@ -31,7 +31,7 @@
 
             settings.EnableFeatureByDefault<NamespaceA.MyFeature>();
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             Assert.True(dependingFeature.IsActive);
 

--- a/src/NServiceBus.Core.Tests/Features/FeatureDifferingOnlyByNamespaceTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDifferingOnlyByNamespaceTests.cs
@@ -31,7 +31,7 @@
 
             settings.EnableFeatureByDefault<NamespaceA.MyFeature>();
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             Assert.True(dependingFeature.IsActive);
 

--- a/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
@@ -28,7 +28,7 @@
             featureSettings.Add(featureWithTrueCondition);
             featureSettings.Add(featureWithFalseCondition);
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             Assert.True(featureWithTrueCondition.IsActive);
             Assert.False(featureWithFalseCondition.IsActive);
@@ -41,7 +41,7 @@
         {
             featureSettings.Add(new MyFeatureWithDefaults());
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             Assert.True(settings.HasSetting("Test1"));
         }
@@ -52,7 +52,7 @@
             featureSettings.Add(new MyFeatureWithDefaultsNotActive());
             featureSettings.Add(new MyFeatureWithDefaultsNotActiveDueToUnsatisfiedPrerequisite());
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             Assert.False(settings.HasSetting("Test1"));
             Assert.False(settings.HasSetting("Test2"));

--- a/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
@@ -28,7 +28,7 @@
             featureSettings.Add(featureWithTrueCondition);
             featureSettings.Add(featureWithFalseCondition);
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             Assert.True(featureWithTrueCondition.IsActive);
             Assert.False(featureWithFalseCondition.IsActive);
@@ -41,7 +41,7 @@
         {
             featureSettings.Add(new MyFeatureWithDefaults());
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             Assert.True(settings.HasSetting("Test1"));
         }
@@ -52,7 +52,7 @@
             featureSettings.Add(new MyFeatureWithDefaultsNotActive());
             featureSettings.Add(new MyFeatureWithDefaultsNotActiveDueToUnsatisfiedPrerequisite());
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             Assert.False(settings.HasSetting("Test1"));
             Assert.False(settings.HasSetting("Test2"));

--- a/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
@@ -25,7 +25,7 @@
 
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             await featureSettings.StartFeatures(null, null);
             await featureSettings.StopFeatures(null);
@@ -41,7 +41,7 @@
 
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             await featureSettings.StartFeatures(null, null);
             await featureSettings.StopFeatures(null);
@@ -57,7 +57,7 @@
             featureSettings.Add(feature1);
             featureSettings.Add(feature2);
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             Assert.ThrowsAsync<InvalidOperationException>(async () => await featureSettings.StartFeatures(null, null));
 
@@ -73,7 +73,7 @@
             featureSettings.Add(feature1);
             featureSettings.Add(feature2);
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             await featureSettings.StartFeatures(null, null);
 
@@ -88,7 +88,7 @@
             var feature = new FeatureWithStartupTaskThatThrows(throwOnStart: false, throwOnStop: true);
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(null, null, null, null);
+            featureSettings.SetupFeatures(null);
 
             await featureSettings.StartFeatures(null, null);
 

--- a/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
@@ -25,7 +25,7 @@
 
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             await featureSettings.StartFeatures(null, null);
             await featureSettings.StopFeatures(null);
@@ -41,7 +41,7 @@
 
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             await featureSettings.StartFeatures(null, null);
             await featureSettings.StopFeatures(null);
@@ -57,7 +57,7 @@
             featureSettings.Add(feature1);
             featureSettings.Add(feature2);
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             Assert.ThrowsAsync<InvalidOperationException>(async () => await featureSettings.StartFeatures(null, null));
 
@@ -73,7 +73,7 @@
             featureSettings.Add(feature1);
             featureSettings.Add(feature2);
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             await featureSettings.StartFeatures(null, null);
 
@@ -88,7 +88,7 @@
             var feature = new FeatureWithStartupTaskThatThrows(throwOnStart: false, throwOnStop: true);
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(null);
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             await featureSettings.StartFeatures(null, null);
 

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -91,7 +91,8 @@ namespace NServiceBus
 
             recoverabilityComponent = new RecoverabilityComponent(settings);
 
-            var featureStats = featureActivator.SetupFeatures(() => new FeatureConfigurationContext(settings, containerComponent.ContainerConfiguration, pipelineComponent.PipelineSettings, routingComponent, receiveConfiguration));
+            var featureConfigurationContext = new FeatureConfigurationContext(settings, containerComponent.ContainerConfiguration, pipelineComponent.PipelineSettings, routingComponent, receiveConfiguration);
+            var featureStats = featureActivator.SetupFeatures(featureConfigurationContext);
             settings.AddStartupDiagnosticsSection("Features", featureStats);
 
             recoverabilityComponent.Initialize(receiveConfiguration);

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -91,7 +91,7 @@ namespace NServiceBus
 
             recoverabilityComponent = new RecoverabilityComponent(settings);
 
-            var featureStats = featureActivator.SetupFeatures(containerComponent.ContainerConfiguration, pipelineComponent.PipelineSettings, routingComponent, receiveConfiguration);
+            var featureStats = featureActivator.SetupFeatures(() => new FeatureConfigurationContext(settings, containerComponent.ContainerConfiguration, pipelineComponent.PipelineSettings, routingComponent, receiveConfiguration));
             settings.AddStartupDiagnosticsSection("Features", featureStats);
 
             recoverabilityComponent.Initialize(receiveConfiguration);

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -189,13 +189,16 @@ namespace NServiceBus.Features
                     return false;
                 }
                 settings.MarkFeatureAsActive(featureType);
+
                 featureInfo.Feature.SetupFeature(featureConfigurationContext);
 
                 featureInfo.TaskControllers = new List<FeatureStartupTaskController>(featureConfigurationContext.TaskControllers);
-                featureConfigurationContext.TaskControllers.Clear();
 
                 featureInfo.Diagnostics.StartupTasks = featureInfo.TaskControllers.Select(d => d.Name).ToList();
                 featureInfo.Diagnostics.Active = true;
+
+                featureConfigurationContext.TaskControllers.Clear();
+
                 return true;
             }
             settings.MarkFeatureAsDeactivated(featureType);

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -190,13 +190,9 @@ namespace NServiceBus.Features
                 }
                 settings.MarkFeatureAsActive(featureType);
 
-                featureInfo.Feature.SetupFeature(featureConfigurationContext);
+                featureInfo.InitializeFrom(featureConfigurationContext);
 
-                featureInfo.TaskControllers = new List<FeatureStartupTaskController>(featureConfigurationContext.TaskControllers);
-
-                featureInfo.Diagnostics.StartupTasks = featureInfo.TaskControllers.Select(d => d.Name).ToList();
-                featureInfo.Diagnostics.Active = true;
-
+                // because we reuse the context the task controller list needs to be cleared.
                 featureConfigurationContext.TaskControllers.Clear();
 
                 return true;
@@ -226,12 +222,27 @@ namespace NServiceBus.Features
 
             public FeatureDiagnosticData Diagnostics { get; }
             public Feature Feature { get; }
-            public IReadOnlyList<FeatureStartupTaskController> TaskControllers { get; set; }
+            public IReadOnlyList<FeatureStartupTaskController> TaskControllers => taskControllers;
+
+            public void InitializeFrom(FeatureConfigurationContext featureConfigurationContext)
+            {
+                Feature.SetupFeature(featureConfigurationContext);
+                var featureStartupTasks = new List<string>();
+                foreach (var controller in featureConfigurationContext.TaskControllers)
+                {
+                    taskControllers.Add(controller);
+                    featureStartupTasks.Add(controller.Name);
+                }
+                Diagnostics.StartupTasks = featureStartupTasks; 
+                Diagnostics.Active = true;
+            }
 
             public override string ToString()
             {
                 return $"{Feature.Name} [{Feature.Version}]";
             }
+
+            private List<FeatureStartupTaskController> taskControllers = new List<FeatureStartupTaskController>();
         }
 
         class Node

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -242,7 +242,7 @@ namespace NServiceBus.Features
                 return $"{Feature.Name} [{Feature.Version}]";
             }
 
-            private List<FeatureStartupTaskController> taskControllers = new List<FeatureStartupTaskController>();
+            List<FeatureStartupTaskController> taskControllers = new List<FeatureStartupTaskController>();
         }
 
         class Node

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -5,7 +5,6 @@ namespace NServiceBus.Features
     using System.Linq;
     using System.Threading.Tasks;
     using ObjectBuilder;
-    using Pipeline;
     using Settings;
 
     class FeatureActivator

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -191,11 +191,7 @@ namespace NServiceBus.Features
                 settings.MarkFeatureAsActive(featureType);
                 featureInfo.Feature.SetupFeature(featureConfigurationContext);
 
-                foreach (var taskController in featureConfigurationContext.TaskControllers)
-                {
-                    featureInfo.TaskControllers.Add(taskController);
-                }
-
+                featureInfo.AddTaskControllers(featureConfigurationContext.TaskControllers);
                 featureConfigurationContext.TaskControllers.Clear();
 
                 featureInfo.Diagnostics.StartupTasks = featureConfigurationContext.TaskControllers.Select(d => d.Name).ToList();
@@ -225,14 +221,24 @@ namespace NServiceBus.Features
                 Feature = feature;
             }
 
+            public void AddTaskControllers(IList<FeatureStartupTaskController> controllersToAdd)
+            {
+                foreach (var taskController in controllersToAdd)
+                {
+                    taskControllers.Add(taskController);
+                }
+            }
+
             public FeatureDiagnosticData Diagnostics { get; }
             public Feature Feature { get; }
-            public IList<FeatureStartupTaskController> TaskControllers { get; set; }
+            public IReadOnlyList<FeatureStartupTaskController> TaskControllers => taskControllers;
 
             public override string ToString()
             {
                 return $"{Feature.Name} [{Feature.Version}]";
             }
+
+            List<FeatureStartupTaskController> taskControllers = new List<FeatureStartupTaskController>();
         }
 
         class Node

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -191,10 +191,10 @@ namespace NServiceBus.Features
                 settings.MarkFeatureAsActive(featureType);
                 featureInfo.Feature.SetupFeature(featureConfigurationContext);
 
-                featureInfo.AddTaskControllers(featureConfigurationContext.TaskControllers);
+                featureInfo.TaskControllers = new List<FeatureStartupTaskController>(featureConfigurationContext.TaskControllers);
                 featureConfigurationContext.TaskControllers.Clear();
 
-                featureInfo.Diagnostics.StartupTasks = featureConfigurationContext.TaskControllers.Select(d => d.Name).ToList();
+                featureInfo.Diagnostics.StartupTasks = featureInfo.TaskControllers.Select(d => d.Name).ToList();
                 featureInfo.Diagnostics.Active = true;
                 return true;
             }
@@ -221,24 +221,14 @@ namespace NServiceBus.Features
                 Feature = feature;
             }
 
-            public void AddTaskControllers(IList<FeatureStartupTaskController> controllersToAdd)
-            {
-                foreach (var taskController in controllersToAdd)
-                {
-                    taskControllers.Add(taskController);
-                }
-            }
-
             public FeatureDiagnosticData Diagnostics { get; }
             public Feature Feature { get; }
-            public IReadOnlyList<FeatureStartupTaskController> TaskControllers => taskControllers;
+            public IReadOnlyList<FeatureStartupTaskController> TaskControllers { get; set; }
 
             public override string ToString()
             {
                 return $"{Feature.Name} [{Feature.Version}]";
             }
-
-            List<FeatureStartupTaskController> taskControllers = new List<FeatureStartupTaskController>();
         }
 
         class Node


### PR DESCRIPTION
After talk to @danielmarbach and @timbussmann I realized that the current code led us to believe that the features infrastructure had a bunch of dependencies. That isn't the case since they where only there to be exposed on the `FeatureSetupContext`. This change changes the code to highlight that the features have no dependencies on other "components".

It also have the added benefit of causing less churn on tests next time we need to expose something new on the feature setup context.