### PR TITLE
Move non-standard stuff into separate props file

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -1,0 +1,7 @@
+<Project>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.1.2-alpha" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,12 +1,10 @@
 <Project>
 
+  <Import Project="Custom.Build.props" Condition="Exists('Custom.Build.props')" />
+
   <PropertyGroup>
     <LangVersion>7.3</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.1.2-alpha" PrivateAssets="All" />
-  </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.sln
+++ b/src/NServiceBus.sln
@@ -25,6 +25,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.TransportTests"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E3BC3CE8-9EA6-41BE-89AD-23876257B740}"
 	ProjectSection(SolutionItems) = preProject
+		Custom.Build.props = Custom.Build.props
 		Directory.Build.props = Directory.Build.props
 		..\GitVersion.yml = ..\GitVersion.yml
 	EndProjectSection


### PR DESCRIPTION
This is the sort of thing we'll need to do for any repos that have customized Directory.Build.props files.

I'm not sure I'm happy with the name of the new file. `Local.Build.props` doesn't really seem to convey the intention of the file.

Can we think of something better?