### PR TITLE
Remove CancellationToken from the new seam

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransport.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransport.cs
@@ -15,7 +15,7 @@ namespace NServiceBus
         {
         }
 
-        public override async Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken = default)
+        public override async Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses)
         {
             Guard.AgainstNull(nameof(hostSettings), hostSettings);
 

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeDispatcher.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeDispatcher.cs
@@ -7,7 +7,7 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport
 
     class FakeDispatcher : IMessageDispatcher
     {
-        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
+        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction)
         {
             return Task.CompletedTask;
         }

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeReceiver.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeReceiver.cs
@@ -26,14 +26,13 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport
         }
 
         public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage,
-            Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events,
-            CancellationToken cancellationToken = default)
+            Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events)
         {
             startupSequence.Add($"{nameof(IMessageReceiver)}.{nameof(Initialize)} for receiver {Id}");
             return Task.CompletedTask;
         }
 
-        public Task StartReceive(CancellationToken cancellationToken = default)
+        public Task StartReceive()
         {
             startupSequence.Add($"{nameof(IMessageReceiver)}.{nameof(StartReceive)} for receiver {Id}");
 
@@ -46,7 +45,7 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport
             return Task.CompletedTask;
         }
 
-        public async Task StopReceive(CancellationToken cancellationToken = default)
+        public async Task StopReceive()
         {
             startupSequence.Add($"{nameof(IMessageReceiver)}.{nameof(StopReceive)} for receiver {Id}");
 
@@ -63,14 +62,12 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport
 
         class FakeSubscriptionManager : ISubscriptionManager
         {
-            public Task Subscribe(MessageMetadata eventType, ContextBag context,
-                CancellationToken cancellationToken = default)
+            public Task Subscribe(MessageMetadata eventType, ContextBag context)
             {
                 return Task.CompletedTask;
             }
 
-            public Task Unsubscribe(MessageMetadata eventType, ContextBag context,
-                CancellationToken cancellationToken = default)
+            public Task Unsubscribe(MessageMetadata eventType, ContextBag context)
             {
                 return Task.CompletedTask;
             }

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransport.cs
@@ -17,12 +17,11 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport
         {
         }
 
-        public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses,
-            CancellationToken cancellationToken = default)
+        public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses)
         {
             StartupSequence.Add($"{nameof(TransportDefinition)}.{nameof(Initialize)}");
 
-            var infrastructure = new FakeTransportInfrastructure(StartupSequence, hostSettings, receivers, sendingAddresses,cancellationToken, this);
+            var infrastructure = new FakeTransportInfrastructure(StartupSequence, hostSettings, receivers, sendingAddresses, this);
 
             infrastructure.ConfigureSendInfrastructure();
             infrastructure.ConfigureReceiveInfrastructure();

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
@@ -13,29 +13,26 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport
         readonly HostSettings hostSettings;
         readonly ReceiveSettings[] receivers;
         readonly string[] sendingAddresses;
-        readonly CancellationToken cancellationToken;
         readonly FakeTransport transportSettings;
 
         public FakeTransportInfrastructure(FakeTransport.StartUpSequence startUpSequence, HostSettings hostSettings,
-            ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken,
-            FakeTransport transportSettings)
+            ReceiveSettings[] receivers, string[] sendingAddresses, FakeTransport transportSettings)
         {
             this.startUpSequence = startUpSequence;
             this.hostSettings = hostSettings;
             this.receivers = receivers;
             this.sendingAddresses = sendingAddresses;
-            this.cancellationToken = cancellationToken;
             this.transportSettings = transportSettings;
         }
 
         public void ConfigureReceiveInfrastructure()
         {
             Receivers = receivers
-                .Select(r => 
+                .Select(r =>
                     new FakeReceiver(
-                        r.Id, 
-                        transportSettings, 
-                        startUpSequence, 
+                        r.Id,
+                        transportSettings,
+                        startUpSequence,
                         hostSettings.CriticalErrorAction))
                 .ToList<IMessageReceiver>()
                 .AsReadOnly();

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -80,7 +80,7 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport.ProcessingOptimizations
             {
             }
 
-            public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken = default)
+            public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses)
             {
                 return Task.FromResult<TransportInfrastructure>(new FakeTransportInfrastructure(receivers));
             }

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -43,20 +43,20 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport.ProcessingOptimizations
         {
             PushRuntimeSettings pushSettings;
 
-            public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events, CancellationToken cancellationToken = default)
+            public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events)
             {
                 pushSettings = limitations;
                 return Task.CompletedTask;
             }
 
