### PR TITLE
Set NServiceBus.Subscriptions.EnableMigrationMode in the constructor of SubscriptionMigrationModeSettings

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/When_subscriber_has_subscription_migration_mode_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/When_subscriber_has_subscription_migration_mode_enabled.cs
@@ -49,8 +49,6 @@
                 EndpointSetup<EndpointWithNativePubSub>(c =>
                 {
                     // Enable Migration mode
-                    c.GetSettings().Set("NServiceBus.Subscriptions.EnableMigrationMode", true);
-
                     var settings = new SubscriptionMigrationModeSettings(c.GetSettings());
                     settings.RegisterPublisher(typeof(SomeEvent), Conventions.EndpointNamingConvention(typeof(MessageDrivenPublisher)));
                 });

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/SubscriptionMigrationModeSettings.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/SubscriptionMigrationModeSettings.cs
@@ -17,6 +17,7 @@
         /// </summary>
         public SubscriptionMigrationModeSettings(SettingsHolder settings) : base(settings)
         {
+            settings.Set("NServiceBus.Subscriptions.EnableMigrationMode", true);
         }
 
         /// <summary>


### PR DESCRIPTION
Every transport that wants to enable `EnableMessageDrivenPubSubCompatibilityMode` basically has to have an API like the following

```
        public static SubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this TransportExtensions<SqsTransport> transportExtensions)
        {
            var settings = transportExtensions.GetSettings();
            settings.Set("NServiceBus.Subscriptions.EnableMigrationMode", true);
            return new SubscriptionMigrationModeSettings(settings);
        }
```

you also have to remember to set `            settings.Set("NServiceBus.Subscriptions.EnableMigrationMode", true);`

with this change you can just do

```
        public static SubscriptionMigrationModeSettings EnableMessageDrivenPubSubCompatibilityMode(this TransportExtensions<SqsTransport> transportExtensions)
        {
            return new SubscriptionMigrationModeSettings(transportExtensions.GetSettings());
        }
```
