### PR TITLE
 Support custom recoverability action option

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_custom_policy_defines_custom_action.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_custom_policy_defines_custom_action.cs
@@ -37,7 +37,7 @@
                 {
                     c.Pipeline.Register<FailingBehavior.Registration>();
                     c.Recoverability().CustomPolicy((config, context) => 
-                        RecoverabilityAction.Custom(errorContext =>
+                        RecoverabilityAction.Custom((_, __, ___) =>
                         {
                             var testContext = r.ScenarioContext as Context;
                             testContext.CustomActionInvoked = true;

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_custom_policy_defines_custom_action.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_custom_policy_defines_custom_action.cs
@@ -74,7 +74,7 @@
             }
         }
 
-        class FailingMessage : IMessage
+        public class FailingMessage : IMessage
         {
         }
     }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_custom_policy_defines_custom_action.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_custom_policy_defines_custom_action.cs
@@ -1,0 +1,81 @@
+﻿namespace NServiceBus.AcceptanceTests.Recoverability
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    public class When_custom_policy_defines_custom_action : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_execute_custom_action_and_consume_message()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithCustomRecoverabilityAction>(e => e
+                    .When(s => s.SendLocal(new FailingMessage())))
+                .Done(ctx => ctx.CustomActionInvoked)
+                .Run();
+
+            Assert.IsTrue(context.CustomActionInvoked);
+            Assert.AreEqual(1, context.HandlerInvocations);
+            Assert.IsEmpty(context.FailedMessages);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool CustomActionInvoked { get; set; }
+            public int HandlerInvocations { get; set; }
+        }
+
+        class EndpointWithCustomRecoverabilityAction : EndpointConfigurationBuilder
+        {
+            public EndpointWithCustomRecoverabilityAction()
+            {
+                EndpointSetup<DefaultServer>((c, r) =>
+                {
+                    c.Pipeline.Register<FailingBehavior.Registration>();
+                    c.Recoverability().CustomPolicy((config, context) => 
+                        RecoverabilityAction.Custom(errorContext =>
+                        {
+                            var testContext = r.ScenarioContext as Context;
+                            testContext.CustomActionInvoked = true;
+                            return Task.FromResult(0);
+                        }));
+                });
+            }
+
+            // We need to throw the exception before the CaptureExceptionBehavior inserted by the testing framework.
+            // The testing framework requires a detected failed message to be successfully retried or moved to the error queue.
+            // This behavior is injected into the pipeline before this detection mechanism.
+            public class FailingBehavior : Behavior<ITransportReceiveContext>
+            {
+                Context testContext;
+
+                public FailingBehavior(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public override Task Invoke(ITransportReceiveContext context, Func<Task> next)
+                {
+                    testContext.HandlerInvocations++;
+                    throw new SimulatedException("message handler failure");
+                }
+
+                public class Registration : RegisterStep
+                {
+                    public Registration() : base("FailingBehavior", typeof(FailingBehavior), "Injects a failing behavior into the pipeline")
+                    {
+                        InsertBefore("CaptureExceptionBehavior");
+                    }
+                }
+            }
+        }
+
+        class FailingMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -202,8 +202,7 @@ namespace NServiceBus
     }
     public class CustomAction : NServiceBus.RecoverabilityAction
     {
-        public CustomAction(System.Func<NServiceBus.Transport.ErrorContext, System.Threading.Tasks.Task> customAction) { }
-        public System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult> Invoke(NServiceBus.Transport.ErrorContext errorContext) { }
+        public CustomAction(System.Func<NServiceBus.Transport.ErrorContext, NServiceBus.Transport.IDispatchMessages, System.Threading.Tasks.Task> customAction) { }
     }
     public class DataBusProperty<T> : NServiceBus.IDataBusProperty, System.Runtime.Serialization.ISerializable
         where T :  class
@@ -779,6 +778,7 @@ namespace NServiceBus
     {
         protected RecoverabilityAction() { }
         public static NServiceBus.CustomAction Custom(System.Func<NServiceBus.Transport.ErrorContext, System.Threading.Tasks.Task> customAction) { }
+        public static NServiceBus.CustomAction Custom(System.Func<NServiceBus.Transport.ErrorContext, NServiceBus.Transport.IDispatchMessages, System.Threading.Tasks.Task> customAction) { }
         public static NServiceBus.DelayedRetry DelayedRetry(System.TimeSpan timeSpan) { }
         public static NServiceBus.Discard Discard(string reason) { }
         public static NServiceBus.ImmediateRetry ImmediateRetry() { }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -202,7 +202,7 @@ namespace NServiceBus
     }
     public class CustomAction : NServiceBus.RecoverabilityAction
     {
-        public CustomAction(System.Func<NServiceBus.Transport.ErrorContext, NServiceBus.Transport.IDispatchMessages, System.Threading.Tasks.Task> customAction) { }
+        public CustomAction(System.Func<NServiceBus.Transport.ErrorContext, NServiceBus.ObjectBuilder.IBuilder, NServiceBus.Transport.IDispatchMessages, System.Threading.Tasks.Task> customAction) { }
     }
     public class DataBusProperty<T> : NServiceBus.IDataBusProperty, System.Runtime.Serialization.ISerializable
         where T :  class
@@ -777,8 +777,7 @@ namespace NServiceBus
     public abstract class RecoverabilityAction
     {
         protected RecoverabilityAction() { }
-        public static NServiceBus.CustomAction Custom(System.Func<NServiceBus.Transport.ErrorContext, System.Threading.Tasks.Task> customAction) { }
-        public static NServiceBus.CustomAction Custom(System.Func<NServiceBus.Transport.ErrorContext, NServiceBus.Transport.IDispatchMessages, System.Threading.Tasks.Task> customAction) { }
+        public static NServiceBus.CustomAction Custom(System.Func<NServiceBus.Transport.ErrorContext, NServiceBus.ObjectBuilder.IBuilder, NServiceBus.Transport.IDispatchMessages, System.Threading.Tasks.Task> customAction) { }
         public static NServiceBus.DelayedRetry DelayedRetry(System.TimeSpan timeSpan) { }
         public static NServiceBus.Discard Discard(string reason) { }
         public static NServiceBus.ImmediateRetry ImmediateRetry() { }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -200,6 +200,11 @@ namespace NServiceBus
             "ll be removed in version 8.0.0.", true)]
         public static void EnableCriticalTimePerformanceCounter(this NServiceBus.EndpointConfiguration config) { }
     }
