### PR TITLE
Only add diagnostics if it's not a read-only endpoint

### DIFF
--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -137,7 +137,7 @@ namespace NServiceBus
                 LoadMessageHandlers(configuration, orderedHandlers, hostingConfiguration.Container, hostingConfiguration.AvailableTypes);
             }
 
-            if (configuration != null)
+            if (configuration.IsSendOnlyEndpoint == false)
             {
                 hostingConfiguration.AddStartupDiagnosticsSection("Receiving", new
                 {

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -137,7 +137,7 @@ namespace NServiceBus
                 LoadMessageHandlers(configuration, orderedHandlers, hostingConfiguration.Container, hostingConfiguration.AvailableTypes);
             }
 
-            if (configuration.IsSendOnlyEndpoint == false)
+            if (!configuration.IsSendOnlyEndpoint)
             {
                 hostingConfiguration.AddStartupDiagnosticsSection("Receiving", new
                 {


### PR DESCRIPTION
`Configuration` is never null. Use `IsReadOnlyEndpoint` property to do the check.