### PR TITLE
Create send pipelines in SendComponent

### DIFF
--- a/src/NServiceBus.Core.Tests/Pipeline/FakeRootContext.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/FakeRootContext.cs
@@ -2,7 +2,7 @@
 {
     class FakeRootContext : RootContext
     {
-        public FakeRootContext() : base(null)
+        public FakeRootContext() : base(null, null)
         {
         }
     }

--- a/src/NServiceBus.Core.Tests/Unicast/MessageOperationsTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/MessageOperationsTests.cs
@@ -12,13 +12,20 @@
     [TestFixture]
     public class MessageOperationsTests
     {
+        public void Setup()
+        {
+            messageOperations = new MessageOperations();
+        }
+
+        MessageOperations messageOperations;
+
         [Test]
         public void When_sending_message_interface_should_set_interface_as_message_type()
         {
             var sendPipeline = new FakePipeline<IOutgoingSendContext>();
             var context = CreateContext(sendPipeline);
 
-            MessageOperations.Send<IMyMessage>(context, m => { }, new SendOptions());
+            messageOperations.Send<IMyMessage>(context, m => { }, new SendOptions());
 
             Assert.That(sendPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(IMyMessage)));
         }
@@ -29,7 +36,7 @@
             var sendPipeline = new FakePipeline<IOutgoingSendContext>();
             var context = CreateContext(sendPipeline);
 
-            MessageOperations.Send<MyMessage>(context, m => { }, new SendOptions());
+            messageOperations.Send<MyMessage>(context, m => { }, new SendOptions());
 
             Assert.That(sendPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(MyMessage)));
         }
@@ -40,7 +47,7 @@
             var sendPipeline = new FakePipeline<IOutgoingSendContext>();
             var context = CreateContext(sendPipeline);
 
-            MessageOperations.Send<MyMessage>(context, m => { }, new SendOptions());
+            messageOperations.Send<MyMessage>(context, m => { }, new SendOptions());
 
             var messageId = sendPipeline.ReceivedContext.MessageId;
             Assert.IsNotNull(messageId);
@@ -57,7 +64,7 @@
             var sendOptions = new SendOptions();
             sendOptions.SetMessageId(expectedMessageID);
 
-            MessageOperations.Send<MyMessage>(context, m => { }, sendOptions);
+            messageOperations.Send<MyMessage>(context, m => { }, sendOptions);
 
             Assert.AreEqual(expectedMessageID, sendPipeline.ReceivedContext.MessageId);
             Assert.AreEqual(expectedMessageID, sendPipeline.ReceivedContext.Headers[Headers.MessageId]);
@@ -71,7 +78,7 @@
             var sendOptions = new SendOptions();
             sendOptions.SetHeader("header1", "header1 value");
 
-            MessageOperations.Send<MyMessage>(context, m => { }, sendOptions);
+            messageOperations.Send<MyMessage>(context, m => { }, sendOptions);
             sendPipeline.ReceivedContext.Headers.Add("header2", "header2 value");
             sendPipeline.ReceivedContext.Headers["header1"] = "updated header1 value";
 
@@ -86,7 +93,7 @@
             var replyPipeline = new FakePipeline<IOutgoingReplyContext>();
             var context = CreateContext(replyPipeline);
 
-            MessageOperations.Reply<IMyMessage>(context, m => { }, new ReplyOptions());
+            messageOperations.Reply<IMyMessage>(context, m => { }, new ReplyOptions());
 
             Assert.That(replyPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(IMyMessage)));
         }
@@ -97,7 +104,7 @@
             var replyPipeline = new FakePipeline<IOutgoingReplyContext>();
             var context = CreateContext(replyPipeline);
 
-            MessageOperations.Reply<MyMessage>(context, m => { }, new ReplyOptions());
+            messageOperations.Reply<MyMessage>(context, m => { }, new ReplyOptions());
 
             Assert.That(replyPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(MyMessage)));
         }
@@ -108,7 +115,7 @@
             var replyPipeline = new FakePipeline<IOutgoingReplyContext>();
             var context = CreateContext(replyPipeline);
 
-            MessageOperations.Reply<MyMessage>(context, m => { }, new ReplyOptions());
+            messageOperations.Reply<MyMessage>(context, m => { }, new ReplyOptions());
 
             var messageId = replyPipeline.ReceivedContext.MessageId;
             Assert.IsNotNull(messageId);
@@ -125,7 +132,7 @@
             var replyOptions = new ReplyOptions();
             replyOptions.SetMessageId(expectedMessageID);
 
-            MessageOperations.Reply<MyMessage>(context, m => { }, replyOptions);
+            messageOperations.Reply<MyMessage>(context, m => { }, replyOptions);
 
             Assert.AreEqual(expectedMessageID, replyPipeline.ReceivedContext.MessageId);
             Assert.AreEqual(expectedMessageID, replyPipeline.ReceivedContext.Headers[Headers.MessageId]);
@@ -139,7 +146,7 @@
             var replyOptions = new ReplyOptions();
             replyOptions.SetHeader("header1", "header1 value");
 
-            MessageOperations.Reply<MyMessage>(context, m => { }, replyOptions);
+            messageOperations.Reply<MyMessage>(context, m => { }, replyOptions);
             replyPipeline.ReceivedContext.Headers.Add("header2", "header2 value");
             replyPipeline.ReceivedContext.Headers["header1"] = "updated header1 value";
 
@@ -154,7 +161,7 @@
             var publishPipeline = new FakePipeline<IOutgoingPublishContext>();
             var context = CreateContext(publishPipeline);
 
-            MessageOperations.Publish<IMyMessage>(context, m => { }, new PublishOptions());
+            messageOperations.Publish<IMyMessage>(context, m => { }, new PublishOptions());
 
             Assert.That(publishPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(IMyMessage)));
         }
