### PR TITLE
Running endpoint instance throws meaningful exceptions in stopping/stopped states.

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Stopping/When_transport_infrastructure_throws_on_stop.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Stopping/When_transport_infrastructure_throws_on_stop.cs
@@ -19,9 +19,9 @@
                 .Done(c => c.EndpointsStarted)
                 .Run();
 
-            var logItem = context.Logs.FirstOrDefault(item => item.Message.Contains("shutdown") && item.Level == LogLevel.Warn);
+            var logItem = context.Logs.FirstOrDefault(item => item.Message.Contains("Shutdown of the transport") && item.Level == LogLevel.Error);
             Assert.IsNotNull(logItem);
-            StringAssert.Contains("Exception occurred during shutdown of the transport. System.InvalidOperationException: ExceptionInInfrastructureStop", logItem.Message);
+            StringAssert.Contains("Shutdown of the transport infrastructure failed. System.InvalidOperationException: ExceptionInInfrastructureStop", logItem.Message);
         }
 
         public class EndpointThatThrowsOnInfrastructureStop : EndpointConfigurationBuilder

--- a/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/RunningEndpointInstanceTest.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Unicast.Tests
 {
+    using System;
     using System.Threading.Tasks;
     using NUnit.Framework;
     using Settings;
@@ -7,22 +8,43 @@
     [TestFixture]
     public class RunningEndpointInstanceTest
     {
-        [Test]
-        public async Task ShouldAllowMultipleStops()
+        static RunningEndpointInstance Create()
         {
             var settings = new SettingsHolder();
 
-            var testee = new RunningEndpointInstance(
+            var testInstance = new RunningEndpointInstance(
                 settings,
                 new HostingComponent(null, true),
                 null,
                 new FeatureComponent(settings),
                 new MessageSession(new FakeRootContext()),
                 null);
+            return testInstance;
+        }
 
-            await testee.Stop();
+        [Test]
+        public async Task ShouldAllowMultipleStops()
+        {
+            var testInstance = Create();
 
-            Assert.That(async () => await testee.Stop(), Throws.Nothing);
+            await testInstance.Stop();
+
+            Assert.That(async () => await testInstance.Stop(), Throws.Nothing);
+        }
+
+        [Test]
+        public async Task ShouldThrowExceptionAfterInvokingStop()
+        {
+            var testInstance = Create();
+
+            await testInstance.Stop();
+
+            Assert.Throws<InvalidOperationException>(() => testInstance.Send(new object(), new SendOptions()), "Invoking messaging operations on the endpoint instance after it has been triggered to stop is not supported.");
+            Assert.Throws<InvalidOperationException>(() => testInstance.Send<object>(_=> { }, new SendOptions()), "Invoking messaging operations on the endpoint instance after it has been triggered to stop is not supported.");
+            Assert.Throws<InvalidOperationException>(() => testInstance.Publish(new object(), new PublishOptions()), "Invoking messaging operations on the endpoint instance after it has been triggered to stop is not supported.");
+            Assert.Throws<InvalidOperationException>(() => testInstance.Publish<object>(_ => { }, new PublishOptions()), "Invoking messaging operations on the endpoint instance after it has been triggered to stop is not supported.");
+            Assert.Throws<InvalidOperationException>(() => testInstance.Subscribe(typeof(object), new SubscribeOptions()), "Invoking messaging operations on the endpoint instance after it has been triggered to stop is not supported.");
+            Assert.Throws<InvalidOperationException>(() => testInstance.Unsubscribe(typeof(object), new UnsubscribeOptions()), "Invoking messaging operations on the endpoint instance after it has been triggered to stop is not supported.");
         }
     }
 }

--- a/src/NServiceBus.Core/IMessageSession.cs
+++ b/src/NServiceBus.Core/IMessageSession.cs
@@ -12,7 +12,7 @@ namespace NServiceBus
         /// Sends the provided message.
         /// </summary>
         /// <param name="message">The message to send.</param>
-        /// <param name="sendOptions">The sendOptions for the send.</param>
+        /// <param name="sendOptions">The options for the send.</param>
         Task Send(object message, SendOptions sendOptions);
 
         /// <summary>
@@ -20,14 +20,14 @@ namespace NServiceBus
         /// </summary>
         /// <typeparam name="T">The type of message, usually an interface.</typeparam>
         /// <param name="messageConstructor">An action which initializes properties of the message.</param>
-        /// <param name="sendOptions">The sendOptions for the send.</param>
+        /// <param name="sendOptions">The options for the send.</param>
         Task Send<T>(Action<T> messageConstructor, SendOptions sendOptions);
 
         /// <summary>
         /// Publish the message to subscribers.
         /// </summary>
         /// <param name="message">The message to publish.</param>
-        /// <param name="publishOptions">The sendOptions for the publish.</param>
+        /// <param name="publishOptions">The options for the publish.</param>
         Task Publish(object message, PublishOptions publishOptions);
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace NServiceBus
         /// </summary>
         /// <typeparam name="T">The type of message, usually an interface.</typeparam>
         /// <param name="messageConstructor">An action which initializes properties of the message.</param>
-        /// <param name="publishOptions">Specific sendOptions for this event.</param>
+        /// <param name="publishOptions">Specific options for this event.</param>
         Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions);
 
         /// <summary>

