### PR TITLE
Add additional log information when handlers fail

### DIFF
--- a/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
@@ -20,7 +20,7 @@
                 {
                     GetDate = () => dateTime
                 };
-                logger1.Write("Foo");
+                logger1.WriteLine("Foo");
                 var files1 = tempPath.GetFiles();
                 Assert.AreEqual(1, files1.Count);
                 Assert.AreEqual($"Foo{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(files1.First()));
@@ -28,7 +28,7 @@
                 {
                     GetDate = () => dateTime
                 };
-                logger2.Write("Bar");
+                logger2.WriteLine("Bar");
                 var files2 = tempPath.GetFiles();
                 Assert.AreEqual(1, files2.Count);
                 Assert.AreEqual($"Foo{Environment.NewLine}Bar{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(files2.First()));
@@ -44,10 +44,10 @@
                 {
                     GetDate = () => new DateTime(2010, 10, 1)
                 };
-                logger.Write("Foo");
+                logger.WriteLine("Foo");
                 var single = tempPath.GetSingle();
                 File.Delete(single);
-                logger.Write("Bar");
+                logger.WriteLine("Bar");
                 Assert.AreEqual($"Bar{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(single));
             }
         }
@@ -61,11 +61,11 @@
                 {
                     GetDate = () => new DateTime(2010, 10, 1)
                 };
-                logger.Write("Foo");
+                logger.WriteLine("Foo");
                 var single = tempPath.GetSingle();
                 using (LockFile(single))
                 {
-                    logger.Write("Bar");
+                    logger.WriteLine("Bar");
                 }
                 Assert.AreEqual($"Foo{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(single));
             }
@@ -85,10 +85,10 @@
                 {
                     GetDate = () => new DateTime(2010, 10, 1)
                 };
-                logger.Write("Foo");
+                logger.WriteLine("Foo");
                 var singleFile = tempPath.GetSingle();
                 File.Delete(singleFile);
-                logger.Write("Bar");
+                logger.WriteLine("Bar");
                 Assert.AreEqual($"Bar{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(singleFile));
             }
         }
@@ -117,12 +117,12 @@
                 {
                     GetDate = () => dateTime
                 };
-                logger1.Write("Some long text");
+                logger1.WriteLine("Some long text");
                 var logger2 = new RollingLogger(tempPath.TempDirectory, maxFileSize: 10)
                 {
                     GetDate = () => dateTime
                 };
-                logger2.Write("Bar");
+                logger2.WriteLine("Bar");
                 var files = tempPath.GetFiles();
 
                 Assert.AreEqual(2, files.Count);
@@ -146,12 +146,12 @@
                 {
                     GetDate = () => new DateTime(2010, 10, 1)
                 };
-                logger1.Write("Foo");
+                logger1.WriteLine("Foo");
                 var logger2 = new RollingLogger(tempPath.TempDirectory, maxFileSize: 10)
                 {
                     GetDate = () => new DateTime(2010, 10, 2)
                 };
-                logger2.Write("Bar");
+                logger2.WriteLine("Bar");
                 var files = tempPath.GetFiles();
 
                 Assert.AreEqual(2, files.Count);
@@ -172,7 +172,7 @@
             using (var tempPath = new TempPath())
             {
                 var logger = new RollingLogger(tempPath.TempDirectory);
-                logger.Write("Foo");
+                logger.WriteLine("Foo");
                 var singleFile = tempPath.GetSingle();
                 Assert.AreEqual($"Foo{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(singleFile));
             }
@@ -184,8 +184,8 @@
             using (var tempPath = new TempPath())
             {
                 var logger = new RollingLogger(tempPath.TempDirectory);
-                logger.Write("Foo");
-                logger.Write("Bar");
+                logger.WriteLine("Foo");
+                logger.WriteLine("Bar");
                 var singleFile = tempPath.GetSingle();
                 Assert.AreEqual($"Foo{Environment.NewLine}Bar{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(singleFile));
             }
@@ -200,8 +200,8 @@
                 {
                     GetDate = () => new DateTime(2010, 10, 1)
                 };
-                logger.Write("Some long text");
-                logger.Write("Bar");
+                logger.WriteLine("Some long text");
+                logger.WriteLine("Bar");
                 var files = tempPath.GetFiles();
                 Assert.AreEqual(2, files.Count);
 
@@ -226,7 +226,7 @@
                 };
                 for (var i = 0; i < 100; i++)
                 {
-                    logger.Write("Some long text");
+                    logger.WriteLine("Some long text");
                     Assert.LessOrEqual(tempPath.GetFiles().Count, 11);
                 }
             }
