### PR TITLE
Fix return value description for DeduplicateMessage

### DIFF
--- a/src/NServiceBus.Core/Gateway/IDeduplicateMessages.cs
+++ b/src/NServiceBus.Core/Gateway/IDeduplicateMessages.cs
@@ -10,7 +10,7 @@
     public interface IDeduplicateMessages
     {
         /// <summary>
-        /// Returns true if the message is a duplicate.
+        /// Returns false if the message is a duplicate.
         /// </summary>
         /// <param name="clientId">The client id that defines the range of ids to check for duplicates.</param>
         /// <param name="timeReceived">The time received of the message to allow the storage to do cleanup.</param>


### PR DESCRIPTION
Since this interface has to stay until the next major version we should also just fix the description.
As pointed out [here](https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.Core/Persistence/InMemory/Gateway/InMemoryGatewayDeduplication.cs#L20), `false` is returned to indicate a duplicate message and `true` to indicate an "unknown"/new message.

Same behavior is used in [RavenDB](https://github.com/Particular/NServiceBus.RavenDB/blob/master/src/NServiceBus.RavenDB/Gateway/RavenDeduplication.cs) and [NHibernate](https://github.com/Particular/NServiceBus.NHibernate/blob/master/src/NServiceBus.NHibernate/Deduplication/GatewayDeduplication.cs)