### PR TITLE
Add batch subscribe API

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_excluding_event_type_from_autosubscribe.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_excluding_event_type_from_autosubscribe.cs
@@ -66,7 +66,7 @@
                 {
                     await next(context).ConfigureAwait(false);
 
-                    testContext.EventsSubscribedTo.Add(context.EventType);
+                    testContext.EventsSubscribedTo.AddRange(context.EventTypes);
                 }
 
                 Context testContext;

--- a/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga.cs
@@ -56,7 +56,7 @@ namespace NServiceBus.AcceptanceTests.Core.AutomaticSubscriptions
                 {
                     await next(context).ConfigureAwait(false);
 
-                    testContext.EventsSubscribedTo.Add(context.EventType);
+                    testContext.EventsSubscribedTo.AddRange(context.EventTypes);
                 }
 
                 Context testContext;

--- a/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs
@@ -60,7 +60,7 @@ namespace NServiceBus.AcceptanceTests.Core.AutomaticSubscriptions
                 {
                     await next(context).ConfigureAwait(false);
 
-                    testContext.EventsSubscribedTo.Add(context.EventType);
+                    testContext.EventsSubscribedTo.AddRange(context.EventTypes);
                 }
 
                 Context testContext;

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeReceiver.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeReceiver.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus.AcceptanceTests.Core.FakeTransport
 {
-    using System.Collections.Generic;
     using Extensibility;
     using Unicast.Messages;
     using System;
@@ -23,7 +22,7 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport
         }
 
         public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage,
