### PR TITLE
Use AssemblyLoadContext APIs on .NET Core

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
+++ b/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="[3.12.0, 4.0.0)" />
-    <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="0.11.0" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
+++ b/src/NServiceBus.AcceptanceTesting/NServiceBus.AcceptanceTesting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
@@ -9,6 +9,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\NServiceBus.Core\NServiceBus.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Reference Include="System.Transactions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
-    <NoWarn>$(NoWarn);CA2007</NoWarn>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
@@ -18,9 +17,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" PrivateAssets="All" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -21,13 +21,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" PrivateAssets="All" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Approvals" Version="0.2.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="0.11.0" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>
     <PackageId>NServiceBus.AcceptanceTests.Sources</PackageId>
     <Description>Acceptance tests for NServiceBus core functionality</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <BlockInvalidTargetFrameworks>false</BlockInvalidTargetFrameworks>
   </PropertyGroup>
 
   <!-- Workaround for https://github.com/dotnet/sdk/issues/1479 -->

--- a/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
+++ b/src/NServiceBus.ContainerTests/NServiceBus.ContainerTests.csproj
@@ -12,10 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" PrivateAssets="All" />
-    <PackageReference Include="NUnit" Version="[3.12.0, 4.0.0)" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Core.Analyzer/NServiceBus.Core.Analyzer.csproj
+++ b/src/NServiceBus.Core.Analyzer/NServiceBus.Core.Analyzer.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="0.11.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.2.2" />
   </ItemGroup>
 

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -6,6 +6,9 @@ namespace NServiceBus.Hosting.Helpers
     using System.Linq;
     using System.Reflection;
     using System.Runtime.CompilerServices;
+#if NETCOREAPP
+    using System.Runtime.Loader;
+#endif
     using System.Text;
     using Logging;
 
@@ -153,8 +156,12 @@ namespace NServiceBus.Hosting.Helpers
 
             try
             {
+#if NETCOREAPP
+                var context = AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly());
+                assembly = context.LoadFromAssemblyPath(assemblyPath);
+#else
                 assembly = Assembly.LoadFrom(assemblyPath);
-
+#endif
                 return true;
             }
             catch (Exception ex) when (ex is BadImageFormatException || ex is FileLoadException)

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
@@ -4,7 +4,7 @@
 #if NETFRAMEWORK
     using System.Reflection;
 #endif
-#if NETSTANDARD
+#if NETCOREAPP
     using System.IO;
     using System.Reflection.Metadata;
     using System.Reflection.PortableExecutable;
@@ -39,7 +39,7 @@
         }
 #endif
 
-#if NETSTANDARD
+#if NETCOREAPP
         public void ValidateAssemblyFile(string assemblyPath, out bool shouldLoad, out string reason)
         {
             using (var stream = File.OpenRead(assemblyPath))

--- a/src/NServiceBus.Core/Licensing/Browser.cs
+++ b/src/NServiceBus.Core/Licensing/Browser.cs
@@ -1,5 +1,4 @@
-﻿#if NETSTANDARD
-namespace NServiceBus
+﻿namespace NServiceBus
 {
     using System.Diagnostics;
     using System.Runtime.InteropServices;
@@ -40,31 +39,3 @@ namespace NServiceBus
         }
     }
 }
-#else
-namespace NServiceBus
-{
-    using System.Diagnostics;
-
-    static class Browser
-    {
-        public static bool TryOpen(string url)
-        {
-            using (var process = new Process())
-            {
-                process.StartInfo.FileName = url;
-
-                try
-                {
-                    process.Start();
-                }
-                catch
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-    }
-}
-#endif

--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -2,9 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Diagnostics;
-#if NETSTANDARD
     using System.Runtime.InteropServices;
-#endif
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -178,7 +176,6 @@ namespace NServiceBus
             return $"https://particular.net/license/nservicebus?v={version}&t={isRenewal}&p={platform}";
         }
 
-#if NETSTANDARD
         string GetPlatformCode()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -198,9 +195,6 @@ namespace NServiceBus
 
             return "unknown";
         }
