### PR TITLE
Cleanup persister use in tests

### DIFF
--- a/src/NServiceBus.AcceptanceTests/ConfigureEndpointLearningPersistence.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureEndpointLearningPersistence.cs
@@ -7,17 +7,6 @@ using NUnit.Framework;
 
 public class ConfigureEndpointLearningPersistence : IConfigureEndpointTestExecution
 {
-    bool useInMemoryPersistenceForSubscriptionAndTimeoutSupport;
-
-    public ConfigureEndpointLearningPersistence() : this(true)
-    {
-    }
-
-    public ConfigureEndpointLearningPersistence(bool useInMemoryPersistenceForSubscriptionAndTimeoutSupport)
-    {
-        this.useInMemoryPersistenceForSubscriptionAndTimeoutSupport = useInMemoryPersistenceForSubscriptionAndTimeoutSupport;
-    }
-
     public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings, PublisherMetadata publisherMetadata)
     {
         var testRunId = TestContext.CurrentContext.Test.ID;
@@ -35,12 +24,6 @@ public class ConfigureEndpointLearningPersistence : IConfigureEndpointTestExecut
         }
 
         storageDir = Path.Combine(tempDir, testRunId);
-
-        if (useInMemoryPersistenceForSubscriptionAndTimeoutSupport)
-        {
-            configuration.UsePersistence<InMemoryPersistence, StorageType.Subscriptions>();
-            configuration.UsePersistence<InMemoryPersistence, StorageType.Timeouts>();
-        }
 
         configuration.UsePersistence<LearningPersistence, StorageType.Sagas>()
             .SagaStorageDirectory(storageDir);

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
@@ -4,7 +4,7 @@
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using NServiceBus.DelayedDelivery;
-    using NServiceBus.Extensibility;
+    using Extensibility;
     using NServiceBus.Routing;
     using Settings;
     using Transport;

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -31,7 +31,12 @@
         {
             public ThrottledEndpoint()
             {
-                EndpointSetup<DefaultServer>(c => c.UseTransport<FakeTransport>());
+                var template = new DefaultServer
+                {
+                    PersistenceConfiguration = new ConfigureEndpointInMemoryPersistence()
+                };
+
+                EndpointSetup(template, (endpointConfiguration, _) => endpointConfiguration.UseTransport<FakeTransport>());
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -31,7 +31,10 @@
         {
             public ThrottledEndpoint()
             {
-                EndpointSetup<DefaultServer>(c => c.UseTransport<FakeTransport>());
+                EndpointSetup<DefaultServer>(c => {
+                    c.UseTransport<FakeTransport>();
+                    c.UsePersistence<InMemoryPersistence>();
+                });
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -49,7 +49,7 @@
             {
                 // The LimitMessageProcessingConcurrencyTo setting only applies to the input queue
                 if (pushSettings.InputQueue == Conventions.EndpointNamingConvention(typeof(ThrottledEndpoint)))
-                {   
+                {
                     Assert.AreEqual(10, limitations.MaxConcurrency);
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -31,10 +31,7 @@
         {
             public ThrottledEndpoint()
             {
-                EndpointSetup<DefaultServer>(c => {
-                    c.UseTransport<FakeTransport>();
-                    c.UsePersistence<InMemoryPersistence>();
-                });
+                EndpointSetup<DefaultServer>(c => c.UseTransport<FakeTransport>());
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
@@ -52,8 +52,6 @@
             {
                 var template = new DefaultServer();
                 template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
-                // use a persistence which doesn't support subscription persistence
-                template.PersistenceConfiguration = new ConfigureEndpointLearningPersistence(false);
 
                 EndpointSetup(template,
                     // DisablePublishing API is only available on the message-driven pub/sub transport settings.
@@ -84,8 +82,6 @@
             {
                 var template = new DefaultServer();
                 template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
-                // publisher requires a subscription storage
-                template.PersistenceConfiguration = new ConfigureEndpointLearningPersistence(true);
 
                 EndpointSetup(template, (endpoint, _) => endpoint.OnEndpointSubscribed<Context>((args, context) =>
                 {

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
@@ -86,13 +86,12 @@
                 };
 
                 EndpointSetup(template, (c, _) => c.OnEndpointSubscribed<Context>((args, context) =>
-                     {
-                         if (args.MessageType.Contains(typeof(TestEvent).FullName))
-                         {
-                             context.ReceivedSubscription = true;
-                         }
-                     })
-                );
+                {
+                    if (args.MessageType.Contains(typeof(TestEvent).FullName))
+                    {
+                        context.ReceivedSubscription = true;
+                    }
+                }));
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
@@ -50,10 +50,8 @@
         {
             public EndpointWithDisabledPublishing()
             {
-                var template = new DefaultServer
-                {
-                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true)
-                };
+                var template = new DefaultServer();
+                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
 
                 EndpointSetup(template,
                     // DisablePublishing API is only available on the message-driven pub/sub transport settings.
@@ -82,10 +80,8 @@
         {
             public PublishingEndpoint()
             {
-                var template = new DefaultServer
-                {
-                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true)
-                };
+                var template = new DefaultServer();
+                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
 
                 EndpointSetup(template, (c, _) => c.OnEndpointSubscribed<Context>((args, context) =>
                      {

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
@@ -50,8 +50,10 @@
         {
             public EndpointWithDisabledPublishing()
             {
-                var template = new DefaultServer();
-                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
+                var template = new DefaultServer
+                {
+                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true)
+                };
 
                 EndpointSetup(template,
                     // DisablePublishing API is only available on the message-driven pub/sub transport settings.
@@ -82,8 +84,7 @@
             {
                 var template = new DefaultServer
                 {
-                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true),
-                    PersistenceConfiguration = new ConfigureEndpointInMemoryPersistence()
+                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true)
                 };
 
                 EndpointSetup(template, (c, _) => c.OnEndpointSubscribed<Context>((args, context) =>

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
@@ -52,7 +52,6 @@
             {
                 var template = new DefaultServer();
                 template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
-
                 EndpointSetup(template,
                     // DisablePublishing API is only available on the message-driven pub/sub transport settings.
                     (c, _) => c.GetSettings().Set("NServiceBus.PublishSubscribe.EnablePublishing", false),
@@ -82,7 +81,6 @@
             {
                 var template = new DefaultServer();
                 template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
-
                 EndpointSetup(template, (c, _) => c.OnEndpointSubscribed<Context>((args, context) =>
                      {
                          if (args.MessageType.Contains(typeof(TestEvent).FullName))

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
@@ -80,20 +80,20 @@
         {
             public PublishingEndpoint()
             {
-                var template = new DefaultServer();
-                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
-
-                EndpointSetup(template, (c, _) =>
+                var template = new DefaultServer
                 {
-                    c.OnEndpointSubscribed<Context>((args, context) =>
-                    {
-                        if (args.MessageType.Contains(typeof(TestEvent).FullName))
-                        {
-                            context.ReceivedSubscription = true;
-                        }
-                    });
-                    c.UsePersistence<InMemoryPersistence, StorageType.Subscriptions>();
-                });
+                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true),
+                    PersistenceConfiguration = new ConfigureEndpointInMemoryPersistence()
+                };
+
+                EndpointSetup(template, (c, _) => c.OnEndpointSubscribed<Context>((args, context) =>
+                     {
+                         if (args.MessageType.Contains(typeof(TestEvent).FullName))
+                         {
+                             context.ReceivedSubscription = true;
+                         }
+                     })
+                );
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
@@ -55,10 +55,7 @@
 
                 EndpointSetup(template,
                     // DisablePublishing API is only available on the message-driven pub/sub transport settings.
-                    (c, _) => {
-                        c.GetSettings().Set("NServiceBus.PublishSubscribe.EnablePublishing", false);
-                        c.UsePersistence<InMemoryPersistence, StorageType.Subscriptions>();
-                    },
+                    (c, _) => c.GetSettings().Set("NServiceBus.PublishSubscribe.EnablePublishing", false),
                     pm => pm.RegisterPublisherFor<TestEvent>(typeof(PublishingEndpoint)));
             }
 

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
@@ -37,7 +37,6 @@
             {
                 var template = new DefaultServer();
                 template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(true, true);
-
                 EndpointSetup(template, (configuration, _) => configuration.SendOnly());
             }
         }
@@ -48,7 +47,6 @@
             {
                 var template = new DefaultServer();
                 template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
-
                 EndpointSetup(template, (configuration, _) => configuration.SendOnly());
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
@@ -45,8 +45,12 @@
         {
             public MessageDrivenPubSubSendOnlyEndpoint()
             {
-                var template = new DefaultServer();
-                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
+                var template = new DefaultServer
+                {
+                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true),
+                    PersistenceConfiguration = new ConfigureEndpointInMemoryPersistence()
+                };
+
                 EndpointSetup(template, (configuration, _) => configuration.SendOnly());
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
@@ -45,11 +45,8 @@
         {
             public MessageDrivenPubSubSendOnlyEndpoint()
             {
-                var template = new DefaultServer
-                {
-                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true),
-                    PersistenceConfiguration = new ConfigureEndpointInMemoryPersistence()
-                };
+                var template = new DefaultServer();
+                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
                 EndpointSetup(template, (configuration, _) => configuration.SendOnly());
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
@@ -35,10 +35,8 @@
         {
             public NativePubSubSendOnlyEndpoint()
             {
-                var template = new DefaultServer
-                {
-                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(true, true)
-                };
+                var template = new DefaultServer();
+                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(true, true);
 
                 EndpointSetup(template, (configuration, _) => configuration.SendOnly());
             }
@@ -48,10 +46,8 @@
         {
             public MessageDrivenPubSubSendOnlyEndpoint()
             {
-                var template = new DefaultServer
-                {
-                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true)
-                };
+                var template = new DefaultServer();
+                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
 
                 EndpointSetup(template, (configuration, _) => configuration.SendOnly());
             }

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
@@ -35,8 +35,11 @@
         {
             public NativePubSubSendOnlyEndpoint()
             {
-                var template = new DefaultServer();
-                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(true, true);
+                var template = new DefaultServer
+                {
+                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(true, true)
+                };
+
                 EndpointSetup(template, (configuration, _) => configuration.SendOnly());
             }
         }
@@ -45,12 +48,13 @@
         {
             public MessageDrivenPubSubSendOnlyEndpoint()
             {
-                var template = new DefaultServer();
-                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
-                EndpointSetup(template, (configuration, _) => {
-                    configuration.SendOnly();
-                    configuration.UsePersistence<InMemoryPersistence, StorageType.Subscriptions>();
-                });
+                var template = new DefaultServer
+                {
+                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true),
+                    PersistenceConfiguration = new ConfigureEndpointInMemoryPersistence()
+                };
+
+                EndpointSetup(template, (configuration, _) => configuration.SendOnly());
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
@@ -50,8 +50,7 @@
             {
                 var template = new DefaultServer
                 {
-                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true),
-                    PersistenceConfiguration = new ConfigureEndpointInMemoryPersistence()
+                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true)
                 };
 
                 EndpointSetup(template, (configuration, _) => configuration.SendOnly());

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
@@ -47,7 +47,10 @@
             {
                 var template = new DefaultServer();
                 template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
-                EndpointSetup(template, (configuration, _) => configuration.SendOnly());
+                EndpointSetup(template, (configuration, _) => {
+                    configuration.SendOnly();
+                    configuration.UsePersistence<InMemoryPersistence, StorageType.Subscriptions>();
+                });
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_subscribing_on_send_only_endpoint.cs
@@ -45,8 +45,11 @@
         {
             public MessageDrivenPubSubSendOnlyEndpoint()
             {
-                var template = new DefaultServer();
-                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
+                var template = new DefaultServer
+                {
+                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true),
+                    PersistenceConfiguration = new ConfigureEndpointInMemoryPersistence()
+                };
                 EndpointSetup(template, (configuration, _) => configuration.SendOnly());
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_unsubscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_unsubscribing_on_send_only_endpoint.cs
@@ -35,11 +35,8 @@
         {
             public NativePubSubSendOnlyEndpoint()
             {
-                var template = new DefaultServer
-                {
-                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(true, true)
-                };
-
+                var template = new DefaultServer();
+                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(true, true);
                 EndpointSetup(template, (configuration, _) => configuration.SendOnly());
             }
         }
@@ -48,11 +45,8 @@
         {
             public MessageDrivenPubSubSendOnlyEndpoint()
             {
-                var template = new DefaultServer
-                {
-                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true)
-                };
-
+                var template = new DefaultServer();
+                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
                 EndpointSetup(template, (configuration, _) => configuration.SendOnly());
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_unsubscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_unsubscribing_on_send_only_endpoint.cs
@@ -45,8 +45,12 @@
         {
             public MessageDrivenPubSubSendOnlyEndpoint()
             {
-                var template = new DefaultServer();
-                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
+                var template = new DefaultServer
+                {
+                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true),
+                    PersistenceConfiguration = new ConfigureEndpointInMemoryPersistence()
+                };
+
                 EndpointSetup(template, (configuration, _) => configuration.SendOnly());
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_unsubscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_unsubscribing_on_send_only_endpoint.cs
@@ -35,8 +35,11 @@
         {
             public NativePubSubSendOnlyEndpoint()
             {
-                var template = new DefaultServer();
-                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(true, true);
+                var template = new DefaultServer
+                {
+                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(true, true)
+                };
+
                 EndpointSetup(template, (configuration, _) => configuration.SendOnly());
             }
         }
@@ -45,12 +48,13 @@
         {
             public MessageDrivenPubSubSendOnlyEndpoint()
             {
-                var template = new DefaultServer();
-                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
-                EndpointSetup(template, (configuration, _) => {
-                    configuration.SendOnly();
-                    configuration.UsePersistence<InMemoryPersistence, StorageType.Subscriptions>();
-                });
+                var template = new DefaultServer
+                {
+                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true),
+                    PersistenceConfiguration = new ConfigureEndpointInMemoryPersistence()
+                };
+
+                EndpointSetup(template, (configuration, _) => configuration.SendOnly());
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_unsubscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_unsubscribing_on_send_only_endpoint.cs
@@ -50,8 +50,7 @@
             {
                 var template = new DefaultServer
                 {
-                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true),
-                    PersistenceConfiguration = new ConfigureEndpointInMemoryPersistence()
+                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true)
                 };
 
                 EndpointSetup(template, (configuration, _) => configuration.SendOnly());

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_unsubscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_unsubscribing_on_send_only_endpoint.cs
@@ -47,7 +47,10 @@
             {
                 var template = new DefaultServer();
                 template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
-                EndpointSetup(template, (configuration, _) => configuration.SendOnly());
+                EndpointSetup(template, (configuration, _) => {
+                    configuration.SendOnly();
+                    configuration.UsePersistence<InMemoryPersistence, StorageType.Subscriptions>();
+                });
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_unsubscribing_on_send_only_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_unsubscribing_on_send_only_endpoint.cs
@@ -45,12 +45,8 @@
         {
             public MessageDrivenPubSubSendOnlyEndpoint()
             {
-                var template = new DefaultServer
-                {
-                    TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true),
-                    PersistenceConfiguration = new ConfigureEndpointInMemoryPersistence()
-                };
-
+                var template = new DefaultServer();
+                template.TransportConfiguration = new ConfigureEndpointAcceptanceTestingTransport(false, true);
                 EndpointSetup(template, (configuration, _) => configuration.SendOnly());
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_initializing_transport.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_initializing_transport.cs
@@ -21,6 +21,7 @@
             CollectionAssert.AreEqual(new List<string>
             {
                 $"{nameof(TransportDefinition)}.{nameof(TransportDefinition.Initialize)}",
+                $"{nameof(TransportInfrastructure)}.{nameof(TransportInfrastructure.ConfigureSubscriptionInfrastructure)}",
                 $"{nameof(TransportInfrastructure)}.{nameof(TransportInfrastructure.ConfigureReceiveInfrastructure)}",
                 $"{nameof(ICreateQueues)}.{nameof(ICreateQueues.CreateQueueIfNecessary)}",
                 $"{nameof(TransportReceiveInfrastructure)}.PreStartupCheck",


### PR DESCRIPTION
https://github.com/Particular/NServiceBus/pull/5455 made me look into why we would need storage configured for tests that run with a fully capable transport. Turned out that we only needed it for some test using the `FakeTransport`, I made it "support" native pubsub and timeouts so all tests are now green with the added bonus that we assert that `ConfigureSubscriptionInfrastructure` is called in the correct startup order