### PR TITLE
Lock settings outside feature component

### DIFF
--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -97,9 +97,9 @@ namespace NServiceBus
 
             var featureConfigurationContext = new FeatureConfigurationContext(settings, containerComponent.ContainerConfiguration, pipelineComponent.PipelineSettings, routingComponent, receiveConfiguration);
 
-            //note: This is where the settings gets locked since the feature component (unfortunately) uses the settings to store feature state.
-            // Locking happens just before the Features gets "setup"
             featureComponent.Initalize(containerComponent, featureConfigurationContext);
+            //The settings can only be locked after initializing the feature component since it uses the settings to store & share feature state.
+            settings.PreventChanges();
 
             recoverabilityComponent.Initialize(receiveConfiguration);
 

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -58,8 +58,6 @@ namespace NServiceBus.Features
                 ActivateFeature(feature, enabledFeatures, featureConfigurationContext);
             }
 
-            settings.PreventChanges();
-
             return features.Select(t => t.Diagnostics).ToArray();
         }
 


### PR DESCRIPTION
I can't see any good reason why we would lock the settings inside the features component. There is no need to lock them as part of the feature initialization as the feature setup process still requires write access and afterwards there is no further access to the settings.