### PR TITLE
Intellisense doco indicating SendLocal is a shortcut

### DIFF
--- a/src/NServiceBus.Core/IMessageSessionExtensions.cs
+++ b/src/NServiceBus.Core/IMessageSessionExtensions.cs
@@ -78,7 +78,7 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Sends the message back to the current endpoint. Shortcut for <see cref="RoutingOptionExtensions.RouteToThisEndpoint(SendOptions)">sendOptions.RouteToThisEndpoint()</see>/
+        /// Sends the message back to the current endpoint. Shortcut for <see cref="RoutingOptionExtensions.RouteToThisEndpoint(SendOptions)">sendOptions.RouteToThisEndpoint().</see>/
         /// </summary>
         /// <param name="session">Object being extended.</param>
         /// <param name="message">The message to send.</param>
@@ -95,7 +95,7 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Instantiates a message of type T and sends it back to the current endpoint. Shortcut for <see cref="RoutingOptionExtensions.RouteToThisEndpoint(SendOptions)">sendOptions.RouteToThisEndpoint()</see>/
+        /// Instantiates a message of type T and sends it back to the current endpoint. Shortcut for <see cref="RoutingOptionExtensions.RouteToThisEndpoint(SendOptions)">sendOptions.RouteToThisEndpoint().</see>/
         /// </summary>
         /// <typeparam name="T">The type of message, usually an interface.</typeparam>
         /// <param name="session">Object being extended.</param>

--- a/src/NServiceBus.Core/IMessageSessionExtensions.cs
+++ b/src/NServiceBus.Core/IMessageSessionExtensions.cs
@@ -78,7 +78,7 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Sends the message back to the current endpoint.
+        /// Sends the message back to the current endpoint. Shortcut for <see cref="RoutingOptionExtensions.RouteToThisEndpoint(SendOptions)">sendOptions.RouteToThisEndpoint()</see>/
         /// </summary>
         /// <param name="session">Object being extended.</param>
         /// <param name="message">The message to send.</param>
@@ -95,7 +95,7 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Instantiates a message of type T and sends it back to the current endpoint.
+        /// Instantiates a message of type T and sends it back to the current endpoint. Shortcut for <see cref="RoutingOptionExtensions.RouteToThisEndpoint(SendOptions)">sendOptions.RouteToThisEndpoint()</see>/
         /// </summary>
         /// <typeparam name="T">The type of message, usually an interface.</typeparam>
         /// <param name="session">Object being extended.</param>

--- a/src/NServiceBus.Core/IMessageSessionExtensions.cs
+++ b/src/NServiceBus.Core/IMessageSessionExtensions.cs
@@ -78,7 +78,7 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Sends the message back to the current endpoint. Shortcut for <see cref="RoutingOptionExtensions.RouteToThisEndpoint(SendOptions)">sendOptions.RouteToThisEndpoint().</see>/
+        /// Sends the message back to the current endpoint. Shortcut for <see cref="RoutingOptionExtensions.RouteToThisEndpoint(SendOptions)">sendOptions.RouteToThisEndpoint()</see>.
         /// </summary>
         /// <param name="session">Object being extended.</param>
         /// <param name="message">The message to send.</param>
@@ -95,7 +95,7 @@ namespace NServiceBus
         }
 
         /// <summary>
-        /// Instantiates a message of type T and sends it back to the current endpoint. Shortcut for <see cref="RoutingOptionExtensions.RouteToThisEndpoint(SendOptions)">sendOptions.RouteToThisEndpoint().</see>/
+        /// Instantiates a message of type T and sends it back to the current endpoint. Shortcut for <see cref="RoutingOptionExtensions.RouteToThisEndpoint(SendOptions)">sendOptions.RouteToThisEndpoint()</see>.
         /// </summary>
         /// <typeparam name="T">The type of message, usually an interface.</typeparam>
         /// <param name="session">Object being extended.</param>


### PR DESCRIPTION
Users do not see a send options parameter and don't know that SendLocal is just a shortcut.