-#else
-        string GetPlatformCode() => "windows";
-#endif
 
         internal ActiveLicenseFindResult result;
 

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="LightInject.Source" Version="5.0.3" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Licensing.Sources" Version="3.4.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="0.11.0" PrivateAssets="All" />
     <PackageReference Include="SimpleJson" Version="0.38.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>NServiceBus</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
@@ -17,26 +17,22 @@
     <Reference Include="System.Security" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="5.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="5.0.0" />
   </ItemGroup>
 
-  <!-- Public dependencies -->
-  <ItemGroup>
+  <ItemGroup Label="Public dependencies">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Label="Private dependencies">
     <PackageReference Include="Fody" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.8.0" PrivateAssets="All" />
     <PackageReference Include="LightInject.Source" Version="5.0.3" PrivateAssets="All" />
-    <PackageReference Include="SimpleJson" Version="0.38.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Licensing.Sources" Version="3.4.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
+    <PackageReference Include="SimpleJson" Version="0.38.0" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -41,8 +41,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="NServiceBus.targets" />
-    <Content Include="NServiceBus.targets" PackagePath="build" />
     <None Include="..\..\packaging\nuget\tools\init.ps1" Pack="true" PackagePath="tools" Visible="false" />
     <None Include="..\NServiceBus.Core.Analyzer\bin\$(Configuration)\**\NServiceBus.Core.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/cs/NServiceBus.Core.Analyzer.dll" Link="NServiceBus.Core.Analyzer.dll" Visible="false" />
     <None Include="..\NServiceBus.Core.Analyzer\tools\*.ps1" Pack="true" PackagePath="tools" Visible="false" />

--- a/src/NServiceBus.Core/NServiceBus.targets
+++ b/src/NServiceBus.Core/NServiceBus.targets
@@ -1,7 +1,0 @@
-﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <Target Name="NServiceBusVerifyMinimumFrameworkVersion" BeforeTargets="Build" Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <Error Condition= "$(TargetFrameworkVersion.TrimStart('v')) &lt; 4.7.2" Text="NServiceBus requires .NET Framework 4.7.2 or greater." />
-  </Target>
-
-</Project>

--- a/src/NServiceBus.Core/ObjectBuilder/LightInject/LightInject.Microsoft.DependencyInjection.g.cs
+++ b/src/NServiceBus.Core/ObjectBuilder/LightInject/LightInject.Microsoft.DependencyInjection.g.cs
@@ -40,6 +40,7 @@
 namespace LightInject.Microsoft.DependencyInjection
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
     using System.Reflection;

--- a/src/NServiceBus.Core/ObjectBuilder/LightInject/LightInject.g.cs
+++ b/src/NServiceBus.Core/ObjectBuilder/LightInject/LightInject.g.cs
@@ -26,12 +26,6 @@
     http://twitter.com/bernhardrichter
 ******************************************************************************/
 
-#if NET472
-// LightInject doesn't target .NET 4.7.2 directly but it's covered by the .NET Standard 2.0 support
-// However, the NETSTANDARD2_0 is not defined when we target .NET 4.7.2 directly so we have to do this manually
-#define NETSTANDARD2_0
-#endif
-
 //NOTE: This is LightInject 6.3.4: https://github.com/seesharper/LightInject/blob/v6.3.4/src/LightInject/LightInject.cs with all public types made internal.
 
 [module: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1126:PrefixCallsCorrectly", Justification = "Reviewed")]
@@ -529,7 +523,7 @@ namespace LightInject
         IServiceRegistry RegisterPropertyDependency<TDependency>(
             Func<IServiceFactory, PropertyInfo, TDependency> factory);
 
-#if NET452 || NET46 || NETSTANDARD1_6 || NETSTANDARD2_0 || NETCOREAPP2_0
+#if NET452 || NET472 || NETSTANDARD1_6 || NETSTANDARD2_0 || NETCOREAPP
         /// <summary>
         /// Registers composition roots from assemblies in the base directory that match the <paramref name="searchPattern"/>.
         /// </summary>
@@ -943,7 +937,7 @@ namespace LightInject
         void EndScope(Scope scope);
     }
 