+    public class CustomAction : NServiceBus.RecoverabilityAction
+    {
+        public CustomAction(System.Func<NServiceBus.Transport.ErrorContext, System.Threading.Tasks.Task> customAction) { }
+        public System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult> Invoke(NServiceBus.Transport.ErrorContext errorContext) { }
+    }
     public class DataBusProperty<T> : NServiceBus.IDataBusProperty, System.Runtime.Serialization.ISerializable
         where T :  class
     {
@@ -773,6 +778,7 @@ namespace NServiceBus
     public abstract class RecoverabilityAction
     {
         protected RecoverabilityAction() { }
+        public static NServiceBus.CustomAction Custom(System.Func<NServiceBus.Transport.ErrorContext, System.Threading.Tasks.Task> customAction) { }
         public static NServiceBus.DelayedRetry DelayedRetry(System.TimeSpan timeSpan) { }
         public static NServiceBus.Discard Discard(string reason) { }
         public static NServiceBus.ImmediateRetry ImmediateRetry() { }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -202,8 +202,7 @@ namespace NServiceBus
     }
     public class CustomAction : NServiceBus.RecoverabilityAction
     {
-        public CustomAction(System.Func<NServiceBus.Transport.ErrorContext, System.Threading.Tasks.Task> customAction) { }
-        public System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult> Invoke(NServiceBus.Transport.ErrorContext errorContext) { }
+        public CustomAction(System.Func<NServiceBus.Transport.ErrorContext, NServiceBus.Transport.IDispatchMessages, System.Threading.Tasks.Task> customAction) { }
     }
     public class DataBusProperty<T> : NServiceBus.IDataBusProperty, System.Runtime.Serialization.ISerializable
         where T :  class
@@ -779,6 +778,7 @@ namespace NServiceBus
     {
         protected RecoverabilityAction() { }
         public static NServiceBus.CustomAction Custom(System.Func<NServiceBus.Transport.ErrorContext, System.Threading.Tasks.Task> customAction) { }
+        public static NServiceBus.CustomAction Custom(System.Func<NServiceBus.Transport.ErrorContext, NServiceBus.Transport.IDispatchMessages, System.Threading.Tasks.Task> customAction) { }
         public static NServiceBus.DelayedRetry DelayedRetry(System.TimeSpan timeSpan) { }
         public static NServiceBus.Discard Discard(string reason) { }
         public static NServiceBus.ImmediateRetry ImmediateRetry() { }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -202,7 +202,7 @@ namespace NServiceBus
     }
     public class CustomAction : NServiceBus.RecoverabilityAction
     {
-        public CustomAction(System.Func<NServiceBus.Transport.ErrorContext, NServiceBus.Transport.IDispatchMessages, System.Threading.Tasks.Task> customAction) { }
+        public CustomAction(System.Func<NServiceBus.Transport.ErrorContext, NServiceBus.ObjectBuilder.IBuilder, NServiceBus.Transport.IDispatchMessages, System.Threading.Tasks.Task> customAction) { }
     }
     public class DataBusProperty<T> : NServiceBus.IDataBusProperty, System.Runtime.Serialization.ISerializable
         where T :  class
@@ -777,8 +777,7 @@ namespace NServiceBus
     public abstract class RecoverabilityAction
     {
         protected RecoverabilityAction() { }
-        public static NServiceBus.CustomAction Custom(System.Func<NServiceBus.Transport.ErrorContext, System.Threading.Tasks.Task> customAction) { }
-        public static NServiceBus.CustomAction Custom(System.Func<NServiceBus.Transport.ErrorContext, NServiceBus.Transport.IDispatchMessages, System.Threading.Tasks.Task> customAction) { }
+        public static NServiceBus.CustomAction Custom(System.Func<NServiceBus.Transport.ErrorContext, NServiceBus.ObjectBuilder.IBuilder, NServiceBus.Transport.IDispatchMessages, System.Threading.Tasks.Task> customAction) { }
         public static NServiceBus.DelayedRetry DelayedRetry(System.TimeSpan timeSpan) { }
         public static NServiceBus.Discard Discard(string reason) { }
         public static NServiceBus.ImmediateRetry ImmediateRetry() { }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -200,6 +200,11 @@ namespace NServiceBus
             "ll be removed in version 8.0.0.", true)]
         public static void EnableCriticalTimePerformanceCounter(this NServiceBus.EndpointConfiguration config) { }
     }
