### PR TITLE
Missing AcceptanceTestingTimeoutPersistence  IPersistTimeouts registration 

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/TimeoutPersister/AcceptanceTestingTimeoutPersistence.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/TimeoutPersister/AcceptanceTestingTimeoutPersistence.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTesting
 {
+    using System;
     using Features;
     using Timeout.Core;
     using Microsoft.Extensions.DependencyInjection;
@@ -13,7 +14,9 @@
 
         protected internal override void Setup(FeatureConfigurationContext context)
         {
-            context.Services.AddSingleton<IQueryTimeouts, AcceptanceTestingTimeoutPersister>();
+            context.Services.AddSingleton(x => new AcceptanceTestingTimeoutPersister(() => DateTimeOffset.UtcNow));
+            context.Services.AddSingleton<IQueryTimeouts>(x => x.GetService<AcceptanceTestingTimeoutPersister>());
+            context.Services.AddSingleton<IPersistTimeouts>(x => x.GetService<AcceptanceTestingTimeoutPersister>());
         }
     }
 }


### PR DESCRIPTION
Fix missing registration for IPersistTimeouts during AcceptanceTestingTimeoutPersistence feature setup.