### PR TITLE
Enable some missing core acceptance tests

### DIFF
--- a/src/NServiceBus.AcceptanceTests/ApprovalFiles/When_endpoint_is_warmed_up.Make_sure_things_are_in_DI.approved.txt
+++ b/src/NServiceBus.AcceptanceTests/ApprovalFiles/When_endpoint_is_warmed_up.Make_sure_things_are_in_DI.approved.txt
@@ -2,8 +2,11 @@
 NServiceBus.InferredMessageTypeEnricherBehavior - Transient
 NServiceBus.Persistence.ISynchronizedStorage - Singleton
 NServiceBus.Persistence.ISynchronizedStorageAdapter - Singleton
+NServiceBus.SubscriptionReceiverBehavior - Transient
 NServiceBus.Transport.IDispatchMessages - Singleton
 NServiceBus.Unicast.MessageHandlerRegistry - Singleton
+NServiceBus.Unicast.Messages.MessageMetadataRegistry - Singleton
+NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.ISubscriptionStorage - Singleton
 ----------- Registrations not used by the core, can be removed in next major if downstreams have been confirmed to not use it -----------
 NServiceBus.CriticalError - Singleton
 NServiceBus.Hosting.HostInformation - Singleton
@@ -13,6 +16,6 @@ NServiceBus.MessageInterfaces.IMessageMapper - Singleton
 NServiceBus.Notifications - Singleton
 NServiceBus.Pipeline.IBehavior - Transient
 NServiceBus.Pipeline.IBehavior`2[[NServiceBus.Pipeline.IIncomingLogicalMessageContext, NServiceBus.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c],[NServiceBus.Pipeline.IIncomingLogicalMessageContext, NServiceBus.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c]] - Transient
+NServiceBus.Pipeline.IBehavior`2[[NServiceBus.Pipeline.IIncomingPhysicalMessageContext, NServiceBus.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c],[NServiceBus.Pipeline.IIncomingPhysicalMessageContext, NServiceBus.Core, Version=8.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c]] - Transient
 NServiceBus.Pipeline.LogicalMessageFactory - Singleton
 NServiceBus.Settings.ReadOnlySettings - Singleton
-NServiceBus.Unicast.Messages.MessageMetadataRegistry - Singleton

--- a/src/NServiceBus.AcceptanceTests/Core/TestSuiteConstraints.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/TestSuiteConstraints.cs
@@ -8,6 +8,9 @@
 
         public bool SupportsCrossQueueTransactions => true;
 
+        // Disable native pub-sub for tests that require message-driven pub-sub. The tests in the "Core"
+        // folder are not shipped to downstreams and therefore are only executed on this test project and
+        // "NServiceBus.Learning.AcceptanceTests" (which is running the tests using native pub-sub).
         public bool SupportsNativePubSub => false;
 
         public bool SupportsDelayedDelivery => false;

--- a/src/NServiceBus.AcceptanceTests/Core/TestSuiteConstraints.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/TestSuiteConstraints.cs
@@ -8,7 +8,7 @@
 
         public bool SupportsCrossQueueTransactions => true;
 
-        public bool SupportsNativePubSub => true;
+        public bool SupportsNativePubSub => false;
 
         public bool SupportsDelayedDelivery => false;
 


### PR DESCRIPTION
I recently noticed that a bunch of acceptance tests that are part of the `Core` folder, and therefore not shipped to downstreams, are never executed because their test requirements were never met.

There are in total 4 tests in the Core folder that require message-driven pub-sub and did not run because the transport in both acceptance tests projects in the repo were configured using native pub-sub. One test required native pub-sub to run. I changed the one test to be compatible with message-driven pub-sub and switched over the configuration of `NServiceBus.AcceptanceTests` to use message-driven pub-sub. Notice that `NServiceBus.Learning.AcceptanceTests` does support native pub-sub and therefore all tests requiring native pub-sub are still run as part of the repo's test suites.

