### PR TITLE
Set HostSettings.CoreSettings to null instead of empty

### DIFF
--- a/src/NServiceBus.Core/Transports/HostSettings.cs
+++ b/src/NServiceBus.Core/Transports/HostSettings.cs
@@ -18,11 +18,11 @@ namespace NServiceBus.Transport
             StartupDiagnostic = startupDiagnostic;
             CriticalErrorAction = criticalErrorAction;
             SetupInfrastructure = setupInfrastructure;
-            CoreSettings = coreSettings ?? new SettingsHolder();
+            CoreSettings = coreSettings;
         }
 
         /// <summary>
-        /// Settings available only when running hosted in an NServiceBus endpoint; Otherwise, an empty settings collection.
+        /// Settings available only when running hosted in an NServiceBus endpoint; Otherwise, <c>null</c>.
         /// Transports can use these settings to validate the hosting endpoint settings.
         /// </summary>
         public ReadOnlySettings CoreSettings { get; }

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -10,7 +10,6 @@
     using Logging;
     using NUnit.Framework;
     using Routing;
-    using Settings;
 
     public abstract class NServiceBusTransportTest
     {
@@ -84,8 +83,7 @@
                 string.Empty,
                 new StartupDiagnosticEntries(),
                 onCriticalError,
-                true,
-                new SettingsHolder());
+                true);
 
             var transport = configurer.CreateTransportDefinition();
 


### PR DESCRIPTION
I think this should be set to null when not explicitly defined, as downstreams will have a hard time to determine whether the collection is empty. There is no direct API available on this type to check if the collection is empty or not so transports should be able to rely on a null check instead.

This is for example an issue for MSMQ right now because MSMQ requires an error queue configuration when running as part of Core but not otherwise, so some checks are only verified when running as part of core.