### PR TITLE
Provide better error message for QueueNotFoundException

### DIFF
--- a/src/NServiceBus.Core.Tests/Unicast/Queuing/QueueNotFoundExceptionTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/Queuing/QueueNotFoundExceptionTests.cs
@@ -1,0 +1,32 @@
+﻿namespace NServiceBus.Unicast.Queuing
+{
+    using NUnit.Framework;
+
+    public class QueueNotFoundExceptionTests
+    {
+        [Test]
+        public void When_has_queue_should_mention_queue_in_error_message()
+        {
+            var queueName = "missing-queue";
+
+            var exception = new QueueNotFoundException {Queue = queueName};
+
+            Assert.AreEqual(queueName, exception.Queue);
+            var expectedMessage = $"Queue '{queueName}' not found. This queue might need to be created manually.";
+            Assert.AreEqual(expectedMessage, exception.Message);
+            StringAssert.Contains(expectedMessage, exception.ToString());
+        }
+
+        [Test]
+        public void When_has_no_queue_should_keep_error_message_generic()
+        {
+            var exception = new QueueNotFoundException();
+
+            Assert.Null(exception.Queue);
+            // This is the standard Exception message which is typically localized.
+            var expectedMessage = "Exception of type 'NServiceBus.Unicast.Queuing.QueueNotFoundException' was thrown.";
+            Assert.AreEqual(expectedMessage, exception.Message);
+            StringAssert.Contains(expectedMessage, exception.ToString());
+        }
+    }
+}

--- a/src/NServiceBus.Core/Unicast/Queuing/QueueNotFoundException.cs
+++ b/src/NServiceBus.Core/Unicast/Queuing/QueueNotFoundException.cs
@@ -37,6 +37,9 @@ namespace NServiceBus.Unicast.Queuing
         /// </summary>
         public string Queue { get; set; }
 
+        /// <inheritdoc />
+        public override string Message => string.IsNullOrEmpty(Queue) ? base.Message : $"Queue '{Queue}' not found. This queue might need to be created manually.";
+
         /// <summary>
         /// Gets the object data for serialization purposes.
         /// </summary>


### PR DESCRIPTION
Currently, the `QueueNotFoundException` doesn't mention the failing queue name anywhere in the exception message, which makes it hard to figure out where and why this problem actually occurred. This PR adds the Queue name property to the output message, making it more visible in log files.