### PR TITLE
Fix for failing AT after behavior change.

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_non_transactional_message_is_moved_to_error_queue.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_non_transactional_message_is_moved_to_error_queue.cs
@@ -46,6 +46,7 @@
                         .Transactions(TransportTransactionMode.None);
                     config.Pipeline.Register(new ThrowingBehavior(), "Behavior that always throws");
                     config.SendFailedMessagesTo(ErrorSpyAddress);
+                    config.Recoverability().Immediate(x => x.NumberOfRetries(0));
                 });
             }
 

--- a/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_with_at_most_once.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/ImmediateDispatch/When_requesting_immediate_dispatch_with_at_most_once.cs
@@ -29,7 +29,11 @@
         {
             public NonTransactionalEndpoint()
             {
-                EndpointSetup<DefaultServer>((config, context) => { config.ConfigureTransport().Transactions(TransportTransactionMode.None); });
+                EndpointSetup<DefaultServer>((config, context) =>
+                {
+                    config.ConfigureTransport().Transactions(TransportTransactionMode.None);
+                    config.Recoverability().Immediate(x => x.NumberOfRetries(0));
+                });
             }
 
             public class InitiatingMessageHandler : IHandleMessages<InitiatingMessage>


### PR DESCRIPTION
 Immediate retries need to be explicitly disabled when using transaction mode none.