### PR TITLE
Remove events parameter from IMessageReceiver.Initialize

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeReceiver.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeReceiver.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus.AcceptanceTests.Core.FakeTransport
 {
-    using System.Collections.Generic;
     using Extensibility;
     using Unicast.Messages;
     using System;
@@ -23,7 +22,7 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport
         }
 
         public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage,
-            Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events)
+            Func<ErrorContext, Task<ErrorHandleResult>> onError)
         {
             startupSequence.Add($"{nameof(IMessageReceiver)}.{nameof(Initialize)} for receiver {Id}");
             return Task.CompletedTask;

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.AcceptanceTests.Core.FakeTransport.ProcessingOptimizations
 {
-    using Unicast.Messages;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -40,7 +39,7 @@
         {
             PushRuntimeSettings pushSettings;
 
-            public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events)
+            public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError)
             {
                 pushSettings = limitations;
                 return Task.CompletedTask;

--- a/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/AcceptanceTestingTransportServer.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/AcceptanceTestingTransportServer.cs
@@ -5,7 +5,6 @@
     using AcceptanceTesting.Customization;
     using AcceptanceTesting.Support;
     using EndpointTemplates;
-    using Features;
 
     class AcceptanceTestingTransportServer : IEndpointSetupTemplate
     {

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2425,7 +2425,7 @@ namespace NServiceBus.Transport
     {
         string Id { get; }
         NServiceBus.Transport.ISubscriptionManager Subscriptions { get; }
-        System.Threading.Tasks.Task Initialize(NServiceBus.Transport.PushRuntimeSettings limitations, System.Func<NServiceBus.Transport.MessageContext, System.Threading.Tasks.Task> onMessage, System.Func<NServiceBus.Transport.ErrorContext, System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult>> onError, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Unicast.Messages.MessageMetadata> events);
+        System.Threading.Tasks.Task Initialize(NServiceBus.Transport.PushRuntimeSettings limitations, System.Func<NServiceBus.Transport.MessageContext, System.Threading.Tasks.Task> onMessage, System.Func<NServiceBus.Transport.ErrorContext, System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult>> onError);
         System.Threading.Tasks.Task StartReceive();
         System.Threading.Tasks.Task StopReceive();
     }

--- a/src/NServiceBus.Core.Tests/Transports/TransportReceiverTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/TransportReceiverTests.cs
@@ -1,7 +1,5 @@
 ﻿namespace NServiceBus.Core.Tests.Transports
 {
-    using System.Collections.Generic;
-    using Unicast.Messages;
     using System;
     using System.Threading.Tasks;
     using NUnit.Framework;
@@ -21,7 +19,7 @@
         [Test]
         public async Task Start_should_start_the_pump()
         {
-            await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled), new List<MessageMetadata>());
+            await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled));
 
             Assert.IsTrue(pump.Started);
         }
@@ -32,14 +30,14 @@
             pump.ThrowOnStart = true;
 
             Assert.ThrowsAsync<InvalidOperationException>(async () =>
-                await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled), new List<MessageMetadata>())
+                await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled))
                 );
         }
 
         [Test]
         public async Task Stop_should_stop_the_pump()
         {
-            await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled), new List<MessageMetadata>());
+            await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled));
 
             await receiver.Stop();
 
@@ -51,7 +49,7 @@
         {
             pump.ThrowOnStop = true;
 
-            await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled), new List<MessageMetadata>());
+            await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled));
 
             Assert.DoesNotThrowAsync(async () => await receiver.Stop());
         }
@@ -68,7 +66,7 @@
             public bool Stopped { get; private set; }
 
 
-            public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events)
+            public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError)
             {
                 return Task.CompletedTask;
             }

--- a/src/NServiceBus.Core/Transports/IMessageReceiver.cs
+++ b/src/NServiceBus.Core/Transports/IMessageReceiver.cs
@@ -1,9 +1,7 @@
 ﻿namespace NServiceBus.Transport
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
-    using Unicast.Messages;
 
     /// <summary>
     /// Allows the transport to push messages to the core.
@@ -13,7 +11,7 @@
         /// <summary>
         /// Initializes the receiver.
         /// </summary>
-        Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events);
+        Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError);
 
         /// <summary>
         /// Starts receiving messages from the input queue.

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -1,7 +1,5 @@
 ﻿namespace NServiceBus
 {
-    using System.Collections.Generic;
-    using Unicast.Messages;
     using System;
     using System.Collections.Concurrent;
     using System.Diagnostics;
@@ -51,7 +49,7 @@
             delayedMessagePoller = new DelayedMessagePoller(messagePumpBasePath, delayedDir);
         }
 
-        public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events)
+        public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError)
         {
             this.onMessage = onMessage;
             this.onError = onError;

--- a/src/NServiceBus.Core/Transports/TransportReceiver.cs
+++ b/src/NServiceBus.Core/Transports/TransportReceiver.cs
@@ -1,8 +1,6 @@
 namespace NServiceBus
 {
-    using System.Collections.Generic;
     using Transport;
-    using Unicast.Messages;
     using System;
     using System.Threading.Tasks;
     using Logging;
@@ -17,7 +15,7 @@ namespace NServiceBus
             this.receiver = receiver;
         }
 
-        public async Task Start(Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events)
+        public async Task Start(Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError)
         {
             if (isStarted)
             {
@@ -27,7 +25,7 @@ namespace NServiceBus
             Logger.DebugFormat("Receiver {0} is starting.", receiver.Id);
 
 
-            await receiver.Initialize(pushRuntimeSettings, onMessage, onError, events).ConfigureAwait(false);
+            await receiver.Initialize(pushRuntimeSettings, onMessage, onError).ConfigureAwait(false);
             await receiver.StartReceive().ConfigureAwait(false);
 
             isStarted = true;

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.TransportTests
 {
     using Transport;
-    using Unicast.Messages;
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
@@ -113,7 +112,7 @@
                     }
 
                     return Task.FromResult(ErrorHandleResult.Handled);
-                }, new MessageMetadata[0]);
+                });
 
             await transportInfrastructure.Receivers[0].StartReceive();
 


### PR DESCRIPTION
This is an intermediary step to remove the events parameter from IMessageReceiver.Initialize and continue to use the `AutoSubscribe` feature for all subscription management. This is due to several issues with the current approach that we want to approach in smaller steps while keeping master stable:
* The current implementation does only subscribe after all feature startup tasks ran, this is different from before, where it happened as part of the FST.
* It requires more complex logic to handle cases where we subscibe via native mechanism but still use core's autosubscribe for compatibility mode
* Currently, the core does not respect any Autosubscribe settings, nor can it be disabled

As a next step, we will introduce a "batch subscribe" API to `ISubscriptionManager` to allow transport to optimize on infrastructure creation.
In a third step, we can look into moving the call of the API earlier in the startup procedure and even move it back on the transport API with proper configuration support from a Core perspective.