### PR TITLE
Task-based notifications API

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_delayed_retries_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_delayed_retries_notifications.cs
@@ -70,7 +70,6 @@
                         {
                             testContext.NumberOfDelayedRetriesPerformed++;
                             testContext.LastDelayedRetryInfo = retry;
-                            return Task.FromResult(0);
                         });
                     });
                 });

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_delayed_retries_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_delayed_retries_notifications.cs
@@ -60,7 +60,11 @@
                     recoverability.Immediate(settings =>
                     {
                         settings.NumberOfRetries(3);
-                        settings.OnMessageBeingRetried(_ => testContext.TotalNumberOfImmediateRetriesEventInvocations++);
+                        settings.OnMessageBeingRetried(retry =>
+                        {
+                            testContext.TotalNumberOfImmediateRetriesEventInvocations++;
+                            return Task.FromResult(0);
+                        });
                     });
                     recoverability.Delayed(settings =>
                     {
@@ -70,6 +74,7 @@
                         {
                             testContext.NumberOfDelayedRetriesPerformed++;
                             testContext.LastDelayedRetryInfo = retry;
+                            return Task.FromResult(0);
                         });
                     });
                 });

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_delayed_retries_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_delayed_retries_notifications.cs
@@ -60,11 +60,7 @@
                     recoverability.Immediate(settings =>
                     {
                         settings.NumberOfRetries(3);
-                        settings.OnMessageBeingRetried(retry =>
-                        {
-                            testContext.TotalNumberOfImmediateRetriesEventInvocations++;
-                            return Task.FromResult(0);
-                        });
+                        settings.OnMessageBeingRetried(_ => testContext.TotalNumberOfImmediateRetriesEventInvocations++);
                     });
                     recoverability.Delayed(settings =>
                     {

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_delayed_retries_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_delayed_retries_notifications.cs
@@ -52,7 +52,11 @@
                     config.EnableFeature<TimeoutManager>();
 
                     var recoverability = config.Recoverability();
-                    recoverability.Failed(f => f.OnMessageSentToErrorQueue(_ => testContext.MessageSentToError = true));
+                    recoverability.Failed(f => f.OnMessageSentToErrorQueue(failedMessage =>
+                    {
+                        testContext.MessageSentToError = true;
+                        return Task.FromResult(0);
+                    }));
                     recoverability.Immediate(settings =>
                     {
                         settings.NumberOfRetries(3);

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_delayed_retries_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_delayed_retries_notifications.cs
@@ -52,11 +52,7 @@
                     config.EnableFeature<TimeoutManager>();
 
                     var recoverability = config.Recoverability();
-                    recoverability.Failed(f => f.OnMessageSentToErrorQueue(failedMessage =>
-                    {
-                        testContext.MessageSentToError = true;
-                        return Task.FromResult(0);
-                    }));
+                    recoverability.Failed(f => f.OnMessageSentToErrorQueue(_ => testContext.MessageSentToError = true));
                     recoverability.Immediate(settings =>
                     {
                         settings.NumberOfRetries(3);

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_delayed_retries_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_delayed_retries_notifications.cs
@@ -1,0 +1,106 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Recoverability
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Faults;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_subscribing_to_delayed_retries_notifications : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_trigger_notification_on_delayed_retry()
+        {
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
+                .WithEndpoint<DelayedRetriesEndpoint>(b =>
+                {
+                    b.DoNotFailOnErrorMessages();
+                    b.When((session, c) => session.SendLocal(new MessageToBeRetried
+                    {
+                        Id = c.Id
+                    }));
+                })
+                .Done(c => c.MessageSentToError)
+                .Run();
+
+            Assert.IsInstanceOf<SimulatedException>(context.LastDelayedRetryInfo.Exception);
+            // Immediate Retries max retries = 3 means we will be processing 4 times. Delayed Retries max retries = 2 means we will do 3 * Immediate Retries
+            Assert.AreEqual(4 * 3, context.TotalNumberOfHandlerInvocations);
+            Assert.AreEqual(2, context.NumberOfDelayedRetriesPerformed);
+            Assert.AreEqual(2, context.LastDelayedRetryInfo.RetryAttempt);
+        }
+
+        class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+            public int TotalNumberOfImmediateRetriesEventInvocations { get; set; }
+            public int TotalNumberOfHandlerInvocations { get; set; }
+            public int NumberOfDelayedRetriesPerformed { get; set; }
+            public bool MessageSentToError { get; set; }
+            public DelayedRetryMessage LastDelayedRetryInfo { get; set; }
+        }
+
+        public class DelayedRetriesEndpoint : EndpointConfigurationBuilder
+        {
+            public DelayedRetriesEndpoint()
+            {
+                EndpointSetup<DefaultServer>((config, context) =>
+                {
+                    var testContext = (Context)context.ScenarioContext;
+                    config.EnableFeature<TimeoutManager>();
+
+                    var recoverability = config.Recoverability();
+                    recoverability.Failed(f => f.OnMessageSentToErrorQueue(failedMessage =>
+                    {
+                        testContext.MessageSentToError = true;
+                        return Task.FromResult(0);
+                    }));
+                    recoverability.Immediate(settings =>
+                    {
+                        settings.NumberOfRetries(3);
+                        settings.OnMessageBeingRetried(retry =>
+                        {
+                            testContext.TotalNumberOfImmediateRetriesEventInvocations++;
+                            return Task.FromResult(0);
+                        });
+                    });
+                    recoverability.Delayed(settings =>
+                    {
+                        settings.NumberOfRetries(2);
+                        settings.TimeIncrease(TimeSpan.FromMilliseconds(1));
+                        settings.OnMessageBeingRetried(retry =>
+                        {
+                            testContext.NumberOfDelayedRetriesPerformed++;
+                            testContext.LastDelayedRetryInfo = retry;
+                            return Task.FromResult(0);
+                        });
+                    });
+                });
+            }
+
+            class MessageToBeRetriedHandler : IHandleMessages<MessageToBeRetried>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MessageToBeRetried message, IMessageHandlerContext context)
+                {
+                    if (message.Id != Context.Id)
+                    {
+                        return Task.FromResult(0); // messages from previous test runs must be ignored
+                    }
+
+                    Context.TotalNumberOfHandlerInvocations++;
+
+                    throw new SimulatedException("Simulated exception message");
+                }
+            }
+        }
+
+        public class MessageToBeRetried : IMessage
+        {
+            public Guid Id { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_error_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_error_notifications.cs
@@ -59,11 +59,7 @@
                     {
                         settings.NumberOfRetries(2);
                         settings.TimeIncrease(TimeSpan.FromMilliseconds(1));
-                        settings.OnMessageBeingRetried(retry =>
-                        {
-                            testContext.NumberOfDelayedRetriesPerformed++;
-                            return Task.FromResult(0);
-                        });
+                        settings.OnMessageBeingRetried(_ => testContext.NumberOfDelayedRetriesPerformed++);
                     });
                     recoverability.Immediate(settings =>
                     {

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_error_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_error_notifications.cs
@@ -70,7 +70,6 @@
                     {
                         testContext.MessageSentToErrorException = failedMessage.Exception;
                         testContext.MessageSentToError = true;
-                        return Task.FromResult(0);
                     }));
                 });
             }

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_error_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_error_notifications.cs
@@ -55,12 +55,6 @@
                     config.EnableFeature<TimeoutManager>();
 
                     var recoverability = config.Recoverability();
-                    recoverability.Failed(f => f.OnMessageSentToErrorQueue(failedMessage =>
-                    {
-                        testContext.MessageSentToErrorException = failedMessage.Exception;
-                        testContext.MessageSentToError = true;
-                        return Task.FromResult(0);
-                    }));
                     recoverability.Delayed(settings =>
                     {
                         settings.NumberOfRetries(2);
@@ -74,12 +68,14 @@
                     recoverability.Immediate(settings =>
                     {
                         settings.NumberOfRetries(3);
-                        settings.OnMessageBeingRetried(retry =>
-                        {
-                            testContext.TotalNumberOfImmediateRetriesEventInvocations++;
-                            return Task.FromResult(0);
-                        });
+                        settings.OnMessageBeingRetried(_ => testContext.TotalNumberOfImmediateRetriesEventInvocations++);
                     });
+                    recoverability.Failed(f => f.OnMessageSentToErrorQueue(failedMessage =>
+                    {
+                        testContext.MessageSentToErrorException = failedMessage.Exception;
+                        testContext.MessageSentToError = true;
+                        return Task.FromResult(0);
+                    }));
                 });
             }
 

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_error_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_error_notifications.cs
@@ -70,6 +70,7 @@
                     {
                         testContext.MessageSentToErrorException = failedMessage.Exception;
                         testContext.MessageSentToError = true;
+                        return Task.FromResult(0);
                     }));
                 });
             }

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_immediate_retries_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_immediate_retries_notifications.cs
@@ -1,0 +1,85 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Recoverability
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Faults;
+    using NUnit.Framework;
+
+    public class When_subscribing_to_immediate_retries_notifications : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_trigger_notification_on_immediate_retry()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<RetryingEndpoint>(b =>
+                {
+                    b.DoNotFailOnErrorMessages();
+                    b.When((session, c) => session.SendLocal(new MessageToBeRetried()));
+                })
+                .Done(c => c.MessageSentToError)
+                .Run();
+
+            Assert.IsInstanceOf<SimulatedException>(context.LastImmediateRetryInfo.Exception);
+            // Immediate Retries max retries = 3 means we will be processing 4 times. Delayed Retries max retries = 2 means we will do 3 * Immediate Retries
+            Assert.AreEqual(4, context.TotalNumberOfHandlerInvocations);
+            Assert.AreEqual(3, context.TotalNumberOfImmediateRetriesEventInvocations);
+            Assert.AreEqual(2, context.LastImmediateRetryInfo.RetryAttempt);
+        }
+
+        class Context : ScenarioContext
+        {
+            public int TotalNumberOfImmediateRetriesEventInvocations { get; set; }
+            public int TotalNumberOfHandlerInvocations { get; set; }
+            public bool MessageSentToError { get; set; }
+            public ImmediateRetryMessage LastImmediateRetryInfo { get; set; }
+        }
+
+        public class RetryingEndpoint : EndpointConfigurationBuilder
+        {
+            public RetryingEndpoint()
+            {
+                EndpointSetup<DefaultServer>((config, context) =>
+                {
+                    var testContext = (Context)context.ScenarioContext;
+
+                    var recoverability = config.Recoverability();
+                    recoverability.Failed(f => f.OnMessageSentToErrorQueue(failedMessage =>
+                    {
+                        testContext.MessageSentToError = true;
+                        return Task.FromResult(0);
+                    }));
+
+                    recoverability.Immediate(immediateRetriesSettings =>
+                    {
+                        immediateRetriesSettings.NumberOfRetries(3);
+                        immediateRetriesSettings.OnMessageBeingRetried(retryInfo =>
+                        {
+                            testContext.TotalNumberOfImmediateRetriesEventInvocations++;
+                            testContext.LastImmediateRetryInfo = retryInfo;
+                            return Task.FromResult(0);
+                        });
+                    });
+                });
+            }
+
+            class MessageToBeRetriedHandler : IHandleMessages<MessageToBeRetried>
+            {
+                public Context Context { get; set; }
+
+                public Task Handle(MessageToBeRetried message, IMessageHandlerContext context)
+                {
+                    Context.TotalNumberOfHandlerInvocations++;
+
+                    throw new SimulatedException("Simulated exception message");
+                }
+            }
+        }
+
+        public class MessageToBeRetried : IMessage
+        {
+            public Guid Id { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_immediate_retries_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_immediate_retries_notifications.cs
@@ -45,7 +45,12 @@
                     var testContext = (Context)context.ScenarioContext;
 
                     var recoverability = config.Recoverability();
-                    recoverability.Failed(f => f.OnMessageSentToErrorQueue(_ => testContext.MessageSentToError = true));
+                    recoverability.Failed(f => f.OnMessageSentToErrorQueue(failedMessage =>
+                    {
+                        testContext.MessageSentToError = true;
+                        return Task.FromResult(0);
+                    }));
+
                     recoverability.Immediate(immediateRetriesSettings =>
                     {
                         immediateRetriesSettings.NumberOfRetries(3);

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_immediate_retries_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_immediate_retries_notifications.cs
@@ -58,6 +58,7 @@
                         {
                             testContext.TotalNumberOfImmediateRetriesEventInvocations++;
                             testContext.LastImmediateRetryInfo = retryInfo;
+                            return Task.FromResult(0);
                         });
                     });
                 });

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_immediate_retries_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_immediate_retries_notifications.cs
@@ -58,7 +58,6 @@
                         {
                             testContext.TotalNumberOfImmediateRetriesEventInvocations++;
                             testContext.LastImmediateRetryInfo = retryInfo;
-                            return Task.FromResult(0);
                         });
                     });
                 });

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_immediate_retries_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_immediate_retries_notifications.cs
@@ -45,12 +45,7 @@
                     var testContext = (Context)context.ScenarioContext;
 
                     var recoverability = config.Recoverability();
