### PR TITLE
Adjust names of the PipelineComponent lifecycle methods

### DIFF
--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -103,7 +103,7 @@ namespace NServiceBus
 
             recoverabilityComponent.Initialize(receiveConfiguration);
 
-            pipelineComponent.RegisterBehaviorsInContainer(containerComponent.ContainerConfiguration);
+            pipelineComponent.Initialize(containerComponent);
             containerComponent.ContainerConfiguration.ConfigureComponent(b => settings.Get<Notifications>(), DependencyLifecycle.SingleInstance);
 
             var eventAggregator = new EventAggregator(settings.Get<NotificationSubscriptions>());
@@ -137,8 +137,6 @@ namespace NServiceBus
 
         public async Task<IStartableEndpoint> CreateStartableEndpoint()
         {
-            pipelineComponent.Initialize(containerComponent.Builder);
-
             var shouldRunInstallers = settings.GetOrDefault<bool>("Installers.Enable");
 
             if (shouldRunInstallers)
@@ -153,9 +151,7 @@ namespace NServiceBus
                 await RunInstallers(containerComponent.Builder, username).ConfigureAwait(false);
             }
 
-            var messageSession = new MessageSession(pipelineComponent.CreateRootContext(containerComponent.Builder));
-
-            return new StartableEndpoint(settings, containerComponent, featureComponent, transportInfrastructure, receiveComponent, criticalError, messageSession, recoverabilityComponent);
+            return new StartableEndpoint(settings, containerComponent, featureComponent, transportInfrastructure, receiveComponent, criticalError, pipelineComponent, recoverabilityComponent);
         }
 
         async Task RunInstallers(IBuilder builder, string username)

--- a/src/NServiceBus.Core/Pipeline/PipelineComponent.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineComponent.cs
@@ -25,9 +25,9 @@ namespace NServiceBus
             rootContextExtensions.Set(item);
         }
 
-        public RootContext CreateRootContext(IBuilder scopedBuilder, ContextBag extensions = null)
+        public RootContext CreateRootContext(IBuilder builder, ContextBag extensions = null)
         {
-            var context = new RootContext(scopedBuilder);
+            var context = new RootContext(builder);
 
             context.Extensions.Merge(rootContextExtensions);
 

--- a/src/NServiceBus.Core/Pipeline/PipelineComponent.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineComponent.cs
@@ -44,6 +44,7 @@ namespace NServiceBus
         public void Initialize(ContainerComponent containerComponent)
         {
             container = containerComponent;
+
             foreach (var registeredBehavior in modifications.Replacements)
             {
                 container.ContainerConfiguration.ConfigureComponent(registeredBehavior.BehaviorType, DependencyLifecycle.InstancePerCall);


### PR DESCRIPTION
Aligns the names of pipeline components lifecycle methods to the "standard" `Initialize` and `Start`. It also moves the `Start` method to `IStartableEndpoint.Start()` which is the correct spot to invoke it.

### Behavior changes

* Message session is created on start and not when the startable instance is created. This should have no externally visible effect
* Pipeline cache is only created on Start. This should have no externally visible effect
