### PR TITLE
Throw better exceptions when subscribing/unsubscribing on send-only endpoints

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/EndpointConfigurationBuilder.cs
@@ -43,12 +43,7 @@
                 configurationBuilderCustomization = b => { };
             }
 
-            publisherMetadata?.Invoke(configuration.PublisherMetadata);
-
-            return EndpointSetup<T>((bc, esc) =>
-            {
-                configurationBuilderCustomization(bc);
-            });
+            return EndpointSetup<T>((bc, _) => configurationBuilderCustomization(bc), publisherMetadata);
         }
 
         public EndpointConfigurationBuilder EndpointSetup<T>(Action<EndpointConfiguration, RunDescriptor> configurationBuilderCustomization, Action<PublisherMetadata> publisherMetadata = null) where T : IEndpointSetupTemplate, new()
@@ -58,12 +53,17 @@
                 configurationBuilderCustomization = (rd, b) => { };
             }
 
+            var template = new T();
+            return EndpointSetup(template, configurationBuilderCustomization, publisherMetadata);
+        }
+
+        public EndpointConfigurationBuilder EndpointSetup(IEndpointSetupTemplate endpointTemplate, Action<EndpointConfiguration, RunDescriptor> configurationBuilderCustomization, Action<PublisherMetadata> publisherMetadata = null)
+        {
             publisherMetadata?.Invoke(configuration.PublisherMetadata);
 
             configuration.GetConfiguration = async runDescriptor =>
             {
-                var endpointSetupTemplate = new T();
-                var endpointConfiguration = await endpointSetupTemplate.GetConfiguration(runDescriptor, configuration, bc =>
+                var endpointConfiguration = await endpointTemplate.GetConfiguration(runDescriptor, configuration, bc =>
                 {
                     configurationBuilderCustomization(bc, runDescriptor);
                 }).ConfigureAwait(false);

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
@@ -51,7 +51,7 @@
             }
         }
 
-        class SomeEvent : IEvent
+        public class SomeEvent : IEvent
         {
         }
     }

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
@@ -1,0 +1,58 @@
+﻿namespace NServiceBus.AcceptanceTests.PublishSubscribe
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_subscribing_on_send_only_endpoint : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_throw_InvalidOperationException_on_native_pubsub()
+        {
+            var exception = Assert.ThrowsAsync<InvalidOperationException>(() => Scenario.Define<ScenarioContext>()
+                .WithEndpoint<NativePubSubSendOnlyEndpoint>(e => e
+                    .When(s => s.Subscribe<SomeEvent>()))
+                .Done(c => c.EndpointsStarted)
+                .Run());
+
+            StringAssert.Contains("Send-only endpoints cannot subscribe to events", exception.Message);
+        }
+
+        [Test]
+        public void Should_throw_InvalidOperationException_on_message_driven_pubsub()
+        {
+            var exception = Assert.ThrowsAsync<InvalidOperationException>(() => Scenario.Define<ScenarioContext>()
+                .WithEndpoint<MessageDrivenPubSubSendOnlyEndpoint>(e => e
+                    .When(s => s.Subscribe<SomeEvent>()))
+                .Done(c => c.EndpointsStarted)
+                .Run());
+
+            StringAssert.Contains("Send-only endpoints cannot subscribe to events", exception.Message);
+        }
+
+        class NativePubSubSendOnlyEndpoint : EndpointConfigurationBuilder
+        {
+            public NativePubSubSendOnlyEndpoint()
+            {
+                var template = new DefaultServer();
+                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(true, true);
+                EndpointSetup(template, (configuration, _) => configuration.SendOnly());
+            }
+        }
+
+        class MessageDrivenPubSubSendOnlyEndpoint : EndpointConfigurationBuilder
+        {
+            public MessageDrivenPubSubSendOnlyEndpoint()
+            {
+                var template = new DefaultServer();
+                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
+                EndpointSetup(template, (configuration, _) => configuration.SendOnly());
+            }
+        }
+
+        class SomeEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_unsubscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_unsubscribing_on_send_only_endpoint.cs
@@ -1,0 +1,58 @@
+﻿namespace NServiceBus.AcceptanceTests.PublishSubscribe
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_unsubscribing_on_send_only_endpoint : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_throw_InvalidOperationException_on_native_pubsub()
+        {
+            var exception = Assert.ThrowsAsync<InvalidOperationException>(() => Scenario.Define<ScenarioContext>()
+                .WithEndpoint<NativePubSubSendOnlyEndpoint>(e => e
+                    .When(s => s.Unsubscribe<SomeEvent>()))
+                .Done(c => c.EndpointsStarted)
+                .Run());
+
+            StringAssert.Contains("Send-only endpoints cannot unsubscribe to events", exception.Message);
+        }
+
+        [Test]
+        public void Should_throw_InvalidOperationException_on_message_driven_pubsub()
+        {
+            var exception = Assert.ThrowsAsync<InvalidOperationException>(() => Scenario.Define<ScenarioContext>()
+                .WithEndpoint<MessageDrivenPubSubSendOnlyEndpoint>(e => e
+                    .When(s => s.Unsubscribe<SomeEvent>()))
+                .Done(c => c.EndpointsStarted)
+                .Run());
+
+            StringAssert.Contains("Send-only endpoints cannot unsubscribe to events", exception.Message);
+        }
+
+        class NativePubSubSendOnlyEndpoint : EndpointConfigurationBuilder
+        {
+            public NativePubSubSendOnlyEndpoint()
+            {
+                var template = new DefaultServer();
+                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(true, true);
+                EndpointSetup(template, (configuration, _) => configuration.SendOnly());
+            }
+        }
+
+        class MessageDrivenPubSubSendOnlyEndpoint : EndpointConfigurationBuilder
+        {
+            public MessageDrivenPubSubSendOnlyEndpoint()
+            {
+                var template = new DefaultServer();
+                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
+                EndpointSetup(template, (configuration, _) => configuration.SendOnly());
+            }
+        }
+
+        class SomeEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_unsubscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_unsubscribing_on_send_only_endpoint.cs
@@ -51,7 +51,7 @@
             }
         }
 