@@ -238,8 +238,8 @@
             using (var tempPath = new TempPath())
             {
                 var logger = new RollingLogger(tempPath.TempDirectory, maxFileSize: 10);
-                logger.Write("Foo");
-                logger.Write("Some long text");
+                logger.WriteLine("Foo");
+                logger.WriteLine("Some long text");
                 var singleFile = tempPath.GetSingle();
                 Assert.AreEqual($"Foo{Environment.NewLine}Some long text{Environment.NewLine}", NonLockingFileReader.ReadAllTextWithoutLocking(singleFile));
             }
@@ -254,9 +254,9 @@
                 {
                     GetDate = () => new DateTime(2010, 10, 1)
                 };
-                logger.Write("Foo");
+                logger.WriteLine("Foo");
                 logger.GetDate = () => new DateTime(2010, 10, 2);
-                logger.Write("Bar");
+                logger.WriteLine("Bar");
                 var files = tempPath.GetFiles();
                 Assert.AreEqual(2, files.Count);
 
@@ -338,11 +338,11 @@
                 {
                     GetDate = () => new DateTime(2010, 10, 1)
                 };
-                logger.Write("Long text0");
-                logger.Write("Long text1");
-                logger.Write("Long text2");
-                logger.Write("Long text3");
-                logger.Write("Long text4");
+                logger.WriteLine("Long text0");
+                logger.WriteLine("Long text1");
+                logger.WriteLine("Long text2");
+                logger.WriteLine("Long text3");
+                logger.WriteLine("Long text4");
                 var files = tempPath.GetFiles();
                 Assert.AreEqual(3, files.Count, "Should be numberOfArchiveFilesToKeep + 1 (the current file) ");
 
@@ -369,15 +369,15 @@
                 {
                     GetDate = () => new DateTime(2010, 10, 1)
                 };
-                logger.Write("Foo1");
+                logger.WriteLine("Foo1");
                 logger.GetDate = () => new DateTime(2010, 10, 2);
-                logger.Write("Foo2");
+                logger.WriteLine("Foo2");
                 logger.GetDate = () => new DateTime(2010, 10, 3);
-                logger.Write("Foo3");
+                logger.WriteLine("Foo3");
                 logger.GetDate = () => new DateTime(2010, 10, 4);
-                logger.Write("Foo4");
+                logger.WriteLine("Foo4");
                 logger.GetDate = () => new DateTime(2010, 10, 5);
-                logger.Write("Foo5");
+                logger.WriteLine("Foo5");
                 var files = tempPath.GetFiles();
                 Assert.AreEqual(3, files.Count, "Should be numberOfArchiveFilesToKeep + 1 (the current file) ");
 
@@ -404,7 +404,7 @@
                 {
                     GetDate = () => new DateTime(2010, 10, 1)
                 };
-                logger.Write("Foo");
+                logger.WriteLine("Foo");
                 var singleFile = tempPath.GetSingle();
                 Assert.AreEqual("nsb_log_2010-10-01_0.txt", Path.GetFileName(singleFile));
             }

--- a/src/NServiceBus.Core/Logging/ColoredConsoleLogger.cs
+++ b/src/NServiceBus.Core/Logging/ColoredConsoleLogger.cs
@@ -14,7 +14,7 @@
             }
         }
 
-        public static void Write(string message, LogLevel logLevel)
+        public static void WriteLine(string message, LogLevel logLevel)
         {
             if (!logToConsole)
             {

--- a/src/NServiceBus.Core/Logging/DefaultLog.cs
+++ b/src/NServiceBus.Core/Logging/DefaultLog.cs
@@ -1,8 +1,6 @@
 namespace NServiceBus
 {
     using System;
-    using System.Collections;
-    using System.Text;
     using Logging;
 
     class NamedLogger : ILog
@@ -26,7 +24,7 @@ namespace NServiceBus
 
         public void Debug(string message, Exception exception)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Debug, message + Environment.NewLine + ExceptionOutput(exception));
+            defaultLoggerFactory.Write(name, LogLevel.Debug, message, exception);
         }
 
         public void DebugFormat(string format, params object[] args)
@@ -41,7 +39,7 @@ namespace NServiceBus
 
         public void Info(string message, Exception exception)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Info, message + Environment.NewLine + ExceptionOutput(exception));
+            defaultLoggerFactory.Write(name, LogLevel.Info, message, exception);
         }
 
         public void InfoFormat(string format, params object[] args)
@@ -56,7 +54,7 @@ namespace NServiceBus
 
         public void Warn(string message, Exception exception)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Warn, message + Environment.NewLine + ExceptionOutput(exception));
