### PR TITLE
Create receive pipeline in component

### DIFF
--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -8,12 +8,13 @@ namespace NServiceBus
 
     class MainPipelineExecutor : IPipelineExecutor
     {
-        public MainPipelineExecutor(IBuilder builder, PipelineComponent pipelineComponent, MessageOperations messageOperations, INotificationSubscriptions<ReceivePipelineCompleted> receivePipelineNotification)
+        public MainPipelineExecutor(IBuilder builder, PipelineComponent pipelineComponent, MessageOperations messageOperations, INotificationSubscriptions<ReceivePipelineCompleted> receivePipelineNotification, Pipeline<ITransportReceiveContext> receivePipeline)
         {
             this.builder = builder;
             this.pipelineComponent = pipelineComponent;
             this.messageOperations = messageOperations;
             this.receivePipelineNotification = receivePipelineNotification;
+            this.receivePipeline = receivePipeline;
         }
 
         public async Task Invoke(MessageContext messageContext)
@@ -29,7 +30,7 @@ namespace NServiceBus
 
                 try
                 {
-                    await transportReceiveContext.InvokePipeline<ITransportReceiveContext>().ConfigureAwait(false);
+                    await receivePipeline.Invoke(transportReceiveContext).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {
@@ -50,5 +51,6 @@ namespace NServiceBus
         readonly PipelineComponent pipelineComponent;
         readonly MessageOperations messageOperations;
         readonly INotificationSubscriptions<ReceivePipelineCompleted> receivePipelineNotification;
+        readonly Pipeline<ITransportReceiveContext> receivePipeline;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/PipelineCache.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineCache.cs
@@ -17,7 +17,6 @@ namespace NServiceBus
             FromMainPipeline<IRoutingContext>(rootBuilder);
             FromMainPipeline<IBatchDispatchContext>(rootBuilder);
             FromMainPipeline<IForwardingContext>(rootBuilder);
-            FromMainPipeline<ITransportReceiveContext>(rootBuilder);
         }
 
         public IPipeline<TContext> Pipeline<TContext>()

--- a/src/NServiceBus.Core/Pipeline/PipelineComponent.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineComponent.cs
@@ -40,11 +40,6 @@ namespace NServiceBus
             return Task.FromResult(0);
         }
 
-        public void AddRootContextItem<T>(T item)
-        {
-            rootContextExtensions.Set(item);
-        }
-
         public RootContext CreateRootContext(IBuilder scopedBuilder, MessageOperations messageOperations, ContextBag extensions = null)
         {
             var context = new RootContext(scopedBuilder, messageOperations);

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -17,13 +17,13 @@ namespace NServiceBus
     {
         ReceiveComponent(ReceiveConfiguration transportReceiveConfiguration,
             Func<IPushMessages> messagePumpFactory,
-            PipelineComponent pipeline,
+            PipelineComponent pipelineComponent,
             CriticalError criticalError,
             string errorQueue)
         {
             this.transportReceiveConfiguration = transportReceiveConfiguration;
             this.messagePumpFactory = messagePumpFactory;
-            this.pipeline = pipeline;
+            this.pipelineComponent = pipelineComponent;
             this.criticalError = criticalError;
             this.errorQueue = errorQueue;
         }
@@ -33,7 +33,7 @@ namespace NServiceBus
         public static ReceiveComponent Initialize(Configuration configuration,
             ReceiveConfiguration transportReceiveConfiguration,
             TransportComponent transportComponent,
-            PipelineComponent pipeline,
+            PipelineComponent pipelineComponent,
             string errorQueue,
             HostingComponent hostingComponent,
             PipelineSettings pipelineSettings)
@@ -49,7 +49,7 @@ namespace NServiceBus
 
             var receiveComponent = new ReceiveComponent(transportReceiveConfiguration,
                 messagePumpFactory,
-                pipeline,
+                pipelineComponent,
                 hostingComponent.CriticalError,
                 errorQueue);
 
@@ -111,7 +111,8 @@ namespace NServiceBus
                 return;
             }
 
-            mainPipelineExecutor = new MainPipelineExecutor(builder, pipeline, messageOperations, transportReceiveConfiguration.PipelineCompletedSubscribers);
+            var receivePipeline = pipelineComponent.CreatePipeline<ITransportReceiveContext>(builder);
+            mainPipelineExecutor = new MainPipelineExecutor(builder, pipelineComponent, messageOperations, transportReceiveConfiguration.PipelineCompletedSubscribers, receivePipeline);
 
             if (transportReceiveConfiguration.PurgeOnStartup)
             {
@@ -258,7 +259,7 @@ namespace NServiceBus
         ReceiveConfiguration transportReceiveConfiguration;
         List<TransportReceiver> receivers = new List<TransportReceiver>();
         Func<IPushMessages> messagePumpFactory;
-        PipelineComponent pipeline;
+        PipelineComponent pipelineComponent;
         IPipelineExecutor mainPipelineExecutor;
         CriticalError criticalError;
         string errorQueue;


### PR DESCRIPTION
Removes `AddRootContextItem` from the PipelineComponent as it's only usage is internal.
By building the receive pipeline explicitly, it removes another usage of the pipeline cache which is the only remaining on the RootContext except for the builder.