### PR TITLE
Emit pipeline and message operation events for diagnostics purposes

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>NServiceBus</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net452'">

--- a/src/NServiceBus.Core/Pipeline/PipelineEventSource.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineEventSource.cs
@@ -1,0 +1,118 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Diagnostics.Tracing;
+    using System.Runtime.CompilerServices;
+
+    /// <summary>
+    /// Do not rename the methods or parameters on this class nor change the event declarations because it directly affects
+    /// the events that are generated.
+    /// </summary>
+    [EventSource(Name = EventSourceName)]
+    [SuppressMessage("ReSharper", "ParameterHidesMember")]
+    sealed class PipelineEventSource : EventSource
+    {
+        PipelineEventSource()
+        {
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [Event(MainPipelineStartEventId, Message = "Main Pipeline for MessageId '{0}' started.", Level = EventLevel.Informational)]
+        public void MainStart(string MessageId) // used within already existing state machine. Enabled check done as part of method implementation
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(MainPipelineStartEventId, MessageId);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [Event(MainPipelineStopEventId, Message = "Main Pipeline for MessageId '{0}' stopped.", Level = EventLevel.Informational)]
+        public unsafe void MainStop(string MessageId, bool IsFaulted) // used within already existing state machine. Enabled check done as part of method implementation
+        {
+            if (IsEnabled())
+            {
+                fixed(char* messageIdPtr = MessageId)
+                {
+                    var eventPayload = stackalloc EventData[2];
+
+                    eventPayload[0].Size = (MessageId.Length + 1) * 2;
+                    eventPayload[0].DataPointer = (IntPtr)messageIdPtr;
+
+                    eventPayload[1].Size = sizeof(bool);
+                    eventPayload[1].DataPointer = (IntPtr)(&IsFaulted);
+                    WriteEventCore(MainPipelineStopEventId, 2, eventPayload);
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [Event(SatellitePipelineStartEventId, Message = "Satellite Pipeline '{0}' for MessageId '{1}' started.", Level = EventLevel.Informational)]
+        public void SatelliteStart(string Name, string MessageId) // used on on hot path where async state machine was optimized away. Enable check done as part of caller
+        {
+            WriteEvent(SatellitePipelineStartEventId, Name, MessageId);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [Event(SatellitePipelineStopEventId, Message = "Satellite Pipeline '{0}' for MessageId '{1}' stopped.", Level = EventLevel.Informational)]
+        public unsafe void SatelliteStop(string Name, string MessageId, bool IsFaulted) // used on on hot path where async state machine was optimized away. Enable check done as part of caller
+        {
+            fixed(char* namePtr = Name)
+            fixed(char* messageIdPtr = MessageId)
+            {
+                var eventPayload = stackalloc EventData[3];
+
+                eventPayload[0].Size = (Name.Length + 1) * 2;
+                eventPayload[0].DataPointer = (IntPtr)namePtr;
+
+                eventPayload[1].Size = (MessageId.Length + 1) * 2;
+                eventPayload[1].DataPointer = (IntPtr)messageIdPtr;
+
+                eventPayload[2].Size = sizeof(bool);
+                eventPayload[2].DataPointer = (IntPtr)(&IsFaulted);
+                WriteEventCore(SatellitePipelineStopEventId, 3, eventPayload);
+            }
+        }
+
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [Event(PipelineStartEventId, Message = "Pipeline '{0}' started.'", Level = EventLevel.Verbose
+#if NETSTANDARD
+            , ActivityOptions = EventActivityOptions.Recursive // Pipelines are started within pipeline, to avoid auto-stop we need recursive on the platform it is available
+#endif
+        )]
+        public void InvokeStart(string Name) // used on on hot path where async state machine was optimized away. Enable check done as part of caller
+        {
+            WriteEvent(PipelineStartEventId, Name);
+        }
+
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [Event(PipelineStopEventId, Message = "Pipeline '{0}' stopped.'", Level = EventLevel.Verbose)]
+        public unsafe void InvokeStop(string Name, bool IsFaulted) // used on on hot path where async state machine was optimized away. Enable check done as part of caller
+        {
+            fixed(char* namePtr = Name)
+            {
+                var eventPayload = stackalloc EventData[2];
+
+                eventPayload[0].Size = (Name.Length + 1) * 2;
+                eventPayload[0].DataPointer = (IntPtr)namePtr;
+
+                eventPayload[1].Size = sizeof(bool);
+                eventPayload[1].DataPointer = (IntPtr)(&IsFaulted);
+                WriteEventCore(PipelineStopEventId, 2, eventPayload);
+            }
+        }
+
+        const string EventSourceName = "NServiceBus.Pipeline";
+        const int MainPipelineStartEventId = 1;
+        const int MainPipelineStopEventId = 2;
+        const int PipelineStartEventId = 3;
+        const int PipelineStopEventId = 4;
+        const int SatellitePipelineStartEventId = 5;
+        const int SatellitePipelineStopEventId = 6;
+
+        internal static readonly PipelineEventSource Log = new PipelineEventSource();
+    }
+}

--- a/src/NServiceBus.Core/Unicast/MessageOperationsEventSource.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperationsEventSource.cs
@@ -1,0 +1,66 @@
+﻿namespace NServiceBus
+{
+    using System;
+    using System.Diagnostics.Tracing;
+
+    /// <summary>
+    /// Do not rename the methods or parameters on this class nor change the event declarations because it directly affects
+    /// the events that are generated.
+    /// </summary>
+    /// <remarks>
+    /// Operations here are used on on hot path where async state machine was optimized away. Enable check done as
+    /// part of caller
+    /// </remarks>
+    [EventSource(Name = EventSourceName)]
+    sealed class MessageOperationsEventSource : EventSource
+    {
+        MessageOperationsEventSource()
+        {
+        }
+
+        [Event(SendStartEventId, Message = "Sending message with MessageId '{0}' started.", Level = EventLevel.Informational)]
+        public void SendStart(string MessageId) => WriteEvent(SendStartEventId, MessageId);
+
+        [Event(SendStopEventId, Message = "Sending message with MessageId '{0}' stopped.", Level = EventLevel.Informational)]
+        public void SendStop(string MessageId, bool IsFaulted) => WriteEvent(SendStopEventId, MessageId, IsFaulted);
+
+        [Event(PublishStartEventId, Message = "Publishing message with MessageId '{0}' started.", Level = EventLevel.Informational)]
+        public void PublishStart(string MessageId) => WriteEvent(PublishStartEventId, MessageId);
+
+        [Event(PublishStopEventId, Message = "Publishing message with MessageId '{0}' stopped.", Level = EventLevel.Informational)]
+        public void PublishStop(string MessageId, bool IsFaulted) => WriteEvent(PublishStopEventId, MessageId, IsFaulted);
+
+        [Event(ReplyStartEventId, Message = "Replying message with MessageId '{0}' started.", Level = EventLevel.Informational)]
+        public void ReplyStart(string MessageId) => WriteEvent(ReplyStartEventId, MessageId);
+
+        [Event(ReplyStopEventId, Message = "Replying message with MessageId '{0}' stopped.", Level = EventLevel.Informational)]
+        public void ReplyStop(string MessageId, bool IsFaulted) => WriteEvent(ReplyStopEventId, MessageId, IsFaulted);
+
+        // optimized version for the common signature
+        [NonEvent]
+        unsafe void WriteEvent(int EventId, string MessageId, bool IsFaulted)
+        {
+            fixed(char* messageIdPtr = MessageId)
+            {
+                var eventPayload = stackalloc EventData[2];
+
+                eventPayload[0].Size = (MessageId.Length + 1) * 2;
+                eventPayload[0].DataPointer = (IntPtr)messageIdPtr;
+
+                eventPayload[1].Size = sizeof(bool);
+                eventPayload[1].DataPointer = (IntPtr)(&IsFaulted);
+                WriteEventCore(EventId, 2, eventPayload);
+            }
+        }
+
+        const string EventSourceName = "NServiceBus.Messages";
+        const int SendStartEventId = 1;
+        const int SendStopEventId = 2;
+        const int PublishStartEventId = 3;
+        const int PublishStopEventId = 4;
+        const int ReplyStartEventId = 5;
+        const int ReplyStopEventId = 6;
+
+        internal static readonly MessageOperationsEventSource Log = new MessageOperationsEventSource();
+    }
+}

--- a/src/NServiceBus.Testing.Fakes/AsyncLocal.cs
+++ b/src/NServiceBus.Testing.Fakes/AsyncLocal.cs
@@ -1,0 +1,36 @@
+﻿#if NETFRAMEWORK
+namespace System.Threading
+{
+    using Runtime.Remoting.Messaging;
+
+    // Provides a polyfill of AsyncLocal in .NET 4.5.2
+    sealed class AsyncLocal<T>
+    {
+        readonly string id;
+
+        // Gets or sets the value of the ambient data.
+        public T Value
+        {
+            get
+            {
+                var localValue = CallContext.LogicalGetData(id);
+                if (localValue != null)
+                {
+                    return (T)localValue;
+                }
+                return default;
+            }
+            set
+            {
+                // ReSharper disable once ArrangeAccessorOwnerBody
+                CallContext.LogicalSetData(id, value);
+            }
+        }
+
+        public AsyncLocal()
+        {
+            id = Guid.NewGuid().ToString();
+        }
+    }
+}
+#endif


### PR DESCRIPTION
While attending Dotnetos in Warsaw and listening to Adam Sitnik it became clear to me that we have been totally neglecting the value of event sources. Having event sources in strategic places allows us as well as the customers to emit high performance tracing information that has only very minimal impact on the runtime. The information is available across all the platforms and allows to troubleshoot or compare the performance where required. 

For us event sources furthermore allow us to have to equal runs and compare them in a comparison session (even automated) to verify whether the performance of the pipeline and the operations has regressed or not.

EventSources are an old concept but microsoft embraces them even in .NET Core and with the combination of EventPipes it is possible to consume them everywhere. 

### Naming of event sources

I compared names of event sources across corefx as well as ASPNETCore and there are no consistent naming guidelines. After synchronizing with David Fowler it became clear that newer event sources follow the dotted notation and no longer the dashed notation. Like

- `NServiceBus.Pipeline` instead of `NServiceBus-Pipeline`

### Unsafe

The event sources have a bunch of convenience `WriteEvent` methods that allow writing certain types of primitive types without allocating an `object[] args` array. For performance reasons where these methods can't be used the `stackalloc` approach with event data has to be used. In order to do so unsafe code has to be enabled. There are no consequences for the consumers of NSB. It's fine, let it go ;)

### IsEnabled

EventSources are enabled when required. In order to not suffer from performance penalties, it is required to check whether the event source is enabled or not. Generally, when you look at the production event sources from Microsoft you can see multiple patterns. 

- Check `IsEnabled` on the caller before calling the event method
- Check `IsEnabled` within the implementation of the event method
- Check `IsEnabled` within a method that is marked with `[NonEvent]` attribute that delegates to the event method
- Check `IsEnabled` within a method that is marked with `[NonEvent]` attribute that delegates to the event method in combination with `Debug.Assert(IsEnabled)`. 

Because we have cases where an existing async statemachine is available like in the main pipeline executor and we have cases where the statemachine was deliberately optimized away I went with

- Check `IsEnabled` on the caller before calling the event method for cases where the state machine was deliberately omited because we need to check for fast path vs slow path execution in the caller anyway
- Check `IsEnabled` within the implementation of the event method where an existing state machine is already available

The fast path uses the following pattern

```
return !Log.IsEnabled() ? fastPathInvoke() : SlowPathInvokeWithEventsEmit();
```

### Start/Stop

The event sources here leverage the automatic start and stop tracking that became available when you have .NET 4.6 or higher installed (also supported in NETCore). Methods that end with `Start` and a corresponding `Stop` will automatically created implicit scopes (that even support async) and do the execution / duration time measurement for us. Furthermore this trickery allows us to track conversations. For example (notice the `ActivityId` colum and the TextFilter)

A message session conversation

![SessionSendActivity](https://user-images.githubusercontent.com/174258/66986366-15ff8d80-f0bf-11e9-9cd7-b7beea70746c.PNG)

and incoming pipeline conversation

![ReceiveActivity](https://user-images.githubusercontent.com/174258/66986391-2283e600-f0bf-11e9-99dc-c9347192bb62.PNG)

with that every conversation gets a unique activity id that can be nested. See 

https://blogs.msdn.microsoft.com/vancem/2015/09/14/exploring-eventsource-activity-correlation-and-causation-features/

Because pipelines are nested in the platform where it is available the recursive behavior has to be enabled to prevent the event source magic to do the auto-stop. See _Error Handling and Recursion_  in

https://msdnshared.blob.core.windows.net/media/2016/07/EventSourceActivities.docx

To follow the guidance it also has Non-recursive entry points like `MainStart` and `MainStop`

### Parameter names

The parameter names do not follow our coding guidelines. The reason is simple. The parameter names become columns / properties in the event data that can be filtered upon. For example

![image](https://user-images.githubusercontent.com/174258/66986835-ea30d780-f0bf-11e9-8bd4-a38ffe3cf183.png)

### Events emitted

![Events](https://user-images.githubusercontent.com/174258/66986962-16e4ef00-f0c0-11e9-8916-9801553db856.PNG)

General-purpose pipeline events are verbose while the other ones are informational

### Enable in perfview

Alt-C

![Settings](https://user-images.githubusercontent.com/174258/66986940-0df41d80-f0c0-11e9-8192-73443810725b.PNG)

Start Collect






