### PR TITLE
Additional DateTimeOffset refactorings accompanying #5646

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_message_is_audited.cs
@@ -22,9 +22,9 @@
                 .Done(c => c.IsMessageHandledByTheAuditEndpoint)
                 .Run();
 
-            var processingStarted = DateTimeExtensions.ToUtcDateTime(context.Headers[Headers.ProcessingStarted]);
-            var processingEnded = DateTimeExtensions.ToUtcDateTime(context.Headers[Headers.ProcessingEnded]);
-            var timeSent = DateTimeExtensions.ToUtcDateTime(context.Headers[Headers.TimeSent]);
+            var processingStarted = DateTimeOffsetHelper.ToDateTimeOffset(context.Headers[Headers.ProcessingStarted]);
+            var processingEnded = DateTimeOffsetHelper.ToDateTimeOffset(context.Headers[Headers.ProcessingEnded]);
+            var timeSent = DateTimeOffsetHelper.ToDateTimeOffset(context.Headers[Headers.TimeSent]);
 
             Assert.That(processingStarted, Is.EqualTo(now).Within(TimeSpan.FromSeconds(30)), nameof(processingStarted));
             Assert.That(processingEnded, Is.EqualTo(now).Within(TimeSpan.FromSeconds(30)), nameof(processingEnded));

--- a/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_message_is_faulted.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_message_is_faulted.cs
@@ -23,10 +23,10 @@
                 .Done(c => c.IsMessageHandledByTheAuditEndpoint && c.IsMessageHandledByTheFaultEndpoint)
                 .Run();
 
-            var processingStarted = DateTimeExtensions.ToUtcDateTime(context.Headers[Headers.ProcessingStarted]);
-            var processingEnded = DateTimeExtensions.ToUtcDateTime(context.Headers[Headers.ProcessingEnded]);
-            var timeSent = DateTimeExtensions.ToUtcDateTime(context.Headers[Headers.TimeSent]);
-            var timeSentWhenFailedMessageWasSentToTheErrorQueue = DateTimeExtensions.ToUtcDateTime(context.FaultHeaders[Headers.TimeSent]);
+            var processingStarted = DateTimeOffsetHelper.ToDateTimeOffset(context.Headers[Headers.ProcessingStarted]);
+            var processingEnded = DateTimeOffsetHelper.ToDateTimeOffset(context.Headers[Headers.ProcessingEnded]);
+            var timeSent = DateTimeOffsetHelper.ToDateTimeOffset(context.Headers[Headers.TimeSent]);
+            var timeSentWhenFailedMessageWasSentToTheErrorQueue = DateTimeOffsetHelper.ToDateTimeOffset(context.FaultHeaders[Headers.TimeSent]);
 
             Assert.That(processingStarted, Is.EqualTo(now).Within(TimeSpan.FromSeconds(30)), nameof(processingStarted));
             Assert.That(processingEnded, Is.EqualTo(now).Within(TimeSpan.FromSeconds(30)), nameof(processingEnded));
@@ -120,7 +120,7 @@
 
                 public Task Handle(MessageThatFails message, IMessageHandlerContext context)
                 {
-                    testContext.TimeSentOnTheFailingMessageWhenItWasHandled = DateTimeExtensions.ToUtcDateTime(context.MessageHeaders[Headers.TimeSent]);
+                    testContext.TimeSentOnTheFailingMessageWhenItWasHandled = DateTimeOffsetHelper.ToDateTimeOffset(context.MessageHeaders[Headers.TimeSent]);
                     testContext.FaultHeaders = context.MessageHeaders.ToDictionary(x => x.Key, x => x.Value);
                     testContext.IsMessageHandledByTheFaultEndpoint = true;
 

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -187,9 +187,25 @@ namespace NServiceBus
         public object GetValue() { }
         public void SetValue(object valueToSet) { }
     }