+    public class CustomAction : NServiceBus.RecoverabilityAction
+    {
+        public CustomAction(System.Func<NServiceBus.Transport.ErrorContext, System.Threading.Tasks.Task> customAction) { }
+        public System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult> Invoke(NServiceBus.Transport.ErrorContext errorContext) { }
+    }
     public class DataBusProperty<T> : NServiceBus.IDataBusProperty, System.Runtime.Serialization.ISerializable
         where T :  class
     {
@@ -773,6 +778,7 @@ namespace NServiceBus
     public abstract class RecoverabilityAction
     {
         protected RecoverabilityAction() { }
+        public static NServiceBus.CustomAction Custom(System.Func<NServiceBus.Transport.ErrorContext, System.Threading.Tasks.Task> customAction) { }
         public static NServiceBus.DelayedRetry DelayedRetry(System.TimeSpan timeSpan) { }
         public static NServiceBus.Discard Discard(string reason) { }
         public static NServiceBus.ImmediateRetry ImmediateRetry() { }

--- a/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
@@ -201,6 +201,9 @@
                 return Task.FromResult(0);
             });
 
+            var fakeBuilder = new FakeBuilder();
+            fakeBuilder.Register<IDispatchMessages>(dispatcher);
+
             return new RecoverabilityExecutor(
                 raiseNotifications,
                 immediateRetriesSupported,
@@ -211,7 +214,7 @@
                 new MoveToErrorsExecutor(dispatcher, new Dictionary<string, string>(), headers => { }),
                 messageRetryNotification,
                 messageFaultedNotification,
-                new FakeBuilder());
+                fakeBuilder);
         }
 
         FakeDispatcher dispatcher;

