### PR TITLE
Do not register behaviors that are not needed for read only endpoint

### DIFF
--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -138,7 +138,7 @@ namespace NServiceBus
                 return receiveComponent;
             }
 
-            receiveComponent.BindQueues(queueBindings);
+            receiveComponent.BindQueues(configuration.transportSeam.QueueBindings);
 
             pipelineSettings.Register("TransportReceiveToPhysicalMessageProcessingConnector", b =>
             {

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -160,7 +160,7 @@ namespace NServiceBus
                 LoadMessageHandlers(configuration, orderedHandlers, hostingConfiguration.Container, hostingConfiguration.AvailableTypes);
             }
 
-            if (!configuration.IsSendOnlyEndpoint)
+            if (configuration.IsSendOnlyEndpoint == false)
             {
                 hostingConfiguration.AddStartupDiagnosticsSection("Receiving", new
                 {

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -135,33 +135,33 @@ namespace NServiceBus
 
             receiveComponent.BindQueues(configuration.transportSeam.QueueBindings);
 
-            pipelineSettings.Register("TransportReceiveToPhysicalMessageProcessingConnector", b =>
-            {
-                var storage = hostingConfiguration.Container.HasComponent<IOutboxStorage>() ? b.Build<IOutboxStorage>() : new NoOpOutboxStorage();
-                return new TransportReceiveToPhysicalMessageConnector(storage);
-            }, "Allows to abort processing the message");
-
-            pipelineSettings.Register("LoadHandlersConnector", b =>
-            {
-                var adapter = hostingConfiguration.Container.HasComponent<ISynchronizedStorageAdapter>() ? b.Build<ISynchronizedStorageAdapter>() : new NoOpSynchronizedStorageAdapter();
-                var syncStorage = hostingConfiguration.Container.HasComponent<ISynchronizedStorage>() ? b.Build<ISynchronizedStorage>() : new NoOpSynchronizedStorage();
-
-                return new LoadHandlersConnector(b.Build<MessageHandlerRegistry>(), syncStorage, adapter);
-            }, "Gets all the handlers to invoke from the MessageHandler registry based on the message type.");
-
-            pipelineSettings.Register("ExecuteUnitOfWork", new UnitOfWorkBehavior(), "Executes the UoW");
-
-            pipelineSettings.Register("InvokeHandlers", new InvokeHandlerTerminator(), "Calls the IHandleMessages<T>.Handle(T)");
-
-            if (!hostingConfiguration.Container.HasComponent<MessageHandlerRegistry>())
-            {
-                var orderedHandlers = configuration.ExecuteTheseHandlersFirst;
-
-                LoadMessageHandlers(configuration, orderedHandlers, hostingConfiguration.Container, hostingConfiguration.AvailableTypes);
-            }
-
             if (configuration.IsSendOnlyEndpoint == false)
             {
+                pipelineSettings.Register("TransportReceiveToPhysicalMessageProcessingConnector", b =>
+                {
+                    var storage = hostingConfiguration.Container.HasComponent<IOutboxStorage>() ? b.Build<IOutboxStorage>() : new NoOpOutboxStorage();
+                    return new TransportReceiveToPhysicalMessageConnector(storage);
+                }, "Allows to abort processing the message");
+
+                pipelineSettings.Register("LoadHandlersConnector", b =>
+                {
+                    var adapter = hostingConfiguration.Container.HasComponent<ISynchronizedStorageAdapter>() ? b.Build<ISynchronizedStorageAdapter>() : new NoOpSynchronizedStorageAdapter();
+                    var syncStorage = hostingConfiguration.Container.HasComponent<ISynchronizedStorage>() ? b.Build<ISynchronizedStorage>() : new NoOpSynchronizedStorage();
+
+                    return new LoadHandlersConnector(b.Build<MessageHandlerRegistry>(), syncStorage, adapter);
+                }, "Gets all the handlers to invoke from the MessageHandler registry based on the message type.");
+
+                pipelineSettings.Register("ExecuteUnitOfWork", new UnitOfWorkBehavior(), "Executes the UoW");
+
+                pipelineSettings.Register("InvokeHandlers", new InvokeHandlerTerminator(), "Calls the IHandleMessages<T>.Handle(T)");
+
+                if (!hostingConfiguration.Container.HasComponent<MessageHandlerRegistry>())
+                {
+                    var orderedHandlers = configuration.ExecuteTheseHandlersFirst;
+
+                    LoadMessageHandlers(configuration, orderedHandlers, hostingConfiguration.Container, hostingConfiguration.AvailableTypes);
+                }
+
                 hostingConfiguration.AddStartupDiagnosticsSection("Receiving", new
                 {
                     configuration.LocalAddress,

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -133,10 +133,10 @@ namespace NServiceBus
                 errorQueue,
                 transportReceiveInfrastructure);
 
-            receiveComponent.BindQueues(configuration.transportSeam.QueueBindings);
-
             if (configuration.IsSendOnlyEndpoint == false)
             {
+                receiveComponent.BindQueues(queueBindings);
+
                 pipelineSettings.Register("TransportReceiveToPhysicalMessageProcessingConnector", b =>
                 {
                     var storage = hostingConfiguration.Container.HasComponent<IOutboxStorage>() ? b.Build<IOutboxStorage>() : new NoOpOutboxStorage();


### PR DESCRIPTION
_Connects to PR #5520_

I was wondering why do we bother to register all the receiving related behaviours if the endpoint is read-only. This PR is to verify if we're breaking any tests by registering these receiving behaviors in `ReceiveComponent` conditionally.