### PR TITLE
Use GetRequiredService internally

### DIFF
--- a/src/NServiceBus.Core/DataBus/DataBus.cs
+++ b/src/NServiceBus.Core/DataBus/DataBus.cs
@@ -36,7 +36,7 @@ namespace NServiceBus.Features
                 context.Container.ConfigureComponent<DefaultDataBusSerializer>(DependencyLifecycle.SingleInstance);
             }
 
-            context.RegisterStartupTask(b => new IDataBusInitializer(b.GetService<IDataBus>()));
+            context.RegisterStartupTask(b => new IDataBusInitializer(b.GetRequiredService<IDataBus>()));
 
             var conventions = context.Settings.Get<Conventions>();
             context.Pipeline.Register(new DataBusReceiveBehavior.Registration(conventions));

--- a/src/NServiceBus.Core/DataBus/DataBusReceiveBehavior.cs
+++ b/src/NServiceBus.Core/DataBus/DataBusReceiveBehavior.cs
@@ -68,7 +68,7 @@
 
         public class Registration : RegisterStep
         {
-            public Registration(Conventions conventions) : base("DataBusReceive", typeof(DataBusReceiveBehavior), "Copies the databus shared data back to the logical message", b => new DataBusReceiveBehavior(b.GetService<IDataBus>(), b.GetService<IDataBusSerializer>(), conventions))
+            public Registration(Conventions conventions) : base("DataBusReceive", typeof(DataBusReceiveBehavior), "Copies the databus shared data back to the logical message", b => new DataBusReceiveBehavior(b.GetRequiredService<IDataBus>(), b.GetRequiredService<IDataBusSerializer>(), conventions))
             {
                 InsertAfter("MutateIncomingMessages");
             }

--- a/src/NServiceBus.Core/DataBus/DataBusSendBehavior.cs
+++ b/src/NServiceBus.Core/DataBus/DataBusSendBehavior.cs
@@ -86,7 +86,7 @@
 
         public class Registration : RegisterStep
         {
-            public Registration(Conventions conventions) : base("DataBusSend", typeof(DataBusSendBehavior), "Saves the payload into the shared location", b => new DataBusSendBehavior(b.GetService<IDataBus>(), b.GetService<IDataBusSerializer>(), conventions))
+            public Registration(Conventions conventions) : base("DataBusSend", typeof(DataBusSendBehavior), "Saves the payload into the shared location", b => new DataBusSendBehavior(b.GetRequiredService<IDataBus>(), b.GetRequiredService<IDataBusSerializer>(), conventions))
             {
                 InsertAfter("MutateOutgoingMessages");
                 InsertAfter("ApplyTimeToBeReceived");

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/TimeoutManager.cs
@@ -48,16 +48,16 @@
             {
                 var waitTime = context.Settings.Get<TimeSpan>("TimeToWaitBeforeTriggeringCriticalErrorForTimeoutPersisterReceiver");
 
-                var criticalError = b.GetService<CriticalError>();
+                var criticalError = b.GetRequiredService<CriticalError>();
 
                 var circuitBreaker = new RepeatedFailuresOverTimeCircuitBreaker("TimeoutStorageConnectivity",
                     waitTime,
                     ex => criticalError.Raise("Repeated failures when fetching timeouts from storage, endpoint will be terminated.", ex));
 
-                return new ExpiredTimeoutsPoller(b.GetService<IQueryTimeouts>(), b.GetService<IDispatchMessages>(), dispatcherAddress, circuitBreaker, () => DateTime.UtcNow);
+                return new ExpiredTimeoutsPoller(b.GetRequiredService<IQueryTimeouts>(), b.GetRequiredService<IDispatchMessages>(), dispatcherAddress, circuitBreaker, () => DateTime.UtcNow);
             }, DependencyLifecycle.SingleInstance);
 
-            context.RegisterStartupTask(b => new TimeoutPollerRunner(b.GetService<ExpiredTimeoutsPoller>()));
+            context.RegisterStartupTask(b => new TimeoutPollerRunner(b.GetRequiredService<ExpiredTimeoutsPoller>()));
         }
 
         static string SetupDispatcherSatellite(FeatureConfigurationContext context, PushRuntimeSettings pushRuntimeSettings)
@@ -70,8 +70,8 @@
                 (builder, messageContext) =>
                 {
                     var dispatchBehavior = new DispatchTimeoutBehavior(
-                        builder.GetService<IDispatchMessages>(),
-                        builder.GetService<IPersistTimeouts>(),
+                        builder.GetRequiredService<IDispatchMessages>(),
+                        builder.GetRequiredService<IPersistTimeouts>(),
                         requiredTransactionSupport);
 
                     return dispatchBehavior.Invoke(messageContext);
@@ -89,9 +89,9 @@
                 (builder, messageContext) =>
                 {
                     var storeBehavior = new StoreTimeoutBehavior(
-                        builder.GetService<ExpiredTimeoutsPoller>(),
-                        builder.GetService<IDispatchMessages>(),
-                        builder.GetService<IPersistTimeouts>(),
+                        builder.GetRequiredService<ExpiredTimeoutsPoller>(),
+                        builder.GetRequiredService<IDispatchMessages>(),
+                        builder.GetRequiredService<IPersistTimeouts>(),
                         context.Settings.EndpointName());
 
                     return storeBehavior.Invoke(messageContext);

--- a/src/NServiceBus.Core/Pipeline/Incoming/IncomingLogicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IncomingLogicalMessageContext.cs
@@ -37,7 +37,7 @@
                 return;
             }
 
-            var factory = Builder.GetService<LogicalMessageFactory>();
+            var factory = Builder.GetRequiredService<LogicalMessageFactory>();
             var newLogicalMessage = factory.Create(newInstance);
 
             Message.Metadata = newLogicalMessage.Metadata;

--- a/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
@@ -6,6 +6,7 @@
     using System.Threading.Tasks;
     using Extensibility;
     using Logging;
+    using Microsoft.Extensions.DependencyInjection;
     using Outbox;
     using Persistence;
     using Pipeline;
@@ -42,7 +43,7 @@
 
                 foreach (var messageHandler in handlersToInvoke)
                 {
-                    messageHandler.Instance = context.Builder.GetService(messageHandler.HandlerType);
+                    messageHandler.Instance = context.Builder.GetRequiredService(messageHandler.HandlerType);
 
                     var handlingContext = this.CreateInvokeHandlerContext(messageHandler, storageSession, context);
                     await stage(handlingContext).ConfigureAwait(false);

--- a/src/NServiceBus.Core/Pipeline/Outgoing/SendComponent.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/SendComponent.cs
@@ -28,7 +28,7 @@
             pipelineSettings.Register(new OutgoingPhysicalToRoutingConnector(), "Starts the message dispatch pipeline");
             pipelineSettings.Register(new RoutingToDispatchConnector(), "Decides if the current message should be batched or immediately be dispatched to the transport");
             pipelineSettings.Register(new BatchToDispatchConnector(), "Passes batched messages over to the immediate dispatch part of the pipeline");
-            pipelineSettings.Register(b => new ImmediateDispatchTerminator(b.GetService<IDispatchMessages>()), "Hands the outgoing messages over to the transport for immediate delivery");
+            pipelineSettings.Register(b => new ImmediateDispatchTerminator(b.GetRequiredService<IDispatchMessages>()), "Hands the outgoing messages over to the transport for immediate delivery");
 
             var sendComponent = new SendComponent(messageMapper, transportSeam.TransportInfrastructure);
             sendComponent.transportSendInfrastructure = sendComponent.transportInfrastructure.ConfigureSendInfrastructure();

--- a/src/NServiceBus.Core/Pipeline/RegisterStep.cs
+++ b/src/NServiceBus.Core/Pipeline/RegisterStep.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.Pipeline
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using Microsoft.Extensions.DependencyInjection;
     using ObjectBuilder;
 
     /// <summary>
@@ -142,7 +143,7 @@ namespace NServiceBus.Pipeline
         {
             var behavior = factoryMethod != null
                 ? factoryMethod(defaultBuilder)
-                : (IBehavior)defaultBuilder.GetService(BehaviorType);
+                : (IBehavior)defaultBuilder.GetRequiredService(BehaviorType);
 
             return behavior;
         }

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -72,7 +72,7 @@ namespace NServiceBus
                 var adapter = b.GetService<ISynchronizedStorageAdapter>() ?? new NoOpSynchronizedStorageAdapter();
                 var syncStorage = b.GetService<ISynchronizedStorage>() ?? new NoOpSynchronizedStorage();
 
-                return new LoadHandlersConnector(b.GetService<MessageHandlerRegistry>(), syncStorage, adapter);
+                return new LoadHandlersConnector(b.GetRequiredService<MessageHandlerRegistry>(), syncStorage, adapter);
             }, "Gets all the handlers to invoke from the MessageHandler registry based on the message type.");
 
             pipelineSettings.Register("ExecuteUnitOfWork", new UnitOfWorkBehavior(), "Executes the UoW");

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityComponent.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityComponent.cs
@@ -91,7 +91,7 @@
 
                 var headerCustomizations = settings.Get<Action<Dictionary<string, string>>>(FaultHeaderCustomization);
 
-                return new MoveToErrorsExecutor(builder.GetService<IDispatchMessages>(), staticFaultMetadata, headerCustomizations);
+                return new MoveToErrorsExecutor(builder.GetRequiredService<IDispatchMessages>(), staticFaultMetadata, headerCustomizations);
             };
 
             Func<string, DelayedRetryExecutor> delayedRetryExecutorFactory = localAddress =>
