### PR TITLE
Initialize transport receivers before Features are started

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/TestSuiteConstraints.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/TestSuiteConstraints.cs
@@ -17,6 +17,8 @@
 
         public bool SupportsOutbox => true;
 
+        public bool SupportsPurgeOnStartup => true;
+
         public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureEndpointAcceptanceTestingTransport(SupportsNativePubSub, SupportsDelayedDelivery);
 
         public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointAcceptanceTestingPersistence();

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/Requires.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/Requires.cs
@@ -51,5 +51,13 @@
                 Assert.Ignore("Ignoring this tests because it requires a persistence providing an Outbox storage.");
             }
         }
+
+        public static void PurgeOnStartupSupport()
+        {
+            if (!TestSuiteConstraints.Current.SupportsPurgeOnStartup)
+            {
+                Assert.Ignore("Ignoring this tests because it requires a transport able to purge queues at startup.");
+            }
+        }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/TestSuiteConstraints.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/TestSuiteConstraints.cs
@@ -14,6 +14,8 @@
 
         bool SupportsOutbox { get; }
 
+        bool SupportsPurgeOnStartup { get; }
+
         IConfigureEndpointTestExecution CreateTransportConfiguration();
 
         IConfigureEndpointTestExecution CreatePersistenceConfiguration();

--- a/src/NServiceBus.AcceptanceTests/Feature/When_purging_queues.cs
+++ b/src/NServiceBus.AcceptanceTests/Feature/When_purging_queues.cs
@@ -6,7 +6,7 @@
     using Features;
     using NUnit.Framework;
 
-    public class When_purging_queues
+    public class When_purging_queues : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_purge_before_FeatureStartupTasks()

--- a/src/NServiceBus.AcceptanceTests/Feature/When_purging_queues.cs
+++ b/src/NServiceBus.AcceptanceTests/Feature/When_purging_queues.cs
@@ -1,0 +1,76 @@
+﻿namespace NServiceBus.AcceptanceTests.Feature
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    public class When_purging_queues
+    {
+        [Test]
+        public async Task Should_purge_before_FeatureStartupTasks()
+        {
+            Requires.PurgeOnStartupSupport();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithStartupTask>()
+                .Done(c => c.LocalMessageReceived)
+                .Run();
+
+            Assert.IsTrue(context.LocalMessageReceived);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool LocalMessageReceived { get; set; }
+        }
+
+        class EndpointWithStartupTask : EndpointConfigurationBuilder
+        {
+            public EndpointWithStartupTask()
+            {
+                EndpointSetup<DefaultServer>(c => c
+                    .PurgeOnStartup(true));
+            }
+
+            class MessageHandler : IHandleMessages<LocalMessage>
+            {
+                readonly Context testContext;
+
+                public MessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(LocalMessage message, IMessageHandlerContext context)
+                {
+                    testContext.LocalMessageReceived = true;
+                    return Task.CompletedTask;
+                }
+            }
+
+            class FeatureWithStartupTask : Feature
+            {
+                public FeatureWithStartupTask() => EnableByDefault();
+
+                protected override void Setup(FeatureConfigurationContext context) =>
+                    context.RegisterStartupTask(new StartupTask());
+
+                class StartupTask : FeatureStartupTask
+                {
+                    protected override Task OnStart(IMessageSession session)
+                    {
+                        return session.SendLocal(new LocalMessage());
+                    }
+
+                    protected override Task OnStop(IMessageSession session) => Task.CompletedTask;
+                }
+            }
+        }
+
+        public class LocalMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Feature/When_subscribing_in_FST.cs
+++ b/src/NServiceBus.AcceptanceTests/Feature/When_subscribing_in_FST.cs
@@ -9,7 +9,7 @@
     /// <summary>
     /// We want to test that subscriptions are possible while the receivers (that own the subscription manager) haven't been started yet.
     /// </summary>
-    public class When_subscribing_in_FST
+    public class When_subscribing_in_FST : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_receive_subscribed_events_native()

--- a/src/NServiceBus.AcceptanceTests/Feature/When_subscribing_in_FST.cs
+++ b/src/NServiceBus.AcceptanceTests/Feature/When_subscribing_in_FST.cs
@@ -1,0 +1,105 @@
+﻿namespace NServiceBus.AcceptanceTests.Feature
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// We want to test that subscriptions are possible while the receivers (that own the subscription manager) haven't been started yet.
+    /// </summary>
+    public class When_subscribing_in_FST
+    {
+        [Test]
+        public async Task Should_receive_subscribed_events_native()
+        {
+            Requires.NativePubSubSupport();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithStartupTask>(e => e
+                    .When(s => s.Publish(new LocalEvent())))
+                .Done(c => c.LocalEventReceived)
+                .Run();
+
+            Assert.IsTrue(context.LocalEventReceived);
+        }
+
+        [Test]
+        public async Task Should_receive_subscribed_events_mdps()
+        {
+            Requires.MessageDrivenPubSub();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithStartupTask>(e => e
+                    .When(ctx => ctx.EndpointSubscribed, s => s.Publish(new LocalEvent())))
+                .Done(c => c.LocalEventReceived)
+                .Run();
+
+            Assert.IsTrue(context.LocalEventReceived);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool EndpointSubscribed { get; set; }
+            public bool LocalEventReceived { get; set; }
+        }
+
+        class EndpointWithStartupTask : EndpointConfigurationBuilder
+        {
+            public EndpointWithStartupTask()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                    {
+                        c.DisableFeature<AutoSubscribe>();
+                        c.OnEndpointSubscribed<Context>((args, ctx) =>
+                        {
+                            if (args.MessageType.Contains(typeof(LocalEvent).FullName))
+                            {
+                                ctx.EndpointSubscribed = true;
+                            }
+                        });
+                    },
+                    p => p.RegisterPublisherFor<LocalEvent>(typeof(EndpointWithStartupTask)));
+            }
+
+            class MessageHandler : IHandleMessages<LocalEvent>
+            {
+                readonly Context testContext;
+
+                public MessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(LocalEvent message, IMessageHandlerContext context)
+                {
+                    testContext.LocalEventReceived = true;
+                    return Task.CompletedTask;
+                }
+            }
+
+            class FeatureWithStartupTask : Feature
+            {
+                public FeatureWithStartupTask() => EnableByDefault();
+
+                protected override void Setup(FeatureConfigurationContext context) =>
+                    context.RegisterStartupTask(new StartupTask());
+
+                class StartupTask : FeatureStartupTask
+                {
+                    protected override Task OnStart(IMessageSession session)
+                    {
+                        return session.Subscribe<LocalEvent>();
+                    }
+
+                    protected override Task OnStop(IMessageSession session) => Task.CompletedTask;
+                }
+            }
+        }
+
+        public class LocalEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -73,7 +73,7 @@ namespace NServiceBus
 
             hostingConfiguration.Services.ConfigureComponent(b => settings.Get<Notifications>(), DependencyLifecycle.SingleInstance);
 
