### PR TITLE
Remove usage of ActiveSagaInstance

### DIFF
--- a/src/NServiceBus.PersistenceTesting/Sagas/When_completing_a_saga_with_correlation_property.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_completing_a_saga_with_correlation_property.cs
@@ -20,10 +20,7 @@
             var persister = configuration.SagaStorage;
             using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context))
             {
-                SetActiveSagaInstanceForGet<SagaWithCorrelationProperty, SagaWithCorrelationPropertyData>(context, new SagaWithCorrelationPropertyData());
-
                 var sagaData = await persister.Get<SagaWithCorrelationPropertyData>(correlatedPropertyName, correlationPropertyData, completeSession, context);
-                SetActiveSagaInstanceForGet<SagaWithCorrelationProperty, SagaWithCorrelationPropertyData>(context, sagaData);
 
                 await persister.Complete(sagaData, completeSession, context);
                 await completeSession.CompleteAsync();

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_concurrent_update_exceed_transaction_timeout_pessimistic.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_concurrent_update_exceed_transaction_timeout_pessimistic.cs
@@ -35,13 +35,11 @@
                 var firstSaveSession = await configuration.SynchronizedStorage.OpenSession(firstContent);
                 try
                 {
-                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(firstContent, saga);
                     var record = await persister.Get<TestSagaData>(saga.Id, firstSaveSession, firstContent);
                     firstSessionGetDone.SetResult(true);
 
                     await Task.Delay(200).ConfigureAwait(false);
 
-                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(firstContent, record);
                     record.DateTimeProperty = firstSessionDateTimeValue;
                     await persister.Update(record, firstSaveSession, firstContent);
                     await secondSessionGetDone.Task.ConfigureAwait(false);
@@ -59,14 +57,11 @@
                 var secondSession = await configuration.SynchronizedStorage.OpenSession(secondContext);
                 try
                 {
-                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(secondContext, saga);
-
                     await firstSessionGetDone.Task.ConfigureAwait(false);
 
                     var recordTask = persister.Get<TestSagaData>(saga.Id, secondSession, secondContext);
                     secondSessionGetDone.SetResult(true);
                     var record = await recordTask.ConfigureAwait(false);
-                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(secondContext, record);
                     record.DateTimeProperty = secondSessionDateTimeValue;
                     await persister.Update(record, secondSession, secondContext);
                     await secondSession.CompleteAsync();

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
@@ -43,13 +43,9 @@
                         var enlistedContextBag = configuration.GetContextBagForSagaStorage();
                         var enlistedSession = await storageAdapter.TryAdapt(transportTransaction, enlistedContextBag);
 
-                        SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(unenlistedContextBag, new TestSagaData {Id = generatedSagaId, SomeId = correlationPropertData});
                         var unenlistedRecord = await persister.Get<TestSagaData>(generatedSagaId, unenlistedSession, unenlistedContextBag);
-                        SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(unenlistedContextBag, unenlistedRecord);
 
-                        SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(enlistedContextBag, new TestSagaData {Id = generatedSagaId, SomeId = correlationPropertData});
                         var enlistedRecord = await persister.Get<TestSagaData>("Id", generatedSagaId, enlistedSession, enlistedContextBag);
-                        SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(enlistedContextBag, enlistedRecord);
 
                         await persister.Update(unenlistedRecord, unenlistedSession, unenlistedContextBag);
                         await persister.Update(enlistedRecord, enlistedSession, enlistedContextBag);

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
@@ -22,11 +22,9 @@
             using (var session = await configuration.SynchronizedStorage.OpenSession(savingContextBag))
             {
                 var sagaData = new TestSagaData {SomeId = correlationPropertData};
-                SetActiveSagaInstanceForSave(savingContextBag, new TestSaga(), sagaData);
-                generatedSagaId = sagaData.Id;
-
-                await persister.Save(sagaData, null, session, savingContextBag);
+                await SaveSagaWithSession(sagaData, session, savingContextBag);
                 await session.CompleteAsync();
+                generatedSagaId = sagaData.Id;
             }
 
             Assert.That(async () =>

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
@@ -22,24 +22,19 @@
                 DateTimeProperty = DateTime.UtcNow
             };
 
-            var persister = configuration.SagaStorage;
-
             var winningContextBag = configuration.GetContextBagForSagaStorage();
             using (var winningSession = await configuration.SynchronizedStorage.OpenSession(winningContextBag))
             {
-                var correlationPropertySaga1 = SetActiveSagaInstanceForSave(winningContextBag, new SagaWithCorrelationProperty(), saga1);
-                await persister.Save(saga1, correlationPropertySaga1, winningSession, winningContextBag);
+                await SaveSagaWithSession(saga1, winningSession, winningContextBag);
                 await winningSession.CompleteAsync();
             }
 
             var losingContextBag = configuration.GetContextBagForSagaStorage();
             using (var losingSession = await configuration.SynchronizedStorage.OpenSession(losingContextBag))
             {
-                var correlationPropertySaga2 = SetActiveSagaInstanceForSave(losingContextBag, new SagaWithCorrelationProperty(), saga2);
-
                 Assert.That(async () =>
                 {
-                    await persister.Save(saga2, correlationPropertySaga2, losingSession, losingContextBag);
+                    await SaveSagaWithSession(saga2, losingSession, losingContextBag);
                     await losingSession.CompleteAsync();
                 }, Throws.InstanceOf<Exception>());
             }

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_different_sagas_with_no_defined_unique_properties.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_different_sagas_with_no_defined_unique_properties.cs
@@ -38,10 +38,8 @@
             var readContextBag = configuration.GetContextBagForSagaStorage();
             using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
             {
-                SetActiveSagaInstanceForGet<SagaWithoutCorrelationProperty, SagaWithoutCorrelationPropertyData>(readContextBag, saga1, typeof(CustomFinder));
                 var saga1Result = await persister.Get<SagaWithoutCorrelationPropertyData>(saga1.Id, readSession, readContextBag);
 
-                SetActiveSagaInstanceForGet<AnotherSagaWithoutCorrelationProperty, AnotherSagaWithoutCorrelationPropertyData>(readContextBag, saga2, typeof(AnotherCustomFinder));
                 var saga2Result = await persister.Get<AnotherSagaWithoutCorrelationPropertyData>(saga2.Id, readSession, readContextBag);
 
                 Assert.AreEqual(saga1.FoundByFinderProperty, saga1Result.FoundByFinderProperty);

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_different_sagas_with_no_defined_unique_properties.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_different_sagas_with_no_defined_unique_properties.cs
@@ -30,12 +30,8 @@
             var savingContextBag = configuration.GetContextBagForSagaStorage();
             using (var session = await configuration.SynchronizedStorage.OpenSession(savingContextBag))
             {
-                var correlationPropertyNoneSaga1 = SetActiveSagaInstanceForSave(savingContextBag, new SagaWithoutCorrelationProperty(), saga1, typeof(CustomFinder));
-                await persister.Save(saga1, correlationPropertyNoneSaga1, session, savingContextBag);
-
-                var correlationPropertyNoneSaga2 = SetActiveSagaInstanceForSave(savingContextBag, new AnotherSagaWithoutCorrelationProperty(), saga2, typeof(AnotherCustomFinder));
-                await persister.Save(saga2, correlationPropertyNoneSaga2, session, savingContextBag);
-
+                await SaveSagaWithSession(saga1, session, savingContextBag);
+                await SaveSagaWithSession(saga2, session, savingContextBag);
                 await session.CompleteAsync();
             }
 

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_different_sagas_with_same_correlation_property_value.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_different_sagas_with_same_correlation_property_value.cs
@@ -25,11 +25,8 @@
             var savingContextBag = configuration.GetContextBagForSagaStorage();
             using (var session = await configuration.SynchronizedStorage.OpenSession(savingContextBag))
             {
-                var correlationPropertySaga1 = SetActiveSagaInstanceForSave(savingContextBag, new SagaWithCorrelationProperty(), saga1);
-                await persister.Save(saga1, correlationPropertySaga1, session, savingContextBag);
-
-                var correlationPropertySaga2 = SetActiveSagaInstanceForSave(savingContextBag, new AnotherSagaWithCorrelatedProperty(), saga2);
-                await persister.Save(saga2, correlationPropertySaga2, session, savingContextBag);
+                await SaveSagaWithSession(saga1, session, savingContextBag);
+                await SaveSagaWithSession(saga2, session, savingContextBag);
 
                 await session.CompleteAsync();
             }

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_different_sagas_with_same_correlation_property_value.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_different_sagas_with_same_correlation_property_value.cs
@@ -34,10 +34,8 @@
             var readContextBag = configuration.GetContextBagForSagaStorage();
             using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
             {
-                SetActiveSagaInstanceForGet<SagaWithCorrelationProperty, SagaWithCorrelationPropertyData>(readContextBag, saga1);
                 var saga1Result = await persister.Get<SagaWithCorrelationPropertyData>(nameof(SagaWithCorrelationPropertyData.CorrelatedProperty), saga1.CorrelatedProperty, readSession, readContextBag);
 
-                SetActiveSagaInstanceForGet<AnotherSagaWithCorrelatedProperty, AnotherSagaWithCorrelatedPropertyData>(readContextBag, saga2);
                 var saga2Result = await persister.Get<AnotherSagaWithCorrelatedPropertyData>(nameof(AnotherSagaWithCorrelatedPropertyData.CorrelatedProperty), saga2.CorrelatedProperty, readSession, readContextBag);
 
                 Assert.AreEqual(saga1.CorrelatedProperty, saga1Result.CorrelatedProperty);

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
@@ -34,14 +34,11 @@
 
             try
             {
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext1, saga);
                 var record1 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession1, winningContext1);
 
                 losingContext1 = configuration.GetContextBagForSagaStorage();
                 losingSaveSession1 = await configuration.SynchronizedStorage.OpenSession(losingContext1);
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext1, saga);
                 staleRecord1 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession1, losingContext1);
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext1, staleRecord1);
 
                 record1.DateTimeProperty = DateTime.UtcNow;
                 await persister.Update(record1, winningSaveSession1, winningContext1);
@@ -73,15 +70,11 @@
             var winningSaveSession2 = await configuration.SynchronizedStorage.OpenSession(winningContext2);
             try
             {
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext2, saga);
                 var record2 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession2, winningContext2);
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext2, record2);
 
                 losingContext2 = configuration.GetContextBagForSagaStorage();
                 losingSaveSession2 = await configuration.SynchronizedStorage.OpenSession(losingContext2);
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext2, saga);
                 staleRecord2 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession2, losingContext2);
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext2, staleRecord2);
 
                 record2.DateTimeProperty = DateTime.UtcNow;
                 await persister.Update(record2, winningSaveSession2, winningContext2);

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_persisting_the_same_saga_twice_in_two_sessions_on_the_same_thread.cs
@@ -21,9 +21,7 @@
             var insertContextBag = configuration.GetContextBagForSagaStorage();
             using (var insertSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag))
             {
-                var correlationProperty = SetActiveSagaInstanceForSave(insertContextBag, new TestSaga(), saga);
-
-                await persister.Save(saga, correlationProperty, insertSession, insertContextBag);
+                await SaveSagaWithSession(saga, insertSession, insertContextBag);
                 await insertSession.CompleteAsync();
             }
 

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_retrieving_same_saga_on_different_threads.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_retrieving_same_saga_on_different_threads.cs
@@ -34,9 +34,7 @@
                 var winningContext = configuration.GetContextBagForSagaStorage();
                 using (var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext))
                 {
-                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, new TestSagaData {Id = generatedSagaId, SomeId = correlationPropertyData});
                     var record = await persister.Get<TestSagaData>(generatedSagaId, winningSaveSession, winningContext);
