### PR TITLE
Remove `new()` constraint on `UseTransport` obsoletion

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1168,7 +1168,7 @@ namespace NServiceBus
         [System.Obsolete("Use `EndpointConfiguration.UseTransport(TransportDefinition)` instead. The member" +
             " currently throws a NotImplementedException. Will be removed in version 9.0.0.", true)]
         public static NServiceBus.TransportExtensions<T> UseTransport<T>(this NServiceBus.EndpointConfiguration endpointConfiguration)
-            where T : NServiceBus.Transport.TransportDefinition, new () { }
+            where T : NServiceBus.Transport.TransportDefinition { }
     }
     public static class XmlSerializationExtensions
     {

--- a/src/NServiceBus.Core/obsoletes-v8.cs
+++ b/src/NServiceBus.Core/obsoletes-v8.cs
@@ -64,7 +64,7 @@ namespace NServiceBus
             RemoveInVersion = "9",
             TreatAsErrorFromVersion = "8",
             ReplacementTypeOrMember = "EndpointConfiguration.UseTransport(TransportDefinition)")]
-        public static TransportExtensions<T> UseTransport<T>(this EndpointConfiguration endpointConfiguration) where T : TransportDefinition, new()
+        public static TransportExtensions<T> UseTransport<T>(this EndpointConfiguration endpointConfiguration) where T : TransportDefinition
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
This is required to properly show obsoletion methods for downstream that with the new seam do not provide a default constructor e.g. SqlTransport that requires connection string. 