### PR TITLE
Make force message rollback more explicit and not rely on a cancelation token source

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -38,7 +38,7 @@
         {
             PushRuntimeSettings pushSettings;
 
-            public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError)
+            public Task Initialize(PushRuntimeSettings limitations, OnMessage onMessage, OnError onError)
             {
                 pushSettings = limitations;
                 return Task.CompletedTask;

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -38,7 +38,7 @@
         {
             PushRuntimeSettings pushSettings;
 
-            public Task Initialize(PushRuntimeSettings limitations, OnMessage onMessage, OnError onError)
+            public Task Initialize(PushRuntimeSettings limitations, Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError)
             {
                 pushSettings = limitations;
                 return Task.CompletedTask;

--- a/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
+++ b/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
@@ -60,7 +60,7 @@
                             var testContext = builder.GetService<Context>();
                             testContext.MessageReceived = true;
                             testContext.TransportTransactionAddedToContext = ReferenceEquals(messageContext.Extensions.Get<TransportTransaction>(), messageContext.TransportTransaction);
-                            return Task.FromResult(true);
+                            return Task.FromResult(new MessageProcessingResult(false));
                         });
 
                     Address = satelliteAddress;

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -758,7 +758,7 @@ namespace NServiceBus
         public Notifications() { }
         public NServiceBus.Faults.ErrorsNotifications Errors { get; }
     }
-    public delegate System.Threading.Tasks.Task OnSatelliteMessage(System.IServiceProvider serviceProvider, NServiceBus.Transport.MessageContext messageContext);
+    public delegate System.Threading.Tasks.Task<NServiceBus.Transport.MessageProcessingResult> OnSatelliteMessage(System.IServiceProvider serviceProvider, NServiceBus.Transport.MessageContext messageContext);
     public static class OutboxConfigExtensions
     {
         public static NServiceBus.Outbox.OutboxSettings EnableOutbox(this NServiceBus.EndpointConfiguration config) { }
@@ -2488,13 +2488,17 @@ namespace NServiceBus.Transport
     }
     public class MessageContext : NServiceBus.Extensibility.IExtendable
     {
-        public MessageContext(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, System.Threading.CancellationTokenSource receiveCancellationTokenSource, NServiceBus.Extensibility.ContextBag context) { }
+        public MessageContext(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, NServiceBus.Extensibility.ContextBag context) { }
         public byte[] Body { get; }
         public NServiceBus.Extensibility.ContextBag Extensions { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public string MessageId { get; }
-        public System.Threading.CancellationTokenSource ReceiveCancellationTokenSource { get; }
         public NServiceBus.Transport.TransportTransaction TransportTransaction { get; }
+    }
+    public class MessageProcessingResult
+    {
+        public MessageProcessingResult(bool forceMessageRollback) { }
+        public bool ForceMessageRollback { get; }
     }
     public class MulticastTransportOperation : NServiceBus.Transport.IOutgoingTransportOperation
     {
@@ -2505,7 +2509,7 @@ namespace NServiceBus.Transport
         public NServiceBus.Transport.DispatchConsistency RequiredDispatchConsistency { get; }
     }
     public delegate System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult> OnError(NServiceBus.Transport.ErrorContext errorContext);
-    public delegate System.Threading.Tasks.Task OnMessage(NServiceBus.Transport.MessageContext messageContext);
+    public delegate System.Threading.Tasks.Task<NServiceBus.Transport.MessageProcessingResult> OnMessage(NServiceBus.Transport.MessageContext messageContext);
     [System.Obsolete("This type is no longer necessary when implementing a transport. Will be removed i" +
         "n version 9.0.0.", true)]
     public class OutboundRoutingPolicy

--- a/src/NServiceBus.Core.Tests/Transports/TransportReceiverTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/TransportReceiverTests.cs
@@ -19,7 +19,7 @@
         [Test]
         public async Task Start_should_start_the_pump()
         {
-            await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled));
+            await receiver.Start(_ => Task.FromResult(SuccessfulMessageProcessingResult), _ => Task.FromResult(ErrorHandleResult.Handled));
 
             Assert.IsTrue(pump.Started);
         }
@@ -30,14 +30,14 @@
             pump.ThrowOnStart = true;
 
             Assert.ThrowsAsync<InvalidOperationException>(async () =>
-                await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled))
+                await receiver.Start(_ => Task.FromResult(SuccessfulMessageProcessingResult), _ => Task.FromResult(ErrorHandleResult.Handled))
                 );
         }
 
         [Test]
         public async Task Stop_should_stop_the_pump()
         {
-            await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled));
+            await receiver.Start(_ => Task.FromResult(SuccessfulMessageProcessingResult), _ => Task.FromResult(ErrorHandleResult.Handled));
 
             await receiver.Stop();
 
