### PR TITLE
Pipeline UOW ordering fix

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/When_using_custom_unit_of_work_with_failed_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/When_using_custom_unit_of_work_with_failed_message.cs
@@ -1,0 +1,84 @@
+namespace NServiceBus.AcceptanceTests.UnitOfWork
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Microsoft.Extensions.DependencyInjection;
+    using NServiceBus.UnitOfWork;
+    using NUnit.Framework;
+
+    public class When_using_custom_unit_of_work_with_failed_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_execute_uow_and_provide_exception_details()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithCustomUnitOfWork>(g =>
+                {
+                    g.DoNotFailOnErrorMessages();
+                    g.When(b => b.SendLocal(new MyMessage()));
+                })
+                .Done(c => c.BeginCalled && c.EndCalled)
+                .Run();
+
+            Assert.True(context.BeginCalled, "Unit of work should have been executed");
+            Assert.True(context.EndCalled, "Unit of work should have been executed");
+            Assert.That(context.EndException, Is.InstanceOf<SimulatedException>().And.Message.Contain("Something went wrong"), "Exception was not provided but should have been");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Done { get; set; }
+            public bool BeginCalled { get; set; }
+            public bool EndCalled { get; set; }
+            public Exception EndException { get; set; }
+        }
+
+        public class EndpointWithCustomUnitOfWork : EndpointConfigurationBuilder
+        {
+            public EndpointWithCustomUnitOfWork()
+            {
+                EndpointSetup<DefaultServer>((c, r) =>
+                {
+                    c.RegisterComponents(services => services.AddSingleton<IManageUnitsOfWork, CustomUnitOfWork>());
+                });
+            }
+
+            class CustomUnitOfWork : IManageUnitsOfWork
+            {
+                public CustomUnitOfWork(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Begin()
+                {
+                    testContext.BeginCalled = true;
+                    return Task.CompletedTask;
+                }
+
+                public Task End(Exception ex = null)
+                {
+                    testContext.EndCalled = true;
+                    testContext.EndException = ex;
+                    return Task.CompletedTask;
+                }
+
+                Context testContext;
+            }
+
+            class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    throw new SimulatedException("Something went wrong");
+                }
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/When_using_custom_unit_of_work_with_successful_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/When_using_custom_unit_of_work_with_successful_message.cs
@@ -1,0 +1,89 @@
+namespace NServiceBus.AcceptanceTests.UnitOfWork
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Microsoft.Extensions.DependencyInjection;
+    using NServiceBus.UnitOfWork;
+    using NUnit.Framework;
+
+    public class When_using_custom_unit_of_work_with_successful_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_execute_uow()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithCustomUnitOfWork>(g => g.When(b => b.SendLocal(new MyMessage())))
+                .Done(c => c.BeginCalled && c.EndCalled)
+                .Run();
+
+            Assert.True(context.BeginCalled, "Unit of work should have been executed");
+            Assert.True(context.EndCalled, "Unit of work should have been executed");
+            Assert.IsNull(context.EndException, "Exception was provided to unit of work but should not have been");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Done { get; set; }
+            public bool BeginCalled { get; set; }
+            public bool EndCalled { get; set; }
+            public Exception EndException { get; set; }
+        }
+
+        public class EndpointWithCustomUnitOfWork : EndpointConfigurationBuilder
+        {
+            public EndpointWithCustomUnitOfWork()
+            {
+                EndpointSetup<DefaultServer>((c, r) =>
+                {
+                    c.RegisterComponents(services => services.AddSingleton<IManageUnitsOfWork, CustomUnitOfWork>());
+                });
+            }
+
+            class CustomUnitOfWork : IManageUnitsOfWork
+            {
+                public CustomUnitOfWork(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Begin()
+                {
+                    testContext.BeginCalled = true;
+                    return Task.CompletedTask;
+                }
+
+                public Task End(Exception ex = null)
+                {
+                    testContext.EndCalled = true;
+                    testContext.EndException = ex;
+                    return Task.CompletedTask;
+                }
+
+                Context testContext;
+            }
+
+            class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                public MyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.Done = true;
+
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/When_using_custom_unit_of_work_with_wrap_handlers_in_scope.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/When_using_custom_unit_of_work_with_wrap_handlers_in_scope.cs
@@ -1,0 +1,86 @@
+namespace NServiceBus.AcceptanceTests.UnitOfWork
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using System.Transactions;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Microsoft.Extensions.DependencyInjection;
+    using NServiceBus.UnitOfWork;
+    using NUnit.Framework;
+
+    public class When_using_custom_unit_of_work_with_wrap_handlers_in_scope : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_fail()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithCustomUnitOfWork>(g =>
+                {
+                    g.DoNotFailOnErrorMessages();
+                    g.When(b => b.SendLocal(new MyMessage()));
+                })
+                .Done(c => c.FailedMessages.Any())
+                .Run();
+
+            Assert.False(context.ShouldNeverBeCalled, "Unit of work should have been executed");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool Done { get; set; }
+            public bool ShouldNeverBeCalled { get; set; }
+        }
+
+        public class EndpointWithCustomUnitOfWork : EndpointConfigurationBuilder
+        {
+            public EndpointWithCustomUnitOfWork()
+            {
+                EndpointSetup<DefaultServer>((c, r) =>
+                {
+                    c.UnitOfWork().WrapHandlersInATransactionScope();
+
+                    c.RegisterComponents(services => services.AddSingleton<IManageUnitsOfWork, CustomUnitOfWork>());
+                });
+            }
+
+            class CustomUnitOfWork : IManageUnitsOfWork
+            {
+                TransactionScope transactionScope;
+                public Task Begin()
+                {
+                    // this only works because we are not using the async state machine
+                    transactionScope = new TransactionScope(TransactionScopeOption.Required, TransactionScopeAsyncFlowOption.Enabled);
+                    return Task.CompletedTask;
+                }
+
+                public Task End(Exception ex = null)
+                {
+                    transactionScope.Complete();
+                    return Task.CompletedTask;
+                }
+            }
+
+            class MyMessageHandler : IHandleMessages<MyMessage>
+            {
+                Context testContext;
+
+                public MyMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ShouldNeverBeCalled = true;
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        public class MyMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWork.cs
+++ b/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWork.cs
@@ -13,7 +13,7 @@
             }
 
             var transactionOptions = context.Settings.Get<Settings>().TransactionOptions;
-            context.Pipeline.Register("HandlerTransactionScopeWrapper", new TransactionScopeUnitOfWorkBehavior(transactionOptions), "Makes sure that the handlers gets wrapped in a transaction scope");
+            context.Pipeline.Register( new TransactionScopeUnitOfWorkBehavior.Registration(transactionOptions));
         }
 
         public class Settings

--- a/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWorkBehavior.cs
+++ b/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWorkBehavior.cs
@@ -28,5 +28,16 @@
         }
 
         readonly TransactionOptions transactionOptions;