-                    recoverability.Failed(f => f.OnMessageSentToErrorQueue(failedMessage =>
-                    {
-                        testContext.MessageSentToError = true;
-                        return Task.FromResult(0);
-                    }));
-
+                    recoverability.Failed(f => f.OnMessageSentToErrorQueue(_ => testContext.MessageSentToError = true));
                     recoverability.Immediate(immediateRetriesSettings =>
                     {
                         immediateRetriesSettings.NumberOfRetries(3);

--- a/src/NServiceBus.AcceptanceTests/Pipeline/When_message_processing_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Pipeline/When_message_processing_fails.cs
@@ -38,12 +38,12 @@
             {
                 EndpointSetup<DefaultServer>((c, r) =>
                 {
-                    c.Notifications.Errors.MessageSentToErrorQueue += (sender, message) =>
+                    c.Recoverability().Failed(settings => settings.OnMessageSentToErrorQueue(failure =>
                     {
                         var testContext = ((Context)r.ScenarioContext);
                         testContext.MessageFailed = true;
-                        testContext.Exception = message.Exception;
-                    };
+                        testContext.Exception = failure.Exception;
+                    }));
                 });
             }
 

--- a/src/NServiceBus.AcceptanceTests/Pipeline/When_message_processing_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Pipeline/When_message_processing_fails.cs
@@ -43,6 +43,7 @@
                         var testContext = ((Context)r.ScenarioContext);
                         testContext.MessageFailed = true;
                         testContext.Exception = failure.Exception;
+                        return Task.FromResult(0);
                     }));
                 });
             }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_disabled.cs
