### PR TITLE
Use Particular.Packaging instead of GitVersionTask in analyzer project

### DIFF
--- a/src/NServiceBus.Core.Analyzer/NServiceBus.Core.Analyzer.csproj
+++ b/src/NServiceBus.Core.Analyzer/NServiceBus.Core.Analyzer.csproj
@@ -5,10 +5,12 @@
     <PackageTargetFallback>portable-net45+win8</PackageTargetFallback>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="5.1.2" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="0.5.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.2.2" />
   </ItemGroup>
 


### PR DESCRIPTION
This changes the analyzer project to reference Particular.Packaging instead of directly referencing GitVersionTask.

This ensures that we keep all the projects using the same version of GitVersionTask by bringing it transitively through Particular.Packaging.