### PR TITLE
Fix performance test

### DIFF
--- a/src/NServiceBus.Core.Tests/Unicast/HandlerInvocationCache.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/HandlerInvocationCache.cs
@@ -23,14 +23,16 @@
             var messageHandler = cache.GetCachedHandlerForMessage<StubMessage>();
             var timeoutHandler = cache.GetCachedHandlerForMessage<StubTimeoutState>();
 
-            await messageHandler.Invoke(stubMessage, null);
-            await timeoutHandler.Invoke(stubTimeout, null);
+            var fakeContext = new TestableMessageHandlerContext();
+
+            await messageHandler.Invoke(stubMessage, fakeContext);
+            await timeoutHandler.Invoke(stubTimeout, fakeContext);
 
             var startNew = Stopwatch.StartNew();
             for (var i = 0; i < 100000; i++)
             {
-                await messageHandler.Invoke(stubMessage, null);
-                await timeoutHandler.Invoke(stubTimeout, null);
+                await messageHandler.Invoke(stubMessage, fakeContext);
+                await timeoutHandler.Invoke(stubTimeout, fakeContext);
             }
             startNew.Stop();
             Trace.WriteLine(startNew.ElapsedMilliseconds);


### PR DESCRIPTION
This test is marked as explicit but it's bring run in Visual Studio 2019 due to [this issue in the NUnit3TestAdapter that will be fixed in v4](https://github.com/nunit/nunit3-vs-adapter/issues/658).

Passing null for message handler context results in NRE but we don't need it to do anything