-            Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events)
+            Func<ErrorContext, Task<ErrorHandleResult>> onError)
         {
             startupSequence.Add($"{nameof(IMessageReceiver)}.{nameof(Initialize)} for receiver {Id}");
             return Task.CompletedTask;

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeReceiver.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeReceiver.cs
@@ -58,15 +58,11 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport
 
         class FakeSubscriptionManager : ISubscriptionManager
         {
-            public Task Subscribe(MessageMetadata eventType, ContextBag context)
-            {
-                return Task.CompletedTask;
-            }
+            public Task Subscribe(MessageMetadata eventType, ContextBag context) => Task.CompletedTask;
 
-            public Task Unsubscribe(MessageMetadata eventType, ContextBag context)
-            {
-                return Task.CompletedTask;
-            }
+            public Task SubscribeAll(MessageMetadata[] eventTypes, ContextBag context) => Task.CompletedTask;
+
+            public Task Unsubscribe(MessageMetadata eventType, ContextBag context) => Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.AcceptanceTests.Core.FakeTransport.ProcessingOptimizations
 {
-    using Unicast.Messages;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -40,7 +39,7 @@
         {
             PushRuntimeSettings pushSettings;
 
-            public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events)
+            public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError)
             {
                 pushSettings = limitations;
                 return Task.CompletedTask;

--- a/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/AcceptanceTestingTransportServer.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/AcceptanceTestingTransportServer.cs
@@ -5,7 +5,6 @@
     using AcceptanceTesting.Customization;
     using AcceptanceTesting.Support;
     using EndpointTemplates;
-    using Features;
 
     class AcceptanceTestingTransportServer : IEndpointSetupTemplate
     {

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_autosubscribe_with_missing_publisher_information.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_autosubscribe_with_missing_publisher_information.cs
@@ -22,9 +22,10 @@
 
             Assert.True(context.EndpointsStarted, "because it should not prevent endpoint startup");
 
-            var log = context.Logs.Single(l => l.Message.Contains($"AutoSubscribe was unable to subscribe to event '{typeof(MyEvent).FullName}': No publisher address could be found for message type '{typeof(MyEvent).FullName}'."));
+            var log = context.Logs.Single(l => l.Message.Contains($"AutoSubscribe was unable to subscribe to an event:"));
             Assert.AreEqual(LogLevel.Error, log.Level);
             Assert.AreEqual(typeof(AutoSubscribe).FullName, log.LoggerName);
+            StringAssert.Contains($"No publisher address could be found for message type '{typeof(MyEvent).FullName}'.", log.Message);
         }
 
         public class Subscriber : EndpointConfigurationBuilder

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1892,7 +1892,7 @@ namespace NServiceBus.Pipeline
     }
     public interface ISubscribeContext : NServiceBus.Extensibility.IExtendable, NServiceBus.Pipeline.IBehaviorContext
     {
-        System.Type EventType { get; }
+        System.Type[] EventTypes { get; }
     }
     public interface ITransportReceiveContext : NServiceBus.Extensibility.IExtendable, NServiceBus.Pipeline.IBehaviorContext
     {
@@ -2448,6 +2448,7 @@ namespace NServiceBus.Transport
     public interface ISubscriptionManager
     {
         System.Threading.Tasks.Task Subscribe(NServiceBus.Unicast.Messages.MessageMetadata eventType, NServiceBus.Extensibility.ContextBag context);
+        System.Threading.Tasks.Task SubscribeAll(NServiceBus.Unicast.Messages.MessageMetadata[] eventTypes, NServiceBus.Extensibility.ContextBag context);
         System.Threading.Tasks.Task Unsubscribe(NServiceBus.Unicast.Messages.MessageMetadata eventType, NServiceBus.Extensibility.ContextBag context);
     }
     public class IncomingMessage

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2425,7 +2425,7 @@ namespace NServiceBus.Transport
     {
         string Id { get; }
         NServiceBus.Transport.ISubscriptionManager Subscriptions { get; }
-        System.Threading.Tasks.Task Initialize(NServiceBus.Transport.PushRuntimeSettings limitations, System.Func<NServiceBus.Transport.MessageContext, System.Threading.Tasks.Task> onMessage, System.Func<NServiceBus.Transport.ErrorContext, System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult>> onError, System.Collections.Generic.IReadOnlyCollection<NServiceBus.Unicast.Messages.MessageMetadata> events);
+        System.Threading.Tasks.Task Initialize(NServiceBus.Transport.PushRuntimeSettings limitations, System.Func<NServiceBus.Transport.MessageContext, System.Threading.Tasks.Task> onMessage, System.Func<NServiceBus.Transport.ErrorContext, System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult>> onError);
         System.Threading.Tasks.Task StartReceive();
         System.Threading.Tasks.Task StopReceive();
     }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1892,6 +1892,8 @@ namespace NServiceBus.Pipeline
     }
     public interface ISubscribeContext : NServiceBus.Extensibility.IExtendable, NServiceBus.Pipeline.IBehaviorContext
     {
+        [System.Obsolete("Use `EventTypes` instead. Will be removed in version 9.0.0.", true)]
+        System.Type EventType { get; }
         System.Type[] EventTypes { get; }
     }
     public interface ITransportReceiveContext : NServiceBus.Extensibility.IExtendable, NServiceBus.Pipeline.IBehaviorContext

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.Routing;
     using NServiceBus.Routing.MessageDrivenSubscriptions;
@@ -16,7 +17,7 @@
         [SetUp]
         public void SetUp()
         {
-            var publishers = new Publishers();
+            publishers = new Publishers();
             publishers.AddOrReplacePublishers("A", new List<PublisherTableEntry> { new PublisherTableEntry(typeof(object), PublisherAddress.CreateFromPhysicalAddresses("publisher1")) });
             router = new SubscriptionRouter(publishers, new EndpointInstances(), i => i.ToString());
             dispatcher = new FakeDispatcher();
@@ -26,10 +27,7 @@
         [Test]
         public async Task Should_include_TimeSent_and_Version_headers()
         {
-            var unsubscribeTerminator = new MessageDrivenUnsubscribeTerminator(router, "replyToAddress", "Endpoint", dispatcher);
-
             await subscribeTerminator.Invoke(new TestableSubscribeContext(), c => Task.CompletedTask);
-            await unsubscribeTerminator.Invoke(new TestableUnsubscribeContext(), c => Task.CompletedTask);
 
             foreach (var dispatchedTransportOperation in dispatcher.DispatchedTransportOperations)
             {
@@ -44,9 +42,14 @@
         [Test]
         public async Task Should_Dispatch_for_all_publishers()
         {
+            publishers.AddOrReplacePublishers("B", new List<PublisherTableEntry>()
+            {
+                new PublisherTableEntry(typeof(object), PublisherAddress.CreateFromPhysicalAddresses("publisher2"))
+            });
+
             await subscribeTerminator.Invoke(new TestableSubscribeContext(), c => Task.CompletedTask);
 
-            Assert.AreEqual(1, dispatcher.DispatchedTransportOperations.Count);
+            Assert.AreEqual(2, dispatcher.DispatchedTransportOperations.Count);
         }
 
         [Test]
@@ -82,9 +85,71 @@
             Assert.AreEqual(11, dispatcher.FailedNumberOfTimes);
         }
 
+        [Test]
+        public void Should_throw_when_no_publisher_for_message_found()
+        {
+            // clear publishers list
+            publishers.AddOrReplacePublishers("A", new List<PublisherTableEntry>());
+
+            var exception = Assert.ThrowsAsync<Exception>(() =>
+                subscribeTerminator.Invoke(new TestableSubscribeContext(), c => Task.CompletedTask));
+
+            StringAssert.Contains($"No publisher address could be found for message type '{typeof(object)}'.", exception.Message);
+        }
+
+        [Test]
+        public async Task Should_dispatch_to_all_publishers_for_all_events()
+        {
+            var context = new TestableSubscribeContext()
+            {
+                EventTypes = new[] { typeof(EventA), typeof(EventB) }
+            };
+
+            publishers.AddOrReplacePublishers("Test", new List<PublisherTableEntry>()
+            {
+                new PublisherTableEntry(typeof(EventA), PublisherAddress.CreateFromPhysicalAddresses("publisher1")),
+                new PublisherTableEntry(typeof(EventA), PublisherAddress.CreateFromPhysicalAddresses("publisher2")),
+                new PublisherTableEntry(typeof(EventB), PublisherAddress.CreateFromPhysicalAddresses("publisher1")),
+                new PublisherTableEntry(typeof(EventB), PublisherAddress.CreateFromPhysicalAddresses("publisher2"))
+            });
+
+            await subscribeTerminator.Invoke(context, c => Task.CompletedTask);
+
+            Assert.AreEqual(4, dispatcher.DispatchedTransportOperations.Count);
+        }
+
+        [Test]
+        public void When_subscribing_multiple_events_should_throw_aggregate_exception_with_all_failures()
+        {
+            var context = new TestableSubscribeContext
+            {
+                EventTypes = new[] { typeof(EventA), typeof(EventB) }
+            };
+            // Marks this message as a SubscribeAll call
+            context.Extensions.Set(MessageSession.SubscribeAllFlagKey, true);
+            var state = context.Extensions.GetOrCreate<MessageDrivenSubscribeTerminator.Settings>();
+            state.MaxRetries = 0;
+            state.RetryDelay = TimeSpan.Zero;
+            dispatcher.FailDispatch(10);
+
+            // no publisher for EventB
+            publishers.AddOrReplacePublishers("Test", new List<PublisherTableEntry>()
+            {
+                new PublisherTableEntry(typeof(EventA), PublisherAddress.CreateFromPhysicalAddresses("publisher1")),
+            });
+
+            var exception = Assert.ThrowsAsync<AggregateException>(() => subscribeTerminator.Invoke(context, c => Task.CompletedTask));
+
+            Assert.AreEqual(2, exception.InnerExceptions.Count);
+            Assert.IsTrue(exception.InnerExceptions.Any(e => e is QueueNotFoundException)); // exception from dispatcher
+            Assert.IsTrue(exception.InnerExceptions.Any(e => e.Message.Contains($"No publisher address could be found for message type '{typeof(EventB)}'"))); // exception from terminator
+        }
+
+
         FakeDispatcher dispatcher;
         SubscriptionRouter router;
         MessageDrivenSubscribeTerminator subscribeTerminator;
+        Publishers publishers;
 
         class FakeDispatcher : IMessageDispatcher
         {
@@ -110,6 +175,14 @@
             }
 
             int? numberOfTimes;
+        }
+
+        class EventA
+        {
+        }
+
+        class EventB
+        {
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/NativeSubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/NativeSubscribeTerminatorTests.cs
@@ -1,0 +1,86 @@
+﻿namespace NServiceBus.Core.Tests.Routing
+{
+    using System;
+    using System.Threading.Tasks;
+    using Extensibility;
+    using NUnit.Framework;
+    using Testing;
+    using Transport;
+    using Unicast.Messages;
+
+    [TestFixture]
+    public class NativeSubscribeTerminatorTests
+    {
+        [Test]
+        public void When_subscriptionmanager_throws_aggregateexception_on_subscribe()
+        {
+            var innerException = new Exception("expected exception");
+            var fakeSubscriptionManager = new FakeSubscriptionManager(new AggregateException(innerException));
+            var terminator =
+                new NativeSubscribeTerminator(fakeSubscriptionManager, new MessageMetadataRegistry(_ => true));
+
+            var exception = Assert.ThrowsAsync<Exception>(() => terminator.Invoke(new TestableSubscribeContext(), _ => Task.CompletedTask));
+
+            Assert.AreSame(innerException, exception);
+        }
+
+        [Test]
+        public void When_subscriptionmanager_throws_exception_on_subscribe()
+        {
+            var expectedException = new Exception("expected exception");
+            var fakeSubscriptionManager = new FakeSubscriptionManager(expectedException);
+            var terminator =
+                new NativeSubscribeTerminator(fakeSubscriptionManager, new MessageMetadataRegistry(_ => true));
+
+            var exception = Assert.ThrowsAsync<Exception>(() => terminator.Invoke(new TestableSubscribeContext(), _ => Task.CompletedTask));
+
+            Assert.AreSame(expectedException, exception);
+        }
+
+        [Test]
+        public void When_subscriptionmanager_throws_aggregateexception_on_subscribeAll()
+        {
+            var aggregateException = new AggregateException(new Exception("expected exception"));
+            var fakeSubscriptionManager = new FakeSubscriptionManager(aggregateException);
+            var terminator =
+                new NativeSubscribeTerminator(fakeSubscriptionManager, new MessageMetadataRegistry(_ => true));
+            var testableSubscribeContext = new TestableSubscribeContext();
+            testableSubscribeContext.Extensions.Set(MessageSession.SubscribeAllFlagKey, true);
+
+            var exception = Assert.ThrowsAsync<AggregateException>(() => terminator.Invoke(testableSubscribeContext, _ => Task.CompletedTask));
+
+            Assert.AreSame(aggregateException, exception);
+        }
+
+        [Test]
+        public void When_subscriptionmanager_throws_exception_on_subscribeAll()
+        {
+            var expectedException = new Exception("expected exception");
+            var fakeSubscriptionManager = new FakeSubscriptionManager(expectedException);
+            var terminator =
+                new NativeSubscribeTerminator(fakeSubscriptionManager, new MessageMetadataRegistry(_ => true));
+            var testableSubscribeContext = new TestableSubscribeContext();
+            testableSubscribeContext.Extensions.Set(MessageSession.SubscribeAllFlagKey, true);
+
+            var exception = Assert.ThrowsAsync<Exception>(() => terminator.Invoke(testableSubscribeContext, _ => Task.CompletedTask));
+
+            Assert.AreSame(expectedException, exception);
+        }
+
+        class FakeSubscriptionManager : ISubscriptionManager
+        {
+            Exception exceptionToThrow;
+
+            public FakeSubscriptionManager(Exception exceptionToThrow)
+            {
+                this.exceptionToThrow = exceptionToThrow;
+            }
+
+            public Task Subscribe(MessageMetadata eventType, ContextBag context) => throw new NotImplementedException();
+
+            public Task SubscribeAll(MessageMetadata[] eventTypes, ContextBag context) => throw exceptionToThrow;
+
+            public Task Unsubscribe(MessageMetadata eventType, ContextBag context) => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Routing/SubscribeContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SubscribeContextTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Core.Tests.Routing
 {
+    using System;
     using Extensibility;
     using NUnit.Framework;
 
@@ -12,7 +13,7 @@
             var context = new ContextBag();
             context.Set("someKey", "someValue");
 
-            var testee = new SubscribeContext(new FakeRootContext(), typeof(object), context);
+            var testee = new SubscribeContext(new FakeRootContext(), new Type[0], context);
             testee.Extensions.Set("someKey", "updatedValue");
             testee.Extensions.Set("anotherKey", "anotherValue");
             context.TryGet("someKey", out string value);
@@ -32,7 +33,7 @@
 
             var parentContext = new FakeRootContext();
 
-            new SubscribeContext(parentContext, typeof(object), context);
+            new SubscribeContext(parentContext, new Type[0], context);
 
             var valueFound = parentContext.TryGet("someKey", out string _);
 

--- a/src/NServiceBus.Core.Tests/Transports/TransportReceiverTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/TransportReceiverTests.cs
@@ -1,7 +1,5 @@
 ﻿namespace NServiceBus.Core.Tests.Transports
 {
-    using System.Collections.Generic;
-    using Unicast.Messages;
     using System;
     using System.Threading.Tasks;
     using NUnit.Framework;
@@ -21,7 +19,7 @@
         [Test]
         public async Task Start_should_start_the_pump()
         {
-            await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled), new List<MessageMetadata>());
+            await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled));
 
             Assert.IsTrue(pump.Started);
         }
@@ -32,14 +30,14 @@
             pump.ThrowOnStart = true;
 
             Assert.ThrowsAsync<InvalidOperationException>(async () =>
-                await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled), new List<MessageMetadata>())
+                await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled))
                 );
         }
 
         [Test]
         public async Task Stop_should_stop_the_pump()
         {
-            await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled), new List<MessageMetadata>());
+            await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled));
 
             await receiver.Stop();
 
