### PR TITLE
Revert renaming of Outbox.TransportOperation Options property

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1752,7 +1752,7 @@ namespace NServiceBus.Outbox
         public byte[] Body { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public string MessageId { get; }
-        public NServiceBus.Transport.DispatchProperties Properties { get; }
+        public NServiceBus.Transport.DispatchProperties Options { get; }
     }
 }
 namespace NServiceBus.Performance.TimeToBeReceived

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
@@ -66,8 +66,8 @@ namespace NServiceBus
                 pendingTransportOperations.Add(
                     new Transport.TransportOperation(
                         message,
-                        DeserializeRoutingStrategy(operation.Properties),
-                        operation.Properties,
+                        DeserializeRoutingStrategy(operation.Options),
+                        operation.Options,
                         DispatchConsistency.Isolated
                         ));
             }

--- a/src/NServiceBus.Core/Reliability/Outbox/TransportOperation.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/TransportOperation.cs
@@ -16,7 +16,7 @@
             Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
 
             MessageId = messageId;
-            Properties = properties;
+            Options = properties;
             Body = body;
             Headers = headers;
         }
@@ -29,7 +29,7 @@
         /// <summary>
         /// Transport specific dispatch operation properties.
         /// </summary>
-        public DispatchProperties Properties { get; }
+        public DispatchProperties Options { get; }
 
         /// <summary>
         /// Gets a byte array to the body content of the outgoing message.


### PR DESCRIPTION
Reverting the changes made recently to rename the property containing the additional properties back to `Options` to keep the breaking changes for persisters smaller.