### PR TITLE
Do not treat TransportExtensions type as error from v8

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1067,7 +1067,7 @@ namespace NServiceBus
         public void ToSaga(System.Linq.Expressions.Expression<System.Func<TSagaData, object>> sagaEntityProperty) { }
     }
     [System.Obsolete("Configure the transport via the TransportDefinition instance\'s properties. Will b" +
-        "e treated as an error from version 9.0.0. Will be removed in version 9.0.0.", false)]
+        "e removed in version 9.0.0.", true)]
     public class TransportExtensions : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         [System.Obsolete("Configure the transport via the TransportDefinition instance\'s properties. Will b" +
@@ -1088,7 +1088,7 @@ namespace NServiceBus
         public NServiceBus.TransportExtensions Transactions(NServiceBus.TransportTransactionMode transportTransactionMode) { }
     }
     [System.Obsolete("Configure the transport via the TransportDefinition instance\'s properties. Will b" +
-        "e treated as an error from version 9.0.0. Will be removed in version 9.0.0.", false)]
+        "e removed in version 9.0.0.", true)]
     public class TransportExtensions<T> : NServiceBus.TransportExtensions
         where T : NServiceBus.Transport.TransportDefinition
     {

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1067,7 +1067,7 @@ namespace NServiceBus
         public void ToSaga(System.Linq.Expressions.Expression<System.Func<TSagaData, object>> sagaEntityProperty) { }
     }
     [System.Obsolete("Configure the transport via the TransportDefinition instance\'s properties. Will b" +
-        "e removed in version 9.0.0.", true)]
+        "e treated as an error from version 9.0.0. Will be removed in version 9.0.0.", false)]
     public class TransportExtensions : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings
     {
         [System.Obsolete("Configure the transport via the TransportDefinition instance\'s properties. Will b" +
@@ -1088,7 +1088,7 @@ namespace NServiceBus
         public NServiceBus.TransportExtensions Transactions(NServiceBus.TransportTransactionMode transportTransactionMode) { }
     }
     [System.Obsolete("Configure the transport via the TransportDefinition instance\'s properties. Will b" +
-        "e removed in version 9.0.0.", true)]
+        "e treated as an error from version 9.0.0. Will be removed in version 9.0.0.", false)]
     public class TransportExtensions<T> : NServiceBus.TransportExtensions
         where T : NServiceBus.Transport.TransportDefinition
     {

--- a/src/NServiceBus.Core/obsoletes-v8.cs
+++ b/src/NServiceBus.Core/obsoletes-v8.cs
@@ -352,7 +352,6 @@ namespace NServiceBus
     // The type itself can't be configured with TreatAsErrorFromVersion 8 as downstream extension methods require the type to obsolete their own extension methods.
     [ObsoleteEx(
         Message = "Configure the transport via the TransportDefinition instance's properties",
-        TreatAsErrorFromVersion = "9.0",
         RemoveInVersion = "9.0")]
     public class TransportExtensions<T> : TransportExtensions where T : TransportDefinition
     {
@@ -407,7 +406,6 @@ namespace NServiceBus
     // The type itself can't be configured with TreatAsErrorFromVersion 8 as downstream extension methods require the type to obsolete their own extension methods.
     [ObsoleteEx(
         Message = "Configure the transport via the TransportDefinition instance's properties",
-        TreatAsErrorFromVersion = "9.0",
         RemoveInVersion = "9.0")]
     public class TransportExtensions : ExposeSettings
     {

--- a/src/NServiceBus.Core/obsoletes-v8.cs
+++ b/src/NServiceBus.Core/obsoletes-v8.cs
@@ -349,9 +349,10 @@ namespace NServiceBus
 {
     using System;
 
+    // The type itself can't be configured with TreatAsErrorFromVersion 8 as downstream extension methods require the type to obsolete their own extension methods.
     [ObsoleteEx(
         Message = "Configure the transport via the TransportDefinition instance's properties",
-        TreatAsErrorFromVersion = "8.0",
+        TreatAsErrorFromVersion = "9.0",
         RemoveInVersion = "9.0")]
     public class TransportExtensions<T> : TransportExtensions where T : TransportDefinition
     {
@@ -403,9 +404,10 @@ namespace NServiceBus
         }
     }
 
+    // The type itself can't be configured with TreatAsErrorFromVersion 8 as downstream extension methods require the type to obsolete their own extension methods.
     [ObsoleteEx(
         Message = "Configure the transport via the TransportDefinition instance's properties",
-        TreatAsErrorFromVersion = "8.0",
+        TreatAsErrorFromVersion = "9.0",
         RemoveInVersion = "9.0")]
     public class TransportExtensions : ExposeSettings
     {

--- a/src/NServiceBus.Core/obsoletes-v8.cs
+++ b/src/NServiceBus.Core/obsoletes-v8.cs
@@ -352,6 +352,7 @@ namespace NServiceBus
     // The type itself can't be configured with TreatAsErrorFromVersion 8 as downstream extension methods require the type to obsolete their own extension methods.
     [ObsoleteEx(
         Message = "Configure the transport via the TransportDefinition instance's properties",
+        TreatAsErrorFromVersion = "9.0",
         RemoveInVersion = "9.0")]
     public class TransportExtensions<T> : TransportExtensions where T : TransportDefinition
     {
@@ -406,6 +407,7 @@ namespace NServiceBus
     // The type itself can't be configured with TreatAsErrorFromVersion 8 as downstream extension methods require the type to obsolete their own extension methods.
     [ObsoleteEx(
         Message = "Configure the transport via the TransportDefinition instance's properties",
+        TreatAsErrorFromVersion = "9.0",
         RemoveInVersion = "9.0")]
     public class TransportExtensions : ExposeSettings
     {


### PR DESCRIPTION
To make sure the downstream extension methods can still compile with obsolete messages of their extension methods.