### PR TITLE
Exception data as strings instead of type and datetime

### DIFF
--- a/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs
@@ -16,7 +16,7 @@
 
             var messageHandler = context.MessageHandler;
 
-            var startTimestamp = DateTime.UtcNow;
+            var startTime = DateTime.UtcNow;
             try
             {
                 await messageHandler
@@ -27,9 +27,9 @@
             catch (Exception e)
             {
                 e.Data["Message type"] = context.MessageMetadata.MessageType.FullName;
-                e.Data["Handler type"] = context.MessageHandler.HandlerType;
-                e.Data["Handler start time"] = startTimestamp;
-                e.Data["Handler failure time"] = DateTime.UtcNow;
+                e.Data["Handler type"] = context.MessageHandler.HandlerType.FullName;
+                e.Data["Handler start time"] = DateTimeExtensions.ToWireFormattedString(startTime);
+                e.Data["Handler failure time"] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
                 throw;
             }
         }


### PR DESCRIPTION
The exception data that is added by the invoke handler terminator does not only influence logging it is also added by the `ExceptionHeaderHelper` to the failed message. The `ExceptionHeaderHelper` blindly invokes `ToString` on the passed data. This causes the date-time that we add to be formatted in the culture aware format of the current runtime environment. By consistently using strings for both the handler type as well as the start and stop time our data is added in a consistent format

Changing how the ExceptionHeaderHelper treats instances of `IFormattable` seemed to me a larger issue than just making sure our data is consistent