### PR TITLE
Start FeatureStartupTasks in feature dependency order

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_feature.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_feature.cs
@@ -1,0 +1,143 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Feature
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_depending_on_feature : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_start_startup_tasks_in_order_of_dependency()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithFeatures>(b => b.CustomConfig(c =>
+                {
+                    c.EnableFeature<DependencyFeature>();
+                    c.EnableFeature<TypedDependentFeature>();
+                }))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.That(context.StartCalled, Is.True);
+            Assert.That(context.StopCalled, Is.True);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool StartCalled { get; set; }
+            public bool StopCalled { get; set; }
+            public bool InitializeCalled { get; set; }
+        }
+
+        public class EndpointWithFeatures : EndpointConfigurationBuilder
+        {
+            public EndpointWithFeatures()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class TypedDependentFeature : Feature
+        {
+            public TypedDependentFeature()
+            {
+                DependsOn<DependencyFeature>();
+            }
+
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.Container.ConfigureComponent<Runner>(DependencyLifecycle.SingleInstance);
+                context.RegisterStartupTask(b => b.Build<Runner>());
+            }
+
+            class Runner : FeatureStartupTask
+            {
+                Dependency dependency;
+
+                public Runner(Dependency dependency)
+                {
+                    this.dependency = dependency;
+                }
+                protected override Task OnStart(IMessageSession session)
+                {
+                    dependency.Start();
+                    return Task.FromResult(0);
+                }
+
+                protected override Task OnStop(IMessageSession session)
+                {
+                    dependency.Stop();
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class DependencyFeature : Feature
+        {
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.Container.ConfigureComponent<Dependency>(DependencyLifecycle.SingleInstance);
+
+                context.Container.ConfigureComponent<Runner>(DependencyLifecycle.SingleInstance);
+                context.RegisterStartupTask(b => b.Build<Runner>());
+            }
+
+            class Runner : FeatureStartupTask
+            {
+                Dependency dependency;
+
+                public Runner(Dependency dependency)
+                {
+                    this.dependency = dependency;
+                }
+                protected override Task OnStart(IMessageSession session)
+                {
+                    dependency.Initialize();
+                    return Task.FromResult(0);
+                }
+
+                protected override Task OnStop(IMessageSession session)
+                {
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        class Dependency
+        {
+            Context context;
+
+            public Dependency(Context context)
+            {
+                this.context = context;
+            }
+
+            public void Start()
+            {
+                if (!context.InitializeCalled)
+                {
+                    throw new InvalidOperationException("Not initialized");
+                }
+                context.StartCalled = true;
+            }
+
+            public void Stop()
+            {
+                if (!context.InitializeCalled)
+                {
+                    throw new InvalidOperationException("Not initialized");
+                }
+
+                context.StopCalled = true;
+            }
+
+            public void Initialize()
+            {
+                context.InitializeCalled = true;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Text;
     using System.Threading.Tasks;
     using NServiceBus.Features;
     using NUnit.Framework;
@@ -32,6 +33,26 @@
 
             Assert.True(feature.TaskStarted);
             Assert.True(feature.TaskStopped);
+        }
+
+        [Test]
+        public async Task Should_start_and_stop_features_in_dependency_order()
+        {
+            var orderBuilder = new StringBuilder();
+
+            featureSettings.Add(new FeatureWithStartupTaskWithDependency(orderBuilder));
+            featureSettings.Add(new FeatureWithStartupThatAnotherFeatureDependsOn(orderBuilder));
+
+            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
+
+            await featureSettings.StartFeatures(null, null);
+            await featureSettings.StopFeatures();
+
+            StringAssert.AreEqualIgnoringCase(@"FeatureWithStartupThatAnotherFeatureDependsOn.Start
+FeatureWithStartupTaskWithDependency.Start
+FeatureWithStartupThatAnotherFeatureDependsOn.Stop
+FeatureWithStartupTaskWithDependency.Stop
+", orderBuilder.ToString());
         }
 
         [Test]
@@ -98,6 +119,85 @@
 
         FeatureActivator featureSettings;
         SettingsHolder settings;
+
+        class FeatureWithStartupTaskWithDependency : TestFeature
+        {
+            public FeatureWithStartupTaskWithDependency(StringBuilder orderBuilder)
+            {
+                EnableByDefault();
+                DependsOn<FeatureWithStartupThatAnotherFeatureDependsOn>();
+
+                this.orderBuilder = orderBuilder;
+            }
+
+            protected internal override void Setup(FeatureConfigurationContext context)
+            {
+                context.RegisterStartupTask(new Runner(orderBuilder));
+            }
+
+            class Runner : FeatureStartupTask
+            {
+                public Runner(StringBuilder orderBuilder)
+                {
+                    this.orderBuilder = orderBuilder;
+                }
+
+                protected override Task OnStart(IMessageSession session)
+                {
+                    orderBuilder.AppendLine($"{nameof(FeatureWithStartupTaskWithDependency)}.Start");
+                    return TaskEx.CompletedTask;
+                }
+
+                protected override Task OnStop(IMessageSession session)
+                {
+                    orderBuilder.AppendLine($"{nameof(FeatureWithStartupTaskWithDependency)}.Stop");
+                    return TaskEx.CompletedTask;
+                }
+
+                StringBuilder orderBuilder;
+            }
+
+            readonly StringBuilder orderBuilder;
+        }
+
+        class FeatureWithStartupThatAnotherFeatureDependsOn : TestFeature
+        {
+            public FeatureWithStartupThatAnotherFeatureDependsOn(StringBuilder orderBuilder)
+            {
+                EnableByDefault();
+
+                this.orderBuilder = orderBuilder;
+            }
+
+            protected internal override void Setup(FeatureConfigurationContext context)
+            {
+                context.RegisterStartupTask(new Runner(orderBuilder));
+            }
+
+            class Runner : FeatureStartupTask
+            {
+                public Runner(StringBuilder orderBuilder)
+                {
+                    this.orderBuilder = orderBuilder;
+                }
+
+                protected override Task OnStart(IMessageSession session)
+                {
+                    orderBuilder.AppendLine($"{nameof(FeatureWithStartupThatAnotherFeatureDependsOn)}.Start");
+                    return TaskEx.CompletedTask;
+                }
+
+                protected override Task OnStop(IMessageSession session)
+                {
+                    orderBuilder.AppendLine($"{nameof(FeatureWithStartupThatAnotherFeatureDependsOn)}.Stop");
+                    return TaskEx.CompletedTask;
+                }
+
+                StringBuilder orderBuilder;
+            }
+
+            readonly StringBuilder orderBuilder;
+        }
 
         class FeatureWithStartupTask : TestFeature
         {

--- a/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
@@ -48,11 +48,13 @@
             await featureSettings.StartFeatures(null, null);
             await featureSettings.StopFeatures();
 
-            StringAssert.AreEqualIgnoringCase(@"FeatureWithStartupThatAnotherFeatureDependsOn.Start
-FeatureWithStartupTaskWithDependency.Start
-FeatureWithStartupThatAnotherFeatureDependsOn.Stop
-FeatureWithStartupTaskWithDependency.Stop
-", orderBuilder.ToString());
+            var expectedOrderBuilder = new StringBuilder();
+            expectedOrderBuilder.AppendLine("FeatureWithStartupThatAnotherFeatureDependsOn.Start");
+            expectedOrderBuilder.AppendLine("FeatureWithStartupTaskWithDependency.Start");
+            expectedOrderBuilder.AppendLine("FeatureWithStartupThatAnotherFeatureDependsOn.Stop");
+            expectedOrderBuilder.AppendLine("FeatureWithStartupTaskWithDependency.Stop");
+
+            Assert.AreEqual(expectedOrderBuilder.ToString(), orderBuilder.ToString());
         }
 
         [Test]

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -62,6 +62,7 @@ namespace NServiceBus.Features
 
         public async Task StartFeatures(IBuilder builder, IMessageSession session)
         {
+            // sequential starting of startup tasks is intended, introducing concurrency here could break a lot of features.
             foreach (var feature in enabledFeatures.Where(f => f.Feature.IsActive))
             {
                 foreach (var taskController in feature.TaskControllers)

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -40,7 +40,6 @@ namespace NServiceBus.Features
             // featuresToActivate is enumerated twice because after setting defaults some new features might got activated.
             var sourceFeatures = Sort(features);
 
-            var enabledFeatures = new List<FeatureInfo>();
             while (true)
             {
                 var featureToActivate = sourceFeatures.FirstOrDefault(x => settings.IsFeatureEnabled(x.Feature.GetType()));
@@ -63,7 +62,7 @@ namespace NServiceBus.Features
 
         public async Task StartFeatures(IBuilder builder, IMessageSession session)
         {
-            foreach (var feature in features.Where(f => f.Feature.IsActive))
+            foreach (var feature in enabledFeatures.Where(f => f.Feature.IsActive))
             {
                 foreach (var taskController in feature.TaskControllers)
                 {
@@ -74,7 +73,7 @@ namespace NServiceBus.Features
 
         public Task StopFeatures()
         {
-            var featureStopTasks = features.Where(f => f.Feature.IsActive)
+            var featureStopTasks = enabledFeatures.Where(f => f.Feature.IsActive)
                 .SelectMany(f => f.TaskControllers)
                 .Select(task => task.Stop());
 
@@ -208,6 +207,7 @@ namespace NServiceBus.Features
         }
 
         List<FeatureInfo> features = new List<FeatureInfo>();
+        List<FeatureInfo> enabledFeatures = new List<FeatureInfo>();
         SettingsHolder settings;
 
         class FeatureInfo


### PR DESCRIPTION
## Who's affected

- Customers or downstream components using features that depend on another feature with startup tasks

## Symptoms

- The startup sequence is violated and can cause exception depending on the reflection order

## Analysis

Ask multiple developers the following question

> If you have two Features `A` and `B` both with a startup task `ATask` and `BTask`. Feature B depends on A. What would your expectation be for the startup tasks?

The answer is always: `ATask` should be started first.

The core answer is:

It depends on the reflection order. 

This is very problematic because

- It violates the logical reasoning
- Features can register dependencies in the container and they can use startup tasks to initialize those dependencies.
- Dependent features can inject dependencies of other features they depend upon into their startup task which depending on the reflection order might or might not work

It can be demonstrated by moving in the acceptance test the `TypedDependentFeature` feature below the `DependencyFeature`. 