-#if NET452 || NET46 || NETSTANDARD1_6 || NETSTANDARD2_0 || NETCOREAPP2_0
+#if NET452 || NET472 || NETSTANDARD1_6 || NETSTANDARD2_0 || NETCOREAPP
 
     /// <summary>
     /// Represents a class that is responsible loading a set of assemblies based on the given search pattern.
@@ -2518,12 +2512,12 @@ namespace LightInject
             ConstructorSelector = new MostResolvableConstructorSelector(CanGetInstance, options.EnableOptionalArguments);
             constructionInfoProvider = new Lazy<IConstructionInfoProvider>(CreateConstructionInfoProvider);
             methodSkeletonFactory = (returnType, parameterTypes) => new DynamicMethodSkeleton(returnType, parameterTypes);
-#if NET452 || NETSTANDARD1_3 || NETSTANDARD1_6 || NETSTANDARD2_0 || NET46 || NETCOREAPP2_0
+#if NET452 || NETSTANDARD1_3 || NETSTANDARD1_6 || NETSTANDARD2_0 || NET472 || NETCOREAPP
             ScopeManagerProvider = new PerLogicalCallContextScopeManagerProvider();
 #else
             ScopeManagerProvider = new PerThreadScopeManagerProvider();
 #endif
-#if NET452 || NET46 || NETSTANDARD1_6 || NETSTANDARD2_0 || NETCOREAPP2_0
+#if NET452 || NET472 || NETSTANDARD1_6 || NETSTANDARD2_0 || NETCOREAPP
             AssemblyLoader = new AssemblyLoader();
 #endif
 
@@ -2566,7 +2560,7 @@ namespace LightInject
             IAssemblyScanner assemblyScanner,
             IConstructorDependencySelector constructorDependencySelector,
             IConstructorSelector constructorSelector,
-#if NET452 || NET46 || NETSTANDARD1_6 || NETCOREAPP2_0
+#if NET452 || NET472 || NETSTANDARD1_6 || NETCOREAPP
             IAssemblyLoader assemblyLoader,
 #endif
             IScopeManagerProvider scopeManagerProvider)
@@ -2590,7 +2584,7 @@ namespace LightInject
             ConstructorDependencySelector = constructorDependencySelector;
             ConstructorSelector = constructorSelector;
             ScopeManagerProvider = scopeManagerProvider;
-#if NET452 || NET46 || NETSTANDARD1_6 || NETCOREAPP2_0
+#if NET452 || NET472 || NETSTANDARD1_6 || NETCOREAPP
             AssemblyLoader = assemblyLoader;
             foreach (var availableService in AvailableServices)
             {
@@ -2651,7 +2645,7 @@ namespace LightInject
         /// Gets or sets the <see cref="IAssemblyScanner"/> instance that is responsible for scanning assemblies.
         /// </summary>
         public IAssemblyScanner AssemblyScanner { get; set; }
-#if NET452 || NETSTANDARD1_6 || NETSTANDARD2_0 || NET46 || NETCOREAPP2_0
+#if NET452 || NETSTANDARD1_6 || NETSTANDARD2_0 || NET472 || NETCOREAPP
 
         /// <summary>
         /// Gets or sets the <see cref="IAssemblyLoader"/> instance that is responsible for loading assemblies during assembly scanning.
@@ -2843,7 +2837,7 @@ namespace LightInject
             return this;
         }
 
-#if NET452 || NETSTANDARD1_6 || NETSTANDARD2_0 || NET46 || NETCOREAPP2_0
+#if NET452 || NETSTANDARD1_6 || NETSTANDARD2_0 || NET472 || NETCOREAPP
         /// <inheritdoc/>
         public IServiceRegistry RegisterAssembly(string searchPattern)
         {
@@ -3318,7 +3312,7 @@ namespace LightInject
                 AssemblyScanner,
                 ConstructorDependencySelector,
                 ConstructorSelector,
-#if NET452 || NET46 || NETSTANDARD1_6 || NETCOREAPP2_0
+#if NET452 || NET472 || NETSTANDARD1_6 || NETCOREAPP
                 AssemblyLoader,
 #endif
                 ScopeManagerProvider);
