### PR TITLE
Remove Subscribe from ISubscriptionManager

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeReceiver.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeReceiver.cs
@@ -58,8 +58,6 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport
 
         class FakeSubscriptionManager : ISubscriptionManager
         {
-            public Task Subscribe(MessageMetadata eventType, ContextBag context) => Task.CompletedTask;
-
             public Task SubscribeAll(MessageMetadata[] eventTypes, ContextBag context) => Task.CompletedTask;
 
             public Task Unsubscribe(MessageMetadata eventType, ContextBag context) => Task.CompletedTask;

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2450,7 +2450,6 @@ namespace NServiceBus.Transport
     }
     public interface ISubscriptionManager
     {
-        System.Threading.Tasks.Task Subscribe(NServiceBus.Unicast.Messages.MessageMetadata eventType, NServiceBus.Extensibility.ContextBag context);
         System.Threading.Tasks.Task SubscribeAll(NServiceBus.Unicast.Messages.MessageMetadata[] eventTypes, NServiceBus.Extensibility.ContextBag context);
         System.Threading.Tasks.Task Unsubscribe(NServiceBus.Unicast.Messages.MessageMetadata eventType, NServiceBus.Extensibility.ContextBag context);
     }

--- a/src/NServiceBus.Core.Tests/Routing/NativeSubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/NativeSubscribeTerminatorTests.cs
@@ -76,8 +76,6 @@
                 this.exceptionToThrow = exceptionToThrow;
             }
 
-            public Task Subscribe(MessageMetadata eventType, ContextBag context) => throw new NotImplementedException();
-
             public Task SubscribeAll(MessageMetadata[] eventTypes, ContextBag context) => throw exceptionToThrow;
 
             public Task Unsubscribe(MessageMetadata eventType, ContextBag context) => throw new NotImplementedException();

--- a/src/NServiceBus.Core/Transports/ISubscriptionManager.cs
+++ b/src/NServiceBus.Core/Transports/ISubscriptionManager.cs
@@ -10,11 +10,6 @@
     public interface ISubscriptionManager
     {
         /// <summary>
-        /// Subscribes to the given event.
-        /// </summary>
-        Task Subscribe(MessageMetadata eventType, ContextBag context);
-
-        /// <summary>
         /// Subscribes to all provided events.
         /// </summary>
         Task SubscribeAll(MessageMetadata[] eventTypes, ContextBag context);

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportSubscriptionManager.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportSubscriptionManager.cs
@@ -16,47 +16,12 @@
             this.basePath = Path.Combine(basePath, ".events");
         }
 
-        public async Task Subscribe(MessageMetadata eventType, ContextBag context)
-        {
-            var eventDir = GetEventDirectory(eventType.MessageType);
-
-            // the subscription directory and the subscription information will be created no matter if there's a publisher for the event assuming that the publisher haven’t started yet
-            Directory.CreateDirectory(eventDir);
-
-            var subscriptionEntryPath = GetSubscriptionEntryPath(eventDir);
-
-            var attempts = 0;
-
-            // since we have a design that can run into concurrency exceptions we perform a few retries
-            while (true)
-            {
-                try
-                {
-                    await AsyncFile.WriteText(subscriptionEntryPath, localAddress).ConfigureAwait(false);
-
-                    return;
-                }
-                catch (IOException)
-                {
-                    attempts++;
-
-                    if (attempts > 10)
-                    {
-                        throw;
-                    }
-
-                    //allow the other task to complete
-                    await Task.Delay(100).ConfigureAwait(false);
-                }
-            }
-        }
-
         public Task SubscribeAll(MessageMetadata[] eventTypes, ContextBag context)
         {
             var tasks = new Task[eventTypes.Length];
             for (int i = 0; i < eventTypes.Length; i++)
             {
-                tasks[i] = Subscribe(eventTypes[i], context);
+                tasks[i] = Subscribe(eventTypes[i]);
             }
 
             return Task.WhenAll(tasks);
@@ -80,6 +45,41 @@
                     }
 
                     File.Delete(subscriptionEntryPath);
+
+                    return;
+                }
+                catch (IOException)
+                {
+                    attempts++;
+
+                    if (attempts > 10)
+                    {
+                        throw;
+                    }
+
+                    //allow the other task to complete
+                    await Task.Delay(100).ConfigureAwait(false);
+                }
+            }
+        }
+
+        async Task Subscribe(MessageMetadata eventType)
+        {
+            var eventDir = GetEventDirectory(eventType.MessageType);
+
+            // the subscription directory and the subscription information will be created no matter if there's a publisher for the event assuming that the publisher haven’t started yet
+            Directory.CreateDirectory(eventDir);
+
+            var subscriptionEntryPath = GetSubscriptionEntryPath(eventDir);
+
+            var attempts = 0;
+
+            // since we have a design that can run into concurrency exceptions we perform a few retries
+            while (true)
+            {
+                try
+                {
+                    await AsyncFile.WriteText(subscriptionEntryPath, localAddress).ConfigureAwait(false);
 
                     return;
                 }


### PR DESCRIPTION
completes the changes to `ISubscriptionManager` by removing the `Subscribe` option that isn't being called anymore, so removal is pretty simple.