--- a/src/NServiceBus.Core/MessageSession.cs
+++ b/src/NServiceBus.Core/MessageSession.cs
@@ -13,31 +13,43 @@ namespace NServiceBus
 
         public Task Send(object message, SendOptions sendOptions)
         {
+            Guard.AgainstNull(nameof(message), message);
+            Guard.AgainstNull(nameof(sendOptions), sendOptions);
             return messageOperations.Send(context, message, sendOptions);
         }
 
         public Task Send<T>(Action<T> messageConstructor, SendOptions sendOptions)
         {
+            Guard.AgainstNull(nameof(messageConstructor), messageConstructor);
+            Guard.AgainstNull(nameof(sendOptions), sendOptions);
             return messageOperations.Send(context, messageConstructor, sendOptions);
         }
 
         public Task Publish(object message, PublishOptions publishOptions)
         {
+            Guard.AgainstNull(nameof(message), message);
+            Guard.AgainstNull(nameof(publishOptions), publishOptions);
             return messageOperations.Publish(context, message, publishOptions);
         }
 
         public Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions)
         {
+            Guard.AgainstNull(nameof(messageConstructor), messageConstructor);
+            Guard.AgainstNull(nameof(publishOptions), publishOptions);
             return messageOperations.Publish(context, messageConstructor, publishOptions);
         }
 
         public Task Subscribe(Type eventType, SubscribeOptions subscribeOptions)
         {
+            Guard.AgainstNull(nameof(eventType), eventType);
+            Guard.AgainstNull(nameof(subscribeOptions), subscribeOptions);
             return messageOperations.Subscribe(context, eventType, subscribeOptions);
         }
 
         public Task Unsubscribe(Type eventType, UnsubscribeOptions unsubscribeOptions)
         {
+            Guard.AgainstNull(nameof(eventType), eventType);
+            Guard.AgainstNull(nameof(unsubscribeOptions), unsubscribeOptions);
             return messageOperations.Unsubscribe(context, eventType, unsubscribeOptions);
         }
 

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -21,72 +21,114 @@ namespace NServiceBus
 
         public async Task Stop()
         {
-            if (stopped)
+            if (status == Status.Stopped)
             {
                 return;
             }
 
             try
             {
+                // Ensures to only continue if all parallel invocations can rely on the endpoint instance to be fully stopped.
                 await stopSemaphore.WaitAsync().ConfigureAwait(false);
 
-                if (stopped)
+                if (status >= Status.Stopping) // Another invocation is already handling Stop
                 {
                     return;
                 }
 
-                Log.Info("Initiating shutdown.");
+                status = Status.Stopping;
 
-                // Cannot throw by design
-                await receiveComponent.Stop().ConfigureAwait(false);
-                await featureComponent.Stop().ConfigureAwait(false);
-                // Can throw
-                await transportInfrastructure.Stop().ConfigureAwait(false);
-            }
-            catch (Exception exception)
-            {
-                Log.Warn("Exception occurred during shutdown of the transport.", exception);
+                try
+                {
+                    Log.Info("Initiating shutdown.");
+
+                    // Cannot throw by design
+                    await receiveComponent.Stop().ConfigureAwait(false);
+                    await featureComponent.Stop().ConfigureAwait(false);
+
+                    // Can throw
+                    await transportInfrastructure.Stop().ConfigureAwait(false);
+                }
+                catch (Exception exception)
+                {
+                    Log.Error("Shutdown of the transport infrastructure failed.", exception);
+
+                    // TODO: Not throwing because reason unknown :)
+                }
+                finally
+                {
+                    settings.Clear();
+                    await hostingComponent.Stop().ConfigureAwait(false);
+                    status = Status.Stopped;
+                    Log.Info("Shutdown complete.");
+                }
             }
             finally
             {
-                settings.Clear();
-                await hostingComponent.Stop().ConfigureAwait(false);
-
-                stopped = true;
-                Log.Info("Shutdown complete.");
-
                 stopSemaphore.Release();
             }
         }
 
         public Task Send(object message, SendOptions sendOptions)
         {
+            Guard.AgainstNull(nameof(message), message);
+            Guard.AgainstNull(nameof(sendOptions), sendOptions);
+
+            GuardAgainstUseWhenNotStarted();
             return messageSession.Send(message, sendOptions);
         }
 
         public Task Send<T>(Action<T> messageConstructor, SendOptions sendOptions)
         {
+            Guard.AgainstNull(nameof(messageConstructor), messageConstructor);
+            Guard.AgainstNull(nameof(sendOptions), sendOptions);
+
+            GuardAgainstUseWhenNotStarted();
             return messageSession.Send(messageConstructor, sendOptions);
         }
 
         public Task Publish(object message, PublishOptions publishOptions)
         {
+            Guard.AgainstNull(nameof(message), message);
+            Guard.AgainstNull(nameof(publishOptions), publishOptions);
+
+            GuardAgainstUseWhenNotStarted();
             return messageSession.Publish(message, publishOptions);
         }
 
         public Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions)
         {
+            Guard.AgainstNull(nameof(messageConstructor), messageConstructor);
+            Guard.AgainstNull(nameof(publishOptions), publishOptions);
+
+            GuardAgainstUseWhenNotStarted();
             return messageSession.Publish(messageConstructor, publishOptions);
         }
 
         public Task Subscribe(Type eventType, SubscribeOptions subscribeOptions)
         {
+            Guard.AgainstNull(nameof(eventType), eventType);
+            Guard.AgainstNull(nameof(subscribeOptions), subscribeOptions);
+
+            GuardAgainstUseWhenNotStarted();
             return messageSession.Subscribe(eventType, subscribeOptions);
         }
 
         public Task Unsubscribe(Type eventType, UnsubscribeOptions unsubscribeOptions)
         {
+            Guard.AgainstNull(nameof(eventType), eventType);
+            Guard.AgainstNull(nameof(unsubscribeOptions), unsubscribeOptions);
+
+            GuardAgainstUseWhenNotStarted();
             return messageSession.Unsubscribe(eventType, unsubscribeOptions);
+        }
+
+        void GuardAgainstUseWhenNotStarted()
+        {
+            if (status >= Status.Stopping)
+            {
+                throw new InvalidOperationException("Invoking messaging operations on the endpoint instance after it has been triggered to stop is not supported.");
+            }
         }
 
         HostingComponent hostingComponent;
@@ -97,9 +139,16 @@ namespace NServiceBus
 
         SettingsHolder settings;
 
-        volatile bool stopped;
+        volatile Status status = Status.Running;
         SemaphoreSlim stopSemaphore = new SemaphoreSlim(1);
 
         static ILog Log = LogManager.GetLogger<RunningEndpointInstance>();
+
+        enum Status
+        {
+            Running = 1,
+            Stopping = 2,
+            Stopped = 3
+        }
     }
 }


### PR DESCRIPTION
Resolves https://github.com/Particular/NServiceBus/issues/5221.

* State check implemented in `RunningEndpointInstance` and not in `MessageSession` as `MessageSession` can not verify the current state.
* No need to inline `MessageSession`
* No custom exception required. `InvalidOprationException`  is enough.
* Not added XML exception documentation because non of our public API has that. Also, that should include null checks that will be too much.

