### PR TITLE
Add test to make sure transports float context to on error

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_missing_publisher_information.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_missing_publisher_information.cs
@@ -8,7 +8,7 @@
     using Logging;
     using NUnit.Framework;
 
-    public class When_autosubscribe_with_missing_publisher_information : NServiceBusAcceptanceTest
+    public class When_missing_publisher_information : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_log_events_with_missing_routes()

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2401,8 +2401,7 @@ namespace NServiceBus.Transport
     }
     public class ErrorContext
     {
-        public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures) { }
-        public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures, NServiceBus.Extensibility.ReadOnlyContextBag context) { }
+        public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures, NServiceBus.Extensibility.ContextBag context) { }
         public int DelayedDeliveriesPerformed { get; }
         public System.Exception Exception { get; }
         public NServiceBus.Extensibility.ReadOnlyContextBag Extensions { get; }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2401,7 +2401,7 @@ namespace NServiceBus.Transport
     }
     public class ErrorContext
     {
-        public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures, NServiceBus.Extensibility.ContextBag context) { }
+        public ErrorContext(System.Exception exception, System.Collections.Generic.Dictionary<string, string> headers, string transportMessageId, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, int immediateProcessingFailures, NServiceBus.Extensibility.ReadOnlyContextBag context) { }
         public int DelayedDeliveriesPerformed { get; }
         public System.Exception Exception { get; }
         public NServiceBus.Extensibility.ReadOnlyContextBag Extensions { get; }

--- a/src/NServiceBus.Core.Tests/Recoverability/DefaultRecoverabilityPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/DefaultRecoverabilityPolicyTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using NServiceBus.Extensibility;
     using NUnit.Framework;
     using Transport;
 
@@ -168,7 +169,8 @@
                 "message-id",
                 new byte[0],
                 new TransportTransaction(),
