### PR TITLE
Demo the benefits of static factory method for components

### DIFF
--- a/src/NServiceBus.Core/ConfigureQueueCreation.cs
+++ b/src/NServiceBus.Core/ConfigureQueueCreation.cs
@@ -14,7 +14,7 @@ namespace NServiceBus
         public static void DoNotCreateQueues(this EndpointConfiguration config)
         {
             Guard.AgainstNull(nameof(config), config);
-            config.Settings.Set("Transport.CreateQueues", false);
+            config.Settings.Get<InstallationComponent.Configuration>().ShouldCreateQueues = false;
         }
 
         /// <summary>
@@ -23,7 +23,7 @@ namespace NServiceBus
         public static bool CreateQueues(this ReadOnlySettings settings)
         {
             Guard.AgainstNull(nameof(settings), settings);
-            return !settings.TryGet("Transport.CreateQueues", out bool createQueues) || createQueues;
+            return settings.Get<InstallationComponent.Configuration>().ShouldCreateQueues;
         }
     }
 }

--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -26,6 +26,8 @@ namespace NServiceBus
         {
             ValidateEndpointName(endpointName);
 
+            Settings.Set(new InstallationComponent.Configuration(Settings));
+
             Settings.Set(new StartupDiagnosticEntries());
 
             Settings.Set("NServiceBus.Routing.EndpointName", endpointName);

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -112,7 +112,7 @@ namespace NServiceBus
             queueBindings = settings.Get<QueueBindings>();
             receiveComponent = CreateReceiveComponent(receiveConfiguration, transportInfrastructure, pipelineComponent, queueBindings, eventAggregator);
 
-            installationComponent = InstallationComponent.Initialize(new InstallationComponent.Configuration(settings), concreteTypes, containerComponent, receiveComponent, queueBindings);
+            installationComponent = InstallationComponent.Initialize(settings.Get<InstallationComponent.Configuration>(), concreteTypes, containerComponent, receiveComponent, queueBindings);
 
             settings.AddStartupDiagnosticsSection("Endpoint",
                 new

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -112,7 +112,7 @@ namespace NServiceBus
             queueBindings = settings.Get<QueueBindings>();
             receiveComponent = CreateReceiveComponent(receiveConfiguration, transportInfrastructure, pipelineComponent, queueBindings, eventAggregator);
 
-            installationComponent = InstallationComponent.Initialize(settings, concreteTypes, containerComponent, receiveComponent);
+            installationComponent = InstallationComponent.Initialize(new InstallationComponent.Configuration(settings), concreteTypes, containerComponent, receiveComponent, queueBindings);
 
             settings.AddStartupDiagnosticsSection("Endpoint",
                 new

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -112,9 +112,7 @@ namespace NServiceBus
             queueBindings = settings.Get<QueueBindings>();
             receiveComponent = CreateReceiveComponent(receiveConfiguration, transportInfrastructure, pipelineComponent, queueBindings, eventAggregator);
 
-            installationComponent = new InstallationComponent(settings);
-
-            installationComponent.Initialize(concreteTypes, containerComponent, receiveComponent);
+            installationComponent = InstallationComponent.Initialize(settings, concreteTypes, containerComponent, receiveComponent);
 
             settings.AddStartupDiagnosticsSection("Endpoint",
                 new

--- a/src/NServiceBus.Core/Installation/InstallationComponent.cs
+++ b/src/NServiceBus.Core/Installation/InstallationComponent.cs
@@ -18,11 +18,11 @@
             this.queueBindings = queueBindings;
         }
 
-        public static InstallationComponent Initialize(Configuration settings, List<Type> concreteTypes, ContainerComponent containerComponent, ReceiveComponent receiveComponent, QueueBindings queueBindings)
+        public static InstallationComponent Initialize(Configuration configuration, List<Type> concreteTypes, ContainerComponent containerComponent, ReceiveComponent receiveComponent, QueueBindings queueBindings)
         {
-            var component = new InstallationComponent(settings, containerComponent, receiveComponent, queueBindings);
+            var component = new InstallationComponent(configuration, containerComponent, receiveComponent, queueBindings);
 
-            if (!settings.ShouldRunInstallers)
+            if (!configuration.ShouldRunInstallers)
             {
                 return component;
             }
@@ -79,16 +79,48 @@
 
         public class Configuration
         {
-            public Configuration(ReadOnlySettings settings)
+            public Configuration(SettingsHolder settings)
             {
-                InstallationUserName = settings.GetOrDefault<string>("Installers.UserName");
-                ShouldRunInstallers = settings.GetOrDefault<bool>("Installers.Enable");
-                ShouldCreateQueues = settings.CreateQueues();
+                this.settings = settings;
+
+                settings.SetDefault("Transport.CreateQueues", true);
             }
 
-            public string InstallationUserName { get; }
-            public bool ShouldRunInstallers { get; }
-            public bool ShouldCreateQueues { get; }
+            public string InstallationUserName
+            {
+                get
+                {
+                    return settings.GetOrDefault<string>("Installers.UserName");
+                }
+                set
+                {
+                    settings.Set("Installers.UserName", value);
+                }
+            }
+            public bool ShouldRunInstallers
+            {
+                get
+                {
+                    return settings.GetOrDefault<bool>("Installers.Enable");
+                }
+                set
+                {
+                    settings.Set("Installers.Enable", value);
+                }
+            }
+            public bool ShouldCreateQueues
+            {
+                get
+                {
+                    return settings.Get<bool>("Transport.CreateQueues");
+                }
+                set
+                {
+                    settings.Set("Transport.CreateQueues", value);
+                }
+            }
+
+            SettingsHolder settings;
         }
     }
 }

--- a/src/NServiceBus.Core/Installation/InstallationComponent.cs
+++ b/src/NServiceBus.Core/Installation/InstallationComponent.cs
@@ -10,25 +10,19 @@
 
     class InstallationComponent
     {
-        InstallationComponent(ContainerComponent containerComponent, ReceiveComponent receiveComponent, bool shouldRunInstallers, bool shouldCreateQueues, string installationUserName, QueueBindings queueBindings)
+        InstallationComponent(Configuration configuration, ContainerComponent containerComponent, ReceiveComponent receiveComponent, QueueBindings queueBindings)
         {
+            this.configuration = configuration;
             this.containerComponent = containerComponent;
             this.receiveComponent = receiveComponent;
-            this.shouldRunInstallers = shouldRunInstallers;
-            this.shouldCreateQueues = shouldCreateQueues;
-            this.installationUserName = installationUserName;
             this.queueBindings = queueBindings;
         }
 
-        public static InstallationComponent Initialize(ReadOnlySettings settings, List<Type> concreteTypes, ContainerComponent containerComponent, ReceiveComponent receiveComponent)
+        public static InstallationComponent Initialize(Configuration settings, List<Type> concreteTypes, ContainerComponent containerComponent, ReceiveComponent receiveComponent, QueueBindings queueBindings)
         {
-            var shouldRunInstallers = settings.GetOrDefault<bool>("Installers.Enable");
-            var installationUserName = GetInstallationUserName(settings);
+            var component = new InstallationComponent(settings, containerComponent, receiveComponent, queueBindings);
 
-            var component = new InstallationComponent(containerComponent, receiveComponent, shouldRunInstallers, settings.CreateQueues(), installationUserName, settings.Get<QueueBindings>());
-
-
-            if (!shouldRunInstallers)
+            if (!settings.ShouldRunInstallers)
             {
                 return component;
             }
@@ -43,12 +37,14 @@
 
         public async Task Start()
         {
-            if (!shouldRunInstallers)
+            if (!configuration.ShouldRunInstallers)
             {
                 return;
             }
 
-            if (shouldCreateQueues)
+            var installationUserName = GetInstallationUserName();
+
+            if (configuration.ShouldCreateQueues)
             {
                 await receiveComponent.CreateQueuesIfNecessary(queueBindings, installationUserName).ConfigureAwait(false);
             }
@@ -59,30 +55,40 @@
             }
         }
 
-        static string GetInstallationUserName(ReadOnlySettings settings)
+        string GetInstallationUserName()
         {
-            if (!settings.TryGet("Installers.UserName", out string userName))
+            if (configuration.InstallationUserName != null)
             {
-                if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-                {
-                    userName = $"{Environment.UserDomainName}\\{Environment.UserName}";
-                }
-                else
-                {
-                    userName = Environment.UserName;
-                }
+                return configuration.InstallationUserName;
             }
 
-            return userName;
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                return $"{Environment.UserDomainName}\\{Environment.UserName}";
+            }
+
+            return Environment.UserName;
         }
 
+        Configuration configuration;
         ContainerComponent containerComponent;
         ReceiveComponent receiveComponent;
-        bool shouldRunInstallers;
-        bool shouldCreateQueues;
-        string installationUserName;
         QueueBindings queueBindings;
 
         static bool IsINeedToInstallSomething(Type t) => typeof(INeedToInstallSomething).IsAssignableFrom(t);
+
+        public class Configuration
+        {
+            public Configuration(ReadOnlySettings settings)
+            {
+                InstallationUserName = settings.GetOrDefault<string>("Installers.UserName");
+                ShouldRunInstallers = settings.GetOrDefault<bool>("Installers.Enable");
+                ShouldCreateQueues = settings.CreateQueues();
+            }
+
+            public string InstallationUserName { get; }
+            public bool ShouldRunInstallers { get; }
+            public bool ShouldCreateQueues { get; }
+        }
     }
 }


### PR DESCRIPTION
This PR demonstrates some ideas by @timbussmann and @danielmarbach and shows:

* how using a static factory method for component creation makes sure that we can't use them before they are correctly initialized. 
* how access to settings can be isolated into a nested `Configuration` class that moves all uses of the "magical" settings keys into a single place. 
* how this allows us to start moving away from settings in the next major by changing all the `Configuration` classes to just plain properties instead of using the settings holder to store the values