-            public Task StartReceive(CancellationToken cancellationToken = default)
+            public Task StartReceive()
             {
                 Assert.AreEqual(10, pushSettings.MaxConcurrency);
 
                 return Task.CompletedTask;
             }
 
-            public Task StopReceive(CancellationToken cancellationToken = default)
+            public Task StopReceive()
             {
                 return Task.CompletedTask;
             }
@@ -68,7 +68,7 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport.ProcessingOptimizations
 
         class FakeDispatcher : IMessageDispatcher
         {
-            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction)
             {
                 return Task.FromResult(0);
             }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2370,15 +2370,15 @@ namespace NServiceBus.Transport
     }
     public interface IMessageDispatcher
     {
-        System.Threading.Tasks.Task Dispatch(NServiceBus.Transport.TransportOperations outgoingMessages, NServiceBus.Transport.TransportTransaction transaction, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task Dispatch(NServiceBus.Transport.TransportOperations outgoingMessages, NServiceBus.Transport.TransportTransaction transaction);
     }
     public interface IMessageReceiver
     {
         string Id { get; }
         NServiceBus.Transport.ISubscriptionManager Subscriptions { get; }
-        System.Threading.Tasks.Task Initialize(NServiceBus.Transport.PushRuntimeSettings limitations, System.Func<NServiceBus.Transport.MessageContext, System.Threading.Tasks.Task> onMessage, System.Func<NServiceBus.Transport.ErrorContext, System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult>> onError, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Unicast.Messages.MessageMetadata> events, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task StartReceive(System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task StopReceive(System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task Initialize(NServiceBus.Transport.PushRuntimeSettings limitations, System.Func<NServiceBus.Transport.MessageContext, System.Threading.Tasks.Task> onMessage, System.Func<NServiceBus.Transport.ErrorContext, System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult>> onError, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Unicast.Messages.MessageMetadata> events);
+        System.Threading.Tasks.Task StartReceive();
+        System.Threading.Tasks.Task StopReceive();
     }
     public interface IOutgoingTransportOperation
     {
@@ -2398,8 +2398,8 @@ namespace NServiceBus.Transport
     }
     public interface ISubscriptionManager
     {
-        System.Threading.Tasks.Task Subscribe(NServiceBus.Unicast.Messages.MessageMetadata eventType, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);
-        System.Threading.Tasks.Task Unsubscribe(NServiceBus.Unicast.Messages.MessageMetadata eventType, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task Subscribe(NServiceBus.Unicast.Messages.MessageMetadata eventType, NServiceBus.Extensibility.ContextBag context);
+        System.Threading.Tasks.Task Unsubscribe(NServiceBus.Unicast.Messages.MessageMetadata eventType, NServiceBus.Extensibility.ContextBag context);
     }
     public class IncomingMessage
     {

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -656,7 +656,7 @@ namespace NServiceBus
         public bool RestrictPayloadSize { get; set; }
         public string StorageDirectory { get; set; }
         public override System.Collections.Generic.IReadOnlyCollection<NServiceBus.TransportTransactionMode> GetSupportedTransactionModes() { }
-        public override System.Threading.Tasks.Task<NServiceBus.Transport.TransportInfrastructure> Initialize(NServiceBus.Transport.HostSettings hostSettings, NServiceBus.Transport.ReceiveSettings[] receivers, string[] sendingAddresses, System.Threading.CancellationToken cancellationToken = default) { }
+        public override System.Threading.Tasks.Task<NServiceBus.Transport.TransportInfrastructure> Initialize(NServiceBus.Transport.HostSettings hostSettings, NServiceBus.Transport.ReceiveSettings[] receivers, string[] sendingAddresses) { }
         public override string ToTransportAddress(NServiceBus.Transport.QueueAddress queueAddress) { }
     }
     public static class LoadMessageHandlersExtensions
@@ -2531,7 +2531,7 @@ namespace NServiceBus.Transport
         public bool SupportsTTBR { get; }
         public virtual NServiceBus.TransportTransactionMode TransportTransactionMode { get; set; }
         public abstract System.Collections.Generic.IReadOnlyCollection<NServiceBus.TransportTransactionMode> GetSupportedTransactionModes();
-        public abstract System.Threading.Tasks.Task<NServiceBus.Transport.TransportInfrastructure> Initialize(NServiceBus.Transport.HostSettings hostSettings, NServiceBus.Transport.ReceiveSettings[] receivers, string[] sendingAddresses, System.Threading.CancellationToken cancellationToken = default);
+        public abstract System.Threading.Tasks.Task<NServiceBus.Transport.TransportInfrastructure> Initialize(NServiceBus.Transport.HostSettings hostSettings, NServiceBus.Transport.ReceiveSettings[] receivers, string[] sendingAddresses);
         public abstract string ToTransportAddress(NServiceBus.Transport.QueueAddress address);
     }
     public abstract class TransportInfrastructure

--- a/src/NServiceBus.Core.Tests/Recoverability/DelayedRetryExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/DelayedRetryExecutorTests.cs
@@ -116,7 +116,7 @@ namespace NServiceBus.Core.Tests.Recoverability
 
             public TransportTransaction Transaction { get; private set; }
 
-            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction)
             {
                 TransportOperations = outgoingMessages;
                 Transaction = transaction;

--- a/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
@@ -147,7 +147,7 @@ namespace NServiceBus.Core.Tests.Recoverability
 
             public TransportTransaction Transaction { get; private set; }
 
-            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction)
             {
                 TransportOperations = outgoingMessages;
                 Transaction = transaction;

--- a/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
@@ -274,7 +274,7 @@ namespace NServiceBus.Core.Tests.Recoverability
         {
             public TransportOperations TransportOperations { get; private set; }
 
-            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction)
             {
                 TransportOperations = outgoingMessages;
                 return Task.CompletedTask;

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
@@ -96,7 +96,7 @@ namespace NServiceBus.Core.Tests.Routing
 
             public List<TransportOperations> DispatchedTransportOperations { get; } = new List<TransportOperations>();
 
-            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction)
             {
                 if (numberOfTimes.HasValue && FailedNumberOfTimes < numberOfTimes.Value)
                 {

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensionsTests.cs
@@ -166,8 +166,7 @@ namespace NServiceBus.Core.Tests.Routing.MessageDrivenSubscriptions
         {
         }
 
-        public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses,
-            CancellationToken cancellationToken = default)
+        public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses)
         {
             throw new NotImplementedException();
         }

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
@@ -92,7 +92,7 @@ namespace NServiceBus.Core.Tests.Routing
                 numberOfTimes = times;
             }
 
-            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction)
             {
                 if (numberOfTimes.HasValue && FailedNumberOfTimes < numberOfTimes.Value)
                 {

--- a/src/NServiceBus.Core.Tests/Timeout/FakeMessageDispatcher.cs
+++ b/src/NServiceBus.Core.Tests/Timeout/FakeMessageDispatcher.cs
@@ -15,7 +15,7 @@ namespace NServiceBus.Core.Tests.Timeout
             set { messagesSent = value; }
         }
 
-        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transportTransaction, CancellationToken cancellationToken = default)
+        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transportTransaction)
         {
             MessagesSent += outgoingMessages.MulticastTransportOperations.Count + outgoingMessages.UnicastTransportOperations.Count;
             return Task.CompletedTask;

--- a/src/NServiceBus.Core.Tests/Transports/Learning/LearningTransportDispatcherTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/Learning/LearningTransportDispatcherTests.cs
@@ -22,8 +22,8 @@ namespace NServiceBus.Core.Tests.Transports.Learning
             var messageAtThreshold = new OutgoingMessage("id", headers, new byte[MessageSizeLimit]);
             var messageAboveThreshold = new OutgoingMessage("id", headers, new byte[MessageSizeLimit + 1]);
 
-            await dispatcher.Dispatch(new TransportOperations(new TransportOperation(messageAtThreshold, new UnicastAddressTag("my-destination"))), new TransportTransaction(), CancellationToken.None);
-            var ex = Assert.ThrowsAsync<Exception>(async () => await dispatcher.Dispatch(new TransportOperations(new TransportOperation(messageAboveThreshold, new UnicastAddressTag("my-destination"))), new TransportTransaction(), CancellationToken.None));
+            await dispatcher.Dispatch(new TransportOperations(new TransportOperation(messageAtThreshold, new UnicastAddressTag("my-destination"))), new TransportTransaction());
+            var ex = Assert.ThrowsAsync<Exception>(async () => await dispatcher.Dispatch(new TransportOperations(new TransportOperation(messageAboveThreshold, new UnicastAddressTag("my-destination"))), new TransportTransaction()));
 
             StringAssert.Contains("The total size of the 'TestMessage' message", ex.Message);
         }

--- a/src/NServiceBus.Core.Tests/Transports/TransportReceiverTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/TransportReceiverTests.cs
@@ -33,7 +33,7 @@ namespace NServiceBus.Core.Tests.Transports
         {
             pump.ThrowOnStart = true;
 
-            Assert.ThrowsAsync<InvalidOperationException>(async () => 
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
                 await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled), new List<MessageMetadata>())
                 );
         }
