### PR TITLE
Register terminators when using migration-mode on send-only endpoints

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/When_send_only_endpoint_uses_migration_mode.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/When_send_only_endpoint_uses_migration_mode.cs
@@ -43,7 +43,7 @@
             }
         }
 
-        class SomeEvent : IEvent
+        public class SomeEvent : IEvent
         {
         }
     }

--- a/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/When_send_only_endpoint_uses_migration_mode.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/When_send_only_endpoint_uses_migration_mode.cs
@@ -1,0 +1,50 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.SubscriptionMigration
+{
+    using System;
+    using AcceptanceTesting;
+    using Configuration.AdvancedExtensibility;
+    using NUnit.Framework;
+
+    public class When_send_only_endpoint_uses_migration_mode : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_throw_InvalidOperationException_on_subscribe()
+        {
+            var exception = Assert.ThrowsAsync<InvalidOperationException>(() => Scenario.Define<ScenarioContext>()
+                .WithEndpoint<SendOnlyEndpoint>(c => c
+                    .When(s => s.Subscribe<SomeEvent>()))
+                .Done(c => c.EndpointsStarted)
+                .Run());
+
+            StringAssert.Contains("Send-only endpoints cannot subscribe to events", exception.Message);
+        }
+
+        [Test]
+        public void Should_throw_InvalidOperationException_on_unsubscribe()
+        {
+            var exception = Assert.ThrowsAsync<InvalidOperationException>(() => Scenario.Define<ScenarioContext>()
+                .WithEndpoint<SendOnlyEndpoint>(c => c
+                    .When(s => s.Unsubscribe<SomeEvent>()))
+                .Done(c => c.EndpointsStarted)
+                .Run());
+
+            StringAssert.Contains("Send-only endpoints cannot unsubscribe to events", exception.Message);
+        }
+
+        class SendOnlyEndpoint : EndpointConfigurationBuilder
+        {
+            public SendOnlyEndpoint()
+            {
+                EndpointSetup<EndpointWithNativePubSub>(c =>
+                {
+                    c.GetSettings().Set("NServiceBus.Subscriptions.EnableMigrationMode", true);
+                    c.SendOnly();
+                });
+            }
+        }
+
+        class SomeEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/SubscriptionMigrationMode.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/SubscriptionMigrationMode.cs
@@ -55,6 +55,11 @@
                 context.Container.RegisterSingleton(authorizer);
                 context.Pipeline.Register<SubscriptionReceiverBehavior.Registration>();
             }
+            else
+            {
+                context.Pipeline.Register(new SendOnlySubscribeTerminator(), "Throws an exception when trying to subscribe from a send-only endpoint");
+                context.Pipeline.Register(new SendOnlyUnsubscribeTerminator(), "Throws an exception when trying to unsubscribe from a send-only endpoint");
+            }
 
             context.Container.ConfigureComponent<MessageDrivenSubscriptions.InitializableSubscriptionStorage>(DependencyLifecycle.SingleInstance);
 


### PR DESCRIPTION
The current behavior will crash endpoint startup because the subscribe/unsubscribe pipelines are built at startup time instead of lazily (in that case it only throws on subscribe/unsubscribe runtime). This change contains the same terminators also used by the native and the message-driven pubsub features for send-only endpoints (and the tests are very similar)