@@ -51,7 +49,7 @@
         {
             pump.ThrowOnStop = true;
 
-            await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled), new List<MessageMetadata>());
+            await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled));
 
             Assert.DoesNotThrowAsync(async () => await receiver.Stop());
         }
@@ -68,7 +66,7 @@
             public bool Stopped { get; private set; }
 
 
-            public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events)
+            public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError)
             {
                 return Task.CompletedTask;
             }

--- a/src/NServiceBus.Core/MessageSession.cs
+++ b/src/NServiceBus.Core/MessageSession.cs
@@ -46,6 +46,13 @@ namespace NServiceBus
             return messageOperations.Subscribe(context, eventType, subscribeOptions);
         }
 
+        public Task SubscribeAll(Type[] eventTypes, SubscribeOptions subscribeOptions)
+        {
+            // set a flag on the context so that subscribe implementations know which send API was used.
+            subscribeOptions.Context.Set(SubscribeAllFlagKey, true);
+            return messageOperations.Subscribe(context, eventTypes, subscribeOptions);
+        }
+
         public Task Unsubscribe(Type eventType, UnsubscribeOptions unsubscribeOptions)
         {
             Guard.AgainstNull(nameof(eventType), eventType);
@@ -55,5 +62,7 @@ namespace NServiceBus
 
         RootContext context;
         MessageOperations messageOperations;
+
+        internal const string SubscribeAllFlagKey = "NServiceBus.SubscribeAllFlag";
     }
 }