@@ -165,7 +172,7 @@
             var publishPipeline = new FakePipeline<IOutgoingPublishContext>();
             var context = CreateContext(publishPipeline);
 
-            MessageOperations.Publish<MyMessage>(context, m => { }, new PublishOptions());
+            messageOperations.Publish<MyMessage>(context, m => { }, new PublishOptions());
 
             Assert.That(publishPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(MyMessage)));
         }
@@ -176,7 +183,7 @@
             var publishPipeline = new FakePipeline<IOutgoingPublishContext>();
             var context = CreateContext(publishPipeline);
 
-            MessageOperations.Publish<MyMessage>(context, m => { }, new PublishOptions());
+            messageOperations.Publish<MyMessage>(context, m => { }, new PublishOptions());
 
             var messageId = publishPipeline.ReceivedContext.MessageId;
             Assert.IsNotNull(messageId);
@@ -193,7 +200,7 @@
             var publishOptions = new PublishOptions();
             publishOptions.SetMessageId(expectedMessageID);
 
-            MessageOperations.Publish<MyMessage>(context, m => { }, publishOptions);
+            messageOperations.Publish<MyMessage>(context, m => { }, publishOptions);
 
             Assert.AreEqual(expectedMessageID, publishPipeline.ReceivedContext.MessageId);
             Assert.AreEqual(expectedMessageID, publishPipeline.ReceivedContext.Headers[Headers.MessageId]);
@@ -207,7 +214,7 @@
             var publishOptions = new PublishOptions();
             publishOptions.SetHeader("header1", "header1 value");
 
-            MessageOperations.Publish<MyMessage>(context, m => { }, publishOptions);
+            messageOperations.Publish<MyMessage>(context, m => { }, publishOptions);
             publishPipeline.ReceivedContext.Headers.Add("header2", "header2 value");
             publishPipeline.ReceivedContext.Headers["header1"] = "updated header1 value";
 

--- a/src/NServiceBus.Core.Tests/Unicast/MessageOperationsTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/MessageOperationsTests.cs
@@ -31,7 +31,7 @@
             var sendPipeline = new FakePipeline<IOutgoingSendContext>();
             var messageOperations = CreateMessageOperations(sendPipeline: sendPipeline);
 
-            messageOperations.Send<IMyMessage>(new TestableMessageHandlerContext(), m => { }, new SendOptions());
+            messageOperations.Send<IMyMessage>(new RootContext(null, messageOperations), m => { }, new SendOptions());
 
             Assert.That(sendPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(IMyMessage)));
         }
@@ -42,7 +42,7 @@
             var sendPipeline = new FakePipeline<IOutgoingSendContext>();
             var messageOperations = CreateMessageOperations(sendPipeline: sendPipeline);
 
-            messageOperations.Send<MyMessage>(new TestableMessageHandlerContext(), m => { }, new SendOptions());
+            messageOperations.Send<MyMessage>(new RootContext(null, messageOperations), m => { }, new SendOptions());
 
             Assert.That(sendPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(MyMessage)));
         }
@@ -53,7 +53,7 @@
             var sendPipeline = new FakePipeline<IOutgoingSendContext>();
             var messageOperations = CreateMessageOperations(sendPipeline: sendPipeline);
 
-            messageOperations.Send<MyMessage>(new TestableMessageHandlerContext(), m => { }, new SendOptions());
+            messageOperations.Send<MyMessage>(new RootContext(null, messageOperations), m => { }, new SendOptions());
 
             var messageId = sendPipeline.ReceivedContext.MessageId;
             Assert.IsNotNull(messageId);
@@ -70,7 +70,7 @@
 
             var sendOptions = new SendOptions();
             sendOptions.SetMessageId(expectedMessageID);
-            messageOperations.Send<MyMessage>(new TestableMessageHandlerContext(), m => { }, sendOptions);
+            messageOperations.Send<MyMessage>(new RootContext(null, messageOperations), m => { }, sendOptions);
 
             Assert.AreEqual(expectedMessageID, sendPipeline.ReceivedContext.MessageId);
             Assert.AreEqual(expectedMessageID, sendPipeline.ReceivedContext.Headers[Headers.MessageId]);
@@ -84,7 +84,7 @@
 
             var sendOptions = new SendOptions();
             sendOptions.SetHeader("header1", "header1 value");
-            messageOperations.Send<MyMessage>(new TestableMessageHandlerContext(), m => { }, sendOptions);
+            messageOperations.Send<MyMessage>(new RootContext(null, messageOperations), m => { }, sendOptions);
             sendPipeline.ReceivedContext.Headers.Add("header2", "header2 value");
             sendPipeline.ReceivedContext.Headers["header1"] = "updated header1 value";
 
@@ -99,7 +99,7 @@
             var replyPipeline = new FakePipeline<IOutgoingReplyContext>();
             var messageOperations = CreateMessageOperations(replyPipeline: replyPipeline);
 
-            messageOperations.Reply<IMyMessage>(new TestableMessageHandlerContext(), m => { }, new ReplyOptions());
+            messageOperations.Reply<IMyMessage>(new RootContext(null, messageOperations), m => { }, new ReplyOptions());
 
             Assert.That(replyPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(IMyMessage)));
         }
@@ -110,7 +110,7 @@
             var replyPipeline = new FakePipeline<IOutgoingReplyContext>();
             var messageOperations = CreateMessageOperations(replyPipeline: replyPipeline);
 
-            messageOperations.Reply<MyMessage>(new TestableMessageHandlerContext(), m => { }, new ReplyOptions());
+            messageOperations.Reply<MyMessage>(new RootContext(null, messageOperations), m => { }, new ReplyOptions());
 
             Assert.That(replyPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(MyMessage)));
         }