@@ -70,13 +70,12 @@ namespace NServiceBus.Core.Tests.Transports
             public bool Stopped { get; private set; }
 
 
-            public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events,
-                CancellationToken cancellationToken = default)
+            public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events)
             {
                 return Task.CompletedTask;
             }
 
-            public Task StartReceive(CancellationToken cancellationToken = default)
+            public Task StartReceive()
             {
                 if (ThrowOnStart)
                 {
@@ -88,7 +87,7 @@ namespace NServiceBus.Core.Tests.Transports
                 return Task.CompletedTask;
             }
 
-            public Task StopReceive(CancellationToken cancellationToken = default)
+            public Task StopReceive()
             {
                 if (ThrowOnStop)
                 {

--- a/src/NServiceBus.Core/Pipeline/Outgoing/ImmediateDispatchTerminator.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/ImmediateDispatchTerminator.cs
@@ -19,7 +19,7 @@ namespace NServiceBus
         {
             var transaction = context.Extensions.GetOrCreate<TransportTransaction>();
             var operations = context.Operations as TransportOperation[] ?? context.Operations.ToArray();
-            return dispatcher.Dispatch(new TransportOperations(operations), transaction, CancellationToken.None);
+            return dispatcher.Dispatch(new TransportOperations(operations), transaction);
         }
 
         readonly IMessageDispatcher dispatcher;

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -193,7 +193,7 @@ namespace NServiceBus
             {
                 Logger.DebugFormat("Receiver {0} is starting.", messageReceiver.Id);
 
-                await messageReceiver.StartReceive(CancellationToken.None).ConfigureAwait(false);
+                await messageReceiver.StartReceive().ConfigureAwait(false);
                 //TODO: If we fails starting N-th receiver then we need to stop and dispose N-1 receivers
             }
         }
@@ -219,7 +219,7 @@ namespace NServiceBus
                 Logger.DebugFormat("Stopping {0} receiver", receiver.Id);
                 try
                 {
-                    await receiver.StopReceive(CancellationToken.None).ConfigureAwait(false);
+                    await receiver.StopReceive().ConfigureAwait(false);
                     (receiver as IDisposable)?.Dispose();
                     Logger.DebugFormat("Stopped {0} receiver", receiver.Id);
                 }

--- a/src/NServiceBus.Core/Recoverability/DelayedRetryExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/DelayedRetryExecutor.cs
@@ -33,7 +33,7 @@ namespace NServiceBus
 
             var transportOperations = new TransportOperations(new TransportOperation(outgoingMessage, messageDestination, messageProperties.ToDictionary()));
 
-            await dispatcher.Dispatch(transportOperations, transportTransaction, CancellationToken.None).ConfigureAwait(false);
+            await dispatcher.Dispatch(transportOperations, transportTransaction).ConfigureAwait(false);
 
             return currentDelayedRetriesAttempt;
         }

--- a/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
@@ -40,7 +40,7 @@ namespace NServiceBus
 
             var transportOperations = new TransportOperations(new TransportOperation(outgoingMessage, new UnicastAddressTag(errorQueueAddress)));
 
-            return dispatcher.Dispatch(transportOperations, transportTransaction, CancellationToken.None);
+            return dispatcher.Dispatch(transportOperations, transportTransaction);
         }
 
         IMessageDispatcher dispatcher;

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -60,7 +60,7 @@ namespace NServiceBus
             {
                 var transportOperation = new TransportOperation(subscriptionMessage, new UnicastAddressTag(destination));
                 var transportTransaction = context.GetOrCreate<TransportTransaction>();
-                await dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction, CancellationToken.None).ConfigureAwait(false);
+                await dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction).ConfigureAwait(false);
             }
             catch (QueueNotFoundException ex)
             {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -60,7 +60,7 @@ namespace NServiceBus
             {
                 var transportOperation = new TransportOperation(unsubscribeMessage, new UnicastAddressTag(destination));
                 var transportTransaction = context.GetOrCreate<TransportTransaction>();
-                await dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction, CancellationToken.None).ConfigureAwait(false);
+                await dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction).ConfigureAwait(false);
             }
             catch (QueueNotFoundException ex)
             {

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationSubscribeTerminator.cs
@@ -69,7 +69,7 @@ namespace NServiceBus
             {
                 var transportOperation = new TransportOperation(subscriptionMessage, new UnicastAddressTag(destination));
                 var transportTransaction = context.GetOrCreate<TransportTransaction>();
-                await dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction, CancellationToken.None).ConfigureAwait(false);
+                await dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction).ConfigureAwait(false);
             }
             catch (QueueNotFoundException ex)
             {

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationUnsubscribeTerminator.cs
@@ -68,7 +68,7 @@ namespace NServiceBus
             {
                 var transportOperation = new TransportOperation(unsubscribeMessage, new UnicastAddressTag(destination));
                 var transportTransaction = context.GetOrCreate<TransportTransaction>();
-                await dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction, CancellationToken.None).ConfigureAwait(false);
+                await dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction).ConfigureAwait(false);
             }
             catch (QueueNotFoundException ex)
             {

--- a/src/NServiceBus.Core/Transports/IMessageDispatcher.cs
+++ b/src/NServiceBus.Core/Transports/IMessageDispatcher.cs
@@ -12,6 +12,6 @@ namespace NServiceBus.Transport
         /// <summary>
         /// Dispatches the given operations to the transport.
         /// </summary>
-        Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default);
+        Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction);
     }
 }