--- a/src/NServiceBus.Core/Routing/ISubscribeContext.cs
+++ b/src/NServiceBus.Core/Routing/ISubscribeContext.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// Provides context for subscription requests.
     /// </summary>
-    public interface ISubscribeContext : IBehaviorContext
+    public partial interface ISubscribeContext : IBehaviorContext
     {
         /// <summary>
         /// The type of the events.

--- a/src/NServiceBus.Core/Routing/ISubscribeContext.cs
+++ b/src/NServiceBus.Core/Routing/ISubscribeContext.cs
@@ -8,8 +8,8 @@
     public interface ISubscribeContext : IBehaviorContext
     {
         /// <summary>
-        /// The type of the event.
+        /// The type of the events.
         /// </summary>
-        Type EventType { get; }
+        Type[] EventTypes { get; }
     }
 }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -21,33 +21,58 @@
             this.dispatcher = dispatcher;
         }
 
-        protected override Task Terminate(ISubscribeContext context)
+        protected override async Task Terminate(ISubscribeContext context)
         {
-            var eventType = context.EventType;
+            var subscribeTasks = new List<Task>();
 
-            var publisherAddresses = subscriptionRouter.GetAddressesForEventType(eventType);
-            if (publisherAddresses.Count == 0)
+            foreach (var eventType in context.EventTypes)
             {
-                throw new Exception($"No publisher address could be found for message type '{eventType}'. Ensure that a publisher has been configured for the event type and that the configured publisher endpoint has at least one known instance.");
+                try
+                {
+                    var publisherAddresses = subscriptionRouter.GetAddressesForEventType(eventType);
+                    if (publisherAddresses.Count == 0)
+                    {
+                        throw new Exception($"No publisher address could be found for message type '{eventType}'. Ensure that a publisher has been configured for the event type and that the configured publisher endpoint has at least one known instance.");
+                    }
+
+                    foreach (var publisherAddress in publisherAddresses)
+                    {
+                        Logger.Debug($"Subscribing to {eventType.AssemblyQualifiedName} at publisher queue {publisherAddress}");
+
+                        var subscriptionMessage = ControlMessageFactory.Create(MessageIntentEnum.Subscribe);
+
+                        subscriptionMessage.Headers[Headers.SubscriptionMessageType] = eventType.AssemblyQualifiedName;
+                        subscriptionMessage.Headers[Headers.ReplyToAddress] = subscriberAddress;
+                        subscriptionMessage.Headers[Headers.SubscriberTransportAddress] = subscriberAddress;
+                        subscriptionMessage.Headers[Headers.SubscriberEndpoint] = subscriberEndpoint;
+                        subscriptionMessage.Headers[Headers.TimeSent] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);
+                        subscriptionMessage.Headers[Headers.NServiceBusVersion] = GitVersionInformation.MajorMinorPatch;
+
+                        subscribeTasks.Add(SendSubscribeMessageWithRetries(publisherAddress, subscriptionMessage, eventType.AssemblyQualifiedName, context.Extensions));
+                    }
+                }
+                catch (Exception e)
+                {
+                    subscribeTasks.Add(Task.FromException(e));
+                }
             }
 
