### PR TITLE
Make it possible to extend the delivery constraints

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -707,6 +707,7 @@ namespace NServiceBus
     public class NonDurableDelivery : NServiceBus.DeliveryConstraints.DeliveryConstraint
     {
         public NonDurableDelivery() { }
+        protected override void Serialize(System.Collections.Generic.Dictionary<string, string> options) { }
     }
     public class Notifications
     {
@@ -1417,6 +1418,7 @@ namespace NServiceBus.DelayedDelivery
     {
         public DelayDeliveryWith(System.TimeSpan delay) { }
         public System.TimeSpan Delay { get; }
+        protected override void Serialize(System.Collections.Generic.Dictionary<string, string> options) { }
     }
     public abstract class DelayedDeliveryConstraint : NServiceBus.DeliveryConstraints.DeliveryConstraint
     {
@@ -1426,6 +1428,7 @@ namespace NServiceBus.DelayedDelivery
     {
         public DoNotDeliverBefore(System.DateTime at) { }
         public System.DateTime At { get; }
+        protected override void Serialize(System.Collections.Generic.Dictionary<string, string> options) { }
     }
     public class static ExternalTimeoutManagerConfigurationExtensions
     {
@@ -1437,6 +1440,8 @@ namespace NServiceBus.DeliveryConstraints
     public abstract class DeliveryConstraint
     {
         protected DeliveryConstraint() { }
+        protected static void RegisterDeserializer(System.Action<System.Collections.Generic.IReadOnlyDictionary<string, string>, System.Collections.Generic.ICollection<NServiceBus.DeliveryConstraints.DeliveryConstraint>> factory) { }
+        protected virtual void Serialize(System.Collections.Generic.Dictionary<string, string> options) { }
     }
     public class static DeliveryConstraintContextExtensions
     {
@@ -1942,6 +1947,7 @@ namespace NServiceBus.Performance.TimeToBeReceived
     {
         public DiscardIfNotReceivedBefore(System.TimeSpan maxTime) { }
         public System.TimeSpan MaxTime { get; }
+        protected override void Serialize(System.Collections.Generic.Dictionary<string, string> options) { }
     }
 }
 namespace NServiceBus.Persistence

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -707,6 +707,7 @@ namespace NServiceBus
     public class NonDurableDelivery : NServiceBus.DeliveryConstraints.DeliveryConstraint
     {
         public NonDurableDelivery() { }
+        protected override void Serialize(System.Collections.Generic.Dictionary<string, string> options) { }
     }
     public class Notifications
     {
@@ -1419,6 +1420,7 @@ namespace NServiceBus.DelayedDelivery
     {
         public DelayDeliveryWith(System.TimeSpan delay) { }
         public System.TimeSpan Delay { get; }
+        protected override void Serialize(System.Collections.Generic.Dictionary<string, string> options) { }
     }
     public abstract class DelayedDeliveryConstraint : NServiceBus.DeliveryConstraints.DeliveryConstraint
     {
@@ -1428,6 +1430,7 @@ namespace NServiceBus.DelayedDelivery
     {
         public DoNotDeliverBefore(System.DateTime at) { }
         public System.DateTime At { get; }
+        protected override void Serialize(System.Collections.Generic.Dictionary<string, string> options) { }
     }
     public class static ExternalTimeoutManagerConfigurationExtensions
     {
@@ -1439,6 +1442,8 @@ namespace NServiceBus.DeliveryConstraints
     public abstract class DeliveryConstraint
     {
         protected DeliveryConstraint() { }
+        protected static void RegisterDeserializer(System.Action<System.Collections.Generic.IReadOnlyDictionary<string, string>, System.Collections.Generic.ICollection<NServiceBus.DeliveryConstraints.DeliveryConstraint>> factory) { }
+        protected virtual void Serialize(System.Collections.Generic.Dictionary<string, string> options) { }
     }
     public class static DeliveryConstraintContextExtensions
     {
@@ -1944,6 +1949,7 @@ namespace NServiceBus.Performance.TimeToBeReceived
     {
         public DiscardIfNotReceivedBefore(System.TimeSpan maxTime) { }
         public System.TimeSpan MaxTime { get; }
+        protected override void Serialize(System.Collections.Generic.Dictionary<string, string> options) { }
     }
 }
 namespace NServiceBus.Persistence

--- a/src/NServiceBus.Core/DelayedDelivery/DelayDeliveryWith.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/DelayDeliveryWith.cs
@@ -1,6 +1,8 @@
 ﻿namespace NServiceBus.DelayedDelivery
 {
     using System;
+    using System.Collections.Generic;
+    using DeliveryConstraints;
 
     /// <summary>
     /// Represent a constraint that the message can't be delivered before the specified delay has elapsed.
@@ -18,9 +20,28 @@
             Delay = delay;
         }
 
+        static DelayDeliveryWith()
+        {
+            RegisterDeserializer(Deserialize);
+        }
+
         /// <summary>
         /// The requested delay.
         /// </summary>
         public TimeSpan Delay { get; }
+
+        /// <inheritdoc/>
+        protected override void Serialize(Dictionary<string, string> options)
+        {
+            options["DelayDeliveryFor"] = Delay.ToString();
+        }
+
+        static void Deserialize(IReadOnlyDictionary<string, string> options, ICollection<DeliveryConstraint> constraints)
+        {
+            if (options.TryGetValue("DelayDeliveryFor", out var delay))
+            {
+                constraints.Add(new DelayDeliveryWith(TimeSpan.Parse(delay)));
+            }
+        }
     }
 }

--- a/src/NServiceBus.Core/DeliveryConstraints/DeliveryConstraint.cs
+++ b/src/NServiceBus.Core/DeliveryConstraints/DeliveryConstraint.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.DeliveryConstraints
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -8,5 +9,39 @@
     public abstract class DeliveryConstraint
     {
         internal static List<DeliveryConstraint> EmptyConstraints = new List<DeliveryConstraint>(0);
+        static List<Action<IReadOnlyDictionary<string, string>, ICollection<DeliveryConstraint>>> deserializes = new List<Action<IReadOnlyDictionary<string, string>, ICollection<DeliveryConstraint>>>();
+
+        internal void SerializeInternal(Dictionary<string, string> options)
+        {
+            Serialize(options);
+        }
+
+        /// <summary>
+        /// Serializes the content of the delivery constraint into the provided dictionary.
+        /// </summary>
+        /// <param name="options">The options dictionary.</param>
+        protected virtual void Serialize(Dictionary<string, string> options)
+        {
+        }
+
+        internal static List<DeliveryConstraint> DeserializeInternal(IReadOnlyDictionary<string, string> options)
+        {
+            var constraints = new List<DeliveryConstraint>(deserializes.Count);
+            foreach (var factory in deserializes)
+            {
+                factory(options, constraints);
+            }
+            return constraints;
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="factory"></param>
+        /// <remarks>Not thread safe</remarks>
+        protected static void RegisterDeserializer(Action<IReadOnlyDictionary<string, string>, ICollection<DeliveryConstraint>> factory)
+        {
+            deserializes.Add(factory);
+        }
     }
 }

--- a/src/NServiceBus.Core/Performance/TimeToBeReceived/DiscardIfNotReceivedBefore.cs
+++ b/src/NServiceBus.Core/Performance/TimeToBeReceived/DiscardIfNotReceivedBefore.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Performance.TimeToBeReceived
 {
     using System;
+    using System.Collections.Generic;
     using DeliveryConstraints;
 
     /// <summary>
@@ -17,9 +18,28 @@
             MaxTime = maxTime;
         }
 
+        static DiscardIfNotReceivedBefore()
+        {
+            RegisterDeserializer(Deserialize);
+        }
+
         /// <summary>
         /// The max time to wait before discarding the message.
         /// </summary>
         public TimeSpan MaxTime { get; }
+
+        /// <inheritdoc/>
+        protected override void Serialize(Dictionary<string, string> options)
+        {
+            options["TimeToBeReceived"] = MaxTime.ToString();
+        }
+
+        static void Deserialize(IReadOnlyDictionary<string, string> options, ICollection<DeliveryConstraint> constraints)
+        {
+            if (options.TryGetValue("TimeToBeReceived", out var ttbr))
+            {
+                constraints.Add(new DiscardIfNotReceivedBefore(TimeSpan.Parse(ttbr)));
+            }
+        }
     }
 }

--- a/src/NServiceBus.Core/Routing/NonDurableDelivery.cs
+++ b/src/NServiceBus.Core/Routing/NonDurableDelivery.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus
 {
+    using System.Collections.Generic;
     using DeliveryConstraints;
 
     /// <summary>
@@ -7,5 +8,23 @@
     /// </summary>
     public class NonDurableDelivery : DeliveryConstraint
     {
+        static  NonDurableDelivery()
+        {
+            RegisterDeserializer(Deserialize);
+        }
+
+        /// <inheritdoc/>
+        protected override void Serialize(Dictionary<string, string> options)
+        {
+            options["NonDurable"] = true.ToString();
+        }
+
+        static void Deserialize(IReadOnlyDictionary<string, string> options, ICollection<DeliveryConstraint> constraints)
+        {
+            if (options.ContainsKey("NonDurable"))
+            {
+                constraints.Add(new NonDurableDelivery());
+            }
+        }
     }
 }


### PR DESCRIPTION
As part of fixing the SNS / SQS race conditions when publishing to topic when the SQS queue policy has not yet propagated when wanted to leverage the delivery constraints to float that into the dispatcher to make sure publish options can enforce the necessity to check the topology as needed (which is for me a delivery constraint). Once I went down the path of inheriting from DeliveryConstraints I ran into all sorts of tests failing because the serialization and deserialization logic in the core cannot deal with extended delivery constraints even though the inheritance hierarchy is wide open. Either we fix this to allow inheritance (this PR) or we make the whole hierarchy close by default in the next version of core. 

The static factory approach is a tradeoff between speed of the existing solution vs making it possible to extend the deserialization. 