### PR TITLE
Transport seam improvements to better support NServiceBus.Raw

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -183,6 +183,7 @@ namespace NServiceBus
     {
         public CriticalError(System.Func<NServiceBus.ICriticalErrorContext, System.Threading.Tasks.Task> onCriticalErrorAction) { }
         public virtual void Raise(string errorMessage, System.Exception exception) { }
+        public void SetStopCallback(System.Func<System.Threading.Tasks.Task> endpointStopCallback) { }
     }
     public class CriticalErrorContext : NServiceBus.ICriticalErrorContext
     {
@@ -2715,6 +2716,7 @@ namespace NServiceBus.Transport
     public class TransportSubscriptionInfrastructure
     {
         public TransportSubscriptionInfrastructure(System.Func<NServiceBus.Transport.IManageSubscriptions> subscriptionManagerFactory) { }
+        public System.Func<NServiceBus.Transport.IManageSubscriptions> SubscriptionManagerFactory { get; }
     }
     public sealed class TransportTransaction : NServiceBus.Extensibility.ContextBag
     {

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -183,6 +183,7 @@ namespace NServiceBus
     {
         public CriticalError(System.Func<NServiceBus.ICriticalErrorContext, System.Threading.Tasks.Task> onCriticalErrorAction) { }
         public virtual void Raise(string errorMessage, System.Exception exception) { }
+        public void SetStopCallback(System.Func<System.Threading.Tasks.Task> endpointStopCallback) { }
     }
     public class CriticalErrorContext : NServiceBus.ICriticalErrorContext
     {
@@ -2717,6 +2718,7 @@ namespace NServiceBus.Transport
     public class TransportSubscriptionInfrastructure
     {
         public TransportSubscriptionInfrastructure(System.Func<NServiceBus.Transport.IManageSubscriptions> subscriptionManagerFactory) { }
+        public System.Func<NServiceBus.Transport.IManageSubscriptions> SubscriptionManagerFactory { get; }
     }
     public sealed class TransportTransaction : NServiceBus.Extensibility.ContextBag
     {

--- a/src/NServiceBus.Core/ConfigureQueueCreation.cs
+++ b/src/NServiceBus.Core/ConfigureQueueCreation.cs
@@ -23,7 +23,7 @@ namespace NServiceBus
         public static bool CreateQueues(this ReadOnlySettings settings)
         {
             Guard.AgainstNull(nameof(settings), settings);
-            return settings.Get<ReceiveComponent.Configuration>().CreateQueues;
+            return settings.Get<bool>("ReceiveComponent.Legacy.CreateQueues");
         }
     }
 }

--- a/src/NServiceBus.Core/Hosting/HostingComponent.cs
+++ b/src/NServiceBus.Core/Hosting/HostingComponent.cs
@@ -75,7 +75,7 @@
 
             var endpointInstance = await startableEndpoint.Start().ConfigureAwait(false);
 
-            configuration.CriticalError.SetEndpoint(endpointInstance);
+            configuration.CriticalError.SetStopCallback(endpointInstance.Stop);
 
             return endpointInstance;
         }

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.Settings.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.Settings.cs
@@ -70,7 +70,9 @@ namespace NServiceBus
             public void RegisterReceiveConfigurationForBackwardsCompatibility(Configuration configuration)
             {
                 //note: remove once settings.LogicalAddress() , .LocalAddress() and .InstanceSpecificQueue() has been obsoleted
-                settings.Set(configuration);
+                settings.Set("ReceiveComponent.Legacy.LogicalAddress", configuration.LogicalAddress);
+                settings.Set("ReceiveComponent.Legacy.LocalAddress", configuration.LocalAddress);
+                settings.Set("ReceiveComponent.Legacy.InstanceSpecificQueue", configuration.InstanceSpecificQueue);
             }
 
             public void SetDefaultPushRuntimeSettings(PushRuntimeSettings pushRuntimeSettings)

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.Settings.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.Settings.cs
@@ -69,10 +69,15 @@ namespace NServiceBus
 
             public void RegisterReceiveConfigurationForBackwardsCompatibility(Configuration configuration)
             {
-                //note: remove once settings.LogicalAddress() , .LocalAddress() and .InstanceSpecificQueue() has been obsoleted
+                //note: remove once settings.LogicalAddress() , .LocalAddress() and .InstanceSpecificQueue() and others has been obsoleted
                 settings.Set("ReceiveComponent.Legacy.LogicalAddress", configuration.LogicalAddress);
                 settings.Set("ReceiveComponent.Legacy.LocalAddress", configuration.LocalAddress);
                 settings.Set("ReceiveComponent.Legacy.InstanceSpecificQueue", configuration.InstanceSpecificQueue);
+                settings.Set("ReceiveComponent.Legacy.CreateQueues", configuration.CreateQueues);
+                if (!configuration.IsSendOnlyEndpoint)
+                {
+                    settings.Set("ReceiveComponent.Legacy.ReceiveTransactionMode", configuration.TransactionMode);
+                }
             }
 
             public void SetDefaultPushRuntimeSettings(PushRuntimeSettings pushRuntimeSettings)

--- a/src/NServiceBus.Core/SettingsExtensions.cs
+++ b/src/NServiceBus.Core/SettingsExtensions.cs
@@ -34,12 +34,12 @@ namespace NServiceBus
         {
             Guard.AgainstNull(nameof(settings), settings);
 
-            if (!settings.TryGet<ReceiveComponent.Configuration>(out var receiveConfiguration))
+            if (!settings.TryGet<LogicalAddress>("ReceiveComponent.Legacy.LogicalAddress", out var result))
             {
                 throw new InvalidOperationException("LogicalAddress isn't available since this endpoint is configured to run in send-only mode.");
             }
 
-            return receiveConfiguration.LogicalAddress;
+            return result;
         }
 
         /// <summary>
@@ -49,12 +49,12 @@ namespace NServiceBus
         {
             Guard.AgainstNull(nameof(settings), settings);
 
-            if (!settings.TryGet<ReceiveComponent.Configuration>(out var receiveConfiguration))
+            if (!settings.TryGet<string>("ReceiveComponent.Legacy.LocalAddress", out var result))
             {
                 throw new InvalidOperationException("LocalAddress isn't available since this endpoint is configured to run in send-only mode.");
             }
 
-            return receiveConfiguration.LocalAddress;
+            return result;
         }
 
         /// <summary>
@@ -64,12 +64,12 @@ namespace NServiceBus
         {
             Guard.AgainstNull(nameof(settings), settings);
 
-            if (!settings.TryGet<ReceiveComponent.Configuration>(out var receiveConfiguration))
+            if (!settings.TryGet<string>("ReceiveComponent.Legacy.InstanceSpecificQueue", out var result))
             {
                 throw new InvalidOperationException("Instance-specific queue name isn't available since this endpoint is configured to run in send-only mode.");
             }
 
-            return receiveConfiguration.InstanceSpecificQueue;
+            return result;
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/TransactionModeSettingsExtensions.cs
+++ b/src/NServiceBus.Core/Transports/TransactionModeSettingsExtensions.cs
@@ -15,14 +15,11 @@ namespace NServiceBus.ConsistencyGuarantees
         {
             Guard.AgainstNull(nameof(settings), settings);
 
-            var receiveConfiguration = settings.Get<ReceiveComponent.Configuration>();
-
-            if (receiveConfiguration.IsSendOnlyEndpoint)
+            if (!settings.TryGet<TransportTransactionMode>("ReceiveComponent.Legacy.ReceiveTransactionMode", out var result))
             {
                 throw new InvalidOperationException("Receive transaction mode isn't available since this endpoint is configured to run in send-only mode.");
             }
-
-            return receiveConfiguration.TransactionMode;
+            return result;
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/TransportSubscriptionInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/TransportSubscriptionInfrastructure.cs
@@ -16,6 +16,9 @@ namespace NServiceBus.Transport
             SubscriptionManagerFactory = subscriptionManagerFactory;
         }
 
-        internal Func<IManageSubscriptions> SubscriptionManagerFactory { get; }
+        /// <summary>
+        /// Factory for creating a subscription manager.
+        /// </summary>
+        public Func<IManageSubscriptions> SubscriptionManagerFactory { get; }
     }
 }


### PR DESCRIPTION
This PR contains changes that would make it much easier and much less hacky to use NServiceBus transports as stand-alone beings, outside of the context of NServiceBus. The changes include:
 - Instead of registering `ReceiveComponent.Configuration` in the settings bag, register only values of three selected properties that are used by the transports
 - Make the registration of *stop the endpoint* callback public in the `CriticalError` class
 - Make the subscription infrastructure factory public (similar properties in similar classes are public so this does not break any rules)

The only thing left out is the handling of connection strings.