### PR TITLE
remove R# suppressions

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/Outbox/AcceptanceTestingOutboxPersistence.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/Outbox/AcceptanceTestingOutboxPersistence.cs
@@ -58,7 +58,6 @@
             readonly AcceptanceTestingOutboxStorage acceptanceTestingOutboxStorage;
             readonly TimeSpan timeToKeepDeduplicationData;
 
-// ReSharper disable once NotAccessedField.Local
             Timer cleanupTimer;
         }
     }

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/SagaPersister/AcceptanceTestingSagaPersister.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/SagaPersister/AcceptanceTestingSagaPersister.cs
@@ -161,7 +161,6 @@ namespace NServiceBus.AcceptanceTesting
 
             public IContainSagaData GetSagaCopy()
             {
-                // ReSharper disable once ConvertClosureToMethodGroup, no allocations are needed!
                 var canBeShallowCopied = canBeShallowCopiedCache.GetOrAdd(data.GetType(), type => CanBeShallowCopied(type));
                 return canBeShallowCopied ? shallowCopy(data) : DeepCopy(data);
             }


### PR DESCRIPTION
Introduced in https://github.com/Particular/NServiceBus/pull/5781.

Note that we removed all R# artifacts in https://github.com/Particular/NServiceBus/pull/5776/files as part of switching over to StyleCop.Analyzers.