@@ -42,7 +42,11 @@
                 {
                     var scenarioContext = (Context) context.ScenarioContext;
                     configure.Recoverability().Immediate(immediate => immediate.NumberOfRetries(0));
-                    configure.Notifications.Errors.MessageSentToErrorQueue += (sender, message) => scenarioContext.GaveUp = true;
+                    configure.Recoverability().Failed(f => f.OnMessageSentToErrorQueue(message =>
+                    {
+                        scenarioContext.GaveUp = true;
+                        return Task.FromResult(0);
+                    }));
                 });
             }
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_disabled.cs
@@ -42,7 +42,11 @@
                 {
                     var scenarioContext = (Context) context.ScenarioContext;
                     configure.Recoverability().Immediate(immediate => immediate.NumberOfRetries(0));
-                    configure.Recoverability().Failed(f => f.OnMessageSentToErrorQueue(_ => scenarioContext.GaveUp = true));
+                    configure.Recoverability().Failed(f => f.OnMessageSentToErrorQueue(message =>
+                    {
+                        scenarioContext.GaveUp = true;
+                        return Task.FromResult(0);
+                    }));
                 });
             }
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_disabled.cs
@@ -42,11 +42,7 @@
                 {
                     var scenarioContext = (Context) context.ScenarioContext;
                     configure.Recoverability().Immediate(immediate => immediate.NumberOfRetries(0));
-                    configure.Recoverability().Failed(f => f.OnMessageSentToErrorQueue(message =>
-                    {
-                        scenarioContext.GaveUp = true;
-                        return Task.FromResult(0);
-                    }));
+                    configure.Recoverability().Failed(f => f.OnMessageSentToErrorQueue(_ => scenarioContext.GaveUp = true));
                 });
             }
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_with_dtc_on.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_with_dtc_on.cs
@@ -49,11 +49,7 @@
                 EndpointSetup<DefaultServer>((b, context) =>
                 {
                     var scenarioContext = (Context) context.ScenarioContext;
-                    b.Recoverability().Failed(f => f.OnMessageSentToErrorQueue(message =>
-                    {
-                        scenarioContext.GaveUpOnRetries = true;
-                        return Task.FromResult(0);
-                    }));
+                    b.Recoverability().Failed(f => f.OnMessageSentToErrorQueue(_ => scenarioContext.GaveUpOnRetries = true));
                     var recoverability = b.Recoverability();
                     recoverability.Immediate(settings => settings.NumberOfRetries(maxretries));
                     recoverability.Delayed(settings => settings.NumberOfRetries(0));

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_with_dtc_on.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_with_dtc_on.cs
@@ -49,7 +49,11 @@
                 EndpointSetup<DefaultServer>((b, context) =>
                 {
                     var scenarioContext = (Context) context.ScenarioContext;
-                    b.Recoverability().Failed(f => f.OnMessageSentToErrorQueue(_ => scenarioContext.GaveUpOnRetries = true));
+                    b.Recoverability().Failed(f => f.OnMessageSentToErrorQueue(message =>
+                    {
+                        scenarioContext.GaveUpOnRetries = true;
+                        return Task.FromResult(0);
+                    }));
                     var recoverability = b.Recoverability();
                     recoverability.Immediate(settings => settings.NumberOfRetries(maxretries));
                     recoverability.Delayed(settings => settings.NumberOfRetries(0));

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_with_dtc_on.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_with_dtc_on.cs
@@ -49,7 +49,11 @@
                 EndpointSetup<DefaultServer>((b, context) =>
                 {
                     var scenarioContext = (Context) context.ScenarioContext;
-                    b.Notifications.Errors.MessageSentToErrorQueue += (sender, message) => scenarioContext.GaveUpOnRetries = true;
+                    b.Recoverability().Failed(f => f.OnMessageSentToErrorQueue(message =>
+                    {
+                        scenarioContext.GaveUpOnRetries = true;
+                        return Task.FromResult(0);
+                    }));
                     var recoverability = b.Recoverability();
                     recoverability.Immediate(settings => settings.NumberOfRetries(maxretries));
                     recoverability.Delayed(settings => settings.NumberOfRetries(0));

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_with_native_transactions.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_with_native_transactions.cs
@@ -43,11 +43,7 @@
                 EndpointSetup<DefaultServer>((config, context) =>
                 {
                     var scenarioContext = (Context) context.ScenarioContext;
-                    config.Recoverability().Failed(f => f.OnMessageSentToErrorQueue(message =>
-                    {
-                        scenarioContext.ForwardedToErrorQueue = true;
-                        return Task.FromResult(0);
-                    }));
+                    config.Recoverability().Failed(f => f.OnMessageSentToErrorQueue(_ => scenarioContext.ForwardedToErrorQueue = true));
 
                     var recoverability = config.Recoverability();
                     recoverability.Immediate(immediate => immediate.NumberOfRetries(numberOfRetries));

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_with_native_transactions.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_with_native_transactions.cs
@@ -43,7 +43,11 @@
                 EndpointSetup<DefaultServer>((config, context) =>
                 {
                     var scenarioContext = (Context) context.ScenarioContext;
-                    config.Notifications.Errors.MessageSentToErrorQueue += (sender, message) => scenarioContext.ForwardedToErrorQueue = true;
+                    config.Recoverability().Failed(f => f.OnMessageSentToErrorQueue(message =>
+                    {
+                        scenarioContext.ForwardedToErrorQueue = true;
+                        return Task.FromResult(0);
+                    }));
 
                     var recoverability = config.Recoverability();
                     recoverability.Immediate(immediate => immediate.NumberOfRetries(numberOfRetries));

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_with_native_transactions.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_with_native_transactions.cs
@@ -43,7 +43,11 @@
                 EndpointSetup<DefaultServer>((config, context) =>
                 {
                     var scenarioContext = (Context) context.ScenarioContext;
-                    config.Recoverability().Failed(f => f.OnMessageSentToErrorQueue(_ => scenarioContext.ForwardedToErrorQueue = true));
+                    config.Recoverability().Failed(f => f.OnMessageSentToErrorQueue(message =>
+                    {
+                        scenarioContext.ForwardedToErrorQueue = true;
+                        return Task.FromResult(0);
+                    }));
 
                     var recoverability = config.Recoverability();
                     recoverability.Immediate(immediate => immediate.NumberOfRetries(numberOfRetries));

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -813,7 +813,6 @@ namespace NServiceBus
     public class RetryFailedSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         public NServiceBus.RetryFailedSettings HeaderCustomization(System.Action<System.Collections.Generic.Dictionary<string, string>> customization) { }
-        public NServiceBus.RetryFailedSettings OnMessageSentToErrorQueue(System.Action<NServiceBus.Faults.FailedMessage> notificationCallback) { }
         public NServiceBus.RetryFailedSettings OnMessageSentToErrorQueue(System.Func<NServiceBus.Faults.FailedMessage, System.Threading.Tasks.Task> notificationCallback) { }
     }
     public class static RoutingFeatureSettingsExtensions

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -238,6 +238,8 @@ namespace NServiceBus
     public class DelayedRetriesSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         public NServiceBus.DelayedRetriesSettings NumberOfRetries(int numberOfRetries) { }
+        public NServiceBus.DelayedRetriesSettings OnMessageBeingRetried(System.Action<NServiceBus.Faults.DelayedRetryMessage> notificationCallback) { }
+        public NServiceBus.DelayedRetriesSettings OnMessageBeingRetried(System.Func<NServiceBus.Faults.DelayedRetryMessage, System.Threading.Tasks.Task> notificationCallback) { }
         public NServiceBus.DelayedRetriesSettings TimeIncrease(System.TimeSpan timeIncrease) { }
     }
     public sealed class DelayedRetry : NServiceBus.RecoverabilityAction
@@ -587,6 +589,8 @@ namespace NServiceBus
     public class ImmediateRetriesSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         public void NumberOfRetries(int numberOfRetries) { }
+        public NServiceBus.ImmediateRetriesSettings OnMessageBeingRetried(System.Action<NServiceBus.Faults.ImmediateRetryMessage> notificationCallback) { }
+        public NServiceBus.ImmediateRetriesSettings OnMessageBeingRetried(System.Func<NServiceBus.Faults.ImmediateRetryMessage, System.Threading.Tasks.Task> notificationCallback) { }
     }
     public sealed class ImmediateRetry : NServiceBus.RecoverabilityAction { }
     public class static InMemoryGatewayPersistenceConfigurationExtensions
@@ -809,6 +813,8 @@ namespace NServiceBus
     public class RetryFailedSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         public NServiceBus.RetryFailedSettings HeaderCustomization(System.Action<System.Collections.Generic.Dictionary<string, string>> customization) { }
+        public NServiceBus.RetryFailedSettings OnMessageSentToErrorQueue(System.Action<NServiceBus.Faults.FailedMessage> notificationCallback) { }
+        public NServiceBus.RetryFailedSettings OnMessageSentToErrorQueue(System.Func<NServiceBus.Faults.FailedMessage, System.Threading.Tasks.Task> notificationCallback) { }
     }
     public class static RoutingFeatureSettingsExtensions
     {
@@ -1498,8 +1504,11 @@ namespace NServiceBus.Faults
     public class ErrorsNotifications
     {
         public ErrorsNotifications() { }
+        [System.ObsoleteAttribute(@"The .NET event based error notifications will be deprecated in favor of Task-based callbacks. Use endpointConfiguration.Recoverability().Delayed(settings => settings.OnMessageBeingRetried(callback)) instead. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
         public event System.EventHandler<NServiceBus.Faults.DelayedRetryMessage> MessageHasBeenSentToDelayedRetries;
+        [System.ObsoleteAttribute(@"The .NET event based error notifications will be deprecated in favor of Task-based callbacks. Use endpointConfiguration.Recoverability().Immediate(settings => settings.OnMessageBeingRetried(callback)) instead. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
         public event System.EventHandler<NServiceBus.Faults.ImmediateRetryMessage> MessageHasFailedAnImmediateRetryAttempt;
+        [System.ObsoleteAttribute(@"The .NET event based error notifications will be deprecated in favor of Task-based callbacks. Use endpointConfiguration.Recoverability().Failed(settings => settings.OnMessageSentToErrorQueue(callback)) instead. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
         public event System.EventHandler<NServiceBus.Faults.FailedMessage> MessageSentToErrorQueue;
     }
     public class FailedMessage

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -238,7 +238,6 @@ namespace NServiceBus
     public class DelayedRetriesSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         public NServiceBus.DelayedRetriesSettings NumberOfRetries(int numberOfRetries) { }
-        public NServiceBus.DelayedRetriesSettings OnMessageBeingRetried(System.Action<NServiceBus.Faults.DelayedRetryMessage> notificationCallback) { }
         public NServiceBus.DelayedRetriesSettings OnMessageBeingRetried(System.Func<NServiceBus.Faults.DelayedRetryMessage, System.Threading.Tasks.Task> notificationCallback) { }
         public NServiceBus.DelayedRetriesSettings TimeIncrease(System.TimeSpan timeIncrease) { }
     }
@@ -589,7 +588,6 @@ namespace NServiceBus
     public class ImmediateRetriesSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         public void NumberOfRetries(int numberOfRetries) { }
-        public NServiceBus.ImmediateRetriesSettings OnMessageBeingRetried(System.Action<NServiceBus.Faults.ImmediateRetryMessage> notificationCallback) { }
         public NServiceBus.ImmediateRetriesSettings OnMessageBeingRetried(System.Func<NServiceBus.Faults.ImmediateRetryMessage, System.Threading.Tasks.Task> notificationCallback) { }
     }
     public sealed class ImmediateRetry : NServiceBus.RecoverabilityAction { }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -813,7 +813,6 @@ namespace NServiceBus
     public class RetryFailedSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         public NServiceBus.RetryFailedSettings HeaderCustomization(System.Action<System.Collections.Generic.Dictionary<string, string>> customization) { }
-        public NServiceBus.RetryFailedSettings OnMessageSentToErrorQueue(System.Action<NServiceBus.Faults.FailedMessage> notificationCallback) { }
         public NServiceBus.RetryFailedSettings OnMessageSentToErrorQueue(System.Func<NServiceBus.Faults.FailedMessage, System.Threading.Tasks.Task> notificationCallback) { }
     }
     public class static RoutingFeatureSettingsExtensions

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -238,6 +238,8 @@ namespace NServiceBus
     public class DelayedRetriesSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         public NServiceBus.DelayedRetriesSettings NumberOfRetries(int numberOfRetries) { }
+        public NServiceBus.DelayedRetriesSettings OnMessageBeingRetried(System.Action<NServiceBus.Faults.DelayedRetryMessage> notificationCallback) { }
+        public NServiceBus.DelayedRetriesSettings OnMessageBeingRetried(System.Func<NServiceBus.Faults.DelayedRetryMessage, System.Threading.Tasks.Task> notificationCallback) { }
         public NServiceBus.DelayedRetriesSettings TimeIncrease(System.TimeSpan timeIncrease) { }
     }
     public sealed class DelayedRetry : NServiceBus.RecoverabilityAction
@@ -587,6 +589,8 @@ namespace NServiceBus
     public class ImmediateRetriesSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         public void NumberOfRetries(int numberOfRetries) { }
+        public NServiceBus.ImmediateRetriesSettings OnMessageBeingRetried(System.Action<NServiceBus.Faults.ImmediateRetryMessage> notificationCallback) { }
+        public NServiceBus.ImmediateRetriesSettings OnMessageBeingRetried(System.Func<NServiceBus.Faults.ImmediateRetryMessage, System.Threading.Tasks.Task> notificationCallback) { }
     }
     public sealed class ImmediateRetry : NServiceBus.RecoverabilityAction { }
     public class static InMemoryGatewayPersistenceConfigurationExtensions
@@ -809,6 +813,8 @@ namespace NServiceBus
     public class RetryFailedSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         public NServiceBus.RetryFailedSettings HeaderCustomization(System.Action<System.Collections.Generic.Dictionary<string, string>> customization) { }
+        public NServiceBus.RetryFailedSettings OnMessageSentToErrorQueue(System.Action<NServiceBus.Faults.FailedMessage> notificationCallback) { }
+        public NServiceBus.RetryFailedSettings OnMessageSentToErrorQueue(System.Func<NServiceBus.Faults.FailedMessage, System.Threading.Tasks.Task> notificationCallback) { }
     }
     public class static RoutingFeatureSettingsExtensions
     {
@@ -1500,8 +1506,11 @@ namespace NServiceBus.Faults
     public class ErrorsNotifications
     {
         public ErrorsNotifications() { }
+        [System.ObsoleteAttribute(@"The .NET event based error notifications will be deprecated in favor of Task-based callbacks. Use endpointConfiguration.Recoverability().Delayed(settings => settings.OnMessageBeingRetried(callback)) instead. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
         public event System.EventHandler<NServiceBus.Faults.DelayedRetryMessage> MessageHasBeenSentToDelayedRetries;
+        [System.ObsoleteAttribute(@"The .NET event based error notifications will be deprecated in favor of Task-based callbacks. Use endpointConfiguration.Recoverability().Immediate(settings => settings.OnMessageBeingRetried(callback)) instead. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
         public event System.EventHandler<NServiceBus.Faults.ImmediateRetryMessage> MessageHasFailedAnImmediateRetryAttempt;
+        [System.ObsoleteAttribute(@"The .NET event based error notifications will be deprecated in favor of Task-based callbacks. Use endpointConfiguration.Recoverability().Failed(settings => settings.OnMessageSentToErrorQueue(callback)) instead. Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0.", false)]
         public event System.EventHandler<NServiceBus.Faults.FailedMessage> MessageSentToErrorQueue;
     }
     public class FailedMessage

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -238,7 +238,6 @@ namespace NServiceBus
     public class DelayedRetriesSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         public NServiceBus.DelayedRetriesSettings NumberOfRetries(int numberOfRetries) { }
-        public NServiceBus.DelayedRetriesSettings OnMessageBeingRetried(System.Action<NServiceBus.Faults.DelayedRetryMessage> notificationCallback) { }
         public NServiceBus.DelayedRetriesSettings OnMessageBeingRetried(System.Func<NServiceBus.Faults.DelayedRetryMessage, System.Threading.Tasks.Task> notificationCallback) { }
         public NServiceBus.DelayedRetriesSettings TimeIncrease(System.TimeSpan timeIncrease) { }
     }
@@ -589,7 +588,6 @@ namespace NServiceBus
     public class ImmediateRetriesSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         public void NumberOfRetries(int numberOfRetries) { }
-        public NServiceBus.ImmediateRetriesSettings OnMessageBeingRetried(System.Action<NServiceBus.Faults.ImmediateRetryMessage> notificationCallback) { }
         public NServiceBus.ImmediateRetriesSettings OnMessageBeingRetried(System.Func<NServiceBus.Faults.ImmediateRetryMessage, System.Threading.Tasks.Task> notificationCallback) { }
     }
     public sealed class ImmediateRetry : NServiceBus.RecoverabilityAction { }

--- a/src/NServiceBus.Core/DeepCopy.cs
+++ b/src/NServiceBus.Core/DeepCopy.cs
@@ -27,7 +27,7 @@ namespace System
             return (type.IsValueType & type.IsPrimitive);
         }
 
-        public static Object Copy(this Object originalObject)
+        public static Object DeepCopy(this Object originalObject)
         {
             return InternalCopy(originalObject, new Dictionary<Object, Object>(new ReferenceEqualityComparer()));
         }
@@ -75,9 +75,9 @@ namespace System
                 fieldInfo.SetValue(cloneObject, clonedFieldValue);
             }
         }
-        public static T Copy<T>(this T original)
+        public static T DeepCopy<T>(this T original)
         {
-            return (T)Copy((Object)original);
+            return (T)DeepCopy((Object)original);
         }
     }
 

--- a/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/SagaPersister/InMemorySagaPersister.cs
@@ -156,7 +156,7 @@ namespace NServiceBus
 
             static IContainSagaData DeepCopy(IContainSagaData source)
             {
-                return source.Copy();
+                return source.DeepCopy();
             }
 
             public IContainSagaData GetSagaCopy()

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -18,10 +18,9 @@ namespace NServiceBus
         {
             var pipelineStartedAt = DateTime.UtcNow;
 
-            var message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.Body);
             using (var childBuilder = builder.CreateChildBuilder())
             {
-                
+                var message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.Body);
 
                 var rootContext = pipelineComponent.CreateRootContext(childBuilder, messageContext.Extensions);
                 var transportReceiveContext = new TransportReceiveContext(message, messageContext.TransportTransaction, messageContext.ReceiveCancellationTokenSource, rootContext);
@@ -30,8 +29,6 @@ namespace NServiceBus
 
                 await transportReceiveContext.RaiseNotification(new ReceivePipelineCompleted(message, pipelineStartedAt, DateTime.UtcNow)).ConfigureAwait(false);
             }
-
-            
         }
 
         readonly IBuilder builder;

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -18,9 +18,10 @@ namespace NServiceBus
         {
             var pipelineStartedAt = DateTime.UtcNow;
 
+            var message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.Body);
             using (var childBuilder = builder.CreateChildBuilder())
             {
-                var message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.Body);
+                
 
                 var rootContext = pipelineComponent.CreateRootContext(childBuilder, messageContext.Extensions);
                 var transportReceiveContext = new TransportReceiveContext(message, messageContext.TransportTransaction, messageContext.ReceiveCancellationTokenSource, rootContext);
@@ -29,6 +30,8 @@ namespace NServiceBus
 
                 await transportReceiveContext.RaiseNotification(new ReceivePipelineCompleted(message, pipelineStartedAt, DateTime.UtcNow)).ConfigureAwait(false);
             }
+
+            
         }
 
         readonly IBuilder builder;

--- a/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
@@ -9,47 +9,47 @@ namespace NServiceBus.Faults
     /// </summary>
     public class ErrorsNotifications
     {
-        /// <summary>
-        /// Notification when a message is moved to the error queue.
-        /// </summary>
-        public event EventHandler<FailedMessage> MessageSentToErrorQueue;
+        ///// <summary>
+        ///// Notification when a message is moved to the error queue.
+        ///// </summary>
+        //public event EventHandler<FailedMessage> MessageSentToErrorQueue;
 
-        /// <summary>
-        /// Notification when a message fails a immediate retry.
-        /// </summary>
-        public event EventHandler<ImmediateRetryMessage> MessageHasFailedAnImmediateRetryAttempt;
+        ///// <summary>
+        ///// Notification when a message fails a immediate retry.
+        ///// </summary>
+        //public event EventHandler<ImmediateRetryMessage> MessageHasFailedAnImmediateRetryAttempt;
 
-        /// <summary>
-        /// Notification when a message is sent to Delayed Retries queue.
-        /// </summary>
-        public event EventHandler<DelayedRetryMessage> MessageHasBeenSentToDelayedRetries;
+        ///// <summary>
+        ///// Notification when a message is sent to Delayed Retries queue.
+        ///// </summary>
+        //public event EventHandler<DelayedRetryMessage> MessageHasBeenSentToDelayedRetries;
 
         internal void InvokeMessageHasBeenSentToErrorQueue(IncomingMessage message, Exception exception, string errorQueue)
         {
-            MessageSentToErrorQueue?.Invoke(this, new FailedMessage(
-                message.MessageId,
-                new Dictionary<string, string>(message.Headers),
-                CopyOfBody(message.Body), exception, errorQueue));
+            //MessageSentToErrorQueue?.Invoke(this, new FailedMessage(
+            //    message.MessageId,
+            //    new Dictionary<string, string>(message.Headers),
+            //    CopyOfBody(message.Body), exception, errorQueue));
         }
 
         internal void InvokeMessageHasFailedAnImmediateRetryAttempt(int immediateRetryAttempt, IncomingMessage message, Exception exception)
         {
-            MessageHasFailedAnImmediateRetryAttempt?.Invoke(this, new ImmediateRetryMessage(
-                message.MessageId,
-                new Dictionary<string, string>(message.Headers),
-                CopyOfBody(message.Body),
-                exception,
-                immediateRetryAttempt));
+            //MessageHasFailedAnImmediateRetryAttempt?.Invoke(this, new ImmediateRetryMessage(
+            //    message.MessageId,
+            //    new Dictionary<string, string>(message.Headers),
+            //    CopyOfBody(message.Body),
+            //    exception,
+            //    immediateRetryAttempt));
         }
 
         internal void InvokeMessageHasBeenSentToDelayedRetries(int delayedRetryAttempt, IncomingMessage message, Exception exception)
         {
-            MessageHasBeenSentToDelayedRetries?.Invoke(this, new DelayedRetryMessage(
-                message.MessageId,
-                new Dictionary<string, string>(message.Headers),
-                CopyOfBody(message.Body),
-                exception,
-                delayedRetryAttempt));
+            //MessageHasBeenSentToDelayedRetries?.Invoke(this, new DelayedRetryMessage(
+            //    message.MessageId,
+            //    new Dictionary<string, string>(message.Headers),
+            //    CopyOfBody(message.Body),
+            //    exception,
+            //    delayedRetryAttempt));
         }
 
         static byte[] CopyOfBody(byte[] body)

--- a/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
@@ -41,7 +41,9 @@ namespace NServiceBus.Faults
             MessageSentToErrorQueue?.Invoke(this, new FailedMessage(
                 message.MessageId,
                 new Dictionary<string, string>(message.Headers),
-                CopyOfBody(message.Body), exception, errorQueue));
+                message.Body.Copy(),
+                exception,
+                errorQueue));
         }
 
         internal void InvokeMessageHasFailedAnImmediateRetryAttempt(int immediateRetryAttempt, IncomingMessage message, Exception exception)
@@ -49,7 +51,7 @@ namespace NServiceBus.Faults
             MessageHasFailedAnImmediateRetryAttempt?.Invoke(this, new ImmediateRetryMessage(
                 message.MessageId,
                 new Dictionary<string, string>(message.Headers),
-                CopyOfBody(message.Body),
+                message.Body.Copy(),
                 exception,
                 immediateRetryAttempt));
         }
@@ -59,23 +61,9 @@ namespace NServiceBus.Faults
             MessageHasBeenSentToDelayedRetries?.Invoke(this, new DelayedRetryMessage(
                 message.MessageId,
                 new Dictionary<string, string>(message.Headers),
-                CopyOfBody(message.Body),
+                message.Body.Copy(),
                 exception,
                 delayedRetryAttempt));
-        }
-
-        static byte[] CopyOfBody(byte[] body)
-        {
-            if (body == null)
-            {
-                return null;
-            }
-
-            var copyBody = new byte[body.Length];
-
-            Buffer.BlockCopy(body, 0, copyBody, 0, body.Length);
-
-            return copyBody;
         }
     }
 }

