### PR TITLE
Explicit transport seam settings

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -635,6 +635,7 @@ namespace NServiceBus
         public override string ExampleConnectionStringForErrorMessage { get; }
         public override bool RequiresConnectionString { get; }
         public override NServiceBus.Transport.TransportInfrastructure Initialize(NServiceBus.Settings.SettingsHolder settings, string connectionString) { }
+        public override NServiceBus.Transport.TransportInfrastructure Initialize(string endpointName, string connectionString, NServiceBus.StartupDiagnosticEntries startupDiagnostics, NServiceBus.Settings.SettingsHolder settings) { }
     }
     public class static LearningTransportConfigurationExtensions
     {
@@ -2665,6 +2666,7 @@ namespace NServiceBus.Transport
         public abstract string ExampleConnectionStringForErrorMessage { get; }
         public virtual bool RequiresConnectionString { get; }
         public abstract NServiceBus.Transport.TransportInfrastructure Initialize(NServiceBus.Settings.SettingsHolder settings, string connectionString);
+        public virtual NServiceBus.Transport.TransportInfrastructure Initialize(string endpointName, string connectionString, NServiceBus.StartupDiagnosticEntries startupDiagnostics, NServiceBus.Settings.SettingsHolder settings) { }
     }
     public abstract class TransportInfrastructure
     {
@@ -2678,8 +2680,10 @@ namespace NServiceBus.Transport
         public abstract NServiceBus.TransportTransactionMode TransactionMode { get; }
         public abstract NServiceBus.Routing.EndpointInstance BindToLocalEndpoint(NServiceBus.Routing.EndpointInstance instance);
         public abstract NServiceBus.Transport.TransportReceiveInfrastructure ConfigureReceiveInfrastructure();
+        public virtual NServiceBus.Transport.TransportReceiveInfrastructure ConfigureReceiveInfrastructure(string localAddress) { }
         public abstract NServiceBus.Transport.TransportSendInfrastructure ConfigureSendInfrastructure();
         public abstract NServiceBus.Transport.TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure();
+        public virtual NServiceBus.Transport.TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure(string localAddress) { }
         public virtual string MakeCanonicalForm(string transportAddress) { }
         public virtual System.Threading.Tasks.Task Start() { }
         public virtual System.Threading.Tasks.Task Stop() { }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -635,6 +635,7 @@ namespace NServiceBus
         public override string ExampleConnectionStringForErrorMessage { get; }
         public override bool RequiresConnectionString { get; }
         public override NServiceBus.Transport.TransportInfrastructure Initialize(NServiceBus.Settings.SettingsHolder settings, string connectionString) { }
+        public override NServiceBus.Transport.TransportInfrastructure Initialize(string endpointName, string connectionString, NServiceBus.StartupDiagnosticEntries startupDiagnostics, NServiceBus.Settings.SettingsHolder settings) { }
     }
     public class static LearningTransportConfigurationExtensions
     {
@@ -2667,6 +2668,7 @@ namespace NServiceBus.Transport
         public abstract string ExampleConnectionStringForErrorMessage { get; }
         public virtual bool RequiresConnectionString { get; }
         public abstract NServiceBus.Transport.TransportInfrastructure Initialize(NServiceBus.Settings.SettingsHolder settings, string connectionString);
+        public virtual NServiceBus.Transport.TransportInfrastructure Initialize(string endpointName, string connectionString, NServiceBus.StartupDiagnosticEntries startupDiagnostics, NServiceBus.Settings.SettingsHolder settings) { }
     }
     public abstract class TransportInfrastructure
     {
@@ -2680,8 +2682,10 @@ namespace NServiceBus.Transport
         public abstract NServiceBus.TransportTransactionMode TransactionMode { get; }
         public abstract NServiceBus.Routing.EndpointInstance BindToLocalEndpoint(NServiceBus.Routing.EndpointInstance instance);
         public abstract NServiceBus.Transport.TransportReceiveInfrastructure ConfigureReceiveInfrastructure();
+        public virtual NServiceBus.Transport.TransportReceiveInfrastructure ConfigureReceiveInfrastructure(string localAddress) { }
         public abstract NServiceBus.Transport.TransportSendInfrastructure ConfigureSendInfrastructure();
         public abstract NServiceBus.Transport.TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure();
+        public virtual NServiceBus.Transport.TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure(string localAddress) { }
         public virtual string MakeCanonicalForm(string transportAddress) { }
         public virtual System.Threading.Tasks.Task Start() { }
         public virtual System.Threading.Tasks.Task Stop() { }

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -35,7 +35,7 @@ namespace NServiceBus
 
             if (!configuration.IsSendOnlyEndpoint)
             {
-                transportReceiveInfrastructure = configuration.transportSeam.TransportInfrastructure.ConfigureReceiveInfrastructure();
+                transportReceiveInfrastructure = configuration.transportSeam.TransportInfrastructure.ConfigureReceiveInfrastructure(configuration.LocalAddress);
 
                 if (configuration.CreateQueues)
                 {

--- a/src/NServiceBus.Core/Routing/NativePublishSubscribeFeature.cs
+++ b/src/NServiceBus.Core/Routing/NativePublishSubscribeFeature.cs
@@ -20,7 +20,8 @@ namespace NServiceBus.Features
 
             if (canReceive)
             {
-                var transportSubscriptionInfrastructure = transportInfrastructure.ConfigureSubscriptionInfrastructure();
+                var localAddress = context.Settings.LocalAddress();
+                var transportSubscriptionInfrastructure = transportInfrastructure.ConfigureSubscriptionInfrastructure(localAddress);
                 var subscriptionManager = transportSubscriptionInfrastructure.SubscriptionManagerFactory();
 
                 context.Pipeline.Register(new NativeSubscribeTerminator(subscriptionManager), "Requests the transport to subscribe to a given message type");

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/SubscriptionMigrationMode.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/SubscriptionMigrationMode.cs
@@ -36,7 +36,8 @@
             if (canReceive)
             {
                 var endpointInstances = context.Routing.EndpointInstances;
-                var transportSubscriptionInfrastructure = transportInfrastructure.ConfigureSubscriptionInfrastructure();
+                var localAddress = context.Settings.LocalAddress();
+                var transportSubscriptionInfrastructure = transportInfrastructure.ConfigureSubscriptionInfrastructure(localAddress);
                 var subscriptionManager = transportSubscriptionInfrastructure.SubscriptionManagerFactory();
 
                 var subscriptionRouter = new SubscriptionRouter(publishers, endpointInstances, i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)));

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransport.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransport.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus
 {
+    using System;
     using Settings;
     using Transport;
 
@@ -29,8 +30,21 @@
         /// <returns>The supported factories.</returns>
         public override TransportInfrastructure Initialize(SettingsHolder settings, string connectionString)
         {
+            throw new NotSupportedException("Use the Initialize(string, string, StartupDiagnosticEntries, SettingsHolder) overload to create a TransportInfrastructure.");
+        }
+
+        /// <summary>
+        /// Initializes all the factories and supported features for the transport. This method is called right before all features
+        /// are activated and the settings will be locked down. This means you can use the SettingsHolder both for providing
+        /// default capabilities as well as for initializing the transport's configuration based on those settings (the user cannot
+        /// provide information anymore at this stage).
+        /// </summary>
+        public override TransportInfrastructure Initialize(string endpointName, string connectionString, StartupDiagnosticEntries startupDiagnostics, SettingsHolder settings)
+        {
+            Guard.AgainstNullAndEmpty(nameof(endpointName), endpointName);
             Guard.AgainstNull(nameof(settings), settings);
-            return new LearningTransportInfrastructure(settings);
+
+            return new LearningTransportInfrastructure(endpointName, settings);
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -26,6 +26,7 @@
             transactionMode = settings.RequiredTransactionMode;
 
             PathChecker.ThrowForBadPath(settings.InputQueue, "InputQueue");
+            PathChecker.ThrowForBadPath(settings.ErrorQueue, "ErrorQueue");
 
             messagePumpBasePath = Path.Combine(basePath, settings.InputQueue);
             bodyDir = Path.Combine(messagePumpBasePath, BodyDirName);

--- a/src/NServiceBus.Core/Transports/TransportDefinition.cs
+++ b/src/NServiceBus.Core/Transports/TransportDefinition.cs
@@ -27,5 +27,25 @@ namespace NServiceBus.Transport
         /// <param name="connectionString">The connection string.</param>
         /// <returns>The supported factories.</returns>
         public abstract TransportInfrastructure Initialize(SettingsHolder settings, string connectionString);
+
+        /// <summary>
+        /// Initializes all the factories and supported features for the transport. This method is called right before all features
+        /// are activated and the settings will be locked down. This means you can use the SettingsHolder both for providing
+        /// default capabilities as well as for initializing the transport's configuration based on those settings (the user cannot
+        /// provide information anymore at this stage).
+        /// </summary>
+        /// <param name="endpointName">The name of the endpoint.</param>
+        /// <param name="connectionString">The connection string.</param>
+        /// <param name="startupDiagnostics"><see cref="StartupDiagnosticEntries"/> to store additional startup diagnostic information.</param>
+        /// <param name="settings">An instance of the current settings.</param>
+        /// <returns>The supported factories.</returns>
+        public virtual TransportInfrastructure Initialize(
+            string endpointName,
+            string connectionString,
+            StartupDiagnosticEntries startupDiagnostics,
+            SettingsHolder settings)
+        {
+            return Initialize(settings, connectionString);
+        }
     }
 }

--- a/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
@@ -31,6 +31,14 @@ namespace NServiceBus.Transport
         public abstract TransportReceiveInfrastructure ConfigureReceiveInfrastructure();
 
         /// <summary>
+        /// Gets the factories to receive message.
+        /// </summary>
+        public virtual TransportReceiveInfrastructure ConfigureReceiveInfrastructure(string localAddress)
+        {
+            return ConfigureReceiveInfrastructure();
+        }
+
+        /// <summary>
         /// Gets the factories to send message.
         /// </summary>
         public abstract TransportSendInfrastructure ConfigureSendInfrastructure();
@@ -39,6 +47,14 @@ namespace NServiceBus.Transport
         /// Gets the factory to manage subscriptions.
         /// </summary>
         public abstract TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure();
+
+        /// <summary>
+        /// Gets the factory to manage subscriptions.
+        /// </summary>
+        public virtual TransportSubscriptionInfrastructure ConfigureSubscriptionInfrastructure(string localAddress)
+        {
+            return ConfigureSubscriptionInfrastructure();
+        }
 
         /// <summary>
         /// Returns the discriminator for this endpoint instance.

--- a/src/NServiceBus.Core/Transports/TransportSeam.cs
+++ b/src/NServiceBus.Core/Transports/TransportSeam.cs
@@ -17,7 +17,11 @@
             var transportDefinition = transportSettings.TransportDefinition;
             var connectionString = transportSettings.TransportConnectionString.GetConnectionStringOrRaiseError(transportDefinition);
 
-            var transportInfrastructure = transportDefinition.Initialize(transportSettings.settings, connectionString);
+            var transportInfrastructure = transportDefinition.Initialize(
+                hostingConfiguration.EndpointName,
+                connectionString,
+                hostingConfiguration.StartupDiagnostics,
+                transportSettings.settings);
 
             //RegisterTransportInfrastructureForBackwardsCompatibility
             transportSettings.settings.Set(transportInfrastructure);

--- a/src/NServiceBus.TransportTests/ConfigureLearningTransportInfrastructure.cs
+++ b/src/NServiceBus.TransportTests/ConfigureLearningTransportInfrastructure.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.Settings;
 using NServiceBus.TransportTests;
+using NUnit.Framework;
 
 class ConfigureLearningTransportInfrastructure : IConfigureTransportInfrastructure
 {
@@ -16,7 +17,7 @@ class ConfigureLearningTransportInfrastructure : IConfigureTransportInfrastructu
 
         return new TransportConfigurationResult
         {
-            TransportInfrastructure = transportDefinition.Initialize(settings, ""),
+            TransportInfrastructure = transportDefinition.Initialize(TestContext.CurrentContext.Test.ID, "", new StartupDiagnosticEntries(), settings),
             PurgeInputQueueOnStartup = true
         };
     }

--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -34,6 +34,7 @@
     </_PackageFiles>
     <_PackageFiles Remove="**\obj\**\*.cs" />
     <_PackageFiles Remove="ConfigureLearningTransportInfrastructure.cs" />
+    <_PackageFiles Remove="When_starting_transport_outside_of_an_endpoint.cs" />
   </ItemGroup>
   <!-- End Workaround -->
 

--- a/src/NServiceBus.TransportTests/When_starting_transport_outside_of_an_endpoint.cs
+++ b/src/NServiceBus.TransportTests/When_starting_transport_outside_of_an_endpoint.cs
@@ -1,0 +1,64 @@
+﻿using NUnit.Framework;
+
+namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using Routing;
+    using Settings;
+    using Transport;
+
+    [TestFixture]
+    public class When_starting_transport_outside_of_an_endpoint
+    {
+        [Test]
+        public async Task Should_send_and_receive_messages()
+        {
+            var learningTransport = new LearningTransport();
+            var diagnostics = new StartupDiagnosticEntries();
+            var settings = new SettingsHolder();
+
+            var transportInfrastructure = learningTransport.Initialize(
+                "EndpointName", string.Empty, diagnostics, settings);
+
+            var receiving = transportInfrastructure.ConfigureReceiveInfrastructure("LocalAddress");
+
+            var receivePump = receiving.MessagePumpFactory();
+
+            var messageReceived = false;
+
+            await receivePump.Init(
+                c =>
+                {
+                    messageReceived = true;
+                    return Task.FromResult(0);
+                },
+                er => Task.FromResult(ErrorHandleResult.Handled),
+                new CriticalError(context => Task.FromResult(0)),
+                new PushSettings("input-queue", "error-queue", false, TransportTransactionMode.ReceiveOnly));
+
+            receivePump.Start(new PushRuntimeSettings());
+
+            var sending = transportInfrastructure.ConfigureSendInfrastructure();
+
+            var dispatcher = sending.DispatcherFactory();
+
+            await dispatcher.Dispatch(new TransportOperations(new[]
+            {
+                new TransportOperation(new OutgoingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]), new UnicastAddressTag("input-queue")),
+            }), new TransportTransaction(), new ContextBag());
+
+            var stopwatch = Stopwatch.StartNew();
+
+            while (messageReceived == false && stopwatch.Elapsed < TimeSpan.FromMinutes(1))
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1));
+            }
+
+            Assert.IsTrue(messageReceived);
+        }
+    }
+}


### PR DESCRIPTION
adds some new, optional overloads which provide more information about the endpoint name and local address to help setup transport infrastructure without requiring to pull this information from the settings class.

* Most of the transports require the local address to setup their native pub/sub infrastructure, this is currently not provided and requires hacks by the transport infrastructure.
* Most of the transports require the endpoint name for various reasons. This is currently only provided via the settings.

Relying on the settings causes issues when trying to setup the transport seam outside of the typical NServiceBus configuration, e.g. when trying to use the transport only (see NSB.Raw and the needs of ServiceControl). Since transports have a lot of hidden dependencies based on the settings, it's very difficult and tricky to configure the settings with all the information a transport requires. By making those explicit on the API we can help to make this easier to use and also easier to maintain.