-            var subscribeTasks = new List<Task>(publisherAddresses.Count);
-            foreach (var publisherAddress in publisherAddresses)
+            var t = Task.WhenAll(subscribeTasks);
+            try
             {
-                Logger.Debug($"Subscribing to {eventType.AssemblyQualifiedName} at publisher queue {publisherAddress}");
-
-                var subscriptionMessage = ControlMessageFactory.Create(MessageIntentEnum.Subscribe);
-
-                subscriptionMessage.Headers[Headers.SubscriptionMessageType] = eventType.AssemblyQualifiedName;
-                subscriptionMessage.Headers[Headers.ReplyToAddress] = subscriberAddress;
-                subscriptionMessage.Headers[Headers.SubscriberTransportAddress] = subscriberAddress;
-                subscriptionMessage.Headers[Headers.SubscriberEndpoint] = subscriberEndpoint;
-                subscriptionMessage.Headers[Headers.TimeSent] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);
-                subscriptionMessage.Headers[Headers.NServiceBusVersion] = GitVersionInformation.MajorMinorPatch;
-
-                subscribeTasks.Add(SendSubscribeMessageWithRetries(publisherAddress, subscriptionMessage, eventType.AssemblyQualifiedName, context.Extensions));
+                await t.ConfigureAwait(false);
             }
