### PR TITLE
Add generic support for ConfigureTransport extension

### DIFF
--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -8,16 +8,17 @@
 
     public static class ConfigureExtensions
     {
-        public static RoutingSettings ConfigureRouting(this EndpointConfiguration configuration)
-        {
-            return new RoutingSettings(configuration.GetSettings());
-        }
+        public static RoutingSettings ConfigureRouting(this EndpointConfiguration configuration) =>
+            new RoutingSettings(configuration.GetSettings());
 
-        public static TransportDefinition ConfigureTransport(this EndpointConfiguration configuration)
-        {
-            //TODO this is kind of a hack because the acceptance testing framework doesn't give any access to the transport definition to individual tests.
-            return configuration.GetSettings().Get<TransportDefinition>();
-        }
+        // This is kind of a hack because the acceptance testing framework doesn't give any access to the transport definition to individual tests.
+        public static TransportDefinition ConfigureTransport(this EndpointConfiguration configuration) =>
+            configuration.GetSettings().Get<TransportDefinition>();
+
+        public static TTransportDefinition ConfigureTransport<TTransportDefinition>(
+            this EndpointConfiguration configuration)
+            where TTransportDefinition : TransportDefinition =>
+            (TTransportDefinition)configuration.GetSettings().Get<TransportDefinition>();
 
         public static async Task DefineTransport(this EndpointConfiguration config, RunDescriptor runDescriptor, EndpointCustomizationConfiguration endpointCustomizationConfiguration)
         {

--- a/src/NServiceBus.Learning.AcceptanceTests/When_disabling_payload_restrictions.cs
+++ b/src/NServiceBus.Learning.AcceptanceTests/When_disabling_payload_restrictions.cs
@@ -32,7 +32,7 @@
             {
                 EndpointSetup<DefaultServer>(c =>
                 {
-                    var transport = (LearningTransport)c.ConfigureTransport();
+                    var transport = c.ConfigureTransport<LearningTransport>();
                     transport.RestrictPayloadSize = false;
                 });
             }


### PR DESCRIPTION
This can be used by downstreams when configuring the transport settings as I've seen this helper method being implemented on multiple downstreams.

Instead of using

```
var t = (MyTransport)endpointConfiguration.ConfigureTransport();
```

you can avoid the manual cast every time:

```
var t = endpointConfiguration.ConfigureTransport<MyTransport>();
```

fun fact, this saves exactly 0 characters 😆 