### PR TITLE
Introduce InitializeFrom on FeatureInfo

### DIFF
--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -192,6 +192,9 @@ namespace NServiceBus.Features
 
                 featureInfo.InitializeFrom(featureConfigurationContext);
 
+                // because we reuse the context the task controller list needs to be cleared.
+                featureConfigurationContext.TaskControllers.Clear();
+
                 return true;
             }
             settings.MarkFeatureAsDeactivated(featureType);
@@ -230,7 +233,6 @@ namespace NServiceBus.Features
                     taskControllers.Add(controller);
                     featureStartupTasks.Add(controller.Name);
                 }
-                featureConfigurationContext.TaskControllers.Clear();
                 Diagnostics.StartupTasks = featureStartupTasks; 
                 Diagnostics.Active = true;
             }


### PR DESCRIPTION
Idea to structure the feature activation slightly different. It would mean we don't have to iterate through the controllers multiple times and everything is neatly contained in the initialize method including the side effects on the feature configuration context. Just an idea. Feel free to drop if you don't like it