### PR TITLE
Exclude "core" acceptance tests from inmemory persistence tests

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_overriding_saga_id_creation.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_overriding_saga_id_creation.cs
@@ -40,7 +40,8 @@
                 EndpointSetup<DefaultServer>(config =>
                 {
                     config.EnableFeature<TimeoutManager>();
-                    config.UsePersistence<InMemoryPersistence>();
+                    //use inmemory persistence since the learning saga persister doesn't support custom saga id generators
+                    config.UsePersistence<InMemoryPersistence, StorageType.Sagas>();
                     config.GetSettings().Set<ISagaIdGenerator>(new CustomSagaIdGenerator());
                 });
             }

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_saga_scanned_send_only_and_no_saga_storage.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_saga_scanned_send_only_and_no_saga_storage.cs
@@ -26,8 +26,6 @@
             {
                 EndpointSetup<ServerWithNoDefaultPersistenceDefinitions>(c =>
                 {
-                    c.UsePersistence<InMemoryPersistence, StorageType.Subscriptions>();
-                    
                     c.SendOnly();
                 });
             }

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_saga_scanned_send_only_and_no_saga_storage.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_saga_scanned_send_only_and_no_saga_storage.cs
@@ -39,7 +39,6 @@
 
             public class SagaInSendOnlyEndpointSagaData : ContainSagaData
             {
-                public virtual Guid DataId { get; set; }
             }
         }
 

--- a/src/NServiceBus.Persistence.InMemory.AcceptanceTests/NServiceBus.Persistence.InMemory.AcceptanceTests.csproj
+++ b/src/NServiceBus.Persistence.InMemory.AcceptanceTests/NServiceBus.Persistence.InMemory.AcceptanceTests.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Include="../NServiceBus.AcceptanceTests/**/*.cs" Exclude="../NServiceBus.AcceptanceTests/obj/**/*.*"></Compile>
+    <Compile Include="../NServiceBus.AcceptanceTests/**/*.cs" Exclude="../NServiceBus.AcceptanceTests/obj/**/*.*;../NServiceBus.AcceptanceTests/Core/**/*.*"></Compile>
     <Compile Remove="../NServiceBus.AcceptanceTests/Core/CoreTestSuiteConstraints.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
As discussed in https://github.com/Particular/NServiceBus/pull/5657 the core folder is not meant to be shipped to downstreams, This PR excludes the folder and cleans up one of the tests that no longer need to to take non native pubs sub into account