### PR TITLE
Bring back MessageDrivenSubscriptions

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1281,10 +1281,11 @@ namespace NServiceBus.Features
     {
         protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
     }
-    [System.ObsoleteAttribute("Use \'TransportExtensions<T>.DisablePublishing()\' to avoid the need for a subscrip" +
-        "tion storage if this endpoint does not publish events. Will be removed in versio" +
-        "n 9.0.0.", true)]
-    public class MessageDrivenSubscriptions { }
+    [System.ObsoleteAttribute(@"It's not recommended to disable the MessageDrivenSubscriptions feature and this option will be removed in future versions. Use 'TransportExtensions<T>.DisablePublishing()' to avoid the need for a subscription storage if this endpoint does not publish events. Will be treated as an error from version 9.0.0. Will be removed in version 10.0.0.", false)]
+    public class MessageDrivenSubscriptions : NServiceBus.Features.Feature
+    {
+        protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+    }
     public class Outbox : NServiceBus.Features.Feature
     {
         protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }

--- a/src/NServiceBus.Core/Persistence/InMemory/SubscriptionStorage/InMemorySubscriptionPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/InMemory/SubscriptionStorage/InMemorySubscriptionPersistence.cs
@@ -7,7 +7,7 @@
     {
         internal InMemorySubscriptionPersistence()
         {
-            DependsOn<MessageDrivenSubscriptionsToBeRefactored>();
+            DependsOn<MessageDrivenSubscriptions>();
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -14,11 +14,15 @@ namespace NServiceBus.Features
     /// Many of those features have been moved into components instead. Now that this class is internal in V8 that
     /// refactoring can occur.
     /// </summary>
-    class MessageDrivenSubscriptionsToBeRefactored : Feature
+    [ObsoleteEx(
+        Message = "It's not recommended to disable the MessageDrivenSubscriptions feature and this option will be removed in future versions. Use 'TransportExtensions<T>.DisablePublishing()' to avoid the need for a subscription storage if this endpoint does not publish events.",
+        RemoveInVersion = "10",
+        TreatAsErrorFromVersion = "9")]
+    public class MessageDrivenSubscriptions : Feature
     {
         internal const string EnablePublishingSettingsKey = "NServiceBus.PublishSubscribe.EnablePublishing";
 
-        public MessageDrivenSubscriptionsToBeRefactored()
+        internal MessageDrivenSubscriptions()
         {
             EnableByDefault();
             Defaults(s =>

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
@@ -39,7 +39,7 @@ namespace NServiceBus
         /// </summary>
         public static void DisablePublishing<T>(this TransportExtensions<T> transportExtensions) where T : TransportDefinition, IMessageDrivenSubscriptionTransport
         {
-            transportExtensions.Settings.Set(MessageDrivenSubscriptionsToBeRefactored.EnablePublishingSettingsKey, false);
+            transportExtensions.Settings.Set(MessageDrivenSubscriptions.EnablePublishingSettingsKey, false);
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/SubscriptionMigrationMode.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/SubscriptionMigrationMode.cs
@@ -63,7 +63,7 @@
             }
 
             // implementations of IInitializableSubscriptionStorage are optional and can be provided by persisters.
-            context.RegisterStartupTask(b => new MessageDrivenSubscriptionsToBeRefactored.InitializableSubscriptionStorage(b.GetService<IInitializableSubscriptionStorage>()));
+            context.RegisterStartupTask(b => new MessageDrivenSubscriptions.InitializableSubscriptionStorage(b.GetService<IInitializableSubscriptionStorage>()));
         }
 
         public static bool IsMigrationModeEnabled(ReadOnlySettings settings)

--- a/src/NServiceBus.Core/obsoletes-v8.cs
+++ b/src/NServiceBus.Core/obsoletes-v8.cs
@@ -164,15 +164,6 @@ namespace NServiceBus.Features
     {
         internal InMemoryGatewayPersistence() => throw new NotImplementedException();
     }
-
-    [ObsoleteEx(
-        Message = "Use 'TransportExtensions<T>.DisablePublishing()' to avoid the need for a subscription storage if this endpoint does not publish events.",
-        RemoveInVersion = "9",
-        TreatAsErrorFromVersion = "8")]
-    public class MessageDrivenSubscriptions
-    {
-        internal MessageDrivenSubscriptions() => throw new NotImplementedException();
-    }
 }
 
 namespace NServiceBus


### PR DESCRIPTION
As discussed with @andreasohlund , this brings back the public `MessageDrivenSubscriptions` so that downstream persisters can continue to use `DependsOn<MessageDrivenSubscriptions>`.