### PR TITLE
Receive settings fixes

### DIFF
--- a/src/NServiceBus.Core/Installation/InstallationComponent.cs
+++ b/src/NServiceBus.Core/Installation/InstallationComponent.cs
@@ -76,8 +76,6 @@
             public Configuration(SettingsHolder settings)
             {
                 this.settings = settings;
-
-                settings.SetDefault("Transport.CreateQueues", true);
             }
 
             public string InstallationUserName

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -364,9 +364,14 @@ namespace NServiceBus
             public Settings(SettingsHolder settings)
             {
                 this.settings = settings;
+                ExecuteTheseHandlersFirst = new List<Type>(0);
             }
 
-            public List<Type> ExecuteTheseHandlersFirst => settings.GetOrCreate<List<Type>>();
+            public List<Type> ExecuteTheseHandlersFirst
+            {
+                get => settings.Get<List<Type>>("NServiceBus.ExecuteTheseHandlersFirst");
+                set => settings.Set("NServiceBus.ExecuteTheseHandlersFirst", value);
+            }
 
             public MessageHandlerRegistry MessageHandlerRegistry => settings.GetOrCreate<MessageHandlerRegistry>();
 

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -365,6 +365,7 @@ namespace NServiceBus
             {
                 this.settings = settings;
                 ExecuteTheseHandlersFirst = new List<Type>(0);
+                ShouldCreateQueues = true;
             }
 
             public List<Type> ExecuteTheseHandlersFirst


### PR DESCRIPTION
Contains two fixes:
* `ExecuteTheseHandlersFirst ` didn't read the value from the settings key it used to. See https://github.com/Particular/NServiceBus/commit/e84962eb1848c4dfb1a944f26492dc048297f6dd#diff-2a6bc7a3fd6ac7aef3875cb0b908ccbbL22
* ShouldCreateQeueus default was set in the installation component. Moved this to the receive settings. I avoided the `SetDefault` and accessed the actual property instead. Could that cause any problems?