### PR TITLE
Exclude Microsoft.Data.SqlClient from assembly scanning

### DIFF
--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
@@ -111,6 +111,7 @@
                 case "cc7b13ffcd2ddd51":
                 case "adb9793829ddae60":
                 case "7e34167dcc6d6d8c": // Microsoft.Azure.ServiceBus
+                case "23ec7fc2d6eaa4a5": // Microsoft.Data.SqlClient
                     return true;
                 default:
                     return false;


### PR DESCRIPTION
Azure Functions has [implemented this change](https://github.com/Particular/NServiceBus.AzureFunctions.ServiceBus/pull/104) to avoid picking up `Microsoft.Data.SqlClient` during assembly scanning and loading incorrect assembly.

