### PR TITLE
Improve message convention extensibility

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -145,6 +145,7 @@ namespace NServiceBus
     {
         public ConventionsBuilder(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.Conventions Conventions { get; }
+        public NServiceBus.ConventionsBuilder Add(NServiceBus.IMessageConvention messageConvention) { }
         public NServiceBus.ConventionsBuilder DefiningCommandsAs(System.Func<System.Type, bool> definesCommandType) { }
         public NServiceBus.ConventionsBuilder DefiningDataBusPropertiesAs(System.Func<System.Reflection.PropertyInfo, bool> definesDataBusProperty) { }
         [System.ObsoleteAttribute(@"Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package. This convention configuration does not work in combination with the NServiceBus.Encryption.MessageProperty package. The member currently throws a NotImplementedException. Will be removed in version 8.0.0.", true)]

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -488,6 +488,13 @@ namespace NServiceBus
         System.Threading.Tasks.Task Timeout(T state, NServiceBus.IMessageHandlerContext context);
     }
     public interface IMessage { }
+    public interface IMessageConvention
+    {
+        string Name { get; }
+        bool IsCommandType(System.Type type);
+        bool IsEventType(System.Type type);
+        bool IsMessageType(System.Type type);
+    }
     public interface IMessageCreator
     {
         T CreateInstance<T>();
@@ -704,6 +711,14 @@ namespace NServiceBus
     public sealed class MoveToError : NServiceBus.RecoverabilityAction
     {
         public string ErrorQueue { get; }
+    }
+    public class NServiceBusMarkerInterfaceConvention : NServiceBus.IMessageConvention
+    {
+        public NServiceBusMarkerInterfaceConvention() { }
+        public string Name { get; }
+        public bool IsCommandType(System.Type type) { }
+        public bool IsEventType(System.Type type) { }
+        public bool IsMessageType(System.Type type) { }
     }
     public class NonDurableDelivery : NServiceBus.DeliveryConstraints.DeliveryConstraint
     {

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -145,6 +145,7 @@ namespace NServiceBus
     {
         public ConventionsBuilder(NServiceBus.Settings.SettingsHolder settings) { }
         public NServiceBus.Conventions Conventions { get; }
+        public NServiceBus.ConventionsBuilder Add(NServiceBus.IMessageConvention messageConvention) { }
         public NServiceBus.ConventionsBuilder DefiningCommandsAs(System.Func<System.Type, bool> definesCommandType) { }
         public NServiceBus.ConventionsBuilder DefiningDataBusPropertiesAs(System.Func<System.Reflection.PropertyInfo, bool> definesDataBusProperty) { }
         [System.ObsoleteAttribute(@"Message property encryption is released as a dedicated 'NServiceBus.Encryption.MessageProperty' package. This convention configuration does not work in combination with the NServiceBus.Encryption.MessageProperty package. The member currently throws a NotImplementedException. Will be removed in version 8.0.0.", true)]
@@ -488,6 +489,13 @@ namespace NServiceBus
         System.Threading.Tasks.Task Timeout(T state, NServiceBus.IMessageHandlerContext context);
     }
     public interface IMessage { }
+    public interface IMessageConvention
+    {
+        string Name { get; }
+        bool IsCommandType(System.Type type);
+        bool IsEventType(System.Type type);
+        bool IsMessageType(System.Type type);
+    }
     public interface IMessageCreator
     {
         T CreateInstance<T>();
@@ -704,6 +712,14 @@ namespace NServiceBus
     public sealed class MoveToError : NServiceBus.RecoverabilityAction
     {
         public string ErrorQueue { get; }
+    }
+    public class NServiceBusMarkerInterfaceConvention : NServiceBus.IMessageConvention
+    {
+        public NServiceBusMarkerInterfaceConvention() { }
+        public string Name { get; }
+        public bool IsCommandType(System.Type type) { }
+        public bool IsEventType(System.Type type) { }
+        public bool IsMessageType(System.Type type) { }
     }
     public class NonDurableDelivery : NServiceBus.DeliveryConstraints.DeliveryConstraint
     {

--- a/src/NServiceBus.Core.Tests/ConventionsTests.cs
+++ b/src/NServiceBus.Core.Tests/ConventionsTests.cs
@@ -72,10 +72,8 @@
             [Test]
             public void IsCommandType_should_return_false_for_NServiceBus_types()
             {
-                var conventions = new Conventions
-                {
-                    IsCommandTypeAction = t => t.Assembly == typeof(Conventions).Assembly
-                };
+                var conventions = new Conventions();
+                conventions.DefineCommandTypeConventions(t => t.Assembly == typeof(Conventions).Assembly);
                 Assert.IsFalse(conventions.IsCommandType(typeof(Conventions)));
             }
 
@@ -91,10 +89,8 @@
             [Test]
             public void IsEventType_should_return_false_for_NServiceBus_types()
             {
-                var conventions = new Conventions
-                {
-                    IsEventTypeAction = t => t.Assembly == typeof(Conventions).Assembly
-                };
+                var conventions = new Conventions();
+                conventions.DefineEventTypeConventions(t => t.Assembly == typeof(Conventions).Assembly);
                 Assert.IsFalse(conventions.IsEventType(typeof(Conventions)));
             }
 
@@ -105,11 +101,9 @@
             [Test]
             public void IsCommandType_should_return_true_for_matching_type()
             {
-                var conventions = new Conventions
-                {
-                    IsCommandTypeAction = t => t.Assembly == typeof(Conventions).Assembly ||
-                                               t == typeof(MyConventionCommand)
-                };
+                var conventions = new Conventions();
+                conventions.DefineCommandTypeConventions(t => t.Assembly == typeof(Conventions).Assembly ||
+                                               t == typeof(MyConventionCommand));
                 Assert.IsTrue(conventions.IsCommandType(typeof(MyConventionCommand)));
             }
 
@@ -133,11 +127,9 @@
             [Test]
             public void IsEventType_should_return_true_for_matching_type()
             {
-                var conventions = new Conventions
-                {
-                    IsEventTypeAction = t => t.Assembly == typeof(Conventions).Assembly ||
-                                               t == typeof(MyConventionEvent)
-                };
+                var conventions = new Conventions();
+                conventions.DefineEventTypeConventions(t => t.Assembly == typeof(Conventions).Assembly ||
+                                               t == typeof(MyConventionEvent));
                 Assert.IsTrue(conventions.IsEventType(typeof(MyConventionEvent)));
             }
 

--- a/src/NServiceBus.Core.Tests/ConventionsTests.cs
+++ b/src/NServiceBus.Core.Tests/ConventionsTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Core.Tests
 {
     using NUnit.Framework;
+    using System;
 
     [TestFixture]
     public class ConventionsTests
@@ -135,6 +136,81 @@
 
             public class MyConventionEvent
             {
+            }
+        }
+
+        [TestFixture]
+        public class When_using_custom_convention
+        {
+            [Test]
+            public void IsCommandType_should_return_true_for_matching_type()
+            {
+                var conventions = new Conventions();
+                conventions.Add(new MyConvention());
+                Assert.IsTrue(conventions.IsCommandType(typeof(MyConventionCommand)));
+            }
+
+            [Test]
+            public void IsEventType_should_return_true_for_matching_type()
+            {
+                var conventions = new Conventions();
+                conventions.Add(new MyConvention());
+                Assert.IsTrue(conventions.IsEventType(typeof(MyConventionEvent)));
+            }
+
+            [Test]
+            public void IsMessageType_should_return_true_for_matching_type()
+            {
+                var conventions = new Conventions();
+                conventions.Add(new MyConvention());
+                Assert.IsTrue(conventions.IsMessageType(typeof(MyConventionMessage)));
+            }
+
+            [Test]
+            public void IsCommandType_should_return_true_for_default_convention()
+            {
+                var conventions = new Conventions();
+                conventions.Add(new MyConvention());
+                Assert.IsTrue(conventions.IsCommandType(typeof(DefaultConventionCommand)));
+            }
+
+            [Test]
+            public void IsEventType_should_return_true_for_default_convention()
+            {
+                var conventions = new Conventions();
+                conventions.Add(new MyConvention());
+                Assert.IsTrue(conventions.IsEventType(typeof(DefaultConventionEvent)));
+            }
+
+            [Test]
+            public void IsMessageType_should_return_true_for_default_convention()
+            {
+                var conventions = new Conventions();
+                conventions.Add(new MyConvention());
+                Assert.IsTrue(conventions.IsMessageType(typeof(DefaultConventionMessage)));
+            }
+
+            class DefaultConventionCommand : ICommand { }
+
+            class DefaultConventionEvent : IEvent { }
+
+            class DefaultConventionMessage : IMessage { }
+
+            class MyConventionCommand { }
+
+            class MyConventionEvent { }
+
+            class MyConventionMessage { }
+
+            class MyConvention : IMessageConvention
+            {
+                public string Name => "Test Convention";
+
+                public bool IsCommandType(Type type) => type == typeof(MyConventionCommand);
+
+                public bool IsEventType(Type type) => type == typeof(MyConventionEvent);
+
+                public bool IsMessageType(Type type) => type == typeof(MyConventionMessage);
             }
         }
     }

--- a/src/NServiceBus.Core.Tests/MessageConventionSpecs.cs
+++ b/src/NServiceBus.Core.Tests/MessageConventionSpecs.cs
@@ -31,14 +31,13 @@
         public void Should_cache_the_message_convention()
         {
             var timesCalled = 0;
-            conventions = new Conventions
+            conventions = new Conventions();
+
+            conventions.DefineEventTypeConventions(t =>
             {
-                IsEventTypeAction = t =>
-                {
-                    timesCalled++;
-                    return false;
-                }
-            };
+                timesCalled++;
+                return false;
+            });
 
             conventions.IsEventType(GetType());
             Assert.AreEqual(1, timesCalled);
@@ -55,14 +54,13 @@
         public void Should_cache_the_message_convention()
         {
             var timesCalled = 0;
-            conventions = new Conventions
+            conventions = new Conventions();
+           
+            conventions.DefineCommandTypeConventions(t =>
             {
-                IsCommandTypeAction = t =>
-                {
-                    timesCalled++;
-                    return false;
-                }
-            };
+                timesCalled++;
+                return false;
+            });
 
             conventions.IsCommandType(GetType());
             Assert.AreEqual(1, timesCalled);

--- a/src/NServiceBus.Core.Tests/Sagas/CustomFinderAdapterTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/CustomFinderAdapterTests.cs
@@ -22,10 +22,9 @@
 
             var messageType = typeof(StartSagaMessage);
 
-            var messageConventions = new Conventions
-            {
-                IsCommandTypeAction = t => t == messageType
-            };
+            var messageConventions = new Conventions();
+
+            messageConventions.DefineCommandTypeConventions(t => t == messageType);
 
             var sagaMetadata = SagaMetadata.Create(typeof(TestSaga), availableTypes, messageConventions);
 

--- a/src/NServiceBus.Core/Conventions/Conventions.cs
+++ b/src/NServiceBus.Core/Conventions/Conventions.cs
@@ -43,20 +43,35 @@
                             return false;
                         }
 
-                        foreach(var convention in conventions)
+                        foreach (var convention in conventions)
                         {
-                            if(convention.IsMessageType(type)
-                            || convention.IsCommandType(type)
-                            || convention.IsEventType(type))
+                            if (convention.IsMessageType(type))
                             {
-                                if(logger.IsDebugEnabled)
+                                if (logger.IsDebugEnabled)
                                 {
                                     logger.Debug($"{type.FullName} identified as message type by {convention.Name} convention.");
                                 }
                                 return true;
                             }
-                        }
 
+                            if (convention.IsCommandType(type))
+                            {
+                                if (logger.IsDebugEnabled)
+                                {
+                                    logger.Debug($"{type.FullName} identified as command type by {convention.Name} but does not match message type convention. Treating as a message.");
+                                }
+                                return true;
+                            }
+
+                            if (convention.IsEventType(type))
+                            {
+                                if (logger.IsDebugEnabled)
+                                {
+                                    logger.Debug($"{type.FullName} identified as event type by {convention.Name} but does not match message type convention. Treating as a message.");
+                                }
+                                return true;
+                            }
+                        }
                         return false;
                     });
             }