+    [System.ObsoleteAttribute("Public APIs no longer use DateTime but DateTimeOffset. See the upgrade guide for " +
+        "more details. Use `NServiceBus.DateTimeOffsetExtensions` instead. Will be remove" +
+        "d in version 9.0.0.", true)]
     public class static DateTimeExtensions
     {
-        public static System.DateTimeOffset ToUtcDateTime(string wireFormattedString) { }
+        [System.ObsoleteAttribute("Public APIs no longer use DateTime but DateTimeOffset. See the upgrade guide for " +
+            "more details. Use `NServiceBus.DateTimeOffsetHelper.ToDateTimeOffset` instead. T" +
+            "he member currently throws a NotImplementedException. Will be removed in version" +
+            " 9.0.0.", true)]
+        public static System.DateTime ToUtcDateTime(string wireFormattedString) { }
+        [System.ObsoleteAttribute("Public APIs no longer use DateTime but DateTimeOffset. See the upgrade guide for " +
+            "more details. Use `NServiceBus.DateTimeOffsetHelper.ToWireFormattedString` inste" +
+            "ad. The member currently throws a NotImplementedException. Will be removed in ve" +
+            "rsion 9.0.0.", true)]
+        public static string ToWireFormattedString(System.DateTime dateTime) { }
+    }
+    public class static DateTimeOffsetHelper
+    {
+        public static System.DateTimeOffset ToDateTimeOffset(string wireFormattedString) { }
         public static string ToWireFormattedString(System.DateTimeOffset dateTime) { }
     }
     public class static DefaultRecoverabilityPolicy
@@ -2027,7 +2043,7 @@ namespace NServiceBus.Sagas
 {
     public class ActiveSagaInstance
     {
-        public ActiveSagaInstance(NServiceBus.Saga saga, NServiceBus.Sagas.SagaMetadata metadata, System.Func<System.DateTimeOffset> currentUtcDateTimeProvider) { }
+        public ActiveSagaInstance(NServiceBus.Saga saga, NServiceBus.Sagas.SagaMetadata metadata, System.Func<System.DateTimeOffset> currentDateTimeOffsetProvider) { }
         public System.DateTimeOffset Created { get; }
         public NServiceBus.Saga Instance { get; }
         public bool IsNew { get; }

--- a/src/NServiceBus.Core.Tests/DateTimeExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/DateTimeExtensionsTests.cs
@@ -11,8 +11,8 @@
         public void When_roundtripping_constructed_date_should_be_equal()
         {
             var date = new DateTimeOffset(2016, 8, 29, 16, 37, 25, 75, TimeSpan.Zero);
-            var dateString = DateTimeExtensions.ToWireFormattedString(date);
-            var result = DateTimeExtensions.ToUtcDateTime(dateString);
+            var dateString = DateTimeOffsetHelper.ToWireFormattedString(date);
+            var result = DateTimeOffsetHelper.ToDateTimeOffset(dateString);
 
             Assert.AreEqual(date, result);
         }
@@ -21,8 +21,8 @@
         public void When_roundtripping_UtcNow_should_be_accurate_to_microseconds()
         {
             var date = DateTimeOffset.UtcNow;
-            var dateString = DateTimeExtensions.ToWireFormattedString(date);
-            var result = DateTimeExtensions.ToUtcDateTime(dateString);
+            var dateString = DateTimeOffsetHelper.ToWireFormattedString(date);
+            var result = DateTimeOffsetHelper.ToDateTimeOffset(dateString);
 
             Assert.AreEqual(date.Year, result.Year);
             Assert.AreEqual(date.Month, result.Month);
@@ -40,7 +40,7 @@
         {
             var dateString = "2016-08-16 10:06:20:123456 Z";
             var date = DateTimeOffset.ParseExact(dateString, "yyyy-MM-dd HH:mm:ss:ffffff Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
-            var result = DateTimeExtensions.ToUtcDateTime(dateString);
+            var result = DateTimeOffsetHelper.ToDateTimeOffset(dateString);
 
             Assert.AreEqual(date.Year, result.Year);
             Assert.AreEqual(date.Month, result.Month);
@@ -58,7 +58,7 @@
         {
             var dateString = "201-08-16 10:06:20:123456 Z";
 
-            var exception = Assert.Throws<FormatException>(() => DateTimeExtensions.ToUtcDateTime(dateString));
+            var exception = Assert.Throws<FormatException>(() => DateTimeOffsetHelper.ToDateTimeOffset(dateString));
             Assert.AreEqual(exception.Message, "String was not recognized as a valid DateTime.");
         }
 
@@ -67,7 +67,7 @@
         {
             var dateString = "201j-08-16 10:06:20:123456 Z";
 
-            var exception = Assert.Throws<FormatException>(() => DateTimeExtensions.ToUtcDateTime(dateString));
+            var exception = Assert.Throws<FormatException>(() => DateTimeOffsetHelper.ToDateTimeOffset(dateString));
             Assert.AreEqual(exception.Message, "String was not recognized as a valid DateTime.");
         }
     }

--- a/src/NServiceBus.Core.Tests/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/DelayedDelivery/RouteDeferredMessageToTimeoutManagerBehaviorTests.cs
@@ -72,7 +72,7 @@
                 return Task.CompletedTask;
             });
 
-            Assert.LessOrEqual(DateTimeExtensions.ToUtcDateTime(headers[TimeoutManagerHeaders.Expire]), DateTimeOffset.UtcNow + delay);
+            Assert.LessOrEqual(DateTimeOffsetHelper.ToDateTimeOffset(headers[TimeoutManagerHeaders.Expire]), DateTimeOffset.UtcNow + delay);
         }
 
         [Test]
@@ -90,7 +90,7 @@
                 return Task.CompletedTask;
             });
 
