### PR TITLE
Protecting pipeline from modifications after endpoint is started

### DIFF
--- a/src/NServiceBus.Core.Tests/Pipeline/PipelineSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/PipelineSettingsTests.cs
@@ -1,0 +1,33 @@
+namespace NServiceBus.Core.Tests.Pipeline
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+    using Settings;
+
+    [TestFixture]
+    public class PipelineSettingsTests
+    {
+        [Test]
+        public void Register_ThrowsWhenChangesArePrevented()
+        {
+            var settingsHolder = new SettingsHolder();
+            var pipelineSettings = new PipelineSettings(settingsHolder);
+
+            pipelineSettings.PreventChanges();
+
+            Assert.Throws<InvalidOperationException>(() => pipelineSettings.Register(typeof(Behavior1), "newStep"));
+            Assert.Throws<InvalidOperationException>(() => pipelineSettings.Remove("newStep"));
+            Assert.Throws<InvalidOperationException>(() => pipelineSettings.Replace("newStep", typeof(Behavior1)));
+        }
+
+        class Behavior1 : IBehavior<IIncomingPhysicalMessageContext, IIncomingPhysicalMessageContext>
+        {
+            public Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
+            {
+                return next(context);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -85,6 +85,9 @@ namespace NServiceBus
             // As well as all the other components have been initialized
             settings.PreventChanges();
 
+            // Comment
+            pipelineSettings.PreventChanges();
+
             settings.AddStartupDiagnosticsSection("Endpoint",
                 new
                 {

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -85,7 +85,7 @@ namespace NServiceBus
             // As well as all the other components have been initialized
             settings.PreventChanges();
 
-            // Comment
+            // The pipeline settings can be locked after the endpoint is configured. It prevents end users from modyfing pipeline after an endpoint has started.
             pipelineSettings.PreventChanges();
 
             settings.AddStartupDiagnosticsSection("Endpoint",

--- a/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
@@ -25,7 +25,7 @@ namespace NServiceBus.Pipeline
         {
             // I can only remove a behavior that is registered and other behaviors do not depend on, eg InsertBefore/After
             Guard.AgainstNullAndEmpty(nameof(stepId), stepId);
-            EnsureWriteEnabled(stepId, "remove");
+            EnsureWriteEnabled(stepId, nameof(Remove));
 
             modifications.Removals.Add(new RemoveStep(stepId));
         }
@@ -40,7 +40,7 @@ namespace NServiceBus.Pipeline
         {
             BehaviorTypeChecker.ThrowIfInvalid(newBehavior, nameof(newBehavior));
             Guard.AgainstNullAndEmpty(nameof(stepId), stepId);
-            EnsureWriteEnabled(stepId, "replace");
+            EnsureWriteEnabled(stepId, nameof(Replace));
 
             modifications.Replacements.Add(new ReplaceStep(stepId, newBehavior, description));
         }
@@ -56,7 +56,7 @@ namespace NServiceBus.Pipeline
         {
             BehaviorTypeChecker.ThrowIfInvalid(typeof(T), nameof(newBehavior));
             Guard.AgainstNullAndEmpty(nameof(stepId), stepId);
-            EnsureWriteEnabled(stepId, "replace");
+            EnsureWriteEnabled(stepId, nameof(Replace));
 
             modifications.Replacements.Add(new ReplaceStep(stepId, typeof(T), description, builder => newBehavior));
         }
@@ -72,7 +72,7 @@ namespace NServiceBus.Pipeline
         {
             BehaviorTypeChecker.ThrowIfInvalid(typeof(T), "newBehavior");
             Guard.AgainstNullAndEmpty(nameof(stepId), stepId);
-            EnsureWriteEnabled(stepId, "replace");
+            EnsureWriteEnabled(stepId, nameof(Replace));
 
             modifications.Replacements.Add(new ReplaceStep(stepId, typeof(T), description, b => factoryMethod(b)));
         }
@@ -98,7 +98,7 @@ namespace NServiceBus.Pipeline
         public void Register(string stepId, Type behavior, string description)
         {
             BehaviorTypeChecker.ThrowIfInvalid(behavior, nameof(behavior));
-            EnsureWriteEnabled(stepId, "register");
+            EnsureWriteEnabled(stepId, nameof(Register));
 
             Guard.AgainstNullAndEmpty(nameof(stepId), stepId);
             Guard.AgainstNullAndEmpty(nameof(description), description);


### PR DESCRIPTION
fixes: https://github.com/Particular/NServiceBus/issues/4873

At the moment the Settings are being locked preventing from being modified. This PR introduces a similar mechanism for Pipeline modifications (Register, Remove, Replace) highlighting common errors when modifying pipeline after an endpoint has started. 