### PR TITLE
Rethink the Pipelinesettings API

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1814,6 +1814,7 @@ namespace NServiceBus.Pipeline
             where T : NServiceBus.Pipeline.IBehavior { }
         public void RegisterOrReplace<T>(string stepId, System.Func<System.IServiceProvider, T> factoryMethod, string description = null)
             where T : NServiceBus.Pipeline.IBehavior { }
+        [System.ObsoleteAttribute(@"Removing behaviors from the pipeline is discouraged, to disable a behavior replace the behavior by an empty one. Documentation: https://docs.particular.net/nservicebus/pipeline/manipulate-with-behaviors. The member currently throws a NotImplementedException. Will be removed in version 9.0.0.", true)]
         public void Remove(string stepId) { }
         public void Replace(string stepId, System.Type newBehavior, string description = null) { }
         public void Replace<T>(string stepId, T newBehavior, string description = null)

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1809,6 +1809,11 @@ namespace NServiceBus.Pipeline
         public void Register<TRegisterStep>()
             where TRegisterStep : NServiceBus.Pipeline.RegisterStep, new () { }
         public void Register(NServiceBus.Pipeline.RegisterStep registration) { }
+        public void RegisterOrReplace(string stepId, System.Type behavior, string description = null) { }
+        public void RegisterOrReplace<T>(string stepId, T behavior, string description = null)
+            where T : NServiceBus.Pipeline.IBehavior { }
+        public void RegisterOrReplace<T>(string stepId, System.Func<System.IServiceProvider, T> factoryMethod, string description = null)
+            where T : NServiceBus.Pipeline.IBehavior { }
         public void Remove(string stepId) { }
         public void Replace(string stepId, System.Type newBehavior, string description = null) { }
         public void Replace<T>(string stepId, T newBehavior, string description = null)

--- a/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
@@ -23,7 +23,7 @@ namespace NServiceBus.Core.Tests.Pipeline
             replacements = new List<ReplaceStep>();
             addOrReplacements = new List<AddOrReplaceStep>();
 
-            coordinator = new StepRegistrationsCoordinator(removals, replacements, addOrReplacements);
+            coordinator = new StepRegistrationsCoordinator(replacements, addOrReplacements);
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
@@ -14,14 +14,14 @@ namespace NServiceBus.Core.Tests.Pipeline
         StepRegistrationsCoordinator coordinator;
         List<RemoveStep> removals;
         List<ReplaceStep> replacements;
-        List<AddOrReplaceStep> addOrReplacements;
+        List<RegisterOrReplaceStep> addOrReplacements;
 
         [SetUp]
         public void Setup()
         {
             removals = new List<RemoveStep>();
             replacements = new List<ReplaceStep>();
-            addOrReplacements = new List<AddOrReplaceStep>();
+            addOrReplacements = new List<RegisterOrReplaceStep>();
 
             coordinator = new StepRegistrationsCoordinator(replacements, addOrReplacements);
         }
@@ -74,7 +74,7 @@ namespace NServiceBus.Core.Tests.Pipeline
         [Test]
         public void Registrations_AddOrReplace_WhenDoesNotExist()
         {
-            addOrReplacements.Add(AddOrReplaceStep.Create("1", typeof(ReplacedBehavior), "new"));
+            addOrReplacements.Add(RegisterOrReplaceStep.Create("1", typeof(ReplacedBehavior), "new"));
 
             var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 
@@ -88,7 +88,7 @@ namespace NServiceBus.Core.Tests.Pipeline
         {
             coordinator.Register("1", typeof(FakeBehavior), "1");
 
-            addOrReplacements.Add(AddOrReplaceStep.Create("1", typeof(ReplacedBehavior), "new"));
+            addOrReplacements.Add(RegisterOrReplaceStep.Create("1", typeof(ReplacedBehavior), "new"));
 
             var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 

--- a/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
@@ -14,14 +14,16 @@ namespace NServiceBus.Core.Tests.Pipeline
         StepRegistrationsCoordinator coordinator;
         List<RemoveStep> removals;
         List<ReplaceStep> replacements;
+        List<AddOrReplaceStep> addOrReplacements;
 
         [SetUp]
         public void Setup()
         {
             removals = new List<RemoveStep>();
             replacements = new List<ReplaceStep>();
+            addOrReplacements = new List<AddOrReplaceStep>();
 
-            coordinator = new StepRegistrationsCoordinator(removals, replacements);
+            coordinator = new StepRegistrationsCoordinator(removals, replacements, addOrReplacements);
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
@@ -12,14 +12,12 @@ namespace NServiceBus.Core.Tests.Pipeline
     class BehaviorRegistrationsCoordinatorTests
     {
         StepRegistrationsCoordinator coordinator;
-        List<RemoveStep> removals;
         List<ReplaceStep> replacements;
         List<RegisterOrReplaceStep> addOrReplacements;
 
         [SetUp]
         public void Setup()
         {
-            removals = new List<RemoveStep>();
             replacements = new List<ReplaceStep>();
             addOrReplacements = new List<RegisterOrReplaceStep>();
 
@@ -33,11 +31,9 @@ namespace NServiceBus.Core.Tests.Pipeline
             coordinator.Register("2", typeof(FakeBehavior), "2");
             coordinator.Register("3", typeof(FakeBehavior), "3");
 
-            removals.Add(new RemoveStep("1"));
-
             var model = coordinator.BuildPipelineModelFor<IRootContext>();
 
-            Assert.AreEqual(2, model.Count);
+            Assert.AreEqual(3, model.Count);
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
@@ -74,7 +74,7 @@ namespace NServiceBus.Core.Tests.Pipeline
         [Test]
         public void Registrations_AddOrReplace_WhenDoesNotExist()
         {
-            addOrReplacements.Add( AddOrReplaceStep.Create("1", typeof(ReplacedBehavior), "new"));
+            addOrReplacements.Add(AddOrReplaceStep.Create("1", typeof(ReplacedBehavior), "new"));
 
             var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 

--- a/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
@@ -70,46 +70,31 @@ namespace NServiceBus.Core.Tests.Pipeline
             Assert.AreEqual("new", model[0].Description);
             Assert.AreEqual("2", model[1].Description);
         }
-        
+
         [Test]
         public void Registrations_AddOrReplace_WhenDoesNotExist()
         {
-            addOrReplacements.Add( new AddOrReplaceStep(
-                    RegisterStep.Create("1", typeof(ReplacedBehavior), "new"), 
-                    new ReplaceStep("1", typeof(ReplacedBehavior), "new")));
-            
+            addOrReplacements.Add( AddOrReplaceStep.Create("1", typeof(ReplacedBehavior), "new"));
+
             var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 
             Assert.AreEqual(1, model.Count);
             Assert.AreEqual(typeof(ReplacedBehavior).FullName, model[0].BehaviorType.FullName);
             Assert.AreEqual("new", model[0].Description);
         }
-        
+
         [Test]
         public void Registrations_AddOrReplace_WhenExists()
         {
             coordinator.Register("1", typeof(FakeBehavior), "1");
-            
-            addOrReplacements.Add( new AddOrReplaceStep(
-                RegisterStep.Create("1", typeof(ReplacedBehavior), "new"), 
-                new ReplaceStep("1", typeof(ReplacedBehavior), "new")));
-            
+
+            addOrReplacements.Add(AddOrReplaceStep.Create("1", typeof(ReplacedBehavior), "new"));
+
             var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 
             Assert.AreEqual(1, model.Count);
             Assert.AreEqual(typeof(ReplacedBehavior).FullName, model[0].BehaviorType.FullName);
             Assert.AreEqual("new", model[0].Description);
-        }
-        
-        [Test]
-        public void Registrations_AddOrReplace_WithDifferentStepIds()
-        {
-            addOrReplacements.Add( new AddOrReplaceStep(
-                RegisterStep.Create("1", typeof(ReplacedBehavior), "new"), 
-                new ReplaceStep("2", typeof(ReplacedBehavior), "new")));
-
-            var exception = Assert.Throws<Exception>(() => coordinator.BuildPipelineModelFor<IRootContext>() );
-            Assert.AreEqual("Encountered AddOrReplace-registrations in the pipeline for which the ID differs between Add and Replace.", exception.Message);
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
@@ -16,7 +16,7 @@
                 RegisterStep.Create("Root1", typeof(RootBehavior), "desc"),
                 RegisterStep.Create("Root1", typeof(ChildBehaviorOfChildContextNotInheritedFromParentContext), "desc"),
 
-            }, new List<RemoveStep>(), new List<ReplaceStep>());
+            }, new List<RemoveStep>(), new List<ReplaceStep>(), new List<AddOrReplaceStep>());
 
 
             var ex = Assert.Throws<Exception>(() => builder.Build());
@@ -34,7 +34,8 @@
             }, new List<RemoveStep>(), new List<ReplaceStep>
             {
                 new ReplaceStep("DoesNotExist", typeof(RootBehavior), "desc"),
-            });
+            },
+            new List<AddOrReplaceStep>());
 
 
             var ex = Assert.Throws<Exception>(() => builder.Build());
