### PR TITLE
Add support for setting an additional assembly scanning path

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -15,7 +15,7 @@ namespace NServiceBus
     public class AssemblyScannerConfiguration
     {
         public AssemblyScannerConfiguration() { }
-        public string CustomAssemblyScanningPath { get; set; }
+        public string AdditionalAssemblyScanningPath { get; set; }
         public bool ScanAppDomainAssemblies { get; set; }
         public bool ScanAssembliesInNestedDirectories { get; set; }
         public bool ThrowExceptions { get; set; }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -15,6 +15,7 @@ namespace NServiceBus
     public class AssemblyScannerConfiguration
     {
         public AssemblyScannerConfiguration() { }
+        public string CustomAssemblyScanningPath { get; set; }
         public bool ScanAppDomainAssemblies { get; set; }
         public bool ScanAssembliesInNestedDirectories { get; set; }
         public bool ThrowExceptions { get; set; }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -15,7 +15,7 @@ namespace NServiceBus
     public class AssemblyScannerConfiguration
     {
         public AssemblyScannerConfiguration() { }
-        public string CustomAssemblyScanningPath { get; set; }
+        public string AdditionalAssemblyScanningPath { get; set; }
         public bool ScanAppDomainAssemblies { get; set; }
         public bool ScanAssembliesInNestedDirectories { get; set; }
         public bool ThrowExceptions { get; set; }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -15,6 +15,7 @@ namespace NServiceBus
     public class AssemblyScannerConfiguration
     {
         public AssemblyScannerConfiguration() { }
+        public string CustomAssemblyScanningPath { get; set; }
         public bool ScanAppDomainAssemblies { get; set; }
         public bool ScanAssembliesInNestedDirectories { get; set; }
         public bool ThrowExceptions { get; set; }

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScanningComponentTests.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScanningComponentTests.cs
@@ -16,7 +16,7 @@
 
             var configuration = new AssemblyScanningComponent.Configuration(settingsHolder);
 
-            configuration.AssemblyScannerConfiguration.CustomAssemblyScanningPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestDlls", "Nested", "Subfolder");
+            configuration.AssemblyScannerConfiguration.AdditionalAssemblyScanningPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestDlls", "Nested", "Subfolder");
 
             var component = AssemblyScanningComponent.Initialize(configuration, settingsHolder);
 

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScanningComponentTests.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/AssemblyScanningComponentTests.cs
@@ -1,0 +1,28 @@
+﻿namespace NServiceBus.Core.Tests.AssemblyScanner
+{
+    using System.IO;
+    using System.Linq;
+    using Settings;
+    using NUnit.Framework;
+
+    [TestFixture]
+    class AssemblyScanningComponentTests
+    {
+        [Test]
+        public void Should_initialize_scanner_with_custom_path_when_provided()
+        {
+            var settingsHolder = new SettingsHolder();
+            settingsHolder.Set(new HostingComponent.Settings(settingsHolder));
+
+            var configuration = new AssemblyScanningComponent.Configuration(settingsHolder);
+
+            configuration.AssemblyScannerConfiguration.CustomAssemblyScanningPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestDlls", "Nested", "Subfolder");
+
+            var component = AssemblyScanningComponent.Initialize(configuration, settingsHolder);
+
+            var foundTypeFromScannedPath = component.AvailableTypes.Any(x => x.Name == "NestedClass");
+
+            Assert.True(foundTypeFromScannedPath, "Was expected to scan a custom path, but 'nested.dll' was not scanned.");
+        }
+    }
+}

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -27,7 +27,12 @@ namespace NServiceBus.Hosting.Helpers
         /// </summary>
         public AssemblyScanner(string baseDirectoryToScan)
         {
-            this.baseDirectoryToScan = baseDirectoryToScan;
+            this.baseDirectoriesToScan = new[] { baseDirectoryToScan };
+        }
+
+        internal AssemblyScanner(string[] baseDirectoriesToScan)
+        {
+            this.baseDirectoriesToScan = baseDirectoriesToScan;
         }
 
         internal AssemblyScanner(Assembly assemblyToScan)
@@ -81,11 +86,14 @@ namespace NServiceBus.Hosting.Helpers
 
             var assemblies = new List<Assembly>();
 
-            foreach (var assemblyFile in ScanDirectoryForAssemblyFiles(baseDirectoryToScan, ScanNestedDirectories))
+            foreach (var directoryToScan in baseDirectoriesToScan)
             {
-                if (TryLoadScannableAssembly(assemblyFile.FullName, results, out var assembly))
+                foreach (var assemblyFile in ScanDirectoryForAssemblyFiles(directoryToScan, ScanNestedDirectories))
                 {
-                    assemblies.Add(assembly);
+                    if (TryLoadScannableAssembly(assemblyFile.FullName, results, out var assembly))
+                    {
+                        assemblies.Add(assembly);
+                    }
                 }
             }
 
@@ -410,7 +418,7 @@ namespace NServiceBus.Hosting.Helpers
         internal bool ScanNestedDirectories;
         internal List<Type> TypesToSkip = new List<Type>();
         Assembly assemblyToScan;
-        string baseDirectoryToScan;
+        string[] baseDirectoriesToScan;
         const string NServicebusCoreAssemblyName = "NServiceBus.Core";
 
         static string[] FileSearchPatternsToUse =

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -83,15 +83,11 @@ namespace NServiceBus.Hosting.Helpers
 
             var assemblies = new List<Assembly>();
 
-            foreach (var directoryToScan in GetDirectoriesToScan())
+            ScanAssembliesInDirectory(baseDirectoryToScan, assemblies, results);
+
+            if (!string.IsNullOrWhiteSpace(AdditionalAssemblyScanningPath))
             {
-                foreach (var assemblyFile in ScanDirectoryForAssemblyFiles(directoryToScan, ScanNestedDirectories))
-                {
-                    if (TryLoadScannableAssembly(assemblyFile.FullName, results, out var assembly))
-                    {
-                        assemblies.Add(assembly);
-                    }
-                }
+                ScanAssembliesInDirectory(AdditionalAssemblyScanningPath, assemblies, results);
             }
 
             var platformAssembliesString = (string)AppDomain.CurrentDomain.GetData("TRUSTED_PLATFORM_ASSEMBLIES");
@@ -122,13 +118,14 @@ namespace NServiceBus.Hosting.Helpers
             return results;
         }
 
-        IEnumerable<string> GetDirectoriesToScan()
+        void ScanAssembliesInDirectory(string directoryToScan, List<Assembly> assemblies, AssemblyScannerResults results)
         {
-            yield return baseDirectoryToScan;
-
-            if (!string.IsNullOrWhiteSpace(AdditionalAssemblyScanningPath))
+            foreach (var assemblyFile in ScanDirectoryForAssemblyFiles(directoryToScan, ScanNestedDirectories))
             {
-                yield return AdditionalAssemblyScanningPath;
+                if (TryLoadScannableAssembly(assemblyFile.FullName, results, out var assembly))
+                {
+                    assemblies.Add(assembly);
+                }
             }
         }
 

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -83,11 +83,7 @@ namespace NServiceBus.Hosting.Helpers
 
             var assemblies = new List<Assembly>();
 
-            var directoriesToScan = string.IsNullOrWhiteSpace(AdditionalAssemblyScanningPath)
-                ? new[] {baseDirectoryToScan}
-                : new[] {baseDirectoryToScan, AdditionalAssemblyScanningPath};
-
-            foreach (var directoryToScan in directoriesToScan)
+            foreach (var directoryToScan in GetDirectoriesToScan())
             {
                 foreach (var assemblyFile in ScanDirectoryForAssemblyFiles(directoryToScan, ScanNestedDirectories))
                 {
@@ -124,6 +120,16 @@ namespace NServiceBus.Hosting.Helpers
             results.RemoveDuplicates();
 
             return results;
+        }
+
+        IEnumerable<string> GetDirectoriesToScan()
+        {
+            yield return baseDirectoryToScan;
+
+            if (!string.IsNullOrWhiteSpace(AdditionalAssemblyScanningPath))
+            {
+                yield return AdditionalAssemblyScanningPath;
+            }
         }
 
         bool TryLoadScannableAssembly(string assemblyPath, AssemblyScannerResults results, out Assembly assembly)

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -27,12 +27,7 @@ namespace NServiceBus.Hosting.Helpers
         /// </summary>
         public AssemblyScanner(string baseDirectoryToScan)
         {
-            this.baseDirectoriesToScan = new[] { baseDirectoryToScan };
-        }
-
-        internal AssemblyScanner(string[] baseDirectoriesToScan)
-        {
-            this.baseDirectoriesToScan = baseDirectoriesToScan;
+            this.baseDirectoryToScan = baseDirectoryToScan;
         }
 
         internal AssemblyScanner(Assembly assemblyToScan)
@@ -51,6 +46,8 @@ namespace NServiceBus.Hosting.Helpers
         public bool ScanAppDomainAssemblies { get; set; } = true;
 
         internal string CoreAssemblyName { get; set; } = NServicebusCoreAssemblyName;
+
+        internal string AdditionalAssemblyScanningPath { get; set; }
 
         /// <summary>
         /// Traverses the specified base directory including all sub-directories, generating a list of assemblies that should be
@@ -86,7 +83,11 @@ namespace NServiceBus.Hosting.Helpers
 
             var assemblies = new List<Assembly>();
 
-            foreach (var directoryToScan in baseDirectoriesToScan)
+            var directoriesToScan = string.IsNullOrWhiteSpace(AdditionalAssemblyScanningPath)
+                ? new[] {baseDirectoryToScan}
+                : new[] {baseDirectoryToScan, AdditionalAssemblyScanningPath};
+
+            foreach (var directoryToScan in directoriesToScan)
             {
                 foreach (var assemblyFile in ScanDirectoryForAssemblyFiles(directoryToScan, ScanNestedDirectories))
                 {
@@ -418,7 +419,7 @@ namespace NServiceBus.Hosting.Helpers
         internal bool ScanNestedDirectories;
         internal List<Type> TypesToSkip = new List<Type>();
         Assembly assemblyToScan;
-        string[] baseDirectoriesToScan;
+        string baseDirectoryToScan;
         const string NServicebusCoreAssemblyName = "NServiceBus.Core";
 
         static string[] FileSearchPatternsToUse =

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
@@ -27,9 +27,9 @@
         public bool ScanAssembliesInNestedDirectories { get; set; }
 
         /// <summary>
-        /// Defines a custom path for assembly scanning.
+        /// Defines an additional path for assembly scanning.
         /// </summary>
-        public string CustomAssemblyScanningPath { get; set; }
+        public string AdditionalAssemblyScanningPath { get; set; }
 
         /// <summary>
         /// A list of <see cref="Assembly" />s to ignore in the assembly scanning.

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
@@ -27,6 +27,11 @@
         public bool ScanAssembliesInNestedDirectories { get; set; }
 
         /// <summary>
+        /// Defines a custom path for assembly scanning.
+        /// </summary>
+        public string CustomAssemblyScanningPath { get; set; }
+
+        /// <summary>
         /// A list of <see cref="Assembly" />s to ignore in the assembly scanning.
         /// </summary>
         /// <param name="assemblies">The file name of the assembly.</param>

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
@@ -22,9 +22,12 @@
             {
                 var directoryToScan = AppDomain.CurrentDomain.RelativeSearchPath ?? AppDomain.CurrentDomain.BaseDirectory;
 
-                assemblyScanner = string.IsNullOrWhiteSpace(assemblyScannerSettings.AdditionalAssemblyScanningPath)
-                    ? new AssemblyScanner(directoryToScan)
-                    : new AssemblyScanner(new[] {directoryToScan, assemblyScannerSettings.AdditionalAssemblyScanningPath});
+                assemblyScanner = new AssemblyScanner(directoryToScan);
+
+                if (!string.IsNullOrWhiteSpace(assemblyScannerSettings.AdditionalAssemblyScanningPath))
+                {
+                    assemblyScanner.AdditionalAssemblyScanningPath = assemblyScannerSettings.AdditionalAssemblyScanningPath;
+                }
 
                 availableTypes = new List<Type>();
             }

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
@@ -20,9 +20,12 @@
 
             if (shouldScanBinDirectory)
             {
-                var directoryToScan = assemblyScannerSettings.CustomAssemblyScanningPath ?? AppDomain.CurrentDomain.RelativeSearchPath ?? AppDomain.CurrentDomain.BaseDirectory;
+                var directoryToScan = AppDomain.CurrentDomain.RelativeSearchPath ?? AppDomain.CurrentDomain.BaseDirectory;
 
-                assemblyScanner = new AssemblyScanner(directoryToScan);
+                assemblyScanner = string.IsNullOrWhiteSpace(assemblyScannerSettings.AdditionalAssemblyScanningPath)
+                    ? new AssemblyScanner(directoryToScan)
+                    : new AssemblyScanner(new[] {directoryToScan, assemblyScannerSettings.AdditionalAssemblyScanningPath});
+
                 availableTypes = new List<Type>();
             }
             else

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
@@ -11,6 +11,8 @@
     {
         public static AssemblyScanningComponent Initialize(Configuration configuration, SettingsHolder settings)
         {
+            var assemblyScannerSettings = configuration.AssemblyScannerConfiguration;
+
             var shouldScanBinDirectory = configuration.UserProvidedTypes == null;
 
             List<Type> availableTypes;
@@ -18,7 +20,7 @@
 
             if (shouldScanBinDirectory)
             {
-                var directoryToScan = AppDomain.CurrentDomain.RelativeSearchPath ?? AppDomain.CurrentDomain.BaseDirectory;
+                var directoryToScan = assemblyScannerSettings.CustomAssemblyScanningPath ?? AppDomain.CurrentDomain.RelativeSearchPath ?? AppDomain.CurrentDomain.BaseDirectory;
 
                 assemblyScanner = new AssemblyScanner(directoryToScan);
                 availableTypes = new List<Type>();
@@ -28,8 +30,6 @@
                 assemblyScanner = new AssemblyScanner(Assembly.GetExecutingAssembly());
                 availableTypes = configuration.UserProvidedTypes;
             }
-
-            var assemblyScannerSettings = configuration.AssemblyScannerConfiguration;
 
             assemblyScanner.AssembliesToSkip = assemblyScannerSettings.ExcludedAssemblies;
             assemblyScanner.TypesToSkip = assemblyScannerSettings.ExcludedTypes;

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
@@ -11,8 +11,6 @@
     {
         public static AssemblyScanningComponent Initialize(Configuration configuration, SettingsHolder settings)
         {
-            var assemblyScannerSettings = configuration.AssemblyScannerConfiguration;
-
             var shouldScanBinDirectory = configuration.UserProvidedTypes == null;
 
             List<Type> availableTypes;
@@ -23,12 +21,6 @@
                 var directoryToScan = AppDomain.CurrentDomain.RelativeSearchPath ?? AppDomain.CurrentDomain.BaseDirectory;
 
                 assemblyScanner = new AssemblyScanner(directoryToScan);
-
-                if (!string.IsNullOrWhiteSpace(assemblyScannerSettings.AdditionalAssemblyScanningPath))
-                {
-                    assemblyScanner.AdditionalAssemblyScanningPath = assemblyScannerSettings.AdditionalAssemblyScanningPath;
-                }
-
                 availableTypes = new List<Type>();
             }
             else
@@ -37,11 +29,14 @@
                 availableTypes = configuration.UserProvidedTypes;
             }
 
+            var assemblyScannerSettings = configuration.AssemblyScannerConfiguration;
+
             assemblyScanner.AssembliesToSkip = assemblyScannerSettings.ExcludedAssemblies;
             assemblyScanner.TypesToSkip = assemblyScannerSettings.ExcludedTypes;
             assemblyScanner.ScanNestedDirectories = assemblyScannerSettings.ScanAssembliesInNestedDirectories;
             assemblyScanner.ThrowExceptions = assemblyScannerSettings.ThrowExceptions;
             assemblyScanner.ScanAppDomainAssemblies = assemblyScannerSettings.ScanAppDomainAssemblies;
+            assemblyScanner.AdditionalAssemblyScanningPath = assemblyScannerSettings.AdditionalAssemblyScanningPath;
 
             var scannableAssemblies = assemblyScanner.GetScannableAssemblies();
 

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
@@ -53,7 +53,8 @@
                         FileVersion = FileVersionRetriever.GetFileVersion(a)
                     }),
                     scannableAssemblies.ErrorsThrownDuringScanning,
-                    scannableAssemblies.SkippedFiles
+                    scannableAssemblies.SkippedFiles,
+                    Settings = assemblyScannerSettings
                 });
             }
 


### PR DESCRIPTION
Partially addresses https://github.com/Particular/NServiceBus.AzureFunctions/issues/44 part 1: `The Core doesn't allow assembly scanning with an alternate path`