@@ -100,7 +100,7 @@
                 {
                     return new DelayedRetryExecutor(
                         localAddress,
-                        builder.GetService<IDispatchMessages>(),
+                        builder.GetRequiredService<IDispatchMessages>(),
                         settings.DoesTransportSupportConstraint<DelayedDeliveryConstraint>()
                             ? null
                             : settings.Get<TimeoutManagerAddressConfiguration>().TransportAddress);

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -34,7 +34,7 @@
 
             context.RegisterStartupTask(b =>
             {
-                var handlerRegistry = b.GetService<MessageHandlerRegistry>();
+                var handlerRegistry = b.GetRequiredService<MessageHandlerRegistry>();
                 var messageTypesHandled = GetMessageTypesHandledByThisEndpoint(handlerRegistry, conventions, settings);
                 return new ApplySubscriptions(messageTypesHandled, settings.ExcludedTypes);
             });

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -66,7 +66,7 @@ namespace NServiceBus.Features
 
                 context.Pipeline.Register("UnicastPublishRouterConnector", b =>
                 {
-                    var unicastPublishRouter = new UnicastPublishRouter(b.GetService<MessageMetadataRegistry>(), i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)), b.GetService<ISubscriptionStorage>());
+                    var unicastPublishRouter = new UnicastPublishRouter(b.GetRequiredService<MessageMetadataRegistry>(), i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)), b.GetRequiredService<ISubscriptionStorage>());
                     return new UnicastPublishConnector(unicastPublishRouter, distributionPolicy);
                 }, "Determines how the published messages should be routed");
 
