### PR TITLE
Obsolete removed OutgoingPipelineFeature

### DIFF
--- a/src/NServiceBus.Core/obsoletes.cs
+++ b/src/NServiceBus.Core/obsoletes.cs
@@ -1148,4 +1148,24 @@ namespace NServiceBus
         }
     }
 }
+
+namespace NServiceBus.Features
+{
+    // Just to make sure we remove it in v8. We keep it around for now just in case some external feature
+    // depended on it using `DependsOn(string featureTypeName)`
+    [ObsoleteEx(
+        RemoveInVersion = "8",
+        TreatAsErrorFromVersion = "7")]
+    class OutgoingPipelineFeature : Feature
+    {
+        public OutgoingPipelineFeature()
+        {
+            EnableByDefault();
+        }
+
+        protected internal override void Setup(FeatureConfigurationContext context)
+        {
+        }
+    }
+}
 #pragma warning restore 1591


### PR DESCRIPTION
The feature was removed as part of but I forgot to obsolete the internal feature.

I noticed that we started just wrapping the whole obsoleted class including the namespaces instead of moving them to the already existing namespaces in the obsoletes.cs. Not sure whether that was intentional or not. I continued with that approach as it's actually easier to obsolete a class that way and it doesn't seem to case issues.