+            defaultLoggerFactory.Write(name, LogLevel.Warn, message, exception);
         }
 
         public void WarnFormat(string format, params object[] args)
@@ -71,7 +69,7 @@ namespace NServiceBus
 
         public void Error(string message, Exception exception)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Error, message + Environment.NewLine + ExceptionOutput(exception));
+            defaultLoggerFactory.Write(name, LogLevel.Error, message, exception);
         }
 
         public void ErrorFormat(string format, params object[] args)
@@ -86,31 +84,12 @@ namespace NServiceBus
 
         public void Fatal(string message, Exception exception)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Fatal, message + Environment.NewLine + ExceptionOutput(exception));
+            defaultLoggerFactory.Write(name, LogLevel.Fatal, message, exception);
         }
 
         public void FatalFormat(string format, params object[] args)
         {
             defaultLoggerFactory.Write(name, LogLevel.Fatal, string.Format(format, args));
-        }
-
-        static string ExceptionOutput(Exception exception)
-        {
-            var stringBuilder = new StringBuilder();
-            stringBuilder.AppendLine(exception.ToString());
-            if (exception.Data.Count > 0)
-            {
-                stringBuilder.AppendLine("Exception details:");
-
-#pragma warning disable DE0006 // API is deprecated
-                foreach (DictionaryEntry exceptionData in exception.Data)
-#pragma warning restore DE0006 // API is deprecated
-                {
-                    stringBuilder.Append('\t').Append(exceptionData.Key).Append(": ").AppendLine(exceptionData.Value.ToString());
-                }
-            }
-
-            return stringBuilder.ToString();
         }
 
         DefaultLoggerFactory defaultLoggerFactory;

--- a/src/NServiceBus.Core/Logging/DefaultLog.cs
+++ b/src/NServiceBus.Core/Logging/DefaultLog.cs
@@ -1,6 +1,8 @@
 namespace NServiceBus
 {
     using System;
+    using System.Collections;
+    using System.Text;
     using Logging;
 
     class NamedLogger : ILog
@@ -24,7 +26,7 @@ namespace NServiceBus
 
         public void Debug(string message, Exception exception)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Debug, message + Environment.NewLine + exception);
+            defaultLoggerFactory.Write(name, LogLevel.Debug, message + Environment.NewLine + ExceptionOutput(exception));
         }
 
         public void DebugFormat(string format, params object[] args)
@@ -39,7 +41,7 @@ namespace NServiceBus
 
         public void Info(string message, Exception exception)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Info, message + Environment.NewLine + exception);
+            defaultLoggerFactory.Write(name, LogLevel.Info, message + Environment.NewLine + ExceptionOutput(exception));
         }
 
         public void InfoFormat(string format, params object[] args)
@@ -54,7 +56,7 @@ namespace NServiceBus
 
         public void Warn(string message, Exception exception)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Warn, message + Environment.NewLine + exception);
+            defaultLoggerFactory.Write(name, LogLevel.Warn, message + Environment.NewLine + ExceptionOutput(exception));
         }
 
         public void WarnFormat(string format, params object[] args)
@@ -69,7 +71,7 @@ namespace NServiceBus
 
         public void Error(string message, Exception exception)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Error, message + Environment.NewLine + exception);
+            defaultLoggerFactory.Write(name, LogLevel.Error, message + Environment.NewLine + ExceptionOutput(exception));
         }
 
         public void ErrorFormat(string format, params object[] args)
@@ -84,12 +86,31 @@ namespace NServiceBus
 
         public void Fatal(string message, Exception exception)
         {
-            defaultLoggerFactory.Write(name, LogLevel.Fatal, message + Environment.NewLine + exception);
+            defaultLoggerFactory.Write(name, LogLevel.Fatal, message + Environment.NewLine + ExceptionOutput(exception));
         }
 
         public void FatalFormat(string format, params object[] args)
         {
             defaultLoggerFactory.Write(name, LogLevel.Fatal, string.Format(format, args));
+        }
+
+        static string ExceptionOutput(Exception exception)
+        {
+            var stringBuilder = new StringBuilder();
+            stringBuilder.AppendLine(exception.ToString());
+            if (exception.Data.Count > 0)
+            {
+                stringBuilder.AppendLine("Exception details:");
+
+#pragma warning disable DE0006 // API is deprecated
+                foreach (DictionaryEntry exceptionData in exception.Data)
+#pragma warning restore DE0006 // API is deprecated
+                {
+                    stringBuilder.Append('\t').Append(exceptionData.Key).Append(": ").AppendLine(exceptionData.Value.ToString());
+                }
+            }
+
+            return stringBuilder.ToString();
         }
 
         DefaultLoggerFactory defaultLoggerFactory;