-            return Task.WhenAll(subscribeTasks);
+            catch (Exception)
+            {
+                // if subscribing via SubscribeAll, throw an AggregateException
+                if (context.Extensions.TryGet<bool>(MessageSession.SubscribeAllFlagKey, out var flag) && flag)
+                {
+                    throw t.Exception;
+                }
+
+                // otherwise throw the first exception to not change exception behavior when calling subscribe.
+                throw;
+            }
         }
 
         async Task SendSubscribeMessageWithRetries(string destination, OutgoingMessage subscriptionMessage, string messageType, ContextBag context, int retriesCount = 0)

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceSubscribeBestPracticesBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceSubscribeBestPracticesBehavior.cs
@@ -15,7 +15,10 @@ namespace NServiceBus
         {
             if (!context.Extensions.TryGet(out EnforceBestPracticesOptions options) || options.Enabled)
             {
-                validations.AssertIsValidForPubSub(context.EventType);
+                foreach (var eventType in context.EventTypes)
+                {
+                    validations.AssertIsValidForPubSub(eventType);
+                }
             }
 
             return next(context);

--- a/src/NServiceBus.Core/Routing/SubscribeContext.cs
+++ b/src/NServiceBus.Core/Routing/SubscribeContext.cs
@@ -6,18 +6,18 @@
 
     class SubscribeContext : BehaviorContext, ISubscribeContext
     {
-        public SubscribeContext(IBehaviorContext parentContext, Type eventType, ContextBag extensions)
+        public SubscribeContext(IBehaviorContext parentContext, Type[] eventTypes, ContextBag extensions)
             : base(parentContext)
         {
             Guard.AgainstNull(nameof(parentContext), parentContext);
-            Guard.AgainstNull(nameof(eventType), eventType);
+            Guard.AgainstNull(nameof(eventTypes), eventTypes);
             Guard.AgainstNull(nameof(extensions), extensions);
 
             Merge(extensions);
 
-            EventType = eventType;
+            EventTypes = eventTypes;
         }
 
-        public Type EventType { get; }
+        public Type[] EventTypes { get; }
     }
 }

--- a/src/NServiceBus.Core/Routing/SubscribeContext.cs
+++ b/src/NServiceBus.Core/Routing/SubscribeContext.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.ComponentModel;
     using Extensibility;
     using Pipeline;
 
@@ -19,5 +20,8 @@
         }
 
         public Type[] EventTypes { get; }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Type EventType => throw new NotImplementedException();
     }
 }

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationSubscribeTerminator.cs
@@ -28,35 +28,75 @@
 
         protected override async Task Terminate(ISubscribeContext context)
         {
-            var eventType = context.EventType;
-
-            var eventMetadata = messageMetadataRegistry.GetMessageMetadata(eventType);
-            await subscriptionManager.Subscribe(eventMetadata, context.Extensions).ConfigureAwait(false);
-
-            var publisherAddresses = subscriptionRouter.GetAddressesForEventType(eventType);
-            if (publisherAddresses.Count == 0)
+            var eventMetadata = new MessageMetadata[context.EventTypes.Length];
+            for (int i = 0; i < context.EventTypes.Length; i++)
             {
-                return;
+                eventMetadata[i] = messageMetadataRegistry.GetMessageMetadata(context.EventTypes[i]);
+            }
+            try
+            {
+                await subscriptionManager.SubscribeAll(eventMetadata, context.Extensions).ConfigureAwait(false);
+            }
+            catch (AggregateException e)
+            {
+                if (context.Extensions.TryGet<bool>(MessageSession.SubscribeAllFlagKey, out var flag) && flag)
+                {
+                    throw;
+                }
+
+                // if this is called from Subscribe, rethrow the expected single exception
+                throw e.InnerException ?? e;
             }
 
-            var subscribeTasks = new List<Task>(publisherAddresses.Count);
-            foreach (var publisherAddress in publisherAddresses)
+            var subscribeTasks = new List<Task>();
+            foreach (var eventType in context.EventTypes)
             {
-                Logger.Debug($"Subscribing to {eventType.AssemblyQualifiedName} at publisher queue {publisherAddress}");
+                try
+                {
+                    var publisherAddresses = subscriptionRouter.GetAddressesForEventType(eventType);
+                    if (publisherAddresses.Count == 0)
+                    {
+                        continue;
+                    }
 
-                var subscriptionMessage = ControlMessageFactory.Create(MessageIntentEnum.Subscribe);
+                    foreach (var publisherAddress in publisherAddresses)
+                    {
+                        Logger.Debug($"Subscribing to {eventType.AssemblyQualifiedName} at publisher queue {publisherAddress}");
 
-                subscriptionMessage.Headers[Headers.SubscriptionMessageType] = eventType.AssemblyQualifiedName;
-                subscriptionMessage.Headers[Headers.ReplyToAddress] = subscriberAddress;
-                subscriptionMessage.Headers[Headers.SubscriberTransportAddress] = subscriberAddress;
-                subscriptionMessage.Headers[Headers.SubscriberEndpoint] = subscriberEndpoint;
-                subscriptionMessage.Headers[Headers.TimeSent] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);
-                subscriptionMessage.Headers[Headers.NServiceBusVersion] = GitVersionInformation.MajorMinorPatch;
+                        var subscriptionMessage = ControlMessageFactory.Create(MessageIntentEnum.Subscribe);
 
-                subscribeTasks.Add(SendSubscribeMessageWithRetries(publisherAddress, subscriptionMessage, eventType.AssemblyQualifiedName, context.Extensions));
+                        subscriptionMessage.Headers[Headers.SubscriptionMessageType] = eventType.AssemblyQualifiedName;
+                        subscriptionMessage.Headers[Headers.ReplyToAddress] = subscriberAddress;
+                        subscriptionMessage.Headers[Headers.SubscriberTransportAddress] = subscriberAddress;
+                        subscriptionMessage.Headers[Headers.SubscriberEndpoint] = subscriberEndpoint;
+                        subscriptionMessage.Headers[Headers.TimeSent] = DateTimeOffsetHelper.ToWireFormattedString(DateTimeOffset.UtcNow);
+                        subscriptionMessage.Headers[Headers.NServiceBusVersion] = GitVersionInformation.MajorMinorPatch;
+
+                        subscribeTasks.Add(SendSubscribeMessageWithRetries(publisherAddress, subscriptionMessage, eventType.AssemblyQualifiedName, context.Extensions));
+                    }
+                }
+                catch (Exception e)
+                {
+                    subscribeTasks.Add(Task.FromException(e));
+                }
             }
 