@@ -49,10 +49,13 @@
         {
             pump.ThrowOnStop = true;
 
-            await receiver.Start(_ => Task.CompletedTask, _ => Task.FromResult(ErrorHandleResult.Handled));
+            await receiver.Start(_ => Task.FromResult(SuccessfulMessageProcessingResult), _ => Task.FromResult(ErrorHandleResult.Handled));
 
             Assert.DoesNotThrowAsync(async () => await receiver.Stop());
         }
+
+
+        static MessageProcessingResult SuccessfulMessageProcessingResult = new MessageProcessingResult(false);
 
         MessageReceiver pump;
         TransportReceiver receiver;

--- a/src/NServiceBus.Core/Pipeline/IPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/IPipelineExecutor.cs
@@ -5,6 +5,6 @@
 
     interface IPipelineExecutor
     {
-        Task Invoke(MessageContext messageContext);
+        Task<MessageProcessingResult> Invoke(MessageContext messageContext);
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveContext.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus
 {
-    using System.Threading;
     using Pipeline;
     using Transport;
 
@@ -12,10 +11,9 @@
         /// <summary>
         /// Creates a new transport receive context.
         /// </summary>
-        public TransportReceiveContext(IncomingMessage receivedMessage, TransportTransaction transportTransaction, CancellationTokenSource cancellationTokenSource, RootContext rootContext)
+        public TransportReceiveContext(IncomingMessage receivedMessage, TransportTransaction transportTransaction, RootContext rootContext)
             : base(rootContext)
         {
-            this.cancellationTokenSource = cancellationTokenSource;
             Message = receivedMessage;
             Set(Message);
             Set(transportTransaction);
@@ -31,9 +29,10 @@
         /// </summary>
         public void AbortReceiveOperation()
         {
-            cancellationTokenSource.Cancel();
+            ReceiveOperationWasAborted = true;
         }
 
-        CancellationTokenSource cancellationTokenSource;
+        internal bool ReceiveOperationWasAborted { get; private set; }
+
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveContext.cs
@@ -3,14 +3,8 @@
     using Pipeline;
     using Transport;
 
-    /// <summary>
-    /// Context containing a physical message.
-    /// </summary>
     class TransportReceiveContext : BehaviorContext, ITransportReceiveContext
     {
-        /// <summary>
-        /// Creates a new transport receive context.
-        /// </summary>
         public TransportReceiveContext(IncomingMessage receivedMessage, TransportTransaction transportTransaction, RootContext rootContext)
             : base(rootContext)
         {
@@ -19,19 +13,13 @@
             Set(transportTransaction);
         }
 
-        /// <summary>
-        /// The physical message being processed.
-        /// </summary>
         public IncomingMessage Message { get; }
 
-        /// <summary>
-        /// Allows the pipeline to flag that it has been aborted and the receive operation should be rolled back.
-        /// </summary>
         public void AbortReceiveOperation()
         {
             ReceiveOperationWasAborted = true;
         }
 
-        internal bool ReceiveOperationWasAborted { get; private set; }
+        public bool ReceiveOperationWasAborted { get; private set; }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveContext.cs
@@ -33,6 +33,5 @@
         }
 
         internal bool ReceiveOperationWasAborted { get; private set; }
-
     }
 }

--- a/src/NServiceBus.Core/Pipeline/SatellitePipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/SatellitePipelineExecutor.cs
@@ -12,7 +12,7 @@
             satelliteDefinition = definition;
         }
 
-        public Task Invoke(MessageContext messageContext)
+        public Task<MessageProcessingResult> Invoke(MessageContext messageContext)
         {
             messageContext.Extensions.Set(messageContext.TransportTransaction);
 

--- a/src/NServiceBus.Core/Receiving/OnSatelliteMessage.cs
+++ b/src/NServiceBus.Core/Receiving/OnSatelliteMessage.cs
@@ -7,5 +7,5 @@
     /// <summary>
     /// Processes an incoming satellite message.
     /// </summary>
-    public delegate Task OnSatelliteMessage(IServiceProvider serviceProvider, MessageContext messageContext);
+    public delegate Task<MessageProcessingResult> OnSatelliteMessage(IServiceProvider serviceProvider, MessageContext messageContext);
 }

--- a/src/NServiceBus.Core/Transports/IMessageReceiver.cs
+++ b/src/NServiceBus.Core/Transports/IMessageReceiver.cs
@@ -36,7 +36,7 @@
     /// <summary>
     /// Processes an incoming message.
     /// </summary>
