### PR TITLE
Obsolete message forwarding

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Installers/When_creating_queues.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Installers/When_creating_queues.cs
@@ -85,7 +85,9 @@
                 .WithEndpoint<Endpoint>(e => e.CustomConfig(endpointConfig =>
                  {
                      endpointConfig.AuditProcessedMessagesTo("myAudit");
+#pragma warning disable 618
                      endpointConfig.ForwardReceivedMessagesTo("myForwardingEndpoint");
+#pragma warning restore 618
                      endpointConfig.MakeInstanceUniquelyAddressable(instanceDiscriminator);
                  }))
                 .Done(c => c.EndpointsStarted)

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_modifying_headers_during_forwarding.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_modifying_headers_during_forwarding.cs
@@ -36,7 +36,9 @@
             {
                 EndpointSetup<DefaultServer>(e =>
                 {
+#pragma warning disable 618
                     e.ForwardReceivedMessagesTo("forwardingQueue");
+#pragma warning restore 618
                     e.Pipeline.Register(typeof(ForwardingBehavior), "Adds headers to a forwarded message");
                     e.Pipeline.Register(typeof(MainPipelineBehavior), "Adds headers to a forwarded message");
                 });

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_modifying_headers_during_forwarding.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_modifying_headers_during_forwarding.cs
@@ -76,6 +76,7 @@
                 }
             }
 
+#pragma warning disable 618
             class ForwardingBehavior : Behavior<IForwardingContext>
             {
                 public override Task Invoke(IForwardingContext context, Func<Task> next)
@@ -84,6 +85,7 @@
                     return next();
                 }
             }
+#pragma warning restore 618
         }
 
         class SomeMessage

--- a/src/NServiceBus.AcceptanceTests/Forwarding/When_forwarding_is_configured_for_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Forwarding/When_forwarding_is_configured_for_endpoint.cs
@@ -59,7 +59,9 @@
         {
             public EndpointThatForwards()
             {
+#pragma warning disable 618
                 EndpointSetup<DefaultServer>(c => c.ForwardReceivedMessagesTo("endpoint_forward_receiver"));
+#pragma warning restore 618
             }
 
             public class MessageToForwardHandler : IHandleMessages<MessageToForward>

--- a/src/NServiceBus.AcceptanceTests/Outbox/When_dispatching_forwarded_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Outbox/When_dispatching_forwarded_messages.cs
@@ -41,7 +41,9 @@
                     {
                         b.EnableOutbox();
                         b.Pipeline.Register("BlowUpAfterDispatchBehavior", new BlowUpAfterDispatchBehavior(), "For testing");
+#pragma warning disable 618
                         b.ForwardReceivedMessagesTo(Conventions.EndpointNamingConvention(typeof(ForwardingSpyEndpoint)));
+#pragma warning restore 618
                     });
             }
 

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -67,6 +67,8 @@ namespace NServiceBus
     }
     public class static ConfigureForwarding
     {
+        [System.ObsoleteAttribute("Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0." +
+            "", false)]
         public static void ForwardReceivedMessagesTo(this NServiceBus.EndpointConfiguration config, string address) { }
     }
     public class static ConfigureLicenseExtensions

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -65,6 +65,8 @@ namespace NServiceBus
     {
         public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.FileShareDataBus> BasePath(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.FileShareDataBus> config, string basePath) { }
     }