-            await Task.WhenAll(subscribeTasks).ConfigureAwait(false);
+            var t = Task.WhenAll(subscribeTasks);
+            try
+            {
+                await t.ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // if subscribing via SubscribeAll, throw an AggregateException
+                if (context.Extensions.TryGet<bool>(MessageSession.SubscribeAllFlagKey, out var flag) && flag)
+                {
+                    throw t.Exception;
+                }
+
+                // otherwise throw the first exception to not change exception behavior when calling subscribe.
+                throw;
+            }
         }
 
         async Task SendSubscribeMessageWithRetries(string destination, OutgoingMessage subscriptionMessage, string messageType, ContextBag context, int retriesCount = 0)

--- a/src/NServiceBus.Core/Transports/IMessageReceiver.cs
+++ b/src/NServiceBus.Core/Transports/IMessageReceiver.cs
@@ -1,9 +1,7 @@
 ﻿namespace NServiceBus.Transport
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
-    using Unicast.Messages;
 
     /// <summary>
     /// Allows the transport to push messages to the core.
@@ -13,7 +11,7 @@
         /// <summary>
         /// Initializes the receiver.
         /// </summary>
-        Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events);
+        Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError);
 
         /// <summary>
         /// Starts receiving messages from the input queue.

--- a/src/NServiceBus.Core/Transports/ISubscriptionManager.cs
+++ b/src/NServiceBus.Core/Transports/ISubscriptionManager.cs
@@ -15,6 +15,11 @@
         Task Subscribe(MessageMetadata eventType, ContextBag context);
 
         /// <summary>
+        /// Subscribes to all provided events.
+        /// </summary>
+        Task SubscribeAll(MessageMetadata[] eventTypes, ContextBag context);
+
+        /// <summary>
         /// Unsubscribes from the given event.
         /// </summary>
         Task Unsubscribe(MessageMetadata eventType, ContextBag context);

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -1,7 +1,5 @@
 ﻿namespace NServiceBus
 {
-    using System.Collections.Generic;
-    using Unicast.Messages;
     using System;
     using System.Collections.Concurrent;
     using System.Diagnostics;
@@ -51,7 +49,7 @@
             delayedMessagePoller = new DelayedMessagePoller(messagePumpBasePath, delayedDir);
         }
 
-        public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events)
+        public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError)
         {
             this.onMessage = onMessage;
             this.onError = onError;

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportSubscriptionManager.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportSubscriptionManager.cs
@@ -51,6 +51,17 @@
             }
         }
 