@@ -52,8 +53,8 @@
             }, new List<RemoveStep>
             {
                 new RemoveStep("DoesNotExist"),
-            }, new List<ReplaceStep>());
-
+            },
+            new List<ReplaceStep>(), new List<AddOrReplaceStep>());
 
             var ex = Assert.Throws<Exception>(() => builder.Build());
 
@@ -73,8 +74,12 @@
                 someBehaviorRegistration,
                 anotherBehaviorRegistration,
 
-            }, new List<RemoveStep> { new RemoveStep("SomeBehaviorOfParentContext")}, new List<ReplaceStep>());
-
+            },
+            new List<RemoveStep>
+            {
+                new RemoveStep("SomeBehaviorOfParentContext")
+            },
+            new List<ReplaceStep>(), new List<AddOrReplaceStep>());
 
             var ex = Assert.Throws<Exception>(() => builder.Build());
 
@@ -94,7 +99,8 @@
                 someBehaviorRegistration,
                 anotherBehaviorRegistration,
 
-            }, new List<RemoveStep> { new RemoveStep("SomeBehaviorOfParentContext") }, new List<ReplaceStep>());
+            }, new List<RemoveStep> { new RemoveStep("SomeBehaviorOfParentContext") },
+            new List<ReplaceStep>(), new List<AddOrReplaceStep>());
 
 
             var ex = Assert.Throws<Exception>(() => builder.Build());
@@ -109,8 +115,7 @@
             {
                 RegisterStep.Create("Child", typeof(ChildBehaviorOfChildContext), "desc"),
 
-            }, new List<RemoveStep>(), new List<ReplaceStep>());
-
+            }, new List<RemoveStep>(), new List<ReplaceStep>(), new List<AddOrReplaceStep>());
 
             var ex = Assert.Throws<Exception>(() => builder.Build());
 
@@ -126,8 +131,7 @@
                 RegisterStep.Create("ParentContextToChildContextConnector", typeof(ParentContextToChildContextConnector), "desc"),
                 RegisterStep.Create("ParentContextToChildContextNotInheritedFromParentContextConnector", typeof(ParentContextToChildContextNotInheritedFromParentContextConnector), "desc")
 
-            }, new List<RemoveStep>(), new List<ReplaceStep>());
-
+            }, new List<RemoveStep>(), new List<ReplaceStep>(), new List<AddOrReplaceStep>());
 
             var ex = Assert.Throws<Exception>(() => builder.Build());
 
@@ -147,8 +151,7 @@
                 someBehaviorRegistration,
                 anotherBehaviorRegistration,
 
-            }, new List<RemoveStep>(), new List<ReplaceStep>());
-
+            }, new List<RemoveStep>(), new List<ReplaceStep>(), new List<AddOrReplaceStep>());
 
             var ex = Assert.Throws<Exception>(() => builder.Build());
 
@@ -168,7 +171,7 @@
                 someBehaviorRegistration,
                 anotherBehaviorRegistration,
 
-            }, new List<RemoveStep>(), new List<ReplaceStep>());
+            }, new List<RemoveStep>(), new List<ReplaceStep>(), new List<AddOrReplaceStep>());
 
 
             var ex = Assert.Throws<Exception>(() => builder.Build());
@@ -184,7 +187,7 @@
                 RegisterStep.Create("Root", typeof(RootBehavior), "desc"),
                 RegisterStep.Create("ParentContextToChildContextNotInheritedFromParentContextConnector", typeof(ParentContextToChildContextNotInheritedFromParentContextConnector), "desc"),
                 RegisterStep.Create("Child", typeof(ChildBehaviorOfChildContextNotInheritedFromParentContext), "desc")
-            }, new List<RemoveStep>(), new List<ReplaceStep>());
+            }, new List<RemoveStep>(), new List<ReplaceStep>(), new List<AddOrReplaceStep>());
 
 
             var model = builder.Build();
@@ -200,7 +203,7 @@
                 RegisterStep.Create("Root", typeof(RootBehavior), "desc"),
                 RegisterStep.Create("ParentContextToChildContextConnector", typeof(ParentContextToChildContextConnector), "desc"),
                 RegisterStep.Create("Child", typeof(ChildBehaviorOfChildContextNotInheritedFromParentContext), "desc")
-            }, new List<RemoveStep>(), new List<ReplaceStep>());
+            }, new List<RemoveStep>(), new List<ReplaceStep>(), new List<AddOrReplaceStep>());
 
 
             var model = builder.Build();
@@ -218,7 +221,7 @@
                 RegisterStep.Create("Child", typeof(ChildBehaviorOfChildContextNotInheritedFromParentContext), "desc"),
                 RegisterStep.Create("Terminator", typeof(Terminator), "desc")
 
-            }, new List<RemoveStep>(), new List<ReplaceStep>());
+            }, new List<RemoveStep>(), new List<ReplaceStep>(), new List<AddOrReplaceStep>());
 
 
             var model = builder.Build();