+    [System.ObsoleteAttribute("Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0." +
+        "", false)]
     public class static ConfigureForwarding
     {
         [System.ObsoleteAttribute("Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0." +
@@ -1610,6 +1612,8 @@ namespace NServiceBus.Features
         Active = 2,
         Deactivated = 3,
     }
+    [System.ObsoleteAttribute("Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0." +
+        "", false)]
     public class ForwardReceivedMessages : NServiceBus.Features.Feature
     {
         protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
@@ -2016,6 +2020,8 @@ namespace NServiceBus.Pipeline
     {
         System.Collections.Generic.IEnumerable<NServiceBus.Transport.TransportOperation> Operations { get; }
     }
+    [System.ObsoleteAttribute("Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0." +
+        "", false)]
     public interface IForwardingContext : NServiceBus.Extensibility.IExtendable, NServiceBus.Pipeline.IBehaviorContext
     {
         string Address { get; }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -65,6 +65,8 @@ namespace NServiceBus
     {
         public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.FileShareDataBus> BasePath(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.FileShareDataBus> config, string basePath) { }
     }
+    [System.ObsoleteAttribute("Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0." +
+        "", false)]
     public class static ConfigureForwarding
     {
         [System.ObsoleteAttribute("Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0." +
@@ -1612,6 +1614,8 @@ namespace NServiceBus.Features
         Active = 2,
         Deactivated = 3,
     }
+    [System.ObsoleteAttribute("Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0." +
+        "", false)]
     public class ForwardReceivedMessages : NServiceBus.Features.Feature
     {
         protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
@@ -2018,6 +2022,8 @@ namespace NServiceBus.Pipeline
     {
         System.Collections.Generic.IEnumerable<NServiceBus.Transport.TransportOperation> Operations { get; }
     }
+    [System.ObsoleteAttribute("Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0." +
+        "", false)]
     public interface IForwardingContext : NServiceBus.Extensibility.IExtendable, NServiceBus.Pipeline.IBehaviorContext
     {
         string Address { get; }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -67,6 +67,8 @@ namespace NServiceBus
     }
     public class static ConfigureForwarding
     {
+        [System.ObsoleteAttribute("Will be treated as an error from version 8.0.0. Will be removed in version 9.0.0." +
+            "", false)]
         public static void ForwardReceivedMessagesTo(this NServiceBus.EndpointConfiguration config, string address) { }
     }
     public class static ConfigureLicenseExtensions

--- a/src/NServiceBus.Core/Forwarding/ConfigureForwarding.cs
+++ b/src/NServiceBus.Core/Forwarding/ConfigureForwarding.cs
@@ -10,6 +10,7 @@
         /// </summary>
         /// <param name="config">The <see cref="EndpointConfiguration" /> instance to apply the settings to.</param>
         /// <param name="address">The address to forward successfully processed messages to.</param>
+        [ObsoleteEx(TreatAsErrorFromVersion = "8", RemoveInVersion = "9" )]
         public static void ForwardReceivedMessagesTo(this EndpointConfiguration config, string address)
         {
             Guard.AgainstNull(nameof(config), config);

--- a/src/NServiceBus.Core/Forwarding/ConfigureForwarding.cs
+++ b/src/NServiceBus.Core/Forwarding/ConfigureForwarding.cs
@@ -3,6 +3,7 @@
     /// <summary>
     /// Contains extension methods to <see cref="EndpointConfiguration" />.
     /// </summary>
+    [ObsoleteEx(TreatAsErrorFromVersion = "8", RemoveInVersion = "9")]
     public static class ConfigureForwarding
     {
         /// <summary>

--- a/src/NServiceBus.Core/Forwarding/ForwardReceivedMessages.cs
+++ b/src/NServiceBus.Core/Forwarding/ForwardReceivedMessages.cs
@@ -5,6 +5,7 @@
     /// <summary>
     /// Provides message forwarding capabilities.
     /// </summary>
+    [ObsoleteEx(TreatAsErrorFromVersion = "8", RemoveInVersion = "9")]
     public class ForwardReceivedMessages : Feature
     {
         internal ForwardReceivedMessages()

--- a/src/NServiceBus.Core/Forwarding/IForwardingContext.cs
+++ b/src/NServiceBus.Core/Forwarding/IForwardingContext.cs
@@ -5,6 +5,7 @@ namespace NServiceBus.Pipeline
     /// <summary>
     /// Provide context to behaviors on the forwarding pipeline.
     /// </summary>
+    [ObsoleteEx(TreatAsErrorFromVersion = "8", RemoveInVersion = "9")]
     public interface IForwardingContext : IBehaviorContext
     {
         /// <summary>

--- a/src/NServiceBus.Testing.Fakes/TestableForwardingContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableForwardingContext.cs
@@ -9,7 +9,9 @@ namespace NServiceBus.Testing
     /// <summary>
     /// A testable implementation for <see cref="IForwardingContext" />.
     /// </summary>
+#pragma warning disable 618
     public partial class TestableForwardingContext : TestableBehaviorContext, IForwardingContext
+#pragma warning restore 618
     {
         /// <summary>
         /// The message to be forwarded.


### PR DESCRIPTION
This feature is often used accidentally when message auditing is desired instead. Message forwarding will be moved into [a sample](https://github.com/Particular/docs.particular.net/pull/4934). 