+        public Task SubscribeAll(MessageMetadata[] eventTypes, ContextBag context)
+        {
+            var tasks = new Task[eventTypes.Length];
+            for (int i = 0; i < eventTypes.Length; i++)
+            {
+                tasks[i] = Subscribe(eventTypes[i], context);
+            }
+
+            return Task.WhenAll(tasks);
+        }
+
         public async Task Unsubscribe(MessageMetadata eventType, ContextBag context)
         {
             var eventDir = GetEventDirectory(eventType.MessageType);

--- a/src/NServiceBus.Core/Transports/TransportReceiver.cs
+++ b/src/NServiceBus.Core/Transports/TransportReceiver.cs
@@ -1,8 +1,6 @@
 namespace NServiceBus
 {
-    using System.Collections.Generic;
     using Transport;
-    using Unicast.Messages;
     using System;
     using System.Threading.Tasks;
     using Logging;
@@ -17,7 +15,7 @@ namespace NServiceBus
             this.receiver = receiver;
         }
 
-        public async Task Start(Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, IReadOnlyCollection<MessageMetadata> events)
+        public async Task Start(Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError)
         {
             if (isStarted)
             {
@@ -27,7 +25,7 @@ namespace NServiceBus
             Logger.DebugFormat("Receiver {0} is starting.", receiver.Id);
 
 
-            await receiver.Initialize(pushRuntimeSettings, onMessage, onError, events).ConfigureAwait(false);
+            await receiver.Initialize(pushRuntimeSettings, onMessage, onError).ConfigureAwait(false);
             await receiver.StartReceive().ConfigureAwait(false);
 
             isStarted = true;

--- a/src/NServiceBus.Core/Unicast/MessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperations.cs
@@ -67,9 +67,14 @@ namespace NServiceBus
 
         public Task Subscribe(IBehaviorContext context, Type eventType, SubscribeOptions options)
         {
+            return Subscribe(context, new Type[] { eventType }, options);
+        }
+
+        public Task Subscribe(IBehaviorContext context, Type[] eventTypes, SubscribeOptions options)
+        {
             var subscribeContext = new SubscribeContext(
                 context,
-                eventType,
+                eventTypes,
                 options.Context);
 
             MergeDispatchProperties(subscribeContext, options.DispatchProperties);

--- a/src/NServiceBus.Core/obsoletes-v8.cs
+++ b/src/NServiceBus.Core/obsoletes-v8.cs
@@ -1334,4 +1334,26 @@ namespace NServiceBus.Transport
         public static string GetTransportAddress(this ReadOnlySettings settings, LogicalAddress logicalAddress) => throw new NotImplementedException();
     }
 }
+
+namespace NServiceBus.Pipeline
+{
+    using System;
+    using System.ComponentModel;
+
+    /// <summary>
+    /// Provides context for subscription requests.
+    /// </summary>
+    public partial interface ISubscribeContext
+    {
+        /// <summary>
+        /// The type of the event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "EventTypes",
+            TreatAsErrorFromVersion = "8",
+            RemoveInVersion = "9")]
+        Type EventType { get; }
+    }
+}
 #pragma warning restore 1591

--- a/src/NServiceBus.Testing.Fakes/TestableSubscribeContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableSubscribeContext.cs
@@ -9,8 +9,8 @@
     public partial class TestableSubscribeContext : TestableBehaviorContext, ISubscribeContext
     {
         /// <summary>
-        /// The type of the event.
+        /// The types of the events.
         /// </summary>
-        public Type EventType { get; set; } = typeof(object);
+        public Type[] EventTypes { get; set; } = new Type[0];
     }
 }

--- a/src/NServiceBus.Testing.Fakes/TestableSubscribeContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableSubscribeContext.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Testing
 {
     using System;
+    using System.ComponentModel;
     using Pipeline;
 
     /// <summary>
@@ -8,6 +9,9 @@
     /// </summary>
     public partial class TestableSubscribeContext : TestableBehaviorContext, ISubscribeContext
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Type EventType => throw new NotImplementedException();
+
         /// <summary>
         /// The types of the events.
         /// </summary>

--- a/src/NServiceBus.Testing.Fakes/TestableSubscribeContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableSubscribeContext.cs
@@ -11,6 +11,6 @@
         /// <summary>
         /// The types of the events.
         /// </summary>
-        public Type[] EventTypes { get; set; } = new Type[0];
+        public Type[] EventTypes { get; set; } = { typeof(object) };
     }
 }

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.TransportTests
 {
     using Transport;
-    using Unicast.Messages;
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
@@ -113,7 +112,7 @@
                     }
 
                     return Task.FromResult(ErrorHandleResult.Handled);
-                }, new MessageMetadata[0]);
+                });
 
             await transportInfrastructure.Receivers[0].StartReceive();
 


### PR DESCRIPTION
Adds a new API to the subscriptin manager that allows subscribing events in batches.
To make this work, the pipeline had the be changed internally to support multiple event subscriptions in one go, the public, user-facing API remains at the single event subscribe API for now though. Behaviors would have to be adjusted though.

While this is fairly straight-forward, there are some details to get right on exception handling. The code currently tries to to deal with cases that subscribing can both throw aggregate exceptions or regular exceptions. When using SubscribeAll, aggregate should be preferred to give the caller more information about every potential failure of subscribe as the behavior currently does not stop subscribing on the first error but continues.