### PR TITLE
Fix race on When_blowing_up_just_after_dispatch

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Outbox/When_blowing_up_just_after_dispatch.cs
+++ b/src/NServiceBus.AcceptanceTests/Outbox/When_blowing_up_just_after_dispatch.cs
@@ -18,15 +18,15 @@
                 .WithEndpoint<NonDtcReceivingEndpoint>(b => b
                     .DoNotFailOnErrorMessages() // PlaceOrder should fail due to exception after dispatch
                     .When(session => session.SendLocal(new PlaceOrder())))
-                .Done(c => c.OrderAckReceived == 1)
+                .Done(c => c.OrderAckReceived)
                 .Run(TimeSpan.FromSeconds(20));
 
-            Assert.AreEqual(1, context.OrderAckReceived, "Order ack should have been received since outbox dispatch isn't part of the receive tx");
+            Assert.IsTrue(context.OrderAckReceived, "Order ack should have been received since outbox dispatch isn't part of the receive tx");
         }
 
         public class Context : ScenarioContext
         {
-            public int OrderAckReceived { get; set; }
+            public bool OrderAckReceived { get; set; }
         }
 
         public class NonDtcReceivingEndpoint : EndpointConfigurationBuilder
@@ -68,7 +68,7 @@
 
                 public Task Handle(SendOrderAcknowledgment message, IMessageHandlerContext context)
                 {
-                    testContext.OrderAckReceived++;
+                    testContext.OrderAckReceived = true;
                     return Task.FromResult(0);
                 }
 


### PR DESCRIPTION
I was hunting down several bugs in ASP because this test randomly failing. It helped me to find a few things but still, it is randomly failing. I think this test makes wrong assumptions by trying to be accurate. When we blow up right after dispatch the message will go through retries. Due to that, it is entirely possible to handle yet another retry between the done condition being observed as true and actually shutting down. From the perspective of the test we only care about the fact that the operations go out and not how many times they go out so a bool flag is way more representative of the behavior, we want to observe. I decided against having a greater or equal condition. 