@@ -89,8 +89,8 @@ namespace NServiceBus.Features
                 var subscriberAddress = context.Receiving.LocalAddress;
                 var subscriptionRouter = new SubscriptionRouter(publishers, endpointInstances, i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)));
 
-                context.Pipeline.Register(b => new MessageDrivenSubscribeTerminator(subscriptionRouter, subscriberAddress, context.Settings.EndpointName(), b.GetService<IDispatchMessages>()), "Sends subscription requests when message driven subscriptions is in use");
-                context.Pipeline.Register(b => new MessageDrivenUnsubscribeTerminator(subscriptionRouter, subscriberAddress, context.Settings.EndpointName(), b.GetService<IDispatchMessages>()), "Sends requests to unsubscribe when message driven subscriptions is in use");
+                context.Pipeline.Register(b => new MessageDrivenSubscribeTerminator(subscriptionRouter, subscriberAddress, context.Settings.EndpointName(), b.GetRequiredService<IDispatchMessages>()), "Sends subscription requests when message driven subscriptions is in use");
+                context.Pipeline.Register(b => new MessageDrivenUnsubscribeTerminator(subscriptionRouter, subscriberAddress, context.Settings.EndpointName(), b.GetRequiredService<IDispatchMessages>()), "Sends requests to unsubscribe when message driven subscriptions is in use");
             }
             else
             {

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/SubscriptionMigrationMode.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/SubscriptionMigrationMode.cs
@@ -30,7 +30,7 @@
 
             context.Pipeline.Register(b =>
             {
-                var unicastPublishRouter = new UnicastPublishRouter(b.GetService<MessageMetadataRegistry>(), i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)), b.GetService<ISubscriptionStorage>());
+                var unicastPublishRouter = new UnicastPublishRouter(b.GetRequiredService<MessageMetadataRegistry>(), i => transportInfrastructure.ToTransportAddress(LogicalAddress.CreateRemoteAddress(i)), b.GetRequiredService<ISubscriptionStorage>());
                 return new MigrationModePublishConnector(distributionPolicy, unicastPublishRouter);
             }, "Determines how the published messages should be routed");
 
