### PR TITLE
Fix leanringtransport directory check

### DIFF
--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
@@ -54,7 +54,6 @@
                 }
 
                 // When no solution file was found try to find a learning transport directory
-                // don't ignore casing due to linux support
                 var learningTransportDirectory = Path.Combine(directory, DefaultLearningTransportDirectory);
                 if (Directory.Exists(learningTransportDirectory))
                 {

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
@@ -16,7 +16,6 @@
         public LearningTransportInfrastructure(SettingsHolder settings)
         {
             this.settings = settings;
-
             if (!settings.TryGet(StorageLocationKey, out storagePath))
             {
                 storagePath = FindStoragePath();
@@ -56,9 +55,10 @@
 
                 // When no solution file was found try to find a learning transport directory
                 // don't ignore casing due to linux support
-                if (Directory.EnumerateDirectories(directory).Any(dir => dir.Equals(DefaultLearningTransportDirectory, StringComparison.Ordinal)))
+                var learningTransportDirectory = Path.Combine(directory, DefaultLearningTransportDirectory);
+                if (Directory.Exists(learningTransportDirectory))
                 {
-                    return Path.Combine(directory, DefaultLearningTransportDirectory);
+                    return learningTransportDirectory;
                 }
 
                 var parent = Directory.GetParent(directory);


### PR DESCRIPTION
The current implementation to detect `.learningtransport` directories doesn't actually work as the directories returned by `Directory.EnumerateDirectories` return the full path of the directory, not just the directory name. Therefore, the equality check can never be true.

I tried to use a simpler approach and just check for the existence of the specific directory. `Directory.Exists` states to be case-insensitive, but testing this on WSL, it seems to be case-sensitive when running on linux, so it should be fine in regards to that aspect.