-                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, record);
 
                     startSecondTaskSync.SetResult(true);
                     await firstTaskCanCompleteSync.Task;
@@ -54,9 +52,7 @@
                 var losingSaveContext = configuration.GetContextBagForSagaStorage();
                 using (var losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingSaveContext))
                 {
-                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingSaveContext, new TestSagaData {Id = generatedSagaId, SomeId = correlationPropertyData});
                     var staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingSaveContext);
-                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingSaveContext, staleRecord);
 
                     firstTaskCanCompleteSync.SetResult(true);
                     await firstTask;

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_retrieving_same_saga_on_different_threads.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_retrieving_same_saga_on_different_threads.cs
@@ -20,11 +20,10 @@
             using (var insertSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag))
             {
                 var sagaData = new TestSagaData {SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow};
-                var correlationProperty = SetActiveSagaInstanceForSave(insertContextBag, new TestSaga(), sagaData);
-                generatedSagaId = sagaData.Id;
 
-                await persister.Save(sagaData, correlationProperty, insertSession, insertContextBag);
+                await SaveSagaWithSession(sagaData, insertSession, insertContextBag);
                 await insertSession.CompleteAsync();
+                generatedSagaId = sagaData.Id;
             }
 
             var startSecondTaskSync = new TaskCompletionSource<bool>();

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_retrieving_same_saga_on_the_same_thread.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_retrieving_same_saga_on_the_same_thread.cs
@@ -21,11 +21,9 @@
             using (var insertSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag))
             {
                 var sagaData = new TestSagaData {SomeId = correlationPropertyData, DateTimeProperty = DateTime.UtcNow};
-                var correlationProperty = SetActiveSagaInstanceForSave(insertContextBag, new TestSaga(), sagaData);
-                generatedSagaId = sagaData.Id;
-
-                await persister.Save(sagaData, correlationProperty, insertSession, insertContextBag);
+                await SaveSagaWithSession(sagaData, insertSession, insertContextBag);
                 await insertSession.CompleteAsync();
+                generatedSagaId = sagaData.Id;
             }
 
             ContextBag losingContext;

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_retrieving_same_saga_on_the_same_thread.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_retrieving_same_saga_on_the_same_thread.cs
@@ -34,15 +34,11 @@
             var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext);
             try
             {
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, new TestSagaData {Id = generatedSagaId, SomeId = correlationPropertyData});
                 var record = await persister.Get<TestSagaData>(generatedSagaId, winningSaveSession, winningContext);
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, record);
 
                 losingContext = configuration.GetContextBagForSagaStorage();
                 losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingContext);
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext, new TestSagaData {Id = generatedSagaId, SomeId = correlationPropertyData});
                 staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingContext);
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext, staleRecord);
 
                 record.DateTimeProperty = DateTime.UtcNow;
                 await persister.Update(record, winningSaveSession, winningContext);

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_rolling_back_storage_session.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_rolling_back_storage_session.cs
@@ -21,7 +21,6 @@
             {
                 var sagaFromStorage = await GetById(sagaData.Id);
                 sagaFromStorage.SomethingWeCareAbout = "Particular.Platform";
-                SetActiveSagaInstanceForSave(contextBag, new TestSaga(), sagaFromStorage);
 
                 await configuration.SagaStorage.Update(sagaFromStorage, session, contextBag);
                 await session.CompleteAsync();

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_updating_a_saga_found_using_correlation_property.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_updating_a_saga_found_using_correlation_property.cs
@@ -26,9 +26,7 @@
             var persister = configuration.SagaStorage;
             using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context))
             {
-                SetActiveSagaInstanceForGet<SagaWithCorrelationProperty, SagaWithCorrelationPropertyData>(context, new SagaWithCorrelationPropertyData());
                 var sagaData = await persister.Get<SagaWithCorrelationPropertyData>(correlatedPropertyName, correlationPropertyData, completeSession, context);
-                SetActiveSagaInstanceForGet<SagaWithCorrelationProperty, SagaWithCorrelationPropertyData>(context, sagaData);
 
                 sagaData.SomeProperty = updatedValue;
 

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_updating_a_saga_with_no_defined_unique_property.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_updating_a_saga_with_no_defined_unique_property.cs
@@ -30,9 +30,7 @@
             var persister = configuration.SagaStorage;
             using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context))
             {
-                SetActiveSagaInstanceForGet<SagaWithoutCorrelationProperty, SagaWithoutCorrelationPropertyData>(context, new SagaWithoutCorrelationPropertyData(), typeof(CustomFinder));
                 sagaData = await persister.Get<SagaWithoutCorrelationPropertyData>(sagaData.Id, completeSession, context);
-                SetActiveSagaInstanceForGet<SagaWithoutCorrelationProperty, SagaWithoutCorrelationPropertyData>(context, sagaData, typeof(CustomFinder));
 
                 sagaData.FoundByFinderProperty = updateValue;
 

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_worker_tries_to_complete_saga_update_by_another_optimistic.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_worker_tries_to_complete_saga_update_by_another_optimistic.cs
@@ -29,15 +29,11 @@
             var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext);
             try
             {
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, saga);
                 var record = await persister.Get<TestSagaData>(saga.Id, winningSaveSession, winningContext);
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(winningContext, record);
 
                 losingContext = configuration.GetContextBagForSagaStorage();
                 losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingContext);
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext, saga);
                 staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingContext);