--- a/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/ErrorsNotifications.cs
@@ -9,47 +9,59 @@ namespace NServiceBus.Faults
     /// </summary>
     public class ErrorsNotifications
     {
-        ///// <summary>
-        ///// Notification when a message is moved to the error queue.
-        ///// </summary>
-        //public event EventHandler<FailedMessage> MessageSentToErrorQueue;
+        /// <summary>
+        /// Notification when a message is moved to the error queue.
+        /// </summary>
+        [ObsoleteEx(
+            Message = "The .NET event based error notifications will be deprecated in favor of Task-based callbacks. Use endpointConfiguration.Recoverability().Failed(settings => settings.OnMessageSentToErrorQueue(callback)) instead.",
+            RemoveInVersion = "9.0", 
+            TreatAsErrorFromVersion = "8.0")]
+        public event EventHandler<FailedMessage> MessageSentToErrorQueue;
 
-        ///// <summary>
-        ///// Notification when a message fails a immediate retry.
-        ///// </summary>
-        //public event EventHandler<ImmediateRetryMessage> MessageHasFailedAnImmediateRetryAttempt;
+        /// <summary>
+        /// Notification when a message fails a immediate retry.
+        /// </summary>
+        [ObsoleteEx(
+            Message = "The .NET event based error notifications will be deprecated in favor of Task-based callbacks. Use endpointConfiguration.Recoverability().Immediate(settings => settings.OnMessageBeingRetried(callback)) instead.",
+            RemoveInVersion = "9.0",
+            TreatAsErrorFromVersion = "8.0")]
+        public event EventHandler<ImmediateRetryMessage> MessageHasFailedAnImmediateRetryAttempt;
 
-        ///// <summary>
-        ///// Notification when a message is sent to Delayed Retries queue.
-        ///// </summary>
-        //public event EventHandler<DelayedRetryMessage> MessageHasBeenSentToDelayedRetries;
+        /// <summary>
+        /// Notification when a message is sent to Delayed Retries queue.
+        /// </summary>
+        [ObsoleteEx(
+            Message = "The .NET event based error notifications will be deprecated in favor of Task-based callbacks. Use endpointConfiguration.Recoverability().Delayed(settings => settings.OnMessageBeingRetried(callback)) instead.",
+            RemoveInVersion = "9.0",
+            TreatAsErrorFromVersion = "8.0")]
+        public event EventHandler<DelayedRetryMessage> MessageHasBeenSentToDelayedRetries;
 
         internal void InvokeMessageHasBeenSentToErrorQueue(IncomingMessage message, Exception exception, string errorQueue)
         {
-            //MessageSentToErrorQueue?.Invoke(this, new FailedMessage(
-            //    message.MessageId,
-            //    new Dictionary<string, string>(message.Headers),
-            //    CopyOfBody(message.Body), exception, errorQueue));
+            MessageSentToErrorQueue?.Invoke(this, new FailedMessage(
+                message.MessageId,
+                new Dictionary<string, string>(message.Headers),
+                CopyOfBody(message.Body), exception, errorQueue));
         }
 
         internal void InvokeMessageHasFailedAnImmediateRetryAttempt(int immediateRetryAttempt, IncomingMessage message, Exception exception)
         {
-            //MessageHasFailedAnImmediateRetryAttempt?.Invoke(this, new ImmediateRetryMessage(
-            //    message.MessageId,
-            //    new Dictionary<string, string>(message.Headers),
-            //    CopyOfBody(message.Body),
-            //    exception,
-            //    immediateRetryAttempt));
+            MessageHasFailedAnImmediateRetryAttempt?.Invoke(this, new ImmediateRetryMessage(
+                message.MessageId,
+                new Dictionary<string, string>(message.Headers),
+                CopyOfBody(message.Body),
+                exception,
+                immediateRetryAttempt));
         }
 
         internal void InvokeMessageHasBeenSentToDelayedRetries(int delayedRetryAttempt, IncomingMessage message, Exception exception)
         {
-            //MessageHasBeenSentToDelayedRetries?.Invoke(this, new DelayedRetryMessage(
-            //    message.MessageId,
-            //    new Dictionary<string, string>(message.Headers),
-            //    CopyOfBody(message.Body),
-            //    exception,
-            //    delayedRetryAttempt));
+            MessageHasBeenSentToDelayedRetries?.Invoke(this, new DelayedRetryMessage(
+                message.MessageId,
+                new Dictionary<string, string>(message.Headers),
+                CopyOfBody(message.Body),
+                exception,
+                delayedRetryAttempt));
         }
 
         static byte[] CopyOfBody(byte[] body)

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityMessageUtilities.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityMessageUtilities.cs
@@ -1,0 +1,21 @@
+﻿namespace NServiceBus
+{
+    using System;
+
+    static class RecoverabilityExtensions
+    {
+        public static byte[] Copy(this byte[] body)
+        {
+            if (body == null)
+            {
+                return null;
+            }
+
+            var copyBody = new byte[body.Length];
+
+            Buffer.BlockCopy(body, 0, copyBody, 0, body.Length);
+
+            return copyBody;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Recoverability/Settings/DelayedRetriesSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/DelayedRetriesSettings.cs
@@ -41,12 +41,13 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// 
+        /// Registers a callback which is invoked when a message fails processing and will be retried after a delay.
         /// </summary>
         public DelayedRetriesSettings OnMessageBeingRetried(Func<DelayedRetryMessage, Task> notificationCallback)
         {
-            var subscriptions = Settings.Get<NotificationSubscriptions>();
+            Guard.AgainstNull(nameof(notificationCallback), notificationCallback);
 
+            var subscriptions = Settings.Get<NotificationSubscriptions>();
             subscriptions.Subscribe<MessageToBeRetried>(retry =>
             {
                 if (retry.IsImmediateRetry)
@@ -61,6 +62,5 @@ namespace NServiceBus
 
             return this;
         }
-
     }
 }

--- a/src/NServiceBus.Core/Recoverability/Settings/DelayedRetriesSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/DelayedRetriesSettings.cs
@@ -43,6 +43,20 @@ namespace NServiceBus
         /// <summary>
         /// Registers a callback which is invoked when a message fails processing and will be retried after a delay.
         /// </summary>
+        public DelayedRetriesSettings OnMessageBeingRetried(Action<DelayedRetryMessage> notificationCallback)
+        {
+            Guard.AgainstNull(nameof(notificationCallback), notificationCallback);
+
+            return OnMessageBeingRetried(x =>
+            {
+                notificationCallback(x);
+                return TaskEx.CompletedTask;
+            });
+        }
+
+        /// <summary>
+        /// Registers a callback which is invoked when a message fails processing and will be retried after a delay.
+        /// </summary>
         public DelayedRetriesSettings OnMessageBeingRetried(Func<DelayedRetryMessage, Task> notificationCallback)
         {
             Guard.AgainstNull(nameof(notificationCallback), notificationCallback);

--- a/src/NServiceBus.Core/Recoverability/Settings/DelayedRetriesSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/DelayedRetriesSettings.cs
@@ -55,25 +55,11 @@ namespace NServiceBus
                 }
 
                 var headerCopy = new Dictionary<string, string>(retry.Message.Headers);
-                var bodyCopy = CopyOfBody(retry.Message.Body);
+                var bodyCopy = retry.Message.Body.Copy();
                 return notificationCallback(new DelayedRetryMessage(retry.Message.MessageId, headerCopy, bodyCopy, retry.Exception, retry.Attempt));
             });
 
             return this;
-
-            byte[] CopyOfBody(byte[] body)
-            {
-                if (body == null)
-                {
-                    return null;
-                }
-
-                var copyBody = new byte[body.Length];
-
-                Buffer.BlockCopy(body, 0, copyBody, 0, body.Length);
-
-                return copyBody;
-            }
         }
 
     }

