### PR TITLE
Add ContextBag to ErrorContext

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -2509,10 +2509,10 @@ namespace NServiceBus.Transport
     public class ErrorContext
     {
         public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures) { }
-        public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures, NServiceBus.Extensibility.ContextBag context) { }
+        public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures, NServiceBus.Extensibility.ReadOnlyContextBag context) { }
         public int DelayedDeliveriesPerformed { get; }
         public System.Exception Exception { get; }
-        public NServiceBus.Extensibility.ContextBag Extensions { get; }
+        public NServiceBus.Extensibility.ReadOnlyContextBag Extensions { get; }
         public int ImmediateProcessingFailures { get; }
         public NServiceBus.Transport.IncomingMessage Message { get; }
         public NServiceBus.Transport.TransportTransaction TransportTransaction { get; }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -2509,8 +2509,10 @@ namespace NServiceBus.Transport
     public class ErrorContext
     {
         public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures) { }
+        public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures, NServiceBus.Extensibility.ContextBag context) { }
         public int DelayedDeliveriesPerformed { get; }
         public System.Exception Exception { get; }
+        public NServiceBus.Extensibility.ContextBag Extensions { get; }
         public int ImmediateProcessingFailures { get; }
         public NServiceBus.Transport.IncomingMessage Message { get; }
         public NServiceBus.Transport.TransportTransaction TransportTransaction { get; }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -2511,8 +2511,10 @@ namespace NServiceBus.Transport
     public class ErrorContext
     {
         public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures) { }
+        public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures, NServiceBus.Extensibility.ContextBag context) { }
         public int DelayedDeliveriesPerformed { get; }
         public System.Exception Exception { get; }
+        public NServiceBus.Extensibility.ContextBag Extensions { get; }
         public int ImmediateProcessingFailures { get; }
         public NServiceBus.Transport.IncomingMessage Message { get; }
         public NServiceBus.Transport.TransportTransaction TransportTransaction { get; }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -2511,10 +2511,10 @@ namespace NServiceBus.Transport
     public class ErrorContext
     {
         public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures) { }
-        public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures, NServiceBus.Extensibility.ContextBag context) { }
+        public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures, NServiceBus.Extensibility.ReadOnlyContextBag context) { }
         public int DelayedDeliveriesPerformed { get; }
         public System.Exception Exception { get; }
-        public NServiceBus.Extensibility.ContextBag Extensions { get; }
+        public NServiceBus.Extensibility.ReadOnlyContextBag Extensions { get; }
         public int ImmediateProcessingFailures { get; }
         public NServiceBus.Transport.IncomingMessage Message { get; }
         public NServiceBus.Transport.TransportTransaction TransportTransaction { get; }

--- a/src/NServiceBus.Core.Tests/Recoverability/ErrorContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/ErrorContextTests.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.Core.Tests.Recoverability
+{
+    using System;
+    using System.Collections.Generic;
+    using Extensibility;
+    using NUnit.Framework;
+    using Transport;
+
+    [TestFixture]
+    public class ErrorContextTests
+    {
+        [Test]
+        public void Can_pass_additional_information_via_context_bag()
+        {
+            var contextBag = new ContextBag();
+            contextBag.Set("MyKey", "MyValue");
+            var context = new ErrorContext(new Exception(), new Dictionary<string, string>(), "ID", new byte[0], new TransportTransaction(), 0, contextBag);
+
+            Assert.AreEqual("MyValue", context.Extensions.Get<string>("MyKey"));
+        }
+    }
+}

--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -73,7 +73,7 @@
         public IncomingMessage Message { get; }
 
         /// <summary>
-        /// A <see cref="ContextBag" /> which can be used to extend the current object.
+        /// A collection of additional information provided by the transport.
         /// </summary>
         public ReadOnlyContextBag Extensions { get; }
     }

--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using Extensibility;
 
     /// <summary>
     /// The context for messages that has failed processing.
@@ -11,7 +12,28 @@
         /// <summary>
         /// Initializes the error context.
         /// </summary>
+        /// <param name="exception">The exception that caused the message processing failure.</param>
+        /// <param name="headers">The message headers.</param>
+        /// <param name="transportMessageId">Native message id.</param>
+        /// <param name="body">The message body.</param>
+        /// <param name="transportTransaction">Transaction (along with connection if applicable) used to receive the message.</param>
+        /// <param name="immediateProcessingFailures">Number of conducted immediate retry attempts.</param>
         public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, byte[] body, TransportTransaction transportTransaction, int immediateProcessingFailures)