-        class SomeEvent : IEvent
+        public class SomeEvent : IEvent
         {
         }
     }

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -6,10 +6,24 @@
 
     public static class ConfigureExtensions
     {
+        public static async Task DefineTransport(this EndpointConfiguration config, RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration)
+        {
+            var transportConfiguration = TestSuiteConstraints.Current.CreateTransportConfiguration();
+            await transportConfiguration.Configure(endpointCustomizationConfiguration.EndpointName, config, runDescriptor.Settings, endpointCustomizationConfiguration.PublisherMetadata);
+            runDescriptor.OnTestCompleted(_ => transportConfiguration.Cleanup());
+        }
+
         public static async Task DefineTransport(this EndpointConfiguration config, IConfigureEndpointTestExecution transportConfiguration,RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration)
         {
             await transportConfiguration.Configure(endpointCustomizationConfiguration.EndpointName, config, runDescriptor.Settings, endpointCustomizationConfiguration.PublisherMetadata);
             runDescriptor.OnTestCompleted(_ => transportConfiguration.Cleanup());
+        }
+
+        public static async Task DefinePersistence(this EndpointConfiguration config, RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration)
+        {
+            var persistenceConfiguration = TestSuiteConstraints.Current.CreatePersistenceConfiguration();
+            await persistenceConfiguration.Configure(endpointCustomizationConfiguration.EndpointName, config, runDescriptor.Settings, endpointCustomizationConfiguration.PublisherMetadata);
+            runDescriptor.OnTestCompleted(_ => persistenceConfiguration.Cleanup());
         }
 
         public static async Task DefinePersistence(this EndpointConfiguration config, IConfigureEndpointTestExecution persistenceConfiguration, RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration)

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -6,16 +6,14 @@
 
     public static class ConfigureExtensions
     {
-        public static async Task DefineTransport(this EndpointConfiguration config, RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration)
+        public static async Task DefineTransport(this EndpointConfiguration config, IConfigureEndpointTestExecution transportConfiguration,RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration)
         {
-            var transportConfiguration = TestSuiteConstraints.Current.CreateTransportConfiguration();
             await transportConfiguration.Configure(endpointCustomizationConfiguration.EndpointName, config, runDescriptor.Settings, endpointCustomizationConfiguration.PublisherMetadata);
             runDescriptor.OnTestCompleted(_ => transportConfiguration.Cleanup());
         }
 
-        public static async Task DefinePersistence(this EndpointConfiguration config, RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration)
+        public static async Task DefinePersistence(this EndpointConfiguration config, IConfigureEndpointTestExecution persistenceConfiguration, RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration)
         {
-            var persistenceConfiguration = TestSuiteConstraints.Current.CreatePersistenceConfiguration();
             await persistenceConfiguration.Configure(endpointCustomizationConfiguration.EndpointName, config, runDescriptor.Settings, endpointCustomizationConfiguration.PublisherMetadata);
             runDescriptor.OnTestCompleted(_ => persistenceConfiguration.Cleanup());
         }

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/DefaultServer.cs
@@ -4,16 +4,15 @@
     using System.Threading.Tasks;
     using AcceptanceTesting.Support;
 
-    public class DefaultServer : IEndpointSetupTemplate
+    public class DefaultServer : ExternallyManagedContainerServer
     {
-        public Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration, Action<EndpointConfiguration> configurationBuilderCustomization)
+        public override Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration, Action<EndpointConfiguration> configurationBuilderCustomization)
         {
-            return new ExternallyManagedContainerServer()
-                .GetConfiguration(runDescriptor, endpointCustomizationConfiguration, endpointConfiguration =>
-                {
-                    endpointConfiguration.UseContainer(new AcceptanceTestingContainer());
-                    configurationBuilderCustomization(endpointConfiguration);
-                });
+            return base.GetConfiguration(runDescriptor, endpointCustomizationConfiguration, endpointConfiguration =>
+            {
+                endpointConfiguration.UseContainer(new AcceptanceTestingContainer());
+                configurationBuilderCustomization(endpointConfiguration);
+            });
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ExternallyManagedContainerServer.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ExternallyManagedContainerServer.cs
@@ -8,7 +8,10 @@
 
     public class ExternallyManagedContainerServer : IEndpointSetupTemplate
     {
-        public async Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointConfiguration, Action<EndpointConfiguration> configurationBuilderCustomization)
+        public IConfigureEndpointTestExecution TransportConfiguration { get; set; } = TestSuiteConstraints.Current.CreateTransportConfiguration();
+        public IConfigureEndpointTestExecution PersistenceConfiguration { get; set; } = TestSuiteConstraints.Current.CreatePersistenceConfiguration();
+
+        public virtual async Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointConfiguration, Action<EndpointConfiguration> configurationBuilderCustomization)
         {
             var configuration = new EndpointConfiguration(endpointConfiguration.EndpointName);
 
@@ -22,11 +25,11 @@
             recoverability.Immediate(immediate => immediate.NumberOfRetries(0));
             configuration.SendFailedMessagesTo("error");
 
-            await configuration.DefineTransport(runDescriptor, endpointConfiguration).ConfigureAwait(false);
+            await configuration.DefineTransport(TransportConfiguration, runDescriptor, endpointConfiguration).ConfigureAwait(false);
 
             configuration.RegisterComponentsAndInheritanceHierarchy(runDescriptor);
 
-            await configuration.DefinePersistence(runDescriptor, endpointConfiguration).ConfigureAwait(false);
+            await configuration.DefinePersistence(PersistenceConfiguration, runDescriptor, endpointConfiguration).ConfigureAwait(false);
 
             configurationBuilderCustomization(configuration);
 

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ServerWithNoDefaultPersistenceDefinitions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ServerWithNoDefaultPersistenceDefinitions.cs
@@ -35,7 +35,7 @@
                 .Immediate(immediate => immediate.NumberOfRetries(0));
             builder.SendFailedMessagesTo("error");
 
-            await builder.DefineTransport(runDescriptor, endpointConfiguration).ConfigureAwait(false);
+            await builder.DefineTransport(TestSuiteConstraints.Current.CreateTransportConfiguration(), runDescriptor, endpointConfiguration).ConfigureAwait(false);
 
             builder.RegisterComponentsAndInheritanceHierarchy(runDescriptor);
 

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -87,8 +87,8 @@ namespace NServiceBus.Features
             }
             else
             {
-                context.Pipeline.Register(new SendOnlySubscribeTerminator(), "Throws an exception when trying to subscribe on a send-only endpoint");
-                context.Pipeline.Register(new SendOnlyUnsubscribeTerminator(), "Throws an exception when trying to unsubscribe on a send-only endpoint");
+                context.Pipeline.Register(new SendOnlySubscribeTerminator(), "Throws an exception when trying to subscribe from a send-only endpoint");
+                context.Pipeline.Register(new SendOnlyUnsubscribeTerminator(), "Throws an exception when trying to unsubscribe from a send-only endpoint");
             }
         }
     }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -85,6 +85,11 @@ namespace NServiceBus.Features
                 context.Container.RegisterSingleton(authorizer);
                 context.Pipeline.Register<SubscriptionReceiverBehavior.Registration>();
             }