--- a/src/NServiceBus.Core/Transports/IMessageReceiver.cs
+++ b/src/NServiceBus.Core/Transports/IMessageReceiver.cs
@@ -15,17 +15,17 @@ namespace NServiceBus.Transport
         /// <summary>
         /// Initializes the receiver.
         /// </summary>
-        Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events, CancellationToken cancellationToken = default);
+        Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events);
 
         /// <summary>
         /// Starts receiving messages from the input queue.
         /// </summary>
-        Task StartReceive(CancellationToken cancellationToken = default);
+        Task StartReceive();
 
         /// <summary>
         /// Stops receiving messages.
         /// </summary>
-        Task StopReceive(CancellationToken cancellationToken = default);
+        Task StopReceive();
 
         /// <summary>
         /// The <see cref="ISubscriptionManager"/> for this receiver. Will be <c>null</c> if publish-subscribe has been disabled on the <see cref="ReceiveSettings"/>.

--- a/src/NServiceBus.Core/Transports/ISubscriptionManager.cs
+++ b/src/NServiceBus.Core/Transports/ISubscriptionManager.cs
@@ -13,11 +13,11 @@ namespace NServiceBus.Transport
         /// <summary>
         /// Subscribes to the given event.
         /// </summary>
-        Task Subscribe(MessageMetadata eventType, ContextBag context, CancellationToken cancellationToken = default);
+        Task Subscribe(MessageMetadata eventType, ContextBag context);
 
         /// <summary>
         /// Unsubscribes from the given event.
         /// </summary>