@@ -4063,7 +4057,7 @@ namespace LightInject
         }
 #endif
 
-#if NET452 || NET46 || NETCOREAPP2_0
+#if NET452 || NET472 || NETCOREAPP
         private Action<IEmitter> GetEmitMethodForDefaultValue(ConstructorDependency constructorDependency)
         {
             Type parameterType = constructorDependency.Parameter.ParameterType;
@@ -4929,7 +4923,7 @@ namespace LightInject
                 return dynamicMethod.CreateDelegate(delegateType);
             }
 
-#if NET452 || NET46 || NETCOREAPP2_0
+#if NET452 || NET472 || NETCOREAPP
             private void CreateDynamicMethod(Type returnType, Type[] parameterTypes)
             {
                 dynamicMethod = new DynamicMethod(
@@ -5021,7 +5015,7 @@ namespace LightInject
         }
     }
 
-#if NET452 || NETSTANDARD1_3 || NETSTANDARD1_6 || NETSTANDARD2_0 || NET46 || NETCOREAPP2_0
+#if NET452 || NETSTANDARD1_3 || NETSTANDARD1_6 || NETSTANDARD2_0 || NET472 || NETCOREAPP
 
     /// <summary>
     /// Manages a set of <see cref="Scope"/> instances.
@@ -6764,7 +6758,7 @@ namespace LightInject
             InternalTypes.Add(typeof(Registration));
             InternalTypes.Add(typeof(ServiceContainer));
             InternalTypes.Add(typeof(ConstructionInfo));
-#if NET452 || NET46 || NETSTANDARD1_6 || NETSTANDARD2_0 || NETCOREAPP2_0
+#if NET452 || NET472 || NETSTANDARD1_6 || NETSTANDARD2_0 || NETCOREAPP
             InternalTypes.Add(typeof(AssemblyLoader));
 #endif
             InternalTypes.Add(typeof(TypeConstructionInfoBuilder));
@@ -6791,7 +6785,7 @@ namespace LightInject
             InternalTypes.Add(typeof(GetInstanceDelegate));
             InternalTypes.Add(typeof(ContainerOptions));
             InternalTypes.Add(typeof(CompositionRootAttributeExtractor));
-#if NET452 || NET46 || NETSTANDARD1_3 || NETSTANDARD1_6 || NETSTANDARD2_0 || NETCOREAPP2_0
+#if NET452 || NET472 || NETSTANDARD1_3 || NETSTANDARD1_6 || NETSTANDARD2_0 || NETCOREAPP
             InternalTypes.Add(typeof(PerLogicalCallContextScopeManagerProvider));
             InternalTypes.Add(typeof(PerLogicalCallContextScopeManager));
             InternalTypes.Add(typeof(LogicalThreadStorage<>));
@@ -7189,7 +7183,7 @@ namespace LightInject
             return propertyInfo.SetMethod == null || propertyInfo.SetMethod.IsStatic || propertyInfo.SetMethod.IsPrivate || propertyInfo.GetIndexParameters().Length > 0;
         }
     }
-#if NET452 || NET46 || NETCOREAPP2_0
+#if NET452 || NET472 || NETCOREAPP
 
     /// <summary>
     /// Loads all assemblies from the application base directory that matches the given search pattern.
@@ -8267,7 +8261,7 @@ namespace LightInject
     }
 #endif
 
-#if NETSTANDARD1_3 || NETSTANDARD1_6 || NETSTANDARD2_0 || NET46 || NETCOREAPP2_0
+#if NETSTANDARD1_3 || NETSTANDARD1_6 || NETSTANDARD2_0 || NET472 || NETCOREAPP
     /// <summary>
     /// Provides storage per logical thread of execution.
     /// </summary>