-            Assert.AreEqual(headers[TimeoutManagerHeaders.Expire], DateTimeExtensions.ToWireFormattedString(at));
+            Assert.AreEqual(headers[TimeoutManagerHeaders.Expire], DateTimeOffsetHelper.ToWireFormattedString(at));
         }
 
         TestableRoutingContext CreateContext(RoutingStrategy routingStrategy, params DeliveryConstraint[] deliveryConstraints)

--- a/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
@@ -100,8 +100,8 @@
             Assert.AreSame(thrownException, caughtException);
             Assert.AreEqual("System.Object", caughtException.Data["Message type"]);
             Assert.AreEqual("NServiceBus.Core.Tests.Pipeline.Incoming.InvokeHandlerTerminatorTest+FakeMessageHandler", caughtException.Data["Handler type"]);
-            Assert.That(DateTimeExtensions.ToUtcDateTime((string)caughtException.Data["Handler start time"]), Is.EqualTo(DateTimeOffset.UtcNow).Within(TimeSpan.FromSeconds(5)));
-            Assert.That(DateTimeExtensions.ToUtcDateTime((string)caughtException.Data["Handler failure time"]), Is.EqualTo(DateTimeOffset.UtcNow).Within(TimeSpan.FromSeconds(5)));
+            Assert.That(DateTimeOffsetHelper.ToDateTimeOffset((string)caughtException.Data["Handler start time"]), Is.EqualTo(DateTimeOffset.UtcNow).Within(TimeSpan.FromSeconds(5)));
+            Assert.That(DateTimeOffsetHelper.ToDateTimeOffset((string)caughtException.Data["Handler failure time"]), Is.EqualTo(DateTimeOffset.UtcNow).Within(TimeSpan.FromSeconds(5)));
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Recoverability/DefaultRecoverabilityPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/DefaultRecoverabilityPolicyTests.cs
@@ -149,7 +149,7 @@
             var moreThanADayAgo = now.AddHours(-24).AddTicks(-1);
             var headers = new Dictionary<string, string>
             {
-                {Headers.DelayedRetriesTimestamp, DateTimeExtensions.ToWireFormattedString(moreThanADayAgo)}
+                {Headers.DelayedRetriesTimestamp, DateTimeOffsetHelper.ToWireFormattedString(moreThanADayAgo)}
             };
 
             var errorContext = CreateErrorContext(headers: headers);

--- a/src/NServiceBus.Core.Tests/Recoverability/DelayedRetryExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/DelayedRetryExecutorTests.cs
@@ -61,7 +61,7 @@
 
             Assert.IsNull(deliveryConstraint);
             Assert.AreEqual(EndpointInputQueue, transportOperation.Message.Headers[TimeoutManagerHeaders.RouteExpiredTimeoutTo]);