@@ -44,9 +44,9 @@
                 var subscriberAddress = context.Receiving.LocalAddress;
 
                 context.Pipeline.Register(b =>
-                    new MigrationSubscribeTerminator(subscriptionManager, subscriptionRouter, b.GetService<IDispatchMessages>(), subscriberAddress, context.Settings.EndpointName()), "Requests the transport to subscribe to a given message type");
+                    new MigrationSubscribeTerminator(subscriptionManager, subscriptionRouter, b.GetRequiredService<IDispatchMessages>(), subscriberAddress, context.Settings.EndpointName()), "Requests the transport to subscribe to a given message type");
                 context.Pipeline.Register(b =>
-                    new MigrationUnsubscribeTerminator(subscriptionManager,subscriptionRouter, b.GetService<IDispatchMessages>(), subscriberAddress, context.Settings.EndpointName()), "Sends requests to unsubscribe when message driven subscriptions is in use");
+                    new MigrationUnsubscribeTerminator(subscriptionManager,subscriptionRouter, b.GetRequiredService<IDispatchMessages>(), subscriberAddress, context.Settings.EndpointName()), "Sends requests to unsubscribe when message driven subscriptions is in use");
 
                 var authorizer = context.Settings.GetSubscriptionAuthorizer();
                 if (authorizer == null)

--- a/src/NServiceBus.Core/Sagas/CustomFinderAdapter.cs
+++ b/src/NServiceBus.Core/Sagas/CustomFinderAdapter.cs
@@ -4,6 +4,7 @@ namespace NServiceBus
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Extensibility;
+    using Microsoft.Extensions.DependencyInjection;
     using Persistence;
     using Sagas;
 
@@ -13,7 +14,7 @@ namespace NServiceBus
         {
             var customFinderType = (Type) finderDefinition.Properties["custom-finder-clr-type"];
 
-            var finder = (IFindSagas<TSagaData>.Using<TMessage>) builder.GetService(customFinderType);
+            var finder = (IFindSagas<TSagaData>.Using<TMessage>) builder.GetRequiredService(customFinderType);
 
             return await finder
                 .FindBy((TMessage) message, storageSession, context)

--- a/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
@@ -6,6 +6,7 @@
     using System.Linq;
     using System.Threading.Tasks;
     using Logging;
+    using Microsoft.Extensions.DependencyInjection;
     using Pipeline;
     using Sagas;
     using Transport;
@@ -260,7 +261,7 @@
             }
 
             var finderType = finderDefinition.Type;
-            var finder = (SagaFinder)context.Builder.GetService(finderType);
+            var finder = (SagaFinder)context.Builder.GetRequiredService(finderType);
 
             return finder.Find(context.Builder, finderDefinition, context.SynchronizedStorageSession, context.Extensions, context.MessageBeingHandled, context.MessageHeaders);
         }

--- a/src/NServiceBus.Core/Sagas/Sagas.cs
+++ b/src/NServiceBus.Core/Sagas/Sagas.cs
@@ -60,7 +60,7 @@
             }
 
             // Register the Saga related behaviors for incoming messages
-            context.Pipeline.Register("InvokeSaga", b => new SagaPersistenceBehavior(b.GetService<ISagaPersister>(), sagaIdGenerator, b.GetService<ICancelDeferredMessages>(), sagaMetaModel), "Invokes the saga logic");
+            context.Pipeline.Register("InvokeSaga", b => new SagaPersistenceBehavior(b.GetRequiredService<ISagaPersister>(), sagaIdGenerator, b.GetRequiredService<ICancelDeferredMessages>(), sagaMetaModel), "Invokes the saga logic");
             context.Pipeline.Register("InvokeSagaNotFound", new InvokeSagaNotFoundBehavior(), "Invokes saga not found logic");
             context.Pipeline.Register("AttachSagaDetailsToOutGoingMessage", new AttachSagaDetailsToOutGoingMessageBehavior(), "Makes sure that outgoing messages have saga info attached to them");
         }


### PR DESCRIPTION
During the migration to `IServiceProvider`, usages of `Build(Type t)` have been changed to `GetService(Type t)`. However, `Build` did throw an exception if the resolved type was `null`, therefore it's behavior matches better with `GetRequiredService(Type t)`. This PR adjust all usages that do not expect the resolved service to be null with `GetRequiredService`. There are 5 remaining usages of `GetService` that can resolve `null` and that's properly handled by the code.