+            else
+            {
+                context.Pipeline.Register(new SendOnlySubscribeTerminator(), "Throws an exception when trying to subscribe on a send-only endpoint");
+                context.Pipeline.Register(new SendOnlyUnsubscribeTerminator(), "Throws an exception when trying to unsubscribe on a send-only endpoint");
+            }
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/NativePublishSubscribeFeature.cs
+++ b/src/NServiceBus.Core/Routing/NativePublishSubscribeFeature.cs
@@ -26,6 +26,11 @@ namespace NServiceBus.Features
                 context.Pipeline.Register(new NativeSubscribeTerminator(subscriptionManager), "Requests the transport to subscribe to a given message type");
                 context.Pipeline.Register(new NativeUnsubscribeTerminator(subscriptionManager), "Requests the transport to unsubscribe to a given message type");
             }
+            else
+            {
+                context.Pipeline.Register(new SendOnlySubscribeTerminator(), "Throws an exception when trying to subscribe on a send-only endpoint");
+                context.Pipeline.Register(new SendOnlyUnsubscribeTerminator(), "Throws an exception when trying to unsubscribe on a send-only endpoint");
+            }
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/NativePublishSubscribeFeature.cs
+++ b/src/NServiceBus.Core/Routing/NativePublishSubscribeFeature.cs
@@ -28,8 +28,8 @@ namespace NServiceBus.Features
             }
             else
             {
-                context.Pipeline.Register(new SendOnlySubscribeTerminator(), "Throws an exception when trying to subscribe on a send-only endpoint");
-                context.Pipeline.Register(new SendOnlyUnsubscribeTerminator(), "Throws an exception when trying to unsubscribe on a send-only endpoint");
+                context.Pipeline.Register(new SendOnlySubscribeTerminator(), "Throws an exception when trying to subscribe from a send-only endpoint");
+                context.Pipeline.Register(new SendOnlyUnsubscribeTerminator(), "Throws an exception when trying to unsubscribe from a send-only endpoint");
             }
         }
     }