--- a/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
@@ -6,6 +6,7 @@
     using System.Threading.Tasks;
     using Extensibility;
     using NUnit.Framework;
+    using Testing;
     using Transport;
 
     [TestFixture]
@@ -163,25 +164,8 @@
         [Test]
         public async Task When_providing_custom_action_should_invoke()
         {
-            var invokedCustomAction = false;
-            var customAction = RecoverabilityAction.Custom(errorCtx =>
-            {
-                invokedCustomAction = true;
-                return TaskEx.CompletedTask;
-            });
-            var recoverabilityExecutor = CreateExecutor(RetryPolicy.Return(new RecoverabilityAction[] {customAction}));
-
-            var result = await recoverabilityExecutor.Invoke(CreateErrorContext());
-
-            Assert.AreEqual(ErrorHandleResult.Handled, result);
-            Assert.IsTrue(invokedCustomAction);
-        }
-        
-        [Test]
-        public async Task When_providing_custom_action_with_dispatcher_should_pass_dispatcher()
-        {
             IDispatchMessages caughtDispatcher = null;
-            var customAction = RecoverabilityAction.Custom((errorCtx, disp) =>
+            var customAction = RecoverabilityAction.Custom((errorCtx, builder, disp) =>
             {
                 caughtDispatcher = disp;
                 
@@ -227,7 +211,7 @@
                 new MoveToErrorsExecutor(dispatcher, new Dictionary<string, string>(), headers => { }),
                 messageRetryNotification,
                 messageFaultedNotification,
-                dispatcher);
+                new FakeBuilder());
         }
 
         FakeDispatcher dispatcher;

--- a/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
@@ -160,6 +160,23 @@
             Assert.AreEqual(customErrorQueueAddress, failure.ErrorQueue);
         }
 