--- a/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
@@ -40,7 +40,7 @@
         {
             var builder = ConfigurePipelineModelBuilder.Setup()
                 .Register(RegisterStep.Create("Root1", typeof(RootBehavior), "desc"))
-                .RegisterOrReplace(AddOrReplaceStep.Create("SomeBehaviorOfParentContext", typeof(SomeBehaviorOfParentContext), "desc"))
+                .RegisterOrReplace(RegisterOrReplaceStep.Create("SomeBehaviorOfParentContext", typeof(SomeBehaviorOfParentContext), "desc"))
                 .Build(typeof(IParentContext));
 
             var model = builder.Build();
@@ -57,7 +57,7 @@
             var builder = ConfigurePipelineModelBuilder.Setup()
                 .Register(RegisterStep.Create("Root1", typeof(RootBehavior), "desc"))
                 .Register(RegisterStep.Create("SomeBehaviorOfParentContext", typeof(SomeBehaviorOfParentContext), "desc"))
-                .RegisterOrReplace(AddOrReplaceStep.Create("SomeBehaviorOfParentContext", typeof(AnotherBehaviorOfParentContext), "desc"))
+                .RegisterOrReplace(RegisterOrReplaceStep.Create("SomeBehaviorOfParentContext", typeof(AnotherBehaviorOfParentContext), "desc"))
                 .Build(typeof(IParentContext));
 
             var model = builder.Build();
@@ -176,7 +176,7 @@
         class ConfigurePipelineModelBuilder
         {
             List<RegisterStep> registrations = new List<RegisterStep>();
-            List<AddOrReplaceStep> registerOrReplacements = new List<AddOrReplaceStep>();
+            List<RegisterOrReplaceStep> registerOrReplacements = new List<RegisterOrReplaceStep>();
             List<ReplaceStep> replacements = new List<ReplaceStep>();
 
             public static ConfigurePipelineModelBuilder Setup()
@@ -196,7 +196,7 @@
                 return this;
             }
 
-            public ConfigurePipelineModelBuilder RegisterOrReplace(AddOrReplaceStep registration)
+            public ConfigurePipelineModelBuilder RegisterOrReplace(RegisterOrReplaceStep registration)
             {
                 registerOrReplacements.Add(registration);
                 return this;

--- a/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
@@ -43,7 +43,7 @@
         }
 
         [Test]
-        public void ShouldAddWhenAddingOrReplacingABehaviorThatDoesntYetExist()
+        public void ShouldAddWhenAddingOrReplacingABehaviorThatDoesntExist()
         {
             var builder = new PipelineModelBuilder(typeof(IParentContext),
                 new List<RegisterStep>()
@@ -89,7 +89,6 @@
             Assert.That(overriddenBehavior, Is.Not.Null);
             Assert.That(overriddenBehavior.BehaviorType, Is.EqualTo(typeof(AnotherBehaviorOfParentContext)));
         }
-
 
         [Test]
         public void ShouldOnlyAllowRemovalOfExistingRegistrations()

--- a/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
@@ -16,7 +16,7 @@
                 .Register(RegisterStep.Create("Root1", typeof(RootBehavior), "desc"))
                 .Register(RegisterStep.Create("Root1", typeof(ChildBehaviorOfChildContextNotInheritedFromParentContext), "desc"))
                 .Build(typeof(IParentContext));
-            
+
             var ex = Assert.Throws<Exception>(() => builder.Build());
 
             Assert.AreEqual("Step registration with id 'Root1' is already registered for 'NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+RootBehavior'.", ex.Message);
@@ -29,7 +29,7 @@
                 .Register(RegisterStep.Create("Root1", typeof(RootBehavior), "desc"))
                 .Replace(new ReplaceStep("DoesNotExist", typeof(RootBehavior), "desc"))
                 .Build(typeof(IParentContext));
-            
+
             var ex = Assert.Throws<Exception>(() => builder.Build());
 
             Assert.AreEqual("You can only replace an existing step registration, 'DoesNotExist' registration does not exist.", ex.Message);
@@ -42,7 +42,7 @@
                 .Register(RegisterStep.Create("Root1", typeof(RootBehavior), "desc"))
                 .RegisterOrReplace(AddOrReplaceStep.Create("SomeBehaviorOfParentContext", typeof(SomeBehaviorOfParentContext), "desc"))
                 .Build(typeof(IParentContext));
-            
+
             var model = builder.Build();
 
             Assert.That(model.Count, Is.EqualTo(2));
@@ -59,7 +59,7 @@
                 .Register(RegisterStep.Create("SomeBehaviorOfParentContext", typeof(SomeBehaviorOfParentContext), "desc"))
                 .RegisterOrReplace(AddOrReplaceStep.Create("SomeBehaviorOfParentContext", typeof(AnotherBehaviorOfParentContext), "desc"))
                 .Build(typeof(IParentContext));
-           
+
             var model = builder.Build();
 
             Assert.That(model.Count, Is.EqualTo(2));
@@ -69,63 +69,12 @@
         }
 
         [Test]
-        public void ShouldOnlyAllowRemovalOfExistingRegistrations()
-        {
-            var builder = ConfigurePipelineModelBuilder.Setup()
-                .Register(RegisterStep.Create("Root1", typeof(RootBehavior), "desc"))
-                .Remove(new RemoveStep("DoesNotExist"))
-                .Build(typeof(IParentContext));
-            
-            var ex = Assert.Throws<Exception>(() => builder.Build());
-
-            Assert.AreEqual("You cannot remove step registration with id 'DoesNotExist', registration does not exist.", ex.Message);
-        }
-
-        [Test]
-        public void ShouldOnlyAllowRemovalWhenNoOtherDependsOnItsBeforeRegistration()
-        {
-            var someBehaviorRegistration = RegisterStep.Create("SomeBehaviorOfParentContext", typeof(SomeBehaviorOfParentContext), "desc");
-            var anotherBehaviorRegistration = RegisterStep.Create("AnotherBehaviorOfParentContext", typeof(AnotherBehaviorOfParentContext), "desc");
-
-            anotherBehaviorRegistration.InsertBefore("SomeBehaviorOfParentContext");
-
-            var builder = ConfigurePipelineModelBuilder.Setup()
-                .Register(someBehaviorRegistration)
-                .Register(anotherBehaviorRegistration)
-                .Remove(new RemoveStep("SomeBehaviorOfParentContext"))
-                .Build(typeof(IParentContext));
-            
-            var ex = Assert.Throws<Exception>(() => builder.Build());
-
-            Assert.AreEqual("You cannot remove step registration with id 'SomeBehaviorOfParentContext', registration with id 'AnotherBehaviorOfParentContext' depends on it.", ex.Message);
-        }
-
-        [Test]
-        public void ShouldOnlyAllowRemovalWhenNoOtherDependsOnItsAfterRegistration()
-        {
-            var someBehaviorRegistration = RegisterStep.Create("SomeBehaviorOfParentContext", typeof(SomeBehaviorOfParentContext), "desc");
-            var anotherBehaviorRegistration = RegisterStep.Create("AnotherBehaviorOfParentContext", typeof(AnotherBehaviorOfParentContext), "desc");
-
-            anotherBehaviorRegistration.InsertAfter("SomeBehaviorOfParentContext");
-
-            var builder = ConfigurePipelineModelBuilder.Setup()
-                .Register(someBehaviorRegistration)
-                .Register(anotherBehaviorRegistration)
-                .Remove(new RemoveStep("SomeBehaviorOfParentContext"))
-                .Build(typeof(IParentContext));
-            
-            var ex = Assert.Throws<Exception>(() => builder.Build());
-
-            Assert.AreEqual("You cannot remove step registration with id 'SomeBehaviorOfParentContext', registration with id 'AnotherBehaviorOfParentContext' depends on it.", ex.Message);
-        }
-
-        [Test]
         public void ShouldDetectMissingBehaviorForRootContext()
         {
             var builder = ConfigurePipelineModelBuilder.Setup()
                 .Register(RegisterStep.Create("Child", typeof(ChildBehaviorOfChildContext), "desc"))
                 .Build(typeof(IParentContext));
-            
+
             var ex = Assert.Throws<Exception>(() => builder.Build());
 
             Assert.AreEqual("Can't find any behaviors/connectors for the root context (NServiceBus.Core.Tests.Pipeline.PipelineModelBuilderTests+IParentContext)", ex.Message);
@@ -157,7 +106,7 @@
                 .Register(someBehaviorRegistration)
                 .Register(anotherBehaviorRegistration)
                 .Build(typeof(IParentContext));
-            
+
             var ex = Assert.Throws<Exception>(() => builder.Build());
 
             Assert.AreEqual("Registration 'DoesNotExist' specified in the insertafter of the 'AnotherBehaviorOfParentContext' step does not exist. Current StepIds: 'SomeBehaviorOfParentContext', 'AnotherBehaviorOfParentContext'", ex.Message);
@@ -175,7 +124,7 @@
                 .Register(someBehaviorRegistration)
                 .Register(anotherBehaviorRegistration)
                 .Build(typeof(IParentContext));
-            
+
             var ex = Assert.Throws<Exception>(() => builder.Build());
 
             Assert.AreEqual("Registration 'DoesNotExist' specified in the insertbefore of the 'AnotherBehaviorOfParentContext' step does not exist. Current StepIds: 'SomeBehaviorOfParentContext', 'AnotherBehaviorOfParentContext'", ex.Message);
@@ -189,7 +138,7 @@
                 .Register(RegisterStep.Create("ParentContextToChildContextNotInheritedFromParentContextConnector", typeof(ParentContextToChildContextNotInheritedFromParentContextConnector), "desc"))
                 .Register(RegisterStep.Create("Child", typeof(ChildBehaviorOfChildContextNotInheritedFromParentContext), "desc"))
                 .Build(typeof(IParentContext));
-            
+
             var model = builder.Build();
 
             Assert.AreEqual(3, model.Count);
@@ -203,7 +152,7 @@
                 .Register(RegisterStep.Create("ParentContextToChildContextConnector", typeof(ParentContextToChildContextConnector), "desc"))
                 .Register(RegisterStep.Create("Child", typeof(ChildBehaviorOfChildContextNotInheritedFromParentContext), "desc"))
                 .Build(typeof(IParentContext));
-            
+
             var model = builder.Build();
 
             Assert.AreEqual(2, model.Count);
@@ -227,8 +176,7 @@
         class ConfigurePipelineModelBuilder
         {
             List<RegisterStep> registrations = new List<RegisterStep>();
-            List<AddOrReplaceStep> registerOrReplacecements = new List<AddOrReplaceStep>();
-            List<RemoveStep> removals = new List<RemoveStep>();
+            List<AddOrReplaceStep> registerOrReplacements = new List<AddOrReplaceStep>();
             List<ReplaceStep> replacements = new List<ReplaceStep>();
 
             public static ConfigurePipelineModelBuilder Setup()
@@ -241,28 +189,22 @@
                 registrations.Add(registration);
                 return this;
             }
-            
+
             public ConfigurePipelineModelBuilder Replace(ReplaceStep registration)
             {
                 replacements.Add(registration);
                 return this;
             }
-            
-            public ConfigurePipelineModelBuilder Remove(RemoveStep removal)
-            {
-                removals.Add(removal);
-                return this;
-            }
-            
+
             public ConfigurePipelineModelBuilder RegisterOrReplace(AddOrReplaceStep registration)
             {
-                registerOrReplacecements.Add(registration);
+                registerOrReplacements.Add(registration);
                 return this;
             }
 
             public PipelineModelBuilder Build(Type parentContextType)
             {
-                return new PipelineModelBuilder(parentContextType, registrations, removals, replacements, registerOrReplacecements);
+                return new PipelineModelBuilder(parentContextType, registrations, replacements, registerOrReplacements);
             }
         }
 

--- a/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
@@ -32,7 +32,7 @@
 
             var ex = Assert.Throws<Exception>(() => builder.Build());
 
-            Assert.AreEqual("You can only replace an existing step registration, 'DoesNotExist' registration does not exist.", ex.Message);
+            Assert.AreEqual("Multiple replacements of the same pipeline behaviour is not supported. Make sure that you only register a single replacement for 'DoesNotExist'.", ex.Message);
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Pipeline/PipelineSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/PipelineSettingsTests.cs
@@ -18,7 +18,6 @@ namespace NServiceBus.Core.Tests.Pipeline
             pipelineSettings.PreventChanges();
 
             Assert.Throws<InvalidOperationException>(() => pipelineSettings.Register(typeof(Behavior1), "newStep"));
-            Assert.Throws<InvalidOperationException>(() => pipelineSettings.Remove("newStep"));
             Assert.Throws<InvalidOperationException>(() => pipelineSettings.Replace("newStep", typeof(Behavior1)));
         }
 

