### PR TITLE
Proposed Saga Mapping API in reverse direction

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -176,6 +176,7 @@ namespace NServiceBus
         where TSagaData :  class, NServiceBus.IContainSagaData
     {
         public NServiceBus.CorrelatedSagaPropertyMapper<TSagaData> ToMessage<TMessage>(System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty) { }
+        public NServiceBus.CorrelatedSagaPropertyMapper<TSagaData> ToMessageHeader<TMessage>(string headerName) { }
     }
     [System.ObsoleteAttribute("Setting a custom correlation ID is no longer supported. Will be removed in versio" +
         "n 8.0.0.", true)]

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -172,6 +172,11 @@ namespace NServiceBus
     {
         public static void StartNewConversation(this NServiceBus.SendOptions sendOptions, string conversationId = null) { }
     }
+    public class CorrelatedSagaPropertyMapper<TSagaData>
+        where TSagaData :  class, NServiceBus.IContainSagaData
+    {
+        public NServiceBus.CorrelatedSagaPropertyMapper<TSagaData> ToMessage<TMessage>(System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty) { }
+    }
     [System.ObsoleteAttribute("Setting a custom correlation ID is no longer supported. Will be removed in versio" +
         "n 8.0.0.", true)]
     public class static CorrelationContextExtensions
@@ -934,6 +939,7 @@ namespace NServiceBus
     {
         public NServiceBus.IToSagaExpression<TSagaData> ConfigureHeaderMapping<TMessage>(string headerName) { }
         public NServiceBus.ToSagaExpression<TSagaData, TMessage> ConfigureMapping<TMessage>(System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty) { }
+        public NServiceBus.CorrelatedSagaPropertyMapper<TSagaData> MapSaga(System.Linq.Expressions.Expression<System.Func<TSagaData, object>> sagaProperty) { }
     }
     public abstract class Saga<TSagaData> : NServiceBus.Saga
         where TSagaData :  class, NServiceBus.IContainSagaData, new ()

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -176,6 +176,7 @@ namespace NServiceBus
         where TSagaData :  class, NServiceBus.IContainSagaData
     {
         public NServiceBus.CorrelatedSagaPropertyMapper<TSagaData> ToMessage<TMessage>(System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty) { }
+        public NServiceBus.CorrelatedSagaPropertyMapper<TSagaData> ToMessageHeader<TMessage>(string headerName) { }
     }
     [System.ObsoleteAttribute("Setting a custom correlation ID is no longer supported. Will be removed in versio" +
         "n 8.0.0.", true)]

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -172,6 +172,11 @@ namespace NServiceBus
     {
         public static void StartNewConversation(this NServiceBus.SendOptions sendOptions, string conversationId = null) { }
     }
+    public class CorrelatedSagaPropertyMapper<TSagaData>
+        where TSagaData :  class, NServiceBus.IContainSagaData
+    {
+        public NServiceBus.CorrelatedSagaPropertyMapper<TSagaData> ToMessage<TMessage>(System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty) { }
+    }
     [System.ObsoleteAttribute("Setting a custom correlation ID is no longer supported. Will be removed in versio" +
         "n 8.0.0.", true)]
     public class static CorrelationContextExtensions
@@ -934,6 +939,7 @@ namespace NServiceBus
     {
         public NServiceBus.IToSagaExpression<TSagaData> ConfigureHeaderMapping<TMessage>(string headerName) { }
         public NServiceBus.ToSagaExpression<TSagaData, TMessage> ConfigureMapping<TMessage>(System.Linq.Expressions.Expression<System.Func<TMessage, object>> messageProperty) { }
+        public NServiceBus.CorrelatedSagaPropertyMapper<TSagaData> MapSaga(System.Linq.Expressions.Expression<System.Func<TSagaData, object>> sagaProperty) { }
     }
     public abstract class Saga<TSagaData> : NServiceBus.Saga
         where TSagaData :  class, NServiceBus.IContainSagaData, new ()

--- a/src/NServiceBus.Core/Sagas/CorrelatedSagaPropertyMapper.cs
+++ b/src/NServiceBus.Core/Sagas/CorrelatedSagaPropertyMapper.cs
@@ -31,5 +31,20 @@ namespace NServiceBus
             sagaPropertyMapper.ConfigureMapping(messageProperty).ToSaga(sagaProperty);
             return this;
         }
+
+        /// <summary>
+        /// Specify how to map <typeparamref name="TMessage"/> messages to instance of <typeparamref name="TSagaData"/>
+        /// using a header.
+        /// </summary>
+        /// <typeparam name="TMessage">The message type to map to.</typeparam>
+        /// <param name="headerName">The name of the header to use for correlation.</param>
+        /// <returns>
+        /// The same mapper instance.
+        /// </returns>
+        public CorrelatedSagaPropertyMapper<TSagaData> ToMessageHeader<TMessage>(string headerName)
+        {
+            sagaPropertyMapper.ConfigureHeaderMapping<TMessage>(headerName).ToSaga(sagaProperty);
+            return this;
+        }
     }
 }

