### PR TITLE
Improve persistence check to throw when both persistences are enabled and different

### DIFF
--- a/src/NServiceBus.Core.Tests/Persistence/PersistenceStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/PersistenceStartupTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Core.Tests.Persistence
 {
     using System;
+    using NServiceBus.Features;
     using NServiceBus.Persistence;
     using NUnit.Framework;
     using Settings;
@@ -17,13 +18,20 @@
 
             Assert.IsFalse(supported);
         }
+    }
 
+    [TestFixture]
+    public class When_persistence_has_been_configured
+    {
         [Test]
-        public void Should_prevent_using_different_persistence_for_sagas_and_outbox()
+        public void Should_prevent_using_different_persistence_for_sagas_and_outbox_for_both_features_enabled()
         {
             var config = new EndpointConfiguration("MyEndpoint");
             config.UsePersistence<FakeSagaPersistence, StorageType.Sagas>();
             config.UsePersistence<FakeOutboxPersistence, StorageType.Outbox>();
+
+            config.EnableFeature<Outbox>();
+            config.EnableFeature<Sagas>();
 
             var startup = new PersistenceStartup();
 
@@ -31,6 +39,29 @@
             {
                 startup.Run(config.Settings);
             }, "Sagas and Outbox need to use the same type of persistence. Saga is configured to use FakeSagaPersistence. Outbox is configured to use FakeOutboxPersistence");
+        }
+
+        [TestCase(true, false)]
+        [TestCase(false, true)]
+        public void Should_not_prevent_using_different_persistence_for_sagas_and_outbox_if_only_one_of_the_features_is_enabled(bool sagasEnabled, bool outboxEnabled)
+        {
+            var config = new EndpointConfiguration("MyEndpoint");
+            config.UsePersistence<FakeSagaPersistence, StorageType.Sagas>();
+            config.UsePersistence<FakeOutboxPersistence, StorageType.Outbox>();
+
+            if (sagasEnabled)
+            {
+                config.EnableFeature<Sagas>();
+            }
+
+            if (outboxEnabled)
+            {
+                config.EnableFeature<Outbox>();
+            }
+
+            var startup = new PersistenceStartup();
+
+            Assert.DoesNotThrow(() => startup.Run(config.Settings), "Should not throw for a single single feature enabled out of the two.");
         }
 
         class FakeSagaPersistence : PersistenceDefinition

--- a/src/NServiceBus.Core/Persistence/PersistenceStartup.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceStartup.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Features;
     using Logging;
     using Persistence;
     using Settings;
@@ -17,12 +18,13 @@
             }
 
             var enabledPersistences = PersistenceStorageMerger.Merge(definitions, settings);
+            var bothFeaturesEnabled = settings.IsFeatureEnabled(typeof(Features.Sagas)) && settings.IsFeatureEnabled(typeof(Features.Outbox));
+
+            ValidateSagaAndOutboxUseSamePersistence(enabledPersistences, bothFeaturesEnabled);
 
             var resultingSupportedStorages = new List<Type>();
             var diagnostics = new Dictionary<string, object>();
-
-            ValidateSagaAndOutboxUseSamePersistence(enabledPersistences);
-
+            
             foreach (var definition in enabledPersistences)
             {
                 var persistenceDefinition = definition.DefinitionType.Construct<PersistenceDefinition>();
@@ -48,14 +50,15 @@
             settings.AddStartupDiagnosticsSection("Persistence", diagnostics);
         }
 
-        static void ValidateSagaAndOutboxUseSamePersistence(List<EnabledPersistence> enabledPersistences)
+        static void ValidateSagaAndOutboxUseSamePersistence(List<EnabledPersistence> enabledPersistences, bool bothFeaturesEnabled)
         {
             var sagaPersisterType = enabledPersistences.FirstOrDefault(p => p.SelectedStorages.Contains(typeof(StorageType.Sagas)));
             var outboxPersisterType = enabledPersistences.FirstOrDefault(p => p.SelectedStorages.Contains(typeof(StorageType.Outbox)));
 
             if (sagaPersisterType != null 
                 && outboxPersisterType != null
-                && sagaPersisterType.DefinitionType != outboxPersisterType.DefinitionType)
+                && sagaPersisterType.DefinitionType != outboxPersisterType.DefinitionType
+                && bothFeaturesEnabled)
             {
                 throw new Exception($"Sagas and the Outbox need to use the same type of persistence. Saga persistence is configured to use {sagaPersisterType.DefinitionType.Name}. Outbox persistence is configured to use {outboxPersisterType.DefinitionType.Name}.");
             }

--- a/src/NServiceBus.Core/Persistence/PersistenceStartup.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceStartup.cs
@@ -18,9 +18,8 @@
             }
 
             var enabledPersistences = PersistenceStorageMerger.Merge(definitions, settings);
-            var bothFeaturesEnabled = settings.IsFeatureEnabled(typeof(Features.Sagas)) && settings.IsFeatureEnabled(typeof(Features.Outbox));
-
-            ValidateSagaAndOutboxUseSamePersistence(enabledPersistences, bothFeaturesEnabled);
+            
+            ValidateSagaAndOutboxUseSamePersistence(enabledPersistences, settings);
 
             var resultingSupportedStorages = new List<Type>();
             var diagnostics = new Dictionary<string, object>();
@@ -50,10 +49,11 @@
             settings.AddStartupDiagnosticsSection("Persistence", diagnostics);
         }
 
-        static void ValidateSagaAndOutboxUseSamePersistence(List<EnabledPersistence> enabledPersistences, bool bothFeaturesEnabled)
+        static void ValidateSagaAndOutboxUseSamePersistence(List<EnabledPersistence> enabledPersistences, SettingsHolder settings)
         {
             var sagaPersisterType = enabledPersistences.FirstOrDefault(p => p.SelectedStorages.Contains(typeof(StorageType.Sagas)));
             var outboxPersisterType = enabledPersistences.FirstOrDefault(p => p.SelectedStorages.Contains(typeof(StorageType.Outbox)));
+            var bothFeaturesEnabled = settings.IsFeatureEnabled(typeof(Features.Sagas)) && settings.IsFeatureEnabled(typeof(Features.Outbox));
 
             if (sagaPersisterType != null 
                 && outboxPersisterType != null


### PR DESCRIPTION
_Follow-up on https://github.com/Particular/NServiceBus/pull/5435_

When one of the features (Sagas or Outbox) is not enabled, we should not throw an exception if those are configured to use different persistences. E.g.

```c#
endpointConfiguration.UsePersistence<InMemoryPersistence>();
endpointConfiguration.UsePersistence<LearningPersistence, StorageType.Sagas>();
```

This PR ensures the exception is solely thrown when both features are enabled and use different persistence.