--- a/src/NServiceBus.Core/Recoverability/Settings/DelayedRetriesSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/DelayedRetriesSettings.cs
@@ -43,20 +43,6 @@ namespace NServiceBus
         /// <summary>
         /// Registers a callback which is invoked when a message fails processing and will be retried after a delay.
         /// </summary>
-        public DelayedRetriesSettings OnMessageBeingRetried(Action<DelayedRetryMessage> notificationCallback)
-        {
-            Guard.AgainstNull(nameof(notificationCallback), notificationCallback);
-
-            return OnMessageBeingRetried(x =>
-            {
-                notificationCallback(x);
-                return TaskEx.CompletedTask;
-            });
-        }
-
-        /// <summary>
-        /// Registers a callback which is invoked when a message fails processing and will be retried after a delay.
-        /// </summary>
         public DelayedRetriesSettings OnMessageBeingRetried(Func<DelayedRetryMessage, Task> notificationCallback)
         {
             Guard.AgainstNull(nameof(notificationCallback), notificationCallback);

--- a/src/NServiceBus.Core/Recoverability/Settings/ImmediateRetriesSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/ImmediateRetriesSettings.cs
@@ -31,20 +31,6 @@ namespace NServiceBus
         /// <summary>
         /// Registers a callback which is invoked when a message fails processing and will be immediately retried.
         /// </summary>
-        public ImmediateRetriesSettings OnMessageBeingRetried(Action<ImmediateRetryMessage> notificationCallback)
-        {
-            Guard.AgainstNull(nameof(notificationCallback), notificationCallback);
-
-            return OnMessageBeingRetried(x =>
-            {
-                notificationCallback(x);
-                return TaskEx.CompletedTask;
-            });
-        }
-
-        /// <summary>
-        /// Registers a callback which is invoked when a message fails processing and will be immediately retried.
-        /// </summary>
         public ImmediateRetriesSettings OnMessageBeingRetried(Func<ImmediateRetryMessage, Task> notificationCallback)
         {
             Guard.AgainstNull(nameof(notificationCallback), notificationCallback);

--- a/src/NServiceBus.Core/Recoverability/Settings/ImmediateRetriesSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/ImmediateRetriesSettings.cs
@@ -29,12 +29,13 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// 
+        /// Registers a callback which is invoked when a message fails processing and will be immediately retried.
         /// </summary>
         public ImmediateRetriesSettings OnMessageBeingRetried(Func<ImmediateRetryMessage, Task> notificationCallback)
         {
-            var subscriptions = Settings.Get<NotificationSubscriptions>();
+            Guard.AgainstNull(nameof(notificationCallback), notificationCallback);
 
+            var subscriptions = Settings.Get<NotificationSubscriptions>();
             subscriptions.Subscribe<MessageToBeRetried>(retry =>
             {
                 if (!retry.IsImmediateRetry)

--- a/src/NServiceBus.Core/Recoverability/Settings/ImmediateRetriesSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/ImmediateRetriesSettings.cs
@@ -43,25 +43,11 @@ namespace NServiceBus
                 }
 
                 var headerCopy = new Dictionary<string, string>(retry.Message.Headers);
-                var bodyCopy = CopyOfBody(retry.Message.Body);
+                var bodyCopy = retry.Message.Body.Copy();
                 return notificationCallback(new ImmediateRetryMessage(retry.Message.MessageId, headerCopy, bodyCopy, retry.Exception, retry.Attempt));
             });
 
             return this;
-
-            byte[] CopyOfBody(byte[] body)
-            {
-                if (body == null)
-                {
-                    return null;
-                }
-
-                var copyBody = new byte[body.Length];
-
-                Buffer.BlockCopy(body, 0, copyBody, 0, body.Length);
-
-                return copyBody;
-            }
         }
     }
 }