--- a/src/NServiceBus.Core/Logging/DefaultLoggerFactory.cs
+++ b/src/NServiceBus.Core/Logging/DefaultLoggerFactory.cs
@@ -71,8 +71,8 @@ namespace NServiceBus
             var fullMessage = stringBuilder.ToString();
             lock (locker)
             {
-                rollingLogger.Write(fullMessage);
-                ColoredConsoleLogger.Write(fullMessage, messageLevel);
+                rollingLogger.WriteLine(fullMessage);
+                ColoredConsoleLogger.WriteLine(fullMessage, messageLevel);
                 Trace.WriteLine(fullMessage);
             }
         }

--- a/src/NServiceBus.Core/Logging/DefaultLoggerFactory.cs
+++ b/src/NServiceBus.Core/Logging/DefaultLoggerFactory.cs
@@ -1,7 +1,9 @@
 namespace NServiceBus
 {
     using System;
+    using System.Collections;
     using System.Diagnostics;
+    using System.Text;
     using Logging;
 
     class DefaultLoggerFactory : ILoggerFactory
@@ -34,15 +36,39 @@ namespace NServiceBus
             };
         }
 
-        public void Write(string name, LogLevel messageLevel, string message)
+        public void Write(string name, LogLevel messageLevel, string message, Exception exception = null)
         {
             if (messageLevel < filterLevel)
             {
                 return;
             }
+
+            var stringBuilder = new StringBuilder();
             var datePart = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss.fff");
             var paddedLevel = messageLevel.ToString().ToUpper().PadRight(5);
-            var fullMessage = $"{datePart} {paddedLevel} {name} {message}";
+            
+            stringBuilder.Append(datePart).Append(' ').Append(paddedLevel).Append(' ').Append(message);
+
+            if (exception != null)
+            {
+                stringBuilder.AppendLine();
+                stringBuilder.Append(exception);
+                if (exception.Data.Count > 0)
+                {
+                    stringBuilder.AppendLine();
+                    stringBuilder.Append("Exception details:");
+
+#pragma warning disable DE0006 // API is deprecated
+                    foreach (DictionaryEntry exceptionData in exception.Data)
+#pragma warning restore DE0006 // API is deprecated
+                    {
+                        stringBuilder.AppendLine();
+                        stringBuilder.Append('\t').Append(exceptionData.Key).Append(": ").Append(exceptionData.Value);
+                    }
+                }
+            }
+
+            var fullMessage = stringBuilder.ToString();
             lock (locker)
             {
                 rollingLogger.Write(fullMessage);

--- a/src/NServiceBus.Core/Logging/RollingLogger.cs
+++ b/src/NServiceBus.Core/Logging/RollingLogger.cs
@@ -17,7 +17,7 @@ namespace NServiceBus
             this.maxFileSize = maxFileSize;
         }
 
-        public void Write(string message)
+        public void WriteLine(string message)
         {
             SyncFileSystem();
             InnerWrite(message);


### PR DESCRIPTION
Fixes #2609

Add additional information about the message and handler types when a message handler fails with an exception. This uses the `Exception.Data` dictionary which allows to add these additional type of information. Other behaviors in the pipeline could make use of this as well and if we merge this, we should document this approach more clearly.

By default, none of the loggers logs the values in `Exception.Data` though. Therefore this PR also adjusts the default logger to log the additional data at the end. A sample log statement would now look something like this:
> 2019-10-01 13:01:00.065 INFO  Immediate Retry is going to retry message 'e5cf778e-e1be-4267-9a6e-aad900b41ae1' because of an exception:
Microsoft.Azure.ServiceBus.MessageLockLostException: test
   at Playground.MyHandler.Handle(MyMessage message, IMessageHandlerContext context) in C:\Users\timbu\source\repos\Playground\Playground\Program.cs:line 45
   at NServiceBus.Pipeline.MessageHandler.Invoke(Object message, IMessageHandlerContext handlerContext) in 
...
[parts of the stacktrace omitted]
...
C:\Projects\NServiceBus\src\NServiceBus.Core\Transports\Learning\LearningTransportMessagePump.cs:line 279
Exception details:
	MessageType: Playground.MyMessage
	MessageHandlerType: Playground.MyHandler

To support this, I've also changed the default logging logic to use a string builder as there is a lot of concatenation going on + some small naming tweaks.