### PR TITLE
Make LogFactory static in transport tests

### DIFF
--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -17,13 +17,18 @@
 
     public abstract class NServiceBusTransportTest
     {
+        static NServiceBusTransportTest()
+        {
+            LogFactory = new TransportTestLoggerFactory();
+            LogManager.UseFactory(LogFactory);
+        }
+
         [SetUp]
         public void SetUp()
         {
             testId = Guid.NewGuid().ToString();
 
-            LogFactory = new TransportTestLoggerFactory();
-            LogManager.UseFactory(LogFactory);
+            LogFactory.LogItems.Clear();
 
             //when using [TestCase] NUnit will reuse the same test instance so we need to make sure that the message pump is a fresh one
             MessagePump = null;
@@ -246,7 +251,7 @@
 
         protected string InputQueueName;
         protected string ErrorQueueName;
-        protected TransportTestLoggerFactory LogFactory;
+        protected static TransportTestLoggerFactory LogFactory;
 
         string testId;
 

--- a/src/NServiceBus.TransportTests/When_on_error_throws.cs
+++ b/src/NServiceBus.TransportTests/When_on_error_throws.cs
@@ -52,6 +52,7 @@
                 }
                 );
 
+            LogFactory.LogItems.Clear();
             await SendMessage(InputQueueName);
 
             var errorContext = await onErrorCalled.Task;


### PR DESCRIPTION
Previously the test was broken. The first run would set the LogManager but as loggers are static all following runs would not get a new logger but re-use their previously acquired static instance.