-    public delegate Task OnMessage(MessageContext messageContext);
+    public delegate Task<MessageProcessingResult> OnMessage(MessageContext messageContext);
 
 
     /// <summary>

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -328,7 +328,7 @@
                 }
             }
 
-            if (messageProcessingResult != null && messageProcessingResult.ForceMessageRollback)
+            if (messageProcessingResult != null && messageProcessingResult.AbortReceiveOperation)
             {
                 transaction.Rollback();
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -328,7 +328,7 @@
                 }
             }
 
-            if (messageProcessingResult.ForceMessageRollback)
+            if (messageProcessingResult != null && messageProcessingResult.ForceMessageRollback)
             {
                 transaction.Rollback();
 

--- a/src/NServiceBus.Core/Transports/MessageContext.cs
+++ b/src/NServiceBus.Core/Transports/MessageContext.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Transport
 {
     using System.Collections.Generic;
-    using System.Threading;
     using Extensibility;
 
     /// <summary>
@@ -16,19 +15,13 @@
         /// <param name="headers">The message headers.</param>
         /// <param name="body">The message body.</param>
         /// <param name="transportTransaction">Transaction (along with connection if applicable) used to receive the message.</param>
-        /// <param name="receiveCancellationTokenSource">
-        /// Allows the pipeline to flag that it has been aborted and the receive operation should be rolled back.
-        /// It also allows the transport to communicate to the pipeline to abort if possible. Transports should check if the token
-        /// has been aborted after invoking the pipeline and roll back the message accordingly.
-        /// </param>
         /// <param name="context">A <see cref="ContextBag" /> which can be used to extend the current object.</param>
-        public MessageContext(string messageId, Dictionary<string, string> headers, byte[] body, TransportTransaction transportTransaction, CancellationTokenSource receiveCancellationTokenSource, ContextBag context)
+        public MessageContext(string messageId, Dictionary<string, string> headers, byte[] body, TransportTransaction transportTransaction, ContextBag context)
         {
             Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
             Guard.AgainstNull(nameof(body), body);
             Guard.AgainstNull(nameof(headers), headers);
             Guard.AgainstNull(nameof(transportTransaction), transportTransaction);
-            Guard.AgainstNull(nameof(receiveCancellationTokenSource), receiveCancellationTokenSource);
             Guard.AgainstNull(nameof(context), context);
 
             Headers = headers;
@@ -36,7 +29,6 @@
             MessageId = messageId;
             Extensions = context;
             TransportTransaction = transportTransaction;
-            ReceiveCancellationTokenSource = receiveCancellationTokenSource;
         }
 
         /// <summary>
@@ -58,12 +50,6 @@
         /// Transaction (along with connection if applicable) used to receive the message.
         /// </summary>
         public TransportTransaction TransportTransaction { get; }
-
-        /// <summary>
-        /// Allows the pipeline to flag that the pipeline has been aborted and the receive operation should be rolled back.
-        /// It also allows the transport to communicate to the pipeline to abort if possible.
-        /// </summary>
-        public CancellationTokenSource ReceiveCancellationTokenSource { get; }
 
         /// <summary>
         /// A <see cref="ContextBag" /> which can be used to extend the current object.

--- a/src/NServiceBus.Core/Transports/MessageProcessingResult.cs
+++ b/src/NServiceBus.Core/Transports/MessageProcessingResult.cs
@@ -8,15 +8,15 @@
         /// <summary>
         /// Initializes the result.
         /// </summary>
-        /// <param name="forceMessageRollback">Indicates that the message receive operation should be aborted and the message rolled back to the inputqueue.</param>
-        public MessageProcessingResult(bool forceMessageRollback)
+        /// <param name="abortReceiveOperation">Indicates that the message receive operation should be aborted and the message rolled back to the inputqueue.</param>
+        public MessageProcessingResult(bool abortReceiveOperation)
         {
-            ForceMessageRollback = forceMessageRollback;
+            AbortReceiveOperation = abortReceiveOperation;
         }
 
         /// <summary>
         /// Indicates that the message receive operation should be aborted and the message rolled back to the inputqueue.
         /// </summary>
-        public bool ForceMessageRollback { get; }
+        public bool AbortReceiveOperation { get; }
     }
 }

