### PR TITLE
Give user defined licenses precedence

### DIFF
--- a/src/NServiceBus.Core/Licensing/ConfigureLicenseExtensions.cs
+++ b/src/NServiceBus.Core/Licensing/ConfigureLicenseExtensions.cs
@@ -12,6 +12,7 @@ namespace NServiceBus
         /// </summary>
         /// <param name="config">The <see cref="EndpointConfiguration" /> instance to apply the settings to.</param>
         /// <param name="licenseText">The license text.</param>
+        /// <remarks>The license provided via code-first API takes precedence over other license sources.</remarks>
         public static void License(this EndpointConfiguration config, string licenseText)
         {
             Guard.AgainstNullAndEmpty(nameof(licenseText), licenseText);
@@ -25,6 +26,7 @@ namespace NServiceBus
         /// </summary>
         /// <param name="config">The <see cref="EndpointConfiguration" /> instance to apply the settings to.</param>
         /// <param name="licenseFile">A relative or absolute path to the license file.</param>
+        /// <remarks>The license provided via code-first API takes precedence over other license sources.</remarks>
         public static void LicensePath(this EndpointConfiguration config, string licenseFile)
         {
             Guard.AgainstNull(nameof(config), config);

--- a/src/NServiceBus.Core/Licensing/LicenseSources.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseSources.cs
@@ -19,14 +19,17 @@ namespace NServiceBus
                 sources.Add(new LicenseSourceFilePath(licenseFilePath));
             }
 
-            var standardSources = LicenseSource.GetStandardLicenseSources();
+            if (licenseText == null && licenseFilePath == null)
+            {
+                var standardSources = LicenseSource.GetStandardLicenseSources();
 
-            sources.AddRange(standardSources);
+                sources.AddRange(standardSources);
 
 #if APPCONFIGLICENSESOURCE
-            sources.Add(new LicenseSourceAppConfigLicenseSetting());
-            sources.Add(new LicenseSourceAppConfigLicensePathSetting());
+                sources.Add(new LicenseSourceAppConfigLicenseSetting());
+                sources.Add(new LicenseSourceAppConfigLicensePathSetting());
 #endif
+            }
 
             return sources.ToArray();
         }


### PR DESCRIPTION
When a user configures a license via `EndpointConfiguration.License(...)` or `EndpointConfiguration.LicensePath(...)`, we still check all the default license sources (directory folders) as well and there is the possibility that a valid license from those locations is taken if the user-provided license isn't valid anymore.

This behavior causes problems with the `When_license_expired` acceptance test on developer machines when the local machine has a valid license in the directories, the test can't be configured to not have a valid license even though there is a specific license configured using `EndpointConfiguration.License(...)`.

Not 100% sure about this change, but it feels like user-configured licenses should take precedence over the default sources and if a user configures a value explicitly, the default sources should not be checked at all.

Thoughts?