### PR TITLE
Add Installation component

### DIFF
--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -133,6 +133,8 @@ namespace NServiceBus
 
         public async Task<IStartableEndpoint> CreateStartableEndpoint()
         {
+            // This is the only component that is started before the user actually calls .Start(). This is due to an old "feature" that allowed users to
+            // run installers by "just creating the endpoint". See https://docs.particular.net/nservicebus/operations/installers#running-installers for more details.
             await installationComponent.Start().ConfigureAwait(false);
 
             return new StartableEndpoint(settings, containerComponent, featureComponent, transportInfrastructure, receiveComponent, criticalError, pipelineComponent, recoverabilityComponent);

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -109,6 +109,9 @@ namespace NServiceBus
 
             pipelineComponent.AddRootContextItem<IEventAggregator>(eventAggregator);
 
+            queueBindings = settings.Get<QueueBindings>();
+            receiveComponent = CreateReceiveComponent(receiveConfiguration, transportInfrastructure, pipelineComponent, queueBindings, eventAggregator);
+
             installationComponent = new InstallationComponent(settings);
 
             installationComponent.Initialize(concreteTypes, containerComponent, receiveComponent);
@@ -121,9 +124,6 @@ namespace NServiceBus
                     NServiceBusVersion = GitVersionInformation.MajorMinorPatch
                 }
             );
-
-            queueBindings = settings.Get<QueueBindings>();
-            receiveComponent = CreateReceiveComponent(receiveConfiguration, transportInfrastructure, pipelineComponent, queueBindings, eventAggregator);
         }
 
         public void UseExternallyManagedBuilder(IBuilder builder)

--- a/src/NServiceBus.Core/Installation/InstallationComponent.cs
+++ b/src/NServiceBus.Core/Installation/InstallationComponent.cs
@@ -1,0 +1,80 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Installation;
+    using Settings;
+    using Transport;
+
+    class InstallationComponent
+    {
+        public InstallationComponent(ReadOnlySettings settings)
+        {
+            this.settings = settings;
+        }
+
+        public void Initialize(List<Type> concreteTypes, ContainerComponent container, ReceiveComponent receiver)
+        {
+            containerComponent = container;
+            receiveComponent = receiver;
+
+            shouldRunInstallers = settings.GetOrDefault<bool>("Installers.Enable");
+
+            if (!shouldRunInstallers)
+            {
+                return;
+            }
+
+            foreach (var installerType in concreteTypes.Where(t => IsINeedToInstallSomething(t)))
+            {
+                containerComponent.ContainerConfiguration.ConfigureComponent(installerType, DependencyLifecycle.InstancePerCall);
+            }
+        }
+
+        public async Task Start()
+        {
+            if (!shouldRunInstallers)
+            {
+                return;
+            }
+
+            var queueBindings = settings.Get<QueueBindings>();
+            var username = GetInstallationUserName();
+
+            if (settings.CreateQueues())
+            {
+                await receiveComponent.CreateQueuesIfNecessary(queueBindings, username).ConfigureAwait(false);
+            }
+
+            foreach (var installer in containerComponent.Builder.BuildAll<INeedToInstallSomething>())
+            {
+                await installer.Install(username).ConfigureAwait(false);
+            }
+        }
+
+        string GetInstallationUserName()
+        {
+            if (!settings.TryGet("Installers.UserName", out string userName))
+            {
+                if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                {
+                    userName = $"{Environment.UserDomainName}\\{Environment.UserName}";
+                }
+                else
+                {
+                    userName = Environment.UserName;
+                }
+            }
+
+            return userName;
+        }
+
+        ReadOnlySettings settings;
+        ContainerComponent containerComponent;
+        ReceiveComponent receiveComponent;
+        bool shouldRunInstallers;
+        static bool IsINeedToInstallSomething(Type t) => typeof(INeedToInstallSomething).IsAssignableFrom(t);
+    }
+}

--- a/src/NServiceBus.Core/Installation/InstallationComponent.cs
+++ b/src/NServiceBus.Core/Installation/InstallationComponent.cs
@@ -75,6 +75,7 @@
         ContainerComponent containerComponent;
         ReceiveComponent receiveComponent;
         bool shouldRunInstallers;
+
         static bool IsINeedToInstallSomething(Type t) => typeof(INeedToInstallSomething).IsAssignableFrom(t);
     }
 }


### PR DESCRIPTION
This cleans up the endpoint creator and makes the dependencies of the installation parts more visible.

### Behavior changes

* Receive component is created before the installer component since it needs to be passed to it. 
   * This should have no visible effect on the ReceiveComponent since the installer just registers intaller instances in the container
   * This should have no visible effect since the InstallerComponent only needs to read 2 settings that aren't controlled by the Receive component. This also highlight a design smell. I think the installer should depend on the transport component instead. See more details below

### Things to note

* This makes the installation component stand out since it's the only component that "starts" before users call `.Start()`. This is due to https://docs.particular.net/nservicebus/operations/installers#running-installers
* The component depends on
   * TypeDiscovery - To find all installers
   * ContainerComponent - To register the installers in the container and later build them
   * ReceiveComponent - To ask it to create queues. 
* Since the receiver just in turn forwards the create queues call to the Transport my hunch is that this dependency should be changed to the Transport instead. No need for the receiver to be the middle man