--- a/src/NServiceBus.Core/Transports/MessageProcessingResult.cs
+++ b/src/NServiceBus.Core/Transports/MessageProcessingResult.cs
@@ -2,7 +2,7 @@
 {
     /// <summary>
     /// Controls how the transport should finalize the processing of the message.
-    /// /// </summary>
+    /// </summary>
     public class MessageProcessingResult
     {
         /// <summary>

--- a/src/NServiceBus.Core/Transports/MessageProcessingResult.cs
+++ b/src/NServiceBus.Core/Transports/MessageProcessingResult.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus.Transport
+{
+    /// <summary>
+    /// Controls how the transport should finalize the processing of the message.
+    /// /// </summary>
+    public class MessageProcessingResult
+    {
+        /// <summary>
+        /// Initializes the result.
+        /// </summary>
+        /// <param name="forceMessageRollback">Indicates that the message receive operation should be aborted and the message rolled back to the inputqueue.</param>
+        public MessageProcessingResult(bool forceMessageRollback)
+        {
+            ForceMessageRollback = forceMessageRollback;
+        }
+
+        /// <summary>
+        /// Indicates that the message receive operation should be aborted and the message rolled back to the inputqueue.
+        /// </summary>
+        public bool ForceMessageRollback { get; }
+    }
+}

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -72,7 +72,7 @@
             configurer?.Cleanup().GetAwaiter().GetResult();
         }
 
-        protected async Task StartPump(Func<MessageContext, Task> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, TransportTransactionMode transactionMode, Action<string, Exception> onCriticalError = null)
+        protected async Task StartPump(Func<MessageContext, Task<MessageProcessingResult>> onMessage, Func<ErrorContext, Task<ErrorHandleResult>> onError, TransportTransactionMode transactionMode, Action<string, Exception> onCriticalError = null)
         {
             InputQueueName = GetTestName() + transactionMode;
             ErrorQueueName = $"{InputQueueName}.error";
@@ -101,7 +101,7 @@
                         return onMessage(context);
                     }
 
-                    return Task.FromResult(0);
+                    return Task.FromResult(SuccessfulMessageProcessingResult);
                 },
                 context =>
                 {
@@ -202,6 +202,7 @@
         protected string InputQueueName;
         protected string ErrorQueueName;
         protected static TransportTestLoggerFactory LogFactory;
+        protected static MessageProcessingResult SuccessfulMessageProcessingResult = new MessageProcessingResult(false);
 
         string testId;
 

--- a/src/NServiceBus.TransportTests/When_failure_happens_after_isolated_send.cs
+++ b/src/NServiceBus.TransportTests/When_failure_happens_after_isolated_send.cs
@@ -23,7 +23,7 @@
                     if (context.Headers.ContainsKey("IsolatedSend"))
                     {
                         onMessageCalled.SetResult(true);
-                        return;
+                        return SuccessfulMessageProcessingResult;
                     }
 
                     await SendMessage(InputQueueName, new Dictionary<string, string>

--- a/src/NServiceBus.TransportTests/When_failure_happens_after_send.cs
+++ b/src/NServiceBus.TransportTests/When_failure_happens_after_send.cs
@@ -23,13 +23,13 @@ namespace NServiceBus.TransportTests
                 if (context.Headers.ContainsKey("CompleteTest"))
                 {
                     onMessageCalled.SetResult(true);
-                    return;
+                    return SuccessfulMessageProcessingResult;
                 }
 
                 if (context.Headers.ContainsKey("EnlistedSend"))
                 {
                     onMessageCalled.SetResult(false);
-                    return;
+                    return SuccessfulMessageProcessingResult;
                 }
 
                 await SendMessage(InputQueueName, new Dictionary<string, string> { { "EnlistedSend", "true" } }, context.TransportTransaction);

--- a/src/NServiceBus.TransportTests/When_message_is_available.cs
+++ b/src/NServiceBus.TransportTests/When_message_is_available.cs
@@ -24,7 +24,7 @@ namespace NServiceBus.TransportTests
                 body = Encoding.UTF8.GetString(context.Body);
 
                 onMessageCalled.SetResult(context);
-                return Task.FromResult(0);
+                return Task.FromResult(SuccessfulMessageProcessingResult);
             },
                 context => Task.FromResult(ErrorHandleResult.Handled), transactionMode);
 

--- a/src/NServiceBus.TransportTests/When_modifying_incoming_headers.cs
+++ b/src/NServiceBus.TransportTests/When_modifying_incoming_headers.cs
@@ -26,7 +26,7 @@
                     }
 
                     messageRetries.SetResult(context);
-                    return Task.FromResult(0);
+                    return Task.FromResult(SuccessfulMessageProcessingResult);
                 },
                 context => Task.FromResult(ErrorHandleResult.RetryRequired),
                 transactionMode);
@@ -88,7 +88,7 @@
                     }
 
                     messageRetries.SetResult(context);
