### PR TITLE
Allow disabling publish functionality

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Persistence/When_a_persistence_does_not_support_subscriptions.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Persistence/When_a_persistence_does_not_support_subscriptions.cs
@@ -16,7 +16,7 @@ namespace NServiceBus.AcceptanceTests.Core.Persistence
                 await Scenario.Define<Context>()
                     .WithEndpoint<Endpoint>(e => e.When(b => b.Subscribe<object>()))
                     .Run();
-            }, Throws.Exception.With.Message.Contains("DisableFeature<MessageDrivenSubscriptions>()"));
+            }, Throws.Exception.With.Message.Contains("transportConfiguration.DisablePublishing()"));
         }
 
         class Endpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
@@ -1,0 +1,96 @@
+﻿namespace NServiceBus.AcceptanceTests.PublishSubscribe
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using Configuration.AdvancedExtensibility;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_disabling_publishing : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_subscribe_to_and_receive_events()
+        {
+            Requires.MessageDrivenPubSub();
+
+            await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithDisabledPublishing>(e => e.When(
+                    c => c.Subscribe<TestEvent>()))
+                .WithEndpoint<PublishingEndpoint>(e => e.When(c =>
+                {
+                    if (c.ReceivedSubscription)
+                    {
+                        return Task.FromResult(true);
+                    }
+
+                    return Task.FromResult(false);
+                }, s => s.Publish(new TestEvent())))
+                .Done(c => c.ReceivedEvent)
+                .Run();
+        }
+
+        [Test]
+        public void Should_throw_when_publishing()
+        {
+            Requires.MessageDrivenPubSub();
+
+            Assert.ThrowsAsync<Exception>(() => Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithDisabledPublishing>(e => e.When(
+                    c => c.Publish(new TestEvent())))
+                .Done(c => c.EndpointsStarted)
+                .Run());
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool ReceivedSubscription { get; set; }
+            public bool ReceivedEvent { get; set; }
+        }
+
+        class EndpointWithDisabledPublishing : EndpointConfigurationBuilder
+        {
+            public EndpointWithDisabledPublishing()
+            {
+                EndpointSetup<DefaultServer>(
+                    // DisablePublishing API is only available on the message-driven pub/sub transport settings.
+                    c => c.GetSettings().Set("NServiceBus.PublishSubscribe.EnablePublishing", false),
+                    pm => pm.RegisterPublisherFor<TestEvent>(typeof(PublishingEndpoint)));
+            }
+
+            class EventHandler : IHandleMessages<TestEvent>
+            {
+                Context testContext;
+
+                public EventHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(TestEvent message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedEvent = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        class PublishingEndpoint : EndpointConfigurationBuilder
+        {
+            public PublishingEndpoint()
+            {
+                EndpointSetup<DefaultServer>(endpoint => endpoint.OnEndpointSubscribed<Context>((args, context) =>
+                {
+                    if (args.MessageType.Contains(typeof(TestEvent).FullName))
+                    {
+                        context.ReceivedSubscription = true;
+                    }
+                }));
+            }
+        }
+
+        public class TestEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
@@ -35,11 +35,13 @@
         {
             Requires.MessageDrivenPubSub();
 
-            Assert.ThrowsAsync<Exception>(() => Scenario.Define<Context>()
+            var exception = Assert.ThrowsAsync<InvalidOperationException>(() => Scenario.Define<Context>()
                 .WithEndpoint<EndpointWithDisabledPublishing>(e => e.When(
                     c => c.Publish(new TestEvent())))
                 .Done(c => c.EndpointsStarted)
                 .Run());
+
+            StringAssert.Contains("Publishing has been explicitly disabled on this endpoint", exception.Message);
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -667,6 +667,8 @@ namespace NServiceBus
     }
     public class static MessageDrivenSubscriptionsConfigExtensions
     {
+        public static void DisablePublishing<T>(this NServiceBus.TransportExtensions<T> transportExtensions)
+            where T : NServiceBus.Transport.TransportDefinition, NServiceBus.Routing.IMessageDrivenSubscriptionTransport { }
         public static void RegisterPublisher<T>(this NServiceBus.RoutingSettings<T> routingSettings, System.Type eventType, string publisherEndpoint)
             where T : NServiceBus.Transport.TransportDefinition, NServiceBus.Routing.IMessageDrivenSubscriptionTransport { }
         public static void RegisterPublisher<T>(this NServiceBus.RoutingSettings<T> routingSettings, System.Reflection.Assembly assembly, string publisherEndpoint)

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -1619,6 +1619,7 @@ namespace NServiceBus.Features
     {
         protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
+    [System.ObsoleteAttribute(@"It's not recommended to disable the MessageDrivenSubscriptions feature and this option will be removed in future versions. Use 'transportSettings.DisablePublishing()' to avoid the need for a subscription storage if this endpoint does not publish events. Use `TransportExtensions<T>.DisablePublishing()` instead. Will be removed in version 8.0.0.", true)]
     public class MessageDrivenSubscriptions : NServiceBus.Features.Feature
     {
         protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -1619,7 +1619,7 @@ namespace NServiceBus.Features
     {
         protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
-    [System.ObsoleteAttribute(@"It's not recommended to disable the MessageDrivenSubscriptions feature and this option will be removed in future versions. Use 'transportSettings.DisablePublishing()' to avoid the need for a subscription storage if this endpoint does not publish events. Use `TransportExtensions<T>.DisablePublishing()` instead. Will be removed in version 8.0.0.", true)]
+    [System.ObsoleteAttribute(@"It's not recommended to disable the MessageDrivenSubscriptions feature and this option will be removed in future versions. Use 'TransportExtensions<T>.DisablePublishing()' to avoid the need for a subscription storage if this endpoint does not publish events. Will be treated as an error from version 8.0.0. Will be removed in version 8.0.0.", false)]
     public class MessageDrivenSubscriptions : NServiceBus.Features.Feature
     {
         protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -667,6 +667,8 @@ namespace NServiceBus
     }
     public class static MessageDrivenSubscriptionsConfigExtensions
     {
+        public static void DisablePublishing<T>(this NServiceBus.TransportExtensions<T> transportExtensions)
+            where T : NServiceBus.Transport.TransportDefinition, NServiceBus.Routing.IMessageDrivenSubscriptionTransport { }
         public static void RegisterPublisher<T>(this NServiceBus.RoutingSettings<T> routingSettings, System.Type eventType, string publisherEndpoint)
             where T : NServiceBus.Transport.TransportDefinition, NServiceBus.Routing.IMessageDrivenSubscriptionTransport { }
         public static void RegisterPublisher<T>(this NServiceBus.RoutingSettings<T> routingSettings, System.Reflection.Assembly assembly, string publisherEndpoint)

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -1621,7 +1621,7 @@ namespace NServiceBus.Features
     {
         protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
-    [System.ObsoleteAttribute(@"It's not recommended to disable the MessageDrivenSubscriptions feature and this option will be removed in future versions. Use 'transportSettings.DisablePublishing()' to avoid the need for a subscription storage if this endpoint does not publish events. Use `TransportExtensions<T>.DisablePublishing()` instead. Will be removed in version 8.0.0.", true)]
+    [System.ObsoleteAttribute(@"It's not recommended to disable the MessageDrivenSubscriptions feature and this option will be removed in future versions. Use 'TransportExtensions<T>.DisablePublishing()' to avoid the need for a subscription storage if this endpoint does not publish events. Will be treated as an error from version 8.0.0. Will be removed in version 8.0.0.", false)]
     public class MessageDrivenSubscriptions : NServiceBus.Features.Feature
     {
         protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -1621,6 +1621,7 @@ namespace NServiceBus.Features
     {
         protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
+    [System.ObsoleteAttribute(@"It's not recommended to disable the MessageDrivenSubscriptions feature and this option will be removed in future versions. Use 'transportSettings.DisablePublishing()' to avoid the need for a subscription storage if this endpoint does not publish events. Use `TransportExtensions<T>.DisablePublishing()` instead. Will be removed in version 8.0.0.", true)]
     public class MessageDrivenSubscriptions : NServiceBus.Features.Feature
     {
         protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/DisabledPublishingConnector.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/DisabledPublishingConnector.cs
@@ -1,0 +1,14 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.Threading.Tasks;
+    using Pipeline;
+
+    class DisabledPublishingConnector : StageConnector<IOutgoingPublishContext, IOutgoingLogicalMessageContext>
+    {
+        public override Task Invoke(IOutgoingPublishContext context, Func<IOutgoingLogicalMessageContext, Task> stage)
+        {
+            throw new InvalidOperationException("Publishing has been explicitly disabled on this endpoint. Remove 'transportSettings.DisablePublishing()' to enable publishing again.");
+        }
+    }
+}

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/DisabledPublishingTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/DisabledPublishingTerminator.cs
@@ -4,9 +4,9 @@
     using System.Threading.Tasks;
     using Pipeline;
 
-    class DisabledPublishingConnector : StageConnector<IOutgoingPublishContext, IOutgoingLogicalMessageContext>
+    class DisabledPublishingTerminator : PipelineTerminator<IOutgoingPublishContext>
     {
-        public override Task Invoke(IOutgoingPublishContext context, Func<IOutgoingLogicalMessageContext, Task> stage)
+        protected override Task Terminate(IOutgoingPublishContext context)
         {
             throw new InvalidOperationException("Publishing has been explicitly disabled on this endpoint. Remove 'transportSettings.DisablePublishing()' to enable publishing again.");
         }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -63,6 +63,10 @@ namespace NServiceBus.Features
                     return new UnicastPublishRouterConnector(unicastPublishRouter, distributionPolicy);
                 }, "Determines how the published messages should be routed");
             }
+            else
+            {
+                context.Pipeline.Register(typeof(DisabledPublishingConnector), "Provides a more meaningful exception message when Publish(...) is called.");
+            }
 
             var canReceive = !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly");
             if (canReceive)

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -8,6 +8,9 @@ namespace NServiceBus.Features
     /// <summary>
     /// Allows subscribers to register by sending a subscription message to this endpoint.
     /// </summary>
+    [ObsoleteEx(Message = "It's not recommended to disable the MessageDrivenSubscriptions feature and this option will be removed in future versions. Use 'transportSettings.DisablePublishing()' to avoid the need for a subscription storage if this endpoint does not publish events.",
+        RemoveInVersion = "8.0",
+        ReplacementTypeOrMember = "TransportExtensions<T>.DisablePublishing()")]
     public class MessageDrivenSubscriptions : Feature
     {
         internal const string EnablePublishingSettingsKey = "NServiceBus.PublishSubscribe.EnablePublishing";
@@ -51,7 +54,7 @@ namespace NServiceBus.Features
             {
                 if (!PersistenceStartup.HasSupportFor<StorageType.Subscriptions>(context.Settings))
                 {
-                    throw new Exception("The selected persistence doesn't have support for subscription storage. Select another persistence or disable the message-driven subscriptions feature using endpointConfiguration.DisableFeature<MessageDrivenSubscriptions>()");
+                    throw new Exception("The selected persistence doesn't have support for subscription storage. Select another persistence or disable the publish functionality using transportConfiguration.DisablePublishing()");
                 }
 
                 context.Pipeline.Register(b =>

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -10,6 +10,8 @@ namespace NServiceBus.Features
     /// </summary>
     public class MessageDrivenSubscriptions : Feature
     {
+        internal const string EnablePublishingSettingsKey = "NServiceBus.PublishSubscribe.EnablePublishing";
+
         internal MessageDrivenSubscriptions()
         {
             EnableByDefault();
@@ -17,6 +19,7 @@ namespace NServiceBus.Features
             {
                 // s.SetDefault<Publishers>(new Publishers()); currently setup by RoutingFeature
                 s.SetDefault(new ConfiguredPublishers());
+                s.SetDefault(EnablePublishingSettingsKey, true);
             });
             Prerequisite(c => c.Settings.Get<TransportInfrastructure>().OutboundRoutingPolicy.Publishes == OutboundRoutingType.Unicast || SubscriptionMigrationMode.IsMigrationModeEnabled(c.Settings), "The transport supports native pub sub");
         }
@@ -32,29 +35,33 @@ namespace NServiceBus.Features
                 return;
             }
 
-            if (!PersistenceStartup.HasSupportFor<StorageType.Subscriptions>(context.Settings))
-            {
-                throw new Exception("The selected persistence doesn't have support for subscription storage. Select another persistence or disable the message-driven subscriptions feature using endpointConfiguration.DisableFeature<MessageDrivenSubscriptions>()");
-            }
-
             var transportInfrastructure = context.Settings.Get<TransportInfrastructure>();
-            var canReceive = !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly");
             var conventions = context.Settings.Get<Conventions>();
             var enforceBestPractices = context.Routing.EnforceBestPractices;
 
             var distributionPolicy = context.Routing.DistributionPolicy;
             var endpointInstances = context.Routing.EndpointInstances;
             var publishers = context.Routing.Publishers;
-            var configuredPublishers = context.Settings.Get<ConfiguredPublishers>();
 
+            var configuredPublishers = context.Settings.Get<ConfiguredPublishers>();
             configuredPublishers.Apply(publishers, conventions, enforceBestPractices);
 
-            context.Pipeline.Register(b =>
+            var publishingEnabled = context.Settings.Get<bool>(EnablePublishingSettingsKey);
+            if (publishingEnabled)
             {
-                var unicastPublishRouter = new UnicastPublishRouter(b.Build<MessageMetadataRegistry>(), i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)), b.Build<ISubscriptionStorage>());
-                return new UnicastPublishRouterConnector(unicastPublishRouter, distributionPolicy);
-            }, "Determines how the published messages should be routed");
+                if (!PersistenceStartup.HasSupportFor<StorageType.Subscriptions>(context.Settings))
+                {
+                    throw new Exception("The selected persistence doesn't have support for subscription storage. Select another persistence or disable the message-driven subscriptions feature using endpointConfiguration.DisableFeature<MessageDrivenSubscriptions>()");
+                }
 
+                context.Pipeline.Register(b =>
+                {
+                    var unicastPublishRouter = new UnicastPublishRouter(b.Build<MessageMetadataRegistry>(), i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)), b.Build<ISubscriptionStorage>());
+                    return new UnicastPublishRouterConnector(unicastPublishRouter, distributionPolicy);
+                }, "Determines how the published messages should be routed");
+            }
+
+            var canReceive = !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly");
             if (canReceive)
             {
                 var subscriberAddress = context.Receiving.LocalAddress;

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -65,7 +65,7 @@ namespace NServiceBus.Features
             }
             else
             {
-                context.Pipeline.Register(typeof(DisabledPublishingConnector), "Provides a more meaningful exception message when Publish(...) is called.");
+                context.Pipeline.Register(typeof(DisabledPublishingTerminator), "Throws an exception when trying to publish with publishing disabled");
             }
 
             var canReceive = !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly");

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -8,9 +8,9 @@ namespace NServiceBus.Features
     /// <summary>
     /// Allows subscribers to register by sending a subscription message to this endpoint.
     /// </summary>
-    [ObsoleteEx(Message = "It's not recommended to disable the MessageDrivenSubscriptions feature and this option will be removed in future versions. Use 'transportSettings.DisablePublishing()' to avoid the need for a subscription storage if this endpoint does not publish events.",
+    [ObsoleteEx(Message = "It's not recommended to disable the MessageDrivenSubscriptions feature and this option will be removed in future versions. Use 'TransportExtensions<T>.DisablePublishing()' to avoid the need for a subscription storage if this endpoint does not publish events.",
         RemoveInVersion = "8.0",
-        ReplacementTypeOrMember = "TransportExtensions<T>.DisablePublishing()")]
+        TreatAsErrorFromVersion = "8.0")]
     public class MessageDrivenSubscriptions : Feature
     {
         internal const string EnablePublishingSettingsKey = "NServiceBus.PublishSubscribe.EnablePublishing";

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Reflection;
+    using Features;
     using Pipeline;
     using Routing;
     using Routing.MessageDrivenSubscriptions;
@@ -31,6 +32,14 @@ namespace NServiceBus
         {
             settings.TryGet("SubscriptionAuthorizer", out Func<IIncomingPhysicalMessageContext, bool> authorizer);
             return authorizer;
+        }
+
+        /// <summary>
+        /// Disables the ability to publish events. This removes the need to provide a subscription storage option. The endpoint can still subscribe to events but isn't allowed to publish it's own events.
+        /// </summary>
+        public static void DisablePublishing<T>(this TransportExtensions<T> transportExtensions) where T : TransportDefinition, IMessageDrivenSubscriptionTransport
+        {
+            transportExtensions.Settings.Set(MessageDrivenSubscriptions.EnablePublishingSettingsKey, false);
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
@@ -35,7 +35,7 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Disables the ability to publish events. This removes the need to provide a subscription storage option. The endpoint can still subscribe to events but isn't allowed to publish it's own events.
+        /// Disables the ability to publish events. This removes the need to provide a subscription storage option. The endpoint can still subscribe to events but isn't allowed to publish its events.
         /// </summary>
         public static void DisablePublishing<T>(this TransportExtensions<T> transportExtensions) where T : TransportDefinition, IMessageDrivenSubscriptionTransport
         {


### PR DESCRIPTION
Fixes #5120

When users use `DisableFeature<MessageDrivenSubscriptions>()` they want to avoid to provide a subscription storage. As the subscription storage is only used when publishing events, this means that people can only choose between completely disable pub-sub or provide a subscription storage, e.g. when they want to subscribe to events but don't publish from this endpoint.

This features provides a new public configuration API which is available to transports using message driven pub-sub. It can be enabled using `transportSettings.DisablePublishing()`. With publishing disabled, an endpoint doesn't need a subscription storage when starting up.

Calling `Publish(...)` when publishing has been disabled causes an InvalidOperationException due to the special pipeline terminator.

This option is not available when using the subscription migration mode at the moment. Since the migration mode mixes both native and message-driven pub-sub, I don't think it's a particularly useful option to disable publishing only for message-driven pub-sub.

The `MessageDrivenSubscriptions` feature is marked obsolete to give a hint to switch to the `DisablePublishing()` functionality instead.