### PR TITLE
Log starting FeatureStartupTasks

### DIFF
--- a/src/NServiceBus.Core/Features/FeatureStartupTaskController.cs
+++ b/src/NServiceBus.Core/Features/FeatureStartupTaskController.cs
@@ -16,6 +16,11 @@
 
         public Task Start(IServiceProvider builder, IMessageSession messageSession)
         {
+            if (Log.IsDebugEnabled)
+            {
+                Log.Debug($"Starting {nameof(FeatureStartupTask)} '{Name}'.");
+            }
+
             instance = factory(builder);
             return instance.PerformStartup(messageSession);
         }


### PR DESCRIPTION
log `FeatureStartupTask`s that are being started. This can be extremely valuable information when investigating issues that might involve FST order.