+        [Test]
+        public async Task When_providing_custom_action_should_invoke()
+        {
+            var invokedCustomAction = false;
+            var customAction = RecoverabilityAction.Custom(errorCtx =>
+            {
+                invokedCustomAction = true;
+                return TaskEx.CompletedTask;
+            });
+            var recoverabilityExecutor = CreateExecutor(RetryPolicy.Return(new RecoverabilityAction[] {customAction}));
+
+            var result = await recoverabilityExecutor.Invoke(CreateErrorContext());
+
+            Assert.AreEqual(ErrorHandleResult.Handled, result);
+            Assert.IsTrue(invokedCustomAction);
+        }
+
         static ErrorContext CreateErrorContext(Exception raisedException = null, string exceptionMessage = "default-message", string messageId = "default-id", int numberOfDeliveryAttempts = 1)
         {
             return new ErrorContext(raisedException ?? new Exception(exceptionMessage), new Dictionary<string, string>(), messageId, new byte[0], new TransportTransaction(), numberOfDeliveryAttempts);

--- a/src/NServiceBus.Core/Recoverability/CustomAction.cs
+++ b/src/NServiceBus.Core/Recoverability/CustomAction.cs
@@ -9,24 +9,20 @@ namespace NServiceBus
     /// </summary>
     public class CustomAction : RecoverabilityAction
     {
-        readonly Func<ErrorContext, Task> customAction;
+        readonly Func<ErrorContext, IDispatchMessages, Task> customAction;
 
         /// <summary>
         /// Creates a new <see cref="CustomAction"/> using the provided callback to resolve a message failure.
         /// </summary>
         /// <param name="customAction">The method invoked to handle a failed message.</param>
-        public CustomAction(Func<ErrorContext, Task> customAction)
+        public CustomAction(Func<ErrorContext, IDispatchMessages, Task> customAction)
         {
             this.customAction = customAction;
         }
 
-        /// <summary>
-        /// Invokes the custom recoverability action.
-        /// </summary>
-        /// <returns>always returns <see cref="ErrorHandleResult.Handled"/> to indicate the transport to consume the message.</returns>
-        public async Task<ErrorHandleResult> Invoke(ErrorContext errorContext)
+        internal async Task<ErrorHandleResult> Invoke(ErrorContext errorContext, IDispatchMessages dispatcher)
         {
-            await customAction(errorContext).ConfigureAwait(false);
+            await customAction(errorContext, dispatcher).ConfigureAwait(false);
             return ErrorHandleResult.Handled;
         }
     }

--- a/src/NServiceBus.Core/Recoverability/CustomAction.cs
+++ b/src/NServiceBus.Core/Recoverability/CustomAction.cs
@@ -1,0 +1,33 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Threading.Tasks;
+    using Transport;
+
+    /// <summary>
+    /// Defines a custom recoverability action, taking care of handling a message processing error.
+    /// </summary>
+    public class CustomAction : RecoverabilityAction
+    {
+        readonly Func<ErrorContext, Task> customAction;
+
+        /// <summary>
+        /// Creates a new <see cref="CustomAction"/> using the provided callback to resolve a message failure.
+        /// </summary>
+        /// <param name="customAction">The method invoked to handle a failed message.</param>
+        public CustomAction(Func<ErrorContext, Task> customAction)
+        {
+            this.customAction = customAction;
+        }
+
+        /// <summary>
+        /// Invokes the custom recoverability action.
+        /// </summary>
+        /// <returns>always returns <see cref="ErrorHandleResult.Handled"/> to indicate the transport to consume the message.</returns>
+        public async Task<ErrorHandleResult> Invoke(ErrorContext errorContext)
+        {
+            await customAction(errorContext).ConfigureAwait(false);
+            return ErrorHandleResult.Handled;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Recoverability/CustomAction.cs
+++ b/src/NServiceBus.Core/Recoverability/CustomAction.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
+    using ObjectBuilder;
     using Transport;
 
     /// <summary>
@@ -9,20 +10,20 @@ namespace NServiceBus
     /// </summary>
     public class CustomAction : RecoverabilityAction
     {
-        readonly Func<ErrorContext, IDispatchMessages, Task> customAction;
+        readonly Func<ErrorContext, IBuilder, IDispatchMessages, Task> customAction;
 
         /// <summary>
         /// Creates a new <see cref="CustomAction"/> using the provided callback to resolve a message failure.
         /// </summary>
         /// <param name="customAction">The method invoked to handle a failed message.</param>
-        public CustomAction(Func<ErrorContext, IDispatchMessages, Task> customAction)
+        public CustomAction(Func<ErrorContext, IBuilder, IDispatchMessages, Task> customAction)
         {
             this.customAction = customAction;
         }
 
-        internal async Task<ErrorHandleResult> Invoke(ErrorContext errorContext, IDispatchMessages dispatcher)
+        internal async Task<ErrorHandleResult> Invoke(ErrorContext errorContext, IBuilder builder, IDispatchMessages dispatcher)
         {
-            await customAction(errorContext, dispatcher).ConfigureAwait(false);
+            await customAction(errorContext, builder, dispatcher).ConfigureAwait(false);
             return ErrorHandleResult.Handled;
         }
     }

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityAction.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityAction.cs
@@ -58,13 +58,23 @@ namespace NServiceBus
             Guard.AgainstNullAndEmpty(nameof(reason), reason);
             return new Discard(reason);
         }
-
+        
         /// <summary>
         /// Creates a custom recoverability action.
         /// </summary>
         /// <param name="customAction">The action to perform for the failed message.</param>
         /// <returns>Custom recoverability action.</returns>
         public static CustomAction Custom(Func<ErrorContext, Task> customAction)
+        {
+            return new CustomAction((e, d) => customAction(e));
+        }        
+
+        /// <summary>
+        /// Creates a custom recoverability action.
+        /// </summary>
+        /// <param name="customAction">The action to perform for the failed message.</param>
+        /// <returns>Custom recoverability action.</returns>
+        public static CustomAction Custom(Func<ErrorContext, IDispatchMessages, Task> customAction)
         {
             return new CustomAction(customAction);
         }

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityAction.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityAction.cs
@@ -1,6 +1,8 @@
 namespace NServiceBus
 {
     using System;
+    using System.Threading.Tasks;
+    using Transport;
 
     /// <summary>
     /// Abstraction representing any recoverability action.
@@ -55,6 +57,16 @@ namespace NServiceBus
         {
             Guard.AgainstNullAndEmpty(nameof(reason), reason);
             return new Discard(reason);
+        }
+
+        /// <summary>
+        /// Creates a custom recoverability action.
+        /// </summary>
+        /// <param name="customAction">The action to perform for the failed message.</param>
+        /// <returns>Custom recoverability action.</returns>
+        public static CustomAction Custom(Func<ErrorContext, Task> customAction)
+        {
+            return new CustomAction(customAction);
         }
 
         static ImmediateRetry CachedImmediateRetry = new ImmediateRetry();

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityAction.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityAction.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
+    using ObjectBuilder;
     using Transport;
 
     /// <summary>
@@ -58,23 +59,13 @@ namespace NServiceBus
             Guard.AgainstNullAndEmpty(nameof(reason), reason);
             return new Discard(reason);
         }
-        
-        /// <summary>
-        /// Creates a custom recoverability action.
-        /// </summary>
-        /// <param name="customAction">The action to perform for the failed message.</param>
-        /// <returns>Custom recoverability action.</returns>
-        public static CustomAction Custom(Func<ErrorContext, Task> customAction)
-        {
-            return new CustomAction((e, d) => customAction(e));
-        }        
 
         /// <summary>
         /// Creates a custom recoverability action.
         /// </summary>
         /// <param name="customAction">The action to perform for the failed message.</param>
         /// <returns>Custom recoverability action.</returns>
-        public static CustomAction Custom(Func<ErrorContext, IDispatchMessages, Task> customAction)
+        public static CustomAction Custom(Func<ErrorContext, IBuilder, IDispatchMessages, Task> customAction)
         {
             return new CustomAction(customAction);
         }

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityComponent.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityComponent.cs
@@ -125,7 +125,7 @@
                 delayedRetriesAvailable,
                 MessageRetryNotification,
                 MessageFaultedNotification,
-                dispatcher);
+                builder);
         }
 
         ImmediateConfig GetImmediateRetryConfig()

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityComponent.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityComponent.cs
@@ -124,7 +124,8 @@
                 immediateRetriesAvailable,
                 delayedRetriesAvailable,
                 MessageRetryNotification,
