### PR TITLE
Ensure internal behaviors implement more performant behavior interfaces

### DIFF
--- a/src/NServiceBus.Core.Tests/Pipeline/EnsureNativeBehaviors.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/EnsureNativeBehaviors.cs
@@ -1,0 +1,44 @@
+﻿namespace NServiceBus.Core.Tests.Pipeline
+{
+    using System;
+    using System.Linq;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public static class EnsureNativeBehvaviors
+    {
+        static readonly Type[] abstractTypesForExternalUseOnly = new[]
+        {
+            typeof(Behavior<>),
+            typeof(ForkConnector<,>),
+        };
+
+        [Test]
+        public static void CoreBehaviorsMustNotUseAbstractClasses()
+        {
+            var violators = typeof(IBehavior).Assembly.GetTypes()
+                .Where(UsesAbstractClass)
+                .ToList();
+
+            Console.Error.WriteLine($"Violators of {nameof(CoreBehaviorsMustNotUseAbstractClasses)}:{Environment.NewLine}{string.Join(Environment.NewLine, violators)}");
+
+            Assert.IsEmpty(violators, $"For performance reasons, built-in behaviors are not allowed to inherit from abstract behavior classes. Implement IBehavior<Tin, TOut> directly, using the same context type for both TIn and TOut.");
+        }
+
+        static bool UsesAbstractClass(Type type)
+        {
+            if (type == null || abstractTypesForExternalUseOnly.Contains(type))
+            {
+                return false;
+            }
+
+            if (type.IsGenericType && abstractTypesForExternalUseOnly.Contains(type.GetGenericTypeDefinition()))
+            {
+                return true;
+            }
+
+            return UsesAbstractClass(type.BaseType);
+        }
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/Incoming/InferredMessageTypeEnricherBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/InferredMessageTypeEnricherBehavior.cs
@@ -4,16 +4,16 @@ namespace NServiceBus
     using System.Threading.Tasks;
     using Pipeline;
 
-    class InferredMessageTypeEnricherBehavior : Behavior<IIncomingLogicalMessageContext>
+    class InferredMessageTypeEnricherBehavior : IBehavior<IIncomingLogicalMessageContext, IIncomingLogicalMessageContext>
     {
-        public override Task Invoke(IIncomingLogicalMessageContext context, Func<Task> next)
+        public Task Invoke(IIncomingLogicalMessageContext context, Func<IIncomingLogicalMessageContext, Task> next)
         {
             if (!context.Headers.ContainsKey(Headers.EnclosedMessageTypes))
             {
                 context.Headers[Headers.EnclosedMessageTypes] = context.Message.MessageType.FullName;
             }
 
-            return next();
+            return next(context);
         }
     }
 }


### PR DESCRIPTION
Test ensures that internal behaviors won't inherit the convenience abstract behaviors `Behavior<TContext>` or `ForkConnector<TFromContext, TForkContext>`, which are provided for convenience of external users and carry a performance overhead in the compiled pipeline.