@@ -105,9 +120,9 @@
                         return false;
                     }
 
-                    foreach(var convention in conventions)
+                    foreach (var convention in conventions)
                     {
-                        if(convention.IsCommandType(type))
+                        if (convention.IsCommandType(type))
                         {
                             if (logger.IsDebugEnabled)
                             {
@@ -158,9 +173,9 @@
                         return false;
                     }
 
-                    foreach(var convention in conventions)
+                    foreach (var convention in conventions)
                     {
-                        if(convention.IsEventType(type))
+                        if (convention.IsEventType(type))
                         {
                             if (logger.IsDebugEnabled)
                             {

--- a/src/NServiceBus.Core/Conventions/Conventions.cs
+++ b/src/NServiceBus.Core/Conventions/Conventions.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus
 {
+    using NServiceBus.Logging;
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
@@ -48,7 +49,10 @@
                             || convention.IsCommandType(type)
                             || convention.IsEventType(type))
                             {
-                                // TODO: Log the matched convention
+                                if(logger.IsDebugEnabled)
+                                {
+                                    logger.Debug($"{type.FullName} identified as message type by {convention.Name} convention.");
+                                }
                                 return true;
                             }
                         }
@@ -105,7 +109,10 @@
                     {
                         if(convention.IsCommandType(type))
                         {
-                            // TODO: Log matching convention
+                            if (logger.IsDebugEnabled)
+                            {
+                                logger.Debug($"{type.FullName} identified as command type by {convention.Name} convention.");
+                            }
                             return true;
                         }
 
@@ -155,7 +162,10 @@
                     {
                         if(convention.IsEventType(type))
                         {
-                            // TODO: Log matching convention
+                            if (logger.IsDebugEnabled)
+                            {
+                                logger.Debug($"{type.FullName} identified as event type by {convention.Name} convention.");
+                            }
                             return true;
                         }
                     }
@@ -170,6 +180,8 @@
         }
 
         internal bool CustomMessageTypeConventionUsed => defaultMessageConvention.ConventionModified || conventions.Count > 1;
+
+        internal string[] RegisteredConventions => conventions.Select(x => x.Name).ToArray();
 
         internal List<DataBusPropertyInfo> GetDataBusProperties(object message)
         {
@@ -225,6 +237,8 @@
 
         IList<IMessageConvention> conventions = new List<IMessageConvention>();
         OverridableMessageConvention defaultMessageConvention;
+
+        static ILog logger = LogManager.GetLogger<Conventions>();
 
         class ConventionCache
         {

--- a/src/NServiceBus.Core/Conventions/Conventions.cs
+++ b/src/NServiceBus.Core/Conventions/Conventions.cs
@@ -208,6 +208,11 @@
             defaultMessageConvention.DefiningEventsAs(definesEventType);
         }
 
+        internal void Add(IMessageConvention messageConvention)
+        {
+            conventions.Add(messageConvention);
+        }
+
         internal Func<PropertyInfo, bool> IsDataBusPropertyAction = p => typeof(IDataBusProperty).IsAssignableFrom(p.PropertyType) && typeof(IDataBusProperty) != p.PropertyType;
 
         ConcurrentDictionary<Type, List<DataBusPropertyInfo>> cache = new ConcurrentDictionary<Type, List<DataBusPropertyInfo>>();

--- a/src/NServiceBus.Core/Conventions/Conventions.cs
+++ b/src/NServiceBus.Core/Conventions/Conventions.cs
@@ -1,6 +1,6 @@
 ﻿namespace NServiceBus
 {
-    using NServiceBus.Logging;
+    using Logging;
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;

--- a/src/NServiceBus.Core/Conventions/ConventionsBuilder.cs
+++ b/src/NServiceBus.Core/Conventions/ConventionsBuilder.cs
@@ -34,7 +34,7 @@ namespace NServiceBus
         public ConventionsBuilder DefiningCommandsAs(Func<Type, bool> definesCommandType)
         {
             Guard.AgainstNull(nameof(definesCommandType), definesCommandType);
-            Conventions.IsCommandTypeAction = definesCommandType;
+            Conventions.DefineCommandTypeConventions(definesCommandType);
             return this;
         }
 
@@ -44,7 +44,7 @@ namespace NServiceBus
         public ConventionsBuilder DefiningEventsAs(Func<Type, bool> definesEventType)
         {
             Guard.AgainstNull(nameof(definesEventType), definesEventType);
-            Conventions.IsEventTypeAction = definesEventType;
+            Conventions.DefineEventTypeConventions(definesEventType);
             return this;
         }
 

--- a/src/NServiceBus.Core/Conventions/ConventionsBuilder.cs
+++ b/src/NServiceBus.Core/Conventions/ConventionsBuilder.cs
@@ -58,6 +58,16 @@ namespace NServiceBus
             return this;
         }
 
+        /// <summary>
+        /// Adds a message convention that will be used to evaluate whether a type is a message, command, or event.
+        /// </summary>
+        public ConventionsBuilder Add(IMessageConvention messageConvention)
+        {
+            Guard.AgainstNull(nameof(messageConvention), messageConvention);
+            Conventions.Add(messageConvention);
+            return this;
+        }
+
 
         /// <summary>
         /// The defined <see cref="Conventions"/>.

--- a/src/NServiceBus.Core/Conventions/IMessageConvention.cs
+++ b/src/NServiceBus.Core/Conventions/IMessageConvention.cs
@@ -1,0 +1,36 @@
+﻿namespace NServiceBus
+{
+    using System;
+
+    /// <summary>
+    /// A set of conventions for determining if a class represents a message, command, or event.
+    /// </summary>
+    public interface IMessageConvention
+    {
+        /// <summary>
+        /// The name of the convention. Used for diagnostic purposes.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Determine if a type is a message type.
+        /// </summary>
+        /// <param name="type">The type to check.</param>
+        /// <returns>true if <paramref name="type"/> represents a message.</returns>
+        bool IsMessageType(Type type);
+
+        /// <summary>
+        /// Determine if a type is a command type.
+        /// </summary>
+        /// <param name="type">The type to check.</param>.
+        /// <returns>true if <paramref name="type"/> represents a command.</returns>
+        bool IsCommandType(Type type);
+
+        /// <summary>
+        /// Determine if a type is an event type.
+        /// </summary>
+        /// <param name="type">The type to check.</param>.
+        /// <returns>true if <paramref name="type"/> represents an event.</returns>
+        bool IsEventType(Type type);
+    }
+}

--- a/src/NServiceBus.Core/Conventions/NServiceBusMarkerInterfaceConvention.cs
+++ b/src/NServiceBus.Core/Conventions/NServiceBusMarkerInterfaceConvention.cs
@@ -1,0 +1,37 @@
+﻿namespace NServiceBus
+{
+    using System;
+
+    /// <summary>
+    /// A message convention that uses the built-in NServiceBus marker interfaces.
+    /// </summary>
+    public class NServiceBusMarkerInterfaceConvention : IMessageConvention
+    {
+        /// <inheritdoc cref="IMessageConvention"/>
+        public string Name => "NServiceBus Marker Interfaces";
+
+        /// <inheritdoc cref="IMessageConvention"/>
+        public bool IsCommandType(Type type)
+        {
+            Guard.AgainstNull(nameof(type), type);
+            return typeof(ICommand).IsAssignableFrom(type) && typeof(ICommand) != type;
+        }
+
+        /// <inheritdoc cref="IMessageConvention"/>
+        public bool IsEventType(Type type)
+        {
+            Guard.AgainstNull(nameof(type), type);
+            return typeof(IEvent).IsAssignableFrom(type) && typeof(IEvent) != type;
+        }
+
+        /// <inheritdoc cref="IMessageConvention"/>
+        public bool IsMessageType(Type type)
+        {
+            Guard.AgainstNull(nameof(type), type);
+            return typeof(IMessage).IsAssignableFrom(type) &&
+                 typeof(IMessage) != type &&
+                 typeof(IEvent) != type &&
+                 typeof(ICommand) != type;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Conventions/OverridableMessageConvention.cs
+++ b/src/NServiceBus.Core/Conventions/OverridableMessageConvention.cs
@@ -1,0 +1,33 @@
+﻿namespace NServiceBus
+{
+    using System;
+
+    class OverridableMessageConvention : IMessageConvention
+    {
+        private readonly IMessageConvention inner;
+        Func<Type, bool> isCommandType;
+        Func<Type, bool> isEventType;
+        Func<Type, bool> isMessageType;
+
+        public OverridableMessageConvention(IMessageConvention inner)
+        {
+            this.inner = inner;
+        }
+
+        public string Name => ConventionModified ? $"Modified {inner.Name}" : inner.Name;
+
+        public bool IsCommandType(Type type) => isCommandType?.Invoke(type) ?? inner.IsCommandType(type);
+
+        public bool IsEventType(Type type) => isEventType?.Invoke(type) ?? inner.IsEventType(type);
+
+        public bool IsMessageType(Type type) => isMessageType?.Invoke(type) ?? inner.IsMessageType(type);
+
+        public void DefiningCommandsAs(Func<Type, bool> isCommandType) => this.isCommandType = isCommandType;
+
+        public void DefiningEventsAs(Func<Type, bool> isEventType) => this.isEventType = isEventType;
+
+        public void DefiningMessagesAs(Func<Type, bool> isMessageType) => this.isMessageType = isMessageType;
+
+        public bool ConventionModified => isCommandType != null || isEventType != null || isMessageType != null;
+    }
+}

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -108,6 +108,7 @@ namespace NServiceBus
             settings.AddStartupDiagnosticsSection("Messages", new
             {
                 CustomConventionUsed = conventions.CustomMessageTypeConventionUsed,
+                MessageConventions = conventions.RegisteredConventions,
                 NumberOfMessagesFoundAtStartup = foundMessages.Count,
                 Messages = foundMessages.Select(m => m.MessageType.FullName)
             });


### PR DESCRIPTION
Enables registering multiple message conventions in isolation. Example:

```csharp
class SuffixMessageConvention : IMessageConvention
{
    public string Name { get; } = "Type name suffix";
    public bool IsCommandType(Type t) => t.FullName.EndsWith("Command");
    public bool IsEventType(Type t) => t.FullName.EndsWith("Event");
    public bool IsMessageType(Type t) => t.FullName.Endswith("Message");
}

// Implements the conventions from https://github.com/mauroservienti/NServiceBus.AttributeConventions
class AttributeMessageConvention : IMessageConvention
{
    public string Name { get; } = "Attribute decorator";
    public bool IsCommandType(Type t) => t.GetCustomAttribute<CommandAttribute>(false) != null;
    public bool IsEventType(Type t) => t.GetCustomAttribute<EventAttribute>(false) != null;
    public bool IsMessageType(Type t) => t.GetCustomAttribute<MessageAttribute>(false) != null;
}

// matches all types that follow the default marker interface conventions and the new suffix and attribute conventions.
endpointConfiguration.Conventions()
  .Add(new SuffixMessageConvention())
  .Add(new AttributeMessageConvention());


// Would match this because it follows the naming convention
public class PlaceOrderCommand { ... }

// Would match this because it follows the attribute convention
[Event] public class OrderPlaced { ... }

// Would match this because it follows the default convention
public class RequestShipmentResponse : IMessage { ... }

// Would not match this because it follows none of the conventions
public class ShipOrderCmd { ... }
```

NOTES:
- The default convention is always applied first
- Calling `DefiningCommandsAs()`, `DefiningEventsAs()`, and `DefiningMessagesAs()` will modify the default convention
  - Did not deprecate these methods yet, although it would make sense to push users towards writing a custom convention instead.
- Does not include databus property conventions as that feels like an orthogonal concern.
- Have not included the ability to turn off the default convention at this stage. It seems like a micro-optimization. It would be odd for a message to adhere to the marker interface convention but not be intended to be matched as the associated message type.