-                MessageFaultedNotification);
+                MessageFaultedNotification,
+                builder.Build<IDispatchMessages>());
         }
 
         ImmediateConfig GetImmediateRetryConfig()

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityComponent.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityComponent.cs
@@ -77,8 +77,8 @@
         {
             var delayedRetriesAvailable = transactionsOn
                                           && (settings.DoesTransportSupportConstraint<DelayedDeliveryConstraint>() || settings.Get<TimeoutManagerAddressConfiguration>().TransportAddress != null);
-
             var immediateRetriesAvailable = transactionsOn;
+            var dispatcher = builder.Build<IDispatchMessages>();
 
             Func<string, MoveToErrorsExecutor> moveToErrorsExecutorFactory = localAddress =>
             {
@@ -93,7 +93,7 @@
 
                 var headerCustomizations = settings.Get<Action<Dictionary<string, string>>>(FaultHeaderCustomization);
 
-                return new MoveToErrorsExecutor(builder.Build<IDispatchMessages>(), staticFaultMetadata, headerCustomizations);
+                return new MoveToErrorsExecutor(dispatcher, staticFaultMetadata, headerCustomizations);
             };
 
             Func<string, DelayedRetryExecutor> delayedRetryExecutorFactory = localAddress =>
@@ -102,7 +102,7 @@
                 {
                     return new DelayedRetryExecutor(
                         localAddress,
-                        builder.Build<IDispatchMessages>(),
+                        dispatcher,
                         settings.DoesTransportSupportConstraint<DelayedDeliveryConstraint>()
                             ? null
                             : settings.Get<TimeoutManagerAddressConfiguration>().TransportAddress);
@@ -125,7 +125,7 @@
                 delayedRetriesAvailable,
                 MessageRetryNotification,
                 MessageFaultedNotification,
-                builder.Build<IDispatchMessages>());
+                dispatcher);
         }
 
         ImmediateConfig GetImmediateRetryConfig()

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Threading.Tasks;
     using Logging;
+    using ObjectBuilder;
     using Transport;
 
     class RecoverabilityExecutor
@@ -17,9 +18,9 @@
             MoveToErrorsExecutor moveToErrorsExecutor,
             INotificationSubscriptions<MessageToBeRetried> messageRetryNotification,
             INotificationSubscriptions<MessageFaulted> messageFaultedNotification,
