### PR TITLE
Add missing obsolete attributes to Express messaging configuration API

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -280,14 +280,26 @@ namespace NServiceBus
         ". See the upgrade guide for more details. Will be removed in version 9.0.0.", true)]
     public static class DurableMessagesConfig
     {
+        [System.Obsolete("Non-durable delivery support has been moved to the transports that can support it" +
+            ". See the upgrade guide for more details. The member currently throws a NotImple" +
+            "mentedException. Will be removed in version 9.0.0.", true)]
         public static void DisableDurableMessages(this NServiceBus.EndpointConfiguration config) { }
+        [System.Obsolete("Non-durable delivery support has been moved to the transports that can support it" +
+            ". See the upgrade guide for more details. The member currently throws a NotImple" +
+            "mentedException. Will be removed in version 9.0.0.", true)]
         public static bool DurableMessagesEnabled(this NServiceBus.Settings.ReadOnlySettings settings) { }
+        [System.Obsolete("Non-durable delivery support has been moved to the transports that can support it" +
+            ". See the upgrade guide for more details. The member currently throws a NotImple" +
+            "mentedException. Will be removed in version 9.0.0.", true)]
         public static void EnableDurableMessages(this NServiceBus.EndpointConfiguration config) { }
     }
     [System.Obsolete("Non-durable delivery support has been moved to the transports that can support it" +
         ". See the upgrade guide for more details. Will be removed in version 9.0.0.", true)]
     public static class DurableMessagesConventionExtensions
     {
+        [System.Obsolete("Non-durable delivery support has been moved to the transports that can support it" +
+            ". See the upgrade guide for more details. The member currently throws a NotImple" +
+            "mentedException. Will be removed in version 9.0.0.", true)]
         public static NServiceBus.ConventionsBuilder DefiningExpressMessagesAs(this NServiceBus.ConventionsBuilder builder, System.Func<System.Type, bool> definesExpressMessageType) { }
     }
     public static class Endpoint

--- a/src/NServiceBus.Core/obsoletes-v8.cs
+++ b/src/NServiceBus.Core/obsoletes-v8.cs
@@ -675,16 +675,28 @@ namespace NServiceBus
         RemoveInVersion = "9")]
     public static class DurableMessagesConfig
     {
+        [ObsoleteEx(
+            Message = "Non-durable delivery support has been moved to the transports that can support it. See the upgrade guide for more details.",
+            TreatAsErrorFromVersion = "8",
+            RemoveInVersion = "9")]
         public static void EnableDurableMessages(this EndpointConfiguration config)
         {
             throw new NotImplementedException();
         }
 
+        [ObsoleteEx(
+            Message = "Non-durable delivery support has been moved to the transports that can support it. See the upgrade guide for more details.",
+            TreatAsErrorFromVersion = "8",
+            RemoveInVersion = "9")]
         public static void DisableDurableMessages(this EndpointConfiguration config)
         {
             throw new NotImplementedException();
         }
 
+        [ObsoleteEx(
+            Message = "Non-durable delivery support has been moved to the transports that can support it. See the upgrade guide for more details.",
+            TreatAsErrorFromVersion = "8",
+            RemoveInVersion = "9")]
         public static bool DurableMessagesEnabled(this ReadOnlySettings settings)
         {
             throw new NotImplementedException();
@@ -702,6 +714,10 @@ namespace NServiceBus
         RemoveInVersion = "9")]
     public static class DurableMessagesConventionExtensions
     {
+        [ObsoleteEx(
+            Message = "Non-durable delivery support has been moved to the transports that can support it. See the upgrade guide for more details.",
+            TreatAsErrorFromVersion = "8",
+            RemoveInVersion = "9")]
         public static ConventionsBuilder DefiningExpressMessagesAs(this ConventionsBuilder builder, Func<Type, bool> definesExpressMessageType)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
Noticed that these obsoleted configuration methods do not show a proper obsolete warning when I updated some samples & snippets.

@andreasohlund was this just overseen or was there some intention behind this?