### PR TITLE
Add target to block < net472

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -46,6 +46,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="NServiceBus.targets" />
+    <Content Include="NServiceBus.targets" PackagePath="build" />
     <None Include="..\..\packaging\nuget\tools\init.ps1" Pack="true" PackagePath="tools" Visible="false" />
     <None Include="..\NServiceBus.Core.Analyzer\bin\$(Configuration)\**\NServiceBus.Core.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/cs/NServiceBus.Core.Analyzer.dll" Link="NServiceBus.Core.Analyzer.dll" Visible="false" />
     <None Include="..\NServiceBus.Core.Analyzer\tools\*.ps1" Pack="true" PackagePath="tools" Visible="false" />

--- a/src/NServiceBus.Core/NServiceBus.targets
+++ b/src/NServiceBus.Core/NServiceBus.targets
@@ -1,0 +1,7 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="NServiceBusVerifyMinimumFrameworkVersion" BeforeTargets="Build" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <Error Condition= "$(TargetFrameworkVersion.TrimStart('v')) &lt; 4.7.2" Text="NServiceBus requires .NET Framework 4.7.2 or greater." />
+  </Target>
+
+</Project>


### PR DESCRIPTION
This adds an MSBuild target that will cause a build error when the package is installed on `net461` through `net471`, which is possible because of the `netstandard2.0` assembly that we currently ship in the package.