### PR TITLE
Rename TransportInfrastructure.DisposeAsync

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransportInfrastructure.cs
@@ -74,7 +74,7 @@
             Dispatcher = new LearningTransportDispatcher(storagePath, int.MaxValue / 1024);
         }
 
-        public override Task DisposeAsync()
+        public override Task Shutdown()
         {
             return Task.CompletedTask;
         }

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
@@ -40,9 +40,9 @@
             Dispatcher = new FakeDispatcher();
         }
 
-        public override Task DisposeAsync()
+        public override Task Shutdown()
         {
-            startUpSequence.Add($"{nameof(TransportInfrastructure)}.{nameof(DisposeAsync)}");
+            startUpSequence.Add($"{nameof(TransportInfrastructure)}.{nameof(Shutdown)}");
 
             if (transportSettings.ErrorOnTransportDispose != null)
             {

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -105,7 +105,7 @@
                 Receivers = receiveSettings.Select(settings => new FakeReceiver()).ToList<IMessageReceiver>().AsReadOnly();
             }
 
-            public override Task DisposeAsync()
+            public override Task Shutdown()
             {
                 return Task.CompletedTask;
             }

--- a/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_initializing_transport.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_initializing_transport.cs
@@ -24,7 +24,7 @@
                 $"{nameof(IMessageReceiver)}.{nameof(IMessageReceiver.Initialize)} for receiver Main",
                 $"{nameof(IMessageReceiver)}.{nameof(IMessageReceiver.StartReceive)} for receiver Main",
                 $"{nameof(IMessageReceiver)}.{nameof(IMessageReceiver.StopReceive)} for receiver Main",
-                $"{nameof(TransportInfrastructure)}.{nameof(TransportInfrastructure.DisposeAsync)}",
+                $"{nameof(TransportInfrastructure)}.{nameof(TransportInfrastructure.Shutdown)}",
             }, context.StartUpSequence);
         }
 
@@ -39,7 +39,7 @@
             CollectionAssert.AreEqual(new List<string>
             {
                 $"{nameof(TransportDefinition)}.{nameof(TransportDefinition.Initialize)}",
-                $"{nameof(TransportInfrastructure)}.{nameof(TransportInfrastructure.DisposeAsync)}",
+                $"{nameof(TransportInfrastructure)}.{nameof(TransportInfrastructure.Shutdown)}",
             }, context.StartUpSequence);
         }
 

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2625,8 +2625,8 @@ namespace NServiceBus.Transport
         protected TransportInfrastructure() { }
         public NServiceBus.Transport.IMessageDispatcher Dispatcher { get; set; }
         public System.Collections.ObjectModel.ReadOnlyCollection<NServiceBus.Transport.IMessageReceiver> Receivers { get; set; }
-        public abstract System.Threading.Tasks.Task DisposeAsync();
         public NServiceBus.Transport.IMessageReceiver GetReceiver(string receiverId) { }
+        public abstract System.Threading.Tasks.Task Shutdown();
     }
     public class TransportOperation
     {

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
@@ -97,7 +97,7 @@
         public const string StorageLocationKey = "LearningTransport.StoragePath";
         public const string NoPayloadSizeRestrictionKey = "LearningTransport.NoPayloadSizeRestrictionKey";
 
-        public override Task DisposeAsync()
+        public override Task Shutdown()
         {
             return Task.CompletedTask;
         }

--- a/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
@@ -30,6 +30,6 @@ namespace NServiceBus.Transport
         /// <summary>
         /// Disposes all transport internal resources.
         /// </summary>
-        public abstract Task DisposeAsync();
+        public abstract Task Shutdown();
     }
 }

--- a/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
+++ b/src/NServiceBus.Core/Unicast/RunningEndpointInstance.cs
@@ -47,7 +47,7 @@ namespace NServiceBus
                     await featureComponent.Stop().ConfigureAwait(false);
 
                     // Can throw
-                    await transportInfrastructure.DisposeAsync().ConfigureAwait(false);
+                    await transportInfrastructure.Shutdown().ConfigureAwait(false);
                 }
                 catch (Exception exception)
                 {

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -68,7 +68,7 @@
         {
             testCancellationTokenSource?.Dispose();
             receiver?.StopReceive().GetAwaiter().GetResult();
-            transportInfrastructure?.DisposeAsync().GetAwaiter().GetResult();
+            transportInfrastructure?.Shutdown().GetAwaiter().GetResult();
             configurer?.Cleanup().GetAwaiter().GetResult();
         }
 


### PR DESCRIPTION
renames the `DisposeAsync` method to `Shutdown` to avoid potential conflicts when downstreams would try to implement the `IAsyncDisposable` interface. Also, it would be better to not use an operation heavily associated with a specific disposable interface for a class that isn't actually implementing this interface.

Not sure about the name. Alternatives could be `Cleanup` instead?

We currently can't implement the `IAsyncDisposable` interface as it is part of C# 8, which is supported on .NET Core 3.1 and .NET Standard 2.1. Another option might be to reference https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces/ that provides the interface for our target platforms (assuming that there is proper `using` support even when not using C# 8).