@@ -8544,7 +8538,7 @@ but either way the scope has to be started with 'container.BeginScope()'";
                 return null;
             }
         }
-#if NET452 || NET46 || NETCOREAPP2_0
+#if NET452 || NET472 || NETCOREAPP
 
         /// <summary>
         /// Gets the method represented by the delegate.

--- a/src/NServiceBus.Core/StartableEndpoint.cs
+++ b/src/NServiceBus.Core/StartableEndpoint.cs
@@ -1,9 +1,7 @@
 namespace NServiceBus
 {
     using System;
-#if NETSTANDARD
     using System.Runtime.InteropServices;
-#endif
     using System.Security.Principal;
     using System.Threading.Tasks;
     using Settings;
@@ -42,14 +40,11 @@ namespace NServiceBus
 
             await receiveComponent.Initialize(builder, recoverabilityComponent, messageOperations, pipelineComponent, pipelineCache, transportInfrastructure).ConfigureAwait(false);
 
-#if NETSTANDARD
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
             }
-#else
-            AppDomain.CurrentDomain.SetPrincipalPolicy(PrincipalPolicy.WindowsPrincipal);
-#endif
+
             await featureComponent.Start(builder, messageSession).ConfigureAwait(false);
 
             var runningInstance = new RunningEndpointInstance(settings, hostingComponent, receiveComponent, featureComponent, messageSession, transportInfrastructure);

--- a/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWork.cs
+++ b/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWork.cs
@@ -1,8 +1,8 @@
 ﻿namespace NServiceBus.Features
 {
-    using ConsistencyGuarantees;
     using System;
     using System.Transactions;
+    using ConsistencyGuarantees;
 
     class TransactionScopeUnitOfWork : Feature
     {

--- a/src/NServiceBus.Learning.AcceptanceTests/NServiceBus.Learning.AcceptanceTests.csproj
+++ b/src/NServiceBus.Learning.AcceptanceTests/NServiceBus.Learning.AcceptanceTests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
-    <NoWarn>$(NoWarn);CA2007</NoWarn>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/NServiceBus.PersistenceTests/NServiceBus.PersistenceTests.csproj
+++ b/src/NServiceBus.PersistenceTests/NServiceBus.PersistenceTests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
-    <NoWarn>$(NoWarn);CA2007</NoWarn>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/NServiceBus.PersistenceTests/NServiceBus.PersistenceTests.csproj
+++ b/src/NServiceBus.PersistenceTests/NServiceBus.PersistenceTests.csproj
@@ -19,13 +19,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="[3.12.0, 4.0.0)" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="0.11.0" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>
     <PackageId>NServiceBus.PersistenceTests.Sources</PackageId>
     <Description>Tests for persistence seam implementations</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <BlockInvalidTargetFrameworks>false</BlockInvalidTargetFrameworks>
   </PropertyGroup>
 
   <!-- Workaround for https://github.com/dotnet/sdk/issues/1479 -->

--- a/src/NServiceBus.Testing.Fakes/NServiceBus.Testing.Fakes.csproj
+++ b/src/NServiceBus.Testing.Fakes/NServiceBus.Testing.Fakes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <RootNamespace>NServiceBus.Testing</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>

--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -17,13 +17,14 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" PrivateAssets="All" />
     <PackageReference Include="NUnit" Version="[3.12.0, 4.0.0)" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="0.11.0" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>
     <PackageId>NServiceBus.TransportTests.Sources</PackageId>
     <Description>Tests for transport seam implementations</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <BlockInvalidTargetFrameworks>false</BlockInvalidTargetFrameworks>
   </PropertyGroup>
 
   <!-- Workaround for https://github.com/dotnet/sdk/issues/1479 -->


### PR DESCRIPTION
This PR changes the assembly scanner to use the `AssemblyLoadContext` APIs to ensure that assemblies are loaded into the correct load context when running on .NET Core.

This PR also includes the changes from #5890 to move to to a `necoreapp2.1` target instead of `netstandard2.0`.