### PR TITLE
Lowered log entry level to Warn as this is not a blocking failure

### DIFF
--- a/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnosticsWriterFactory.cs
+++ b/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnosticsWriterFactory.cs
@@ -30,7 +30,7 @@
                 }
                 catch (Exception e)
                 {
-                    logger.Error("Unable to determine the diagnostics output directory. Check the attached exception for further information, or configure a custom diagnostics directory using 'EndpointConfiguration.SetDiagnosticsPath()'.", e);
+                    logger.Warn("Unable to determine the diagnostics output directory. Check the attached exception for further information, or configure a custom diagnostics directory using 'EndpointConfiguration.SetDiagnosticsPath()'.", e);
 
                     return data => TaskEx.CompletedTask;
                 }
@@ -44,7 +44,7 @@
                 }
                 catch (Exception e)
                 {
-                    logger.Error("Unable to create the diagnostics output directory. Check the attached exception for further information, or change the diagnostics directory using 'EndpointConfiguration.SetDiagnosticsPath()'.", e);
+                    logger.Warn("Unable to create the diagnostics output directory. Check the attached exception for further information, or change the diagnostics directory using 'EndpointConfiguration.SetDiagnosticsPath()'.", e);
 
                     return data => TaskEx.CompletedTask;
                 }


### PR DESCRIPTION
Based on feedback https://github.com/Particular/docs.particular.net/issues/4766


>If setting up the diagnostics part is not blocking, i would put the level of the error on Warn.
>
>See following error. (Since we did the upgrade to nsb v7)
>
>```
>2020-04-03 10:07:25,975 [5] ERROR NServiceBus.HostStartupDiagnostics - Unable to create the diagnostics output directory. Check the attached exception for further information, or change the diagnostics directory using 'EndpointConfiguration.SetDiagnosticsPath()'.
>System.UnauthorizedAccessException: Access to the path 'd:\Services\xyz.diagnostics' is denied.
>at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
>at System.IO.Directory.InternalCreateDirectory(String fullPath, String path, Object dirSecurityObj, Boolean checkHost)
>at System.IO.Directory.InternalCreateDirectoryHelper(String path, Boolean checkHost)
>at System.IO.Directory.CreateDirectory(String path)
>at NServiceBus.HostStartupDiagnostics.BuildDefaultDiagnosticsWriter(ReadOnlySettings settings)
>```