### PR TITLE
Don't use PipelineSettings after PipelineComponent.Initialize

### DIFF
--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -155,20 +155,19 @@ namespace NServiceBus
 
             sendComponent = SendComponent.Initialize(pipelineSettings, hostingConfiguration, routingComponent, messageMapper, transportSeam);
 
-            pipelineComponent = PipelineComponent.Initialize(pipelineSettings, hostingConfiguration);
-
             hostingConfiguration.Container.ConfigureComponent(b => settings.Get<Notifications>(), DependencyLifecycle.SingleInstance);
 
             var installerConfiguration = settings.Get<InstallationComponent.Configuration>();
             receiveComponent = ReceiveComponent.Initialize(
                 receiveConfiguration,
-                pipelineComponent,
                 settings.ErrorQueueAddress(),
                 hostingConfiguration,
                 pipelineSettings,
                 installerConfiguration);
 
             installationComponent = InstallationComponent.Initialize(installerConfiguration, hostingConfiguration);
+
+            pipelineComponent = PipelineComponent.Initialize(pipelineSettings, hostingConfiguration);
 
             // The settings can only be locked after initializing the feature component since it uses the settings to store & share feature state.
             // As well as all the other components have been initialized

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -17,13 +17,11 @@ namespace NServiceBus
     class ReceiveComponent
     {
         ReceiveComponent(Configuration configuration,
-            PipelineComponent pipelineComponent,
             CriticalError criticalError,
             string errorQueue,
             TransportReceiveInfrastructure transportReceiveInfrastructure)
         {
             this.configuration = configuration;
-            this.pipelineComponent = pipelineComponent;
             this.criticalError = criticalError;
             this.errorQueue = errorQueue;
             this.transportReceiveInfrastructure = transportReceiveInfrastructure;
@@ -104,7 +102,6 @@ namespace NServiceBus
 
         public static ReceiveComponent Initialize(
             Configuration configuration,
-            PipelineComponent pipelineComponent,
             string errorQueue,
             HostingComponent.Configuration hostingConfiguration,
             PipelineSettings pipelineSettings,
@@ -128,7 +125,6 @@ namespace NServiceBus
 
             var receiveComponent = new ReceiveComponent(
                 configuration,
-                pipelineComponent,
                 hostingConfiguration.CriticalError,
                 errorQueue,
                 transportReceiveInfrastructure);
@@ -187,7 +183,8 @@ namespace NServiceBus
         public async Task PrepareToStart(IBuilder builder,
             RecoverabilityComponent recoverabilityComponent,
             MessageOperations messageOperations,
-        IPipelineCache pipelineCache)
+            PipelineComponent pipelineComponent,
+            IPipelineCache pipelineCache)
         {
             if (configuration.IsSendOnlyEndpoint)
             {
@@ -349,7 +346,6 @@ namespace NServiceBus
 
         Configuration configuration;
         List<TransportReceiver> receivers = new List<TransportReceiver>();
-        readonly PipelineComponent pipelineComponent;
         IPipelineExecutor mainPipelineExecutor;
         CriticalError criticalError;
         string errorQueue;

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -45,7 +45,7 @@ namespace NServiceBus
 
             AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
 
-            await receiveComponent.PrepareToStart(builder, recoverabilityComponent, messageOperations, pipelineCache).ConfigureAwait(false);
+            await receiveComponent.PrepareToStart(builder, recoverabilityComponent, messageOperations, pipelineComponent, pipelineCache).ConfigureAwait(false);
 
             // This is a hack to maintain the current order of transport infrastructure initialization
             await sendComponent.InvokeSendPreStartupChecksForBackwardsCompatibility().ConfigureAwait(false);


### PR DESCRIPTION
The ReceiveComponent shouldn't register behaviors in the settings after the pipeline component has been initialized as this can cause registrations to be not be applied to the container.