-            IDispatchMessages dispatcher)
+            IBuilder builder)
         {
-            this.dispatcher = dispatcher;
+            this.builder = builder;
             this.configuration = configuration;
             this.recoverabilityPolicy = recoverabilityPolicy;
             this.delayedRetryExecutor = delayedRetryExecutor;
@@ -68,7 +69,7 @@
             if (recoveryAction is CustomAction customAction)
             {
                 Logger.Info($"Invoke custom recoverability action for message with id '{errorContext.Message.MessageId}'.");
-                return customAction.Invoke(errorContext, dispatcher);
+                return customAction.Invoke(errorContext, builder, builder.Build<IDispatchMessages>());
             }
 
             if (recoveryAction is Discard discard)
@@ -149,6 +150,6 @@
 
         static Task<ErrorHandleResult> HandledTask = Task.FromResult(ErrorHandleResult.Handled);
         static ILog Logger = LogManager.GetLogger<RecoverabilityExecutor>();
-        IDispatchMessages dispatcher;
+        IBuilder builder;
     }
 }

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityExecutorFactory.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityExecutorFactory.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using ObjectBuilder;
     using Transport;
 
     class RecoverabilityExecutorFactory
@@ -14,9 +15,9 @@
             bool delayedRetriesAvailable,
             INotificationSubscriptions<MessageToBeRetried> messageRetryNotification,
             INotificationSubscriptions<MessageFaulted> messageFaultedNotification,
-            IDispatchMessages dispatcher)
+            IBuilder builder)
         {
-            this.dispatcher = dispatcher;
+            this.builder = builder;
             this.configuration = configuration;
             this.defaultRecoverabilityPolicy = defaultRecoverabilityPolicy;
             this.delayedRetryExecutorFactory = delayedRetryExecutorFactory;
@@ -52,7 +53,7 @@
                 moveToErrorsExecutor,
                 messageRetryNotification,
                 messageFaultedNotification, 
-                dispatcher);
+                builder);
         }
 
         readonly bool immediateRetriesAvailable;
@@ -64,6 +65,6 @@
         Func<string, DelayedRetryExecutor> delayedRetryExecutorFactory;
         Func<string, MoveToErrorsExecutor> moveToErrorsExecutorFactory;
         RecoverabilityConfig configuration;
-        IDispatchMessages dispatcher;
+        IBuilder builder;
     }
 }

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityExecutorFactory.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityExecutorFactory.cs
@@ -13,8 +13,10 @@
             bool immediateRetriesAvailable,
             bool delayedRetriesAvailable,
             INotificationSubscriptions<MessageToBeRetried> messageRetryNotification,
-            INotificationSubscriptions<MessageFaulted> messageFaultedNotification)
+            INotificationSubscriptions<MessageFaulted> messageFaultedNotification,
+            IDispatchMessages dispatcher)
         {
+            this.dispatcher = dispatcher;
             this.configuration = configuration;
             this.defaultRecoverabilityPolicy = defaultRecoverabilityPolicy;
             this.delayedRetryExecutorFactory = delayedRetryExecutorFactory;
@@ -49,7 +51,8 @@
                 delayedRetryExecutor,
                 moveToErrorsExecutor,
                 messageRetryNotification,
-                messageFaultedNotification);
+                messageFaultedNotification, 
+                dispatcher);
         }
 
         readonly bool immediateRetriesAvailable;
@@ -61,5 +64,6 @@
         Func<string, DelayedRetryExecutor> delayedRetryExecutorFactory;
         Func<string, MoveToErrorsExecutor> moveToErrorsExecutorFactory;
         RecoverabilityConfig configuration;
+        IDispatchMessages dispatcher;
     }
 }


### PR DESCRIPTION
Based in @danielmarbach and @SzymonPobiega spikes around short circuiting the core pipeline, it seemed like the custom behavior would have to work around some recoverability limitations as it's usage in ServiceControl want's to store failed messages in a database at some point instead of retrying.

The current recoverability API doesn't allow this. This API would allow a custom recoverability policy to define an alternative action instead of the existing ack/retry/error-queue options, giving the user full responsibility and flexibility about how to handle the failed message.