-                    return Task.FromResult(0);
+                    return Task.FromResult(SuccessfulMessageProcessingResult);
                 },
                 context =>
                 {

--- a/src/NServiceBus.TransportTests/When_requesting_immediate_retry.cs
+++ b/src/NServiceBus.TransportTests/When_requesting_immediate_retry.cs
@@ -25,7 +25,7 @@ namespace NServiceBus.TransportTests
                     if (hasBeenCalled)
                     {
                         messageRetried.SetResult(true);
-                        return Task.FromResult(0);
+                        return Task.FromResult(SuccessfulMessageProcessingResult);
                     }
                     hasBeenCalled = true;
                     throw new Exception("Simulated exception");

--- a/src/NServiceBus.TransportTests/When_scope_complete_throws.cs
+++ b/src/NServiceBus.TransportTests/When_scope_complete_throws.cs
@@ -22,7 +22,7 @@
                 {
                     // handler enlists a failing transaction enlistment to the DTC transaction which will fail when committing the transaction.
                     Transaction.Current.EnlistDurable(EnlistmentWhichFailsDuringPrepare.Id, new EnlistmentWhichFailsDuringPrepare(), EnlistmentOptions.None);
-                    return Task.FromResult(0);
+                    return Task.FromResult(SuccessfulMessageProcessingResult);
                 },
                 context =>
                 {

--- a/src/NServiceBus.TransportTests/When_scope_throws_after_successful_message_processing.cs
+++ b/src/NServiceBus.TransportTests/When_scope_throws_after_successful_message_processing.cs
@@ -22,7 +22,7 @@
                 context =>
                 {
                     Transaction.Current.EnlistDurable(EnlistmentWhichFailsDuringPrepare.Id, new EnlistmentWhichFailsDuringPrepare(), EnlistmentOptions.None);
-                    return Task.FromResult(0);
+                    return Task.FromResult(SuccessfulMessageProcessingResult);
                 },
                 context =>
                 {

--- a/src/NServiceBus.TransportTests/When_sending_from_on_error.cs
+++ b/src/NServiceBus.TransportTests/When_sending_from_on_error.cs
@@ -24,7 +24,7 @@ namespace NServiceBus.TransportTests
                     if (context.Headers.ContainsKey("FromOnError"))
                     {
                         messageReceived.SetResult(true);
-                        return Task.FromResult(0);
+                        return Task.FromResult(SuccessfulMessageProcessingResult);
                     }
 
                     throw new Exception("Simulated exception");

--- a/src/NServiceBus.TransportTests/When_transaction_level_TransactionScope.cs
+++ b/src/NServiceBus.TransportTests/When_transaction_level_TransactionScope.cs
@@ -23,7 +23,7 @@
                     var contextTransaction = context.TransportTransaction.Get<Transaction>();
                     messageHandled.SetResult(new Tuple<Transaction, Transaction>(currentTransaction, contextTransaction));
 
-                    return Task.FromResult(0);
+                    return Task.FromResult(SuccessfulMessageProcessingResult);
                 },
                 errorContext => Task.FromResult(ErrorHandleResult.Handled),
                 transactionMode);

--- a/src/NServiceBus.TransportTests/When_user_aborts_processing.cs
+++ b/src/NServiceBus.TransportTests/When_user_aborts_processing.cs
@@ -25,12 +25,12 @@ namespace NServiceBus.TransportTests
                     if (hasBeenCalled)
                     {
                         messageRedelivered.SetResult(true);
-                        return Task.FromResult(0);
+                        return Task.FromResult(new MessageProcessingResult(false));
                     }
-                    hasBeenCalled = true;
-                    context.ReceiveCancellationTokenSource.Cancel();
 
-                    return Task.FromResult(0);
+                    hasBeenCalled = true;
+
+                    return Task.FromResult(new MessageProcessingResult(true));
                 },
                 context =>
                 {

--- a/src/NServiceBus.TransportTests/When_using_unicode_characters_in_headers.cs
+++ b/src/NServiceBus.TransportTests/When_using_unicode_characters_in_headers.cs
@@ -15,7 +15,7 @@
             await StartPump(m =>
                 {
                     onMessageCalled.SetResult(m);
-                    return Task.FromResult(0);
+                    return Task.FromResult(SuccessfulMessageProcessingResult);
                 },
                 error => Task.FromResult(ErrorHandleResult.Handled),
                 TransportTransactionMode.None);


### PR DESCRIPTION
As a step towards introducing cancellation token support in v8 we are removing the usage if a token source for forces message rollback since it doesn't make sense for a token to be used since that can cause an exception if the token managed by the transport is observed and that exception will make error handling to be invoked.