### PR TITLE
Add additional exception information

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Pipeline/When_message_processing_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Pipeline/When_message_processing_fails.cs
@@ -16,7 +16,7 @@
                     .When(s => s.SendLocal(new FailingMessage()))
                     .DoNotFailOnErrorMessages())
                 .Done(c => c.MessageFailed)
-                .Run(TimeSpan.FromSeconds(10));
+                .Run();
 
             Assert.IsTrue(context.Exception.Data.Contains("Message type"));
             Assert.IsTrue(context.Exception.Data.Contains("Handler type"));

--- a/src/NServiceBus.AcceptanceTests/Pipeline/When_message_processing_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Pipeline/When_message_processing_fails.cs
@@ -1,0 +1,64 @@
+﻿namespace NServiceBus.AcceptanceTests.Pipeline
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_message_processing_fails : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_provide_additional_exception_information()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithFailingHandler>(e => e
+                    .When(s => s.SendLocal(new FailingMessage()))
+                    .DoNotFailOnErrorMessages())
+                .Done(c => c.MessageFailed)
+                .Run(TimeSpan.FromSeconds(10));
+
+            Assert.IsTrue(context.Exception.Data.Contains("Message type"));
+            Assert.IsTrue(context.Exception.Data.Contains("Handler type"));
+            Assert.IsTrue(context.Exception.Data.Contains("Handler start time"));
+            Assert.IsTrue(context.Exception.Data.Contains("Handler failure time"));
+            Assert.IsTrue(context.Exception.Data.Contains("Message ID"));
+            // we can't assert for the native message ID as not every transport has uses a different ID internally
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool MessageFailed { get; set; }
+            public Exception Exception { get; set; }
+        }
+
+        class EndpointWithFailingHandler : EndpointConfigurationBuilder
+        {
+            public EndpointWithFailingHandler()
+            {
+                EndpointSetup<DefaultServer>((c, r) =>
+                {
+                    c.Notifications.Errors.MessageSentToErrorQueue += (sender, message) =>
+                    {
+                        var testContext = ((Context)r.ScenarioContext);
+                        testContext.MessageFailed = true;
+                        testContext.Exception = message.Exception;
+                    };
+                });
+            }
+
+            class FailingMessageHandler : IHandleMessages<FailingMessage>
+            {
+                public Task Handle(FailingMessage message, IMessageHandlerContext context)
+                {
+                    throw new SimulatedException();
+                }
+            }
+        }
+
+        public class FailingMessage : IMessage
+        {
+            
+        }
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs
@@ -16,6 +16,7 @@
 
             var messageHandler = context.MessageHandler;
 
+            var startTimestamp = DateTime.UtcNow;
             try
             {
                 await messageHandler
@@ -25,9 +26,10 @@
             }
             catch (Exception e)
             {
-                e.Data.Add("MessageType", context.MessageMetadata.MessageType.FullName);
-                e.Data.Add("MessageHandlerType", context.MessageHandler.HandlerType);
-
+                e.Data.Add("Message type", context.MessageMetadata.MessageType.FullName);
+                e.Data.Add("Handler type", context.MessageHandler.HandlerType);
+                e.Data.Add("Handler start time", startTimestamp);
+                e.Data.Add("Handler failure time", DateTime.UtcNow);
                 throw;
             }
         }

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -34,7 +34,7 @@ namespace NServiceBus
                     e.Data.Add("Message ID", message.MessageId);
                     if (message.NativeMessageId != message.MessageId)
                     {
-                        e.Data.Add("Transport ID", message.NativeMessageId);
+                        e.Data.Add("Transport message ID", message.NativeMessageId);
                     }
 
                     throw;


### PR DESCRIPTION
Adding some additional information to the `Exception.Data` bag when a message handler fails so this information is also available in logs even when running on non-debug log-levels.