### PR TITLE
Start FeatureStartupTasks in feature dependency order

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_feature.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_feature.cs
@@ -1,0 +1,143 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Feature
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_depending_on_feature : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_start_startup_tasks_in_order_of_dependency()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithFeatures>(b => b.CustomConfig(c =>
+                {
+                    c.EnableFeature<DependencyFeature>();
+                    c.EnableFeature<TypedDependentFeature>();
+                }))
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.That(context.StartCalled, Is.True);
+            Assert.That(context.StopCalled, Is.True);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool StartCalled { get; set; }
+            public bool StopCalled { get; set; }
+            public bool InitializeCalled { get; set; }
+        }
+
+        public class EndpointWithFeatures : EndpointConfigurationBuilder
+        {
+            public EndpointWithFeatures()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+        }
+
+        public class TypedDependentFeature : Feature
+        {
+            public TypedDependentFeature()
+            {
+                DependsOn<DependencyFeature>();
+            }
+
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.Container.ConfigureComponent<Runner>(DependencyLifecycle.SingleInstance);
+                context.RegisterStartupTask(b => b.Build<Runner>());
+            }
+
+            class Runner : FeatureStartupTask
+            {
+                Dependency dependency;
+
+                public Runner(Dependency dependency)
+                {
+                    this.dependency = dependency;
+                }
+                protected override Task OnStart(IMessageSession session)
+                {
+                    dependency.Start();
+                    return Task.FromResult(0);
+                }
+
+                protected override Task OnStop(IMessageSession session)
+                {
+                    dependency.Stop();
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class DependencyFeature : Feature
+        {
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                context.Container.ConfigureComponent<Dependency>(DependencyLifecycle.SingleInstance);
+
+                context.Container.ConfigureComponent<Runner>(DependencyLifecycle.SingleInstance);
+                context.RegisterStartupTask(b => b.Build<Runner>());
+            }
+
+            class Runner : FeatureStartupTask
+            {
+                Dependency dependency;
+
+                public Runner(Dependency dependency)
+                {
+                    this.dependency = dependency;
+                }
+                protected override Task OnStart(IMessageSession session)
+                {
+                    dependency.Initialize();
+                    return Task.FromResult(0);
+                }
+
+                protected override Task OnStop(IMessageSession session)
+                {
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        class Dependency
+        {
+            Context context;
+
+            public Dependency(Context context)
+            {
+                this.context = context;
+            }
+
+            public void Start()
+            {
+                if (!context.InitializeCalled)
+                {
+                    throw new InvalidOperationException("Not initialized");
+                }
+                context.StartCalled = true;
+            }
+
+            public void Stop()
+            {
+                if (!context.InitializeCalled)
+                {
+                    throw new InvalidOperationException("Not initialized");
+                }
+
+                context.StopCalled = true;
+            }
+
+            public void Initialize()
+            {
+                context.InitializeCalled = true;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -40,7 +40,6 @@ namespace NServiceBus.Features
             // featuresToActivate is enumerated twice because after setting defaults some new features might got activated.
             var sourceFeatures = Sort(features);
 
-            var enabledFeatures = new List<FeatureInfo>();
             while (true)
             {
                 var featureToActivate = sourceFeatures.FirstOrDefault(x => settings.IsFeatureEnabled(x.Feature.GetType()));
@@ -63,7 +62,8 @@ namespace NServiceBus.Features
 
         public async Task StartFeatures(IBuilder builder, IMessageSession session)
         {
-            foreach (var feature in features.Where(f => f.Feature.IsActive))
+            // sequential starting of startup tasks is intended, introducing concurrency here could break a lot of features.
+            foreach (var feature in enabledFeatures.Where(f => f.Feature.IsActive))
             {
                 foreach (var taskController in feature.TaskControllers)
                 {
@@ -74,7 +74,7 @@ namespace NServiceBus.Features
 
         public Task StopFeatures()
         {
-            var featureStopTasks = features.Where(f => f.Feature.IsActive)
+            var featureStopTasks = enabledFeatures.Where(f => f.Feature.IsActive)
                 .SelectMany(f => f.TaskControllers)
                 .Select(task => task.Stop());
 
@@ -208,6 +208,7 @@ namespace NServiceBus.Features
         }
 
         List<FeatureInfo> features = new List<FeatureInfo>();
+        List<FeatureInfo> enabledFeatures = new List<FeatureInfo>();
         SettingsHolder settings;
 
         class FeatureInfo


### PR DESCRIPTION
Backport of #5620 for  release-7.2 branch

## Who's affected

- Customers or downstream components using features that depend on another feature with startup tasks

## Symptoms

- The startup sequence is violated and can cause exception depending on the reflection order

## Analysis

Ask multiple developers the following question

> If you have two Features `A` and `B` both with a startup task `ATask` and `BTask`. Feature B depends on A. What would your expectation be for the startup tasks?

The answer is always: `ATask` should be started first.

The core answer is:

It depends on the reflection order. 

This is very problematic because

- It violates the logical reasoning
- Features can register dependencies in the container and they can use startup tasks to initialize those dependencies.
- Dependent features can inject dependencies of other features they depend upon into their startup task which depending on the reflection order might or might not work

It can be demonstrated by moving in the acceptance test the `TypedDependentFeature` feature below the `DependencyFeature`. 


