### PR TITLE
Avoid NRE for logging outside test scenario

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
+++ b/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
@@ -105,6 +105,12 @@
         void Log(string message, LogLevel messageSeverity)
         {
             var context = ScenarioContext.Current;
+            if (context == null)
+            {
+                // avoid NRE in case something logs outside of a test scenario
+                Console.WriteLine(message);
+                return;
+            }
 
             if (context.LogLevel > messageSeverity)
                 return;

--- a/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
+++ b/src/NServiceBus.AcceptanceTesting/ContextAppender.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Diagnostics;
     using Logging;
+    using NUnit.Framework;
 
     class ContextAppender : ILog
     {
@@ -108,7 +109,7 @@
             if (context == null)
             {
                 // avoid NRE in case something logs outside of a test scenario
-                Console.WriteLine(message);
+                TestContext.WriteLine(message);
                 return;
             }
 


### PR DESCRIPTION
In case some code/tests are run outside of a test `Scenario`, logging causes an NRE in case a test Scenario ran before. This happens because the test scenarios setup a custom logger (using the `ContextAppender`) which is then cached in the static logger field. Once some other code tries to log using this cached logger, it will potentially run into an NRE because `Scenario.Current` is `null`. Due to the `Scenario.Current` being an async local variable, it won't preserve after a test completed.

There could also be the explicit goal to catch logging attempts outside of a defined test scenario in the acceptance tests so I'm not 100% whether this makes sense, but I ran into this [here](https://github.com/Particular/NServiceBus.RavenDB/pull/451) where I had to move a test to the regular unit test project which is unfortunate as it would suit the acceptance tests better imo.