-                SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(losingContext, staleRecord);
 
                 record.DateTimeProperty = DateTime.UtcNow;
                 await persister.Update(record, winningSaveSession, winningContext);

--- a/src/NServiceBus.PersistenceTesting/Sagas/When_worker_tries_to_complete_saga_update_by_another_pessimistic.cs
+++ b/src/NServiceBus.PersistenceTesting/Sagas/When_worker_tries_to_complete_saga_update_by_another_pessimistic.cs
@@ -29,11 +29,9 @@
                 var firstSaveSession = await configuration.SynchronizedStorage.OpenSession(firstContent);
                 try
                 {
-                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(firstContent, saga);
                     var record = await persister.Get<TestSagaData>(saga.Id, firstSaveSession, firstContent);
                     firstSessionGetDone.SetResult(true);
 
-                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(firstContent, record);
                     record.DateTimeProperty = firstSessionDateTimeValue;
                     await persister.Update(record, firstSaveSession, firstContent);
                     await secondSessionGetDone.Task.ConfigureAwait(false);
@@ -51,14 +49,11 @@
                 var secondSession = await configuration.SynchronizedStorage.OpenSession(secondContext);
                 try
                 {
-                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(secondContext, saga);
-
                     await firstSessionGetDone.Task.ConfigureAwait(false);
 
                     var recordTask = persister.Get<TestSagaData>(saga.Id, secondSession, secondContext);
                     secondSessionGetDone.SetResult(true);
                     var record = await recordTask.ConfigureAwait(false);
-                    SetActiveSagaInstanceForGet<TestSaga, TestSagaData>(secondContext, record);
                     record.DateTimeProperty = secondSessionDateTimeValue;
                     await persister.Update(record, secondSession, secondContext);
                     await secondSession.CompleteAsync();


### PR DESCRIPTION
Removes `SetActiveSagaInstanceForGet` and `SetActiveSagaInstanceForSave` to remove a lot of boilerplate code from the tests that isn't even very clear about what it's doing.

From looking at it, I wasn't able to identify an obvious reason we need for those methods, as `ActiveSagaInstance` doesn't seem to be used by persisters although it would potentially be available in the context.

`SetActiveSagaInstanceForGet` didn't seem to do anything meaningful for persisters and was just removed.
`SetActiveSagaInstanceForSave` did some meaningful work which we need to keep but I extracted this into the following two methods:
* `SetupNewSaga` sets up the saga ID and should probably be adjusted to setup other properties for `IContainSagaData` which are typically set by core and persisted.
* `SaveSagaWithSession` is a similar operation to `SaveSaga` but with session support. `SaveSagaWithSession` and `SaveSaga` encapsulat the lookup of the correlation property lookup which is required to save the saga.

I'm sure there is further refactoring potential but this is the first step I tested and I didn't run into issues spiking this on MongoDB and running this on InMemory.