### PR TITLE
Ensure single transport test per file

### DIFF
--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -36,6 +36,8 @@
     <_PackageFiles Remove="**\obj\**\*.cs" />
     <_PackageFiles Remove="ConfigureLearningTransportInfrastructure.cs" />
     <_PackageFiles Remove="StandardsTests.cs" />
+    <_PackageFiles Remove="When_modifying_incoming_headers_between_processing_attempts.cs" />
+    <_PackageFiles Remove="When_modifying_incoming_headers_while_handling_error.cs" />
   </ItemGroup>
   <!-- End Workaround -->
 

--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -35,6 +35,7 @@
     </_PackageFiles>
     <_PackageFiles Remove="**\obj\**\*.cs" />
     <_PackageFiles Remove="ConfigureLearningTransportInfrastructure.cs" />
+    <_PackageFiles Remove="StandardsTests.cs" />
   </ItemGroup>
   <!-- End Workaround -->
 

--- a/src/NServiceBus.TransportTests/StandardsTests.cs
+++ b/src/NServiceBus.TransportTests/StandardsTests.cs
@@ -1,0 +1,29 @@
+﻿namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Linq;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class StandardsTests
+    {
+        [Test]
+        public void Each_test_class_contains_single_test_case()
+        {
+            var assembly = typeof(StandardsTests).Assembly;
+
+            var testTypes = assembly.GetTypes().Where(x => x.Name.StartsWith("When_"));
+
+            foreach (Type testType in testTypes)
+            {
+                var testMethods = testType.GetMethods()
+                    .Where(m => m.GetCustomAttributes(false).Any(a => a is TestCaseAttribute || a is TestAttribute));
+
+                if (testMethods.Count() > 1)
+                {
+                    Assert.Fail($"Test {testType.Name} contains more than one test method. Multiple test methods are not allowed because transports don't support cleanup between running these methods.");
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.TransportTests/When_modifying_incoming_headers.cs
+++ b/src/NServiceBus.TransportTests/When_modifying_incoming_headers.cs
@@ -6,42 +6,6 @@
     using NUnit.Framework;
     using Transport;
 
-    public class When_modifying_incoming_headers_between_processing_attempts : NServiceBusTransportTest
-    {
-        [TestCase(TransportTransactionMode.ReceiveOnly)]
-        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
-        [TestCase(TransportTransactionMode.TransactionScope)]
-        public async Task Should_roll_back_header_modifications_between_processing_attempts(
-            TransportTransactionMode transactionMode)
-        {
-            var messageRetries = new TaskCompletionSource<MessageContext>();
-            var firstInvocation = true;
-
-            OnTestTimeout(() => messageRetries.SetCanceled());
-
-            await StartPump(context =>
-                {
-                    if (firstInvocation)
-                    {
-                        context.Headers["test-header"] = "modified";
-                        firstInvocation = false;
-                        throw new Exception();
-                    }
-
-                    messageRetries.SetResult(context);
-                    return Task.FromResult(0);
-                },
-                context => Task.FromResult(ErrorHandleResult.RetryRequired),
-                transactionMode);
-
-            await SendMessage(InputQueueName, new Dictionary<string, string> { { "test-header", "original" } });
-
-            var retriedMessage = await messageRetries.Task;
-
-            Assert.AreEqual("original", retriedMessage.Headers["test-header"]);
-        }
-    }
-
     public class When_modifying_incoming_headers_before_handling_error : NServiceBusTransportTest
     {
         [TestCase(TransportTransactionMode.None)]
@@ -72,47 +36,6 @@
             var errorContext = await errorHandled.Task;
 
             Assert.AreEqual("original", errorContext.Message.Headers["test-header"]);
-        }
-    }
-
-    public class When_modifying_incoming_headers_while_handling_error : NServiceBusTransportTest
-    {
-        [TestCase(TransportTransactionMode.ReceiveOnly)]
-        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
-        [TestCase(TransportTransactionMode.TransactionScope)]
-        public async Task Should_roll_back_header_modifications_made_while_handling_error(TransportTransactionMode transactionMode)
-        {
-            var messageRetries = new TaskCompletionSource<MessageContext>();
-            var firstInvocation = true;
-
-            OnTestTimeout(() => messageRetries.SetCanceled());
-
-            await StartPump(context =>
-                {
-                    if (firstInvocation)
-                    {
-                        firstInvocation = false;
-                        throw new Exception();
-                    }
-
-                    messageRetries.SetResult(context);
-                    return Task.FromResult(0);
-                },
-                context =>
-                {
-                    context.Message.Headers["test-header"] = "modified";
-                    return Task.FromResult(ErrorHandleResult.RetryRequired);
-                },
-                transactionMode);
-
-            await SendMessage(InputQueueName, new Dictionary<string, string>
-            {
-                {"test-header", "original"}
-            });
-
-            var retriedMessage = await messageRetries.Task;
-
-            Assert.AreEqual("original", retriedMessage.Headers["test-header"]);
         }
     }
 }

--- a/src/NServiceBus.TransportTests/When_modifying_incoming_headers_between_processing_attempts.cs
+++ b/src/NServiceBus.TransportTests/When_modifying_incoming_headers_between_processing_attempts.cs
@@ -1,0 +1,44 @@
+﻿namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using Transport;
+
+    public class When_modifying_incoming_headers_between_processing_attempts : NServiceBusTransportTest
+    {
+        [TestCase(TransportTransactionMode.ReceiveOnly)]
+        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
+        [TestCase(TransportTransactionMode.TransactionScope)]
+        public async Task Should_roll_back_header_modifications_between_processing_attempts(
+            TransportTransactionMode transactionMode)
+        {
+            var messageRetries = new TaskCompletionSource<MessageContext>();
+            var firstInvocation = true;
+
+            OnTestTimeout(() => messageRetries.SetCanceled());
+
+            await StartPump(context =>
+                {
+                    if (firstInvocation)
+                    {
+                        context.Headers["test-header"] = "modified";
+                        firstInvocation = false;
+                        throw new Exception();
+                    }
+
+                    messageRetries.SetResult(context);
+                    return Task.FromResult(0);
+                },
+                context => Task.FromResult(ErrorHandleResult.RetryRequired),
+                transactionMode);
+
+            await SendMessage(InputQueueName, new Dictionary<string, string> { { "test-header", "original" } });
+
+            var retriedMessage = await messageRetries.Task;
+
+            Assert.AreEqual("original", retriedMessage.Headers["test-header"]);
+        }
+    }
+}

--- a/src/NServiceBus.TransportTests/When_modifying_incoming_headers_while_handling_error.cs
+++ b/src/NServiceBus.TransportTests/When_modifying_incoming_headers_while_handling_error.cs
@@ -1,0 +1,49 @@
+﻿namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using Transport;
+
+    public class When_modifying_incoming_headers_while_handling_error : NServiceBusTransportTest
+    {
+        [TestCase(TransportTransactionMode.ReceiveOnly)]
+        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
+        [TestCase(TransportTransactionMode.TransactionScope)]
+        public async Task Should_roll_back_header_modifications_made_while_handling_error(TransportTransactionMode transactionMode)
+        {
+            var messageRetries = new TaskCompletionSource<MessageContext>();
+            var firstInvocation = true;
+
+            OnTestTimeout(() => messageRetries.SetCanceled());
+
+            await StartPump(context =>
+                {
+                    if (firstInvocation)
+                    {
+                        firstInvocation = false;
+                        throw new Exception();
+                    }
+
+                    messageRetries.SetResult(context);
+                    return Task.FromResult(0);
+                },
+                context =>
+                {
+                    context.Message.Headers["test-header"] = "modified";
+                    return Task.FromResult(ErrorHandleResult.RetryRequired);
+                },
+                transactionMode);
+
+            await SendMessage(InputQueueName, new Dictionary<string, string>
+            {
+                {"test-header", "original"}
+            });
+
+            var retriedMessage = await messageRetries.Task;
+
+            Assert.AreEqual("original", retriedMessage.Headers["test-header"]);
+        }
+    }
+}

--- a/src/NServiceBus.TransportTests/When_transaction_level_TransactionScope.cs
+++ b/src/NServiceBus.TransportTests/When_transaction_level_TransactionScope.cs
@@ -16,6 +16,8 @@
         {
             var messageHandled = new TaskCompletionSource<Tuple<Transaction, Transaction>>();
 
+            OnTestTimeout(() => messageHandled.SetCanceled());
+
             await StartPump(
                 context =>
                 {

--- a/src/NServiceBus.TransportTests/When_using_unicode_characters_in_headers.cs
+++ b/src/NServiceBus.TransportTests/When_using_unicode_characters_in_headers.cs
@@ -12,6 +12,8 @@
         {
             var onMessageCalled = new TaskCompletionSource<MessageContext>();
 
+            OnTestTimeout(() => onMessageCalled.SetCanceled());
+
             await StartPump(m =>
                 {
                     onMessageCalled.SetResult(m);


### PR DESCRIPTION
Because some transports, e.g. SQS, don't support purging the queues before the test run. Without purging test methods in the same class share the same queues which leads to flaky behavior.

Also includes missing `OnTimeout` calls in several transport tests.