-            Assert.That(DateTimeExtensions.ToUtcDateTime(transportOperation.Message.Headers[TimeoutManagerHeaders.Expire]), Is.GreaterThan(DateTimeOffset.UtcNow).And.LessThanOrEqualTo(DateTimeOffset.UtcNow + delay));
+            Assert.That(DateTimeOffsetHelper.ToDateTimeOffset(transportOperation.Message.Headers[TimeoutManagerHeaders.Expire]), Is.GreaterThan(DateTimeOffset.UtcNow).And.LessThanOrEqualTo(DateTimeOffset.UtcNow + delay));
             Assert.AreEqual(TimeoutManagerAddress, transportOperation.Destination);
         }
 
@@ -69,7 +69,7 @@
         public async Task Should_update_retry_headers_when_present()
         {
             var delayedRetryExecutor = CreateExecutor(nativeDeferralsOn: true);
-            var originalHeadersTimestamp = DateTimeExtensions.ToWireFormattedString(new DateTime(2012, 12, 12, 0, 0, 0, DateTimeKind.Utc));
+            var originalHeadersTimestamp = DateTimeOffsetHelper.ToWireFormattedString(new DateTime(2012, 12, 12, 0, 0, 0, DateTimeKind.Utc));
 
             var incomingMessage = CreateMessage(new Dictionary<string, string>
             {
@@ -85,9 +85,9 @@
             Assert.AreEqual("3", outgoingMessageHeaders[Headers.DelayedRetries]);
             Assert.AreEqual("2", incomingMessage.Headers[Headers.DelayedRetries]);
 
-            var utcDateTime = DateTimeExtensions.ToUtcDateTime(outgoingMessageHeaders[Headers.DelayedRetriesTimestamp]);
+            var utcDateTime = DateTimeOffsetHelper.ToDateTimeOffset(outgoingMessageHeaders[Headers.DelayedRetriesTimestamp]);
             // the serialization removes precision which may lead to now being greater than the deserialized header value
-            var adjustedNow = DateTimeExtensions.ToUtcDateTime(DateTimeExtensions.ToWireFormattedString(now));
+            var adjustedNow = DateTimeOffsetHelper.ToDateTimeOffset(DateTimeOffsetHelper.ToWireFormattedString(now));
             Assert.That(utcDateTime, Is.GreaterThanOrEqualTo(adjustedNow));
             Assert.AreEqual(originalHeadersTimestamp, incomingMessage.Headers[Headers.DelayedRetriesTimestamp]);
         }

--- a/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageConnectorTests.cs
@@ -28,7 +28,7 @@
 
             options["Destination"] = "test";
 
-            options["DeliverAt"] = DateTimeExtensions.ToWireFormattedString(deliverTime);
+            options["DeliverAt"] = DateTimeOffsetHelper.ToWireFormattedString(deliverTime);
             options["DelayDeliveryFor"] = TimeSpan.FromSeconds(10).ToString();
             options["TimeToBeReceived"] = maxTime.ToString();
 

--- a/src/NServiceBus.Core/DateTimeOffsetExtensions.cs
+++ b/src/NServiceBus.Core/DateTimeOffsetExtensions.cs
@@ -1,0 +1,19 @@
+namespace NServiceBus
+{
+    using System;
+
+    static class DateTimeOffsetExtensions
+    {
+        public static int Microseconds(this DateTimeOffset self)
+        {
+            return (int) Math.Floor((self.Ticks % TimeSpan.TicksPerMillisecond) / (double) ticksPerMicrosecond);
+        }
+
+        public static DateTimeOffset AddMicroseconds(this DateTimeOffset self, int microseconds)
+        {
+            return self.AddTicks(microseconds * ticksPerMicrosecond);
+        }
+
+        const int ticksPerMicrosecond = (int) TimeSpan.TicksPerMillisecond / 1000;
+    }
+}

--- a/src/NServiceBus.Core/DateTimeOffsetHelper.cs
+++ b/src/NServiceBus.Core/DateTimeOffsetHelper.cs
@@ -1,12 +1,12 @@
+﻿using System;
+using System.Globalization;
+
 namespace NServiceBus
 {
-    using System;
-    using System.Globalization;
-
     /// <summary>
     /// Common date time extensions.
     /// </summary>
-    public static class DateTimeExtensions
+    public static class DateTimeOffsetHelper
     {
         /// <summary>
         /// Converts the <see cref="DateTimeOffset" /> to a <see cref="string" /> suitable for transport over the wire.
@@ -20,7 +20,7 @@ namespace NServiceBus
         /// Converts a wire formatted <see cref="string" /> from <see cref="ToWireFormattedString" /> to a UTC
         /// <see cref="DateTimeOffset" />.
         /// </summary>
-        public static DateTimeOffset ToUtcDateTime(string wireFormattedString)
+        public static DateTimeOffset ToDateTimeOffset(string wireFormattedString)
         {
             Guard.AgainstNullAndEmpty(nameof(wireFormattedString), wireFormattedString);
 
@@ -85,18 +85,7 @@ namespace NServiceBus
             return timestamp;
         }
 
-        internal static int Microseconds(this DateTimeOffset self)
-        {
-            return (int)Math.Floor((self.Ticks % TimeSpan.TicksPerMillisecond) / (double)ticksPerMicrosecond);
-        }
-
-        internal static DateTimeOffset AddMicroseconds(this DateTimeOffset self, int microseconds)
-        {
-            return self.AddTicks(microseconds * ticksPerMicrosecond);
-        }
-
         const string format = "yyyy-MM-dd HH:mm:ss:ffffff Z";
         const string errorMessage = "String was not recognized as a valid DateTime.";
-        const int ticksPerMicrosecond = 10;
     }
 }

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/DispatchTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/DispatchTimeoutBehavior.cs
@@ -26,7 +26,7 @@ namespace NServiceBus
                 return;
             }
 
-            timeoutData.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTimeOffset.UtcNow);
+            timeoutData.Headers[Headers.TimeSent] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);
             timeoutData.Headers["NServiceBus.RelatedToTimeoutId"] = timeoutData.Id;
 
             var outgoingMessage = new OutgoingMessage(context.MessageId, timeoutData.Headers, timeoutData.State);

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManager/StoreTimeoutBehavior.cs
@@ -53,7 +53,7 @@ namespace NServiceBus
                     Destination = destination,
                     SagaId = sagaId,
                     State = context.Body,
