### PR TITLE
use dictionary for receivers

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Core.FakeTransport
 {
+    using System.Collections.ObjectModel;
     using System.Linq;
     using Transport;
     using System.Threading.Tasks;
@@ -24,15 +25,14 @@
 
         public void ConfigureReceiveInfrastructure()
         {
-            Receivers = receivers
+            Receivers = new ReadOnlyDictionary<string, IMessageReceiver>(receivers
                 .Select(r =>
                     new FakeReceiver(
                         r.Id,
                         transportSettings,
                         startUpSequence,
                         hostSettings.CriticalErrorAction))
-                .ToList<IMessageReceiver>()
-                .AsReadOnly();
+                .ToDictionary<FakeReceiver, string, IMessageReceiver>(r => r.Id, r => r));
         }
 
         public void ConfigureSendInfrastructure()

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Core.FakeTransport.ProcessingOptimizations
 {
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
@@ -102,7 +103,9 @@
             public FakeTransportInfrastructure(ReceiveSettings[] receiveSettings)
             {
                 Dispatcher = new FakeDispatcher();
-                Receivers = receiveSettings.Select(settings => new FakeReceiver()).ToList<IMessageReceiver>().AsReadOnly();
+                Receivers = new ReadOnlyDictionary<string, IMessageReceiver>(receiveSettings
+                    .Select(settings => new FakeReceiver())
+                    .ToDictionary<FakeReceiver, string, IMessageReceiver>(r => r.Id, r => r));
             }
 
             public override Task Shutdown()

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_custom_policy_provided.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_custom_policy_provided.cs
@@ -5,7 +5,6 @@ namespace NServiceBus.AcceptanceTests.Core.Recoverability
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using Features;
     using NUnit.Framework;
 
     public class When_custom_policy_provided : NServiceBusAcceptanceTest

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2624,8 +2624,7 @@ namespace NServiceBus.Transport
     {
         protected TransportInfrastructure() { }
         public NServiceBus.Transport.IMessageDispatcher Dispatcher { get; set; }
-        public System.Collections.ObjectModel.ReadOnlyCollection<NServiceBus.Transport.IMessageReceiver> Receivers { get; set; }
-        public NServiceBus.Transport.IMessageReceiver GetReceiver(string receiverId) { }
+        public System.Collections.ObjectModel.ReadOnlyDictionary<string, NServiceBus.Transport.IMessageReceiver> Receivers { get; set; }
         public abstract System.Threading.Tasks.Task Shutdown();
     }
     public class TransportOperation

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -103,7 +103,7 @@ namespace NServiceBus
             // get a reference to the subscription manager as soon as the transport has been created:
             configuration.transportSeam.TransportInfrastructureCreated += (_, infrastructure) =>
                 receiveComponent.mainReceiverSubscriptionManager =
-                    infrastructure.GetReceiver(MainReceiverId).Subscriptions;
+                    infrastructure.Receivers[MainReceiverId].Subscriptions;
 
             configuration.transportSeam.Configure(receiveSettings.ToArray());
 
@@ -140,7 +140,7 @@ namespace NServiceBus
                 return;
             }
 
-            var mainPump = transportInfrastructure.GetReceiver(MainReceiverId);
+            var mainPump = transportInfrastructure.Receivers[MainReceiverId];
 
             var receivePipeline = pipelineComponent.CreatePipeline<ITransportReceiveContext>(builder);
             var mainPipelineExecutor = new MainPipelineExecutor(builder, pipelineCache, messageOperations, configuration.PipelineCompletedSubscribers, receivePipeline);
@@ -152,7 +152,7 @@ namespace NServiceBus
                 recoverability.Invoke).ConfigureAwait(false);
             receivers.Add(mainPump);
 
-            var instanceSpecificPump = transportInfrastructure.GetReceiver(InstanceSpecificReceiverId);
+            var instanceSpecificPump = transportInfrastructure.Receivers[InstanceSpecificReceiverId];
             if (instanceSpecificPump != null)
             {
                 var instanceSpecificRecoverabilityExecutor = recoverabilityExecutorFactory.CreateDefault(configuration.InstanceSpecificQueue);
@@ -167,7 +167,7 @@ namespace NServiceBus
             {
                 try
                 {
-                    var satellitePump = transportInfrastructure.GetReceiver(satellite.Name);
+                    var satellitePump = transportInfrastructure.Receivers[satellite.Name];
 
                     var satellitePipeline = new SatellitePipelineExecutor(builder, satellite);
                     var satelliteRecoverabilityExecutor = recoverabilityExecutorFactory.Create(satellite.RecoverabilityPolicy, satellite.ReceiveAddress);

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -152,8 +152,7 @@ namespace NServiceBus
                 recoverability.Invoke).ConfigureAwait(false);
             receivers.Add(mainPump);
 
-            var instanceSpecificPump = transportInfrastructure.Receivers[InstanceSpecificReceiverId];
-            if (instanceSpecificPump != null)
+            if (transportInfrastructure.Receivers.TryGetValue(InstanceSpecificReceiverId, out var instanceSpecificPump))
             {
                 var instanceSpecificRecoverabilityExecutor = recoverabilityExecutorFactory.CreateDefault(configuration.InstanceSpecificQueue);
 

--- a/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Transport
 {
     using System.Collections.ObjectModel;
-    using System.Linq;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -15,17 +14,9 @@ namespace NServiceBus.Transport
         public IMessageDispatcher Dispatcher { get; protected set; }
 
         /// <summary>
-        /// A list of all receivers.
+        /// A collection of all receivers.
         /// </summary>
-        public ReadOnlyCollection<IMessageReceiver> Receivers { get; protected set; }
-
-        /// <summary>
-        /// A helper method to find a receiver inside the <see cref="Receivers"/> collection with a specific id.
-        /// </summary>
-        public IMessageReceiver GetReceiver(string receiverId)
-        {
-            return Receivers.SingleOrDefault(r => r.Id == receiverId);
-        }
+        public ReadOnlyDictionary<string, IMessageReceiver> Receivers { get; protected set; }
 
         /// <summary>
         /// Disposes all transport internal resources.

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -79,7 +79,8 @@
 
             configurer = CreateConfigurer();
 
-            var hostSettings = new HostSettings(InputQueueName,
+            var hostSettings = new HostSettings(
+                InputQueueName,
                 string.Empty,
                 new StartupDiagnosticEntries(),
                 onCriticalError,
@@ -92,7 +93,8 @@
 
             transportInfrastructure = await configurer.Configure(transport, hostSettings, InputQueueName, ErrorQueueName);
 
-            await transportInfrastructure.Receivers[0].Initialize(
+            receiver = transportInfrastructure.Receivers.Single().Value;
+            await receiver.Initialize(
                 new PushRuntimeSettings(8),
                 context =>
                 {
@@ -114,9 +116,7 @@
                     return Task.FromResult(ErrorHandleResult.Handled);
                 });
 
-            await transportInfrastructure.Receivers[0].StartReceive();
-
-            receiver = transportInfrastructure.Receivers[0];
+            await receiver.StartReceive();
         }
 
         string GetUserName()


### PR DESCRIPTION
(based on top of https://github.com/Particular/NServiceBus/pull/5915)

Implements the proposal made by @danielmarbach to use a dictionary instead of a list for faster lookup which is the main usage for core.

It seems to have a potential downside that it is no longer clear in what order the receivers were added and some hacks that assumed the first receiver to be the main receiver don't work with that anymore.

Thoughts?