### PR TITLE
Increase delay to 5 seconds to compensate for send/receive latency

### DIFF
--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_Deferring_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_Deferring_a_message.cs
@@ -13,7 +13,7 @@
         {
             Requires.DelayedDelivery();
 
-            var delay = TimeSpan.FromSeconds(20); // High value needed as most transports have multi second delay latency by default/
+            var delay = TimeSpan.FromSeconds(5); // High value needed as most transports have multi second delay latency by default
 
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) =>

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_Deferring_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_Deferring_a_message.cs
@@ -13,7 +13,7 @@
         {
             Requires.DelayedDelivery();
 
-            var delay = TimeSpan.FromSeconds(2);
+            var delay = TimeSpan.FromSeconds(20); // High value needed as most transports have multi second delay latency by default/
 
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) =>

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_to_non_local.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_to_non_local.cs
@@ -15,7 +15,7 @@
         {
             Requires.DelayedDelivery();
 
-            var delay = TimeSpan.FromSeconds(2);
+            var delay = TimeSpan.FromSeconds(20); // High value needed as most transports have multi second delay latency by default/
 
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) =>

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_to_non_local.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_to_non_local.cs
@@ -15,7 +15,7 @@
         {
             Requires.DelayedDelivery();
 
-            var delay = TimeSpan.FromSeconds(20); // High value needed as most transports have multi second delay latency by default/
+            var delay = TimeSpan.FromSeconds(5); // High value needed as most transports have multi second delay latency by default
 
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.When((session, c) =>


### PR DESCRIPTION
Most transports have a multi-second send/receive latency by default due to setup/teardown. Local testing even had this sometimes be 15 seconds. This ensures the test is not accidentally green due to standard latency.