### PR TITLE
Do not clone OperationProperties

### DIFF
--- a/src/NServiceBus.Core/Transports/TransportOperations.cs
+++ b/src/NServiceBus.Core/Transports/TransportOperations.cs
@@ -24,7 +24,7 @@ namespace NServiceBus.Transport
                     multicastOperations.Add(new MulticastTransportOperation(
                         transportOperation.Message,
                         multicastAddressTag.MessageType,
-                        new DispatchProperties(transportOperation.Properties),
+                        transportOperation.Properties,
                         transportOperation.RequiredDispatchConsistency));
                 }
                 else if (transportOperation.AddressTag is UnicastAddressTag unicastAddressTag)
@@ -32,7 +32,7 @@ namespace NServiceBus.Transport
                     unicastOperations.Add(new UnicastTransportOperation(
                         transportOperation.Message,
                         unicastAddressTag.Destination,
-                        new DispatchProperties(transportOperation.Properties),
+                        transportOperation.Properties,
                         transportOperation.RequiredDispatchConsistency));
                 }
                 else


### PR DESCRIPTION
I think there is no need to clone the properties here? Each operation has it's dedicated OpertionProperties instance and there should be no risk of reuse or something like that which would require cloning.

Thoughts?