-            receiveComponent = ReceiveComponent.Initialize(
+            receiveComponent = ReceiveComponent.Configure(
                 receiveConfiguration,
                 settings.ErrorQueueAddress(),
                 hostingConfiguration,

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -21,7 +21,7 @@ namespace NServiceBus
 
         ISubscriptionManager mainReceiverSubscriptionManager;
 
-        public static ReceiveComponent Initialize(
+        public static ReceiveComponent Configure(
             Configuration configuration,
             string errorQueue,
             HostingComponent.Configuration hostingConfiguration,
@@ -128,7 +128,7 @@ namespace NServiceBus
             return receiveComponent;
         }
 
-        public async Task Start(IServiceProvider builder,
+        public async Task Initialize(IServiceProvider builder,
             RecoverabilityComponent recoverabilityComponent,
             MessageOperations messageOperations,
             PipelineComponent pipelineComponent,
@@ -182,7 +182,10 @@ namespace NServiceBus
                     throw;
                 }
             }
+        }
 
+        public async Task Start()
+        {
             foreach (var messageReceiver in receivers)
             {
                 Logger.DebugFormat("Receiver {0} is starting.", messageReceiver.Id);

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -40,6 +40,8 @@ namespace NServiceBus
             var rootContext = new RootContext(builder, messageOperations, pipelineCache);
             var messageSession = new MessageSession(rootContext);
 
+            await receiveComponent.Initialize(builder, recoverabilityComponent, messageOperations, pipelineComponent, pipelineCache, transportInfrastructure).ConfigureAwait(false);
+
 #if NETSTANDARD
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -52,7 +54,7 @@ namespace NServiceBus
 
             var runningInstance = new RunningEndpointInstance(settings, hostingComponent, receiveComponent, featureComponent, messageSession, transportInfrastructure);
 
-            await receiveComponent.Start(builder, recoverabilityComponent, messageOperations, pipelineComponent, pipelineCache, transportInfrastructure).ConfigureAwait(false);
+            await receiveComponent.Start().ConfigureAwait(false);
 
             return runningInstance;
         }

--- a/src/NServiceBus.Learning.AcceptanceTests/TestSuiteConstraints.cs
+++ b/src/NServiceBus.Learning.AcceptanceTests/TestSuiteConstraints.cs
@@ -14,6 +14,8 @@
 
         public bool SupportsOutbox => false;
 
+        public bool SupportsPurgeOnStartup => true;
+
         public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureEndpointLearningTransport();
 
         public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointLearningPersistence();

--- a/src/NServiceBus.TransportTests/ConfigureLearningTransportInfrastructure.cs
+++ b/src/NServiceBus.TransportTests/ConfigureLearningTransportInfrastructure.cs
@@ -16,8 +16,7 @@ class ConfigureLearningTransportInfrastructure : IConfigureTransportInfrastructu
         };
     }
 
-    public async Task<TransportInfrastructure> Configure(TransportDefinition transportDefinition, HostSettings hostSettings, string inputQueueName,
-        string errorQueueName)
+    public async Task<TransportInfrastructure> Configure(TransportDefinition transportDefinition, HostSettings hostSettings, string inputQueueName, string errorQueueName)
     {
         var mainReceiverSettings = new ReceiveSettings(
             "mainReceiver",


### PR DESCRIPTION
`IPushMessages.Init` was executed before Features (and their startup tasks) were executed. This has been changed during the transport seam redesign, probably by accident because the `Initialize` functionality has been reintroduced at a later point. When migrating transports, it might cause issues when initialization logic now runs only after startup tasks have executed (e.g. purging queues or setting up the subscription-manager).

I've added two acceptance tests that failed on downstreams (one in MSMQ, one in ASB) due to the initialize behavior. Those tests would probably be more appropriate as transport tests, but the transport test infrastructure currently doesn't allow for such fine-grained lifecycle control.