--- a/src/NServiceBus.Core/Sagas/CorrelatedSagaPropertyMapper.cs
+++ b/src/NServiceBus.Core/Sagas/CorrelatedSagaPropertyMapper.cs
@@ -1,0 +1,35 @@
+namespace NServiceBus
+{
+    using System;
+    using System.Linq.Expressions;
+
+    /// <summary>
+    /// A helper class that provides syntactical sugar as part of <see cref="Saga.ConfigureHowToFindSaga" />.
+    /// </summary>
+    /// <typeparam name="TSagaData">A type that implements <see cref="IContainSagaData"/>.</typeparam>
+    public class CorrelatedSagaPropertyMapper<TSagaData> where TSagaData : class, IContainSagaData
+    {
+        SagaPropertyMapper<TSagaData> sagaPropertyMapper;
+        Expression<Func<TSagaData, object>> sagaProperty;
+
+        internal CorrelatedSagaPropertyMapper(SagaPropertyMapper<TSagaData> sagaPropertyMapper, Expression<Func<TSagaData, object>> sagaProperty)
+        {
+            this.sagaPropertyMapper = sagaPropertyMapper;
+            this.sagaProperty = sagaProperty;
+        }
+
+        /// <summary>
+        /// Specify how to map <typeparamref name="TMessage"/> messages to instances of <typeparamref name="TSagaData"/>.
+        /// </summary>
+        /// <typeparam name="TMessage">The message type to map to.</typeparam>
+        /// <param name="messageProperty">The message property to use for correlation.</param>
+        /// <returns>
+        /// The same mapper instance.
+        /// </returns>
+        public CorrelatedSagaPropertyMapper<TSagaData> ToMessage<TMessage>(Expression<Func<TMessage, object>> messageProperty)
+        {
+            sagaPropertyMapper.ConfigureMapping(messageProperty).ToSaga(sagaProperty);
+            return this;
+        }
+    }
+}

--- a/src/NServiceBus.Core/Sagas/SagaPropertyMapper.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPropertyMapper.cs
@@ -30,7 +30,6 @@ namespace NServiceBus
             return new ToSagaExpression<TSagaData, TMessage>(sagaMessageFindingConfiguration, messageProperty);
         }
 
-        /// <summary>
         /// Specify how to map between <typeparamref name="TSagaData"/> and <typeparamref name="TMessage"/> using a message header.
         /// </summary>
         /// <typeparam name="TMessage">The message type to map to.</typeparam>
@@ -50,6 +49,21 @@ namespace NServiceBus
             }
 
             return new MessageHeaderToSagaExpression<TSagaData, TMessage>(sagaHeaderFindingConfiguration, headerName);
+        }
+
+        /// <summary>
+        /// Specify the correlation property for instances of <typeparamref name="TSagaData"/>.
+        /// </summary>
+        /// <param name="sagaProperty">The correlation property to use when finding a saga instance.</param>
+        /// <returns>
+        /// A <see cref="CorrelatedSagaPropertyMapper{TSagaData}"/> that provides the fluent chained
+        /// <see cref="CorrelatedSagaPropertyMapper{TSagaData}.ToMessage{TMessage}"/> to map a message type to
+        /// the correlation property.
+        /// </returns>
+        public CorrelatedSagaPropertyMapper<TSagaData> MapSaga(Expression<Func<TSagaData, object>> sagaProperty)
+        {
+            Guard.AgainstNull(nameof(sagaProperty), sagaProperty);
+            return new CorrelatedSagaPropertyMapper<TSagaData>(this, sagaProperty);
         }
 
         IConfigureHowToFindSagaWithMessage sagaMessageFindingConfiguration;

--- a/src/NServiceBus.Core/Sagas/SagaPropertyMapper.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPropertyMapper.cs
@@ -30,6 +30,7 @@ namespace NServiceBus
             return new ToSagaExpression<TSagaData, TMessage>(sagaMessageFindingConfiguration, messageProperty);
         }
 
+        /// <summary>
         /// Specify how to map between <typeparamref name="TSagaData"/> and <typeparamref name="TMessage"/> using a message header.
         /// </summary>
         /// <typeparam name="TMessage">The message type to map to.</typeparam>


### PR DESCRIPTION
The current saga mapping API implies that you can have multiple correlation properties but you can't (we detect this and throw an exception). This proposed alternative puts the definition of the correlation property first, so that you can specify correlation property once and then map different messages to it.

i.e. Instead of this

```csharp
public override void ConfigureHowToFindSaga(SagaPropertyMapper<ProcessOrderSagaData> mapper)
{
    mapper.CreateMapping<SubmitOrder>(msg => msg.OrderId).ToSaga(saga => saga.OrderId);
    mapper.CreateMapping<OrderBilled>(msg => msg.OrderId).ToSaga(saga => saga.OrderId);
    mapper.CreateHeaderMapping<OrderShipped>("Shipping.OrderId").ToSaga(saga => saga.OrderId);
}
```

you can do this instead

```csharp
public override void ConfigureHowToFindSaga(SagaPropertyMapper<ProcessOrderSagaData> mapper)
{
    mapper.MapSaga(saga => saga.OrderId)
        .ToMessage<SubmitOrder>(msg = msg.OrderId)
        .ToMessage<OrderBilled>(msg => msg.OrderId)
        .ToMessageHeader<OrderShipped>("Shipping.OrderId");
}
```

Or, if you prefer a non-chained API

```csharp
public override void ConfigureHowToFindSaga(SagaPropertyMapper<ProcessOrderSagaData> mapper)
{
    var correlate = mapper.MapSaga(saga => saga.OrderId);

    correlate.ToMessage<SubmitOrder>(msg = msg.OrderId);
    correlate.ToMessage<OrderBilled>(msg => msg.OrderId);
    correlate.ToMessageHeader<OrderShipped>("Shipping.OrderId");
}
```