-                    Time = DateTimeExtensions.ToUtcDateTime(expire),
+                    Time = DateTimeOffsetHelper.ToDateTimeOffset(expire),
                     Headers = context.Headers,
                     OwningTimeoutManager = owningTimeoutManager
                 };

--- a/src/NServiceBus.Core/DelayedDelivery/TimeoutManagerRoutingStrategy.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/TimeoutManagerRoutingStrategy.cs
@@ -20,7 +20,7 @@ namespace NServiceBus
         public override AddressTag Apply(Dictionary<string, string> headers)
         {
             headers[TimeoutManagerHeaders.RouteExpiredTimeoutTo] = ultimateDestination;
-            headers[TimeoutManagerHeaders.Expire] = DateTimeExtensions.ToWireFormattedString(deliverAt);
+            headers[TimeoutManagerHeaders.Expire] = DateTimeOffsetHelper.ToWireFormattedString(deliverAt);
 
             return new UnicastAddressTag(timeoutManagerAddress);
         }

--- a/src/NServiceBus.Core/Performance/Statistics/AuditProcessingStatisticsBehavior.cs
+++ b/src/NServiceBus.Core/Performance/Statistics/AuditProcessingStatisticsBehavior.cs
@@ -10,9 +10,9 @@
         {
             if (context.Extensions.TryGet(out ProcessingStatisticsBehavior.State state))
             {
-                context.AddAuditData(Headers.ProcessingStarted, DateTimeExtensions.ToWireFormattedString(state.ProcessingStarted));
+                context.AddAuditData(Headers.ProcessingStarted, DateTimeOffsetHelper.ToWireFormattedString(state.ProcessingStarted));
                 // We can't take the processing time from the state since we don't know it yet.
-                context.AddAuditData(Headers.ProcessingEnded, DateTimeExtensions.ToWireFormattedString(DateTimeOffset.UtcNow));
+                context.AddAuditData(Headers.ProcessingEnded, DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow));
             }
 
             return next(context);

