### PR TITLE
Align behavior names

### DIFF
--- a/src/NServiceBus.AcceptanceTests/ApprovalFiles/When_endpoint_is_warmed_up.Make_sure_things_are_in_DI.approved.txt
+++ b/src/NServiceBus.AcceptanceTests/ApprovalFiles/When_endpoint_is_warmed_up.Make_sure_things_are_in_DI.approved.txt
@@ -3,7 +3,7 @@ NServiceBus.Hosting.HostInformation - SingleInstance
 NServiceBus.LoadHandlersConnector - InstancePerCall
 NServiceBus.StorageInitializer+CallInit - SingleInstance
 NServiceBus.Transport.IDispatchMessages - SingleInstance
-NServiceBus.TransportReceiveToPhysicalMessageProcessingConnector - InstancePerCall
+NServiceBus.TransportReceiveToPhysicalMessageConnector - InstancePerCall
 NServiceBus.Unicast.MessageHandlerRegistry - SingleInstance
 ----------- Likely unused components (Remove in next major if possible) -----------
 NServiceBus.CriticalError - SingleInstance

--- a/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageConnectorTests.cs
@@ -16,7 +16,7 @@
     using TransportOperation = Transport.TransportOperation;
 
     [TestFixture]
-    public class TransportReceiveToPhysicalMessageProcessingConnectorTests
+    public class TransportReceiveToPhysicalMessageConnectorTests
     {
         [Test]
         public async Task Should_honor_stored_delivery_constraints()
@@ -121,7 +121,7 @@
             fakeOutbox = new FakeOutboxStorage();
             fakeBatchPipeline = new FakeBatchPipeline();
 
-            behavior = new TransportReceiveToPhysicalMessageProcessingConnector(fakeOutbox);
+            behavior = new TransportReceiveToPhysicalMessageConnector(fakeOutbox);
         }
 
         Task Invoke(ITransportReceiveContext context)
@@ -129,7 +129,7 @@
             return behavior.Invoke(context, c => TaskEx.CompletedTask);
         }
 
-        TransportReceiveToPhysicalMessageProcessingConnector behavior;
+        TransportReceiveToPhysicalMessageConnector behavior;
 
         FakeBatchPipeline fakeBatchPipeline;
         FakeOutboxStorage fakeOutbox;

