### PR TITLE
Log debug statement when publishing without subscribers with message-driven transport

### DIFF
--- a/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
@@ -97,11 +97,18 @@
         }
 
         [Test]
-        public async Task When_no_subscribers_found_Should_log_a_warning()
+        public async Task When_no_subscribers_found_Should_log_a_warning_once()
         {
-            await router.Route(typeof(Event), new DistributionPolicy(), new TestableOutgoingPublishContext());
+            var distributionPolicy = new DistributionPolicy();
+            var testableOutgoingPublishContext = new TestableOutgoingPublishContext();
 
-            StringAssert.Contains($"No subscribers found for the event of type {typeof(Event).FullName}.", logStatements.ToString());
+            await router.Route(typeof(Event), distributionPolicy, testableOutgoingPublishContext);
+            await router.Route(typeof(Event), distributionPolicy, testableOutgoingPublishContext);
+
+            var warning = $"No subscribers found for the event of type {typeof(Event).FullName}.";
+            var chunks = logStatements.ToString().Split(new[] {warning}, StringSplitOptions.RemoveEmptyEntries);
+
+            Assert.AreEqual(2, chunks.Length, "Expected to find a single warning, but it was logged more than once.");
         }
 
         static string ExtractDestination(UnicastRoutingStrategy route)

--- a/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
@@ -97,18 +97,14 @@
         }
 
         [Test]
-        public async Task When_no_subscribers_found_Should_log_a_warning_once()
+        public async Task When_no_subscribers_found_Should_log_at_debug_level()
         {
-            var distributionPolicy = new DistributionPolicy();
-            var testableOutgoingPublishContext = new TestableOutgoingPublishContext();
-
-            await router.Route(typeof(Event), distributionPolicy, testableOutgoingPublishContext);
-            await router.Route(typeof(Event), distributionPolicy, testableOutgoingPublishContext);
+            await router.Route(typeof(Event), new DistributionPolicy(), new TestableOutgoingPublishContext());
 
             var warning = $"No subscribers found for the event of type {typeof(Event).FullName}.";
-            var chunks = logStatements.ToString().Split(new[] {warning}, StringSplitOptions.RemoveEmptyEntries);
 
-            Assert.AreEqual(2, chunks.Length, "Expected to find a single warning, but it was logged more than once.");
+            StringAssert.Contains(warning, logStatements.ToString());
+            StringAssert.Contains(" DEBUG ", logStatements.ToString());
         }
 
         static string ExtractDestination(UnicastRoutingStrategy route)

--- a/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
@@ -2,9 +2,12 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
+    using System.Text;
     using System.Threading.Tasks;
     using Extensibility;
+    using NServiceBus.Logging;
     using NServiceBus.Routing;
     using NUnit.Framework;
     using Testing;
@@ -19,6 +22,7 @@
         MessageMetadataRegistry metadataRegistry;
         EndpointInstances endpointInstances;
         FakeSubscriptionStorage subscriptionStorage;
+        static StringBuilder logStatements = new StringBuilder();
 
         [Test]
         public async Task When_subscriber_does_not_define_logical_endpoint_should_send_event_to_each_address()
@@ -92,11 +96,26 @@
             Assert.IsEmpty(routes);
         }
 
+        [Test]
+        public async Task When_no_subscribers_found_Should_log_a_warning()
+        {
+            await router.Route(typeof(Event), new DistributionPolicy(), new TestableOutgoingPublishContext());
+
+            StringAssert.Contains($"No subscribers found for the event of type {typeof(Event).FullName}.", logStatements.ToString());
+        }
+
         static string ExtractDestination(UnicastRoutingStrategy route)
         {
             var headers = new Dictionary<string, string>();
             var addressTag = (UnicastAddressTag)route.Apply(headers);
             return addressTag.Destination;
+        }
+
+        [OneTimeSetUp]
+        public void LoggerSetup()
+        {
+            LogManager.Use<TestingLoggerFactory>()
+                .WriteTo(new StringWriter(logStatements));
         }
 
         [SetUp]
@@ -109,6 +128,8 @@
                 metadataRegistry,
                 i => string.Empty,
                 subscriptionStorage);
+
+            logStatements.Clear();
         }
 
         class FakeSubscriptionStorage : ISubscriptionStorage

--- a/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
@@ -5,6 +5,7 @@ namespace NServiceBus
     using System.Linq;
     using System.Threading.Tasks;
     using Extensibility;
+    using Logging;
     using Pipeline;
     using Routing;
     using Unicast.Messages;
@@ -26,7 +27,19 @@ namespace NServiceBus
 
             var subscribers = await GetSubscribers(publishContext, typesToRoute).ConfigureAwait(false);
 
-            return SelectDestinationsForEachEndpoint(publishContext, distributionPolicy, subscribers);
+            var destinations = SelectDestinationsForEachEndpoint(publishContext, distributionPolicy, subscribers);
+
+            WarnIfNoSubscribersFound(messageType, destinations.Count);
+
+            return destinations;
+        }
+
+        static void WarnIfNoSubscribersFound(Type messageType, int subscribersFound)
+        {
+            if (subscribersFound == 0)
+            {
+                logger.WarnFormat("No subscribers found for the event of type {0}.", messageType.FullName);
+            }
         }
 
         Dictionary<string, UnicastRoutingStrategy>.ValueCollection SelectDestinationsForEachEndpoint(IOutgoingPublishContext publishContext, IDistributionPolicy distributionPolicy, IEnumerable<Subscriber> subscribers)
@@ -85,5 +98,6 @@ namespace NServiceBus
         MessageMetadataRegistry messageMetadataRegistry;
         Func<EndpointInstance, string> transportAddressTranslation;
         ISubscriptionStorage subscriptionStorage;
+        static ILog logger = LogManager.GetLogger<UnicastPublishRouter>();
     }
 }

--- a/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus
 {
     using System;
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
@@ -39,12 +38,7 @@ namespace NServiceBus
         {
             if (subscribersFound == 0)
             {
-                eventsWithoutSubscribers.GetOrAdd(messageType.FullName, @event =>
-                {
-                    logger.WarnFormat("No subscribers found for the event of type {0}.", @event);
-
-                    return true;
-                });
+                logger.DebugFormat("No subscribers found for the event of type {0}.", messageType.FullName);
             }
         }
 
@@ -104,7 +98,6 @@ namespace NServiceBus
         MessageMetadataRegistry messageMetadataRegistry;
         Func<EndpointInstance, string> transportAddressTranslation;
         ISubscriptionStorage subscriptionStorage;
-        ConcurrentDictionary<string, bool> eventsWithoutSubscribers = new ConcurrentDictionary<string, bool>();
         static ILog logger = LogManager.GetLogger<UnicastPublishRouter>();
     }
 }


### PR DESCRIPTION
Fixes #4119 

With message-driven pub/sub, when an event is published and no subscribers are found, log a warning.