### PR TITLE
Fix DisablePublishing

### DIFF
--- a/src/NServiceBus.AcceptanceTests/ConfigureEndpointLearningPersistence.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureEndpointLearningPersistence.cs
@@ -7,6 +7,17 @@ using NUnit.Framework;
 
 public class ConfigureEndpointLearningPersistence : IConfigureEndpointTestExecution
 {
+    bool useInMemoryPersistenceForSubscriptionAndTimeoutSupport;
+
+    public ConfigureEndpointLearningPersistence() : this(true)
+    {
+    }
+
+    public ConfigureEndpointLearningPersistence(bool useInMemoryPersistenceForSubscriptionAndTimeoutSupport)
+    {
+        this.useInMemoryPersistenceForSubscriptionAndTimeoutSupport = useInMemoryPersistenceForSubscriptionAndTimeoutSupport;
+    }
+
     public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings, PublisherMetadata publisherMetadata)
     {
         var testRunId = TestContext.CurrentContext.Test.ID;
@@ -25,8 +36,11 @@ public class ConfigureEndpointLearningPersistence : IConfigureEndpointTestExecut
 
         storageDir = Path.Combine(tempDir, testRunId);
 
-        configuration.UsePersistence<InMemoryPersistence, StorageType.Subscriptions>();
-        configuration.UsePersistence<InMemoryPersistence, StorageType.Timeouts>();
+        if (useInMemoryPersistenceForSubscriptionAndTimeoutSupport)
+        {
+            configuration.UsePersistence<InMemoryPersistence, StorageType.Subscriptions>();
+            configuration.UsePersistence<InMemoryPersistence, StorageType.Timeouts>();
+        }
 
         configuration.UsePersistence<LearningPersistence, StorageType.Sagas>()
             .SagaStorageDirectory(storageDir);


### PR DESCRIPTION
The `SubscriptionReceiverBehavior` has a dependency on the subscription storage as it's responsbile for storing incoming subscription messages into the database. This throws an exception as on endpoints with publishing disabled and no subscription storage, the container is unable to build this behavior. This behavior only makes sense to do when publishing is enabled, as the subscription storage is only queried when publishing events.

When there is no `SubscriptionReceiverBehavior` registered, incoming subscription messages will just be discarded later in the pipeline.

This wasn't discovered by the acceptance tests, as those always register a subscription storage by default and therefore the behavior could be resolved from the container. I've made the learning persister configuration for acceptance tests configurable so that this default behavior can be changed and with the changes introduced earlier this week, the test can now be configured to run with a very specific transport+persistence configuration easily.