### PR TITLE
Initialize collection property

### DIFF
--- a/src/NServiceBus.Core/Transports/QueueAddress.cs
+++ b/src/NServiceBus.Core/Transports/QueueAddress.cs
@@ -1,12 +1,15 @@
 namespace NServiceBus.Transport
 {
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
 
     /// <summary>
     /// Represents a queue address.
     /// </summary>
     public class QueueAddress
     {
+        static readonly IReadOnlyDictionary<string, string> EmptyProperties = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(0));
+
         /// <summary>
         /// Creates a new instance of <see cref="QueueAddress"/>.
         /// </summary>
@@ -15,7 +18,7 @@ namespace NServiceBus.Transport
         {
             BaseAddress = baseAddress;
             Discriminator = discriminator;
-            Properties = properties;
+            Properties = properties ?? EmptyProperties;
             Qualifier = qualifier;
         }
 


### PR DESCRIPTION
Initializes the `Properties` property with an empty collection in case `null` is passed. This makes it easier for downstreams to check as they can only check for the necessary values without having to ensure the collection itself is there in the first place.