--- a/src/NServiceBus.Core/Performance/Statistics/ProcessingStatisticsBehavior.cs
+++ b/src/NServiceBus.Core/Performance/Statistics/ProcessingStatisticsBehavior.cs
@@ -14,7 +14,7 @@
             var headers = context.Message.Headers;
             if (headers.TryGetValue(Headers.TimeSent, out var timeSentString))
             {
-                state.TimeSent = DateTimeExtensions.ToUtcDateTime(timeSentString);
+                state.TimeSent = DateTimeOffsetHelper.ToDateTimeOffset(timeSentString);
             }
 
             state.ProcessingStarted = DateTimeOffset.UtcNow;

--- a/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs
@@ -28,8 +28,8 @@
             {
                 e.Data["Message type"] = context.MessageMetadata.MessageType.FullName;
                 e.Data["Handler type"] = context.MessageHandler.HandlerType.FullName;
-                e.Data["Handler start time"] = DateTimeExtensions.ToWireFormattedString(startTime);
-                e.Data["Handler failure time"] = DateTimeExtensions.ToWireFormattedString(DateTimeOffset.UtcNow);
+                e.Data["Handler start time"] = DateTimeOffsetHelper.ToWireFormattedString(startTime);
+                e.Data["Handler failure time"] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);
                 throw;
             }
         }

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
@@ -117,7 +117,7 @@ namespace NServiceBus
         {
             if (constraint is DoNotDeliverBefore doNotDeliverBefore)
             {
-                options["DeliverAt"] = DateTimeExtensions.ToWireFormattedString(doNotDeliverBefore.At);
+                options["DeliverAt"] = DateTimeOffsetHelper.ToWireFormattedString(doNotDeliverBefore.At);
                 return;
             }
 
@@ -142,7 +142,7 @@ namespace NServiceBus
 
             if (options.TryGetValue("DeliverAt", out var deliverAt))
             {
-                constraints.Add(new DoNotDeliverBefore(DateTimeExtensions.ToUtcDateTime(deliverAt)));
+                constraints.Add(new DoNotDeliverBefore(DateTimeOffsetHelper.ToDateTimeOffset(deliverAt)));
             }
 
             if (options.TryGetValue("DelayDeliveryFor", out var delay))

--- a/src/NServiceBus.Core/Pipeline/Outgoing/AttachSenderRelatedInfoOnMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/AttachSenderRelatedInfoOnMessageBehavior.cs
@@ -17,7 +17,7 @@ namespace NServiceBus
 
             if (!message.Headers.ContainsKey(Headers.TimeSent))
             {
-                message.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTimeOffset.UtcNow);
+                message.Headers[Headers.TimeSent] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);
             }
             return next(context);
         }

--- a/src/NServiceBus.Core/Recoverability/DefaultRecoverabilityPolicy.cs
+++ b/src/NServiceBus.Core/Recoverability/DefaultRecoverabilityPolicy.cs
@@ -77,7 +77,7 @@ namespace NServiceBus
 
             try
             {
-                var handledAt = DateTimeExtensions.ToUtcDateTime(timestampHeader);
+                var handledAt = DateTimeOffsetHelper.ToDateTimeOffset(timestampHeader);
 
                 var now = DateTimeOffset.UtcNow;
                 if (now > handledAt.AddDays(1))

--- a/src/NServiceBus.Core/Recoverability/DelayedRetriesHeaderExtensions.cs
+++ b/src/NServiceBus.Core/Recoverability/DelayedRetriesHeaderExtensions.cs
@@ -25,7 +25,7 @@
 
         public static void SetDelayedDeliveryTimestamp(this OutgoingMessage message, DateTimeOffset timestamp)
         {
-            message.Headers[Headers.DelayedRetriesTimestamp] = DateTimeExtensions.ToWireFormattedString(timestamp);
+            message.Headers[Headers.DelayedRetriesTimestamp] = DateTimeOffsetHelper.ToWireFormattedString(timestamp);
         }
     }
 }