-        Task Unsubscribe(MessageMetadata eventType, ContextBag context, CancellationToken cancellationToken = default);
+        Task Unsubscribe(MessageMetadata eventType, ContextBag context);
     }
 }

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransport.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransport.cs
@@ -27,8 +27,7 @@ namespace NServiceBus
         /// default capabilities as well as for initializing the transport's configuration based on those settings (the user cannot
         /// provide information anymore at this stage).
         /// </summary>
-        public override async Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses,
-            CancellationToken cancellationToken = default)
+        public override async Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses)
         {
             Guard.AgainstNull(nameof(hostSettings), hostSettings);
             var learningTransportInfrastructure = new LearningTransportInfrastructure(hostSettings, this, receivers);

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportDispatcher.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportDispatcher.cs
@@ -25,7 +25,7 @@ namespace NServiceBus
             this.maxMessageSizeKB = maxMessageSizeKB;
         }
 
-        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
+        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction)
         {
             return Task.WhenAll(
                 DispatchUnicast(outgoingMessages.UnicastTransportOperations, transaction),

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -20,7 +20,7 @@ namespace NServiceBus
             string basePath,
             Action<string, Exception> criticalErrorAction,
             ISubscriptionManager subscriptionManager,
-            ReceiveSettings receiveSettings, 
+            ReceiveSettings receiveSettings,
             TransportTransactionMode transactionMode)
         {
             Id = id;
@@ -53,7 +53,7 @@ namespace NServiceBus
             delayedMessagePoller = new DelayedMessagePoller(messagePumpBasePath, delayedDir);
         }
 
-        public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events, CancellationToken cancellationToken)
+        public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events)
         {
             this.onMessage = onMessage;
             this.onError = onError;
@@ -70,7 +70,7 @@ namespace NServiceBus
             return Task.CompletedTask;
         }
 
