### PR TITLE
Thread.CurrentPrincipal will throw PlatformNotSupportedException on .NET Core 3.x

### DIFF
--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -1,6 +1,9 @@
 namespace NServiceBus
 {
     using System;
+#if NETSTANDARD
+    using System.Runtime.InteropServices;
+#endif
     using System.Security.Principal;
     using System.Threading.Tasks;
     using Settings;
@@ -30,8 +33,14 @@ namespace NServiceBus
 
             await transportInfrastructure.Start().ConfigureAwait(false);
 
+#if NETSTANDARD
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                 AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
+            }
+#else
             AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
-
+#endif
             await receiveComponent.Initialize(containerComponent, recoverabilityComponent).ConfigureAwait(false);
 
             await featureComponent.Start(messageSession).ConfigureAwait(false);


### PR DESCRIPTION
Backport of #5583 fix for release-7.2 branch