--- a/src/NServiceBus.Core/Recoverability/DelayedRetryExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/DelayedRetryExecutor.cs
@@ -42,7 +42,7 @@
             {
                 // transport doesn't support native deferred messages, reroute to timeout manager:
                 outgoingMessage.Headers[TimeoutManagerHeaders.RouteExpiredTimeoutTo] = endpointInputQueue;
-                outgoingMessage.Headers[TimeoutManagerHeaders.Expire] = DateTimeExtensions.ToWireFormattedString(DateTimeOffset.UtcNow + delay);
+                outgoingMessage.Headers[TimeoutManagerHeaders.Expire] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow + delay);
                 messageDestination = new UnicastAddressTag(timeoutManagerAddress);
             }
 

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -42,7 +42,7 @@
                 subscriptionMessage.Headers[Headers.ReplyToAddress] = subscriberAddress;
                 subscriptionMessage.Headers[Headers.SubscriberTransportAddress] = subscriberAddress;
                 subscriptionMessage.Headers[Headers.SubscriberEndpoint] = subscriberEndpoint;
-                subscriptionMessage.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTimeOffset.UtcNow);
+                subscriptionMessage.Headers[Headers.TimeSent] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);
                 subscriptionMessage.Headers[Headers.NServiceBusVersion] = GitVersionInformation.MajorMinorPatch;
 
                 subscribeTasks.Add(SendSubscribeMessageWithRetries(publisherAddress, subscriptionMessage, eventType.AssemblyQualifiedName, context.Extensions));

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -42,7 +42,7 @@
                 unsubscribeMessage.Headers[Headers.ReplyToAddress] = replyToAddress;
                 unsubscribeMessage.Headers[Headers.SubscriberTransportAddress] = replyToAddress;
                 unsubscribeMessage.Headers[Headers.SubscriberEndpoint] = endpoint;
-                unsubscribeMessage.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTimeOffset.UtcNow);
+                unsubscribeMessage.Headers[Headers.TimeSent] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);
                 unsubscribeMessage.Headers[Headers.NServiceBusVersion] = GitVersionInformation.MajorMinorPatch;
 
                 unsubscribeTasks.Add(SendUnsubscribeMessageWithRetries(publisherAddress, unsubscribeMessage, eventType.AssemblyQualifiedName, context.Extensions));

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationSubscribeTerminator.cs
@@ -45,7 +45,7 @@
                 subscriptionMessage.Headers[Headers.ReplyToAddress] = subscriberAddress;
                 subscriptionMessage.Headers[Headers.SubscriberTransportAddress] = subscriberAddress;
                 subscriptionMessage.Headers[Headers.SubscriberEndpoint] = subscriberEndpoint;
-                subscriptionMessage.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTimeOffset.UtcNow);
+                subscriptionMessage.Headers[Headers.TimeSent] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);
                 subscriptionMessage.Headers[Headers.NServiceBusVersion] = GitVersionInformation.MajorMinorPatch;
 
                 subscribeTasks.Add(SendSubscribeMessageWithRetries(publisherAddress, subscriptionMessage, eventType.AssemblyQualifiedName, context.Extensions));

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationUnsubscribeTerminator.cs
@@ -46,7 +46,7 @@
                 unsubscribeMessage.Headers[Headers.ReplyToAddress] = replyToAddress;
                 unsubscribeMessage.Headers[Headers.SubscriberTransportAddress] = replyToAddress;
                 unsubscribeMessage.Headers[Headers.SubscriberEndpoint] = endpoint;
-                unsubscribeMessage.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTimeOffset.UtcNow);
+                unsubscribeMessage.Headers[Headers.TimeSent] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);
                 unsubscribeMessage.Headers[Headers.NServiceBusVersion] = GitVersionInformation.MajorMinorPatch;
 
                 unsubscribeTasks.Add(SendUnsubscribeMessageWithRetries(publisherAddress, unsubscribeMessage, eventType.AssemblyQualifiedName, context.Extensions));

