### PR TITLE
Make SubscriptionManagerFactory public

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2334,6 +2334,7 @@ namespace NServiceBus.Transport
     public class TransportSubscriptionInfrastructure
     {
         public TransportSubscriptionInfrastructure(System.Func<NServiceBus.Transport.IManageSubscriptions> subscriptionManagerFactory) { }
+        public System.Func<NServiceBus.Transport.IManageSubscriptions> SubscriptionManagerFactory { get; }
     }
     public sealed class TransportTransaction : NServiceBus.Extensibility.ContextBag
     {

--- a/src/NServiceBus.Core/Transports/TransportSubscriptionInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/TransportSubscriptionInfrastructure.cs
@@ -16,6 +16,9 @@ namespace NServiceBus.Transport
             SubscriptionManagerFactory = subscriptionManagerFactory;
         }
 
-        internal Func<IManageSubscriptions> SubscriptionManagerFactory { get; }
+        /// <summary>
+        /// Factory to create the subscription manager.
+        /// </summary>
+        public Func<IManageSubscriptions> SubscriptionManagerFactory { get; }
     }
 }


### PR DESCRIPTION
The SQS transport needs to access the subscription infra to avoid the problem with concurrent calls to subscribe (more detailed description [here](https://github.com/Particular/NServiceBus.AmazonSQS/pull/552)). NServiceBus.Raw also needs to access this. Additionally, the other two *Infrastructure classed have their factory accessors public so there is precedence for it. It does not hurts us and would allow us to remove the hacks from SQS and Raw.

Edit: Problems in SQS are going to be addressed by the new transport seam.