### PR TITLE
Update approval file

### DIFF
--- a/src/NServiceBus.Persistence.InMemory.AcceptanceTests/ApprovalFiles/When_endpoint_is_warmed_up.Make_sure_things_are_in_DI.approved.txt
+++ b/src/NServiceBus.Persistence.InMemory.AcceptanceTests/ApprovalFiles/When_endpoint_is_warmed_up.Make_sure_things_are_in_DI.approved.txt
@@ -3,6 +3,7 @@ NServiceBus.StorageInitializer+CallInit - SingleInstance
 NServiceBus.SubscriptionReceiverBehavior - InstancePerCall
 NServiceBus.Transport.IDispatchMessages - SingleInstance
 NServiceBus.Unicast.MessageHandlerRegistry - SingleInstance
+NServiceBus.Unicast.Messages.MessageMetadataRegistry - SingleInstance
 ----------- Registrations not used by the core, can be removed in next major if downstreams have been confirmed to not use it -----------
 NServiceBus.CriticalError - SingleInstance
 NServiceBus.Hosting.HostInformation - SingleInstance
@@ -15,4 +16,3 @@ NServiceBus.Notifications - SingleInstance
 NServiceBus.ObjectBuilder.IBuilder - SingleInstance
 NServiceBus.Pipeline.LogicalMessageFactory - SingleInstance
 NServiceBus.Settings.ReadOnlySettings - SingleInstance
-NServiceBus.Unicast.Messages.MessageMetadataRegistry - SingleInstance


### PR DESCRIPTION
`MessageMetadataRegistry` now shows up because due to the changes in endpoint startup, the outgoing pipelines are built at startup time instead on-demand. The in-mem tests use a non-native pubsub transport configuration and the message driven pubsub feature resolves the `MessageMetadataRegistry` to build parts of the pipeline.