--- a/src/NServiceBus.Core/Recoverability/Settings/ImmediateRetriesSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/ImmediateRetriesSettings.cs
@@ -31,6 +31,20 @@ namespace NServiceBus
         /// <summary>
         /// Registers a callback which is invoked when a message fails processing and will be immediately retried.
         /// </summary>
+        public ImmediateRetriesSettings OnMessageBeingRetried(Action<ImmediateRetryMessage> notificationCallback)
+        {
+            Guard.AgainstNull(nameof(notificationCallback), notificationCallback);
+
+            return OnMessageBeingRetried(x =>
+            {
+                notificationCallback(x);
+                return TaskEx.CompletedTask;
+            });
+        }
+
+        /// <summary>
+        /// Registers a callback which is invoked when a message fails processing and will be immediately retried.
+        /// </summary>
         public ImmediateRetriesSettings OnMessageBeingRetried(Func<ImmediateRetryMessage, Task> notificationCallback)
         {
             Guard.AgainstNull(nameof(notificationCallback), notificationCallback);

--- a/src/NServiceBus.Core/Recoverability/Settings/RetryFailedSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/RetryFailedSettings.cs
@@ -32,20 +32,6 @@ namespace NServiceBus
         /// <summary>
         /// Registers a callback when a message fails processing and will be moved to the error queue.
         /// </summary>
-        public RetryFailedSettings OnMessageSentToErrorQueue(Action<FailedMessage> notificationCallback)
-        {
-            Guard.AgainstNull(nameof(notificationCallback), notificationCallback);
-
-            return OnMessageSentToErrorQueue(x =>
-            {
-                notificationCallback(x);
-                return TaskEx.CompletedTask;
-            });
-        }
-
-        /// <summary>
-        /// Registers a callback when a message fails processing and will be moved to the error queue.
-        /// </summary>
         public RetryFailedSettings OnMessageSentToErrorQueue(Func<FailedMessage, Task> notificationCallback)
         {
             Guard.AgainstNull(nameof(notificationCallback), notificationCallback);

--- a/src/NServiceBus.Core/Recoverability/Settings/RetryFailedSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/RetryFailedSettings.cs
@@ -30,12 +30,13 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// 
+        /// Registers a callback when a message fails processing and will be moved to the error queue.
         /// </summary>
         public RetryFailedSettings OnMessageSentToErrorQueue(Func<FailedMessage, Task> notificationCallback)
         {
-            var subscriptions = Settings.Get<NotificationSubscriptions>();
+            Guard.AgainstNull(nameof(notificationCallback), notificationCallback);
 
+            var subscriptions = Settings.Get<NotificationSubscriptions>();
             subscriptions.Subscribe<MessageFaulted>(faulted =>
             {
                 var headerCopy = new Dictionary<string, string>(faulted.Message.Headers);

--- a/src/NServiceBus.Core/Recoverability/Settings/RetryFailedSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/RetryFailedSettings.cs
@@ -32,6 +32,20 @@ namespace NServiceBus
         /// <summary>
         /// Registers a callback when a message fails processing and will be moved to the error queue.
         /// </summary>
+        public RetryFailedSettings OnMessageSentToErrorQueue(Action<FailedMessage> notificationCallback)
+        {
+            Guard.AgainstNull(nameof(notificationCallback), notificationCallback);
+
+            return OnMessageSentToErrorQueue(x =>
+            {
+                notificationCallback(x);
+                return TaskEx.CompletedTask;
+            });
+        }
+
+        /// <summary>
+        /// Registers a callback when a message fails processing and will be moved to the error queue.
+        /// </summary>
         public RetryFailedSettings OnMessageSentToErrorQueue(Func<FailedMessage, Task> notificationCallback)
         {
             Guard.AgainstNull(nameof(notificationCallback), notificationCallback);

--- a/src/NServiceBus.Core/Recoverability/Settings/RetryFailedSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/RetryFailedSettings.cs
@@ -2,7 +2,9 @@ namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using Configuration.AdvancedExtensibility;
+    using Faults;
     using Settings;
 
     /// <summary>
@@ -25,6 +27,37 @@ namespace NServiceBus
             Settings.Set(RecoverabilityComponent.FaultHeaderCustomization, customization);
 
             return this;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public RetryFailedSettings OnMessageSentToErrorQueue(Func<FailedMessage, Task> notificationCallback)
+        {
+            var subscriptions = Settings.Get<NotificationSubscriptions>();
+
+            subscriptions.Subscribe<MessageFaulted>(faulted =>
+            {
+                var headerCopy = new Dictionary<string, string>(faulted.Message.Headers);
+                var bodyCopy = CopyOfBody(faulted.Message.Body);
+                return notificationCallback(new FailedMessage(faulted.Message.MessageId, headerCopy, bodyCopy, faulted.Exception, faulted.ErrorQueue));
+            });
+
+            return this;
+
+            byte[] CopyOfBody(byte[] body)
+            {
+                if (body == null)
+                {
+                    return null;
+                }
+
+                var copyBody = new byte[body.Length];
+
+                Buffer.BlockCopy(body, 0, copyBody, 0, body.Length);
+
+                return copyBody;
+            }
         }
     }
 }

--- a/src/NServiceBus.Core/Recoverability/Settings/RetryFailedSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/RetryFailedSettings.cs
@@ -39,25 +39,11 @@ namespace NServiceBus
             subscriptions.Subscribe<MessageFaulted>(faulted =>
             {
                 var headerCopy = new Dictionary<string, string>(faulted.Message.Headers);
-                var bodyCopy = CopyOfBody(faulted.Message.Body);
+                var bodyCopy = faulted.Message.Body.Copy();
                 return notificationCallback(new FailedMessage(faulted.Message.MessageId, headerCopy, bodyCopy, faulted.Exception, faulted.ErrorQueue));
             });
 
             return this;
-
-            byte[] CopyOfBody(byte[] body)
-            {
-                if (body == null)
-                {
-                    return null;
-                }
-
-                var copyBody = new byte[body.Length];
-
-                Buffer.BlockCopy(body, 0, copyBody, 0, body.Length);
-
-                return copyBody;
-            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus/issues/5393

Provides a new notification API which is based on the internal notifications infrastructure which can support async notification subscribers.

The new APIs have been moved to the corresponding recoverability configuration settings and I've tried to give them more accurate and meaningful names.