--- a/src/NServiceBus.Core/Routing/SendOnlySubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/SendOnlySubscribeTerminator.cs
@@ -1,0 +1,14 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.Threading.Tasks;
+    using Pipeline;
+
+    class SendOnlySubscribeTerminator : PipelineTerminator<ISubscribeContext>
+    {
+        protected override Task Terminate(ISubscribeContext context)
+        {
+            throw new InvalidOperationException("Send-only endpoints cannot subscribe to events. Remove the 'endpointConfiguration.SendOnly()' configuration to enable this endpoint to subscribe to events.");
+        }
+    }
+}

--- a/src/NServiceBus.Core/Routing/SendOnlyUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/SendOnlyUnsubscribeTerminator.cs
@@ -1,0 +1,14 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.Threading.Tasks;
+    using Pipeline;
+
+    class SendOnlyUnsubscribeTerminator : PipelineTerminator<IUnsubscribeContext>
+    {
+        protected override Task Terminate(IUnsubscribeContext context)
+        {
+            throw new InvalidOperationException("Send-only endpoints cannot unsubscribe to events. Remove the 'endpointConfiguration.SendOnly()' configuration to enable this endpoint to unsubscribe to events.");
+        }
+    }
+}


### PR DESCRIPTION
_Follow-up to #5120_

* This PR registers special pipeline Terminators when running in send-only so that instead of a pipeline building exception (due to missing pipeline steps) the user receives a more meaningful InvalidOperationException stating that you can't subscribe/unsubscribe on send-only endpoints.
* To properly test this with acceptance tests, we need the ability to configure the endpoint with a message-driven and a native pubsub transport. By default, all acceptance tests run with the learningtransport though. Based on that, I've tweaked the acceptance testing setup slightly to allow overwriting the defaults defined by the `TestSuiteConstraints` class. With that, it's possible to configure custom transport & persistence settings for a single test while still being able to use the setup&cleanup mechanisms properly.