### PR TITLE
Add Microsoft.NETFramework.ReferenceAssemblies to allow build with .N…

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -21,4 +21,11 @@
   </ItemGroup>
   <!-- End Workaround -->
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
…ET Core on non-Windows OSes.