### PR TITLE
Transport seam infrastructure

### DIFF
--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -73,13 +73,11 @@ namespace NServiceBus
 
             hostingConfiguration.Services.ConfigureComponent(b => settings.Get<Notifications>(), DependencyLifecycle.SingleInstance);
 
-            receiveComponent = ReceiveComponent.Configure(
+            receiveComponent = ReceiveComponent.Initialize(
                 receiveConfiguration,
                 settings.ErrorQueueAddress(),
                 hostingConfiguration,
                 pipelineSettings);
-
-            receiveComponent.Initialize(transportSeam);
 
             pipelineComponent = PipelineComponent.Initialize(pipelineSettings, hostingConfiguration);
 

--- a/src/NServiceBus.Core/Pipeline/Outgoing/SendComponent.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/SendComponent.cs
@@ -34,8 +34,6 @@ namespace NServiceBus
 
             var sendComponent = new SendComponent(messageMapper, transportSeam);
 
-            hostingConfiguration.Services.ConfigureComponent(() => sendComponent.transportSeam.TransportInfrastructure.Dispatcher, DependencyLifecycle.SingleInstance);
-
             return sendComponent;
         }
 

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.Configuration.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.Configuration.cs
@@ -20,8 +20,6 @@ namespace NServiceBus
                 throw new Exception($"Specifying a base name for the input queue using `{nameof(ReceiveSettingsExtensions.OverrideLocalAddress)}(baseInputQueueName)` is not supported for send-only endpoints.");
             }
 
-            hostingConfiguration.Services.ConfigureComponent(() => transportSeam.TransportInfrastructure.GetReceiver(MainReceiverId).Subscriptions, DependencyLifecycle.SingleInstance);
-
             var endpointName = settings.EndpointName;
             var discriminator = settings.EndpointInstanceDiscriminator;
             var queueNameBase = settings.CustomLocalAddress ?? endpointName;

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -34,7 +34,7 @@ namespace NServiceBus
 
         public async Task<IEndpointInstance> Start()
         {
-            await transportSeam.Initialize().ConfigureAwait(false);
+            var transportInfrastructure = await transportSeam.CreateTransportInfrastructure().ConfigureAwait(false);
 
             var pipelineCache = pipelineComponent.BuildPipelineCache(builder);
             var messageOperations = sendComponent.CreateMessageOperations(builder, pipelineComponent);
@@ -51,9 +51,9 @@ namespace NServiceBus
 #endif
             await featureComponent.Start(builder, messageSession).ConfigureAwait(false);
 
-            var runningInstance = new RunningEndpointInstance(settings, hostingComponent, receiveComponent, featureComponent, messageSession, transportSeam.TransportInfrastructure);
+            var runningInstance = new RunningEndpointInstance(settings, hostingComponent, receiveComponent, featureComponent, messageSession, transportInfrastructure);
 
-            await receiveComponent.Start(builder, recoverabilityComponent, messageOperations, pipelineComponent, pipelineCache).ConfigureAwait(false);
+            await receiveComponent.Start(builder, recoverabilityComponent, messageOperations, pipelineComponent, pipelineCache, transportInfrastructure).ConfigureAwait(false);
 
             return runningInstance;
         }


### PR DESCRIPTION
proposed small refactoring to hide the `transportSeam.TransportInfrastructure` property. With this, the property can't be accessed accidentally before the transport has been created. In most cases, it is safe to pass the `TransportInfrastructure` instance as an argument to other components, however there is one edge case: We register the `ISubscriptionManager` for the main receiver in the DI container, this registration requires access to the `TransportInfrastructure`. We can't complete that registration (by assigning the internal field value used by the registration) in the `ReceiveComponent.Start` because at this point we expect the pipeline to already been built. The pipeline cache will fail to build because that runs before we start the receiver. With an event (as proposed here) we could ensure that any other internal component gets access to the `TransportInfrastructure` to "complete" any DI registrations made by that component before anything else happens.

Alternatively to using an event, we could also workaround this "race condition" by calling `receiveComponent.FinishDiRegistration(transportInfrastructure);` right after creating the transport infrastructure and before building the pipeline. This way we can also hide the `TransportInfrastructure` property on `TransportSeam` and make the behavior more explicit.