--- a/src/NServiceBus.Core/Pipeline/AddOrReplaceStep.cs
+++ b/src/NServiceBus.Core/Pipeline/AddOrReplaceStep.cs
@@ -1,17 +1,26 @@
 namespace NServiceBus
 {
+    using System;
     using Pipeline;
 
     class AddOrReplaceStep
     {
-        public AddOrReplaceStep(RegisterStep registerStep, ReplaceStep replaceStep)
+        private AddOrReplaceStep(string stepId, RegisterStep registerStep, ReplaceStep replaceStep)
         {
+            StepId = stepId;
             RegisterStep = registerStep;
             ReplaceStep = replaceStep;
         }
 
         public RegisterStep RegisterStep { get; }
         public ReplaceStep ReplaceStep { get; }
-        public string StepId => ReplaceStep.ReplaceId;
+        public string StepId { get; }
+
+        public static AddOrReplaceStep Create(string stepId, Type behaviorType, string description = null, Func<IServiceProvider, IBehavior> factoryMethod = null)
+        {
+            var register = RegisterStep.Create(stepId, behaviorType, description, factoryMethod);
+            var replace = new ReplaceStep(stepId, behaviorType, description, factoryMethod);
+            return new AddOrReplaceStep(stepId, register, replace);
+        }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/AddOrReplaceStep.cs
+++ b/src/NServiceBus.Core/Pipeline/AddOrReplaceStep.cs
@@ -5,7 +5,7 @@ namespace NServiceBus
 
     class AddOrReplaceStep
     {
-        private AddOrReplaceStep(string stepId, RegisterStep registerStep, ReplaceStep replaceStep)
+        AddOrReplaceStep(string stepId, RegisterStep registerStep, ReplaceStep replaceStep)
         {
             StepId = stepId;
             RegisterStep = registerStep;

--- a/src/NServiceBus.Core/Pipeline/AddOrReplaceStep.cs
+++ b/src/NServiceBus.Core/Pipeline/AddOrReplaceStep.cs
@@ -1,0 +1,17 @@
+namespace NServiceBus
+{
+    using Pipeline;
+
+    class AddOrReplaceStep
+    {
+        public AddOrReplaceStep(RegisterStep registerStep, ReplaceStep replaceStep)
+        {
+            RegisterStep = registerStep;
+            ReplaceStep = replaceStep;
+        }
+
+        public RegisterStep RegisterStep { get; }
+        public ReplaceStep ReplaceStep { get; }
+        public string StepId => ReplaceStep.ReplaceId;
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/Pipeline.cs
+++ b/src/NServiceBus.Core/Pipeline/Pipeline.cs
@@ -12,7 +12,7 @@
     {
         public Pipeline(IServiceProvider builder, PipelineModifications pipelineModifications)
         {
-            var coordinator = new StepRegistrationsCoordinator(pipelineModifications.Removals, pipelineModifications.Replacements, pipelineModifications.AdditionsOrReplacements);
+            var coordinator = new StepRegistrationsCoordinator(pipelineModifications.Replacements, pipelineModifications.AdditionsOrReplacements);
 
             foreach (var rego in pipelineModifications.Additions)
             {

--- a/src/NServiceBus.Core/Pipeline/Pipeline.cs
+++ b/src/NServiceBus.Core/Pipeline/Pipeline.cs
@@ -12,7 +12,7 @@
     {
         public Pipeline(IServiceProvider builder, PipelineModifications pipelineModifications)
         {
-            var coordinator = new StepRegistrationsCoordinator(pipelineModifications.Removals, pipelineModifications.Replacements);
+            var coordinator = new StepRegistrationsCoordinator(pipelineModifications.Removals, pipelineModifications.Replacements, pipelineModifications.AdditionsOrReplacements);
 
             foreach (var rego in pipelineModifications.Additions)
             {

--- a/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
@@ -25,7 +25,7 @@ namespace NServiceBus
             // Let's do some validation too
             if (addOrReplaceSteps.Any(addOrReplaceStep => addOrReplaceStep.RegisterStep.StepId != addOrReplaceStep.ReplaceStep.ReplaceId))
             {
-                throw new Exception("Encountered AddOrReplace-registrations in the pipeline for which the ID differs between Add and Replace.");
+                throw new Exception("Encountered RegisterOrReplace-registrations in the pipeline for which the ID differs between Add and Replace.");
             }
 
             var totalAdditions = addOrReplaceSteps.Where(addOrReplaceStep => additions.All(addition => addition.StepId != addOrReplaceStep.StepId))

--- a/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
@@ -68,7 +68,7 @@ namespace NServiceBus
             {
                 if (!registrations.ContainsKey(metadata.ReplaceId))
                 {
-                    var message = $"You can only replace an existing step registration, '{metadata.ReplaceId}' registration does not exist.";
+                    var message = $"Multiple replacements of the same pipeline behaviour is not supported. Make sure that you only register a single replacement for '{metadata.ReplaceId}:";
                     throw new Exception(message);
                 }
 

--- a/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
@@ -22,12 +22,6 @@ namespace NServiceBus
             var registrations = new Dictionary<string, RegisterStep>(StringComparer.CurrentCultureIgnoreCase);
             var listOfBeforeAndAfterIds = new List<string>();
 
-            // Let's do some validation too
-            if (addOrReplaceSteps.Any(addOrReplaceStep => addOrReplaceStep.RegisterStep.StepId != addOrReplaceStep.ReplaceStep.ReplaceId))
-            {
-                throw new Exception("Encountered RegisterOrReplace-registrations in the pipeline for which the ID differs between Add and Replace.");
-            }
-
             var totalAdditions = addOrReplaceSteps.Where(addOrReplaceStep => additions.All(addition => addition.StepId != addOrReplaceStep.StepId))
                 .Select(x => x.RegisterStep)
                 .ToList();

--- a/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
@@ -58,9 +58,9 @@ namespace NServiceBus
             var groupedReplacements = replacements.GroupBy(x => x.ReplaceId);
             if (groupedReplacements.Any(x => x.Count() > 1))
             {
-                var duplicateReplaceIdentifiers = groupedReplacements.Where(x => x.Count() > 1).Select(x => x.Key);
-                var duplicateIdentifiersList = string.Join(",", duplicateReplaceIdentifiers);
-                var message = $"You can only replace an existing step once, '{duplicateIdentifiersList}' were detected more than once in the pipeline replacement process";
+                var duplicateReplaceIdentifiers = groupedReplacements.Where(x => x.Count() > 1).Select(x => $"'{x.Key}'");
+                var duplicateIdentifiersList = string.Join(", ", duplicateReplaceIdentifiers);
+                var message = $"Multiple replacements of the same pipeline behaviour is not supported. Make sure that you only register a single replacement for: {duplicateIdentifiersList}";
                 throw new Exception(message);
             }
 

--- a/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
@@ -8,7 +8,7 @@ namespace NServiceBus
 
     class PipelineModelBuilder
     {
-        public PipelineModelBuilder(Type rootContextType, List<RegisterStep> additions, List<ReplaceStep> replacements, List<AddOrReplaceStep> addOrReplaceSteps)
+        public PipelineModelBuilder(Type rootContextType, List<RegisterStep> additions, List<ReplaceStep> replacements, List<RegisterOrReplaceStep> addOrReplaceSteps)
         {
             this.rootContextType = rootContextType;
             this.additions = additions;
@@ -241,7 +241,7 @@ namespace NServiceBus
 
         List<RegisterStep> additions;
         List<ReplaceStep> replacements;
-        List<AddOrReplaceStep> addOrReplaceSteps;
+        List<RegisterOrReplaceStep> addOrReplaceSteps;
 
         Type rootContextType;
         static CaseInsensitiveIdComparer idComparer = new CaseInsensitiveIdComparer();

--- a/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
@@ -28,10 +28,10 @@ namespace NServiceBus
                 throw new Exception("Encountered AddOrReplace-registrations in the pipeline for which the ID differs between Add and Replace.");
             }
 
-            var totalAdditions = addOrReplaceSteps.Where(addOrReplaceStep => additions.Any(addition => addition.StepId == addOrReplaceStep.StepId))
+            var totalAdditions = addOrReplaceSteps.Where(addOrReplaceStep => additions.All(addition => addition.StepId != addOrReplaceStep.StepId))
                 .Select(x => x.RegisterStep)
                 .ToList();
-            var totalReplacements = addOrReplaceSteps.Where(addOrReplaceStep => additions.All(addition => addition.StepId != addOrReplaceStep.StepId))
+            var totalReplacements = addOrReplaceSteps.Where(addOrReplaceStep => additions.Any(addition => addition.StepId == addOrReplaceStep.StepId))
                 .Select(x => x.ReplaceStep)
                 .ToList();
 

--- a/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
@@ -55,9 +55,9 @@ namespace NServiceBus
 
             //  Step 2: validate and apply replacements
             var groupedReplacements = replacements.GroupBy(x => x.ReplaceId).ToList();
-            if (groupedReplacements.Any(x => x.Any()))
+            if (groupedReplacements.Any(x => x.Count() > 1))
             {
-                var duplicateReplaceIdentifiers = groupedReplacements.Where(x => x.Any()).Select(x => $"'{x.Key}'");
+                var duplicateReplaceIdentifiers = groupedReplacements.Where(x => x.Count() > 1).Select(x => $"'{x.Key}'");
                 var duplicateIdentifiersList = string.Join(", ", duplicateReplaceIdentifiers);
                 var message = $"Multiple replacements of the same pipeline behaviour is not supported. Make sure that you only register a single replacement for: {duplicateIdentifiersList}.";
                 throw new Exception(message);
@@ -67,7 +67,7 @@ namespace NServiceBus
             {
                 if (!registrations.ContainsKey(metadata.ReplaceId))
                 {
-                    var message = $"Multiple replacements of the same pipeline behaviour is not supported. Make sure that you only register a single replacement for '{metadata.ReplaceId}.";
+                    var message = $"Multiple replacements of the same pipeline behaviour is not supported. Make sure that you only register a single replacement for '{metadata.ReplaceId}'.";
                     throw new Exception(message);
                 }
 

--- a/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
@@ -59,7 +59,7 @@ namespace NServiceBus
             {
                 var duplicateReplaceIdentifiers = groupedReplacements.Where(x => x.Count() > 1).Select(x => $"'{x.Key}'");
                 var duplicateIdentifiersList = string.Join(", ", duplicateReplaceIdentifiers);
-                var message = $"Multiple replacements of the same pipeline behaviour is not supported. Make sure that you only register a single replacement for: {duplicateIdentifiersList}";
+                var message = $"Multiple replacements of the same pipeline behaviour is not supported. Make sure that you only register a single replacement for: {duplicateIdentifiersList}.";
                 throw new Exception(message);
             }
 
@@ -67,7 +67,7 @@ namespace NServiceBus
             {
                 if (!registrations.ContainsKey(metadata.ReplaceId))
                 {
-                    var message = $"Multiple replacements of the same pipeline behaviour is not supported. Make sure that you only register a single replacement for '{metadata.ReplaceId}:";
+                    var message = $"Multiple replacements of the same pipeline behaviour is not supported. Make sure that you only register a single replacement for '{metadata.ReplaceId}.";
                     throw new Exception(message);
                 }
 

--- a/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
@@ -8,11 +8,10 @@ namespace NServiceBus
 
     class PipelineModelBuilder
     {
-        public PipelineModelBuilder(Type rootContextType, List<RegisterStep> additions, List<RemoveStep> removals, List<ReplaceStep> replacements, List<AddOrReplaceStep> addOrReplaceSteps)
+        public PipelineModelBuilder(Type rootContextType, List<RegisterStep> additions, List<ReplaceStep> replacements, List<AddOrReplaceStep> addOrReplaceSteps)
         {
             this.rootContextType = rootContextType;
             this.additions = additions;
-            this.removals = removals;
             this.replacements = replacements;
             this.addOrReplaceSteps = addOrReplaceSteps;
         }
@@ -74,27 +73,6 @@ namespace NServiceBus
 
                 var registerStep = registrations[metadata.ReplaceId];
                 registerStep.Replace(metadata);
-            }
-
-            // Step 3: validate the removals
-            foreach (var metadata in removals.Distinct(idComparer))
-            {
-                if (!registrations.ContainsKey(metadata.RemoveId))
-                {
-                    var message = $"You cannot remove step registration with id '{metadata.RemoveId}', registration does not exist.";
-                    throw new Exception(message);
-                }
-
-                if (listOfBeforeAndAfterIds.Contains(metadata.RemoveId, StringComparer.CurrentCultureIgnoreCase))
-                {
-                    var add = additions.First(mr => (mr.Befores != null && mr.Befores.Select(b => b.DependsOnId).Contains(metadata.RemoveId, StringComparer.CurrentCultureIgnoreCase)) ||
-                                                    (mr.Afters != null && mr.Afters.Select(b => b.DependsOnId).Contains(metadata.RemoveId, StringComparer.CurrentCultureIgnoreCase)));
-
-                    var message = $"You cannot remove step registration with id '{metadata.RemoveId}', registration with id '{add.StepId}' depends on it.";
-                    throw new Exception(message);
-                }
-
-                registrations.Remove(metadata.RemoveId);
             }
 
             var stages = registrations.Values.GroupBy(r => r.GetInputContext()).ToList();
@@ -262,7 +240,6 @@ namespace NServiceBus
         }
 
         List<RegisterStep> additions;
-        List<RemoveStep> removals;
         List<ReplaceStep> replacements;
         List<AddOrReplaceStep> addOrReplaceSteps;
 

--- a/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModelBuilder.cs
@@ -54,10 +54,10 @@ namespace NServiceBus
             }
 
             //  Step 2: validate and apply replacements
-            var groupedReplacements = replacements.GroupBy(x => x.ReplaceId);
-            if (groupedReplacements.Any(x => x.Count() > 1))
+            var groupedReplacements = replacements.GroupBy(x => x.ReplaceId).ToList();
+            if (groupedReplacements.Any(x => x.Any()))
             {
-                var duplicateReplaceIdentifiers = groupedReplacements.Where(x => x.Count() > 1).Select(x => $"'{x.Key}'");
+                var duplicateReplaceIdentifiers = groupedReplacements.Where(x => x.Any()).Select(x => $"'{x.Key}'");
                 var duplicateIdentifiersList = string.Join(", ", duplicateReplaceIdentifiers);
                 var message = $"Multiple replacements of the same pipeline behaviour is not supported. Make sure that you only register a single replacement for: {duplicateIdentifiersList}.";
                 throw new Exception(message);

--- a/src/NServiceBus.Core/Pipeline/PipelineModifications.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModifications.cs
@@ -6,7 +6,6 @@
     class PipelineModifications
     {
         public List<RegisterStep> Additions = new List<RegisterStep>();
-        public List<RemoveStep> Removals = new List<RemoveStep>();
         public List<ReplaceStep> Replacements = new List<ReplaceStep>();
         public List<AddOrReplaceStep> AdditionsOrReplacements = new List<AddOrReplaceStep>();
     }

--- a/src/NServiceBus.Core/Pipeline/PipelineModifications.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModifications.cs
@@ -8,5 +8,6 @@
         public List<RegisterStep> Additions = new List<RegisterStep>();
         public List<RemoveStep> Removals = new List<RemoveStep>();
         public List<ReplaceStep> Replacements = new List<ReplaceStep>();
+        public List<AddOrReplaceStep> AdditionsOrReplacements = new List<AddOrReplaceStep>();
     }
 }

--- a/src/NServiceBus.Core/Pipeline/PipelineModifications.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineModifications.cs
@@ -7,6 +7,6 @@
     {
         public List<RegisterStep> Additions = new List<RegisterStep>();
         public List<ReplaceStep> Replacements = new List<ReplaceStep>();
-        public List<AddOrReplaceStep> AdditionsOrReplacements = new List<AddOrReplaceStep>();
+        public List<RegisterOrReplaceStep> AdditionsOrReplacements = new List<RegisterOrReplaceStep>();
     }
 }

--- a/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
@@ -7,26 +7,13 @@ namespace NServiceBus.Pipeline
     /// <summary>
     /// Manages the pipeline configuration.
     /// </summary>
-    public class PipelineSettings : ExposeSettings
+    public partial class PipelineSettings : ExposeSettings
     {
         /// <summary>
         /// Initializes a new instance of <see cref="PipelineSettings" />.
         /// </summary>
         internal PipelineSettings(SettingsHolder settings) : base(settings)
         {
-        }
-
-        /// <summary>
-        /// Removes the specified step from the pipeline.
-        /// </summary>
-        /// <param name="stepId">The identifier of the step to remove.</param>
-        public void Remove(string stepId)
-        {
-            // I can only remove a behavior that is registered and other behaviors do not depend on, eg InsertBefore/After
-            Guard.AgainstNullAndEmpty(nameof(stepId), stepId);
-            EnsureWriteEnabled(stepId, nameof(Remove));
-
-            modifications.Removals.Add(new RemoveStep(stepId));
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
@@ -43,7 +43,7 @@ namespace NServiceBus.Pipeline
 
             modifications.Replacements.Add(new ReplaceStep(stepId, newBehavior, description));
         }
-        
+
         /// <summary>
         /// Replaces an existing step behavior with a new one.
         /// </summary>
@@ -75,9 +75,9 @@ namespace NServiceBus.Pipeline
 
             modifications.Replacements.Add(new ReplaceStep(stepId, typeof(T), description, b => factoryMethod(b)));
         }
-        
+
         /// <summary>
-        /// Replaces an existing step behavior with a new one if it exists in the pipeline
+        /// Replaces an existing step behavior with a new one if it exists in the pipeline.
         /// </summary>
         /// <param name="stepId">The identifier of the step to replace its implementation.</param>
         /// <param name="behavior">The new <see cref="Behavior{TContext}" /> to use.</param>
@@ -91,7 +91,7 @@ namespace NServiceBus.Pipeline
 
             modifications.AdditionsOrReplacements.Add(new AddOrReplaceStep(RegisterStep.Create(stepId, behavior, description), new ReplaceStep(stepId, behavior, description)));
         }
-        
+
         /// <summary>
         /// Replaces an existing step behavior with a new one.
         /// </summary>

--- a/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
@@ -43,7 +43,7 @@ namespace NServiceBus.Pipeline
 
             modifications.Replacements.Add(new ReplaceStep(stepId, newBehavior, description));
         }
-
+        
         /// <summary>
         /// Replaces an existing step behavior with a new one.
         /// </summary>
@@ -67,6 +67,53 @@ namespace NServiceBus.Pipeline
         /// <param name="factoryMethod">The factory method to create new instances of the behavior.</param>
         /// <param name="description">The description of the new behavior.</param>
         public void Replace<T>(string stepId, Func<IServiceProvider, T> factoryMethod, string description = null)
+            where T : IBehavior
+        {
+            BehaviorTypeChecker.ThrowIfInvalid(typeof(T), "newBehavior");
+            Guard.AgainstNullAndEmpty(nameof(stepId), stepId);
+            EnsureWriteEnabled(stepId, nameof(Replace));
+
+            modifications.Replacements.Add(new ReplaceStep(stepId, typeof(T), description, b => factoryMethod(b)));
+        }
+        
+        /// <summary>
+        /// Replaces an existing step behavior with a new one if it exists in the pipeline
+        /// </summary>
+        /// <param name="stepId">The identifier of the step to replace its implementation.</param>
+        /// <param name="newBehavior">The new <see cref="Behavior{TContext}" /> to use.</param>
+        /// <param name="description">The description of the new behavior.</param>
+        public void ReplaceIfExists(string stepId, Type newBehavior, string description = null)
+        {
+            BehaviorTypeChecker.ThrowIfInvalid(newBehavior, nameof(newBehavior));
+            Guard.AgainstNullAndEmpty(nameof(stepId), stepId);
+            EnsureWriteEnabled(stepId, nameof(Replace));
+
+            modifications.Replacements.Add(new ReplaceStep(stepId, newBehavior, description));
+        }
+        
+        /// <summary>
+        /// Replaces an existing step behavior with a new one.
+        /// </summary>
+        /// <param name="stepId">The identifier of the step to replace its implementation.</param>
+        /// <param name="newBehavior">The new <see cref="Behavior{TContext}" /> to use.</param>
+        /// <param name="description">The description of the new behavior.</param>
+        public void ReplaceIfExists<T>(string stepId, T newBehavior, string description = null)
+            where T : IBehavior
+        {
+            BehaviorTypeChecker.ThrowIfInvalid(typeof(T), nameof(newBehavior));
+            Guard.AgainstNullAndEmpty(nameof(stepId), stepId);
+            EnsureWriteEnabled(stepId, nameof(Replace));
+
+            modifications.Replacements.Add(new ReplaceStep(stepId, typeof(T), description, builder => newBehavior));
+        }
+
+        /// <summary>
+        /// Replaces an existing step behavior with a new one.
+        /// </summary>
+        /// <param name="stepId">The identifier of the step to replace its implementation.</param>
+        /// <param name="factoryMethod">The factory method to create new instances of the behavior.</param>
+        /// <param name="description">The description of the new behavior.</param>
+        public void ReplaceIfExists<T>(string stepId, Func<IServiceProvider, T> factoryMethod, string description = null)
             where T : IBehavior
         {
             BehaviorTypeChecker.ThrowIfInvalid(typeof(T), "newBehavior");

--- a/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
@@ -79,7 +79,7 @@ namespace NServiceBus.Pipeline
             EnsureWriteEnabled(stepId, nameof(Replace));
             EnsureWriteEnabled(stepId, nameof(Register));
 
-            modifications.AdditionsOrReplacements.Add(AddOrReplaceStep.Create(stepId, behavior, description));
+            modifications.AdditionsOrReplacements.Add(RegisterOrReplaceStep.Create(stepId, behavior, description));
         }
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace NServiceBus.Pipeline
             EnsureWriteEnabled(stepId, nameof(Replace));
             EnsureWriteEnabled(stepId, nameof(Register));
 
-            modifications.AdditionsOrReplacements.Add(AddOrReplaceStep.Create(stepId, typeof(T), description,builder => behavior));
+            modifications.AdditionsOrReplacements.Add(RegisterOrReplaceStep.Create(stepId, typeof(T), description,builder => behavior));
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace NServiceBus.Pipeline
             EnsureWriteEnabled(stepId, nameof(Replace));
             EnsureWriteEnabled(stepId, nameof(Register));
 
-            modifications.AdditionsOrReplacements.Add(AddOrReplaceStep.Create(stepId, typeof(T), description, b => factoryMethod(b)));
+            modifications.AdditionsOrReplacements.Add(RegisterOrReplaceStep.Create(stepId, typeof(T), description, b => factoryMethod(b)));
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
+++ b/src/NServiceBus.Core/Pipeline/PipelineSettings.cs
@@ -80,31 +80,35 @@ namespace NServiceBus.Pipeline
         /// Replaces an existing step behavior with a new one if it exists in the pipeline
         /// </summary>
         /// <param name="stepId">The identifier of the step to replace its implementation.</param>
-        /// <param name="newBehavior">The new <see cref="Behavior{TContext}" /> to use.</param>
+        /// <param name="behavior">The new <see cref="Behavior{TContext}" /> to use.</param>
         /// <param name="description">The description of the new behavior.</param>
-        public void ReplaceIfExists(string stepId, Type newBehavior, string description = null)
+        public void AddOrReplace(string stepId, Type behavior, string description = null)
         {
-            BehaviorTypeChecker.ThrowIfInvalid(newBehavior, nameof(newBehavior));
+            BehaviorTypeChecker.ThrowIfInvalid(behavior, nameof(behavior));
             Guard.AgainstNullAndEmpty(nameof(stepId), stepId);
             EnsureWriteEnabled(stepId, nameof(Replace));
+            EnsureWriteEnabled(stepId, nameof(Register));
 
-            modifications.Replacements.Add(new ReplaceStep(stepId, newBehavior, description));
+            modifications.AdditionsOrReplacements.Add(new AddOrReplaceStep(RegisterStep.Create(stepId, behavior, description), new ReplaceStep(stepId, behavior, description)));
         }
         
         /// <summary>
         /// Replaces an existing step behavior with a new one.
         /// </summary>
         /// <param name="stepId">The identifier of the step to replace its implementation.</param>
-        /// <param name="newBehavior">The new <see cref="Behavior{TContext}" /> to use.</param>
+        /// <param name="behavior">The new <see cref="Behavior{TContext}" /> to use.</param>
         /// <param name="description">The description of the new behavior.</param>
-        public void ReplaceIfExists<T>(string stepId, T newBehavior, string description = null)
+        public void AddOrReplace<T>(string stepId, T behavior, string description = null)
             where T : IBehavior
         {
-            BehaviorTypeChecker.ThrowIfInvalid(typeof(T), nameof(newBehavior));
+            BehaviorTypeChecker.ThrowIfInvalid(typeof(T), nameof(behavior));
             Guard.AgainstNullAndEmpty(nameof(stepId), stepId);
             EnsureWriteEnabled(stepId, nameof(Replace));
+            EnsureWriteEnabled(stepId, nameof(Register));
 
-            modifications.Replacements.Add(new ReplaceStep(stepId, typeof(T), description, builder => newBehavior));
+            modifications.AdditionsOrReplacements.Add(new AddOrReplaceStep(
+                RegisterStep.Create(stepId, typeof(T), description, builder => behavior), 
+                new ReplaceStep(stepId, typeof(T), description, builder => behavior)));
         }
 
         /// <summary>
@@ -113,14 +117,17 @@ namespace NServiceBus.Pipeline
         /// <param name="stepId">The identifier of the step to replace its implementation.</param>
         /// <param name="factoryMethod">The factory method to create new instances of the behavior.</param>
         /// <param name="description">The description of the new behavior.</param>
-        public void ReplaceIfExists<T>(string stepId, Func<IServiceProvider, T> factoryMethod, string description = null)
+        public void AddOrReplace<T>(string stepId, Func<IServiceProvider, T> factoryMethod, string description = null)
             where T : IBehavior
         {
-            BehaviorTypeChecker.ThrowIfInvalid(typeof(T), "newBehavior");
+            BehaviorTypeChecker.ThrowIfInvalid(typeof(T), "behavior");
             Guard.AgainstNullAndEmpty(nameof(stepId), stepId);
             EnsureWriteEnabled(stepId, nameof(Replace));
+            EnsureWriteEnabled(stepId, nameof(Register));
 
-            modifications.Replacements.Add(new ReplaceStep(stepId, typeof(T), description, b => factoryMethod(b)));
+            modifications.AdditionsOrReplacements.Add(new AddOrReplaceStep(
+                RegisterStep.Create(stepId, typeof(T), description, b => factoryMethod(b)), 
+                new ReplaceStep(stepId, typeof(T), description, b => factoryMethod(b))));
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Pipeline/RegisterOrReplaceStep.cs
+++ b/src/NServiceBus.Core/Pipeline/RegisterOrReplaceStep.cs
@@ -3,9 +3,9 @@ namespace NServiceBus
     using System;
     using Pipeline;
 
-    class AddOrReplaceStep
+    class RegisterOrReplaceStep
     {
-        AddOrReplaceStep(string stepId, RegisterStep registerStep, ReplaceStep replaceStep)
+        RegisterOrReplaceStep(string stepId, RegisterStep registerStep, ReplaceStep replaceStep)
         {
             StepId = stepId;
             RegisterStep = registerStep;
@@ -16,11 +16,11 @@ namespace NServiceBus
         public ReplaceStep ReplaceStep { get; }
         public string StepId { get; }
 
-        public static AddOrReplaceStep Create(string stepId, Type behaviorType, string description = null, Func<IServiceProvider, IBehavior> factoryMethod = null)
+        public static RegisterOrReplaceStep Create(string stepId, Type behaviorType, string description = null, Func<IServiceProvider, IBehavior> factoryMethod = null)
         {
             var register = RegisterStep.Create(stepId, behaviorType, description, factoryMethod);
             var replace = new ReplaceStep(stepId, behaviorType, description, factoryMethod);
-            return new AddOrReplaceStep(stepId, register, replace);
+            return new RegisterOrReplaceStep(stepId, register, replace);
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/StepRegistrationsCoordinator.cs
+++ b/src/NServiceBus.Core/Pipeline/StepRegistrationsCoordinator.cs
@@ -6,9 +6,8 @@ namespace NServiceBus
 
     class StepRegistrationsCoordinator
     {
-        public StepRegistrationsCoordinator(List<RemoveStep> removals, List<ReplaceStep> replacements, List<AddOrReplaceStep> addOrReplaceSteps)
+        public StepRegistrationsCoordinator(List<ReplaceStep> replacements, List<AddOrReplaceStep> addOrReplaceSteps)
         {
-            this.removals = removals;
             this.replacements = replacements;
             this.addOrReplaceSteps = addOrReplaceSteps;
         }
@@ -25,12 +24,11 @@ namespace NServiceBus
 
         public List<RegisterStep> BuildPipelineModelFor<TRootContext>() where TRootContext : IBehaviorContext
         {
-            var pipelineModelBuilder = new PipelineModelBuilder(typeof(TRootContext), additions, removals, replacements, addOrReplaceSteps);
+            var pipelineModelBuilder = new PipelineModelBuilder(typeof(TRootContext), additions, replacements, addOrReplaceSteps);
             return pipelineModelBuilder.Build();
         }
 
         List<RegisterStep> additions = new List<RegisterStep>();
-        List<RemoveStep> removals;
         List<ReplaceStep> replacements;
         List<AddOrReplaceStep> addOrReplaceSteps;
     }

--- a/src/NServiceBus.Core/Pipeline/StepRegistrationsCoordinator.cs
+++ b/src/NServiceBus.Core/Pipeline/StepRegistrationsCoordinator.cs
@@ -25,22 +25,22 @@ namespace NServiceBus
 
         public List<RegisterStep> BuildPipelineModelFor<TRootContext>() where TRootContext : IBehaviorContext
         {
-            var relevantRemovals = removals.Where(removal => additions.Any(a => a.StepId == removal.RemoveId)).ToList();
-            var relevantReplacements = replacements.Where(replacement => additions.Any(a => a.StepId == replacement.ReplaceId)).ToList();
+            // var relevantRemovals = removals.Where(removal => additions.Any(a => a.StepId == removal.RemoveId)).ToList();
+            // var relevantReplacements = replacements.Where(replacement => additions.Any(a => a.StepId == replacement.ReplaceId)).ToList();
+            //
+            // var irrelevantReplacementsThatShouldFail = replacements
+            //     .Where(registeredReplacement => relevantReplacements.All(relevantReplacement => relevantReplacement.ReplaceId != registeredReplacement.ReplaceId))
+            //     //.Where(replacement => replacement.FailIfStepNotFound)
+            //     .ToList();
+            //
+            // if (irrelevantReplacementsThatShouldFail.Any())
+            // {
+            //     var replaceIdentifiers = irrelevantReplacementsThatShouldFail.Select(x => x.ReplaceId);
+            //     var pipelineIdentifiersNotFound = string.Join(",", replaceIdentifiers);
+            //     throw new InvalidOperationException($"Pipeline replacements were registered for the following ID's: {pipelineIdentifiersNotFound}. These could not be found in the pipeline and could therefore not be replaced. Please verify if the correct ID was used");
+            // }
 
-            var irrelevantReplacementsThatShouldFail = replacements
-                .Where(registeredReplacement => relevantReplacements.All(relevantReplacement => relevantReplacement.ReplaceId != registeredReplacement.ReplaceId))
-                //.Where(replacement => replacement.FailIfStepNotFound)
-                .ToList();
-
-            if (irrelevantReplacementsThatShouldFail.Any())
-            {
-                var replaceIdentifiers = irrelevantReplacementsThatShouldFail.Select(x => x.ReplaceId);
-                var pipelineIdentifiersNotFound = string.Join(",", replaceIdentifiers);
-                throw new InvalidOperationException($"Pipeline replacements were registered for the following ID's: {pipelineIdentifiersNotFound}. These could not be found in the pipeline and could therefore not be replaced. Please verify if the correct ID was used");
-            }
-
-            var pipelineModelBuilder = new PipelineModelBuilder(typeof(TRootContext), additions, relevantRemovals, relevantReplacements);
+            var pipelineModelBuilder = new PipelineModelBuilder(typeof(TRootContext), additions, removals, replacements);
             return pipelineModelBuilder.Build();
         }
 

--- a/src/NServiceBus.Core/Pipeline/StepRegistrationsCoordinator.cs
+++ b/src/NServiceBus.Core/Pipeline/StepRegistrationsCoordinator.cs
@@ -2,15 +2,15 @@ namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using Pipeline;
 
     class StepRegistrationsCoordinator
     {
-        public StepRegistrationsCoordinator(List<RemoveStep> removals, List<ReplaceStep> replacements)
+        public StepRegistrationsCoordinator(List<RemoveStep> removals, List<ReplaceStep> replacements, List<AddOrReplaceStep> addOrReplaceSteps)
         {
             this.removals = removals;
             this.replacements = replacements;
+            this.addOrReplaceSteps = addOrReplaceSteps;
         }
 
         public void Register(string pipelineStep, Type behavior, string description)
@@ -25,27 +25,13 @@ namespace NServiceBus
 
         public List<RegisterStep> BuildPipelineModelFor<TRootContext>() where TRootContext : IBehaviorContext
         {
-            // var relevantRemovals = removals.Where(removal => additions.Any(a => a.StepId == removal.RemoveId)).ToList();
-            // var relevantReplacements = replacements.Where(replacement => additions.Any(a => a.StepId == replacement.ReplaceId)).ToList();
-            //
-            // var irrelevantReplacementsThatShouldFail = replacements
-            //     .Where(registeredReplacement => relevantReplacements.All(relevantReplacement => relevantReplacement.ReplaceId != registeredReplacement.ReplaceId))
-            //     //.Where(replacement => replacement.FailIfStepNotFound)
-            //     .ToList();
-            //
-            // if (irrelevantReplacementsThatShouldFail.Any())
-            // {
-            //     var replaceIdentifiers = irrelevantReplacementsThatShouldFail.Select(x => x.ReplaceId);
-            //     var pipelineIdentifiersNotFound = string.Join(",", replaceIdentifiers);
-            //     throw new InvalidOperationException($"Pipeline replacements were registered for the following ID's: {pipelineIdentifiersNotFound}. These could not be found in the pipeline and could therefore not be replaced. Please verify if the correct ID was used");
-            // }
-
-            var pipelineModelBuilder = new PipelineModelBuilder(typeof(TRootContext), additions, removals, replacements);
+            var pipelineModelBuilder = new PipelineModelBuilder(typeof(TRootContext), additions, removals, replacements, addOrReplaceSteps);
             return pipelineModelBuilder.Build();
         }
 
         List<RegisterStep> additions = new List<RegisterStep>();
         List<RemoveStep> removals;
         List<ReplaceStep> replacements;
+        List<AddOrReplaceStep> addOrReplaceSteps;
     }
 }

--- a/src/NServiceBus.Core/Pipeline/StepRegistrationsCoordinator.cs
+++ b/src/NServiceBus.Core/Pipeline/StepRegistrationsCoordinator.cs
@@ -6,7 +6,7 @@ namespace NServiceBus
 
     class StepRegistrationsCoordinator
     {
-        public StepRegistrationsCoordinator(List<ReplaceStep> replacements, List<AddOrReplaceStep> addOrReplaceSteps)
+        public StepRegistrationsCoordinator(List<ReplaceStep> replacements, List<RegisterOrReplaceStep> addOrReplaceSteps)
         {
             this.replacements = replacements;
             this.addOrReplaceSteps = addOrReplaceSteps;
@@ -30,6 +30,6 @@ namespace NServiceBus
 
         List<RegisterStep> additions = new List<RegisterStep>();
         List<ReplaceStep> replacements;
-        List<AddOrReplaceStep> addOrReplaceSteps;
+        List<RegisterOrReplaceStep> addOrReplaceSteps;
     }
 }

--- a/src/NServiceBus.Core/obsoletes-v8.cs
+++ b/src/NServiceBus.Core/obsoletes-v8.cs
@@ -32,7 +32,7 @@ namespace NServiceBus
     {
         [ObsoleteEx(
             Message = "Use the externally managed container mode to integrate with third party dependency injection containers.",
-            RemoveInVersion = "9.0", 
+            RemoveInVersion = "9.0",
             TreatAsErrorFromVersion = "8.0")]
         public void UseContainer<T>(Action<ContainerCustomizations> customizations = null) where T : ContainerDefinition, new()
         {
@@ -113,8 +113,8 @@ namespace NServiceBus.ObjectBuilder
     using Microsoft.Extensions.DependencyInjection;
 
     [ObsoleteEx(
-        ReplacementTypeOrMember = nameof(IServiceProvider), 
-        TreatAsErrorFromVersion = "8.0.0", 
+        ReplacementTypeOrMember = nameof(IServiceProvider),
+        TreatAsErrorFromVersion = "8.0.0",
         RemoveInVersion = "9.0.0")]
     public interface IBuilder : IDisposable
     {
@@ -357,6 +357,18 @@ namespace NServiceBus.Pipeline
         RemoveInVersion = "9")]
     public interface IForwardingContext : IBehaviorContext
     {
+    }
+
+    public partial class PipelineSettings
+    {
+        [ObsoleteEx(
+            Message = "Removing behaviors from the pipeline is discouraged, to disable a behavior replace the behavior by an empty one. Documentation: https://docs.particular.net/nservicebus/pipeline/manipulate-with-behaviors ",
+            TreatAsErrorFromVersion = "8",
+            RemoveInVersion = "9")]
+        public void Remove(string stepId)
+        {
+            throw new NotImplementedException();
+        }
     }
 }
 


### PR DESCRIPTION
- Register should throw if the step id already existed
- Replace should throw if the step id does not exist
- New RegisterOrReplace API is added to support adding or removing, this should never throw
- Remove API is deprecated