### PR TITLE
Make sure that messages can't be retried for more than 24 hours

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_delayed_retries_over_24hours.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_delayed_retries_over_24hours.cs
@@ -22,9 +22,9 @@ namespace NServiceBus.AcceptanceTests.Core.Recoverability
                 .Done(c => c.FailedMessages.Any())
                 .Run(TimeSpan.FromSeconds(10));
 
-            var failedMessage = context.FailedMessages.Single();
+            var failedMessage = context.FailedMessages.Values.First().First();
 
-            StringAssert.AreNotEqualIgnoringCase(context.FailedMessages.First().Value.First().Headers[Headers.DelayedRetries], "5");
+            Assert.AreEqual(1, int.Parse(failedMessage.Headers[Headers.DelayedRetries]));
         }
 
         class Context : ScenarioContext
@@ -38,9 +38,9 @@ namespace NServiceBus.AcceptanceTests.Core.Recoverability
             {
                 EndpointSetup<DefaultServer, Context>((config, context) =>
                  {
-                     config.GetSettings().Set("Recoverablity.MaxDurationOfDelayedRetries", TimeSpan.FromSeconds(5));
+                     config.GetSettings().Set("Recoverablity.MaxDurationOfDelayedRetries", TimeSpan.FromSeconds(1));
                      var recoverability = config.Recoverability();
-                     recoverability.Delayed(settings => settings.NumberOfRetries(5).TimeIncrease(TimeSpan.FromSeconds(2)));
+                     recoverability.Delayed(settings => settings.NumberOfRetries(2).TimeIncrease(TimeSpan.FromSeconds(1)));
                  });
             }
 
@@ -52,7 +52,6 @@ namespace NServiceBus.AcceptanceTests.Core.Recoverability
                 }
             }
         }
-
 
         public class MessageToBeRetried : IMessage
         {

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_delayed_retries_over_24hours.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_delayed_retries_over_24hours.cs
@@ -1,0 +1,61 @@
+namespace NServiceBus.AcceptanceTests.Core.Recoverability
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NServiceBus.Configuration.AdvancedExtensibility;
+    using NUnit.Framework;
+
+    public class When_delayed_retries_over_24hours : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_move_message_to_error()
+        {
+            Requires.DelayedDelivery();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<RetryEndpoint>(b => b
+                    .When(session => session.SendLocal(new MessageToBeRetried()))
+                    .DoNotFailOnErrorMessages())
+                .Done(c => c.FailedMessages.Any())
+                .Run(TimeSpan.FromSeconds(10));
+
+            var failedMessage = context.FailedMessages.Single();
+
+            StringAssert.AreNotEqualIgnoringCase(context.FailedMessages.First().Value.First().Headers[Headers.DelayedRetries], "5");
+        }
+
+        class Context : ScenarioContext
+        {
+            public byte[] OriginalBody { get; set; }
+        }
+
+        public class RetryEndpoint : EndpointConfigurationBuilder
+        {
+            public RetryEndpoint()
+            {
+                EndpointSetup<DefaultServer, Context>((config, context) =>
+                 {
+                     config.GetSettings().Set("Recoverablity.MaxDurationOfDelayedRetries", TimeSpan.FromSeconds(5));
+                     var recoverability = config.Recoverability();
+                     recoverability.Delayed(settings => settings.NumberOfRetries(5).TimeIncrease(TimeSpan.FromSeconds(2)));
+                 });
+            }
+
+            class MessageToBeRetriedHandler : IHandleMessages<MessageToBeRetried>
+            {
+                public Task Handle(MessageToBeRetried message, IMessageHandlerContext context)
+                {
+                    throw new SimulatedException();
+                }
+            }
+        }
+
+
+        public class MessageToBeRetried : IMessage
+        {
+        }
+    }
+}


### PR DESCRIPTION
Per our documentation 24h is the max time a message can be retried since it was retried the first time. This PR fixes an issue where this rule was only enforced between retries. This would mean that a message could be retried for ever as long as the delay was not increased above 24 hours.