-                numberOfDeliveryAttempts);
+                numberOfDeliveryAttempts,
+                new ContextBag());
 
         static Func<ErrorContext, RecoverabilityAction> CreatePolicy(int maxImmediateRetries = 2, int maxDelayedRetries = 2, TimeSpan? delayedRetryDelay = null, HashSet<Type> unrecoverableExceptions = null)
         {

--- a/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
@@ -5,6 +5,7 @@
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
     using NUnit.Framework;
     using Transport;
 
@@ -162,7 +163,7 @@
 
         static ErrorContext CreateErrorContext(Exception raisedException = null, string exceptionMessage = "default-message", string messageId = "default-id", int numberOfDeliveryAttempts = 1)
         {
-            return new ErrorContext(raisedException ?? new Exception(exceptionMessage), new Dictionary<string, string>(), messageId, new byte[0], new TransportTransaction(), numberOfDeliveryAttempts);
+            return new ErrorContext(raisedException ?? new Exception(exceptionMessage), new Dictionary<string, string>(), messageId, new byte[0], new TransportTransaction(), numberOfDeliveryAttempts, new ContextBag());
         }
 
         RecoverabilityExecutor CreateExecutor(Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> policy, bool delayedRetriesSupported = true, bool immediateRetriesSupported = true, bool raiseNotifications = true)

--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -9,22 +9,6 @@
     /// </summary>
     public class ErrorContext
     {
-        static ReadOnlyContextBag emptyBag = new ContextBag();
-
-        /// <summary>
-        /// Initializes the error context.
-        /// </summary>
-        /// <param name="exception">The exception that caused the message processing failure.</param>
-        /// <param name="headers">The message headers.</param>
-        /// <param name="transportMessageId">Native message id.</param>
-        /// <param name="body">The message body.</param>
-        /// <param name="transportTransaction">Transaction (along with connection if applicable) used to receive the message.</param>
-        /// <param name="immediateProcessingFailures">Number of failed immediate processing attempts.</param>
-        public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, byte[] body, TransportTransaction transportTransaction, int immediateProcessingFailures)
-            : this(exception, headers, transportMessageId, body, transportTransaction, immediateProcessingFailures, emptyBag)
-        {
-        }
-
         /// <summary>
         /// Initializes the error context.
         /// </summary>
@@ -35,7 +19,7 @@
         /// <param name="transportTransaction">Transaction (along with connection if applicable) used to receive the message.</param>
         /// <param name="immediateProcessingFailures">Number of failed immediate processing attempts.</param>
         /// <param name="context">A <see cref="ContextBag" /> which can be used to extend the current object.</param>
-        public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, byte[] body, TransportTransaction transportTransaction, int immediateProcessingFailures, ReadOnlyContextBag context)
+        public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, byte[] body, TransportTransaction transportTransaction, int immediateProcessingFailures, ContextBag context)
         {
             Exception = exception;
             TransportTransaction = transportTransaction;

--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -18,8 +18,8 @@
         /// <param name="body">The message body.</param>
         /// <param name="transportTransaction">Transaction (along with connection if applicable) used to receive the message.</param>
         /// <param name="immediateProcessingFailures">Number of failed immediate processing attempts.</param>
-        /// <param name="context">A <see cref="ContextBag" /> which can be used to extend the current object.</param>
-        public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, byte[] body, TransportTransaction transportTransaction, int immediateProcessingFailures, ContextBag context)
+        /// <param name="context">A <see cref="ReadOnlyContextBag" /> which can be used to extend the current object.</param>
+        public ErrorContext(Exception exception, Dictionary<string, string> headers, string transportMessageId, byte[] body, TransportTransaction transportTransaction, int immediateProcessingFailures, ReadOnlyContextBag context)
         {
             Exception = exception;
             TransportTransaction = transportTransaction;

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -300,6 +300,7 @@
             {
                 transportTransaction.Set(transaction);
             }
+
             var processingContext = new ContextBag();
 
             var messageContext = new MessageContext(messageId, headers, body, transportTransaction, processingContext);

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -300,8 +300,9 @@
             {
                 transportTransaction.Set(transaction);
             }
+            var processingContext = new ContextBag();
 
-            var messageContext = new MessageContext(messageId, headers, body, transportTransaction, new ContextBag());
+            var messageContext = new MessageContext(messageId, headers, body, transportTransaction, processingContext);
 
             try
             {
@@ -323,7 +324,7 @@
                 headers = HeaderSerializer.Deserialize(message);
                 headers.Remove(LearningTransportHeaders.TimeToBeReceived);
 
-                var errorContext = new ErrorContext(exception, headers, messageId, body, transportTransaction, processingFailures);
+                var errorContext = new ErrorContext(exception, headers, messageId, body, transportTransaction, processingFailures, processingContext);
 
                 ErrorHandleResult actionToTake;
                 try

--- a/src/NServiceBus.TransportTests/When_processing_fails.cs
+++ b/src/NServiceBus.TransportTests/When_processing_fails.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.TransportTests
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using NUnit.Framework;
     using Transport;
@@ -18,18 +17,20 @@ namespace NServiceBus.TransportTests
 
             OnTestTimeout(() => onErrorCalled.SetCanceled());
 
-            await StartPump((context, _) =>
-            {
-                context.Extensions.Set("MyKey", "MyValue");
+            await StartPump(
+                (context, _) =>
+                {
+                    context.Extensions.Set("MyKey", "MyValue");
 
-                throw new Exception("Simulated exception");
-            },
-            (context, _) =>
-            {
-                onErrorCalled.SetResult(context);
+                    throw new Exception("Simulated exception");
+                },
+                (context, _) =>
+                {
+                    onErrorCalled.SetResult(context);
 
-                return Task.FromResult(ErrorHandleResult.Handled);
-            }, transactionMode);
+                    return Task.FromResult(ErrorHandleResult.Handled);
+                },
+                transactionMode);
 
             await SendMessage(InputQueueName);
 

--- a/src/NServiceBus.TransportTests/When_processing_fails.cs
+++ b/src/NServiceBus.TransportTests/When_processing_fails.cs
@@ -1,0 +1,41 @@
+namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using Transport;
+
+    public class When_processing_fails : NServiceBusTransportTest
+    {
+        [TestCase(TransportTransactionMode.None)]
+        [TestCase(TransportTransactionMode.ReceiveOnly)]
+        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
+        [TestCase(TransportTransactionMode.TransactionScope)]
+        public async Task Should_float_context_to_error(TransportTransactionMode transactionMode)
+        {
+            var onErrorCalled = new TaskCompletionSource<ErrorContext>();
+
+            OnTestTimeout(() => onErrorCalled.SetCanceled());
+
+            await StartPump((context, _) =>
+            {
+                context.Extensions.Set("MyKey", "MyValue");
+
+                throw new Exception("Simulated exception");
+            },
+            (context, _) =>
+            {
+                onErrorCalled.SetResult(context);
+
+                return Task.FromResult(ErrorHandleResult.Handled);
+            }, transactionMode);
+
+            await SendMessage(InputQueueName, new Dictionary<string, string>());
+
+            var errorContext = await onErrorCalled.Task;
+
+            Assert.AreEqual("MyValue", errorContext.Extensions.Get<string>("MyKey"));
+        }
+    }
+}

--- a/src/NServiceBus.TransportTests/When_processing_fails.cs
+++ b/src/NServiceBus.TransportTests/When_processing_fails.cs
@@ -31,7 +31,7 @@ namespace NServiceBus.TransportTests
                 return Task.FromResult(ErrorHandleResult.Handled);
             }, transactionMode);
 
-            await SendMessage(InputQueueName, new Dictionary<string, string>());
+            await SendMessage(InputQueueName);
 
             var errorContext = await onErrorCalled.Task;
 


### PR DESCRIPTION
Transports should float the context of `OnMessage` to `OnError` to enable users to share state between calls to them.

Examples of this are [satellites ](https://docs.particular.net/nservicebus/satellites/#implementing-a-satellite ) that want to access context items added by `OnMessage` in their error handling via the `ErrorContext`

```
public class MySatelliteFeature :
    Feature
{
    public MySatelliteFeature()
    {
        EnableByDefault();
    }
    protected override void Setup(FeatureConfigurationContext context)
    {
        context.AddSatelliteReceiver(
            name: "MyCustomSatellite",
            transportAddress: "targetQueue",
            runtimeSettings: PushRuntimeSettings.Default,
            recoverabilityPolicy: (config, errorContext) =>
            {
                if(errorContext.Extension.Get<string>("SomeKey") =="SomeValue" )
                {
                       //do something
                }
                return RecoverabilityAction.MoveToError(config.Failed.ErrorQueue);
            },
            onMessage: OnMessage);
    }

    Task OnMessage(IBuilder builder, MessageContext context)
    {
        context.Extensions.Set("SomeKey", "SomeValue");
        return Task.CompletedTask;
    }
```

This PR adds a test to make sure the proper floating of the context and fixes the learning transport implementation.