--- a/src/NServiceBus.Core.Tests/Routing/DetermineRouteForPublishBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DetermineRouteForPublishBehaviorTests.cs
@@ -13,7 +13,7 @@
         [Test]
         public async Task Should_use_to_all_subscribers_strategy()
         {
-            var behavior = new MulticastPublishRouterBehavior();
+            var behavior = new MulticastPublishConnector();
 
             var context = new TestableOutgoingPublishContext
             {

--- a/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
@@ -16,7 +16,7 @@
         [Test]
         public async Task Should_default_to_reply_address_of_incoming_message_for_replies()
         {
-            var behavior = new UnicastReplyRouterConnector();
+            var behavior = new ReplyConnector();
 
             var context = CreateContext(new OutgoingLogicalMessage(typeof(MyReply), new MyReply()));
 
@@ -41,7 +41,7 @@
         [Test]
         public void Should_throw_if_incoming_message_has_no_reply_to_address()
         {
-            var behavior = new UnicastReplyRouterConnector();
+            var behavior = new ReplyConnector();
 
             var context = CreateContext(new OutgoingLogicalMessage(typeof(MyReply), new MyReply()));
 
@@ -56,7 +56,7 @@
         [Test]
         public async Task Should_use_explicit_route_for_replies_if_present()
         {
-            var behavior = new UnicastReplyRouterConnector();
+            var behavior = new ReplyConnector();
             var options = new ReplyOptions();
 
             options.SetDestination("CustomReplyToAddress");

--- a/src/NServiceBus.Core.Tests/Routing/Routers/MulticastPublishConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/MulticastPublishConnectorTests.cs
@@ -5,12 +5,12 @@
     using Testing;
 
     [TestFixture]
-    public class MulticastPublishRouterBehaviorTests
+    public class MulticastPublishConnectorTests
     {
         [Test]
         public async Task Should_set_messageintent_to_publish()
         {
-            var router = new MulticastPublishRouterBehavior();
+            var router = new MulticastPublishConnector();
             var context = new TestableOutgoingPublishContext();
 
             await router.Invoke(context, ctx => TaskEx.CompletedTask);

--- a/src/NServiceBus.Core.Tests/Routing/Routers/ReplyConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/ReplyConnectorTests.cs
@@ -5,14 +5,14 @@
     using Testing;
 
     [TestFixture]
-    public class UnicastReplyRouterConnectorTests
+    public class ReplyConnectorTests
     {
         [Test]
         public async Task Should_set_messageintent_to_reply()
         {
-            var router = new UnicastReplyRouterConnector();
+            var router = new ReplyConnector();
             var context = new TestableOutgoingReplyContext();
-            context.Extensions.Set(new UnicastReplyRouterConnector.State { ExplicitDestination = "Fake" });
+            context.Extensions.Set(new ReplyConnector.State { ExplicitDestination = "Fake" });
 
             await router.Invoke(context, ctx => TaskEx.CompletedTask);
 

--- a/src/NServiceBus.Core.Tests/Routing/Routers/SendConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/SendConnectorTests.cs
@@ -11,7 +11,7 @@
     using Unicast.Messages;
 
     [TestFixture]
-    public class UnicastSendRouterConnectorTests
+    public class SendConnectorTests
     {
         [Test]
         public async Task Should_set_messageintent_to_send()
@@ -63,7 +63,7 @@
         }
 
 
-        static UnicastSendRouterConnector InitializeBehavior(FakeRouter router = null)
+        static SendConnector InitializeBehavior(FakeRouter router = null)
         {
             var metadataRegistry = new MessageMetadataRegistry(new Conventions().IsMessageType);
             metadataRegistry.RegisterMessageTypesFoundIn(new List<Type>
@@ -72,7 +72,7 @@
                 typeof(MessageWithoutRouting)
             });
 
-            return new UnicastSendRouterConnector(router ?? new FakeRouter());
+            return new SendConnector(router ?? new FakeRouter());
         }
 
         class FakeRouter : UnicastSendRouter

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastPublishConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastPublishConnectorTests.cs
@@ -9,12 +9,12 @@
     using Testing;
 
     [TestFixture]
-    public class UnicastPublishRouterConnectorTests
+    public class UnicastPublishConnectorTests
     {
         [Test]
         public async Task Should_set_messageintent_to_publish()
         {
-            var router = new UnicastPublishRouterConnector(new FakePublishRouter(), new DistributionPolicy());
+            var router = new UnicastPublishConnector(new FakePublishRouter(), new DistributionPolicy());
             var context = new TestableOutgoingPublishContext();
 
             await router.Invoke(context, ctx => TaskEx.CompletedTask);

--- a/src/NServiceBus.Core.Tests/Utils/Reflection/ExtensionMethodsTests.cs
+++ b/src/NServiceBus.Core.Tests/Utils/Reflection/ExtensionMethodsTests.cs
@@ -44,7 +44,7 @@
         [Test]
         public void Should_return_true_for_particular_assembly()
         {
-            Assert.IsTrue(typeof(TransportReceiveToPhysicalMessageProcessingConnector).IsFromParticularAssembly());
+            Assert.IsTrue(typeof(TransportReceiveToPhysicalMessageConnector).IsFromParticularAssembly());
         }
 
         [Test]

--- a/src/NServiceBus.Core/Audit/Audit.cs
+++ b/src/NServiceBus.Core/Audit/Audit.cs
@@ -26,7 +26,7 @@
         {
             var auditConfig = context.Settings.Get<AuditConfigReader.Result>();
 
-            context.Pipeline.Register(new AuditToDispatchConnector(auditConfig.TimeToBeReceived), "Dispatches the audit message to the transport");
+            context.Pipeline.Register(new AuditToRoutingConnector(auditConfig.TimeToBeReceived), "Dispatches the audit message to the transport");
             context.Pipeline.Register("AuditProcessedMessage", new InvokeAuditPipelineBehavior(auditConfig.Address), "Execute the audit pipeline");
 
             context.Settings.Get<QueueBindings>().BindSending(auditConfig.Address);

--- a/src/NServiceBus.Core/Audit/Audit.cs
+++ b/src/NServiceBus.Core/Audit/Audit.cs
@@ -26,7 +26,7 @@
         {
             var auditConfig = context.Settings.Get<AuditConfigReader.Result>();
 
-            context.Pipeline.Register(new AuditToRoutingConnector(auditConfig.TimeToBeReceived), "Dispatches the audit message to the transport");
+            context.Pipeline.Register("AuditToDispatchConnector", new AuditToRoutingConnector(auditConfig.TimeToBeReceived), "Dispatches the audit message to the transport");
             context.Pipeline.Register("AuditProcessedMessage", new InvokeAuditPipelineBehavior(auditConfig.Address), "Execute the audit pipeline");
 
             context.Settings.Get<QueueBindings>().BindSending(auditConfig.Address);

--- a/src/NServiceBus.Core/Audit/AuditContext.cs
+++ b/src/NServiceBus.Core/Audit/AuditContext.cs
@@ -27,9 +27,9 @@ namespace NServiceBus
         {
             Guard.AgainstNullAndEmpty(nameof(key), key);
             Guard.AgainstNullAndEmpty(nameof(value), value);
-            if (!Extensions.TryGet(out AuditToDispatchConnector.State state))
+            if (!Extensions.TryGet(out AuditToRoutingConnector.State state))
             {
-                state = new AuditToDispatchConnector.State();
+                state = new AuditToRoutingConnector.State();
                 Extensions.Set(state);
             }
             state.AuditValues[key] = value;

--- a/src/NServiceBus.Core/Audit/AuditToRoutingConnector.cs
+++ b/src/NServiceBus.Core/Audit/AuditToRoutingConnector.cs
@@ -8,9 +8,9 @@ namespace NServiceBus
     using Pipeline;
     using Routing;
 
-    class AuditToDispatchConnector : StageConnector<IAuditContext, IRoutingContext>
+    class AuditToRoutingConnector : StageConnector<IAuditContext, IRoutingContext>
     {
-        public AuditToDispatchConnector(TimeSpan? timeToBeReceived)
+        public AuditToRoutingConnector(TimeSpan? timeToBeReceived)
         {
             this.timeToBeReceived = timeToBeReceived;
         }

--- a/src/NServiceBus.Core/Pipeline/Incoming/DeserializeMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/DeserializeMessageConnector.cs
@@ -12,9 +12,9 @@ namespace NServiceBus
     using Transport;
     using Unicast.Messages;
 
-    class DeserializeLogicalMessagesConnector : StageConnector<IIncomingPhysicalMessageContext, IIncomingLogicalMessageContext>
+    class DeserializeMessageConnector : StageConnector<IIncomingPhysicalMessageContext, IIncomingLogicalMessageContext>
     {
-        public DeserializeLogicalMessagesConnector(MessageDeserializerResolver deserializerResolver, LogicalMessageFactory logicalMessageFactory, MessageMetadataRegistry messageMetadataRegistry, IMessageMapper mapper)
+        public DeserializeMessageConnector(MessageDeserializerResolver deserializerResolver, LogicalMessageFactory logicalMessageFactory, MessageMetadataRegistry messageMetadataRegistry, IMessageMapper mapper)
         {
             this.deserializerResolver = deserializerResolver;
             this.logicalMessageFactory = logicalMessageFactory;
@@ -149,6 +149,6 @@ namespace NServiceBus
             ';'
         };
 
-        static readonly ILog log = LogManager.GetLogger<DeserializeLogicalMessagesConnector>();
+        static readonly ILog log = LogManager.GetLogger<DeserializeMessageConnector>();
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/ReceiveFeature.cs
@@ -17,7 +17,7 @@
 
         protected internal override void Setup(FeatureConfigurationContext context)
         {
-            context.Pipeline.Register("TransportReceiveToPhysicalMessageProcessingConnector", b => b.Build<TransportReceiveToPhysicalMessageProcessingConnector>(), "Allows to abort processing the message");
+            context.Pipeline.Register("TransportReceiveToPhysicalMessageProcessingConnector", b => b.Build<TransportReceiveToPhysicalMessageConnector>(), "Allows to abort processing the message");
             context.Pipeline.Register("LoadHandlersConnector", b => b.Build<LoadHandlersConnector>(), "Gets all the handlers to invoke from the MessageHandler registry based on the message type.");
 
             context.Pipeline.Register("ExecuteUnitOfWork", new UnitOfWorkBehavior(), "Executes the UoW");
@@ -28,7 +28,7 @@
             {
                 var storage = context.Container.HasComponent<IOutboxStorage>() ? b.Build<IOutboxStorage>() : new NoOpOutbox();
 
-                return new TransportReceiveToPhysicalMessageProcessingConnector(storage);
+                return new TransportReceiveToPhysicalMessageConnector(storage);
             }, DependencyLifecycle.InstancePerCall);
 
             context.Container.ConfigureComponent(b =>

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
@@ -12,9 +12,9 @@ namespace NServiceBus
     using Transport;
     using TransportOperation = Outbox.TransportOperation;
 
-    class TransportReceiveToPhysicalMessageProcessingConnector : IStageForkConnector<ITransportReceiveContext, IIncomingPhysicalMessageContext, IBatchDispatchContext>
+    class TransportReceiveToPhysicalMessageConnector : IStageForkConnector<ITransportReceiveContext, IIncomingPhysicalMessageContext, IBatchDispatchContext>
     {
-        public TransportReceiveToPhysicalMessageProcessingConnector(IOutboxStorage outboxStorage)
+        public TransportReceiveToPhysicalMessageConnector(IOutboxStorage outboxStorage)
         {
             this.outboxStorage = outboxStorage;
         }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -60,7 +60,7 @@ namespace NServiceBus.Features
                 context.Pipeline.Register(b =>
                 {
                     var unicastPublishRouter = new UnicastPublishRouter(b.Build<MessageMetadataRegistry>(), i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)), b.Build<ISubscriptionStorage>());
-                    return new UnicastPublishRouterConnector(unicastPublishRouter, distributionPolicy);
+                    return new UnicastPublishConnector(unicastPublishRouter, distributionPolicy);
                 }, "Determines how the published messages should be routed");
             }
             else

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -57,7 +57,7 @@ namespace NServiceBus.Features
                     throw new Exception("The selected persistence doesn't have support for subscription storage. Select another persistence or disable the publish functionality using transportConfiguration.DisablePublishing()");
                 }
 
-                context.Pipeline.Register(b =>
+                context.Pipeline.Register("UnicastPublishRouterConnector", b =>
                 {
                     var unicastPublishRouter = new UnicastPublishRouter(b.Build<MessageMetadataRegistry>(), i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)), b.Build<ISubscriptionStorage>());
                     return new UnicastPublishConnector(unicastPublishRouter, distributionPolicy);

--- a/src/NServiceBus.Core/Routing/NativePublishSubscribeFeature.cs
+++ b/src/NServiceBus.Core/Routing/NativePublishSubscribeFeature.cs
@@ -16,7 +16,7 @@ namespace NServiceBus.Features
             var transportInfrastructure = context.Settings.Get<TransportInfrastructure>();
             var canReceive = !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly");
 
-            context.Pipeline.Register(new MulticastPublishRouterBehavior(), "Determines how the published messages should be routed");
+            context.Pipeline.Register(new MulticastPublishConnector(), "Determines how the published messages should be routed");
 
             if (canReceive)
             {

--- a/src/NServiceBus.Core/Routing/NativePublishSubscribeFeature.cs
+++ b/src/NServiceBus.Core/Routing/NativePublishSubscribeFeature.cs
@@ -16,7 +16,7 @@ namespace NServiceBus.Features
             var transportInfrastructure = context.Settings.Get<TransportInfrastructure>();
             var canReceive = !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly");
 
-            context.Pipeline.Register(new MulticastPublishConnector(), "Determines how the published messages should be routed");
+            context.Pipeline.Register("MulticastPublishRouterBehavior", new MulticastPublishConnector(), "Determines how the published messages should be routed");
 
             if (canReceive)
             {

--- a/src/NServiceBus.Core/Routing/Routers/MulticastPublishConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/MulticastPublishConnector.cs
@@ -5,7 +5,7 @@ namespace NServiceBus
     using Pipeline;
     using Routing;
 
-    class MulticastPublishRouterBehavior : StageConnector<IOutgoingPublishContext, IOutgoingLogicalMessageContext>
+    class MulticastPublishConnector : StageConnector<IOutgoingPublishContext, IOutgoingLogicalMessageContext>
     {
         public override Task Invoke(IOutgoingPublishContext context, Func<IOutgoingLogicalMessageContext, Task> stage)
         {

--- a/src/NServiceBus.Core/Routing/Routers/ReplyConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/ReplyConnector.cs
@@ -6,7 +6,7 @@ namespace NServiceBus
     using Routing;
     using Unicast.Queuing;
 
-    class UnicastReplyRouterConnector : StageConnector<IOutgoingReplyContext, IOutgoingLogicalMessageContext>
+    class ReplyConnector : StageConnector<IOutgoingReplyContext, IOutgoingLogicalMessageContext>
     {
         public override async Task Invoke(IOutgoingReplyContext context, Func<IOutgoingLogicalMessageContext, Task> stage)
         {

--- a/src/NServiceBus.Core/Routing/Routers/SendConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/SendConnector.cs
@@ -5,9 +5,9 @@ namespace NServiceBus
     using Pipeline;
     using Unicast.Queuing;
 
-    class UnicastSendRouterConnector : StageConnector<IOutgoingSendContext, IOutgoingLogicalMessageContext>
+    class SendConnector : StageConnector<IOutgoingSendContext, IOutgoingLogicalMessageContext>
     {
-        public UnicastSendRouterConnector(UnicastSendRouter unicastSendRouter)
+        public SendConnector(UnicastSendRouter unicastSendRouter)
         {
             this.unicastSendRouter = unicastSendRouter;
         }

--- a/src/NServiceBus.Core/Routing/RoutingComponent.cs
+++ b/src/NServiceBus.Core/Routing/RoutingComponent.cs
@@ -50,13 +50,13 @@ namespace NServiceBus
 
             var pipelineSettings = pipelineComponent.PipelineSettings;
 
-            pipelineSettings.Register(b =>
+            pipelineSettings.Register("UnicastSendRouterConnector", b =>
             {
                 var router = new UnicastSendRouter(receiveConfiguration == null, receiveConfiguration?.QueueNameBase, receiveConfiguration?.InstanceSpecificQueue, DistributionPolicy, UnicastRoutingTable, EndpointInstances, i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)));
                 return new SendConnector(router);
             }, "Determines how the message being sent should be routed");
 
-            pipelineSettings.Register(new ReplyConnector(), "Determines how replies should be routed");
+            pipelineSettings.Register("UnicastReplyRouterConnector", new ReplyConnector(), "Determines how replies should be routed");
 
             EnforceBestPractices = ShouldEnforceBestPractices(settings);
             if (EnforceBestPractices)

--- a/src/NServiceBus.Core/Routing/RoutingComponent.cs
+++ b/src/NServiceBus.Core/Routing/RoutingComponent.cs
@@ -53,10 +53,10 @@ namespace NServiceBus
             pipelineSettings.Register(b =>
             {
                 var router = new UnicastSendRouter(receiveConfiguration == null, receiveConfiguration?.QueueNameBase, receiveConfiguration?.InstanceSpecificQueue, DistributionPolicy, UnicastRoutingTable, EndpointInstances, i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)));
-                return new UnicastSendRouterConnector(router);
+                return new SendConnector(router);
             }, "Determines how the message being sent should be routed");
 
-            pipelineSettings.Register(new UnicastReplyRouterConnector(), "Determines how replies should be routed");
+            pipelineSettings.Register(new ReplyConnector(), "Determines how replies should be routed");
 
             EnforceBestPractices = ShouldEnforceBestPractices(settings);
             if (EnforceBestPractices)

--- a/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
+++ b/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
@@ -31,7 +31,7 @@
             Guard.AgainstNull(nameof(options), options);
             Guard.AgainstNullAndEmpty(nameof(destination), destination);
 
-            options.Context.GetOrCreate<UnicastReplyRouterConnector.State>()
+            options.Context.GetOrCreate<ReplyConnector.State>()
                 .ExplicitDestination = destination;
         }
 
@@ -44,7 +44,7 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            options.Context.TryGet(out UnicastReplyRouterConnector.State state);
+            options.Context.TryGet(out ReplyConnector.State state);
             return state?.ExplicitDestination;
         }
 

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/SubscriptionMigrationMode.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/SubscriptionMigrationMode.cs
@@ -30,7 +30,7 @@
             context.Pipeline.Register(b =>
             {
                 var unicastPublishRouter = new UnicastPublishRouter(b.Build<MessageMetadataRegistry>(), i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)), b.Build<ISubscriptionStorage>());
-                return new MigrationRouterConnector(distributionPolicy, unicastPublishRouter);
+                return new MigrationModePublishConnector(distributionPolicy, unicastPublishRouter);
             }, "Determines how the published messages should be routed");
 
             if (canReceive)

--- a/src/NServiceBus.Core/Serialization/SerializationFeature.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationFeature.cs
@@ -52,7 +52,7 @@
 
             var logicalMessageFactory = new LogicalMessageFactory(messageMetadataRegistry, mapper);
             context.Pipeline.Register("DeserializeLogicalMessagesConnector", new DeserializeMessageConnector(resolver, logicalMessageFactory, messageMetadataRegistry, mapper), "Deserializes the physical message body into logical messages");
-            context.Pipeline.Register("DeserializeMessageConnector", new SerializeMessageConnector(defaultSerializer, messageMetadataRegistry), "Converts a logical message into a physical message");
+            context.Pipeline.Register("SerializeMessageConnector", new SerializeMessageConnector(defaultSerializer, messageMetadataRegistry), "Converts a logical message into a physical message");
 
             context.Container.ConfigureComponent(_ => mapper, DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent(_ => messageMetadataRegistry, DependencyLifecycle.SingleInstance);

--- a/src/NServiceBus.Core/Serialization/SerializationFeature.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationFeature.cs
@@ -51,7 +51,7 @@
             var resolver = new MessageDeserializerResolver(defaultSerializer, additionalDeserializers);
 
             var logicalMessageFactory = new LogicalMessageFactory(messageMetadataRegistry, mapper);
-            context.Pipeline.Register(new DeserializeLogicalMessagesConnector(resolver, logicalMessageFactory, messageMetadataRegistry, mapper), "Deserializes the physical message body into logical messages");
+            context.Pipeline.Register(new DeserializeMessageConnector(resolver, logicalMessageFactory, messageMetadataRegistry, mapper), "Deserializes the physical message body into logical messages");
             context.Pipeline.Register(new SerializeMessageConnector(defaultSerializer, messageMetadataRegistry), "Converts a logical message into a physical message");
 
             context.Container.ConfigureComponent(_ => mapper, DependencyLifecycle.SingleInstance);

--- a/src/NServiceBus.Core/Serialization/SerializationFeature.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationFeature.cs
@@ -51,8 +51,8 @@
             var resolver = new MessageDeserializerResolver(defaultSerializer, additionalDeserializers);
 
             var logicalMessageFactory = new LogicalMessageFactory(messageMetadataRegistry, mapper);
-            context.Pipeline.Register(new DeserializeMessageConnector(resolver, logicalMessageFactory, messageMetadataRegistry, mapper), "Deserializes the physical message body into logical messages");
-            context.Pipeline.Register(new SerializeMessageConnector(defaultSerializer, messageMetadataRegistry), "Converts a logical message into a physical message");
+            context.Pipeline.Register("DeserializeLogicalMessagesConnector", new DeserializeMessageConnector(resolver, logicalMessageFactory, messageMetadataRegistry, mapper), "Deserializes the physical message body into logical messages");
+            context.Pipeline.Register("DeserializeMessageConnector", new SerializeMessageConnector(defaultSerializer, messageMetadataRegistry), "Converts a logical message into a physical message");
 
             context.Container.ConfigureComponent(_ => mapper, DependencyLifecycle.SingleInstance);
             context.Container.ConfigureComponent(_ => messageMetadataRegistry, DependencyLifecycle.SingleInstance);

--- a/src/NServiceBus.Persistence.InMemory.AcceptanceTests/ApprovalFiles/When_endpoint_is_warmed_up.Make_sure_things_are_in_DI.approved.txt
+++ b/src/NServiceBus.Persistence.InMemory.AcceptanceTests/ApprovalFiles/When_endpoint_is_warmed_up.Make_sure_things_are_in_DI.approved.txt
@@ -4,7 +4,7 @@ NServiceBus.LoadHandlersConnector - InstancePerCall
 NServiceBus.StorageInitializer+CallInit - SingleInstance
 NServiceBus.SubscriptionReceiverBehavior - InstancePerCall
 NServiceBus.Transport.IDispatchMessages - SingleInstance
-NServiceBus.TransportReceiveToPhysicalMessageProcessingConnector - InstancePerCall
+NServiceBus.TransportReceiveToPhysicalMessageConnector - InstancePerCall
 NServiceBus.Unicast.MessageHandlerRegistry - SingleInstance
 ----------- Likely unused components (Remove in next major if possible) -----------
 NServiceBus.CriticalError - SingleInstance


### PR DESCRIPTION
fixes https://github.com/Particular/NServiceBus/issues/3621

* Made sure that all connectors end with "Connector" and all terminators end with "Terminator".
* I did not strictly rename them to match the `<TFrom>To<TTo>Connector` because, as also pointed out in the related issue by Mike, it might be more useful to give them more meaningful names.
* The renamed behaviors are still registered with their old ids for now to minimize impact on something relying on those ids.
  * We should raise a followup issue to change to registration ids with the next major to align them with the behavior/connector name.
* Some missing "terminators" pointed out in #3621 are now satellite behaviors which don't use the main pipleline infrastructure (e.g. not implementing the behavior, connector and terminator interfaces), therefore I did not rename those.