### PR TITLE
Refactored IMessageSession option argument

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -466,12 +466,12 @@ namespace NServiceBus
     }
     public interface IMessageSession
     {
-        System.Threading.Tasks.Task Publish(object message, NServiceBus.PublishOptions options);
+        System.Threading.Tasks.Task Publish(object message, NServiceBus.PublishOptions publishOptions);
         System.Threading.Tasks.Task Publish<T>(System.Action<T> messageConstructor, NServiceBus.PublishOptions publishOptions);
-        System.Threading.Tasks.Task Send(object message, NServiceBus.SendOptions options);
-        System.Threading.Tasks.Task Send<T>(System.Action<T> messageConstructor, NServiceBus.SendOptions options);
-        System.Threading.Tasks.Task Subscribe(System.Type eventType, NServiceBus.SubscribeOptions options);
-        System.Threading.Tasks.Task Unsubscribe(System.Type eventType, NServiceBus.UnsubscribeOptions options);
+        System.Threading.Tasks.Task Send(object message, NServiceBus.SendOptions sendOptions);
+        System.Threading.Tasks.Task Send<T>(System.Action<T> messageConstructor, NServiceBus.SendOptions sendOptions);
+        System.Threading.Tasks.Task Subscribe(System.Type eventType, NServiceBus.SubscribeOptions subscribeOptions);
+        System.Threading.Tasks.Task Unsubscribe(System.Type eventType, NServiceBus.UnsubscribeOptions unsubscribeOptions);
     }
     public class static IMessageSessionExtensions
     {

--- a/src/NServiceBus.Core.Tests/Scheduler/ScheduleTests.cs
+++ b/src/NServiceBus.Core.Tests/Scheduler/ScheduleTests.cs
@@ -56,19 +56,19 @@
 
             public TaskDefinition ScheduledDefinition { get; private set; }
 
-            public Task Send(object message, SendOptions options)
+            public Task Send(object message, SendOptions sendOptions)
             {
-                ScheduledDefinition = options.Context.Get<ScheduleBehavior.State>().TaskDefinition;
+                ScheduledDefinition = sendOptions.Context.Get<ScheduleBehavior.State>().TaskDefinition;
                 defaultScheduler.Schedule(ScheduledDefinition);
                 return defaultScheduler.Start(ScheduledDefinition.Id, new TestablePipelineContext());
             }
 
-            public Task Send<T>(Action<T> messageConstructor, SendOptions options)
+            public Task Send<T>(Action<T> messageConstructor, SendOptions sendOptions)
             {
                 throw new NotImplementedException();
             }
 
-            public Task Publish(object message, PublishOptions options)
+            public Task Publish(object message, PublishOptions publishOptions)
             {
                 throw new NotImplementedException();
             }
@@ -78,12 +78,12 @@
                 throw new NotImplementedException();
             }
 
-            public Task Subscribe(Type eventType, SubscribeOptions options)
+            public Task Subscribe(Type eventType, SubscribeOptions subscribeOptions)
             {
                 throw new NotImplementedException();
             }
 
-            public Task Unsubscribe(Type eventType, UnsubscribeOptions options)
+            public Task Unsubscribe(Type eventType, UnsubscribeOptions unsubscribeOptions)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.Core/IMessageSession.cs
+++ b/src/NServiceBus.Core/IMessageSession.cs
@@ -12,30 +12,30 @@ namespace NServiceBus
         /// Sends the provided message.
         /// </summary>
         /// <param name="message">The message to send.</param>
-        /// <param name="options">The options for the send.</param>
-        Task Send(object message, SendOptions options);
+        /// <param name="sendOptions">The sendOptions for the send.</param>
+        Task Send(object message, SendOptions sendOptions);
 
         /// <summary>
         /// Instantiates a message of type T and sends it.
         /// </summary>
         /// <typeparam name="T">The type of message, usually an interface.</typeparam>
         /// <param name="messageConstructor">An action which initializes properties of the message.</param>
-        /// <param name="options">The options for the send.</param>
-        Task Send<T>(Action<T> messageConstructor, SendOptions options);
+        /// <param name="sendOptions">The sendOptions for the send.</param>
+        Task Send<T>(Action<T> messageConstructor, SendOptions sendOptions);
 
         /// <summary>
         /// Publish the message to subscribers.
         /// </summary>
         /// <param name="message">The message to publish.</param>
-        /// <param name="options">The options for the publish.</param>
-        Task Publish(object message, PublishOptions options);
+        /// <param name="publishOptions">The sendOptions for the publish.</param>
+        Task Publish(object message, PublishOptions publishOptions);
 
         /// <summary>
         /// Instantiates a message of type T and publishes it.
         /// </summary>
         /// <typeparam name="T">The type of message, usually an interface.</typeparam>
         /// <param name="messageConstructor">An action which initializes properties of the message.</param>
-        /// <param name="publishOptions">Specific options for this event.</param>
+        /// <param name="publishOptions">Specific sendOptions for this event.</param>
         Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions);
 
         /// <summary>
