### PR TITLE
Add handler types and order to startup diagnostics

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
@@ -3,8 +3,8 @@
     using System.IO;
     using System.Threading.Tasks;
     using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
     using EndpointTemplates;
-    using NServiceBus;
     using NUnit.Framework;
 
     public class When_endpoint_starts : NServiceBusAcceptanceTest
@@ -26,7 +26,7 @@
                 .Done(c => c.EndpointsStarted)
                 .Run();
 
-            var endpointName = AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(MyEndpoint));
+            var endpointName = Conventions.EndpointNamingConvention(typeof(MyEndpoint));
             var startupDiagnoticsFileName = $"{endpointName}-configuration.txt";
 
             var pathToFile = Path.Combine(basePath, startupDiagnoticsFileName);
@@ -56,7 +56,7 @@
             }
         }
 
-        class MyMessage:IMessage
+        class MyMessage : IMessage
         {
 
         }

--- a/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
@@ -3,8 +3,8 @@
     using System.IO;
     using System.Threading.Tasks;
     using AcceptanceTesting;
-    using AcceptanceTesting.Customization;
     using EndpointTemplates;
+    using NServiceBus;
     using NUnit.Framework;
 
     public class When_endpoint_starts : NServiceBusAcceptanceTest
@@ -26,7 +26,7 @@
                 .Done(c => c.EndpointsStarted)
                 .Run();
 
-            var endpointName = Conventions.EndpointNamingConvention(typeof(MyEndpoint));
+            var endpointName = AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(MyEndpoint));
             var startupDiagnoticsFileName = $"{endpointName}-configuration.txt";
 
             var pathToFile = Path.Combine(basePath, startupDiagnoticsFileName);
@@ -46,6 +46,19 @@
                 EndpointSetup<DefaultServer>(c => c.SetDiagnosticsPath(basePath))
                    .EnableStartupDiagnostics();
             }
+        }
+
+        class MyMessageHandler : IHandleMessages<MyMessage>
+        {
+            public Task Handle(MyMessage message, IMessageHandlerContext context)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+
+        class MyMessage:IMessage
+        {
+
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
@@ -56,7 +56,7 @@
             }
         }
 
-        class MyMessage : IMessage
+        public class MyMessage : IMessage
         {
         }
     }

--- a/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Hosting/When_endpoint_starts.cs
@@ -58,7 +58,6 @@
 
         class MyMessage : IMessage
         {
-
         }
     }
 }

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -83,9 +83,9 @@ namespace NServiceBus
 
             if (!externalHandlerRegistryUsed)
             {
-                var orderedHandlers = configuration.ExecuteTheseHandlersFirst;
+                var messageHandlerRegistry = configuration.messageHandlerRegistry;
 
-                var messageHandlerRegistry = LoadMessageHandlers(configuration, orderedHandlers, hostingConfiguration.Container, hostingConfiguration.AvailableTypes);
+                RegisterMessageHandlers(messageHandlerRegistry, configuration.ExecuteTheseHandlersFirst, hostingConfiguration.Container, hostingConfiguration.AvailableTypes);
 
                 foreach (var messageType in messageHandlerRegistry.GetMessageTypes())
                 {
@@ -262,7 +262,7 @@ namespace NServiceBus
             }
         }
 
-        static MessageHandlerRegistry LoadMessageHandlers(Configuration configuration, List<Type> orderedTypes, IConfigureComponents container, ICollection<Type> availableTypes)
+        static void RegisterMessageHandlers(MessageHandlerRegistry handlerRegistry, List<Type> orderedTypes, IConfigureComponents container, ICollection<Type> availableTypes)
         {
             var types = new List<Type>(availableTypes);
 
@@ -273,15 +273,6 @@ namespace NServiceBus
 
             types.InsertRange(0, orderedTypes);
 
-            var handlerRegistry = configuration.messageHandlerRegistry;
-
-            ConfigureMessageHandlersIn(handlerRegistry, types, container);
-
-            return handlerRegistry;
-        }
-
-        static void ConfigureMessageHandlersIn(MessageHandlerRegistry handlerRegistry, IEnumerable<Type> types, IConfigureComponents container)
-        {
             foreach (var t in types.Where(IsMessageHandler))
             {
                 container.ConfigureComponent(t, DependencyLifecycle.InstancePerUnitOfWork);

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -78,11 +78,10 @@ namespace NServiceBus
 
             pipelineSettings.Register("InvokeHandlers", new InvokeHandlerTerminator(), "Calls the IHandleMessages<T>.Handle(T)");
 
-            var externalHandlerRegistry = hostingConfiguration.Container.HasComponent<MessageHandlerRegistry>();
-
+            var externalHandlerRegistryUsed = hostingConfiguration.Container.HasComponent<MessageHandlerRegistry>();
             var handlerDiagnostics = new Dictionary<string, List<string>>();
 
-            if (!externalHandlerRegistry)
+            if (!externalHandlerRegistryUsed)
             {
                 var orderedHandlers = configuration.ExecuteTheseHandlersFirst;
 
@@ -112,7 +111,7 @@ namespace NServiceBus
                     TransactionMode = s.RequiredTransportTransactionMode.ToString("G"),
                     s.RuntimeSettings.MaxConcurrency
                 }).ToArray(),
-                ExternalHandlerRegistry = externalHandlerRegistry,
+                ExternalHandlerRegistry = externalHandlerRegistryUsed,
                 MessageHandlers = handlerDiagnostics
             });
 


### PR DESCRIPTION
This record all handlers loaded for each message type and in what order they would be invoked.

```
{
...
   "Receiving":{
      "LocalAddress":"EndpointStarts.MyEndpoint",
      "InstanceSpecificQueue":null,
      "LogicalAddress":{
         "Qualifier":null,
         "EndpointInstance":{
            "Endpoint":"EndpointStarts.MyEndpoint",
            "Discriminator":null,
            "Properties":{

            }
         }
      },
      "PurgeOnStartup":false,
      "QueueNameBase":"EndpointStarts.MyEndpoint",
      "TransactionMode":"SendsAtomicWithReceive",
      "MaxConcurrency":8,
      "Satellites":[

      ],
      "ExternalHandlerRegistry":false,
      "MessageHandlers":{
         "NServiceBus.AcceptanceTests.Core.Hosting.When_endpoint_starts+MyMessage":[
            "NServiceBus.AcceptanceTests.Core.Hosting.When_endpoint_starts+MyMessageHandler"
         ]
      }
   },
...
}