+            : this(exception, headers, transportMessageId, body, transportTransaction, immediateProcessingFailures, new ContextBag())
+        {
+        }
+
+        /// <summary>
+        /// Initializes the error context.
+        /// </summary>
+        /// <param name="exception">The exception that caused the message processing failure.</param>
+        /// <param name="headers">The message headers.</param>
+        /// <param name="transportMessageId">Native message id.</param>
+        /// <param name="body">The message body.</param>
+        /// <param name="transportTransaction">Transaction (along with connection if applicable) used to receive the message.</param>
+        /// <param name="immediateProcessingFailures">Number of conducted immediate retry attempts.</param>
+        /// <param name="context">A <see cref="ContextBag" /> which can be used to extend the current object.</param>
+        public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, byte[] body, TransportTransaction transportTransaction, int immediateProcessingFailures, ContextBag context)
         {
             Exception = exception;
             TransportTransaction = transportTransaction;
@@ -20,6 +42,7 @@
             Message = new IncomingMessage(transportMessageId, headers, body);
 
             DelayedDeliveriesPerformed = Message.GetDelayedDeliveriesPerformed();
+            Extensions = context;
         }
 
         /// <summary>
@@ -46,5 +69,10 @@
         /// Failed incoming message.
         /// </summary>
         public IncomingMessage Message { get; }
+
+        /// <summary>
+        /// A <see cref="ContextBag" /> which can be used to extend the current object.
+        /// </summary>
+        public ContextBag Extensions { get; }
     }
 }

--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -19,7 +19,7 @@
         /// <param name="transportMessageId">Native message id.</param>
         /// <param name="body">The message body.</param>
         /// <param name="transportTransaction">Transaction (along with connection if applicable) used to receive the message.</param>
-        /// <param name="immediateProcessingFailures">Number of conducted immediate retry attempts.</param>
+        /// <param name="immediateProcessingFailures">Number of failed immediate processing attempts.</param>
         public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, byte[] body, TransportTransaction transportTransaction, int immediateProcessingFailures)
             : this(exception, headers, transportMessageId, body, transportTransaction, immediateProcessingFailures, emptyBag)
         {

--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -33,7 +33,7 @@
         /// <param name="transportMessageId">Native message id.</param>
         /// <param name="body">The message body.</param>
         /// <param name="transportTransaction">Transaction (along with connection if applicable) used to receive the message.</param>
-        /// <param name="immediateProcessingFailures">Number of conducted immediate retry attempts.</param>
+        /// <param name="immediateProcessingFailures">Number of failed immediate processing attempts.</param>
         /// <param name="context">A <see cref="ContextBag" /> which can be used to extend the current object.</param>
         public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, byte[] body, TransportTransaction transportTransaction, int immediateProcessingFailures, ReadOnlyContextBag context)
         {

--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -9,6 +9,8 @@
     /// </summary>
     public class ErrorContext
     {
+        static ReadOnlyContextBag emptyBag = new ContextBag();
+
         /// <summary>
         /// Initializes the error context.
         /// </summary>
@@ -19,7 +21,7 @@
         /// <param name="transportTransaction">Transaction (along with connection if applicable) used to receive the message.</param>
         /// <param name="immediateProcessingFailures">Number of conducted immediate retry attempts.</param>
         public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, byte[] body, TransportTransaction transportTransaction, int immediateProcessingFailures)
-            : this(exception, headers, transportMessageId, body, transportTransaction, immediateProcessingFailures, new ContextBag())
+            : this(exception, headers, transportMessageId, body, transportTransaction, immediateProcessingFailures, emptyBag)
         {
         }
 
@@ -33,7 +35,7 @@
         /// <param name="transportTransaction">Transaction (along with connection if applicable) used to receive the message.</param>
         /// <param name="immediateProcessingFailures">Number of conducted immediate retry attempts.</param>
         /// <param name="context">A <see cref="ContextBag" /> which can be used to extend the current object.</param>
-        public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, byte[] body, TransportTransaction transportTransaction, int immediateProcessingFailures, ContextBag context)
+        public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, byte[] body, TransportTransaction transportTransaction, int immediateProcessingFailures, ReadOnlyContextBag context)
         {
             Exception = exception;
             TransportTransaction = transportTransaction;
@@ -73,6 +75,6 @@
         /// <summary>
         /// A <see cref="ContextBag" /> which can be used to extend the current object.
         /// </summary>
-        public ContextBag Extensions { get; }
+        public ReadOnlyContextBag Extensions { get; }
     }
 }


### PR DESCRIPTION
Fixes #5333 

I have some mixed feelings about this API because it should technically be unidirectional i.e. transports should be able to add stuff to the bag but then the error policy should only be able to read the bag, not add to it. Using `ContextBag` makes it possibly to modify the bag after it is created. This has the drawback of having to allocate the `ContextBag` even if the transport does not use it.

Thoughts? Should we create a *read only context bag* for such cases? Or am I complicating things too much?