### PR TITLE
Add test to document transport dependency on feature state

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransport.cs
@@ -19,7 +19,7 @@
             {
                 assertion(settings);
             }
-            
+
             return new FakeTransportInfrastructure(settings);
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransport.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Core.FakeTransport
 {
+    using System;
     using System.Collections.Generic;
     using Settings;
     using Transport;
@@ -14,6 +15,11 @@
         {
             settings.GetOrCreate<StartUpSequence>().Add($"{nameof(TransportDefinition)}.{nameof(Initialize)}");
 
+            if (settings.TryGet<Action<ReadOnlySettings>>("FakeTransport.AssertSettings", out var assertion))
+            {
+                assertion(settings);
+            }
+            
             return new FakeTransportInfrastructure(settings);
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportSettingsExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportSettingsExtensions.cs
@@ -44,7 +44,7 @@
 
             return transportExtensions;
         }
-        
+
         public static TransportExtensions<FakeTransport> AssertSettings(this TransportExtensions<FakeTransport> transportExtensions, Action<ReadOnlySettings> assertion)
         {
             transportExtensions.GetSettings().Set("FakeTransport.AssertSettings", assertion);

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportSettingsExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportSettingsExtensions.cs
@@ -1,7 +1,9 @@
 ﻿namespace NServiceBus.AcceptanceTests.Core.FakeTransport
 {
     using System;
+    using System.Collections.Generic;
     using Configuration.AdvancedExtensibility;
+    using NServiceBus.Settings;
     using Transport;
 
     public static class FakeTransportSettingsExtensions
@@ -40,6 +42,12 @@
         public static TransportExtensions<FakeTransport> CollectStartupSequence(this TransportExtensions<FakeTransport> transportExtensions, FakeTransport.StartUpSequence startUpSequence)
         {
             transportExtensions.GetSettings().Set(startUpSequence);
+
+            return transportExtensions;
+        }
+        public static TransportExtensions<FakeTransport> AssertSettings(this TransportExtensions<FakeTransport> transportExtensions, Action<ReadOnlySettings> assertion)
+        {
+            transportExtensions.GetSettings().Set("FakeTransport.AssertSettings", assertion);
 
             return transportExtensions;
         }

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportSettingsExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportSettingsExtensions.cs
@@ -44,6 +44,7 @@
 
             return transportExtensions;
         }
+        
         public static TransportExtensions<FakeTransport> AssertSettings(this TransportExtensions<FakeTransport> transportExtensions, Action<ReadOnlySettings> assertion)
         {
             transportExtensions.GetSettings().Set("FakeTransport.AssertSettings", assertion);

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportSettingsExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportSettingsExtensions.cs
@@ -1,9 +1,8 @@
 ﻿namespace NServiceBus.AcceptanceTests.Core.FakeTransport
 {
     using System;
-    using System.Collections.Generic;
     using Configuration.AdvancedExtensibility;
-    using NServiceBus.Settings;
+    using Settings;
     using Transport;
 
     public static class FakeTransportSettingsExtensions

--- a/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_features_are_setup.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_features_are_setup.cs
@@ -4,7 +4,7 @@
     using AcceptanceTesting;
     using EndpointTemplates;
     using FakeTransport;
-    using NServiceBus.Features;
+    using Features;
     using NUnit.Framework;
 
     public class When_features_are_setup : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_features_are_setup.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_features_are_setup.cs
@@ -26,7 +26,7 @@
                             Assert.False(s.IsFeatureEnabled(typeof(Endpoint.FeatureEnabledByDefaultButDisabledByUser)));
 
                             // this should be "true" but documents that the "active" state can't be used by transports
-                            // since Fetures are activated after the transport have been initialized
+                            // since Features are activated after the transport have been initialized
                             Assert.False(s.IsFeatureActive(typeof(Endpoint.FeatureEnabledByDefault)));
                         });
                 }))

--- a/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_features_are_setup.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_features_are_setup.cs
@@ -1,0 +1,84 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.TransportSeam
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using FakeTransport;
+    using NServiceBus.Features;
+    using NUnit.Framework;
+
+    public class When_features_are_setup : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_provide_feature_state_to_transport_initialization()
+        {
+            await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(c => c.CustomConfig(ec =>
+                {
+                    ec.DisableFeature<Endpoint.FeatureEnabledByDefaultButDisabledByUser>();
+                    ec.EnableFeature<Endpoint.FeatureEnabledByUser>();
+
+                    ec.UseTransport<FakeTransport>()
+                        .AssertSettings(s =>
+                        {
+                            Assert.True(s.IsFeatureEnabled(typeof(Endpoint.FeatureEnabledByDefault)));
+                            Assert.True(s.IsFeatureEnabled(typeof(Endpoint.FeatureEnabledByUser)));
+                            Assert.False(s.IsFeatureEnabled(typeof(Endpoint.FeatureEnabledByDefaultButDisabledByUser)));
+
+                            // this should be "true" but documents that the "active" state can't be used by transports
+                            // since Fetures are activated after the transport have been initialized
+                            Assert.False(s.IsFeatureActive(typeof(Endpoint.FeatureEnabledByDefault)));
+                        });
+                }))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+        }
+
+        class Context : ScenarioContext
+        {
+        }
+
+        class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class FeatureEnabledByDefault : Feature
+            {
+                public FeatureEnabledByDefault()
+                {
+                    EnableByDefault();
+                }
+
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                }
+            }
+
+            public class FeatureEnabledByUser : Feature
+            {
+                public FeatureEnabledByUser()
+                {
+                }
+
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                }
+            }
+
+            public class FeatureEnabledByDefaultButDisabledByUser : Feature
+            {
+                public FeatureEnabledByDefaultButDisabledByUser()
+                {
+                    EnableByDefault();
+                }
+
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_features_are_setup.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_features_are_setup.cs
@@ -59,10 +59,6 @@
 
             public class FeatureEnabledByUser : Feature
             {
-                public FeatureEnabledByUser()
-                {
-                }
-
                 protected override void Setup(FeatureConfigurationContext context)
                 {
                 }


### PR DESCRIPTION
As part of https://github.com/Particular/NServiceBus/pull/5427 we discovered that the transport depends on features "enabled state" to be present in settings so that the transports can make decisions based on if the TimeoutManager is enabled or not.

This test documents this "hidden" dependency.

Once this is merged to master I will adjust https://github.com/Particular/NServiceBus/pull/5427 to pass this new test.

I have run this test locally on https://github.com/Particular/NServiceBus/pull/5427 and it does indeed fail there