-        public Task StartReceive(CancellationToken cancellationToken)
+        public Task StartReceive()
         {
             cancellationTokenSource = new CancellationTokenSource();
 
@@ -83,7 +83,7 @@ namespace NServiceBus
             return Task.CompletedTask;
         }
 
-        public async Task StopReceive(CancellationToken cancellationToken)
+        public async Task StopReceive()
         {
             cancellationTokenSource?.Cancel();
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportSubscriptionManager.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportSubscriptionManager.cs
@@ -18,7 +18,7 @@ namespace NServiceBus
             this.basePath = Path.Combine(basePath, ".events");
         }
 
-        public async Task Subscribe(MessageMetadata eventType, ContextBag context, CancellationToken cancellationToken)
+        public async Task Subscribe(MessageMetadata eventType, ContextBag context)
         {
             var eventDir = GetEventDirectory(eventType.MessageType);
 
@@ -53,7 +53,7 @@ namespace NServiceBus
             }
         }
 
-        public async Task Unsubscribe(MessageMetadata eventType, ContextBag context, CancellationToken cancellationToken)
+        public async Task Unsubscribe(MessageMetadata eventType, ContextBag context)
         {
             var eventDir = GetEventDirectory(eventType.MessageType);
             var subscriptionEntryPath = GetSubscriptionEntryPath(eventDir);

--- a/src/NServiceBus.Core/Transports/TransportDefinition.cs
+++ b/src/NServiceBus.Core/Transports/TransportDefinition.cs
@@ -30,7 +30,7 @@ namespace NServiceBus.Transport
         /// default capabilities as well as for initializing the transport's configuration based on those settings (the user cannot
         /// provide information anymore at this stage).
         /// </summary>
-        public abstract Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken = default);
+        public abstract Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses);
 
 
         /// <summary>