@@ -121,7 +121,7 @@
             var replyPipeline = new FakePipeline<IOutgoingReplyContext>();
             var messageOperations = CreateMessageOperations(replyPipeline: replyPipeline);
 
-            messageOperations.Reply<MyMessage>(new TestableMessageHandlerContext(), m => { }, new ReplyOptions());
+            messageOperations.Reply<MyMessage>(new RootContext(null, messageOperations), m => { }, new ReplyOptions());
 
             var messageId = replyPipeline.ReceivedContext.MessageId;
             Assert.IsNotNull(messageId);
@@ -138,7 +138,7 @@
 
             var replyOptions = new ReplyOptions();
             replyOptions.SetMessageId(expectedMessageID);
-            messageOperations.Reply<MyMessage>(new TestableMessageHandlerContext(), m => { }, replyOptions);
+            messageOperations.Reply<MyMessage>(new RootContext(null, messageOperations), m => { }, replyOptions);
 
             Assert.AreEqual(expectedMessageID, replyPipeline.ReceivedContext.MessageId);
             Assert.AreEqual(expectedMessageID, replyPipeline.ReceivedContext.Headers[Headers.MessageId]);
@@ -152,7 +152,7 @@
 
             var replyOptions = new ReplyOptions();
             replyOptions.SetHeader("header1", "header1 value");
-            messageOperations.Reply<MyMessage>(new TestableMessageHandlerContext(), m => { }, replyOptions);
+            messageOperations.Reply<MyMessage>(new RootContext(null, messageOperations), m => { }, replyOptions);
             replyPipeline.ReceivedContext.Headers.Add("header2", "header2 value");
             replyPipeline.ReceivedContext.Headers["header1"] = "updated header1 value";
 
@@ -167,7 +167,7 @@
             var publishPipeline = new FakePipeline<IOutgoingPublishContext>();
             var messageOperations = CreateMessageOperations(publishPipeline: publishPipeline);
 
-            messageOperations.Publish<IMyMessage>(new TestableMessageHandlerContext(), m => { }, new PublishOptions());
+            messageOperations.Publish<IMyMessage>(new RootContext(null, messageOperations), m => { }, new PublishOptions());
 
             Assert.That(publishPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(IMyMessage)));
         }
@@ -178,7 +178,7 @@
             var publishPipeline = new FakePipeline<IOutgoingPublishContext>();
             var messageOperations = CreateMessageOperations(publishPipeline: publishPipeline);
 
-            messageOperations.Publish<MyMessage>(new TestableMessageHandlerContext(), m => { }, new PublishOptions());
+            messageOperations.Publish<MyMessage>(new RootContext(null, messageOperations), m => { }, new PublishOptions());
 
             Assert.That(publishPipeline.ReceivedContext.Message.MessageType, Is.EqualTo(typeof(MyMessage)));
         }
@@ -189,7 +189,7 @@
             var publishPipeline = new FakePipeline<IOutgoingPublishContext>();
             var messageOperations = CreateMessageOperations(publishPipeline: publishPipeline);
 
-            messageOperations.Publish<MyMessage>(new TestableMessageHandlerContext(), m => { }, new PublishOptions());
+            messageOperations.Publish<MyMessage>(new RootContext(null, messageOperations), m => { }, new PublishOptions());
 
             var messageId = publishPipeline.ReceivedContext.MessageId;
             Assert.IsNotNull(messageId);
@@ -206,7 +206,7 @@
 
             var publishOptions = new PublishOptions();
             publishOptions.SetMessageId(expectedMessageID);
-            messageOperations.Publish<MyMessage>(new TestableMessageHandlerContext(), m => { }, publishOptions);
+            messageOperations.Publish<MyMessage>(new RootContext(null, messageOperations), m => { }, publishOptions);
 
             Assert.AreEqual(expectedMessageID, publishPipeline.ReceivedContext.MessageId);
             Assert.AreEqual(expectedMessageID, publishPipeline.ReceivedContext.Headers[Headers.MessageId]);
@@ -220,7 +220,7 @@
 
             var publishOptions = new PublishOptions();
             publishOptions.SetHeader("header1", "header1 value");
-            messageOperations.Publish<MyMessage>(new TestableMessageHandlerContext(), m => { }, publishOptions);
+            messageOperations.Publish<MyMessage>(new RootContext(null, messageOperations), m => { }, publishOptions);
             publishPipeline.ReceivedContext.Headers.Add("header2", "header2 value");
             publishPipeline.ReceivedContext.Headers["header1"] = "updated header1 value";
 

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -111,10 +111,9 @@ namespace NServiceBus
 
             recoverabilityComponent.Initialize(receiveConfiguration, hostingComponent);
 
-            SendComponent.Initialize(pipelineSettings, hostingComponent, routingComponent);
+            sendComponent = SendComponent.Initialize(pipelineSettings, hostingComponent, routingComponent, messageMapper);
 
             pipelineComponent = PipelineComponent.Initialize(pipelineSettings, containerComponent);
-            pipelineComponent.AddRootContextItem<IMessageMapper>(messageMapper);
 
             containerComponent.ContainerConfiguration.ConfigureComponent(b => settings.Get<Notifications>(), DependencyLifecycle.SingleInstance);
             var eventAggregator = new EventAggregator(settings.Get<NotificationSubscriptions>());
@@ -156,6 +155,7 @@ namespace NServiceBus
                 pipelineComponent,
                 recoverabilityComponent,
                 hostingComponent,
+                sendComponent,
                 builder);
         }
 
@@ -310,5 +310,6 @@ namespace NServiceBus
         RecoverabilityComponent recoverabilityComponent;
         InstallationComponent installationComponent;
         HostingComponent hostingComponent;
+        SendComponent sendComponent;
     }
 }