--- a/src/NServiceBus.Core/Sagas/ActiveSagaInstance.cs
+++ b/src/NServiceBus.Core/Sagas/ActiveSagaInstance.cs
@@ -9,18 +9,18 @@ namespace NServiceBus.Sagas
     /// </summary>
     public class ActiveSagaInstance
     {
-        readonly Func<DateTimeOffset> currentUtcDateTimeProvider;
+        readonly Func<DateTimeOffset> currentDateTimeOffsetProvider;
 
         /// <summary>
         /// Creates a new <see cref="ActiveSagaInstance"/> instance.
         /// </summary>
-        public ActiveSagaInstance(Saga saga, SagaMetadata metadata, Func<DateTimeOffset> currentUtcDateTimeProvider)
+        public ActiveSagaInstance(Saga saga, SagaMetadata metadata, Func<DateTimeOffset> currentDateTimeOffsetProvider)
         {
-            this.currentUtcDateTimeProvider = currentUtcDateTimeProvider;
+            this.currentDateTimeOffsetProvider = currentDateTimeOffsetProvider;
             Instance = saga;
             Metadata = metadata;
 
-            Created = currentUtcDateTimeProvider();
+            Created = currentDateTimeOffsetProvider();
             Modified = Created;
         }
 
@@ -111,7 +111,7 @@ namespace NServiceBus.Sagas
 
         void UpdateModified()
         {
-            Modified = currentUtcDateTimeProvider();
+            Modified = currentDateTimeOffsetProvider();
         }
 
         internal void MarkAsNotFound()

--- a/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
+++ b/src/NServiceBus.Core/Utils/ExceptionHeaderHelper.cs
@@ -19,7 +19,7 @@
             headers["NServiceBus.ExceptionInfo.Message"] = e.GetMessage().Truncate(16384);
             headers["NServiceBus.ExceptionInfo.Source"] = e.Source;
             headers["NServiceBus.ExceptionInfo.StackTrace"] = e.ToString();
-            headers["NServiceBus.TimeOfFailure"] = DateTimeExtensions.ToWireFormattedString(DateTimeOffset.UtcNow);
+            headers["NServiceBus.TimeOfFailure"] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);
 
             if (e.Data == null)
             {

--- a/src/NServiceBus.Core/obsoletes-v8.cs
+++ b/src/NServiceBus.Core/obsoletes-v8.cs
@@ -576,4 +576,34 @@ namespace NServiceBus
     }
 }
 
+namespace NServiceBus
+{
+    [ObsoleteEx(
+        Message = "Public APIs no longer use DateTime but DateTimeOffset. See the upgrade guide for more details.",
+        ReplacementTypeOrMember = "NServiceBus.DateTimeOffsetExtensions",
+        TreatAsErrorFromVersion = "8",
+        RemoveInVersion = "9")]
+    public static class DateTimeExtensions
+    {
+        [ObsoleteEx(
+            Message = "Public APIs no longer use DateTime but DateTimeOffset. See the upgrade guide for more details.",
+            ReplacementTypeOrMember = "NServiceBus.DateTimeOffsetHelper.ToWireFormattedString",
+            TreatAsErrorFromVersion = "8",
+            RemoveInVersion = "9")]
+        public static string ToWireFormattedString(DateTime dateTime)
+        {
+            throw new NotImplementedException();
+        }
+
+        [ObsoleteEx(
+            Message = "Public APIs no longer use DateTime but DateTimeOffset. See the upgrade guide for more details.",
+            ReplacementTypeOrMember = "NServiceBus.DateTimeOffsetHelper.ToDateTimeOffset",
+            TreatAsErrorFromVersion = "8",
+            RemoveInVersion = "9")]
+        public static DateTime ToUtcDateTime(string wireFormattedString)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
 #pragma warning restore 1591


### PR DESCRIPTION
* Adding `DateTime DateTimeExtensions.ToUtcDateTime(string)` to obsolete methods, requires new API `DateTimeOffset DateTimeExtensions.ToDateTimeOffset`.
* Introducing new class DateTimeOffsetExtensions and extracted helper methods to DateTimeOffsetHelper.