### PR TITLE
Expose native message ID on the IncomingMessage

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -2555,6 +2555,7 @@ namespace NServiceBus.Transport
         public byte[] Body { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public string MessageId { get; }
+        public string NativeMessageId { get; }
     }
     public class static IncomingMessageExtensions
     {

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -2557,6 +2557,7 @@ namespace NServiceBus.Transport
         public byte[] Body { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public string MessageId { get; }
+        public string NativeMessageId { get; }
     }
     public class static IncomingMessageExtensions
     {

--- a/src/NServiceBus.Core.Tests/Transports/IncomingMessageTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/IncomingMessageTests.cs
@@ -1,0 +1,47 @@
+﻿namespace NServiceBus.Core.Tests.Transports
+{
+    using System.Collections.Generic;
+    using NUnit.Framework;
+    using Transport;
+
+    [TestFixture]
+    public class IncomingMessageTests
+    {
+        [Test]
+        public void Should_assign_transport_message_id_when_NServiceBus_message_id_header_is_missing()
+        {
+            var headers = new Dictionary<string, string>();
+            var message = new IncomingMessage("nativeId", headers, new byte[]{});
+
+            Assert.AreEqual("nativeId", message.NativeMessageId);
+            Assert.AreEqual("nativeId", message.MessageId);
+            Assert.AreEqual("nativeId", headers[Headers.MessageId]);
+        }
+
+        [Test]
+        public void Should_retain_transport_message_id_when_NServiceBus_message_id_header_is_found()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, "coreId" }
+            };
+            var message = new IncomingMessage("nativeId", headers, new byte[]{});
+
+            Assert.AreEqual("nativeId", message.NativeMessageId);
+            Assert.AreEqual("coreId", message.MessageId);
+        }
+
+        [Test]
+        public void Should_assign_transport_message_id_when_NServiceBus_message_id_header_is_found_without_value()
+        {
+            var headers = new Dictionary<string, string>
+            {
+                { Headers.MessageId, "" }
+            };
+            var message = new IncomingMessage("nativeId", headers, new byte[]{});
+
+            Assert.AreEqual("nativeId", message.NativeMessageId);
+            Assert.AreEqual("nativeId", message.MessageId);
+        }
+    }
+}

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -31,6 +31,7 @@ namespace NServiceBus.Transport
                 headers[NServiceBus.Headers.MessageId] = nativeMessageId;
             }
 
+            NativeMessageId = nativeMessageId;
 
             Headers = headers;
 
@@ -38,9 +39,14 @@ namespace NServiceBus.Transport
         }
 
         /// <summary>
-        /// The id of the message.
+        /// The ID of the message.
         /// </summary>
         public string MessageId { get; }
+
+        /// <summary>
+        /// Native message ID.
+        /// </summary>
+        public string NativeMessageId { get; }
 
         /// <summary>
         /// The message headers.


### PR DESCRIPTION
Fixes #5391 

`IncomingMessage` receives the native message ID from the transport. This PR exposes the native message ID as a `NativeMessageId` property to allow access in advanced scenarios when this value should be logged for troubleshooting.