+
+        public class Registration : RegisterStep
+        {
+            public Registration(TransactionOptions transactionOptions) : base("HandlerTransactionScopeWrapper",
+                typeof(TransactionScopeUnitOfWorkBehavior),
+                "Makes sure that the handlers gets wrapped in a transaction scope",
+                b => new TransactionScopeUnitOfWorkBehavior(transactionOptions))
+            {
+                InsertAfter("ExecuteUnitOfWork");
+            }
+        }
     }
 }


### PR DESCRIPTION
There is a behavior change that was introduced between 7.2 and 7.3 due to internal refactorings

![image](https://user-images.githubusercontent.com/174258/94283239-0d5f3a80-ff51-11ea-8938-3f5b05329a49.png)

as far as I understand the `TransactionScopeUnitOfWorkBehavior` was always placed after the `ExecuteUnitOfWork` behavior which makes sense because a custom unit of work could introduce a transaction scope and that would not be compatible with `endpointConfiguration.UnitOfWork().WrapHandlersInTransactionScope`. In previous versions of NServiceBus up to version 7.2 if a custom unit of work would have added a scope the following exception would have been thrown

> Ambient transaction detected. The transaction scope unit of work is not supported when there already is a scope present.

with the refactorings between 7.2 and 7.3 this behavior was broken similar to #5712. The consequence of this behavior change is that `TransactionScopeUnitOfWorkBehavior` is placed too early in the pipeline which makes causes the behavior now to miss the scenario of custom unit of works spawning scopes as well as it breaks assumptions for Azure Service Bus trying to suppress the serializable scope in the physical pipeline stage
