### PR TITLE
InMemory gateway deduplication can cause message loss

### DIFF
--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/ClientIdStorageTests.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/ClientIdStorageTests.cs
@@ -1,0 +1,48 @@
+﻿namespace NServiceBus.Persistence.InMemory.Tests
+{
+    using NUnit.Framework;
+
+    [TestFixture]
+    class ClientIdStorageTests
+    {
+        [Test]
+        public void Should_detect_duplicates()
+        {
+            var clientIdStorage = new ClientIdStorage(10);
+
+            clientIdStorage.RegisterClientId("A");
+            clientIdStorage.RegisterClientId("B");
+
+            Assert.True(clientIdStorage.IsDuplicate("A"));
+            Assert.False(clientIdStorage.IsDuplicate("C"));
+        }
+
+        [Test]
+        public void Should_evict_oldest_entry_when_LRU_reaches_limit()
+        {
+            var clientIdStorage = new ClientIdStorage(2);
+
+            clientIdStorage.RegisterClientId("A");
+            clientIdStorage.RegisterClientId("B");
+            clientIdStorage.RegisterClientId("C");
+
+            Assert.False(clientIdStorage.IsDuplicate("A"));
+        }
+
+        [Test]
+        public void Should_reset_time_added_for_existing_IDs_when_checked()
+        {
+            var clientIdStorage = new ClientIdStorage(2);
+
+            clientIdStorage.RegisterClientId("A");
+            clientIdStorage.RegisterClientId("B");
+
+            Assert.True(clientIdStorage.IsDuplicate("A"));
+
+            clientIdStorage.RegisterClientId("C");
+
+            Assert.False(clientIdStorage.IsDuplicate("B"));
+            Assert.True(clientIdStorage.IsDuplicate("A"));
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/InMemoryGatewayDeduplicationTests.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/InMemoryGatewayDeduplicationTests.cs
@@ -2,39 +2,72 @@
 {
     using System;
     using System.Threading.Tasks;
+    using System.Transactions;
     using Extensibility;
+    using Features;
     using NUnit.Framework;
+    using Settings;
 
     [TestFixture]
     class InMemoryGatewayDeduplicationTests
     {
         [Test]
-        public async Task Should_return_true_on_first_unique_test()
+        public void Should_have_configured_storage_maxsize()
         {
-            var storage = new InMemoryGatewayDeduplication(2);
+            var settings = new SettingsHolder();
+            var persistenceSettings = new PersistenceExtensions<InMemoryPersistence>(settings);
 
-            await storage.DeduplicateMessage("A", DateTime.UtcNow, new ContextBag());
-            Assert.True(await storage.DeduplicateMessage("B", DateTime.UtcNow, new ContextBag()));
-        }    
+            persistenceSettings.GatewayDeduplicationCacheSize(42);
+
+            Assert.AreEqual(42, settings.Get<int>(InMemoryGatewayPersistence.MaxSizeKey));
+        }
 
         [Test]
-        public async Task Should_return_false_on_second_test()
+        public async Task Should_add_on_transaction_scope_commit()
         {
-            var storage = new InMemoryGatewayDeduplication(2);
+            var storage = CreateInMemoryGatewayDeduplication();
 
-            await storage.DeduplicateMessage("A", DateTime.UtcNow, new ContextBag());
+            using (var scope = new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+            {
+                await storage.DeduplicateMessage("A", DateTime.UtcNow, new ContextBag());
+
+                scope.Complete();
+            }
+
             Assert.False(await storage.DeduplicateMessage("A", DateTime.UtcNow, new ContextBag()));
-        }    
-        
+        }
+
         [Test]
-        public async Task Should_return_true_if_LRU_reaches_limit()
+        public async Task Should_not_add_on_transaction_scope_abort()
         {
-            var storage = new InMemoryGatewayDeduplication(2);
+            var storage = CreateInMemoryGatewayDeduplication();
+
+            using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+            {
+                await storage.DeduplicateMessage("A", DateTime.UtcNow, new ContextBag());
+
+                // no commit
+            }
+
+            Assert.True(await storage.DeduplicateMessage("A", DateTime.UtcNow, new ContextBag()));
+        }
+
+        [Test]
+        // With the gateway persistence seam v1 design it's only safe to deduplicate when there is a tx scope present since the check happens before
+        // the messages have been pushed to the transport. If we add entries earlier they would be considered duplicate when retrying after something went wrong.
+        // Note: The gateway will always wrap the v1 seam invocation in a transaction scope
+        public async Task Should_only_deduplicate_when_scope_is_present()
+        {
+            var storage = CreateInMemoryGatewayDeduplication();
 
             await storage.DeduplicateMessage("A", DateTime.UtcNow, new ContextBag());
-            await storage.DeduplicateMessage("B", DateTime.UtcNow, new ContextBag());
-            await storage.DeduplicateMessage("C", DateTime.UtcNow, new ContextBag());
+
             Assert.True(await storage.DeduplicateMessage("A", DateTime.UtcNow, new ContextBag()));
+        }
+
+        InMemoryGatewayDeduplication CreateInMemoryGatewayDeduplication()
+        {
+            return new InMemoryGatewayDeduplication(new ClientIdStorage(10));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/InMemory/InMemoryGatewayDeduplicationTests.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/InMemory/InMemoryGatewayDeduplicationTests.cs
@@ -4,24 +4,11 @@
     using System.Threading.Tasks;
     using System.Transactions;
     using Extensibility;
-    using Features;
     using NUnit.Framework;
-    using Settings;
 
     [TestFixture]
     class InMemoryGatewayDeduplicationTests
     {
-        [Test]
-        public void Should_have_configured_storage_maxsize()
-        {
-            var settings = new SettingsHolder();
-            var persistenceSettings = new PersistenceExtensions<InMemoryPersistence>(settings);
-
-            persistenceSettings.GatewayDeduplicationCacheSize(42);
-
-            Assert.AreEqual(42, settings.Get<int>(InMemoryGatewayPersistence.MaxSizeKey));
-        }
-
         [Test]
         public async Task Should_add_on_transaction_scope_commit()
         {

--- a/src/NServiceBus.Core/Persistence/InMemory/Gateway/ClientIdStorage.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Gateway/ClientIdStorage.cs
@@ -1,0 +1,58 @@
+﻿namespace NServiceBus
+{
+    using System.Collections.Generic;
+
+    class ClientIdStorage
+    {
+        public ClientIdStorage(int maxSize)
+        {
+            this.maxSize = maxSize;
+        }
+
+        public bool IsDuplicate(string clientId)
+        {
+            lock (clientIdSet)
+            {
+                // This implementation is not 100% consistent since there is a race condition here where another thread might consider the same message as a non-duplicate.
+                // We consider this good enough since this is the inmemory persister which will not be consistent when the endpoint is scaled out anyway.
+                if (clientIdSet.TryGetValue(clientId, out var existingNode)) // O(1)
+                {
+                    clientIdList.Remove(existingNode); // O(1) operation, because we got the node reference
+                    clientIdList.AddLast(existingNode); // O(1) operation
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public void RegisterClientId(string clientId)
+        {
+            lock (clientIdSet)
+            {
+                //another thread might already have added the ID since we checked the last time
+                if (clientIdSet.ContainsKey(clientId))
+                {
+                    // another thread has proceed this ID already and there is a potential duplicate message but there is nothing we can do about it at this stage so just return.
+                    // Throwing would just cause unessessary retries for the client.
+                    return;
+                }
+
+                if (clientIdSet.Count == maxSize)
+                {
+                    var id = clientIdList.First.Value;
+                    clientIdSet.Remove(id); // O(1)
+                    clientIdList.RemoveFirst(); // O(1)
+                }
+
+                var node = clientIdList.AddLast(clientId); // O(1)
+                clientIdSet.Add(clientId, node); // O(1)
+            }
+        }
+
+        readonly int maxSize;
+        readonly LinkedList<string> clientIdList = new LinkedList<string>();
+        readonly Dictionary<string, LinkedListNode<string>> clientIdSet = new Dictionary<string, LinkedListNode<string>>();
+    }
+}

--- a/src/NServiceBus.Core/Persistence/InMemory/Gateway/InMemoryGatewayPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Gateway/InMemoryGatewayPersistence.cs
@@ -25,7 +25,7 @@
             context.Container.RegisterSingleton<IDeduplicateMessages>(new InMemoryGatewayDeduplication(new ClientIdStorage(maxSize)));
         }
 
-        const string MaxSizeKey = "InMemoryGatewayDeduplication.MaxSize";
+        internal const string MaxSizeKey = "InMemoryGatewayDeduplication.MaxSize";
         const int MaxSizeDefault = 10000;
     }
 }

--- a/src/NServiceBus.Core/Persistence/InMemory/Gateway/InMemoryGatewayPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/Gateway/InMemoryGatewayPersistence.cs
@@ -22,7 +22,7 @@
         protected internal override void Setup(FeatureConfigurationContext context)
         {
             var maxSize = context.Settings.Get<int>(MaxSizeKey);
-            context.Container.RegisterSingleton<IDeduplicateMessages>(new InMemoryGatewayDeduplication(maxSize));
+            context.Container.RegisterSingleton<IDeduplicateMessages>(new InMemoryGatewayDeduplication(new ClientIdStorage(maxSize)));
         }
 
         const string MaxSizeKey = "InMemoryGatewayDeduplication.MaxSize";


### PR DESCRIPTION
### Symptoms

Messages are not emitted by the receiving gateway with the following log statement:

`"Message with id: {message-id} has already been dispatched, ignoring incoming gateway message."`

The sending gateway treats the message as successfully transmitted and the message is technically lost.

### Who's affected

All users of the Gateway below version 3.1 that use the InMemory option for deduplication storage.

### Root cause

The record of the message-id is stored before the message is emitted to the transport and is not rolled back should the outgoing operation fail. This leads to the message being considered a duplicate once retried.