### PR TITLE
Avoid exceptions when key already exists

### DIFF
--- a/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs
@@ -26,10 +26,10 @@
             }
             catch (Exception e)
             {
-                e.Data.Add("Message type", context.MessageMetadata.MessageType.FullName);
-                e.Data.Add("Handler type", context.MessageHandler.HandlerType);
-                e.Data.Add("Handler start time", startTimestamp);
-                e.Data.Add("Handler failure time", DateTime.UtcNow);
+                e.Data["Message type"] = context.MessageMetadata.MessageType.FullName;
+                e.Data["Handler type"] = context.MessageHandler.HandlerType;
+                e.Data["Handler start time"] = startTimestamp;
+                e.Data["Handler failure time"] = DateTime.UtcNow;
                 throw;
             }
         }

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -31,10 +31,10 @@ namespace NServiceBus
                 }
                 catch (Exception e)
                 {
-                    e.Data.Add("Message ID", message.MessageId);
+                    e.Data["Message ID"] = message.MessageId;
                     if (message.NativeMessageId != message.MessageId)
                     {
-                        e.Data.Add("Transport message ID", message.NativeMessageId);
+                        e.Data["Transport message ID"] = message.NativeMessageId;
                     }
 
                     throw;


### PR DESCRIPTION
Testing showed that there are some edge cases where an exception object can be reused. E.g. when the pipeline fails to build, it throws an exception inside a builder delegate of a `Lazy<T>`, this causes repeated attempts to build that pipeline to return the same exception instance. Similar issues could also happen with user code. Therefore it's safer to assign or update instead of using `Add` on the `Exception.Data` dictionary.