### PR TITLE
Disables saga feature on send-only endpoint

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_saga_scanned_send_only_and_no_saga_storage.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_saga_scanned_send_only_and_no_saga_storage.cs
@@ -1,0 +1,52 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Sagas
+{
+    using System;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_saga_scanned_send_only_and_no_saga_storage : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_not_throw()
+        {
+            Assert.DoesNotThrowAsync(async () =>
+            {
+                await Scenario.Define<Context>()
+                    .WithEndpoint<SendOnlyEndpointWithSaga>()
+                    .Done(c => c.EndpointsStarted)
+                    .Run();
+            });
+
+        }
+
+        class SendOnlyEndpointWithSaga : EndpointConfigurationBuilder
+        {
+            public SendOnlyEndpointWithSaga()
+            {
+                EndpointSetup<ServerWithNoDefaultPersistenceDefinitions>(c =>
+                {
+                    c.UsePersistence<InMemoryPersistence, StorageType.Subscriptions>();
+                    
+                    c.SendOnly();
+                });
+            }
+        }
+
+        public class SagaInSendOnlyEndpoint : Saga<SagaInSendOnlyEndpoint.SagaInSendOnlyEndpointSagaData>
+        {
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaInSendOnlyEndpointSagaData> mapper)
+            {
+            }
+
+            public class SagaInSendOnlyEndpointSagaData : ContainSagaData
+            {
+                public virtual Guid DataId { get; set; }
+            }
+        }
+
+        public class Context : ScenarioContext
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core/Sagas/Sagas.cs
+++ b/src/NServiceBus.Core/Sagas/Sagas.cs
@@ -29,6 +29,7 @@
 
             Defaults(s => s.Set(new SagaMetadataCollection()));
 
+            Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"), "Sagas are only relevant for endpoints receiving messages.");
             Prerequisite(config => config.Settings.GetAvailableTypes().Any(IsSagaType), "No sagas were found in the scanned types");
         }
 


### PR DESCRIPTION
When a saga is scanned in any of the assemblies picked up of the assembly scanner the saga feature is activated even on send-only endpoints causing the endpoint to throw a 

```
The selected persistence doesn't have support for saga storage. Select another persistence or disable the sagas feature using endpointConfiguration.DisableFeature<Sagas>()
```