### PR TITLE
Improved v8 obsolete messages

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1574,9 +1574,8 @@ namespace NServiceBus.MessageMutator
 }
 namespace NServiceBus.ObjectBuilder.Common
 {
-    [System.ObsoleteAttribute("The NServiceBus dependency injection container API has been deprecated. Use the e" +
-        "xternally managed container mode to use custom containers. Will be removed in ve" +
-        "rsion 9.0.0.", true)]
+    [System.ObsoleteAttribute("Use the externally managed container mode to use custom containers. Will be remov" +
+        "ed in version 9.0.0.", true)]
     public interface IContainer : System.IDisposable { }
 }
 namespace NServiceBus.ObjectBuilder
@@ -1584,25 +1583,19 @@ namespace NServiceBus.ObjectBuilder
     [System.ObsoleteAttribute("Use `IServiceProvider` instead. Will be removed in version 9.0.0.", true)]
     public interface IBuilder : System.IDisposable
     {
-        [System.ObsoleteAttribute("The Build method is not supported anymore. Use `GetService` instead. Will be remo" +
-            "ved in version 9.0.0.", true)]
+        [System.ObsoleteAttribute("Use `GetService` instead. Will be removed in version 9.0.0.", true)]
         object Build(System.Type typeToBuild);
-        [System.ObsoleteAttribute("The Build<T> method is not supported anymore. Use `GetService` instead. Will be r" +
-            "emoved in version 9.0.0.", true)]
+        [System.ObsoleteAttribute("Use `GetService` instead. Will be removed in version 9.0.0.", true)]
         T Build<T>();
-        [System.ObsoleteAttribute("The BuildAll<T> method is not supported anymore. Use `GetServices` instead. Will " +
-            "be removed in version 9.0.0.", true)]
+        [System.ObsoleteAttribute("Use `GetServices` instead. Will be removed in version 9.0.0.", true)]
         System.Collections.Generic.IEnumerable<T> BuildAll<T>();
-        [System.ObsoleteAttribute("The BuildAll method is not supported anymore. Use `GetServices` instead. Will be " +
-            "removed in version 9.0.0.", true)]
+        [System.ObsoleteAttribute("Use `GetServices` instead. Will be removed in version 9.0.0.", true)]
         System.Collections.Generic.IEnumerable<object> BuildAll(System.Type typeToBuild);
-        [System.ObsoleteAttribute("The BuildAndDispatch method is not supported anymore. Will be removed in version " +
-            "9.0.0.", true)]
+        [System.ObsoleteAttribute("Will be removed in version 9.0.0.", true)]
         void BuildAndDispatch(System.Type typeToBuild, System.Action<object> action);
-        [System.ObsoleteAttribute("The CreateChildBuilder method is not supported anymore. Use `CreateScope` instead" +
-            ". Will be removed in version 9.0.0.", true)]
+        [System.ObsoleteAttribute("Use `CreateScope` instead. Will be removed in version 9.0.0.", true)]
         NServiceBus.ObjectBuilder.IBuilder CreateChildBuilder();
-        [System.ObsoleteAttribute("The Release method is not supported anymore. Will be removed in version 9.0.0.", true)]
+        [System.ObsoleteAttribute("Will be removed in version 9.0.0.", true)]
         void Release(object instance);
     }
     [System.ObsoleteAttribute("Use `IServiceCollection` instead. Will be removed in version 9.0.0.", true)]