@@ -43,14 +43,14 @@ namespace NServiceBus
         /// This method is only necessary if you turned off auto-subscribe.
         /// </summary>
         /// <param name="eventType">The type of event to subscribe to.</param>
-        /// <param name="options">Options for the subscribe.</param>
-        Task Subscribe(Type eventType, SubscribeOptions options);
+        /// <param name="subscribeOptions">Options for the subscribe.</param>
+        Task Subscribe(Type eventType, SubscribeOptions subscribeOptions);
 
         /// <summary>
         /// Unsubscribes to receive published messages of the specified type.
         /// </summary>
         /// <param name="eventType">The type of event to unsubscribe to.</param>
-        /// <param name="options">Options for the subscribe.</param>
-        Task Unsubscribe(Type eventType, UnsubscribeOptions options);
+        /// <param name="unsubscribeOptions">Options for the subscribe.</param>
+        Task Unsubscribe(Type eventType, UnsubscribeOptions unsubscribeOptions);
     }
 }

--- a/src/NServiceBus.Core/MessageSession.cs
+++ b/src/NServiceBus.Core/MessageSession.cs
@@ -11,19 +11,19 @@ namespace NServiceBus
             messageOperations = context.Get<MessageOperations>();
         }
 
-        public Task Send(object message, SendOptions options)
+        public Task Send(object message, SendOptions sendOptions)
         {
-            return messageOperations.Send(context, message, options);
+            return messageOperations.Send(context, message, sendOptions);
         }
 
-        public Task Send<T>(Action<T> messageConstructor, SendOptions options)
+        public Task Send<T>(Action<T> messageConstructor, SendOptions sendOptions)
         {
-            return messageOperations.Send(context, messageConstructor, options);
+            return messageOperations.Send(context, messageConstructor, sendOptions);
         }
 
-        public Task Publish(object message, PublishOptions options)
+        public Task Publish(object message, PublishOptions publishOptions)
         {
-            return messageOperations.Publish(context, message, options);
+            return messageOperations.Publish(context, message, publishOptions);
         }
 
         public Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions)
@@ -31,14 +31,14 @@ namespace NServiceBus
             return messageOperations.Publish(context, messageConstructor, publishOptions);
         }
 
-        public Task Subscribe(Type eventType, SubscribeOptions options)
+        public Task Subscribe(Type eventType, SubscribeOptions subscribeOptions)
         {
-            return messageOperations.Subscribe(context, eventType, options);
+            return messageOperations.Subscribe(context, eventType, subscribeOptions);
         }
 
-        public Task Unsubscribe(Type eventType, UnsubscribeOptions options)
+        public Task Unsubscribe(Type eventType, UnsubscribeOptions unsubscribeOptions)
         {
-            return messageOperations.Unsubscribe(context, eventType, options);
+            return messageOperations.Unsubscribe(context, eventType, unsubscribeOptions);
         }
 
         RootContext context;

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -59,19 +59,19 @@ namespace NServiceBus
             }
         }
 
-        public Task Send(object message, SendOptions options)
+        public Task Send(object message, SendOptions sendOptions)
         {
-            return messageSession.Send(message, options);
+            return messageSession.Send(message, sendOptions);
         }
 
-        public Task Send<T>(Action<T> messageConstructor, SendOptions options)
+        public Task Send<T>(Action<T> messageConstructor, SendOptions sendOptions)
         {
-            return messageSession.Send(messageConstructor, options);
+            return messageSession.Send(messageConstructor, sendOptions);
         }
 
-        public Task Publish(object message, PublishOptions options)
+        public Task Publish(object message, PublishOptions publishOptions)
         {
-            return messageSession.Publish(message, options);
+            return messageSession.Publish(message, publishOptions);
         }
 
         public Task Publish<T>(Action<T> messageConstructor, PublishOptions publishOptions)
@@ -79,14 +79,14 @@ namespace NServiceBus
             return messageSession.Publish(messageConstructor, publishOptions);
         }
 
-        public Task Subscribe(Type eventType, SubscribeOptions options)
+        public Task Subscribe(Type eventType, SubscribeOptions subscribeOptions)
         {
-            return messageSession.Subscribe(eventType, options);
+            return messageSession.Subscribe(eventType, subscribeOptions);
         }
 
-        public Task Unsubscribe(Type eventType, UnsubscribeOptions options)
+        public Task Unsubscribe(Type eventType, UnsubscribeOptions unsubscribeOptions)
         {
-            return messageSession.Unsubscribe(eventType, options);
+            return messageSession.Unsubscribe(eventType, unsubscribeOptions);
         }
 
         HostingComponent hostingComponent;


### PR DESCRIPTION
During implementing of https://github.com/Particular/NServiceBus/pull/5770 we saw that `IMessageSession` has inconsistent naming of the `options` argument. This PR aligns all methods on the interface to use the same naming convention.