### PR TITLE
Use IReadOnlyDictionary interface for Receivers property

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransportInfrastructure.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
@@ -51,7 +50,7 @@
                 receivers.Add(receiverSetting.Id, await CreateReceiver(receiverSetting).ConfigureAwait(false));
             }
 
-            Receivers = new ReadOnlyDictionary<string, IMessageReceiver>(receivers);
+            Receivers = receivers;
         }
 
         Task<IMessageReceiver> CreateReceiver(ReceiveSettings receiveSettings)

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.AcceptanceTests.Core.FakeTransport
 {
-    using System.Collections.ObjectModel;
     using System.Linq;
     using Transport;
     using System.Threading.Tasks;
@@ -23,17 +22,15 @@
             this.transportSettings = transportSettings;
         }
 
-        public void ConfigureReceiveInfrastructure()
-        {
-            Receivers = new ReadOnlyDictionary<string, IMessageReceiver>(receivers
+        public void ConfigureReceiveInfrastructure() =>
+            Receivers = receivers
                 .Select(r =>
                     new FakeReceiver(
                         r.Id,
                         transportSettings,
                         startUpSequence,
                         hostSettings.CriticalErrorAction))
-                .ToDictionary<FakeReceiver, string, IMessageReceiver>(r => r.Id, r => r));
-        }
+                .ToDictionary<FakeReceiver, string, IMessageReceiver>(r => r.Id, r => r);
 
         public void ConfigureSendInfrastructure()
         {

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Core.FakeTransport.ProcessingOptimizations
 {
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
@@ -103,9 +102,9 @@
             public FakeTransportInfrastructure(ReceiveSettings[] receiveSettings)
             {
                 Dispatcher = new FakeDispatcher();
-                Receivers = new ReadOnlyDictionary<string, IMessageReceiver>(receiveSettings
+                Receivers = receiveSettings
                     .Select(settings => new FakeReceiver())
-                    .ToDictionary<FakeReceiver, string, IMessageReceiver>(r => r.Id, r => r));
+                    .ToDictionary<FakeReceiver, string, IMessageReceiver>(r => r.Id, r => r);
             }
 
             public override Task Shutdown()

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2636,7 +2636,7 @@ namespace NServiceBus.Transport
     {
         protected TransportInfrastructure() { }
         public NServiceBus.Transport.IMessageDispatcher Dispatcher { get; set; }
-        public System.Collections.ObjectModel.ReadOnlyDictionary<string, NServiceBus.Transport.IMessageReceiver> Receivers { get; set; }
+        public System.Collections.Generic.IReadOnlyDictionary<string, NServiceBus.Transport.IMessageReceiver> Receivers { get; set; }
         public abstract System.Threading.Tasks.Task Shutdown();
     }
     public class TransportOperation

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
@@ -2,7 +2,6 @@
 {
     using System.Collections.Generic;
     using System;
-    using System.Collections.ObjectModel;
     using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
@@ -63,7 +62,7 @@
                 receivers.Add(receiverSetting.Id, await CreateReceiver(receiverSetting).ConfigureAwait(false));
             }
 
-            Receivers = new ReadOnlyDictionary<string, IMessageReceiver>(receivers);
+            Receivers = receivers;
         }
 
         public Task<IMessageReceiver> CreateReceiver(ReceiveSettings receiveSettings)

--- a/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
@@ -1,6 +1,6 @@
 namespace NServiceBus.Transport
 {
-    using System.Collections.ObjectModel;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -16,7 +16,7 @@ namespace NServiceBus.Transport
         /// <summary>
         /// A collection of all receivers.
         /// </summary>
-        public ReadOnlyDictionary<string, IMessageReceiver> Receivers { get; protected set; }
+        public IReadOnlyDictionary<string, IMessageReceiver> Receivers { get; protected set; }
 
         /// <summary>
         /// Disposes all transport internal resources.


### PR DESCRIPTION
following up #5916 , it might be better to use the `IReadOnlyDictionary` interface for the property type as this allows easier assignment in transport. With this, implementations of the `TransportInfrastructure` won't have to always wrap their internal structure in a new `ReadOnlyDictionary`.

Thoughts @danielmarbach ?