--- a/src/NServiceBus.Core/MessageSession.cs
+++ b/src/NServiceBus.Core/MessageSession.cs
@@ -5,41 +5,44 @@ namespace NServiceBus
 
     class MessageSession : IMessageSession
     {
+        
         public MessageSession(RootContext context)
         {
             this.context = context;
+            messageOperations = context.Get<MessageOperations>(); //TODO can we make this a property?
         }
 
         public Task Send(object message, SendOptions options)
         {
-            return MessageOperations.Send(context, message, options);
+            return messageOperations.Send(context, message, options);
         }
 
         public Task Send<T>(Action<T> messageConstructor, SendOptions options)
         {
-            return MessageOperations.Send(context, messageConstructor, options);
+            return messageOperations.Send(context, messageConstructor, options);
         }
 
         public Task Publish(object message, PublishOptions options)
         {
-            return MessageOperations.Publish(context, message, options);
+            return messageOperations.Publish(context, message, options);
         }
 
         public Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions)
         {
-            return MessageOperations.Publish(context, messageConstructor, publishOptions);
+            return messageOperations.Publish(context, messageConstructor, publishOptions);
         }
 
         public Task Subscribe(Type eventType, SubscribeOptions options)
         {
-            return MessageOperations.Subscribe(context, eventType, options);
+            return messageOperations.Subscribe(context, eventType, options);
         }
 
         public Task Unsubscribe(Type eventType, UnsubscribeOptions options)
         {
-            return MessageOperations.Unsubscribe(context, eventType, options);
+            return messageOperations.Unsubscribe(context, eventType, options);
         }
 
         RootContext context;
+        MessageOperations messageOperations;
     }
 }

--- a/src/NServiceBus.Core/MessageSession.cs
+++ b/src/NServiceBus.Core/MessageSession.cs
@@ -8,7 +8,7 @@ namespace NServiceBus
         public MessageSession(RootContext context)
         {
             this.context = context;
-            messageOperations = context.Get<MessageOperations>(); //TODO can we make this a property?
+            messageOperations = context.Get<MessageOperations>();
         }
 
         public Task Send(object message, SendOptions options)

--- a/src/NServiceBus.Core/MessageSession.cs
+++ b/src/NServiceBus.Core/MessageSession.cs
@@ -5,7 +5,6 @@ namespace NServiceBus
 
     class MessageSession : IMessageSession
     {
-        
         public MessageSession(RootContext context)
         {
             this.context = context;

--- a/src/NServiceBus.Core/Pipeline/Incoming/IncomingContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IncomingContext.cs
@@ -13,6 +13,7 @@ namespace NServiceBus
             MessageId = messageId;
             ReplyToAddress = replyToAddress;
             MessageHeaders = headers;
+            messageOperations = parentContext.Extensions.Get<MessageOperations>();
         }
 
         public string MessageId { get; }
@@ -21,34 +22,36 @@ namespace NServiceBus
 
         public IReadOnlyDictionary<string, string> MessageHeaders { get; }
 
+        MessageOperations messageOperations;
+
         public Task Send(object message, SendOptions options)
         {
-            return MessageOperations.Send(this, message, options);
+            return messageOperations.Send(this, message, options);
         }
 
         public Task Send<T>(Action<T> messageConstructor, SendOptions options)
         {
-            return MessageOperations.Send(this, messageConstructor, options);
+            return messageOperations.Send(this, messageConstructor, options);
         }
 
         public Task Publish(object message, PublishOptions options)
         {
-            return MessageOperations.Publish(this, message, options);
+            return messageOperations.Publish(this, message, options);
         }
 
         public Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions)
         {
-            return MessageOperations.Publish(this, messageConstructor, publishOptions);
+            return messageOperations.Publish(this, messageConstructor, publishOptions);
         }
 
         public Task Reply(object message, ReplyOptions options)
         {
-            return MessageOperations.Reply(this, message, options);
+            return messageOperations.Reply(this, message, options);
         }
 
         public Task Reply<T>(Action<T> messageConstructor, ReplyOptions options)
         {
-            return MessageOperations.Reply(this, messageConstructor, options);
+            return messageOperations.Reply(this, messageConstructor, options);
         }
 
         public Task ForwardCurrentMessageTo(string destination)