--- a/src/NServiceBus.Core/obsoletes-v8.cs
+++ b/src/NServiceBus.Core/obsoletes-v8.cs
@@ -120,25 +120,25 @@ namespace NServiceBus.ObjectBuilder
         RemoveInVersion = "9.0.0")]
     public interface IBuilder : IDisposable
     {
-        [ObsoleteEx(Message = "The Build method is not supported anymore.", ReplacementTypeOrMember = nameof(IServiceProvider.GetService), TreatAsErrorFromVersion = "8.0.0", RemoveInVersion = "9.0.0")]
+        [ObsoleteEx(ReplacementTypeOrMember = nameof(IServiceProvider.GetService), TreatAsErrorFromVersion = "8.0.0", RemoveInVersion = "9.0.0")]
         object Build(Type typeToBuild);
 
-        [ObsoleteEx(Message = "The CreateChildBuilder method is not supported anymore.", ReplacementTypeOrMember = nameof(ServiceProviderServiceExtensions.CreateScope), TreatAsErrorFromVersion = "8.0.0", RemoveInVersion = "9.0.0")]
+        [ObsoleteEx(ReplacementTypeOrMember = nameof(ServiceProviderServiceExtensions.CreateScope), TreatAsErrorFromVersion = "8.0.0", RemoveInVersion = "9.0.0")]
         IBuilder CreateChildBuilder();
 
-        [ObsoleteEx(Message = "The Build<T> method is not supported anymore.", ReplacementTypeOrMember = nameof(ServiceProviderServiceExtensions.GetService), TreatAsErrorFromVersion = "8.0.0", RemoveInVersion = "9.0.0")]
+        [ObsoleteEx(ReplacementTypeOrMember = nameof(ServiceProviderServiceExtensions.GetService), TreatAsErrorFromVersion = "8.0.0", RemoveInVersion = "9.0.0")]
         T Build<T>();
 
-        [ObsoleteEx(Message = "The BuildAll<T> method is not supported anymore.", ReplacementTypeOrMember = nameof(ServiceProviderServiceExtensions.GetServices), TreatAsErrorFromVersion = "8.0.0", RemoveInVersion = "9.0.0")]
+        [ObsoleteEx(ReplacementTypeOrMember = nameof(ServiceProviderServiceExtensions.GetServices), TreatAsErrorFromVersion = "8.0.0", RemoveInVersion = "9.0.0")]
         IEnumerable<T> BuildAll<T>();
 
-        [ObsoleteEx(Message = "The BuildAll method is not supported anymore.", ReplacementTypeOrMember = nameof(ServiceProviderServiceExtensions.GetServices), TreatAsErrorFromVersion = "8.0.0", RemoveInVersion = "9.0.0")]
+        [ObsoleteEx(ReplacementTypeOrMember = nameof(ServiceProviderServiceExtensions.GetServices), TreatAsErrorFromVersion = "8.0.0", RemoveInVersion = "9.0.0")]
         IEnumerable<object> BuildAll(Type typeToBuild);
 
-        [ObsoleteEx(Message = "The Release method is not supported anymore.", TreatAsErrorFromVersion = "8.0.0", RemoveInVersion = "9.0.0")]
+        [ObsoleteEx(TreatAsErrorFromVersion = "8.0.0", RemoveInVersion = "9.0.0")]
         void Release(object instance);
 
-        [ObsoleteEx(Message = "The BuildAndDispatch method is not supported anymore.", TreatAsErrorFromVersion = "8.0.0", RemoveInVersion = "9.0.0")]
+        [ObsoleteEx(TreatAsErrorFromVersion = "8.0.0", RemoveInVersion = "9.0.0")]
         void BuildAndDispatch(Type typeToBuild, Action<object> action);
     }
 
@@ -203,7 +203,7 @@ namespace NServiceBus.ObjectBuilder.Common
     using System;
 
     [ObsoleteEx(
-        Message = "The NServiceBus dependency injection container API has been deprecated. Use the externally managed container mode to use custom containers.",
+        Message = "Use the externally managed container mode to use custom containers.",
         RemoveInVersion = "9.0.0",
         TreatAsErrorFromVersion = "8.0.0")]
     public interface IContainer : IDisposable


### PR DESCRIPTION
Removed unneeded text from messages mentioning APIs are obsolete as the obsolete attribute / compiler error already indicates that.