### PR TITLE
Align HostSettings argument type

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2397,7 +2397,7 @@ namespace NServiceBus.Transport
     }
     public class HostSettings
     {
-        public HostSettings(string name, string hostDisplayName, NServiceBus.StartupDiagnosticEntries startupDiagnostic, System.Action<string, System.Exception> criticalErrorAction, bool setupInfrastructure, NServiceBus.Settings.SettingsHolder coreSettings = null) { }
+        public HostSettings(string name, string hostDisplayName, NServiceBus.StartupDiagnosticEntries startupDiagnostic, System.Action<string, System.Exception> criticalErrorAction, bool setupInfrastructure, NServiceBus.Settings.ReadOnlySettings coreSettings = null) { }
         public NServiceBus.Settings.ReadOnlySettings CoreSettings { get; }
         public System.Action<string, System.Exception> CriticalErrorAction { get; }
         public string HostDisplayName { get; }

--- a/src/NServiceBus.Core/Transports/HostSettings.cs
+++ b/src/NServiceBus.Core/Transports/HostSettings.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.Transport
         /// <summary>
         /// Creates a new instance of <see cref="HostSettings"/>.
         /// </summary>
-        public HostSettings(string name, string hostDisplayName, StartupDiagnosticEntries startupDiagnostic, Action<string, Exception> criticalErrorAction, bool setupInfrastructure, SettingsHolder coreSettings = null)
+        public HostSettings(string name, string hostDisplayName, StartupDiagnosticEntries startupDiagnostic, Action<string, Exception> criticalErrorAction, bool setupInfrastructure, ReadOnlySettings coreSettings = null)
         {
             Name = name;
             HostDisplayName = hostDisplayName;


### PR DESCRIPTION
The core settings property is a `IReadOnlySettings` while the parameter on the ctor is a `SettingsHolder`. This can cause some potential issues e.g. when trying to copy over host settings because you can't pass the host settings property as a parameter due to the type mismatch.