### PR TITLE
Make ReceiveComponent.Start async

### DIFF
--- a/src/NServiceBus.Core.Tests/Transports/TransportReceiverTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/TransportReceiverTests.cs
@@ -17,9 +17,9 @@
         }
 
         [Test]
-        public void Start_should_start_the_pump()
+        public async Task Start_should_start_the_pump()
         {
-            receiver.Start();
+            await receiver.Start();
 
             Assert.IsTrue(pump.Started);
         }
@@ -29,13 +29,13 @@
         {
             pump.ThrowOnStart = true;
 
-            Assert.Throws<InvalidOperationException>(() => receiver.Start());
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await receiver.Start());
         }
 
         [Test]
         public async Task Stop_should_stop_the_pump()
         {
-            receiver.Start();
+            await receiver.Start();
 
             await receiver.Stop();
 
@@ -43,11 +43,11 @@
         }
 
         [Test]
-        public void Stop_should_not_throw_when_pump_throws()
+        public async Task Stop_should_not_throw_when_pump_throws()
         {
             pump.ThrowOnStop = true;
 
-            receiver.Start();
+            await receiver.Start();
 
             Assert.DoesNotThrowAsync(async () => await receiver.Stop());
         }
@@ -55,7 +55,7 @@
         [Test]
         public async Task Stop_should_dispose_pump() // for container backward compat reasons
         {
-            receiver.Start();
+            await receiver.Start();
 
             await receiver.Stop();
 

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -75,13 +75,13 @@ namespace NServiceBus
             }
         }
 
-        public void Start()
+        public async Task Start()
         {
             foreach (var receiver in receivers)
             {
                 try
                 {
-                    receiver.Start();
+                    await receiver.Start().ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -41,7 +41,7 @@ namespace NServiceBus
             // set the started endpoint on CriticalError to pass the endpoint to the critical error action
             criticalError.SetEndpoint(runningInstance);
 
-            receiveComponent.Start();
+            await receiveComponent.Start().ConfigureAwait(false);
 
             return runningInstance;
         }

--- a/src/NServiceBus.Core/Transports/TransportReceiver.cs
+++ b/src/NServiceBus.Core/Transports/TransportReceiver.cs
@@ -33,7 +33,7 @@ namespace NServiceBus
             return receiver.Init(c => pipelineExecutor.Invoke(c), c => recoverabilityExecutor.Invoke(c), criticalError, pushSettings);
         }
 
-        public void Start()
+        public Task Start()
         {
             if (isStarted)
             {
@@ -45,6 +45,8 @@ namespace NServiceBus
             receiver.Start(pushRuntimeSettings);
 
             isStarted = true;
+
+            return Task.FromResult(0);
         }
 
         public async Task Stop()


### PR DESCRIPTION
Spelunking the code with @timbussmann made me realize that since the start method is called in the async part of the startup lifecycle it should be task returning.

We can't change the transport seam since it would be a breaking change so I will raise an issue to track this for the next major