@@ -58,12 +61,12 @@ namespace NServiceBus
 
         public Task Subscribe(Type eventType, SubscribeOptions options)
         {
-            return MessageOperations.Subscribe(this, eventType, options);
+            return messageOperations.Subscribe(this, eventType, options);
         }
 
         public Task Unsubscribe(Type eventType, UnsubscribeOptions options)
         {
-            return MessageOperations.Unsubscribe(this, eventType, options);
+            return messageOperations.Unsubscribe(this, eventType, options);
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveContext.cs
@@ -12,15 +12,8 @@
         /// <summary>
         /// Creates a new transport receive context.
         /// </summary>
-        /// <param name="receivedMessage">The received message.</param>
-        /// <param name="transportTransaction">The transport transaction.</param>
-        /// <param name="cancellationTokenSource">
-        /// Allows the pipeline to flag that it has been aborted and the receive operation should be rolled back.
-        /// It also allows the transport to communicate to the pipeline to abort if possible.
-        /// </param>
-        /// <param name="parentContext">The parent context.</param>
-        public TransportReceiveContext(IncomingMessage receivedMessage, TransportTransaction transportTransaction, CancellationTokenSource cancellationTokenSource, IBehaviorContext parentContext)
-            : base(parentContext)
+        public TransportReceiveContext(IncomingMessage receivedMessage, TransportTransaction transportTransaction, CancellationTokenSource cancellationTokenSource, RootContext rootContext)
+            : base(rootContext)
         {
             this.cancellationTokenSource = cancellationTokenSource;
             Message = receivedMessage;

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -2,18 +2,17 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
-    using MessageInterfaces.MessageMapper.Reflection;
     using ObjectBuilder;
     using Pipeline;
     using Transport;
 
     class MainPipelineExecutor : IPipelineExecutor
     {
-        public MainPipelineExecutor(IBuilder builder, PipelineComponent pipelineComponent, SendComponent sendComponent)
+        public MainPipelineExecutor(IBuilder builder, PipelineComponent pipelineComponent, MessageOperations messageOperations)
         {
             this.builder = builder;
             this.pipelineComponent = pipelineComponent;
-            this.sendComponent = sendComponent;
+            this.messageOperations = messageOperations;
         }
 
         public async Task Invoke(MessageContext messageContext)
@@ -24,7 +23,7 @@ namespace NServiceBus
             {
                 var message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.Body);
 
-                var rootContext = pipelineComponent.CreateRootContext(childBuilder, sendComponent.CreateMessageOperations(builder, pipelineComponent), messageContext.Extensions);
+                var rootContext = pipelineComponent.CreateRootContext(childBuilder, messageOperations, messageContext.Extensions);
                 var transportReceiveContext = new TransportReceiveContext(message, messageContext.TransportTransaction, messageContext.ReceiveCancellationTokenSource, rootContext);
 
                 try
@@ -48,6 +47,6 @@ namespace NServiceBus
 
         readonly IBuilder builder;
         readonly PipelineComponent pipelineComponent;
-        readonly SendComponent sendComponent;
+        readonly MessageOperations messageOperations;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -22,7 +22,7 @@ namespace NServiceBus
             {
                 var message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.Body);
 
-                var rootContext = pipelineComponent.CreateRootContext(childBuilder, messageContext.Extensions);
+                var rootContext = pipelineComponent.CreateRootContext(childBuilder, new MessageOperations(), messageContext.Extensions);
                 var transportReceiveContext = new TransportReceiveContext(message, messageContext.TransportTransaction, messageContext.ReceiveCancellationTokenSource, rootContext);
 
                 try

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -2,16 +2,18 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
+    using MessageInterfaces.MessageMapper.Reflection;
     using ObjectBuilder;
     using Pipeline;
     using Transport;
 
     class MainPipelineExecutor : IPipelineExecutor
     {
-        public MainPipelineExecutor(IBuilder builder, PipelineComponent pipelineComponent)
+        public MainPipelineExecutor(IBuilder builder, PipelineComponent pipelineComponent, SendComponent sendComponent)
         {
             this.builder = builder;
             this.pipelineComponent = pipelineComponent;
+            this.sendComponent = sendComponent;
         }
 
         public async Task Invoke(MessageContext messageContext)
@@ -22,7 +24,7 @@ namespace NServiceBus
             {
                 var message = new IncomingMessage(messageContext.MessageId, messageContext.Headers, messageContext.Body);
 
-                var rootContext = pipelineComponent.CreateRootContext(childBuilder, new MessageOperations(), messageContext.Extensions);
+                var rootContext = pipelineComponent.CreateRootContext(childBuilder, sendComponent.CreateMessageOperations(builder, pipelineComponent), messageContext.Extensions);
                 var transportReceiveContext = new TransportReceiveContext(message, messageContext.TransportTransaction, messageContext.ReceiveCancellationTokenSource, rootContext);
 
                 try
@@ -46,5 +48,6 @@ namespace NServiceBus
 
         readonly IBuilder builder;
         readonly PipelineComponent pipelineComponent;
+        readonly SendComponent sendComponent;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingContext.cs
@@ -12,40 +12,43 @@ namespace NServiceBus
         {
             Headers = headers;
             MessageId = messageId;
+            messageOperations = parentContext.Extensions.Get<MessageOperations>();
         }
 
         public string MessageId { get; }
 
         public Dictionary<string, string> Headers { get; }
 
+        MessageOperations messageOperations;
+
         public Task Send(object message, SendOptions options)
         {
-            return MessageOperations.Send(this, message, options);
+            return messageOperations.Send(this, message, options);
         }
 
         public Task Send<T>(Action<T> messageConstructor, SendOptions options)
         {
-            return MessageOperations.Send(this, messageConstructor, options);
+            return messageOperations.Send(this, messageConstructor, options);
         }
 
         public Task Publish(object message, PublishOptions options)
         {
-            return MessageOperations.Publish(this, message, options);
+            return messageOperations.Publish(this, message, options);
         }
 
         public Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions)
         {
-            return MessageOperations.Publish(this, messageConstructor, publishOptions);
+            return messageOperations.Publish(this, messageConstructor, publishOptions);
         }
 
         public Task Subscribe(Type eventType, SubscribeOptions options)
         {
-            return MessageOperations.Subscribe(this, eventType, options);
+            return messageOperations.Subscribe(this, eventType, options);
         }
 
         public Task Unsubscribe(Type eventType, UnsubscribeOptions options)
         {
-            return MessageOperations.Unsubscribe(this, eventType, options);
+            return messageOperations.Unsubscribe(this, eventType, options);
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/PipelineCache.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineCache.cs
@@ -14,15 +14,9 @@ namespace NServiceBus
 
             FromMainPipeline<IAuditContext>(rootBuilder);
             FromMainPipeline<IDispatchContext>(rootBuilder);
-            FromMainPipeline<IOutgoingPublishContext>(rootBuilder);
-            FromMainPipeline<ISubscribeContext>(rootBuilder);
-            FromMainPipeline<IUnsubscribeContext>(rootBuilder);
-            FromMainPipeline<IOutgoingSendContext>(rootBuilder);
-            FromMainPipeline<IOutgoingReplyContext>(rootBuilder);
             FromMainPipeline<IRoutingContext>(rootBuilder);
             FromMainPipeline<IBatchDispatchContext>(rootBuilder);
             FromMainPipeline<IForwardingContext>(rootBuilder);
-            FromMainPipeline<ITransportReceiveContext>(rootBuilder);
         }
 
         public IPipeline<TContext> Pipeline<TContext>()

--- a/src/NServiceBus.Core/Pipeline/PipelineCache.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineCache.cs
@@ -17,6 +17,7 @@ namespace NServiceBus
             FromMainPipeline<IRoutingContext>(rootBuilder);
             FromMainPipeline<IBatchDispatchContext>(rootBuilder);
             FromMainPipeline<IForwardingContext>(rootBuilder);
+            FromMainPipeline<ITransportReceiveContext>(rootBuilder);
         }
 
         public IPipeline<TContext> Pipeline<TContext>()

--- a/src/NServiceBus.Core/Pipeline/PipelineComponent.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineComponent.cs
@@ -29,6 +29,11 @@ namespace NServiceBus
             return new PipelineComponent(modifications);
         }
 
+        public Pipeline<T> CreatePipeline<T>(IBuilder builder) where T : IBehaviorContext
+        {
+            return new Pipeline<T>(builder, modifications);
+        }
+
         public Task Start(IBuilder rootBuilder)
         {
             rootContextExtensions.Set<IPipelineCache>(new PipelineCache(rootBuilder, modifications));

--- a/src/NServiceBus.Core/Pipeline/PipelineComponent.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineComponent.cs
@@ -40,9 +40,9 @@ namespace NServiceBus
             rootContextExtensions.Set(item);
         }
 
-        public RootContext CreateRootContext(IBuilder scopedBuilder, ContextBag extensions = null)
+        public RootContext CreateRootContext(IBuilder scopedBuilder, MessageOperations messageOperations, ContextBag extensions = null)
         {
-            var context = new RootContext(scopedBuilder);
+            var context = new RootContext(scopedBuilder, messageOperations);
 
             context.Extensions.Merge(rootContextExtensions);
 

--- a/src/NServiceBus.Core/Pipeline/RootContext.cs
+++ b/src/NServiceBus.Core/Pipeline/RootContext.cs
@@ -4,8 +4,9 @@ namespace NServiceBus
 
     class RootContext : BehaviorContext
     {
-        public RootContext(IBuilder builder) : base(null)
+        public RootContext(IBuilder builder, MessageOperations messageOperations) : base(null)
         {
+            Set(messageOperations);
             Set(builder);
         }
     }

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -5,7 +5,6 @@ namespace NServiceBus
     using System.Linq;
     using System.Threading.Tasks;
     using Logging;
-    using MessageInterfaces.MessageMapper.Reflection;
     using ObjectBuilder;
     using Transport;
 
@@ -74,14 +73,14 @@ namespace NServiceBus
             return receiveComponent;
         }
 
-        public async Task PrepareToStart(IBuilder builder, RecoverabilityComponent recoverabilityComponent, SendComponent sendComponent)
+        public async Task PrepareToStart(IBuilder builder, RecoverabilityComponent recoverabilityComponent, MessageOperations messageOperations)
         {
             if (IsSendOnly)
             {
                 return;
             }
 
-            mainPipelineExecutor = new MainPipelineExecutor(builder, pipeline, sendComponent);
+            mainPipelineExecutor = new MainPipelineExecutor(builder, pipeline, messageOperations);
 
             if (configuration.PurgeOnStartup)
             {

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -5,6 +5,7 @@ namespace NServiceBus
     using System.Linq;
     using System.Threading.Tasks;
     using Logging;
+    using MessageInterfaces.MessageMapper.Reflection;
     using ObjectBuilder;
     using Transport;
 
@@ -73,14 +74,14 @@ namespace NServiceBus
             return receiveComponent;
         }
 
-        public async Task PrepareToStart(IBuilder builder, RecoverabilityComponent recoverabilityComponent)
+        public async Task PrepareToStart(IBuilder builder, RecoverabilityComponent recoverabilityComponent, SendComponent sendComponent)
         {
             if (IsSendOnly)
             {
                 return;
             }
 
-            mainPipelineExecutor = new MainPipelineExecutor(builder, pipeline);
+            mainPipelineExecutor = new MainPipelineExecutor(builder, pipeline, sendComponent);
 
             if (configuration.PurgeOnStartup)
             {

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -3,7 +3,6 @@ namespace NServiceBus
     using System;
     using System.Security.Principal;
     using System.Threading.Tasks;
-    using MessageInterfaces.MessageMapper.Reflection;
     using ObjectBuilder;
     using Settings;
 
@@ -43,7 +42,7 @@ namespace NServiceBus
 
             AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
 
-            await receiveComponent.PrepareToStart(builder, recoverabilityComponent, sendComponent).ConfigureAwait(false);
+            await receiveComponent.PrepareToStart(builder, recoverabilityComponent, messageOperations).ConfigureAwait(false);
 
             await featureComponent.Start(builder, messageSession).ConfigureAwait(false);
 

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -33,7 +33,7 @@ namespace NServiceBus
         {
             await pipelineComponent.Start(builder).ConfigureAwait(false);
 
-            var messageSession = new MessageSession(pipelineComponent.CreateRootContext(builder));
+            var messageSession = new MessageSession(pipelineComponent.CreateRootContext(builder, new MessageOperations()));
 
             await transportComponent.Start().ConfigureAwait(false);
 

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -55,15 +55,15 @@ namespace NServiceBus
             return runningInstance;
         }
 
-        PipelineComponent pipelineComponent;
-        RecoverabilityComponent recoverabilityComponent;
-        HostingComponent hostingComponent;
+        readonly PipelineComponent pipelineComponent;
+        readonly RecoverabilityComponent recoverabilityComponent;
+        readonly HostingComponent hostingComponent;
         readonly SendComponent sendComponent;
-        IBuilder builder;
-        ContainerComponent containerComponent;
-        FeatureComponent featureComponent;
-        SettingsHolder settings;
-        TransportComponent transportComponent;
-        ReceiveComponent receiveComponent;
+        readonly IBuilder builder;
+        readonly ContainerComponent containerComponent;
+        readonly FeatureComponent featureComponent;
+        readonly SettingsHolder settings;
+        readonly TransportComponent transportComponent;
+        readonly ReceiveComponent receiveComponent;
     }
 }

--- a/src/NServiceBus.Core/Unicast/MessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperations.cs
@@ -7,16 +7,16 @@ namespace NServiceBus
     using MessageInterfaces;
     using Pipeline;
 
-    static class MessageOperations
+    class MessageOperations
     {
-        public static Task Publish<T>(IBehaviorContext context, Action<T> messageConstructor, PublishOptions options)
+        public Task Publish<T>(IBehaviorContext context, Action<T> messageConstructor, PublishOptions options)
         {
             var mapper = context.Extensions.Get<IMessageMapper>();
 
             return Publish(context, typeof(T), mapper.CreateInstance(messageConstructor), options);
         }
 
-        public static Task Publish(IBehaviorContext context, object message, PublishOptions options)
+        public Task Publish(IBehaviorContext context, object message, PublishOptions options)
         {
             var mapper = context.Extensions.Get<IMessageMapper>();
             var messageType = mapper.GetMappedTypeFor(message.GetType());
@@ -24,7 +24,7 @@ namespace NServiceBus
             return Publish(context, messageType, message, options);
         }
 
-        static Task Publish(IBehaviorContext context, Type messageType, object message, PublishOptions options)
+        Task Publish(IBehaviorContext context, Type messageType, object message, PublishOptions options)
         {
             var messageId = options.UserDefinedMessageId ?? CombGuid.Generate().ToString();
             var headers = new Dictionary<string, string>(options.OutgoingHeaders)
@@ -42,7 +42,7 @@ namespace NServiceBus
             return publishContext.InvokePipeline<IOutgoingPublishContext>();
         }
 
-        public static Task Subscribe(IBehaviorContext context, Type eventType, SubscribeOptions options)
+        public Task Subscribe(IBehaviorContext context, Type eventType, SubscribeOptions options)
         {
             var subscribeContext = new SubscribeContext(
                 context,
@@ -52,7 +52,7 @@ namespace NServiceBus
             return subscribeContext.InvokePipeline<ISubscribeContext>();
         }
 
-        public static Task Unsubscribe(IBehaviorContext context, Type eventType, UnsubscribeOptions options)
+        public Task Unsubscribe(IBehaviorContext context, Type eventType, UnsubscribeOptions options)
         {
             var unsubscribeContext = new UnsubscribeContext(
                 context,
@@ -62,14 +62,14 @@ namespace NServiceBus
             return unsubscribeContext.InvokePipeline<IUnsubscribeContext>();
         }
 
-        public static Task Send<T>(IBehaviorContext context, Action<T> messageConstructor, SendOptions options)
+        public Task Send<T>(IBehaviorContext context, Action<T> messageConstructor, SendOptions options)
         {
             var mapper = context.Extensions.Get<IMessageMapper>();
 
             return SendMessage(context, typeof(T), mapper.CreateInstance(messageConstructor), options);
         }
 
-        public static Task Send(IBehaviorContext context, object message, SendOptions options)
+        public Task Send(IBehaviorContext context, object message, SendOptions options)
         {
             var mapper = context.Extensions.Get<IMessageMapper>();
             var messageType = mapper.GetMappedTypeFor(message.GetType());
@@ -77,7 +77,7 @@ namespace NServiceBus
             return SendMessage(context, messageType, message, options);
         }
 
-        static Task SendMessage(this IBehaviorContext context, Type messageType, object message, SendOptions options)
+        Task SendMessage(IBehaviorContext context, Type messageType, object message, SendOptions options)
         {
             var messageId = options.UserDefinedMessageId ?? CombGuid.Generate().ToString();
             var headers = new Dictionary<string, string>(options.OutgoingHeaders)
@@ -102,7 +102,7 @@ namespace NServiceBus
             return outgoingContext.InvokePipeline<IOutgoingSendContext>();
         }
 
-        public static Task Reply(IBehaviorContext context, object message, ReplyOptions options)
+        public Task Reply(IBehaviorContext context, object message, ReplyOptions options)
         {
             var mapper = context.Extensions.Get<IMessageMapper>();
             var messageType = mapper.GetMappedTypeFor(message.GetType());
@@ -110,14 +110,14 @@ namespace NServiceBus
             return ReplyMessage(context, messageType, message, options);
         }
 
-        public static Task Reply<T>(IBehaviorContext context, Action<T> messageConstructor, ReplyOptions options)
+        public Task Reply<T>(IBehaviorContext context, Action<T> messageConstructor, ReplyOptions options)
         {
             var mapper = context.Extensions.Get<IMessageMapper>();
 
             return ReplyMessage(context, typeof(T), mapper.CreateInstance(messageConstructor), options);
         }
 
-        static Task ReplyMessage(this IBehaviorContext context, Type messageType, object message, ReplyOptions options)
+        Task ReplyMessage(IBehaviorContext context, Type messageType, object message, ReplyOptions options)
         {
             var messageId = options.UserDefinedMessageId ?? CombGuid.Generate().ToString();
             var headers = new Dictionary<string, string>(options.OutgoingHeaders)

--- a/src/NServiceBus.Core/Unicast/MessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperations.cs
@@ -9,17 +9,37 @@ namespace NServiceBus
 
     class MessageOperations
     {
+        IMessageMapper messageMapper;
+        readonly IPipeline<IOutgoingPublishContext> publishPipeline;
+        readonly IPipeline<IOutgoingSendContext> sendPipeline;
+        readonly IPipeline<IOutgoingReplyContext> replyPipeline;
+        readonly IPipeline<ISubscribeContext> subscribePipeline;
+        readonly IPipeline<IUnsubscribeContext> unsubscribePipeline;
+
+        public MessageOperations(
+            IMessageMapper messageMapper, 
+            IPipeline<IOutgoingPublishContext> publishPipeline, 
+            IPipeline<IOutgoingSendContext> sendPipeline, 
+            IPipeline<IOutgoingReplyContext> replyPipeline, 
+            IPipeline<ISubscribeContext> subscribePipeline, 
+            IPipeline<IUnsubscribeContext> unsubscribePipeline)
+        {
+            this.messageMapper = messageMapper;
+            this.publishPipeline = publishPipeline;
+            this.sendPipeline = sendPipeline;
+            this.replyPipeline = replyPipeline;
+            this.subscribePipeline = subscribePipeline;
+            this.unsubscribePipeline = unsubscribePipeline;
+        }
+
         public Task Publish<T>(IBehaviorContext context, Action<T> messageConstructor, PublishOptions options)
         {
-            var mapper = context.Extensions.Get<IMessageMapper>();
-
-            return Publish(context, typeof(T), mapper.CreateInstance(messageConstructor), options);
+            return Publish(context, typeof(T), messageMapper.CreateInstance(messageConstructor), options);
         }
 
         public Task Publish(IBehaviorContext context, object message, PublishOptions options)
         {
-            var mapper = context.Extensions.Get<IMessageMapper>();
-            var messageType = mapper.GetMappedTypeFor(message.GetType());
+            var messageType = messageMapper.GetMappedTypeFor(message.GetType());
 
             return Publish(context, messageType, message, options);
         }
@@ -39,7 +59,7 @@ namespace NServiceBus
                 options.Context,
                 context);
 
-            return publishContext.InvokePipeline<IOutgoingPublishContext>();
+            return publishPipeline.Invoke(publishContext);
         }
 
         public Task Subscribe(IBehaviorContext context, Type eventType, SubscribeOptions options)
@@ -49,7 +69,7 @@ namespace NServiceBus
                 eventType,
                 options.Context);
 
-            return subscribeContext.InvokePipeline<ISubscribeContext>();
+            return subscribePipeline.Invoke(subscribeContext);
         }
 
         public Task Unsubscribe(IBehaviorContext context, Type eventType, UnsubscribeOptions options)
@@ -59,20 +79,17 @@ namespace NServiceBus
                 eventType,
                 options.Context);
 
-            return unsubscribeContext.InvokePipeline<IUnsubscribeContext>();
+            return unsubscribePipeline.Invoke(unsubscribeContext);
         }
 
         public Task Send<T>(IBehaviorContext context, Action<T> messageConstructor, SendOptions options)
         {
-            var mapper = context.Extensions.Get<IMessageMapper>();
-
-            return SendMessage(context, typeof(T), mapper.CreateInstance(messageConstructor), options);
+            return SendMessage(context, typeof(T), messageMapper.CreateInstance(messageConstructor), options);
         }
 
         public Task Send(IBehaviorContext context, object message, SendOptions options)
         {
-            var mapper = context.Extensions.Get<IMessageMapper>();
-            var messageType = mapper.GetMappedTypeFor(message.GetType());
+            var messageType = messageMapper.GetMappedTypeFor(message.GetType());
 
             return SendMessage(context, messageType, message, options);
         }
@@ -99,22 +116,19 @@ namespace NServiceBus
                 outgoingContext.AddDeliveryConstraint(options.DelayedDeliveryConstraint);
             }
 
-            return outgoingContext.InvokePipeline<IOutgoingSendContext>();
+            return sendPipeline.Invoke(outgoingContext);
         }
 
         public Task Reply(IBehaviorContext context, object message, ReplyOptions options)
         {
-            var mapper = context.Extensions.Get<IMessageMapper>();
-            var messageType = mapper.GetMappedTypeFor(message.GetType());
+            var messageType = messageMapper.GetMappedTypeFor(message.GetType());
 
             return ReplyMessage(context, messageType, message, options);
         }
 
         public Task Reply<T>(IBehaviorContext context, Action<T> messageConstructor, ReplyOptions options)
         {
-            var mapper = context.Extensions.Get<IMessageMapper>();
-
-            return ReplyMessage(context, typeof(T), mapper.CreateInstance(messageConstructor), options);
+            return ReplyMessage(context, typeof(T), messageMapper.CreateInstance(messageConstructor), options);
         }
 
         Task ReplyMessage(IBehaviorContext context, Type messageType, object message, ReplyOptions options)
@@ -132,7 +146,7 @@ namespace NServiceBus
                 options.Context,
                 context);
 
-            return outgoingContext.InvokePipeline<IOutgoingReplyContext>();
+            return replyPipeline.Invoke(outgoingContext);
         }
     }
 }


### PR DESCRIPTION
Makes the `MessageOperations` class non-static. This way, dependencies can be passed to the instance and don't need to be fetched from the context settings bag at runtime.
The send pipelines are now created as part of initializing the send component. This ensures that the pipelines can be built at startup time.

The remaining challenge is passing down the MessageOperations class the context hierarchy without a breaking change. To do this properly, we would most likely have to break some public APIs so they operations get currently added to the context bag by the root context but this way we need less dependencies in the context bag (message mapper & pipeline cache).

I was also wondering whether we should rename `MessageOperations` to something like  `OutgoingPipelines`?