--- a/src/NServiceBus.Core/Transports/TransportReceiver.cs
+++ b/src/NServiceBus.Core/Transports/TransportReceiver.cs
@@ -30,8 +30,8 @@ namespace NServiceBus
             Logger.DebugFormat("Receiver {0} is starting.", receiver.Id);
 
 
-            await receiver.Initialize(pushRuntimeSettings, onMessage, onError, events, CancellationToken.None).ConfigureAwait(false);
-            await receiver.StartReceive(CancellationToken.None).ConfigureAwait(false);
+            await receiver.Initialize(pushRuntimeSettings, onMessage, onError, events).ConfigureAwait(false);
+            await receiver.StartReceive().ConfigureAwait(false);
 
             isStarted = true;
         }
@@ -45,7 +45,7 @@ namespace NServiceBus
 
             try
             {
-                await receiver.StopReceive(CancellationToken.None).ConfigureAwait(false);
+                await receiver.StopReceive().ConfigureAwait(false);
                 (receiver as IDisposable)?.Dispose();
             }
             catch (Exception exception)

--- a/src/NServiceBus.Core/Transports/TransportSeam.cs
+++ b/src/NServiceBus.Core/Transports/TransportSeam.cs
@@ -28,7 +28,7 @@ namespace NServiceBus
 
         public async Task<TransportInfrastructure> CreateTransportInfrastructure()
         {
-            TransportInfrastructure = await TransportDefinition.Initialize(hostSettings, receivers, QueueBindings.SendingAddresses.ToArray(), CancellationToken.None)
+            TransportInfrastructure = await TransportDefinition.Initialize(hostSettings, receivers, QueueBindings.SendingAddresses.ToArray())
                 .ConfigureAwait(false);
 
             var eventHandlers = TransportInfrastructureCreated;

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -116,9 +116,9 @@ namespace NServiceBus.TransportTests
                     }
 
                     return Task.FromResult(ErrorHandleResult.Handled);
-                }, new MessageMetadata[0], CancellationToken.None);
+                }, new MessageMetadata[0]);
 
-            await TransportInfrastructure.Receivers[0].StartReceive(CancellationToken.None);
+            await TransportInfrastructure.Receivers[0].StartReceive();
 
             receiver = TransportInfrastructure.Receivers[0];
         }
@@ -175,7 +175,7 @@ namespace NServiceBus.TransportTests
 
             var transportOperation = new TransportOperation(message, new UnicastAddressTag(address), operationProperties?.ToDictionary(), dispatchConsistency);
 
-            return TransportInfrastructure.Dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction, CancellationToken.None);
+            return TransportInfrastructure.Dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction);
         }
 
         protected void OnTestTimeout(Action onTimeoutAction)


### PR DESCRIPTION
To simplify the work to the group (@adamralph, @andreasohlund, and @DavidBoike) working on CancellationToken support for V8 is doing, it's better to entirely remove the CancellationToken from the new seam API.

They'll have to rebase multiple times on our branch, and it's easier for them to implement CancellationToken support everywhere instead of dealing with a partial implementation in the new seam.

Since the new seam doesn't use the CancellationToken anywhere for now I went ahead and removed it from the public API.