### PR TITLE
Make CancellationToken parameters optional

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/AcceptanceTestingSynchronizedStorage.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/AcceptanceTestingSynchronizedStorage.cs
@@ -7,7 +7,7 @@ namespace NServiceBus.AcceptanceTesting
 
     class AcceptanceTestingSynchronizedStorage : ISynchronizedStorage
     {
-        public Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag, CancellationToken cancellationToken)
+        public Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag, CancellationToken cancellationToken = default)
         {
             var session = (CompletableSynchronizedStorageSession)new AcceptanceTestingSynchronizedStorageSession();
             return Task.FromResult(session);

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/AcceptanceTestingSynchronizedStorageSession.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/AcceptanceTestingSynchronizedStorageSession.cs
@@ -25,7 +25,7 @@ namespace NServiceBus.AcceptanceTesting
             Transaction = null;
         }
 
-        public Task CompleteAsync(CancellationToken cancellationToken)
+        public Task CompleteAsync(CancellationToken cancellationToken = default)
         {
             if (ownsTransaction)
             {

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/AcceptanceTestingTransactionalSynchronizedStorageAdapter.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/AcceptanceTestingTransactionalSynchronizedStorageAdapter.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.AcceptanceTesting
 
     class AcceptanceTestingTransactionalSynchronizedStorageAdapter : ISynchronizedStorageAdapter
     {
-        public Task<CompletableSynchronizedStorageSession> TryAdapt(OutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken)
+        public Task<CompletableSynchronizedStorageSession> TryAdapt(OutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken = default)
         {
             if (transaction is AcceptanceTestingOutboxTransaction inMemOutboxTransaction)
             {
@@ -21,7 +21,7 @@ namespace NServiceBus.AcceptanceTesting
             return EmptyTask;
         }
 
-        public Task<CompletableSynchronizedStorageSession> TryAdapt(TransportTransaction transportTransaction, ContextBag context, CancellationToken cancellationToken)
+        public Task<CompletableSynchronizedStorageSession> TryAdapt(TransportTransaction transportTransaction, ContextBag context, CancellationToken cancellationToken = default)
         {
             if (transportTransaction.TryGet(out Transaction ambientTransaction))
             {

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/Outbox/AcceptanceTestingOutboxPersistence.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/Outbox/AcceptanceTestingOutboxPersistence.cs
@@ -32,13 +32,13 @@
                 acceptanceTestingOutboxStorage = storage;
             }
 
-            protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+            protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
             {
                 cleanupTimer = new Timer(PerformCleanup, null, TimeSpan.FromMinutes(1), TimeSpan.FromMinutes(1));
                 return Task.CompletedTask;
             }
 
-            protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+            protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
             {
                 using (var waitHandle = new ManualResetEvent(false))
                 {

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/Outbox/AcceptanceTestingOutboxStorage.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/Outbox/AcceptanceTestingOutboxStorage.cs
@@ -9,7 +9,7 @@
 
     class AcceptanceTestingOutboxStorage : IOutboxStorage
     {
-        public Task<OutboxMessage> Get(string messageId, ContextBag context, CancellationToken cancellationToken)
+        public Task<OutboxMessage> Get(string messageId, ContextBag context, CancellationToken cancellationToken = default)
         {
             if (!storage.TryGetValue(messageId, out var storedMessage))
             {
@@ -19,12 +19,12 @@
             return Task.FromResult(new OutboxMessage(messageId, storedMessage.TransportOperations));
         }
 
-        public Task<OutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken)
+        public Task<OutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<OutboxTransaction>(new AcceptanceTestingOutboxTransaction());
         }
 
-        public Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken)
+        public Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken = default)
         {
             var tx = (AcceptanceTestingOutboxTransaction)transaction;
             tx.Enlist(() =>
@@ -37,7 +37,7 @@
             return Task.CompletedTask;
         }
 
-        public Task SetAsDispatched(string messageId, ContextBag context, CancellationToken cancellationToken)
+        public Task SetAsDispatched(string messageId, ContextBag context, CancellationToken cancellationToken = default)
         {
             if (!storage.TryGetValue(messageId, out var storedMessage))
             {

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/Outbox/AcceptanceTestingOutboxTransaction.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/Outbox/AcceptanceTestingOutboxTransaction.cs
@@ -19,7 +19,7 @@
             Transaction = null;
         }
 
-        public Task Commit(CancellationToken cancellationToken)
+        public Task Commit(CancellationToken cancellationToken = default)
         {
             Transaction.Commit();
             return Task.CompletedTask;

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/SagaPersister/AcceptanceTestingSagaPersister.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/SagaPersister/AcceptanceTestingSagaPersister.cs
@@ -21,7 +21,7 @@ namespace NServiceBus.AcceptanceTesting
             byCorrelationIdCollection = byCorrelationId;
         }
 
-        public Task Complete(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken)
+        public Task Complete(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
         {
             ((AcceptanceTestingSynchronizedStorageSession)session).Enlist(() =>
            {
@@ -43,7 +43,7 @@ namespace NServiceBus.AcceptanceTesting
             return Task.CompletedTask;
         }
 
-        public Task<TSagaData> Get<TSagaData>(Guid sagaId, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken)
+        public Task<TSagaData> Get<TSagaData>(Guid sagaId, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
             where TSagaData : class, IContainSagaData
         {
             if (sagas.TryGetValue(sagaId, out var value))
@@ -57,7 +57,7 @@ namespace NServiceBus.AcceptanceTesting
             return CachedSagaDataTask<TSagaData>.Default;
         }
 
-        public Task<TSagaData> Get<TSagaData>(string propertyName, object propertyValue, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken)
+        public Task<TSagaData> Get<TSagaData>(string propertyName, object propertyValue, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
             where TSagaData : class, IContainSagaData
         {
             var key = new CorrelationId(typeof(TSagaData), propertyName, propertyValue);
@@ -71,7 +71,7 @@ namespace NServiceBus.AcceptanceTesting
             return CachedSagaDataTask<TSagaData>.Default;
         }
 
-        public Task Save(IContainSagaData sagaData, SagaCorrelationProperty correlationProperty, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken)
+        public Task Save(IContainSagaData sagaData, SagaCorrelationProperty correlationProperty, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
         {
             ((AcceptanceTestingSynchronizedStorageSession)session).Enlist(() =>
            {
@@ -95,7 +95,7 @@ namespace NServiceBus.AcceptanceTesting
             return Task.CompletedTask;
         }
 
-        public Task Update(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken)
+        public Task Update(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
         {
             ((AcceptanceTestingSynchronizedStorageSession)session).Enlist(() =>
            {

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/SubscriptionStorage/AcceptanceTestingSubscriptionStorage.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/SubscriptionStorage/AcceptanceTestingSubscriptionStorage.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.AcceptanceTesting
 
     class AcceptanceTestingSubscriptionStorage : ISubscriptionStorage
     {
-        public Task Subscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken)
+        public Task Subscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken = default)
         {
             var dict = storage.GetOrAdd(messageType, type => new ConcurrentDictionary<string, Subscriber>(StringComparer.OrdinalIgnoreCase));
 
@@ -19,7 +19,7 @@ namespace NServiceBus.AcceptanceTesting
             return Task.CompletedTask;
         }
 
-        public Task Unsubscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken)
+        public Task Unsubscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken = default)
         {
             if (storage.TryGetValue(messageType, out var dict))
             {
@@ -28,7 +28,7 @@ namespace NServiceBus.AcceptanceTesting
             return Task.CompletedTask;
         }
 
-        public Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context, CancellationToken cancellationToken)
+        public Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context, CancellationToken cancellationToken = default)
         {
             var result = new HashSet<Subscriber>();
             foreach (var m in messageTypes)

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransport.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransport.cs
@@ -14,7 +14,7 @@
         {
         }
 
-        public override async Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken)
+        public override async Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken = default)
         {
             Guard.AgainstNull(nameof(hostSettings), hostSettings);
 

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransportInfrastructure.cs
@@ -75,7 +75,7 @@
             Dispatcher = new LearningTransportDispatcher(storagePath, int.MaxValue / 1024);
         }
 
-        public override Task Shutdown(CancellationToken cancellationToken)
+        public override Task Shutdown(CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }

--- a/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_at_startup.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_at_startup.cs
@@ -86,7 +86,7 @@
                     this.testContext = testContext;
                 }
 
-                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     criticalError.Raise("critical error 1", new SimulatedException(), cancellationToken);
                     testContext.CriticalErrorsRaised++;
@@ -97,7 +97,7 @@
                     return Task.FromResult(0);
                 }
 
-                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_from_a_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_from_a_handler.cs
@@ -96,7 +96,7 @@
                     this.testContext = testContext;
                 }
 
-                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     criticalError.Raise("critical error 1", new SimulatedException(), cancellationToken);
                     testContext.CriticalErrorsRaised++;
@@ -107,7 +107,7 @@
                     return Task.FromResult(0);
                 }
 
-                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_overriding_services_in_registercomponents.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_overriding_services_in_registercomponents.cs
@@ -86,12 +86,12 @@
                         testContext.DependencyBeforeEndpointStart = dependencyBeforeEndpointStart;
                     }
 
-                    protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+                    protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                     {
                         return Task.CompletedTask;
                     }
 
-                    protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+                    protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
                     {
                         return Task.CompletedTask;
                     }

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeDispatcher.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeDispatcher.cs
@@ -6,7 +6,7 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport
 
     class FakeDispatcher : IMessageDispatcher
     {
-        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken)
+        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeReceiver.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeReceiver.cs
@@ -22,13 +22,13 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport
             Id = id;
         }
 
-        public Task Initialize(PushRuntimeSettings limitations, OnMessage onMessage, OnError onError, OnCompleted onCompleted, CancellationToken cancellationToken)
+        public Task Initialize(PushRuntimeSettings limitations, OnMessage onMessage, OnError onError, OnCompleted onCompleted, CancellationToken cancellationToken = default)
         {
             startupSequence.Add($"{nameof(IMessageReceiver)}.{nameof(Initialize)} for receiver {Id}");
             return Task.CompletedTask;
         }
 
-        public Task StartReceive(CancellationToken cancellationToken)
+        public Task StartReceive(CancellationToken cancellationToken = default)
         {
             startupSequence.Add($"{nameof(IMessageReceiver)}.{nameof(StartReceive)} for receiver {Id}");
 
@@ -41,7 +41,7 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport
             return Task.CompletedTask;
         }
 
-        public async Task StopReceive(CancellationToken cancellationToken)
+        public async Task StopReceive(CancellationToken cancellationToken = default)
         {
             startupSequence.Add($"{nameof(IMessageReceiver)}.{nameof(StopReceive)} for receiver {Id}");
 
@@ -58,9 +58,9 @@ namespace NServiceBus.AcceptanceTests.Core.FakeTransport
 
         class FakeSubscriptionManager : ISubscriptionManager
         {
-            public Task SubscribeAll(MessageMetadata[] eventTypes, ContextBag context, CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task SubscribeAll(MessageMetadata[] eventTypes, ContextBag context, CancellationToken cancellationToken = default) => Task.CompletedTask;
 
-            public Task Unsubscribe(MessageMetadata eventType, ContextBag context, CancellationToken cancellationToken) => Task.CompletedTask;
+            public Task Unsubscribe(MessageMetadata eventType, ContextBag context, CancellationToken cancellationToken = default) => Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransport.cs
@@ -16,7 +16,7 @@
         {
         }
 
-        public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken)
+        public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken = default)
         {
             StartupSequence.Add($"{nameof(TransportDefinition)}.{nameof(Initialize)}");
 

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
@@ -38,7 +38,7 @@
             Dispatcher = new FakeDispatcher();
         }
 
-        public override Task Shutdown(CancellationToken cancellationToken)
+        public override Task Shutdown(CancellationToken cancellationToken = default)
         {
             startUpSequence.Add($"{nameof(TransportInfrastructure)}.{nameof(Shutdown)}");
 

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -39,20 +39,20 @@
         {
             PushRuntimeSettings pushSettings;
 
-            public Task Initialize(PushRuntimeSettings limitations, OnMessage onMessage, OnError onError, OnCompleted onCompleted, CancellationToken cancellationToken)
+            public Task Initialize(PushRuntimeSettings limitations, OnMessage onMessage, OnError onError, OnCompleted onCompleted, CancellationToken cancellationToken = default)
             {
                 pushSettings = limitations;
                 return Task.CompletedTask;
             }
 
-            public Task StartReceive(CancellationToken cancellationToken)
+            public Task StartReceive(CancellationToken cancellationToken = default)
             {
                 Assert.AreEqual(10, pushSettings.MaxConcurrency);
 
                 return Task.CompletedTask;
             }
 
-            public Task StopReceive(CancellationToken cancellationToken)
+            public Task StopReceive(CancellationToken cancellationToken = default)
             {
                 return Task.CompletedTask;
             }
@@ -64,7 +64,7 @@
 
         class FakeDispatcher : IMessageDispatcher
         {
-            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
             {
                 return Task.FromResult(0);
             }
@@ -76,7 +76,7 @@
             {
             }
 
-            public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken)
+            public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken = default)
             {
                 return Task.FromResult<TransportInfrastructure>(new FakeTransportInfrastructure(receivers));
             }
@@ -108,7 +108,7 @@
                     .ToDictionary<FakeReceiver, string, IMessageReceiver>(r => r.Id, r => r);
             }
 
-            public override Task Shutdown(CancellationToken cancellationToken)
+            public override Task Shutdown(CancellationToken cancellationToken = default)
             {
                 return Task.CompletedTask;
             }

--- a/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_feature.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_feature.cs
@@ -63,13 +63,13 @@
                 {
                     this.dependency = dependency;
                 }
-                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     dependency.Start();
                     return Task.FromResult(0);
                 }
 
-                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     dependency.Stop();
                     return Task.FromResult(0);
@@ -94,13 +94,13 @@
                 {
                     this.dependency = dependency;
                 }
-                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     dependency.Initialize();
                     return Task.FromResult(0);
                 }
 
-                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/Core/Feature/When_feature_startup_task_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Feature/When_feature_startup_task_fails.cs
@@ -35,12 +35,12 @@
 
             class FailingStartupTask : FeatureStartupTask
             {
-                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     throw new SimulatedException();
                 }
 
-                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/Core/Feature/When_registering_a_startup_task.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Feature/When_registering_a_startup_task.cs
@@ -60,13 +60,13 @@
                         this.scenarioContext = scenarioContext;
                     }
 
-                    protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+                    protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                     {
                         scenarioContext.SendOnlyEndpointWasStarted = true;
                         return Task.FromResult(0);
                     }
 
-                    protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+                    protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
                     {
                         return Task.FromResult(0);
                     }

--- a/src/NServiceBus.AcceptanceTests/Core/Installers/When_installers_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Installers/When_installers_enabled.cs
@@ -41,7 +41,7 @@
                     this.testContext = testContext;
                 }
 
-                public Task Install(string identity, CancellationToken cancellationToken)
+                public Task Install(string identity, CancellationToken cancellationToken = default)
                 {
                     testContext.InstallerCalled = true;
                     return Task.FromResult(0);

--- a/src/NServiceBus.AcceptanceTests/Core/Installers/When_installers_not_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Installers/When_installers_not_enabled.cs
@@ -43,7 +43,7 @@
                     this.testContext = testContext;
                 }
 
-                public Task Install(string identity, CancellationToken cancellationToken)
+                public Task Install(string identity, CancellationToken cancellationToken = default)
                 {
                     testContext.InstallerCalled = true;
                     return Task.FromResult(0);

--- a/src/NServiceBus.AcceptanceTests/Core/Persistence/When_a_persistence_does_not_provide_ISynchronizationContext.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Persistence/When_a_persistence_does_not_provide_ISynchronizationContext.cs
@@ -37,17 +37,17 @@
 
         class NoOpISubscriptionStorage : ISubscriptionStorage
         {
-            public Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context, CancellationToken cancellationToken)
+            public Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context, CancellationToken cancellationToken = default)
             {
                 return Task.FromResult<IEnumerable<Subscriber>>(null);
             }
 
-            public Task Subscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken)
+            public Task Subscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken = default)
             {
                 return Task.FromResult(0);
             }
 
-            public Task Unsubscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken)
+            public Task Unsubscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken = default)
             {
                 return Task.FromResult(0);
             }

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_configuring_subscription_authorizer.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_configuring_subscription_authorizer.cs
@@ -113,9 +113,9 @@
                         testContext.SubscriptionStorage = (FakePersistence.FakeSubscriptionStorage)subscriptionStorage;
                     }
 
-                    protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken) => Task.CompletedTask;
+                    protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
 
-                    protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken) => Task.CompletedTask;
+                    protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
                 }
             }
         }
@@ -147,15 +147,15 @@
             {
                 public ConcurrentBag<string> SubscribedEvents { get; } = new ConcurrentBag<string>();
 
-                public Task Subscribe(Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken)
+                public Task Subscribe(Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken = default)
                 {
                     SubscribedEvents.Add(messageType.TypeName);
                     return Task.CompletedTask;
                 }
 
-                public Task Unsubscribe(Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken) => throw new NotImplementedException();
+                public Task Unsubscribe(Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
-                public Task<IEnumerable<Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context, CancellationToken cancellationToken) => throw new NotImplementedException();
+                public Task<IEnumerable<Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             }
         }
     }

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_adding_state_to_context.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_adding_state_to_context.cs
@@ -53,7 +53,7 @@ namespace NServiceBus.AcceptanceTests.Core.Sagas
                     this.testContext = testContext;
                 }
 
-                public Task<TestSaga07.SagaData07> FindBy(StartSagaMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken)
+                public Task<TestSaga07.SagaData07> FindBy(StartSagaMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken = default)
                 {
                     testContext.ContextBag = context;
                     testContext.FinderUsed = true;

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_finder_cant_find_saga_instance.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_finder_cant_find_saga_instance.cs
@@ -49,7 +49,7 @@
                     this.testContext = testContext;
                 }
 
-                public Task<TestSaga06.SagaData06> FindBy(StartSagaMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken)
+                public Task<TestSaga06.SagaData06> FindBy(StartSagaMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken = default)
                 {
                     testContext.FinderUsed = true;
                     return Task.FromResult(default(TestSaga06.SagaData06));

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_finder_returns_existing_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_finder_returns_existing_saga.cs
@@ -50,7 +50,7 @@
                     this.sagaPersister = sagaPersister;
                 }
 
-                public async Task<TestSaga08.SagaData08> FindBy(SomeOtherMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken)
+                public async Task<TestSaga08.SagaData08> FindBy(SomeOtherMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken = default)
                 {
                     testContext.FinderUsed = true;
                     var sagaData = await sagaPersister.Get<TestSaga08.SagaData08>(message.SagaId, storageSession, (ContextBag)context, cancellationToken).ConfigureAwait(false);

--- a/src/NServiceBus.AcceptanceTests/Core/Stopping/When_feature_startup_task_throws_on_stop.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Stopping/When_feature_startup_task_throws_on_stop.cs
@@ -50,12 +50,12 @@ namespace NServiceBus.AcceptanceTests.Core.Stopping
 
                 class CustomTask : FeatureStartupTask
                 {
-                    protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+                    protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                     {
                         return Task.FromResult(0);
                     }
 
-                    protected override async Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+                    protected override async Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
                     {
                         await Task.Yield();
 

--- a/src/NServiceBus.AcceptanceTests/DataBus/When_using_custom_IDataBus.cs
+++ b/src/NServiceBus.AcceptanceTests/DataBus/When_using_custom_IDataBus.cs
@@ -80,13 +80,13 @@
                 this.context = context;
             }
 
-            public Task<Stream> Get(string key, CancellationToken cancellationToken)
+            public Task<Stream> Get(string key, CancellationToken cancellationToken = default)
             {
                 var fileStream = new FileStream(context.TempPath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true);
                 return Task.FromResult((Stream)fileStream);
             }
 
-            public Task<string> Put(Stream stream, TimeSpan timeToBeReceived, CancellationToken cancellationToken)
+            public Task<string> Put(Stream stream, TimeSpan timeToBeReceived, CancellationToken cancellationToken = default)
             {
                 using (var destination = File.OpenWrite(context.TempPath))
                 {
@@ -95,7 +95,7 @@
                 return Task.FromResult("key");
             }
 
-            public Task Start(CancellationToken cancellationToken)
+            public Task Start(CancellationToken cancellationToken = default)
             {
                 return Task.FromResult(0);
             }

--- a/src/NServiceBus.AcceptanceTests/Feature/When_purging_queues.cs
+++ b/src/NServiceBus.AcceptanceTests/Feature/When_purging_queues.cs
@@ -60,12 +60,12 @@
 
                 class StartupTask : FeatureStartupTask
                 {
-                    protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+                    protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                     {
                         return session.SendLocal(new LocalMessage(), cancellationToken);
                     }
 
-                    protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken) => Task.CompletedTask;
+                    protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Feature/When_subscribing_in_FST.cs
+++ b/src/NServiceBus.AcceptanceTests/Feature/When_subscribing_in_FST.cs
@@ -89,12 +89,12 @@
 
                 class StartupTask : FeatureStartupTask
                 {
-                    protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+                    protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                     {
                         return session.Subscribe<LocalEvent>(cancellationToken);
                     }
 
-                    protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken) => Task.CompletedTask;
+                    protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_publishing_from_sendonly.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_publishing_from_sendonly.cs
@@ -106,17 +106,17 @@
                 }.AsEnumerable());
             }
 
-            public Task Subscribe(Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken)
+            public Task Subscribe(Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken = default)
             {
                 return Task.FromResult(0);
             }
 
-            public Task Unsubscribe(Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken)
+            public Task Unsubscribe(Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken = default)
             {
                 return Task.FromResult(0);
             }
 
-            public Task<IEnumerable<Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context, CancellationToken cancellationToken)
+            public Task<IEnumerable<Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context, CancellationToken cancellationToken = default)
             {
                 return addressTask;
             }

--- a/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired.cs
+++ b/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired.cs
@@ -35,13 +35,13 @@
 
         class DelayReceiverFromStartingTask : FeatureStartupTask
         {
-            protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+            protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
             {
                 await session.SendLocal(new MyMessage(), cancellationToken: cancellationToken);
                 await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
             }
 
-            protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+            protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
             {
                 return Task.FromResult(0);
             }

--- a/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired_convention.cs
+++ b/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired_convention.cs
@@ -35,13 +35,13 @@
 
         class DelayReceiverFromStartingTask : FeatureStartupTask
         {
-            protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+            protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
             {
                 await session.SendLocal(new MyMessage(), cancellationToken: cancellationToken);
                 await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
             }
 
-            protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+            protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
             {
                 return Task.FromResult(0);
             }

--- a/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_used_with_unobtrusive_mode.cs
+++ b/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_used_with_unobtrusive_mode.cs
@@ -35,13 +35,13 @@
 
         class SendMessageAndDelayStartTask : FeatureStartupTask
         {
-            protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+            protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
             {
                 await session.SendLocal(new MyCommand(), cancellationToken);
                 await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
             }
 
-            protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+            protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
             {
                 return Task.FromResult(0);
             }

--- a/src/NServiceBus.Core.Tests/API/Infra/MethodInfoExtensions.cs
+++ b/src/NServiceBus.Core.Tests/API/Infra/MethodInfoExtensions.cs
@@ -14,14 +14,5 @@
 
         public static bool IsVisible(this MethodInfo method) =>
             method.DeclaringType.IsVisible && (method.IsPublic || method.IsFamily || method.IsFamilyOrAssembly);
-
-        public static bool IsExplicitInterfaceImplementation(this MethodInfo method)
-        {
-            const MethodAttributes explicitAttributes =
-                MethodAttributes.PrivateScope | MethodAttributes.Private | MethodAttributes.Final |
-                MethodAttributes.Virtual | MethodAttributes.HideBySig | MethodAttributes.VtableLayoutMask;
-
-            return !method.IsStatic && method.Attributes == explicitAttributes;
-        }
     }
 }

--- a/src/NServiceBus.Core.Tests/API/Infra/MethodInfoExtensions.cs
+++ b/src/NServiceBus.Core.Tests/API/Infra/MethodInfoExtensions.cs
@@ -14,5 +14,14 @@
 
         public static bool IsVisible(this MethodInfo method) =>
             method.DeclaringType.IsVisible && (method.IsPublic || method.IsFamily || method.IsFamilyOrAssembly);
+
+        public static bool IsExplicitInterfaceImplementation(this MethodInfo method)
+        {
+            const MethodAttributes explicitAttributes =
+                MethodAttributes.PrivateScope | MethodAttributes.Private | MethodAttributes.Final |
+                MethodAttributes.Virtual | MethodAttributes.HideBySig | MethodAttributes.VtableLayoutMask;
+
+            return !method.IsStatic && method.Attributes == explicitAttributes;
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/API/Infra/ParameterInfoExtensions.cs
+++ b/src/NServiceBus.Core.Tests/API/Infra/ParameterInfoExtensions.cs
@@ -11,8 +11,5 @@
 
         public static IEnumerable<ParameterInfo> CancellationTokens(this IEnumerable<ParameterInfo> parameters) =>
             parameters.Where(parameter => parameter.ParameterType.IsCancellationToken());
-
-        public static bool IsExplicitlyNamed(this ParameterInfo parameter) =>
-            parameter.Name.Length > 17 && parameter.Name.EndsWith("CancellationToken");
     }
 }

--- a/src/NServiceBus.Core.Tests/API/Infra/ParameterInfoExtensions.cs
+++ b/src/NServiceBus.Core.Tests/API/Infra/ParameterInfoExtensions.cs
@@ -11,5 +11,8 @@
 
         public static IEnumerable<ParameterInfo> CancellationTokens(this IEnumerable<ParameterInfo> parameters) =>
             parameters.Where(parameter => parameter.ParameterType.IsCancellationToken());
+
+        public static bool IsExplicitlyNamed(this ParameterInfo parameter) =>
+            parameter.Name.Length > 17 && parameter.Name.EndsWith("CancellationToken");
     }
 }

--- a/src/NServiceBus.Core.Tests/API/TaskReturningMethods.cs
+++ b/src/NServiceBus.Core.Tests/API/TaskReturningMethods.cs
@@ -76,7 +76,11 @@
         public static void HaveOptionalTokens(bool visible)
         {
             var violators = optionalTokenMethods
-                .Where(method => method.IsVisible() == visible && !method.GetParameters().CancellationTokens().Any(param => param.IsOptional || param.IsExplicitlyNamed()))
+                .Where(method => method.IsVisible() == visible)
+                .Where(method => !method.GetParameters().CancellationTokens().Any(param => param.IsOptional || param.IsExplicitlyNamed()))
+                // Methods explicitly implementing interfaces generate error CS1066: "The default value specified for parameter (name) will
+                // have no effect because it applies to a member that is used in contexts
+                .Where(method => !(method.IsExplicitInterfaceImplementation() && method.GetParameters().CancellationTokens().All(param => !param.IsOptional)))
                 .Prettify()
                 .ToList();
 
@@ -84,5 +88,9 @@
 
             Assert.IsEmpty(violators);
         }
+
+
+
+
     }
 }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -672,7 +672,7 @@ namespace NServiceBus
         public bool RestrictPayloadSize { get; set; }
         public string StorageDirectory { get; set; }
         public override System.Collections.Generic.IReadOnlyCollection<NServiceBus.TransportTransactionMode> GetSupportedTransactionModes() { }
-        public override System.Threading.Tasks.Task<NServiceBus.Transport.TransportInfrastructure> Initialize(NServiceBus.Transport.HostSettings hostSettings, NServiceBus.Transport.ReceiveSettings[] receivers, string[] sendingAddresses, System.Threading.CancellationToken cancellationToken) { }
+        public override System.Threading.Tasks.Task<NServiceBus.Transport.TransportInfrastructure> Initialize(NServiceBus.Transport.HostSettings hostSettings, NServiceBus.Transport.ReceiveSettings[] receivers, string[] sendingAddresses, System.Threading.CancellationToken cancellationToken = default) { }
         public override string ToTransportAddress(NServiceBus.Transport.QueueAddress queueAddress) { }
     }
     public static class LoadMessageHandlersExtensions
@@ -774,7 +774,7 @@ namespace NServiceBus
         public Notifications() { }
         public NServiceBus.Faults.ErrorsNotifications Errors { get; }
     }
-    public delegate System.Threading.Tasks.Task OnSatelliteMessage(System.IServiceProvider serviceProvider, NServiceBus.Transport.MessageContext messageContext, System.Threading.CancellationToken cancellationToken);
+    public delegate System.Threading.Tasks.Task OnSatelliteMessage(System.IServiceProvider serviceProvider, NServiceBus.Transport.MessageContext messageContext, System.Threading.CancellationToken cancellationToken = default);
     public static class OutboxConfigExtensions
     {
         public static NServiceBus.Outbox.OutboxSettings EnableOutbox(this NServiceBus.EndpointConfiguration config) { }
@@ -1271,9 +1271,9 @@ namespace NServiceBus.DataBus
     }
     public interface IDataBus
     {
-        System.Threading.Tasks.Task<System.IO.Stream> Get(string key, System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task<string> Put(System.IO.Stream stream, System.TimeSpan timeToBeReceived, System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task Start(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.IO.Stream> Get(string key, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<string> Put(System.IO.Stream stream, System.TimeSpan timeToBeReceived, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task Start(System.Threading.CancellationToken cancellationToken = default);
     }
     public interface IDataBusSerializer
     {
@@ -1478,8 +1478,8 @@ namespace NServiceBus.Features
     public abstract class FeatureStartupTask
     {
         protected FeatureStartupTask() { }
-        protected abstract System.Threading.Tasks.Task OnStart(NServiceBus.IMessageSession session, System.Threading.CancellationToken cancellationToken);
-        protected abstract System.Threading.Tasks.Task OnStop(NServiceBus.IMessageSession session, System.Threading.CancellationToken cancellationToken);
+        protected abstract System.Threading.Tasks.Task OnStart(NServiceBus.IMessageSession session, System.Threading.CancellationToken cancellationToken = default);
+        protected abstract System.Threading.Tasks.Task OnStop(NServiceBus.IMessageSession session, System.Threading.CancellationToken cancellationToken = default);
     }
     public enum FeatureState
     {
@@ -1574,7 +1574,7 @@ namespace NServiceBus.Installation
 {
     public interface INeedToInstallSomething
     {
-        System.Threading.Tasks.Task Install(string identity, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task Install(string identity, System.Threading.CancellationToken cancellationToken = default);
     }
 }
 namespace NServiceBus.Logging
@@ -1679,21 +1679,21 @@ namespace NServiceBus.MessageMutator
     }
     public class MutateIncomingMessageContext : NServiceBus.ICancellableContext
     {
-        public MutateIncomingMessageContext(object message, System.Collections.Generic.Dictionary<string, string> headers, System.Threading.CancellationToken cancellationToken) { }
+        public MutateIncomingMessageContext(object message, System.Collections.Generic.Dictionary<string, string> headers, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.CancellationToken CancellationToken { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public object Message { get; set; }
     }
     public class MutateIncomingTransportMessageContext : NServiceBus.ICancellableContext
     {
-        public MutateIncomingTransportMessageContext(byte[] body, System.Collections.Generic.Dictionary<string, string> headers, System.Threading.CancellationToken cancellationToken) { }
+        public MutateIncomingTransportMessageContext(byte[] body, System.Collections.Generic.Dictionary<string, string> headers, System.Threading.CancellationToken cancellationToken = default) { }
         public byte[] Body { get; set; }
         public System.Threading.CancellationToken CancellationToken { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
     }
     public class MutateOutgoingMessageContext : NServiceBus.ICancellableContext
     {
-        public MutateOutgoingMessageContext(object outgoingMessage, System.Collections.Generic.Dictionary<string, string> outgoingHeaders, object incomingMessage, System.Collections.Generic.IReadOnlyDictionary<string, string> incomingHeaders, System.Threading.CancellationToken cancellationToken) { }
+        public MutateOutgoingMessageContext(object outgoingMessage, System.Collections.Generic.Dictionary<string, string> outgoingHeaders, object incomingMessage, System.Collections.Generic.IReadOnlyDictionary<string, string> incomingHeaders, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.CancellationToken CancellationToken { get; }
         public System.Collections.Generic.Dictionary<string, string> OutgoingHeaders { get; }
         public object OutgoingMessage { get; set; }
@@ -1702,7 +1702,7 @@ namespace NServiceBus.MessageMutator
     }
     public class MutateOutgoingTransportMessageContext : NServiceBus.ICancellableContext
     {
-        public MutateOutgoingTransportMessageContext(byte[] outgoingBody, object outgoingMessage, System.Collections.Generic.Dictionary<string, string> outgoingHeaders, object incomingMessage, System.Collections.Generic.IReadOnlyDictionary<string, string> incomingHeaders, System.Threading.CancellationToken cancellationToken) { }
+        public MutateOutgoingTransportMessageContext(byte[] outgoingBody, object outgoingMessage, System.Collections.Generic.Dictionary<string, string> outgoingHeaders, object incomingMessage, System.Collections.Generic.IReadOnlyDictionary<string, string> incomingHeaders, System.Threading.CancellationToken cancellationToken = default) { }
         public System.Threading.CancellationToken CancellationToken { get; }
         public byte[] OutgoingBody { get; set; }
         public System.Collections.Generic.Dictionary<string, string> OutgoingHeaders { get; }
@@ -1777,10 +1777,10 @@ namespace NServiceBus.Outbox
 {
     public interface IOutboxStorage
     {
-        System.Threading.Tasks.Task<NServiceBus.Outbox.OutboxTransaction> BeginTransaction(NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task<NServiceBus.Outbox.OutboxMessage> Get(string messageId, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task SetAsDispatched(string messageId, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task Store(NServiceBus.Outbox.OutboxMessage message, NServiceBus.Outbox.OutboxTransaction transaction, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<NServiceBus.Outbox.OutboxTransaction> BeginTransaction(NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<NServiceBus.Outbox.OutboxMessage> Get(string messageId, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task SetAsDispatched(string messageId, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task Store(NServiceBus.Outbox.OutboxMessage message, NServiceBus.Outbox.OutboxTransaction transaction, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);
     }
     public class OutboxMessage
     {
@@ -1791,7 +1791,7 @@ namespace NServiceBus.Outbox
     public class OutboxSettings : NServiceBus.Configuration.AdvancedExtensibility.ExposeSettings { }
     public interface OutboxTransaction : System.IDisposable
     {
-        System.Threading.Tasks.Task Commit(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task Commit(System.Threading.CancellationToken cancellationToken = default);
     }
     public class TransportOperation
     {
@@ -1814,16 +1814,16 @@ namespace NServiceBus.Persistence
 {
     public interface CompletableSynchronizedStorageSession : NServiceBus.Persistence.SynchronizedStorageSession, System.IDisposable
     {
-        System.Threading.Tasks.Task CompleteAsync(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task CompleteAsync(System.Threading.CancellationToken cancellationToken = default);
     }
     public interface ISynchronizedStorage
     {
-        System.Threading.Tasks.Task<NServiceBus.Persistence.CompletableSynchronizedStorageSession> OpenSession(NServiceBus.Extensibility.ContextBag contextBag, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<NServiceBus.Persistence.CompletableSynchronizedStorageSession> OpenSession(NServiceBus.Extensibility.ContextBag contextBag, System.Threading.CancellationToken cancellationToken = default);
     }
     public interface ISynchronizedStorageAdapter
     {
-        System.Threading.Tasks.Task<NServiceBus.Persistence.CompletableSynchronizedStorageSession> TryAdapt(NServiceBus.Outbox.OutboxTransaction transaction, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task<NServiceBus.Persistence.CompletableSynchronizedStorageSession> TryAdapt(NServiceBus.Transport.TransportTransaction transportTransaction, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<NServiceBus.Persistence.CompletableSynchronizedStorageSession> TryAdapt(NServiceBus.Outbox.OutboxTransaction transaction, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<NServiceBus.Persistence.CompletableSynchronizedStorageSession> TryAdapt(NServiceBus.Transport.TransportTransaction transportTransaction, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);
     }
     public abstract class PersistenceDefinition
     {
@@ -2188,7 +2188,7 @@ namespace NServiceBus.Sagas
         protected IFindSagas() { }
         public interface Using<M> : NServiceBus.Sagas.IFinder
         {
-            System.Threading.Tasks.Task<T> FindBy(M message, NServiceBus.Persistence.SynchronizedStorageSession storageSession, NServiceBus.Extensibility.ReadOnlyContextBag context, System.Threading.CancellationToken cancellationToken);
+            System.Threading.Tasks.Task<T> FindBy(M message, NServiceBus.Persistence.SynchronizedStorageSession storageSession, NServiceBus.Extensibility.ReadOnlyContextBag context, System.Threading.CancellationToken cancellationToken = default);
         }
     }
     public interface IFinder { }
@@ -2202,13 +2202,13 @@ namespace NServiceBus.Sagas
     }
     public interface ISagaPersister
     {
-        System.Threading.Tasks.Task Complete(NServiceBus.IContainSagaData sagaData, NServiceBus.Persistence.SynchronizedStorageSession session, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task<TSagaData> Get<TSagaData>(System.Guid sagaId, NServiceBus.Persistence.SynchronizedStorageSession session, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken)
+        System.Threading.Tasks.Task Complete(NServiceBus.IContainSagaData sagaData, NServiceBus.Persistence.SynchronizedStorageSession session, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task<TSagaData> Get<TSagaData>(System.Guid sagaId, NServiceBus.Persistence.SynchronizedStorageSession session, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default)
             where TSagaData :  class, NServiceBus.IContainSagaData;
-        System.Threading.Tasks.Task<TSagaData> Get<TSagaData>(string propertyName, object propertyValue, NServiceBus.Persistence.SynchronizedStorageSession session, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken)
+        System.Threading.Tasks.Task<TSagaData> Get<TSagaData>(string propertyName, object propertyValue, NServiceBus.Persistence.SynchronizedStorageSession session, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default)
             where TSagaData :  class, NServiceBus.IContainSagaData;
-        System.Threading.Tasks.Task Save(NServiceBus.IContainSagaData sagaData, NServiceBus.Sagas.SagaCorrelationProperty correlationProperty, NServiceBus.Persistence.SynchronizedStorageSession session, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task Update(NServiceBus.IContainSagaData sagaData, NServiceBus.Persistence.SynchronizedStorageSession session, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task Save(NServiceBus.IContainSagaData sagaData, NServiceBus.Sagas.SagaCorrelationProperty correlationProperty, NServiceBus.Persistence.SynchronizedStorageSession session, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task Update(NServiceBus.IContainSagaData sagaData, NServiceBus.Persistence.SynchronizedStorageSession session, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);
     }
     public class SagaCorrelationProperty
     {
@@ -2482,15 +2482,15 @@ namespace NServiceBus.Transport
     }
     public interface IMessageDispatcher
     {
-        System.Threading.Tasks.Task Dispatch(NServiceBus.Transport.TransportOperations outgoingMessages, NServiceBus.Transport.TransportTransaction transaction, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task Dispatch(NServiceBus.Transport.TransportOperations outgoingMessages, NServiceBus.Transport.TransportTransaction transaction, System.Threading.CancellationToken cancellationToken = default);
     }
     public interface IMessageReceiver
     {
         string Id { get; }
         NServiceBus.Transport.ISubscriptionManager Subscriptions { get; }
-        System.Threading.Tasks.Task Initialize(NServiceBus.Transport.PushRuntimeSettings limitations, NServiceBus.Transport.OnMessage onMessage, NServiceBus.Transport.OnError onError, NServiceBus.Transport.OnCompleted onCompleted, System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task StartReceive(System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task StopReceive(System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task Initialize(NServiceBus.Transport.PushRuntimeSettings limitations, NServiceBus.Transport.OnMessage onMessage, NServiceBus.Transport.OnError onError, NServiceBus.Transport.OnCompleted onCompleted, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task StartReceive(System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task StopReceive(System.Threading.CancellationToken cancellationToken = default);
     }
     public interface IOutgoingTransportOperation
     {
@@ -2510,8 +2510,8 @@ namespace NServiceBus.Transport
     }
     public interface ISubscriptionManager
     {
-        System.Threading.Tasks.Task SubscribeAll(NServiceBus.Unicast.Messages.MessageMetadata[] eventTypes, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task Unsubscribe(NServiceBus.Unicast.Messages.MessageMetadata eventType, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task SubscribeAll(NServiceBus.Unicast.Messages.MessageMetadata[] eventTypes, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task Unsubscribe(NServiceBus.Unicast.Messages.MessageMetadata eventType, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);
     }
     public class IncomingMessage
     {
@@ -2558,9 +2558,9 @@ namespace NServiceBus.Transport
         public NServiceBus.Transport.DispatchProperties Properties { get; }
         public NServiceBus.Transport.DispatchConsistency RequiredDispatchConsistency { get; }
     }
-    public delegate System.Threading.Tasks.Task OnCompleted(NServiceBus.Transport.CompleteContext completeContext, System.Threading.CancellationToken cancellationToken);
-    public delegate System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult> OnError(NServiceBus.Transport.ErrorContext errorContext, System.Threading.CancellationToken cancellationToken);
-    public delegate System.Threading.Tasks.Task OnMessage(NServiceBus.Transport.MessageContext messageContext, System.Threading.CancellationToken cancellationToken);
+    public delegate System.Threading.Tasks.Task OnCompleted(NServiceBus.Transport.CompleteContext completeContext, System.Threading.CancellationToken cancellationToken = default);
+    public delegate System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult> OnError(NServiceBus.Transport.ErrorContext errorContext, System.Threading.CancellationToken cancellationToken = default);
+    public delegate System.Threading.Tasks.Task OnMessage(NServiceBus.Transport.MessageContext messageContext, System.Threading.CancellationToken cancellationToken = default);
     [System.Obsolete("This type is no longer necessary when implementing a transport. Will be removed i" +
         "n version 9.0.0.", true)]
     public class OutboundRoutingPolicy
@@ -2661,7 +2661,7 @@ namespace NServiceBus.Transport
         public bool SupportsTTBR { get; }
         public virtual NServiceBus.TransportTransactionMode TransportTransactionMode { get; set; }
         public abstract System.Collections.Generic.IReadOnlyCollection<NServiceBus.TransportTransactionMode> GetSupportedTransactionModes();
-        public abstract System.Threading.Tasks.Task<NServiceBus.Transport.TransportInfrastructure> Initialize(NServiceBus.Transport.HostSettings hostSettings, NServiceBus.Transport.ReceiveSettings[] receivers, string[] sendingAddresses, System.Threading.CancellationToken cancellationToken);
+        public abstract System.Threading.Tasks.Task<NServiceBus.Transport.TransportInfrastructure> Initialize(NServiceBus.Transport.HostSettings hostSettings, NServiceBus.Transport.ReceiveSettings[] receivers, string[] sendingAddresses, System.Threading.CancellationToken cancellationToken = default);
         public abstract string ToTransportAddress(NServiceBus.Transport.QueueAddress address);
     }
     public abstract class TransportInfrastructure
@@ -2669,7 +2669,7 @@ namespace NServiceBus.Transport
         protected TransportInfrastructure() { }
         public NServiceBus.Transport.IMessageDispatcher Dispatcher { get; set; }
         public System.Collections.Generic.IReadOnlyDictionary<string, NServiceBus.Transport.IMessageReceiver> Receivers { get; set; }
-        public abstract System.Threading.Tasks.Task Shutdown(System.Threading.CancellationToken cancellationToken);
+        public abstract System.Threading.Tasks.Task Shutdown(System.Threading.CancellationToken cancellationToken = default);
     }
     public class TransportOperation
     {
@@ -2783,9 +2783,9 @@ namespace NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions
     }
     public interface ISubscriptionStorage
     {
-        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber>> GetSubscriberAddressesForMessage(System.Collections.Generic.IEnumerable<NServiceBus.Unicast.Subscriptions.MessageType> messageTypes, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task Subscribe(NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, NServiceBus.Unicast.Subscriptions.MessageType messageType, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken);
-        System.Threading.Tasks.Task Unsubscribe(NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, NServiceBus.Unicast.Subscriptions.MessageType messageType, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken);
+        System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber>> GetSubscriberAddressesForMessage(System.Collections.Generic.IEnumerable<NServiceBus.Unicast.Subscriptions.MessageType> messageTypes, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task Subscribe(NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, NServiceBus.Unicast.Subscriptions.MessageType messageType, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);
+        System.Threading.Tasks.Task Unsubscribe(NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber subscriber, NServiceBus.Unicast.Subscriptions.MessageType messageType, NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);
     }
     public class Subscriber
     {

--- a/src/NServiceBus.Core.Tests/Config/When_using_initialization.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_using_initialization.cs
@@ -13,7 +13,7 @@
 
             endpointConfiguration.TypesToScanInternal(new[] { typeof(FeatureWithInitialization) });
 
-            var ae = Assert.ThrowsAsync<Exception>(() => HostCreator.CreateWithInternallyManagedContainer(endpointConfiguration, default));
+            var ae = Assert.ThrowsAsync<Exception>(() => HostCreator.CreateWithInternallyManagedContainer(endpointConfiguration));
             var expected = $"Unable to create the type '{nameof(FeatureWithInitialization)}'. Types implementing '{nameof(INeedInitialization)}' must have a public parameterless (default) constructor.";
             Assert.AreEqual(expected, ae.Message);
         }

--- a/src/NServiceBus.Core.Tests/DataBus/FileShare/AcceptanceTests.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/FileShare/AcceptanceTests.cs
@@ -23,7 +23,7 @@
             var byteArray = Encoding.ASCII.GetBytes(content);
             using (var stream = new MemoryStream(byteArray))
             {
-                return await dataBus.Put(stream, timeToLive, default);
+                return await dataBus.Put(stream, timeToLive);
             }
         }
 
@@ -33,7 +33,7 @@
             const string content = "Test";
 
             var key = await Put(content, TimeSpan.MaxValue);
-            using (var stream = await dataBus.Get(key, default))
+            using (var stream = await dataBus.Get(key))
             using (var streamReader = new StreamReader(stream))
             {
                 Assert.AreEqual(await streamReader.ReadToEndAsync(), content);
@@ -49,7 +49,7 @@
 
             Parallel.For(0, 10, async i =>
             {
-                using (var stream = await dataBus.Get(key, default))
+                using (var stream = await dataBus.Get(key))
                 using (var streamReader = new StreamReader(stream))
                 {
                     Assert.AreEqual(await streamReader.ReadToEndAsync(), content);

--- a/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_incoming_messages.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_incoming_messages.cs
@@ -60,17 +60,17 @@ namespace NServiceBus.Core.Tests.DataBus
         {
             public Dictionary<string, Stream> StreamsToReturn = new Dictionary<string, Stream>();
 
-            public Task<Stream> Get(string key, CancellationToken cancellationToken)
+            public Task<Stream> Get(string key, CancellationToken cancellationToken = default)
             {
                 return Task.FromResult(StreamsToReturn[key]);
             }
 
-            public Task<string> Put(Stream stream, TimeSpan timeToBeReceived, CancellationToken cancellationToken)
+            public Task<string> Put(Stream stream, TimeSpan timeToBeReceived, CancellationToken cancellationToken = default)
             {
                 throw new NotImplementedException();
             }
 
-            public Task Start(CancellationToken cancellationToken)
+            public Task Start(CancellationToken cancellationToken = default)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_outgoing_messages.cs
+++ b/src/NServiceBus.Core.Tests/DataBus/When_applying_the_databus_message_mutator_to_outgoing_messages.cs
@@ -58,18 +58,18 @@ namespace NServiceBus.Core.Tests.DataBus
 
         class FakeDataBus : IDataBus
         {
-            public Task<Stream> Get(string key, CancellationToken cancellationToken)
+            public Task<Stream> Get(string key, CancellationToken cancellationToken = default)
             {
                 throw new NotImplementedException();
             }
 
-            public Task<string> Put(Stream stream, TimeSpan timeToBeReceived, CancellationToken cancellationToken)
+            public Task<string> Put(Stream stream, TimeSpan timeToBeReceived, CancellationToken cancellationToken = default)
             {
                 TTBRUsed = timeToBeReceived;
                 return Task.FromResult(Guid.NewGuid().ToString());
             }
 
-            public Task Start(CancellationToken cancellationToken)
+            public Task Start(CancellationToken cancellationToken = default)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.Core.Tests/Diagnostics/DiagnosticsWriterTests.cs
+++ b/src/NServiceBus.Core.Tests/Diagnostics/DiagnosticsWriterTests.cs
@@ -25,7 +25,7 @@ namespace NServiceBus.Core.Tests.Diagnostics
 
             var writer = new HostStartupDiagnosticsWriter(testWriter, true);
 
-            await writer.Write(diagnostics.entries, default);
+            await writer.Write(diagnostics.entries);
 
             Approver.Verify(output);
         }

--- a/src/NServiceBus.Core.Tests/Fakes/FakeOutboxTransaction.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/FakeOutboxTransaction.cs
@@ -19,7 +19,7 @@
             Transaction = null;
         }
 
-        public Task Commit(CancellationToken cancellationToken)
+        public Task Commit(CancellationToken cancellationToken = default)
         {
             Transaction.Commit();
             return Task.CompletedTask;

--- a/src/NServiceBus.Core.Tests/Fakes/FakeSynchronizedStorage.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/FakeSynchronizedStorage.cs
@@ -7,7 +7,7 @@
 
     public class FakeSynchronizedStorage : ISynchronizedStorage
     {
-        public Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag, CancellationToken cancellationToken)
+        public Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag, CancellationToken cancellationToken = default)
         {
             var session = (CompletableSynchronizedStorageSession)new FakeSynchronizedStorageSession();
             return Task.FromResult(session);

--- a/src/NServiceBus.Core.Tests/Fakes/FakeSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/FakeSynchronizedStorageSession.cs
@@ -25,7 +25,7 @@
             Transaction = null;
         }
 
-        public Task CompleteAsync(CancellationToken cancellationToken)
+        public Task CompleteAsync(CancellationToken cancellationToken = default)
         {
             if (ownsTransaction)
             {

--- a/src/NServiceBus.Core.Tests/Fakes/FakeTransactionalSynchronizedStorageAdapter.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/FakeTransactionalSynchronizedStorageAdapter.cs
@@ -11,7 +11,7 @@
 
     public class FakeTransactionalSynchronizedStorageAdapter : ISynchronizedStorageAdapter
     {
-        public Task<CompletableSynchronizedStorageSession> TryAdapt(OutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken)
+        public Task<CompletableSynchronizedStorageSession> TryAdapt(OutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken = default)
         {
             if (transaction is FakeOutboxTransaction inMemOutboxTransaction)
             {
@@ -21,7 +21,7 @@
             return EmptyTask;
         }
 
-        public Task<CompletableSynchronizedStorageSession> TryAdapt(TransportTransaction transportTransaction, ContextBag context, CancellationToken cancellationToken)
+        public Task<CompletableSynchronizedStorageSession> TryAdapt(TransportTransaction transportTransaction, ContextBag context, CancellationToken cancellationToken = default)
         {
             if (transportTransaction.TryGet(out Transaction ambientTransaction))
             {

--- a/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
@@ -27,8 +27,8 @@
 
             featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-            await featureSettings.StartFeatures(null, null, default);
-            await featureSettings.StopFeatures(default);
+            await featureSettings.StartFeatures(null, null);
+            await featureSettings.StopFeatures();
 
             Assert.True(feature.TaskStarted);
             Assert.True(feature.TaskStopped);
@@ -44,8 +44,8 @@
 
             featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-            await featureSettings.StartFeatures(null, null, default);
-            await featureSettings.StopFeatures(default);
+            await featureSettings.StartFeatures(null, null);
+            await featureSettings.StopFeatures();
 
             var expectedOrderBuilder = new StringBuilder();
             expectedOrderBuilder.AppendLine("FeatureWithStartupThatAnotherFeatureDependsOn.Start");
@@ -65,8 +65,8 @@
 
             featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-            await featureSettings.StartFeatures(null, null, default);
-            await featureSettings.StopFeatures(default);
+            await featureSettings.StartFeatures(null, null);
+            await featureSettings.StopFeatures();
 
             Assert.True(feature.TaskDisposed);
         }
@@ -81,7 +81,7 @@
 
             featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-            Assert.ThrowsAsync<InvalidOperationException>(async () => await featureSettings.StartFeatures(null, null, default));
+            Assert.ThrowsAsync<InvalidOperationException>(async () => await featureSettings.StartFeatures(null, null));
 
             Assert.False(feature1.TaskStarted && feature1.TaskStopped);
             Assert.False(feature2.TaskStarted && feature2.TaskStopped);
@@ -97,9 +97,9 @@
 
             featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-            await featureSettings.StartFeatures(null, null, default);
+            await featureSettings.StartFeatures(null, null);
 
-            Assert.DoesNotThrowAsync(async () => await featureSettings.StopFeatures(default));
+            Assert.DoesNotThrowAsync(async () => await featureSettings.StopFeatures());
             Assert.True(feature1.TaskStarted && feature1.TaskStopped);
             Assert.True(feature2.TaskStarted && !feature2.TaskStopped);
         }
@@ -112,9 +112,9 @@
 
             featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-            await featureSettings.StartFeatures(null, null, default);
+            await featureSettings.StartFeatures(null, null);
 
-            await featureSettings.StopFeatures(default);
+            await featureSettings.StopFeatures();
             Assert.True(feature.TaskDisposed);
         }
 
@@ -143,13 +143,13 @@
                     this.orderBuilder = orderBuilder;
                 }
 
-                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     orderBuilder.AppendLine($"{nameof(FeatureWithStartupTaskWithDependency)}.Start");
                     return Task.CompletedTask;
                 }
 
-                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     orderBuilder.AppendLine($"{nameof(FeatureWithStartupTaskWithDependency)}.Stop");
                     return Task.CompletedTask;
@@ -182,13 +182,13 @@
                     this.orderBuilder = orderBuilder;
                 }
 
-                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     orderBuilder.AppendLine($"{nameof(FeatureWithStartupThatAnotherFeatureDependsOn)}.Start");
                     return Task.CompletedTask;
                 }
 
-                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     orderBuilder.AppendLine($"{nameof(FeatureWithStartupThatAnotherFeatureDependsOn)}.Stop");
                     return Task.CompletedTask;
@@ -222,13 +222,13 @@
                     this.parentFeature = parentFeature;
                 }
 
-                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     parentFeature.TaskStarted = true;
                     return Task.CompletedTask;
                 }
 
-                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     parentFeature.TaskStopped = true;
                     return Task.CompletedTask;
@@ -272,7 +272,7 @@
                     parentFeature.TaskDisposed = true;
                 }
 
-                protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+                protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     await Task.Yield();
                     if (parentFeature.throwOnStart)
@@ -282,7 +282,7 @@
                     parentFeature.TaskStarted = true;
                 }
 
-                protected override async Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+                protected override async Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     await Task.Yield();
                     if (parentFeature.throwOnStop)
@@ -322,12 +322,12 @@
                     parentFeature.TaskDisposed = true;
                 }
 
-                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     return Task.CompletedTask;
                 }
 
-                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     return Task.CompletedTask;
                 }

--- a/src/NServiceBus.Core.Tests/Pipeline/FakeRootContext.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/FakeRootContext.cs
@@ -2,7 +2,7 @@
 {
     class FakeRootContext : RootContext
     {
-        public FakeRootContext() : base(null, null, null, default)
+        public FakeRootContext() : base(null, null, null)
         {
         }
     }

--- a/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/PipelineModelBuilderTests.cs
@@ -213,7 +213,7 @@
         class ParentContext : BehaviorContext, IParentContext
         {
             public ParentContext(IBehaviorContext parentContext)
-                : base(parentContext, default)
+                : base(parentContext)
             {
             }
         }
@@ -233,7 +233,7 @@
         class ChildContextNotInheritedFromParentContext : BehaviorContext
         {
             public ChildContextNotInheritedFromParentContext(IBehaviorContext parentContext)
-                : base(parentContext, default)
+                : base(parentContext)
             {
             }
         }

--- a/src/NServiceBus.Core.Tests/Recoverability/DelayedRetryExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/DelayedRetryExecutorTests.cs
@@ -24,7 +24,7 @@
             var delayedRetryExecutor = CreateExecutor();
             var incomingMessage = CreateMessage();
 
-            await delayedRetryExecutor.Retry(incomingMessage, TimeSpan.Zero, transportTransaction, default);
+            await delayedRetryExecutor.Retry(incomingMessage, TimeSpan.Zero, transportTransaction);
 
             Assert.AreEqual(dispatcher.Transaction, transportTransaction);
         }
@@ -36,7 +36,7 @@
             var incomingMessage = CreateMessage();
             var delay = TimeSpan.FromSeconds(42);
 
-            await delayedRetryExecutor.Retry(incomingMessage, delay, new TransportTransaction(), default);
+            await delayedRetryExecutor.Retry(incomingMessage, delay, new TransportTransaction());
 
             var transportOperation = dispatcher.UnicastTransportOperations.Single();
             var deliveryConstraint = transportOperation.Properties.DelayDeliveryWith;
@@ -59,7 +59,7 @@
             });
 
             var now = DateTime.UtcNow;
-            await delayedRetryExecutor.Retry(incomingMessage, TimeSpan.Zero, new TransportTransaction(), default);
+            await delayedRetryExecutor.Retry(incomingMessage, TimeSpan.Zero, new TransportTransaction());
 
             var outgoingMessageHeaders = dispatcher.UnicastTransportOperations.Single().Message.Headers;
 
@@ -79,7 +79,7 @@
             var delayedRetryExecutor = CreateExecutor();
             var incomingMessage = CreateMessage();
 
-            await delayedRetryExecutor.Retry(incomingMessage, TimeSpan.Zero, new TransportTransaction(), default);
+            await delayedRetryExecutor.Retry(incomingMessage, TimeSpan.Zero, new TransportTransaction());
 
             var outgoingMessageHeaders = dispatcher.TransportOperations.UnicastTransportOperations.Single().Message.Headers;
 
@@ -110,7 +110,7 @@
 
             public TransportTransaction Transaction { get; private set; }
 
-            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
             {
                 TransportOperations = outgoingMessages;
                 Transaction = transaction;

--- a/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
@@ -27,7 +27,7 @@
             var transportTransaction = new TransportTransaction();
             var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), new byte[0]);
 
-            await moveToErrorsExecutor.MoveToErrorQueue(customErrorQueue, incomingMessage, new Exception(), transportTransaction, default);
+            await moveToErrorsExecutor.MoveToErrorQueue(customErrorQueue, incomingMessage, new Exception(), transportTransaction);
 
             Assert.That(dispatcher.TransportOperations.MulticastTransportOperations.Count(), Is.EqualTo(0));
             Assert.That(dispatcher.TransportOperations.UnicastTransportOperations.Count(), Is.EqualTo(1));
@@ -49,7 +49,7 @@
 
             var incomingMessage = new IncomingMessage("messageId", incomingMessageHeaders, new byte[0]);
 
-            await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, new Exception(), new TransportTransaction(), default);
+            await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, new Exception(), new TransportTransaction());
 
             var outgoingMessage = dispatcher.TransportOperations.UnicastTransportOperations.Single();
             Assert.That(incomingMessage.Headers, Is.SubsetOf(outgoingMessage.Message.Headers));
@@ -62,7 +62,7 @@
             var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), originalMessageBody);
             incomingMessage.UpdateBody(Encoding.UTF8.GetBytes("new body"));
 
-            await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, new Exception(), new TransportTransaction(), default);
+            await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, new Exception(), new TransportTransaction());
 
             var outgoingMessage = dispatcher.TransportOperations.UnicastTransportOperations.Single();
             Assert.That(outgoingMessage.Message.Body, Is.EqualTo(originalMessageBody));
@@ -78,7 +78,7 @@
             };
             var incomingMessage = new IncomingMessage("messageId", retryHeaders, new byte[0]);
 
-            await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, new Exception(), new TransportTransaction(), default);
+            await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, new Exception(), new TransportTransaction());
 
             var outgoingMessage = dispatcher.TransportOperations.UnicastTransportOperations.Single();
             Assert.That(outgoingMessage.Message.Headers.Keys, Does.Not.Contain(Headers.ImmediateRetries));
@@ -91,7 +91,7 @@
             var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), new byte[0]);
             var exception = new InvalidOperationException("test exception");
 
-            await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, exception, new TransportTransaction(), default);
+            await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, exception, new TransportTransaction());
 
             var outgoingMessageHeaders = dispatcher.TransportOperations.UnicastTransportOperations.Single().Message.Headers;
             // we only test presence of some exception headers set by ExceptionHeaderHelper
@@ -108,7 +108,7 @@
             staticFaultMetadata.Add("staticFaultMetadataKey", "staticFaultMetadataValue");
             var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), new byte[0]);
 
-            await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, new Exception(), new TransportTransaction(), default);
+            await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, new Exception(), new TransportTransaction());
 
             var outgoingMessageHeaders = dispatcher.TransportOperations.UnicastTransportOperations.Single().Message.Headers;
             Assert.That(outgoingMessageHeaders, Contains.Item(new KeyValuePair<string, string>("staticFaultMetadataKey", "staticFaultMetadataValue")));
@@ -126,7 +126,7 @@
             Dictionary<string, string> passedInHeaders = null;
             moveToErrorsExecutor = new MoveToErrorsExecutor(dispatcher, staticFaultMetadata, headers => { passedInHeaders = headers; });
 
-            await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, exception, new TransportTransaction(), default);
+            await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, exception, new TransportTransaction());
 
             Assert.NotNull(passedInHeaders);
             Assert.That(passedInHeaders, Contains.Key("staticFaultMetadataKey"));
@@ -144,7 +144,7 @@
 
             public TransportTransaction Transaction { get; private set; }
 
-            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
             {
                 TransportOperations = outgoingMessages;
                 Transaction = transaction;

--- a/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
@@ -31,9 +31,9 @@
             var executor = CreateExecutor(policy, raiseNotifications: false);
             var errorContext = CreateErrorContext();
 
-            await executor.Invoke(errorContext, default); //force retry
-            await executor.Invoke(errorContext, default); //force delayed retry
-            await executor.Invoke(errorContext, default); //force move to errors
+            await executor.Invoke(errorContext); //force retry
+            await executor.Invoke(errorContext); //force delayed retry
+            await executor.Invoke(errorContext); //force move to errors
 
             Assert.IsEmpty(messageRetriedNotifications);
             Assert.IsEmpty(messageFaultedNotifications);
@@ -45,7 +45,7 @@
             var recoverabilityExecutor = CreateExecutor(RetryPolicy.AlwaysRetry());
             var errorContext = CreateErrorContext(numberOfDeliveryAttempts: 1, exceptionMessage: "test", messageId: "message-id");
 
-            await recoverabilityExecutor.Invoke(errorContext, default);
+            await recoverabilityExecutor.Invoke(errorContext);
 
             var failure = messageRetriedNotifications.Single();
 
@@ -61,7 +61,7 @@
             var recoverabilityExecutor = CreateExecutor(RetryPolicy.AlwaysDelay(TimeSpan.FromSeconds(10)));
             var errorContext = CreateErrorContext(numberOfDeliveryAttempts: 1, exceptionMessage: "test", messageId: "message-id");
 
-            await recoverabilityExecutor.Invoke(errorContext, default);
+            await recoverabilityExecutor.Invoke(errorContext);
 
             var failure = messageRetriedNotifications.Single();
 
@@ -77,7 +77,7 @@
             var recoverabilityExecutor = CreateExecutor(RetryPolicy.AlwaysMoveToErrors());
             var errorContext = CreateErrorContext(exceptionMessage: "test", messageId: "message-id");
 
-            await recoverabilityExecutor.Invoke(errorContext, default);
+            await recoverabilityExecutor.Invoke(errorContext);
 
             var failure = messageFaultedNotifications.Single();
 
@@ -93,7 +93,7 @@
                 delayedRetriesSupported: false);
             var errorContext = CreateErrorContext(messageId: "message-id");
 
-            await recoverabilityExecutor.Invoke(errorContext, default);
+            await recoverabilityExecutor.Invoke(errorContext);
 
             var failure = messageFaultedNotifications.Single();
 
@@ -109,7 +109,7 @@
                 immediateRetriesSupported: false);
             var errorContext = CreateErrorContext(messageId: "message-id");
 
-            await recoverabilityExecutor.Invoke(errorContext, default);
+            await recoverabilityExecutor.Invoke(errorContext);
 
             var failure = messageFaultedNotifications.Single();
 
@@ -124,7 +124,7 @@
                 RetryPolicy.Unsupported());
             var errorContext = CreateErrorContext(messageId: "message-id");
 
-            await recoverabilityExecutor.Invoke(errorContext, default);
+            await recoverabilityExecutor.Invoke(errorContext);
 
             var failure = messageFaultedNotifications.Single();
 
@@ -139,7 +139,7 @@
                 RetryPolicy.Discard("not needed anymore"));
             var errorContext = CreateErrorContext(messageId: "message-id");
 
-            var result = await recoverabilityExecutor.Invoke(errorContext, default);
+            var result = await recoverabilityExecutor.Invoke(errorContext);
 
             Assert.AreEqual(ErrorHandleResult.Handled, result);
             Assert.IsEmpty(messageRetriedNotifications);
@@ -153,7 +153,7 @@
             var recoverabilityExecutor = CreateExecutor(RetryPolicy.AlwaysMoveToErrors(customErrorQueueAddress));
             var errorContext = CreateErrorContext();
 
-            await recoverabilityExecutor.Invoke(errorContext, default);
+            await recoverabilityExecutor.Invoke(errorContext);
 
             var failure = messageFaultedNotifications.Single();
 
@@ -272,7 +272,7 @@
         {
             public TransportOperations TransportOperations { get; private set; }
 
-            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
             {
                 TransportOperations = outgoingMessages;
                 return Task.CompletedTask;

--- a/src/NServiceBus.Core.Tests/Reliability/Outbox/FakeOutboxStorage.cs
+++ b/src/NServiceBus.Core.Tests/Reliability/Outbox/FakeOutboxStorage.cs
@@ -12,7 +12,7 @@
 
         public bool WasDispatched { get; set; }
 
-        public Task<OutboxMessage> Get(string messageId, ContextBag options, CancellationToken cancellationToken)
+        public Task<OutboxMessage> Get(string messageId, ContextBag options, CancellationToken cancellationToken = default)
         {
             if (ExistingMessage != null && ExistingMessage.MessageId == messageId)
             {
@@ -22,19 +22,19 @@
             return Task.FromResult(default(OutboxMessage));
         }
 
-        public Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag options, CancellationToken cancellationToken)
+        public Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag options, CancellationToken cancellationToken = default)
         {
             StoredMessage = message;
             return Task.CompletedTask;
         }
 
-        public Task SetAsDispatched(string messageId, ContextBag options, CancellationToken cancellationToken)
+        public Task SetAsDispatched(string messageId, ContextBag options, CancellationToken cancellationToken = default)
         {
             WasDispatched = true;
             return Task.CompletedTask;
         }
 
-        public Task<OutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken)
+        public Task<OutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken = default)
         {
             throw new System.NotImplementedException();
         }

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
@@ -3,14 +3,14 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Routing;
     using NServiceBus.Routing.MessageDrivenSubscriptions;
-    using Transport;
     using NUnit.Framework;
     using Testing;
+    using Transport;
     using Unicast.Queuing;
-    using System.Threading;
 
     [TestFixture]
     public class MessageDrivenSubscribeTerminatorTests
@@ -158,7 +158,7 @@
 
             public List<TransportOperations> DispatchedTransportOperations { get; } = new List<TransportOperations>();
 
-            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
             {
                 if (numberOfTimes.HasValue && FailedNumberOfTimes < numberOfTimes.Value)
                 {

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensionsTests.cs
@@ -166,7 +166,7 @@ namespace NServiceBus.Core.Tests.Routing.MessageDrivenSubscriptions
         {
         }
 
-        public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken)
+        public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
@@ -2,15 +2,15 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Extensibility;
     using NServiceBus.Routing;
     using NServiceBus.Routing.MessageDrivenSubscriptions;
-    using Transport;
-    using Unicast.Queuing;
     using NUnit.Framework;
     using Testing;
-    using System.Threading;
+    using Transport;
+    using Unicast.Queuing;
 
     [TestFixture]
     public class MessageDrivenUnsubscribeTerminatorTests
@@ -90,7 +90,7 @@
                 numberOfTimes = times;
             }
 
-            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken)
+            public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
             {
                 if (numberOfTimes.HasValue && FailedNumberOfTimes < numberOfTimes.Value)
                 {

--- a/src/NServiceBus.Core.Tests/Routing/NativeSubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/NativeSubscribeTerminatorTests.cs
@@ -77,9 +77,9 @@
                 this.exceptionToThrow = exceptionToThrow;
             }
 
-            public Task SubscribeAll(MessageMetadata[] eventTypes, ContextBag context, CancellationToken cancellationToken) => throw exceptionToThrow;
+            public Task SubscribeAll(MessageMetadata[] eventTypes, ContextBag context, CancellationToken cancellationToken = default) => throw exceptionToThrow;
 
-            public Task Unsubscribe(MessageMetadata eventType, ContextBag context, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public Task Unsubscribe(MessageMetadata eventType, ContextBag context, CancellationToken cancellationToken = default) => throw new NotImplementedException();
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
@@ -139,17 +139,17 @@
         class FakeSubscriptionStorage : ISubscriptionStorage
         {
             public List<Subscriber> Subscribers { get; } = new List<Subscriber>();
-            public Task Subscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken)
+            public Task Subscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken = default)
             {
                 throw new NotImplementedException();
             }
 
-            public Task Unsubscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken)
+            public Task Unsubscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken = default)
             {
                 throw new NotImplementedException();
             }
 
-            public Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context, CancellationToken cancellationToken)
+            public Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context, CancellationToken cancellationToken = default)
             {
                 return Task.FromResult<IEnumerable<Subscriber>>(Subscribers);
             }

--- a/src/NServiceBus.Core.Tests/Sagas/CustomFinderAdapterTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/CustomFinderAdapterTests.cs
@@ -40,7 +40,7 @@
 
             var customerFinderAdapter = new CustomFinderAdapter<TestSaga.SagaData, StartSagaMessage>();
 
-            Assert.That(async () => await customerFinderAdapter.Find(services.BuildServiceProvider(), finderDefinition, new FakeSynchronizedStorageSession(), new ContextBag(), new StartSagaMessage(), new Dictionary<string, string>(), default),
+            Assert.That(async () => await customerFinderAdapter.Find(services.BuildServiceProvider(), finderDefinition, new FakeSynchronizedStorageSession(), new ContextBag(), new StartSagaMessage(), new Dictionary<string, string>()),
                 Throws.Exception.With.Message.EqualTo("Return a Task or mark the method as async."));
         }
     }
@@ -66,7 +66,7 @@
 
     class ReturnsNullFinder : IFindSagas<TestSaga.SagaData>.Using<StartSagaMessage>
     {
-        public Task<TestSaga.SagaData> FindBy(StartSagaMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken)
+        public Task<TestSaga.SagaData> FindBy(StartSagaMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken = default)
         {
             return null;
         }

--- a/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
@@ -292,7 +292,7 @@
 
             public class Finder : IFindSagas<SagaData>.Using<StartSagaMessage>
             {
-                public Task<SagaData> FindBy(StartSagaMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken)
+                public Task<SagaData> FindBy(StartSagaMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken = default)
                 {
                     return Task.FromResult(default(SagaData));
                 }
@@ -324,7 +324,7 @@
 
             public class Finder : IFindSagas<SagaData>.Using<StartSagaMessage>
             {
-                public Task<SagaData> FindBy(StartSagaMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken)
+                public Task<SagaData> FindBy(StartSagaMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken = default)
                 {
                     return Task.FromResult(default(SagaData));
                 }
@@ -357,7 +357,7 @@
 
             public class Finder : IFindSagas<SagaData>.Using<StartSagaMessage>
             {
-                public Task<SagaData> FindBy(StartSagaMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken)
+                public Task<SagaData> FindBy(StartSagaMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken = default)
                 {
                     return Task.FromResult(default(SagaData));
                 }
@@ -638,7 +638,7 @@
 
             internal class CustomFinder : IFindSagas<SagaData>.Using<SomeMessage>
             {
-                public Task<SagaData> FindBy(SomeMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken)
+                public Task<SagaData> FindBy(SomeMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken = default)
                 {
                     return Task.FromResult(default(SagaData));
                 }
@@ -733,7 +733,7 @@
 
             public class Finder : IFindSagas<SagaData>.Using<OtherMessage>
             {
-                public Task<SagaData> FindBy(OtherMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken)
+                public Task<SagaData> FindBy(OtherMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken = default)
                 {
                     return Task.FromResult(default(SagaData));
                 }

--- a/src/NServiceBus.Core.Tests/Timeout/FakeMessageDispatcher.cs
+++ b/src/NServiceBus.Core.Tests/Timeout/FakeMessageDispatcher.cs
@@ -12,7 +12,7 @@ namespace NServiceBus.Core.Tests.Timeout
             set { messagesSent = value; }
         }
 
-        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transportTransaction, CancellationToken cancellationToken)
+        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transportTransaction, CancellationToken cancellationToken = default)
         {
             MessagesSent += outgoingMessages.MulticastTransportOperations.Count + outgoingMessages.UnicastTransportOperations.Count;
             return Task.CompletedTask;

--- a/src/NServiceBus.Core.Tests/Transports/Learning/AsyncFileTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/Learning/AsyncFileTests.cs
@@ -15,9 +15,9 @@
 
             try
             {
-                await AsyncFile.WriteText(filePath, originalContent, default);
+                await AsyncFile.WriteText(filePath, originalContent);
 
-                var content = await AsyncFile.ReadText(filePath, default);
+                var content = await AsyncFile.ReadText(filePath);
 
                 Assert.AreEqual(originalContent, content);
             }

--- a/src/NServiceBus.Core.Tests/Transports/Learning/LearningTransportDispatcherTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/Learning/LearningTransportDispatcherTests.cs
@@ -19,8 +19,8 @@
             var messageAtThreshold = new OutgoingMessage("id", headers, new byte[MessageSizeLimit]);
             var messageAboveThreshold = new OutgoingMessage("id", headers, new byte[MessageSizeLimit + 1]);
 
-            await dispatcher.Dispatch(new TransportOperations(new TransportOperation(messageAtThreshold, new UnicastAddressTag("my-destination"))), new TransportTransaction(), default);
-            var ex = Assert.ThrowsAsync<Exception>(async () => await dispatcher.Dispatch(new TransportOperations(new TransportOperation(messageAboveThreshold, new UnicastAddressTag("my-destination"))), new TransportTransaction(), default));
+            await dispatcher.Dispatch(new TransportOperations(new TransportOperation(messageAtThreshold, new UnicastAddressTag("my-destination"))), new TransportTransaction());
+            var ex = Assert.ThrowsAsync<Exception>(async () => await dispatcher.Dispatch(new TransportOperations(new TransportOperation(messageAboveThreshold, new UnicastAddressTag("my-destination"))), new TransportTransaction()));
 
             StringAssert.Contains("The total size of the 'TestMessage' message", ex.Message);
         }

--- a/src/NServiceBus.Core/CriticalError/CriticalError.cs
+++ b/src/NServiceBus.Core/CriticalError/CriticalError.cs
@@ -59,7 +59,7 @@ namespace NServiceBus
             RaiseForEndpoint(errorMessage, exception, cancellationToken);
         }
 
-        void RaiseForEndpoint(string errorMessage, Exception exception, CancellationToken cancellationToken)
+        void RaiseForEndpoint(string errorMessage, Exception exception, CancellationToken cancellationToken = default)
         {
             _ = Task.Run(() =>
             {
@@ -68,7 +68,7 @@ namespace NServiceBus
             }, cancellationToken);
         }
 
-        internal void SetEndpoint(IEndpointInstance endpointInstance, CancellationToken cancellationToken)
+        internal void SetEndpoint(IEndpointInstance endpointInstance, CancellationToken cancellationToken = default)
         {
             lock (endpointCriticalLock)
             {

--- a/src/NServiceBus.Core/DataBus/DataBus.cs
+++ b/src/NServiceBus.Core/DataBus/DataBus.cs
@@ -53,12 +53,12 @@ namespace NServiceBus.Features
                 this.dataBus = dataBus;
             }
 
-            protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+            protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
             {
                 return dataBus.Start(cancellationToken);
             }
 
-            protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+            protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
             {
                 return Task.CompletedTask;
             }

--- a/src/NServiceBus.Core/DataBus/FileShareDataBusImplementation.cs
+++ b/src/NServiceBus.Core/DataBus/FileShareDataBusImplementation.cs
@@ -16,7 +16,7 @@ namespace NServiceBus
 
         public TimeSpan MaxMessageTimeToLive { get; set; }
 
-        public Task<Stream> Get(string key, CancellationToken cancellationToken)
+        public Task<Stream> Get(string key, CancellationToken cancellationToken = default)
         {
             var filePath = Path.Combine(basePath, key);
 
@@ -26,7 +26,7 @@ namespace NServiceBus
             return Task.FromResult((Stream)fileStream);
         }
 
-        public async Task<string> Put(Stream stream, TimeSpan timeToBeReceived, CancellationToken cancellationToken)
+        public async Task<string> Put(Stream stream, TimeSpan timeToBeReceived, CancellationToken cancellationToken = default)
         {
             var key = GenerateKey(timeToBeReceived);
 
@@ -45,7 +45,7 @@ namespace NServiceBus
             return key;
         }
 
-        public Task Start(CancellationToken cancellationToken)
+        public Task Start(CancellationToken cancellationToken = default)
         {
             logger.Info("File share data bus started. Location: " + basePath);
             //TODO: Implement a clean up thread

--- a/src/NServiceBus.Core/DataBus/IDataBus.cs
+++ b/src/NServiceBus.Core/DataBus/IDataBus.cs
@@ -16,7 +16,7 @@ namespace NServiceBus.DataBus
         /// <param name="key">The key to look for.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
         /// <returns>The data <see cref="Stream" />.</returns>
-        Task<Stream> Get(string key, CancellationToken cancellationToken);
+        Task<Stream> Get(string key, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Adds a data item to the bus and returns the assigned key.
@@ -24,11 +24,11 @@ namespace NServiceBus.DataBus
         /// <param name="stream">A create containing the data to be sent on the databus.</param>
         /// <param name="timeToBeReceived">The time to be received specified on the message type. TimeSpan.MaxValue is the default.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
-        Task<string> Put(Stream stream, TimeSpan timeToBeReceived, CancellationToken cancellationToken);
+        Task<string> Put(Stream stream, TimeSpan timeToBeReceived, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Called when the bus starts up to allow the data bus to active background tasks.
         /// </summary>
-        Task Start(CancellationToken cancellationToken);
+        Task Start(CancellationToken cancellationToken = default);
     }
 }

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -57,7 +57,7 @@ namespace NServiceBus.Features
             return features.Select(t => t.Diagnostics).ToArray();
         }
 
-        public async Task StartFeatures(IServiceProvider builder, IMessageSession session, CancellationToken cancellationToken)
+        public async Task StartFeatures(IServiceProvider builder, IMessageSession session, CancellationToken cancellationToken = default)
         {
             // sequential starting of startup tasks is intended, introducing concurrency here could break a lot of features.
             foreach (var feature in enabledFeatures.Where(f => f.Feature.IsActive))
@@ -69,7 +69,7 @@ namespace NServiceBus.Features
             }
         }
 
-        public Task StopFeatures(CancellationToken cancellationToken)
+        public Task StopFeatures(CancellationToken cancellationToken = default)
         {
             var featureStopTasks = enabledFeatures.Where(f => f.Feature.IsActive)
                 .SelectMany(f => f.TaskControllers)

--- a/src/NServiceBus.Core/Features/FeatureComponent.cs
+++ b/src/NServiceBus.Core/Features/FeatureComponent.cs
@@ -31,12 +31,12 @@
             settings.AddStartupDiagnosticsSection("Features", featureStats);
         }
 
-        public Task Start(IServiceProvider builder, IMessageSession messageSession, CancellationToken cancellationToken)
+        public Task Start(IServiceProvider builder, IMessageSession messageSession, CancellationToken cancellationToken = default)
         {
             return featureActivator.StartFeatures(builder, messageSession, cancellationToken);
         }
 
-        public Task Stop(CancellationToken cancellationToken)
+        public Task Stop(CancellationToken cancellationToken = default)
         {
             return featureActivator.StopFeatures(cancellationToken);
         }

--- a/src/NServiceBus.Core/Features/FeatureStartupTask.cs
+++ b/src/NServiceBus.Core/Features/FeatureStartupTask.cs
@@ -12,21 +12,21 @@
         /// Will be called after an endpoint has been started but before processing any messages. This method is only invoked if the feature has been
         /// activated.
         /// </summary>
-        protected abstract Task OnStart(IMessageSession session, CancellationToken cancellationToken);
+        protected abstract Task OnStart(IMessageSession session, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Will be called after an endpoint has been stopped and no longer processes new incoming messages. This method is only invoked if the feature has been
         /// activated.
         /// </summary>
-        protected abstract Task OnStop(IMessageSession session, CancellationToken cancellationToken);
+        protected abstract Task OnStop(IMessageSession session, CancellationToken cancellationToken = default);
 
-        internal Task PerformStartup(IMessageSession session, CancellationToken cancellationToken)
+        internal Task PerformStartup(IMessageSession session, CancellationToken cancellationToken = default)
         {
             messageSession = session;
             return OnStart(session, cancellationToken);
         }
 
-        internal Task PerformStop(CancellationToken cancellationToken)
+        internal Task PerformStop(CancellationToken cancellationToken = default)
         {
             return OnStop(messageSession, cancellationToken);
         }

--- a/src/NServiceBus.Core/Features/FeatureStartupTaskController.cs
+++ b/src/NServiceBus.Core/Features/FeatureStartupTaskController.cs
@@ -15,7 +15,7 @@
 
         public string Name { get; }
 
-        public Task Start(IServiceProvider builder, IMessageSession messageSession, CancellationToken cancellationToken)
+        public Task Start(IServiceProvider builder, IMessageSession messageSession, CancellationToken cancellationToken = default)
         {
             if (Log.IsDebugEnabled)
             {
@@ -26,7 +26,7 @@
             return instance.PerformStartup(messageSession, cancellationToken);
         }
 
-        public async Task Stop(CancellationToken cancellationToken)
+        public async Task Stop(CancellationToken cancellationToken = default)
         {
             try
             {

--- a/src/NServiceBus.Core/Hosting/HostCreator.cs
+++ b/src/NServiceBus.Core/Hosting/HostCreator.cs
@@ -36,7 +36,7 @@
             return externallyManagedContainerHost;
         }
 
-        public static async Task<IStartableEndpoint> CreateWithInternallyManagedContainer(EndpointConfiguration endpointConfiguration, CancellationToken cancellationToken)
+        public static async Task<IStartableEndpoint> CreateWithInternallyManagedContainer(EndpointConfiguration endpointConfiguration, CancellationToken cancellationToken = default)
         {
             var settings = endpointConfiguration.Settings;
 

--- a/src/NServiceBus.Core/Hosting/HostingComponent.cs
+++ b/src/NServiceBus.Core/Hosting/HostingComponent.cs
@@ -63,7 +63,7 @@
 
         // This can't happen at start due to an old "feature" that allowed users to
         // run installers by "just creating the endpoint". See https://docs.particular.net/nservicebus/operations/installers#running-installers for more details.
-        public async Task RunInstallers(CancellationToken cancellationToken)
+        public async Task RunInstallers(CancellationToken cancellationToken = default)
         {
             if (!configuration.ShouldRunInstallers)
             {
@@ -78,7 +78,7 @@
             }
         }
 
-        public async Task<IEndpointInstance> Start(IStartableEndpoint startableEndpoint, CancellationToken cancellationToken)
+        public async Task<IEndpointInstance> Start(IStartableEndpoint startableEndpoint, CancellationToken cancellationToken = default)
         {
             var hostStartupDiagnosticsWriter = HostStartupDiagnosticsWriterFactory.GetDiagnosticsWriter(configuration);
 

--- a/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnosticsWriter.cs
+++ b/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnosticsWriter.cs
@@ -16,7 +16,7 @@
             this.isCustomWriter = isCustomWriter;
         }
 
-        public async Task Write(List<StartupDiagnosticEntries.StartupDiagnosticEntry> entries, CancellationToken cancellationToken)
+        public async Task Write(List<StartupDiagnosticEntries.StartupDiagnosticEntry> entries, CancellationToken cancellationToken = default)
         {
             var deduplicatedEntries = DeduplicateEntries(entries);
             var dictionary = deduplicatedEntries

--- a/src/NServiceBus.Core/Installation/INeedToInstallSomething.cs
+++ b/src/NServiceBus.Core/Installation/INeedToInstallSomething.cs
@@ -13,6 +13,6 @@ namespace NServiceBus.Installation
         /// </summary>
         /// <param name="identity">The user for whom permissions will be given.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
-        Task Install(string identity, CancellationToken cancellationToken);
+        Task Install(string identity, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NServiceBus.Core/MessageMutators/MutateInstanceMessage/MutateIncomingMessageContext.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateInstanceMessage/MutateIncomingMessageContext.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.MessageMutator
         /// <summary>
         /// Initializes the context.
         /// </summary>
-        public MutateIncomingMessageContext(object message, Dictionary<string, string> headers, CancellationToken cancellationToken)
+        public MutateIncomingMessageContext(object message, Dictionary<string, string> headers, CancellationToken cancellationToken = default)
         {
             Guard.AgainstNull(nameof(headers), headers);
             Guard.AgainstNull(nameof(message), message);

--- a/src/NServiceBus.Core/MessageMutators/MutateInstanceMessage/MutateOutgoingMessageContext.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateInstanceMessage/MutateOutgoingMessageContext.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.MessageMutator
         /// <summary>
         /// Initializes the context.
         /// </summary>
-        public MutateOutgoingMessageContext(object outgoingMessage, Dictionary<string, string> outgoingHeaders, object incomingMessage, IReadOnlyDictionary<string, string> incomingHeaders, CancellationToken cancellationToken)
+        public MutateOutgoingMessageContext(object outgoingMessage, Dictionary<string, string> outgoingHeaders, object incomingMessage, IReadOnlyDictionary<string, string> incomingHeaders, CancellationToken cancellationToken = default)
         {
             Guard.AgainstNull(nameof(outgoingHeaders), outgoingHeaders);
             Guard.AgainstNull(nameof(outgoingMessage), outgoingMessage);

--- a/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageContext.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageContext.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.MessageMutator
         /// <summary>
         /// Initializes a new instance of <see cref="MutateOutgoingTransportMessageContext" />.
         /// </summary>
-        public MutateIncomingTransportMessageContext(byte[] body, Dictionary<string, string> headers, CancellationToken cancellationToken)
+        public MutateIncomingTransportMessageContext(byte[] body, Dictionary<string, string> headers, CancellationToken cancellationToken = default)
         {
             Guard.AgainstNull(nameof(headers), headers);
             Guard.AgainstNull(nameof(body), body);

--- a/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateOutgoingTransportMessageContext.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateOutgoingTransportMessageContext.cs
@@ -11,7 +11,7 @@ namespace NServiceBus.MessageMutator
         /// <summary>
         /// Initializes a new instance of <see cref="MutateOutgoingTransportMessageContext" />.
         /// </summary>
-        public MutateOutgoingTransportMessageContext(byte[] outgoingBody, object outgoingMessage, Dictionary<string, string> outgoingHeaders, object incomingMessage, IReadOnlyDictionary<string, string> incomingHeaders, CancellationToken cancellationToken)
+        public MutateOutgoingTransportMessageContext(byte[] outgoingBody, object outgoingMessage, Dictionary<string, string> outgoingHeaders, object incomingMessage, IReadOnlyDictionary<string, string> incomingHeaders, CancellationToken cancellationToken = default)
         {
             Guard.AgainstNull(nameof(outgoingHeaders), outgoingHeaders);
             Guard.AgainstNull(nameof(outgoingBody), outgoingBody);

--- a/src/NServiceBus.Core/Notifications/INotificationSubscriptions.cs
+++ b/src/NServiceBus.Core/Notifications/INotificationSubscriptions.cs
@@ -5,6 +5,6 @@
 
     interface INotificationSubscriptions<TEvent>
     {
-        Task Raise(TEvent @event, CancellationToken cancellationToken);
+        Task Raise(TEvent @event, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NServiceBus.Core/Notifications/Notification.cs
+++ b/src/NServiceBus.Core/Notifications/Notification.cs
@@ -15,9 +15,11 @@
 
         List<Func<TEvent, CancellationToken, Task>> subscriptions = new List<Func<TEvent, CancellationToken, Task>>();
 
-        Task INotificationSubscriptions<TEvent>.Raise(TEvent @event, CancellationToken cancellationToken)
+#pragma warning disable CS1066 // The default value specified will have no effect because it applies to a member that is used in contexts that do not allow optional arguments
+        Task INotificationSubscriptions<TEvent>.Raise(TEvent @event, CancellationToken cancellationToken = default)
         {
             return Task.WhenAll(subscriptions.Select(s => s.Invoke(@event, cancellationToken)));
         }
+#pragma warning restore CS1066 // The default value specified will have no effect because it applies to a member that is used in contexts that do not allow optional arguments
     }
 }

--- a/src/NServiceBus.Core/Notifications/Notification.cs
+++ b/src/NServiceBus.Core/Notifications/Notification.cs
@@ -15,11 +15,9 @@
 
         List<Func<TEvent, CancellationToken, Task>> subscriptions = new List<Func<TEvent, CancellationToken, Task>>();
 
-#pragma warning disable CS1066 // The default value specified will have no effect because it applies to a member that is used in contexts that do not allow optional arguments
-        Task INotificationSubscriptions<TEvent>.Raise(TEvent @event, CancellationToken cancellationToken = default)
+        Task INotificationSubscriptions<TEvent>.Raise(TEvent @event, CancellationToken cancellationToken)
         {
             return Task.WhenAll(subscriptions.Select(s => s.Invoke(@event, cancellationToken)));
         }
-#pragma warning restore CS1066 // The default value specified will have no effect because it applies to a member that is used in contexts that do not allow optional arguments
     }
 }

--- a/src/NServiceBus.Core/Persistence/CompletableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Persistence/CompletableSynchronizedStorageSession.cs
@@ -14,6 +14,6 @@
         /// <summary>
         /// Completes the session by saving the changes.
         /// </summary>
-        Task CompleteAsync(CancellationToken cancellationToken);
+        Task CompleteAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/NServiceBus.Core/Persistence/ISynchronizedStorage.cs
+++ b/src/NServiceBus.Core/Persistence/ISynchronizedStorage.cs
@@ -15,6 +15,6 @@
         /// </summary>
         /// <param name="contextBag">The context information.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
-        Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag, CancellationToken cancellationToken);
+        Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NServiceBus.Core/Persistence/ISynchronizedStorageAdapter.cs
+++ b/src/NServiceBus.Core/Persistence/ISynchronizedStorageAdapter.cs
@@ -18,7 +18,7 @@
         /// <param name="context">Context.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
         /// <returns>Session or null, if unable to adapt.</returns>
-        Task<CompletableSynchronizedStorageSession> TryAdapt(OutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken);
+        Task<CompletableSynchronizedStorageSession> TryAdapt(OutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns a synchronized storage session based on the outbox transaction if possible.
@@ -27,6 +27,6 @@
         /// <param name="context">Context.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
         /// <returns>Session or null, if unable to adapt.</returns>
-        Task<CompletableSynchronizedStorageSession> TryAdapt(TransportTransaction transportTransaction, ContextBag context, CancellationToken cancellationToken);
+        Task<CompletableSynchronizedStorageSession> TryAdapt(TransportTransaction transportTransaction, ContextBag context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NServiceBus.Core/Persistence/Learning/LearningStorageAdapter.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/LearningStorageAdapter.cs
@@ -9,12 +9,12 @@
 
     class LearningStorageAdapter : ISynchronizedStorageAdapter
     {
-        public Task<CompletableSynchronizedStorageSession> TryAdapt(OutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken)
+        public Task<CompletableSynchronizedStorageSession> TryAdapt(OutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<CompletableSynchronizedStorageSession>(null);
         }
 
-        public Task<CompletableSynchronizedStorageSession> TryAdapt(TransportTransaction transportTransaction, ContextBag context, CancellationToken cancellationToken)
+        public Task<CompletableSynchronizedStorageSession> TryAdapt(TransportTransaction transportTransaction, ContextBag context, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<CompletableSynchronizedStorageSession>(null);
         }

--- a/src/NServiceBus.Core/Persistence/Learning/LearningSynchronizedStorage.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/LearningSynchronizedStorage.cs
@@ -12,7 +12,7 @@ namespace NServiceBus
             this.sagaManifests = sagaManifests;
         }
 
-        public Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag, CancellationToken cancellationToken)
+        public Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<CompletableSynchronizedStorageSession>(new LearningSynchronizedStorageSession(sagaManifests));
         }

--- a/src/NServiceBus.Core/Persistence/Learning/LearningSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/LearningSynchronizedStorageSession.cs
@@ -63,7 +63,7 @@ namespace NServiceBus
             deferredActions.Add(new CompleteAction(sagaData, sagaFiles, sagaManifests));
         }
 
-        async Task<SagaStorageFile> Open(Guid sagaId, Type entityType, CancellationToken cancellationToken = default)
+        async Task<SagaStorageFile> Open(Guid sagaId, Type entityType, CancellationToken cancellationToken)
         {
             var sagaManifest = sagaManifests.GetForEntityType(entityType);
 

--- a/src/NServiceBus.Core/Persistence/Learning/LearningSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/LearningSynchronizedStorageSession.cs
@@ -25,7 +25,7 @@ namespace NServiceBus
             sagaFiles.Clear();
         }
 
-        public async Task CompleteAsync(CancellationToken cancellationToken)
+        public async Task CompleteAsync(CancellationToken cancellationToken = default)
         {
             foreach (var action in deferredActions)
             {
@@ -34,7 +34,7 @@ namespace NServiceBus
             deferredActions.Clear();
         }
 
-        public async Task<TSagaData> Read<TSagaData>(Guid sagaId, CancellationToken cancellationToken) where TSagaData : class, IContainSagaData
+        public async Task<TSagaData> Read<TSagaData>(Guid sagaId, CancellationToken cancellationToken = default) where TSagaData : class, IContainSagaData
         {
             var sagaStorageFile = await Open(sagaId, typeof(TSagaData), cancellationToken)
                 .ConfigureAwait(false);
@@ -63,7 +63,7 @@ namespace NServiceBus
             deferredActions.Add(new CompleteAction(sagaData, sagaFiles, sagaManifests));
         }
 
-        async Task<SagaStorageFile> Open(Guid sagaId, Type entityType, CancellationToken cancellationToken)
+        async Task<SagaStorageFile> Open(Guid sagaId, Type entityType, CancellationToken cancellationToken = default)
         {
             var sagaManifest = sagaManifests.GetForEntityType(entityType);
 

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/CompleteAction.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/CompleteAction.cs
@@ -10,7 +10,7 @@ namespace NServiceBus
         {
         }
 
-        public override Task Execute(CancellationToken cancellationToken)
+        public override Task Execute(CancellationToken cancellationToken = default)
         {
             var sagaFile = GetSagaFile();
 

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/LearningSagaPersister.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/LearningSagaPersister.cs
@@ -9,40 +9,40 @@ namespace NServiceBus
 
     class LearningSagaPersister : ISagaPersister
     {
-        public Task Save(IContainSagaData sagaData, SagaCorrelationProperty correlationProperty, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken)
+        public Task Save(IContainSagaData sagaData, SagaCorrelationProperty correlationProperty, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
         {
             var storageSession = (LearningSynchronizedStorageSession)session;
             storageSession.Save(sagaData);
             return Task.CompletedTask;
         }
 
-        public Task Update(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken)
+        public Task Update(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
         {
             var storageSession = (LearningSynchronizedStorageSession)session;
             storageSession.Update(sagaData);
             return Task.CompletedTask;
         }
 
-        public Task<TSagaData> Get<TSagaData>(Guid sagaId, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken)
+        public Task<TSagaData> Get<TSagaData>(Guid sagaId, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
             where TSagaData : class, IContainSagaData
         {
             return Get<TSagaData>(sagaId, session, cancellationToken);
         }
 
-        public Task<TSagaData> Get<TSagaData>(string propertyName, object propertyValue, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken)
+        public Task<TSagaData> Get<TSagaData>(string propertyName, object propertyValue, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
             where TSagaData : class, IContainSagaData
         {
             return Get<TSagaData>(LearningSagaIdGenerator.Generate(typeof(TSagaData), propertyName, propertyValue), session, cancellationToken);
         }
 
-        public Task Complete(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken)
+        public Task Complete(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
         {
             var storageSession = (LearningSynchronizedStorageSession)session;
             storageSession.Complete(sagaData);
             return Task.CompletedTask;
         }
 
-        static Task<TSagaData> Get<TSagaData>(Guid sagaId, SynchronizedStorageSession session, CancellationToken cancellationToken) where TSagaData : class, IContainSagaData
+        static Task<TSagaData> Get<TSagaData>(Guid sagaId, SynchronizedStorageSession session, CancellationToken cancellationToken = default) where TSagaData : class, IContainSagaData
         {
             var storageSession = (LearningSynchronizedStorageSession)session;
             return storageSession.Read<TSagaData>(sagaId, cancellationToken);

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/LearningSagaPersister.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/LearningSagaPersister.cs
@@ -42,7 +42,7 @@ namespace NServiceBus
             return Task.CompletedTask;
         }
 
-        static Task<TSagaData> Get<TSagaData>(Guid sagaId, SynchronizedStorageSession session, CancellationToken cancellationToken = default) where TSagaData : class, IContainSagaData
+        static Task<TSagaData> Get<TSagaData>(Guid sagaId, SynchronizedStorageSession session, CancellationToken cancellationToken) where TSagaData : class, IContainSagaData
         {
             var storageSession = (LearningSynchronizedStorageSession)session;
             return storageSession.Read<TSagaData>(sagaId, cancellationToken);

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaStorageFile.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaStorageFile.cs
@@ -50,7 +50,7 @@ namespace NServiceBus
             return OpenWithRetryOnConcurrency(filePath, FileMode.CreateNew, cancellationToken);
         }
 
-        static async Task<SagaStorageFile> OpenWithRetryOnConcurrency(string filePath, FileMode fileAccess, CancellationToken cancellationToken = default)
+        static async Task<SagaStorageFile> OpenWithRetryOnConcurrency(string filePath, FileMode fileAccess, CancellationToken cancellationToken)
         {
             var numRetries = 0;
 

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaStorageFile.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaStorageFile.cs
@@ -31,7 +31,7 @@ namespace NServiceBus
             fileStream = null;
         }
 
-        public static Task<SagaStorageFile> Open(Guid sagaId, SagaManifest manifest, CancellationToken cancellationToken)
+        public static Task<SagaStorageFile> Open(Guid sagaId, SagaManifest manifest, CancellationToken cancellationToken = default)
         {
             var filePath = manifest.GetFilePath(sagaId);
 
@@ -43,14 +43,14 @@ namespace NServiceBus
             return OpenWithRetryOnConcurrency(filePath, FileMode.Open, cancellationToken);
         }
 
-        public static Task<SagaStorageFile> Create(Guid sagaId, SagaManifest manifest, CancellationToken cancellationToken)
+        public static Task<SagaStorageFile> Create(Guid sagaId, SagaManifest manifest, CancellationToken cancellationToken = default)
         {
             var filePath = manifest.GetFilePath(sagaId);
 
             return OpenWithRetryOnConcurrency(filePath, FileMode.CreateNew, cancellationToken);
         }
 
-        static async Task<SagaStorageFile> OpenWithRetryOnConcurrency(string filePath, FileMode fileAccess, CancellationToken cancellationToken)
+        static async Task<SagaStorageFile> OpenWithRetryOnConcurrency(string filePath, FileMode fileAccess, CancellationToken cancellationToken = default)
         {
             var numRetries = 0;
 
@@ -76,7 +76,7 @@ namespace NServiceBus
             }
         }
 
-        public Task Write(IContainSagaData sagaData, CancellationToken cancellationToken)
+        public Task Write(IContainSagaData sagaData, CancellationToken cancellationToken = default)
         {
             // The token isn't currently required but later, a method in a descendant call stack may get a token overload.
             // When that happens, we want CA2016 to tell us to forward the token, so we want to keep the parameter.
@@ -93,7 +93,7 @@ namespace NServiceBus
             isCompleted = true;
         }
 
-        public async Task<TSagaData> Read<TSagaData>(CancellationToken cancellationToken) where TSagaData : class, IContainSagaData
+        public async Task<TSagaData> Read<TSagaData>(CancellationToken cancellationToken = default) where TSagaData : class, IContainSagaData
         {
             // The token isn't currently required but later, a method in a descendant call stack may get a token overload.
             // When that happens, we want CA2016 to tell us to forward the token, so we want to keep the parameter.

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SaveAction.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SaveAction.cs
@@ -10,7 +10,7 @@ namespace NServiceBus
         {
         }
 
-        public override async Task Execute(CancellationToken cancellationToken)
+        public override async Task Execute(CancellationToken cancellationToken = default)
         {
             var sagaId = sagaData.Id;
             var sagaManifest = sagaManifests.GetForEntityType(sagaData.GetType());

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/StorageAction.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/StorageAction.cs
@@ -15,7 +15,7 @@ namespace NServiceBus
             sagaFileKey = $"{sagaData.GetType().FullName}{sagaData.Id}";
         }
 
-        public abstract Task Execute(CancellationToken cancellationToken);
+        public abstract Task Execute(CancellationToken cancellationToken = default);
 
         protected SagaStorageFile GetSagaFile()
         {

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/UpdateAction.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/UpdateAction.cs
@@ -10,7 +10,7 @@ namespace NServiceBus
         {
         }
 
-        public override Task Execute(CancellationToken cancellationToken)
+        public override Task Execute(CancellationToken cancellationToken = default)
         {
             var sagaFile = GetSagaFile();
 

--- a/src/NServiceBus.Core/Pipeline/BehaviorContext.cs
+++ b/src/NServiceBus.Core/Pipeline/BehaviorContext.cs
@@ -10,7 +10,7 @@ namespace NServiceBus
         protected BehaviorContext(IBehaviorContext parentContext) : this(parentContext, parentContext?.CancellationToken ?? default)
         { }
 
-        public BehaviorContext(IBehaviorContext parentContext, CancellationToken cancellationToken) : base(parentContext?.Extensions)
+        public BehaviorContext(IBehaviorContext parentContext, CancellationToken cancellationToken = default) : base(parentContext?.Extensions)
         {
             if (parentContext != null)
             {

--- a/src/NServiceBus.Core/Pipeline/IPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/IPipelineExecutor.cs
@@ -6,6 +6,6 @@
 
     interface IPipelineExecutor
     {
-        Task Invoke(MessageContext messageContext, CancellationToken cancellationToken);
+        Task Invoke(MessageContext messageContext, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
@@ -60,7 +60,7 @@
             }
         }
 
-        async Task<CompletableSynchronizedStorageSession> AdaptOrOpenNewSynchronizedStorageSession(TransportTransaction transportTransaction, OutboxTransaction outboxTransaction, ContextBag contextBag, CancellationToken cancellationToken = default)
+        async Task<CompletableSynchronizedStorageSession> AdaptOrOpenNewSynchronizedStorageSession(TransportTransaction transportTransaction, OutboxTransaction outboxTransaction, ContextBag contextBag, CancellationToken cancellationToken)
         {
             return await adapter.TryAdapt(outboxTransaction, contextBag, cancellationToken).ConfigureAwait(false)
                    ?? await adapter.TryAdapt(transportTransaction, contextBag, cancellationToken).ConfigureAwait(false)

--- a/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
@@ -60,7 +60,7 @@
             }
         }
 
-        async Task<CompletableSynchronizedStorageSession> AdaptOrOpenNewSynchronizedStorageSession(TransportTransaction transportTransaction, OutboxTransaction outboxTransaction, ContextBag contextBag, CancellationToken cancellationToken)
+        async Task<CompletableSynchronizedStorageSession> AdaptOrOpenNewSynchronizedStorageSession(TransportTransaction transportTransaction, OutboxTransaction outboxTransaction, ContextBag contextBag, CancellationToken cancellationToken = default)
         {
             return await adapter.TryAdapt(outboxTransaction, contextBag, cancellationToken).ConfigureAwait(false)
                    ?? await adapter.TryAdapt(transportTransaction, contextBag, cancellationToken).ConfigureAwait(false)

--- a/src/NServiceBus.Core/Pipeline/Incoming/NoOpOutbox/NoOpCompletableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/NoOpOutbox/NoOpCompletableSynchronizedStorageSession.cs
@@ -10,7 +10,7 @@
     [SkipWeaving]
     class NoOpCompletableSynchronizedStorageSession : CompletableSynchronizedStorageSession
     {
-        public Task CompleteAsync(CancellationToken cancellationToken)
+        public Task CompleteAsync(CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }

--- a/src/NServiceBus.Core/Pipeline/Incoming/NoOpOutbox/NoOpOutboxStorage.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/NoOpOutbox/NoOpOutboxStorage.cs
@@ -7,22 +7,22 @@
 
     class NoOpOutboxStorage : IOutboxStorage
     {
-        public Task<OutboxMessage> Get(string messageId, ContextBag options, CancellationToken cancellationToken)
+        public Task<OutboxMessage> Get(string messageId, ContextBag options, CancellationToken cancellationToken = default)
         {
             return NoOutboxMessageTask;
         }
 
-        public Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag options, CancellationToken cancellationToken)
+        public Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag options, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
 
-        public Task SetAsDispatched(string messageId, ContextBag options, CancellationToken cancellationToken)
+        public Task SetAsDispatched(string messageId, ContextBag options, CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }
 
-        public Task<OutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken)
+        public Task<OutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken = default)
         {
             return Task.FromResult<OutboxTransaction>(new NoOpOutboxTransaction());
         }

--- a/src/NServiceBus.Core/Pipeline/Incoming/NoOpOutbox/NoOpOutboxTransaction.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/NoOpOutbox/NoOpOutboxTransaction.cs
@@ -10,7 +10,7 @@
         {
         }
 
-        public Task Commit(CancellationToken cancellationToken)
+        public Task Commit(CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }

--- a/src/NServiceBus.Core/Pipeline/Incoming/NoOpOutbox/NoOpSynchronizedStorage.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/NoOpOutbox/NoOpSynchronizedStorage.cs
@@ -7,7 +7,7 @@
 
     class NoOpSynchronizedStorage : ISynchronizedStorage
     {
-        public Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag, CancellationToken cancellationToken)
+        public Task<CompletableSynchronizedStorageSession> OpenSession(ContextBag contextBag, CancellationToken cancellationToken = default)
         {
             return NoOpSynchronizedStorageAdapter.EmptyResult;
         }

--- a/src/NServiceBus.Core/Pipeline/Incoming/NoOpOutbox/NoOpSynchronizedStorageAdapter.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/NoOpOutbox/NoOpSynchronizedStorageAdapter.cs
@@ -9,12 +9,12 @@
 
     class NoOpSynchronizedStorageAdapter : ISynchronizedStorageAdapter
     {
-        public Task<CompletableSynchronizedStorageSession> TryAdapt(OutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken)
+        public Task<CompletableSynchronizedStorageSession> TryAdapt(OutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken = default)
         {
             return EmptyResult;
         }
 
-        public Task<CompletableSynchronizedStorageSession> TryAdapt(TransportTransaction transportTransaction, ContextBag context, CancellationToken cancellationToken)
+        public Task<CompletableSynchronizedStorageSession> TryAdapt(TransportTransaction transportTransaction, ContextBag context, CancellationToken cancellationToken = default)
         {
             return EmptyResult;
         }

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -18,7 +18,7 @@ namespace NServiceBus
             this.receivePipeline = receivePipeline;
         }
 
-        public async Task Invoke(MessageContext messageContext, CancellationToken cancellationToken)
+        public async Task Invoke(MessageContext messageContext, CancellationToken cancellationToken = default)
         {
             var pipelineStartedAt = DateTimeOffset.UtcNow;
 

--- a/src/NServiceBus.Core/Pipeline/RootContext.cs
+++ b/src/NServiceBus.Core/Pipeline/RootContext.cs
@@ -5,7 +5,7 @@ namespace NServiceBus
 
     class RootContext : BehaviorContext
     {
-        public RootContext(IServiceProvider builder, MessageOperations messageOperations, IPipelineCache pipelineCache, CancellationToken cancellationToken)
+        public RootContext(IServiceProvider builder, MessageOperations messageOperations, IPipelineCache pipelineCache, CancellationToken cancellationToken = default)
             : base(null, cancellationToken)
         {
             Set(messageOperations);

--- a/src/NServiceBus.Core/Pipeline/SatellitePipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/SatellitePipelineExecutor.cs
@@ -13,7 +13,7 @@
             satelliteDefinition = definition;
         }
 
-        public Task Invoke(MessageContext messageContext, CancellationToken cancellationToken)
+        public Task Invoke(MessageContext messageContext, CancellationToken cancellationToken = default)
         {
             messageContext.Extensions.Set(messageContext.TransportTransaction);
 

--- a/src/NServiceBus.Core/Receiving/OnSatelliteMessage.cs
+++ b/src/NServiceBus.Core/Receiving/OnSatelliteMessage.cs
@@ -8,5 +8,5 @@
     /// <summary>
     /// Processes an incoming satellite message.
     /// </summary>
-    public delegate Task OnSatelliteMessage(IServiceProvider serviceProvider, MessageContext messageContext, CancellationToken cancellationToken);
+    public delegate Task OnSatelliteMessage(IServiceProvider serviceProvider, MessageContext messageContext, CancellationToken cancellationToken = default);
 }

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -129,7 +129,7 @@ namespace NServiceBus
             PipelineComponent pipelineComponent,
             IPipelineCache pipelineCache,
             TransportInfrastructure transportInfrastructure,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default)
         {
             if (configuration.IsSendOnlyEndpoint)
             {
@@ -183,7 +183,7 @@ namespace NServiceBus
             }
         }
 
-        public async Task Start(CancellationToken cancellationToken)
+        public async Task Start(CancellationToken cancellationToken = default)
         {
             foreach (var messageReceiver in receivers)
             {
@@ -200,7 +200,7 @@ namespace NServiceBus
             }
         }
 
-        public Task Stop(CancellationToken cancellationToken)
+        public Task Stop(CancellationToken cancellationToken = default)
         {
             var receiverStopTasks = receivers.Select(async receiver =>
             {

--- a/src/NServiceBus.Core/Recoverability/DelayedRetryExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/DelayedRetryExecutor.cs
@@ -16,7 +16,7 @@
             this.endpointInputQueue = endpointInputQueue;
         }
 
-        public async Task<int> Retry(IncomingMessage message, TimeSpan delay, TransportTransaction transportTransaction, CancellationToken cancellationToken)
+        public async Task<int> Retry(IncomingMessage message, TimeSpan delay, TransportTransaction transportTransaction, CancellationToken cancellationToken = default)
         {
             var outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body);
 

--- a/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
@@ -16,7 +16,7 @@
             this.headerCustomizations = headerCustomizations;
         }
 
-        public Task MoveToErrorQueue(string errorQueueAddress, IncomingMessage message, Exception exception, TransportTransaction transportTransaction, CancellationToken cancellationToken)
+        public Task MoveToErrorQueue(string errorQueueAddress, IncomingMessage message, Exception exception, TransportTransaction transportTransaction, CancellationToken cancellationToken = default)
         {
             message.RevertToOriginalBodyIfNeeded();
 

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
@@ -31,7 +31,7 @@
             raiseNotifications = raiseRecoverabilityNotifications;
         }
 
-        public Task<ErrorHandleResult> Invoke(ErrorContext errorContext, CancellationToken cancellationToken)
+        public Task<ErrorHandleResult> Invoke(ErrorContext errorContext, CancellationToken cancellationToken = default)
         {
             var recoveryAction = recoverabilityPolicy(configuration, errorContext);
 
@@ -74,7 +74,7 @@
             return MoveToError(errorContext, configuration.Failed.ErrorQueue, cancellationToken);
         }
 
-        async Task<ErrorHandleResult> RaiseImmediateRetryNotifications(ErrorContext errorContext, CancellationToken cancellationToken)
+        async Task<ErrorHandleResult> RaiseImmediateRetryNotifications(ErrorContext errorContext, CancellationToken cancellationToken = default)
         {
             Logger.Info($"Immediate Retry is going to retry message '{errorContext.Message.MessageId}' because of an exception:", errorContext.Exception);
 
@@ -93,7 +93,7 @@
             return ErrorHandleResult.RetryRequired;
         }
 
-        async Task<ErrorHandleResult> MoveToError(ErrorContext errorContext, string errorQueue, CancellationToken cancellationToken)
+        async Task<ErrorHandleResult> MoveToError(ErrorContext errorContext, string errorQueue, CancellationToken cancellationToken = default)
         {
             var message = errorContext.Message;
 
@@ -109,7 +109,7 @@
             return ErrorHandleResult.Handled;
         }
 
-        async Task<ErrorHandleResult> DeferMessage(DelayedRetry action, ErrorContext errorContext, CancellationToken cancellationToken)
+        async Task<ErrorHandleResult> DeferMessage(DelayedRetry action, ErrorContext errorContext, CancellationToken cancellationToken = default)
         {
             var message = errorContext.Message;
 

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityExecutor.cs
@@ -74,7 +74,7 @@
             return MoveToError(errorContext, configuration.Failed.ErrorQueue, cancellationToken);
         }
 
-        async Task<ErrorHandleResult> RaiseImmediateRetryNotifications(ErrorContext errorContext, CancellationToken cancellationToken = default)
+        async Task<ErrorHandleResult> RaiseImmediateRetryNotifications(ErrorContext errorContext, CancellationToken cancellationToken)
         {
             Logger.Info($"Immediate Retry is going to retry message '{errorContext.Message.MessageId}' because of an exception:", errorContext.Exception);
 
@@ -93,7 +93,7 @@
             return ErrorHandleResult.RetryRequired;
         }
 
-        async Task<ErrorHandleResult> MoveToError(ErrorContext errorContext, string errorQueue, CancellationToken cancellationToken = default)
+        async Task<ErrorHandleResult> MoveToError(ErrorContext errorContext, string errorQueue, CancellationToken cancellationToken)
         {
             var message = errorContext.Message;
 
@@ -109,7 +109,7 @@
             return ErrorHandleResult.Handled;
         }
 
-        async Task<ErrorHandleResult> DeferMessage(DelayedRetry action, ErrorContext errorContext, CancellationToken cancellationToken = default)
+        async Task<ErrorHandleResult> DeferMessage(DelayedRetry action, ErrorContext errorContext, CancellationToken cancellationToken)
         {
             var message = errorContext.Message;
 

--- a/src/NServiceBus.Core/Reliability/Outbox/IOutboxStorage.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/IOutboxStorage.cs
@@ -16,17 +16,17 @@
         /// If there is no <see cref="OutboxMessage" /> present for the given <paramref name="messageId" /> then null is
         /// returned.
         /// </returns>
-        Task<OutboxMessage> Get(string messageId, ContextBag context, CancellationToken cancellationToken);
+        Task<OutboxMessage> Get(string messageId, ContextBag context, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Stores the outbox message to enable deduplication an re-dispatching of related transport operations.
         /// </summary>
-        Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken);
+        Task Store(OutboxMessage message, OutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Tells the storage that the message has been dispatched and its now safe to clean up the transport operations.
         /// </summary>
-        Task SetAsDispatched(string messageId, ContextBag context, CancellationToken cancellationToken);
+        Task SetAsDispatched(string messageId, ContextBag context, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates the <see cref="OutboxTransaction" />.
@@ -34,6 +34,6 @@
         /// <param name="context">The current pipeline context.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
         /// <returns>The created outbox transaction.</returns>
-        Task<OutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken);
+        Task<OutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NServiceBus.Core/Reliability/Outbox/OutboxTransaction.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/OutboxTransaction.cs
@@ -14,6 +14,6 @@ namespace NServiceBus.Outbox
         /// <summary>
         /// Commits the outbox transaction.
         /// </summary>
-        Task Commit(CancellationToken cancellationToken);
+        Task Commit(CancellationToken cancellationToken = default);
     }
 }

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -61,7 +61,7 @@
                 this.messagesHandledByThisEndpoint = messagesHandledByThisEndpoint;
             }
 
-            protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+            protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
             {
                 try
                 {
@@ -101,7 +101,7 @@
             }
 
 
-            protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+            protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
             {
                 return Task.CompletedTask;
             }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/ISubscriptionStorage.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/ISubscriptionStorage.cs
@@ -13,16 +13,16 @@ namespace NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions
         /// <summary>
         /// Subscribes the given client to messages of a given type.
         /// </summary>
-        Task Subscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken);
+        Task Subscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Unsubscribes the given client from messages of given type.
         /// </summary>
-        Task Unsubscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken);
+        Task Unsubscribe(Subscriber subscriber, MessageType messageType, ContextBag context, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns a list of addresses for subscribers currently subscribed to the given message type.
         /// </summary>
-        Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context, CancellationToken cancellationToken);
+        Task<IEnumerable<Subscriber>> GetSubscriberAddressesForMessage(IEnumerable<MessageType> messageTypes, ContextBag context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -76,7 +76,7 @@
             }
         }
 
-        async Task SendSubscribeMessageWithRetries(string destination, OutgoingMessage subscriptionMessage, string messageType, ContextBag context, int retriesCount, CancellationToken cancellationToken = default)
+        async Task SendSubscribeMessageWithRetries(string destination, OutgoingMessage subscriptionMessage, string messageType, ContextBag context, int retriesCount, CancellationToken cancellationToken)
         {
             var state = context.GetOrCreate<Settings>();
             try

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -76,7 +76,7 @@
             }
         }
 
-        async Task SendSubscribeMessageWithRetries(string destination, OutgoingMessage subscriptionMessage, string messageType, ContextBag context, int retriesCount, CancellationToken cancellationToken)
+        async Task SendSubscribeMessageWithRetries(string destination, OutgoingMessage subscriptionMessage, string messageType, ContextBag context, int retriesCount, CancellationToken cancellationToken = default)
         {
             var state = context.GetOrCreate<Settings>();
             try

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -112,13 +112,13 @@ namespace NServiceBus.Features
                 this.subscriptionStorage = subscriptionStorage;
             }
 
-            protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken)
+            protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
             {
                 subscriptionStorage?.Init();
                 return Task.CompletedTask;
             }
 
-            protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken)
+            protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
             {
                 return Task.CompletedTask;
             }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -51,7 +51,7 @@
             return Task.WhenAll(unsubscribeTasks);
         }
 
-        async Task SendUnsubscribeMessageWithRetries(string destination, OutgoingMessage unsubscribeMessage, string messageType, ContextBag context, int retriesCount, CancellationToken cancellationToken = default)
+        async Task SendUnsubscribeMessageWithRetries(string destination, OutgoingMessage unsubscribeMessage, string messageType, ContextBag context, int retriesCount, CancellationToken cancellationToken)
         {
             var state = context.GetOrCreate<Settings>();
             try

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenUnsubscribeTerminator.cs
@@ -51,7 +51,7 @@
             return Task.WhenAll(unsubscribeTasks);
         }
 
-        async Task SendUnsubscribeMessageWithRetries(string destination, OutgoingMessage unsubscribeMessage, string messageType, ContextBag context, int retriesCount, CancellationToken cancellationToken)
+        async Task SendUnsubscribeMessageWithRetries(string destination, OutgoingMessage unsubscribeMessage, string messageType, ContextBag context, int retriesCount, CancellationToken cancellationToken = default)
         {
             var state = context.GetOrCreate<Settings>();
             try

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationSubscribeTerminator.cs
@@ -100,7 +100,7 @@
             }
         }
 
-        async Task SendSubscribeMessageWithRetries(string destination, OutgoingMessage subscriptionMessage, string messageType, ContextBag context, int retriesCount, CancellationToken cancellationToken = default)
+        async Task SendSubscribeMessageWithRetries(string destination, OutgoingMessage subscriptionMessage, string messageType, ContextBag context, int retriesCount, CancellationToken cancellationToken)
         {
             var state = context.GetOrCreate<MessageDrivenSubscribeTerminator.Settings>();
             try

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationSubscribeTerminator.cs
@@ -100,7 +100,7 @@
             }
         }
 
-        async Task SendSubscribeMessageWithRetries(string destination, OutgoingMessage subscriptionMessage, string messageType, ContextBag context, int retriesCount, CancellationToken cancellationToken)
+        async Task SendSubscribeMessageWithRetries(string destination, OutgoingMessage subscriptionMessage, string messageType, ContextBag context, int retriesCount, CancellationToken cancellationToken = default)
         {
             var state = context.GetOrCreate<MessageDrivenSubscribeTerminator.Settings>();
             try

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationUnsubscribeTerminator.cs
@@ -59,7 +59,7 @@
             await Task.WhenAll(unsubscribeTasks).ConfigureAwait(false);
         }
 
-        async Task SendUnsubscribeMessageWithRetries(string destination, OutgoingMessage unsubscribeMessage, string messageType, ContextBag context, int retriesCount, CancellationToken cancellationToken = default)
+        async Task SendUnsubscribeMessageWithRetries(string destination, OutgoingMessage unsubscribeMessage, string messageType, ContextBag context, int retriesCount, CancellationToken cancellationToken)
         {
             var state = context.GetOrCreate<MessageDrivenUnsubscribeTerminator.Settings>();
             try

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationUnsubscribeTerminator.cs
@@ -59,7 +59,7 @@
             await Task.WhenAll(unsubscribeTasks).ConfigureAwait(false);
         }
 
-        async Task SendUnsubscribeMessageWithRetries(string destination, OutgoingMessage unsubscribeMessage, string messageType, ContextBag context, int retriesCount, CancellationToken cancellationToken)
+        async Task SendUnsubscribeMessageWithRetries(string destination, OutgoingMessage unsubscribeMessage, string messageType, ContextBag context, int retriesCount, CancellationToken cancellationToken = default)
         {
             var state = context.GetOrCreate<MessageDrivenUnsubscribeTerminator.Settings>();
             try

--- a/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
@@ -90,7 +90,7 @@ namespace NServiceBus
             return addresses.Values;
         }
 
-        Task<IEnumerable<Subscriber>> GetSubscribers(IExtendable publishContext, Type[] typesToRoute, CancellationToken cancellationToken = default)
+        Task<IEnumerable<Subscriber>> GetSubscribers(IExtendable publishContext, Type[] typesToRoute, CancellationToken cancellationToken)
         {
             var messageTypes = typesToRoute.Select(t => new MessageType(t));
             return subscriptionStorage.GetSubscriberAddressesForMessage(messageTypes, publishContext.Extensions, cancellationToken);

--- a/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
@@ -90,7 +90,7 @@ namespace NServiceBus
             return addresses.Values;
         }
 
-        Task<IEnumerable<Subscriber>> GetSubscribers(IExtendable publishContext, Type[] typesToRoute, CancellationToken cancellationToken)
+        Task<IEnumerable<Subscriber>> GetSubscribers(IExtendable publishContext, Type[] typesToRoute, CancellationToken cancellationToken = default)
         {
             var messageTypes = typesToRoute.Select(t => new MessageType(t));
             return subscriptionStorage.GetSubscriberAddressesForMessage(messageTypes, publishContext.Extensions, cancellationToken);

--- a/src/NServiceBus.Core/Sagas/CustomFinderAdapter.cs
+++ b/src/NServiceBus.Core/Sagas/CustomFinderAdapter.cs
@@ -11,7 +11,7 @@ namespace NServiceBus
 
     class CustomFinderAdapter<TSagaData, TMessage> : SagaFinder where TSagaData : IContainSagaData
     {
-        public override async Task<IContainSagaData> Find(IServiceProvider builder, SagaFinderDefinition finderDefinition, SynchronizedStorageSession storageSession, ContextBag context, object message, IReadOnlyDictionary<string, string> messageHeaders, CancellationToken cancellationToken)
+        public override async Task<IContainSagaData> Find(IServiceProvider builder, SagaFinderDefinition finderDefinition, SynchronizedStorageSession storageSession, ContextBag context, object message, IReadOnlyDictionary<string, string> messageHeaders, CancellationToken cancellationToken = default)
         {
             var customFinderType = (Type)finderDefinition.Properties["custom-finder-clr-type"];
 

--- a/src/NServiceBus.Core/Sagas/HeaderPropertySagaFinder.cs
+++ b/src/NServiceBus.Core/Sagas/HeaderPropertySagaFinder.cs
@@ -18,7 +18,7 @@
             this.persister = persister;
         }
 
-        public override async Task<IContainSagaData> Find(IServiceProvider builder, SagaFinderDefinition finderDefinition, SynchronizedStorageSession storageSession, ContextBag context, object message, IReadOnlyDictionary<string, string> messageHeaders, CancellationToken cancellationToken)
+        public override async Task<IContainSagaData> Find(IServiceProvider builder, SagaFinderDefinition finderDefinition, SynchronizedStorageSession storageSession, ContextBag context, object message, IReadOnlyDictionary<string, string> messageHeaders, CancellationToken cancellationToken = default)
         {
             var headerName = (string)finderDefinition.Properties["message-header-name"];
 

--- a/src/NServiceBus.Core/Sagas/IFindSagas.cs
+++ b/src/NServiceBus.Core/Sagas/IFindSagas.cs
@@ -22,7 +22,7 @@ namespace NServiceBus.Sagas
             /// Finds a saga entity of the type T using a message of type M.
             /// </summary>
             /// <exception cref="System.Exception">This exception will be thrown if <code>null</code> is returned. Return a Task&lt;T&gt; or mark the method as <code>async</code>.</exception>
-            Task<T> FindBy(M message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken);
+            Task<T> FindBy(M message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken = default);
         }
     }
 }

--- a/src/NServiceBus.Core/Sagas/ISagaPersister.cs
+++ b/src/NServiceBus.Core/Sagas/ISagaPersister.cs
@@ -20,7 +20,7 @@ namespace NServiceBus.Sagas
         /// <param name="session">Storage session.</param>
         /// <param name="context">The current pipeline context.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
-        Task Save(IContainSagaData sagaData, SagaCorrelationProperty correlationProperty, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken);
+        Task Save(IContainSagaData sagaData, SagaCorrelationProperty correlationProperty, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Updates an existing sagaData entity in the persistence store.
@@ -29,7 +29,7 @@ namespace NServiceBus.Sagas
         /// <param name="session">The session.</param>
         /// <param name="context">The current pipeline context.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
-        Task Update(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken);
+        Task Update(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets a sagaData entity from the persistence store by its Id.
@@ -38,7 +38,7 @@ namespace NServiceBus.Sagas
         /// <param name="session">The session.</param>
         /// <param name="context">The current pipeline context.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
-        Task<TSagaData> Get<TSagaData>(Guid sagaId, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken)
+        Task<TSagaData> Get<TSagaData>(Guid sagaId, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
             where TSagaData : class, IContainSagaData;
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace NServiceBus.Sagas
         /// <param name="session">The session.</param>
         /// <param name="context">The current pipeline context.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
-        Task<TSagaData> Get<TSagaData>(string propertyName, object propertyValue, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken)
+        Task<TSagaData> Get<TSagaData>(string propertyName, object propertyValue, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default)
             where TSagaData : class, IContainSagaData;
 
         /// <summary>
@@ -60,6 +60,6 @@ namespace NServiceBus.Sagas
         /// <param name="session">The session.</param>
         /// <param name="context">The current pipeline context.</param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
-        Task Complete(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken);
+        Task Complete(IContainSagaData sagaData, SynchronizedStorageSession session, ContextBag context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NServiceBus.Core/Sagas/LoadSagaByIdWrapper.cs
+++ b/src/NServiceBus.Core/Sagas/LoadSagaByIdWrapper.cs
@@ -11,7 +11,7 @@ namespace NServiceBus
     class LoadSagaByIdWrapper<T> : SagaLoader
         where T : class, IContainSagaData
     {
-        public async Task<IContainSagaData> Load(ISagaPersister persister, string sagaId, SynchronizedStorageSession storageSession, ContextBag context, CancellationToken cancellationToken)
+        public async Task<IContainSagaData> Load(ISagaPersister persister, string sagaId, SynchronizedStorageSession storageSession, ContextBag context, CancellationToken cancellationToken = default)
         {
             return await persister.Get<T>(Guid.Parse(sagaId), storageSession, context, cancellationToken).ConfigureAwait(false);
         }

--- a/src/NServiceBus.Core/Sagas/PropertySagaFinder.cs
+++ b/src/NServiceBus.Core/Sagas/PropertySagaFinder.cs
@@ -15,7 +15,7 @@ namespace NServiceBus
             this.sagaPersister = sagaPersister;
         }
 
-        public override async Task<IContainSagaData> Find(IServiceProvider builder, SagaFinderDefinition finderDefinition, SynchronizedStorageSession storageSession, ContextBag context, object message, IReadOnlyDictionary<string, string> messageHeaders, CancellationToken cancellationToken)
+        public override async Task<IContainSagaData> Find(IServiceProvider builder, SagaFinderDefinition finderDefinition, SynchronizedStorageSession storageSession, ContextBag context, object message, IReadOnlyDictionary<string, string> messageHeaders, CancellationToken cancellationToken = default)
         {
             var propertyAccessor = (Func<object, object>)finderDefinition.Properties["property-accessor"];
             var propertyValue = propertyAccessor(message);

--- a/src/NServiceBus.Core/Sagas/SagaFinder.cs
+++ b/src/NServiceBus.Core/Sagas/SagaFinder.cs
@@ -10,6 +10,6 @@
 
     abstract class SagaFinder
     {
-        public abstract Task<IContainSagaData> Find(IServiceProvider builder, SagaFinderDefinition finderDefinition, SynchronizedStorageSession storageSession, ContextBag context, object message, IReadOnlyDictionary<string, string> messageHeaders, CancellationToken cancellationToken);
+        public abstract Task<IContainSagaData> Find(IServiceProvider builder, SagaFinderDefinition finderDefinition, SynchronizedStorageSession storageSession, ContextBag context, object message, IReadOnlyDictionary<string, string> messageHeaders, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NServiceBus.Core/Sagas/SagaLoader.cs
+++ b/src/NServiceBus.Core/Sagas/SagaLoader.cs
@@ -10,6 +10,6 @@ namespace NServiceBus
     interface SagaLoader
 #pragma warning restore IDE1006 // Naming Styles
     {
-        Task<IContainSagaData> Load(ISagaPersister persister, string sagaId, SynchronizedStorageSession storageSession, ContextBag context, CancellationToken cancellationToken);
+        Task<IContainSagaData> Load(ISagaPersister persister, string sagaId, SynchronizedStorageSession storageSession, ContextBag context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NServiceBus.Core/Transports/IMessageDispatcher.cs
+++ b/src/NServiceBus.Core/Transports/IMessageDispatcher.cs
@@ -11,6 +11,6 @@
         /// <summary>
         /// Dispatches the given operations to the transport.
         /// </summary>
-        Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken);
+        Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NServiceBus.Core/Transports/IMessageReceiver.cs
+++ b/src/NServiceBus.Core/Transports/IMessageReceiver.cs
@@ -11,17 +11,17 @@
         /// <summary>
         /// Initializes the receiver.
         /// </summary>
-        Task Initialize(PushRuntimeSettings limitations, OnMessage onMessage, OnError onError, OnCompleted onCompleted, CancellationToken cancellationToken);
+        Task Initialize(PushRuntimeSettings limitations, OnMessage onMessage, OnError onError, OnCompleted onCompleted, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Starts receiving messages from the input queue.
         /// </summary>
-        Task StartReceive(CancellationToken cancellationToken);
+        Task StartReceive(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Stops receiving messages.
         /// </summary>
-        Task StopReceive(CancellationToken cancellationToken);
+        Task StopReceive(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// The <see cref="ISubscriptionManager"/> for this receiver. Will be <c>null</c> if publish-subscribe has been disabled on the <see cref="ReceiveSettings"/>.
@@ -37,15 +37,15 @@
     /// <summary>
     /// Processes an incoming message.
     /// </summary>
-    public delegate Task OnMessage(MessageContext messageContext, CancellationToken cancellationToken);
+    public delegate Task OnMessage(MessageContext messageContext, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Processes a message that has failed processing.
     /// </summary>
-    public delegate Task<ErrorHandleResult> OnError(ErrorContext errorContext, CancellationToken cancellationToken);
+    public delegate Task<ErrorHandleResult> OnError(ErrorContext errorContext, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Processes a message that has been completed.
     /// </summary>
-    public delegate Task OnCompleted(CompleteContext completeContext, CancellationToken cancellationToken);
+    public delegate Task OnCompleted(CompleteContext completeContext, CancellationToken cancellationToken = default);
 }

--- a/src/NServiceBus.Core/Transports/ISubscriptionManager.cs
+++ b/src/NServiceBus.Core/Transports/ISubscriptionManager.cs
@@ -13,11 +13,11 @@
         /// <summary>
         /// Subscribes to all provided events.
         /// </summary>
-        Task SubscribeAll(MessageMetadata[] eventTypes, ContextBag context, CancellationToken cancellationToken);
+        Task SubscribeAll(MessageMetadata[] eventTypes, ContextBag context, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Unsubscribes from the given event.
         /// </summary>
-        Task Unsubscribe(MessageMetadata eventType, ContextBag context, CancellationToken cancellationToken);
+        Task Unsubscribe(MessageMetadata eventType, ContextBag context, CancellationToken cancellationToken = default);
     }
 }

--- a/src/NServiceBus.Core/Transports/Learning/AsyncDirectory.cs
+++ b/src/NServiceBus.Core/Transports/Learning/AsyncDirectory.cs
@@ -6,7 +6,7 @@ namespace NServiceBus
 
     static class AsyncDirectory
     {
-        public static async Task Move(string sourcePath, string targetPath, CancellationToken cancellationToken)
+        public static async Task Move(string sourcePath, string targetPath, CancellationToken cancellationToken = default)
         {
             var count = 0;
             while (count <= 10)

--- a/src/NServiceBus.Core/Transports/Learning/AsyncFile.cs
+++ b/src/NServiceBus.Core/Transports/Learning/AsyncFile.cs
@@ -7,7 +7,7 @@ namespace NServiceBus
 
     static class AsyncFile
     {
-        public static async Task WriteBytes(string filePath, byte[] bytes, CancellationToken cancellationToken)
+        public static async Task WriteBytes(string filePath, byte[] bytes, CancellationToken cancellationToken = default)
         {
             using (var stream = CreateWriteStream(filePath, FileMode.Create))
             {
@@ -16,7 +16,7 @@ namespace NServiceBus
         }
 
         //write to temp file first so we can do a atomic move
-        public static async Task WriteTextAtomic(string targetPath, string text, CancellationToken cancellationToken)
+        public static async Task WriteTextAtomic(string targetPath, string text, CancellationToken cancellationToken = default)
         {
             var tempFile = Path.GetTempFileName();
             var bytes = Encoding.UTF8.GetBytes(text);
@@ -42,14 +42,14 @@ namespace NServiceBus
             return new FileStream(filePath, fileMode, FileAccess.Write, FileShare.None, bufferSize: 4096, useAsync: true);
         }
 
-        public static Task WriteText(string filePath, string text, CancellationToken cancellationToken)
+        public static Task WriteText(string filePath, string text, CancellationToken cancellationToken = default)
         {
             var bytes = Encoding.UTF8.GetBytes(text);
 
             return WriteBytes(filePath, bytes, cancellationToken);
         }
 
-        public static async Task<string> ReadText(string filePath, CancellationToken cancellationToken)
+        public static async Task<string> ReadText(string filePath, CancellationToken cancellationToken = default)
         {
             using (var stream = new StreamReader(CreateReadStream(filePath), Encoding.UTF8))
             {
@@ -64,7 +64,7 @@ namespace NServiceBus
             }
         }
 
-        public static async Task<byte[]> ReadBytes(string filePath, CancellationToken cancellationToken)
+        public static async Task<byte[]> ReadBytes(string filePath, CancellationToken cancellationToken = default)
         {
             using (var stream = CreateReadStream(filePath))
             {
@@ -81,7 +81,7 @@ namespace NServiceBus
             return new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
         }
 
-        public static async Task<bool> Move(string sourcePath, string targetPath, CancellationToken cancellationToken)
+        public static async Task<bool> Move(string sourcePath, string targetPath, CancellationToken cancellationToken = default)
         {
             try
             {

--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -19,7 +19,7 @@ namespace NServiceBus
 
         public string FileToProcess { get; private set; }
 
-        public Task<bool> BeginTransaction(string incomingFilePath, CancellationToken cancellationToken)
+        public Task<bool> BeginTransaction(string incomingFilePath, CancellationToken cancellationToken = default)
         {
             Directory.CreateDirectory(transactionDir);
             FileToProcess = Path.Combine(transactionDir, Path.GetFileName(incomingFilePath));
@@ -27,7 +27,7 @@ namespace NServiceBus
             return AsyncFile.Move(incomingFilePath, FileToProcess, cancellationToken);
         }
 
-        public async Task Commit(CancellationToken cancellationToken)
+        public async Task Commit(CancellationToken cancellationToken = default)
         {
             await AsyncDirectory.Move(transactionDir, commitDir, cancellationToken).ConfigureAwait(false);
             committed = true;
@@ -46,7 +46,7 @@ namespace NServiceBus
             { }
         }
 
-        public Task Enlist(string messagePath, string messageContents, CancellationToken cancellationToken)
+        public Task Enlist(string messagePath, string messageContents, CancellationToken cancellationToken = default)
         {
             var inProgressFileName = Path.GetFileNameWithoutExtension(messagePath) + ".out";
 

--- a/src/NServiceBus.Core/Transports/Learning/ILearningTransportTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/ILearningTransportTransaction.cs
@@ -7,15 +7,15 @@ namespace NServiceBus
     {
         string FileToProcess { get; }
 
-        Task<bool> BeginTransaction(string incomingFilePath, CancellationToken cancellationToken);
+        Task<bool> BeginTransaction(string incomingFilePath, CancellationToken cancellationToken = default);
 
-        Task Commit(CancellationToken cancellationToken);
+        Task Commit(CancellationToken cancellationToken = default);
 
         void Rollback();
 
         void ClearPendingOutgoingOperations();
 
-        Task Enlist(string messagePath, string messageContents, CancellationToken cancellationToken);
+        Task Enlist(string messagePath, string messageContents, CancellationToken cancellationToken = default);
 
         bool Complete();
     }

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransport.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransport.cs
@@ -24,7 +24,7 @@
         /// default capabilities as well as for initializing the transport's configuration based on those settings (the user cannot
         /// provide information anymore at this stage).
         /// </summary>
-        public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken)
+        public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken = default)
         {
             Guard.AgainstNull(nameof(hostSettings), hostSettings);
             var learningTransportInfrastructure = new LearningTransportInfrastructure(hostSettings, this, receivers);

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportDispatcher.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportDispatcher.cs
@@ -29,7 +29,7 @@ namespace NServiceBus
                 DispatchMulticast(outgoingMessages.MulticastTransportOperations, transaction, cancellationToken));
         }
 
-        async Task DispatchMulticast(IEnumerable<MulticastTransportOperation> transportOperations, TransportTransaction transaction, CancellationToken cancellationToken = default)
+        async Task DispatchMulticast(IEnumerable<MulticastTransportOperation> transportOperations, TransportTransaction transaction, CancellationToken cancellationToken)
         {
             var tasks = new List<Task>();
 
@@ -48,7 +48,7 @@ namespace NServiceBus
                 .ConfigureAwait(false);
         }
 
-        Task DispatchUnicast(IEnumerable<UnicastTransportOperation> operations, TransportTransaction transaction, CancellationToken cancellationToken = default)
+        Task DispatchUnicast(IEnumerable<UnicastTransportOperation> operations, TransportTransaction transaction, CancellationToken cancellationToken)
         {
             return Task.WhenAll(operations.Select(operation =>
             {
@@ -58,7 +58,7 @@ namespace NServiceBus
             }));
         }
 
-        async Task WriteMessage(string destination, IOutgoingTransportOperation transportOperation, TransportTransaction transaction, CancellationToken cancellationToken = default)
+        async Task WriteMessage(string destination, IOutgoingTransportOperation transportOperation, TransportTransaction transaction, CancellationToken cancellationToken)
         {
             var message = transportOperation.Message;
 
@@ -133,7 +133,7 @@ namespace NServiceBus
             }
         }
 
-        async Task<IEnumerable<string>> GetSubscribersFor(Type messageType, CancellationToken cancellationToken = default)
+        async Task<IEnumerable<string>> GetSubscribersFor(Type messageType, CancellationToken cancellationToken)
         {
             var subscribers = new HashSet<string>();
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportDispatcher.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportDispatcher.cs
@@ -22,14 +22,14 @@ namespace NServiceBus
             this.maxMessageSizeKB = maxMessageSizeKB;
         }
 
-        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken)
+        public Task Dispatch(TransportOperations outgoingMessages, TransportTransaction transaction, CancellationToken cancellationToken = default)
         {
             return Task.WhenAll(
                 DispatchUnicast(outgoingMessages.UnicastTransportOperations, transaction, cancellationToken),
                 DispatchMulticast(outgoingMessages.MulticastTransportOperations, transaction, cancellationToken));
         }
 
-        async Task DispatchMulticast(IEnumerable<MulticastTransportOperation> transportOperations, TransportTransaction transaction, CancellationToken cancellationToken)
+        async Task DispatchMulticast(IEnumerable<MulticastTransportOperation> transportOperations, TransportTransaction transaction, CancellationToken cancellationToken = default)
         {
             var tasks = new List<Task>();
 
@@ -48,7 +48,7 @@ namespace NServiceBus
                 .ConfigureAwait(false);
         }
 
-        Task DispatchUnicast(IEnumerable<UnicastTransportOperation> operations, TransportTransaction transaction, CancellationToken cancellationToken)
+        Task DispatchUnicast(IEnumerable<UnicastTransportOperation> operations, TransportTransaction transaction, CancellationToken cancellationToken = default)
         {
             return Task.WhenAll(operations.Select(operation =>
             {
@@ -58,7 +58,7 @@ namespace NServiceBus
             }));
         }
 
-        async Task WriteMessage(string destination, IOutgoingTransportOperation transportOperation, TransportTransaction transaction, CancellationToken cancellationToken)
+        async Task WriteMessage(string destination, IOutgoingTransportOperation transportOperation, TransportTransaction transaction, CancellationToken cancellationToken = default)
         {
             var message = transportOperation.Message;
 
@@ -133,7 +133,7 @@ namespace NServiceBus
             }
         }
 
-        async Task<IEnumerable<string>> GetSubscribersFor(Type messageType, CancellationToken cancellationToken)
+        async Task<IEnumerable<string>> GetSubscribersFor(Type messageType, CancellationToken cancellationToken = default)
         {
             var subscribers = new HashSet<string>();
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
@@ -98,7 +98,7 @@
         public const string StorageLocationKey = "LearningTransport.StoragePath";
         public const string NoPayloadSizeRestrictionKey = "LearningTransport.NoPayloadSizeRestrictionKey";
 
-        public override Task Shutdown(CancellationToken cancellationToken)
+        public override Task Shutdown(CancellationToken cancellationToken = default)
         {
             return Task.CompletedTask;
         }

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -50,7 +50,7 @@
             delayedMessagePoller = new DelayedMessagePoller(messagePumpBasePath, delayedDir);
         }
 
-        public Task Initialize(PushRuntimeSettings limitations, OnMessage onMessage, OnError onError, OnCompleted onCompleted, CancellationToken cancellationToken)
+        public Task Initialize(PushRuntimeSettings limitations, OnMessage onMessage, OnError onError, OnCompleted onCompleted, CancellationToken cancellationToken = default)
         {
             this.onMessage = onMessage;
             this.onError = onError;
@@ -69,7 +69,7 @@
             return Task.CompletedTask;
         }
 
-        public Task StartReceive(CancellationToken cancellationToken)
+        public Task StartReceive(CancellationToken cancellationToken = default)
         {
             messagePumpCancellationTokenSource = new CancellationTokenSource();
             messageProcessingCancellationTokenSource = new CancellationTokenSource();
@@ -81,7 +81,7 @@
             return Task.CompletedTask;
         }
 
-        public async Task StopReceive(CancellationToken cancellationToken)
+        public async Task StopReceive(CancellationToken cancellationToken = default)
         {
             messagePumpCancellationTokenSource?.Cancel();
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportSubscriptionManager.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportSubscriptionManager.cs
@@ -64,7 +64,7 @@
             }
         }
 
-        async Task Subscribe(MessageMetadata eventType, CancellationToken cancellationToken = default)
+        async Task Subscribe(MessageMetadata eventType, CancellationToken cancellationToken)
         {
             var eventDir = GetEventDirectory(eventType.MessageType);
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportSubscriptionManager.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportSubscriptionManager.cs
@@ -1,12 +1,12 @@
 ﻿namespace NServiceBus
 {
-    using Unicast.Messages;
     using System;
     using System.IO;
+    using System.Threading;
     using System.Threading.Tasks;
     using Extensibility;
     using Transport;
-    using System.Threading;
+    using Unicast.Messages;
 
     class LearningTransportSubscriptionManager : ISubscriptionManager
     {
@@ -17,7 +17,7 @@
             this.basePath = Path.Combine(basePath, ".events");
         }
 
-        public Task SubscribeAll(MessageMetadata[] eventTypes, ContextBag context, CancellationToken cancellationToken)
+        public Task SubscribeAll(MessageMetadata[] eventTypes, ContextBag context, CancellationToken cancellationToken = default)
         {
             var tasks = new Task[eventTypes.Length];
             for (int i = 0; i < eventTypes.Length; i++)
@@ -28,7 +28,7 @@
             return Task.WhenAll(tasks);
         }
 
-        public async Task Unsubscribe(MessageMetadata eventType, ContextBag context, CancellationToken cancellationToken)
+        public async Task Unsubscribe(MessageMetadata eventType, ContextBag context, CancellationToken cancellationToken = default)
         {
             var eventDir = GetEventDirectory(eventType.MessageType);
             var subscriptionEntryPath = GetSubscriptionEntryPath(eventDir);
@@ -64,7 +64,7 @@
             }
         }
 
-        async Task Subscribe(MessageMetadata eventType, CancellationToken cancellationToken)
+        async Task Subscribe(MessageMetadata eventType, CancellationToken cancellationToken = default)
         {
             var eventDir = GetEventDirectory(eventType.MessageType);
 

--- a/src/NServiceBus.Core/Transports/Learning/NoTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/NoTransaction.cs
@@ -14,7 +14,7 @@ namespace NServiceBus
 
         public string FileToProcess { get; private set; }
 
-        public Task<bool> BeginTransaction(string incomingFilePath, CancellationToken cancellationToken)
+        public Task<bool> BeginTransaction(string incomingFilePath, CancellationToken cancellationToken = default)
         {
             Directory.CreateDirectory(processingDirectory);
             FileToProcess = Path.Combine(processingDirectory, Path.GetFileName(incomingFilePath));
@@ -22,9 +22,9 @@ namespace NServiceBus
             return AsyncFile.Move(incomingFilePath, FileToProcess, cancellationToken);
         }
 
-        public Task Enlist(string messagePath, string messageContents, CancellationToken cancellationToken) => AsyncFile.WriteText(messagePath, messageContents, cancellationToken);
+        public Task Enlist(string messagePath, string messageContents, CancellationToken cancellationToken = default) => AsyncFile.WriteText(messagePath, messageContents, cancellationToken);
 
-        public Task Commit(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task Commit(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         public void Rollback() { }
 

--- a/src/NServiceBus.Core/Transports/TransportDefinition.cs
+++ b/src/NServiceBus.Core/Transports/TransportDefinition.cs
@@ -30,7 +30,7 @@ namespace NServiceBus.Transport
         /// default capabilities as well as for initializing the transport's configuration based on those settings (the user cannot
         /// provide information anymore at this stage).
         /// </summary>
-        public abstract Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken);
+        public abstract Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken = default);
 
 
         /// <summary>

--- a/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
@@ -22,6 +22,6 @@ namespace NServiceBus.Transport
         /// <summary>
         /// Disposes all transport internal resources.
         /// </summary>
-        public abstract Task Shutdown(CancellationToken cancellationToken);
+        public abstract Task Shutdown(CancellationToken cancellationToken = default);
     }
 }

--- a/src/NServiceBus.Core/Transports/TransportSeam.cs
+++ b/src/NServiceBus.Core/Transports/TransportSeam.cs
@@ -25,7 +25,7 @@
             this.receivers = receivers;
         }
 
-        public async Task<TransportInfrastructure> CreateTransportInfrastructure(CancellationToken cancellationToken)
+        public async Task<TransportInfrastructure> CreateTransportInfrastructure(CancellationToken cancellationToken = default)
         {
             TransportInfrastructure = await TransportDefinition.Initialize(hostSettings, receivers, QueueBindings.SendingAddresses.ToArray(), cancellationToken)
                 .ConfigureAwait(false);

--- a/src/NServiceBus.PersistenceTests/Outbox/OutboxStorageTests.cs
+++ b/src/NServiceBus.PersistenceTests/Outbox/OutboxStorageTests.cs
@@ -35,19 +35,19 @@
             var ctx = configuration.GetContextBagForOutbox();
 
             var messageId = Guid.NewGuid().ToString();
-            await storage.Get(messageId, ctx, default);
+            await storage.Get(messageId, ctx);
 
             var messageToStore = new OutboxMessage(messageId, new[] { new TransportOperation("x", null, null, null) });
-            using (var transaction = await storage.BeginTransaction(ctx, default))
+            using (var transaction = await storage.BeginTransaction(ctx))
             {
-                await storage.Store(messageToStore, transaction, ctx, default);
+                await storage.Store(messageToStore, transaction, ctx);
 
-                await transaction.Commit(default);
+                await transaction.Commit();
             }
 
-            await storage.SetAsDispatched(messageId, ctx, default);
+            await storage.SetAsDispatched(messageId, ctx);
 
-            var message = await storage.Get(messageId, configuration.GetContextBagForOutbox(), default);
+            var message = await storage.Get(messageId, configuration.GetContextBagForOutbox());
 
             Assert.That(message, Is.Not.Null);
             CollectionAssert.IsEmpty(message.TransportOperations);
@@ -63,21 +63,21 @@
             var storage = configuration.OutboxStorage;
             var winningContextBag = configuration.GetContextBagForOutbox();
             var losingContextBag = configuration.GetContextBagForOutbox();
-            await storage.Get("MySpecialId", winningContextBag, default);
-            await storage.Get("MySpecialId", losingContextBag, default);
+            await storage.Get("MySpecialId", winningContextBag);
+            await storage.Get("MySpecialId", losingContextBag);
 
-            using (var transactionA = await storage.BeginTransaction(winningContextBag, default))
+            using (var transactionA = await storage.BeginTransaction(winningContextBag))
             {
-                await storage.Store(new OutboxMessage("MySpecialId", new TransportOperation[0]), transactionA, winningContextBag, default);
-                await transactionA.Commit(default);
+                await storage.Store(new OutboxMessage("MySpecialId", new TransportOperation[0]), transactionA, winningContextBag);
+                await transactionA.Commit();
             }
 
             try
             {
-                using (var transactionB = await storage.BeginTransaction(losingContextBag, default))
+                using (var transactionB = await storage.BeginTransaction(losingContextBag))
                 {
-                    await storage.Store(new OutboxMessage("MySpecialId", new TransportOperation[0]), transactionB, losingContextBag, default);
-                    await transactionB.Commit(default);
+                    await storage.Store(new OutboxMessage("MySpecialId", new TransportOperation[0]), transactionB, losingContextBag);
+                    await transactionB.Commit();
                 }
             }
             catch (Exception)
@@ -96,17 +96,17 @@
             var ctx = configuration.GetContextBagForOutbox();
 
             var messageId = Guid.NewGuid().ToString();
-            await storage.Get(messageId, ctx, default);
+            await storage.Get(messageId, ctx);
 
-            using (var transaction = await storage.BeginTransaction(ctx, default))
+            using (var transaction = await storage.BeginTransaction(ctx))
             {
                 var messageToStore = new OutboxMessage(messageId, new[] { new TransportOperation("x", null, null, null) });
-                await storage.Store(messageToStore, transaction, ctx, default);
+                await storage.Store(messageToStore, transaction, ctx);
 
                 // do not commit
             }
 
-            var message = await storage.Get(messageId, configuration.GetContextBagForOutbox(), default);
+            var message = await storage.Get(messageId, configuration.GetContextBagForOutbox());
             Assert.Null(message);
         }
 
@@ -119,17 +119,17 @@
             var ctx = configuration.GetContextBagForOutbox();
 
             var messageId = Guid.NewGuid().ToString();
-            await storage.Get(messageId, ctx, default);
+            await storage.Get(messageId, ctx);
 
-            using (var transaction = await storage.BeginTransaction(ctx, default))
+            using (var transaction = await storage.BeginTransaction(ctx))
             {
                 var messageToStore = new OutboxMessage(messageId, new[] { new TransportOperation("x", null, null, null) });
-                await storage.Store(messageToStore, transaction, ctx, default);
+                await storage.Store(messageToStore, transaction, ctx);
 
-                await transaction.Commit(default);
+                await transaction.Commit();
             }
 
-            var message = await storage.Get(messageId, configuration.GetContextBagForOutbox(), default);
+            var message = await storage.Get(messageId, configuration.GetContextBagForOutbox());
             Assert.NotNull(message);
         }
 

--- a/src/NServiceBus.PersistenceTests/Sagas/SagaPersisterTests.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/SagaPersisterTests.cs
@@ -31,10 +31,10 @@
         protected async Task SaveSaga<TSagaData>(TSagaData saga) where TSagaData : class, IContainSagaData, new()
         {
             var insertContextBag = configuration.GetContextBagForSagaStorage();
-            using (var insertSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag, default))
+            using (var insertSession = await configuration.SynchronizedStorage.OpenSession(insertContextBag))
             {
                 await SaveSagaWithSession(saga, insertSession, insertContextBag);
-                await insertSession.CompleteAsync(default);
+                await insertSession.CompleteAsync();
             }
         }
 
@@ -43,7 +43,7 @@
         {
             SetupNewSaga(saga);
             var correlationProperty = GetSagaCorrelationProperty(saga);
-            await configuration.SagaStorage.Save(saga, correlationProperty, session, context, default);
+            await configuration.SagaStorage.Save(saga, correlationProperty, session, context);
         }
 
         protected async Task<TSagaData> GetByCorrelationProperty<TSagaData>(string correlatedPropertyName, object correlationPropertyData) where TSagaData : class, IContainSagaData, new()
@@ -52,11 +52,11 @@
             TSagaData sagaData;
             var persister = configuration.SagaStorage;
 
-            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context, default))
+            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context))
             {
-                sagaData = await persister.Get<TSagaData>(correlatedPropertyName, correlationPropertyData, completeSession, context, default);
+                sagaData = await persister.Get<TSagaData>(correlatedPropertyName, correlationPropertyData, completeSession, context);
 
-                await completeSession.CompleteAsync(default);
+                await completeSession.CompleteAsync();
             }
 
             return sagaData;
@@ -66,11 +66,11 @@
         {
             var readContextBag = configuration.GetContextBagForSagaStorage();
             TSagaData sagaData;
-            using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag, default))
+            using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
             {
-                sagaData = await configuration.SagaStorage.Get<TSagaData>(sagaId, readSession, readContextBag, default);
+                sagaData = await configuration.SagaStorage.Get<TSagaData>(sagaId, readSession, readContextBag);
 
-                await readSession.CompleteAsync(default);
+                await readSession.CompleteAsync();
             }
 
             return sagaData;

--- a/src/NServiceBus.PersistenceTests/Sagas/When_completing_a_saga_loaded_by_id.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_completing_a_saga_loaded_by_id.cs
@@ -13,12 +13,12 @@
             await SaveSaga(saga);
 
             var context = configuration.GetContextBagForSagaStorage();
-            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context, default))
+            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context))
             {
-                var sagaData = await configuration.SagaStorage.Get<TestSagaData>(saga.Id, completeSession, context, default);
+                var sagaData = await configuration.SagaStorage.Get<TestSagaData>(saga.Id, completeSession, context);
 
-                await configuration.SagaStorage.Complete(sagaData, completeSession, context, default);
-                await completeSession.CompleteAsync(default);
+                await configuration.SagaStorage.Complete(sagaData, completeSession, context);
+                await completeSession.CompleteAsync();
             }
 
             var completedSaga = await GetById<TestSagaData>(saga.Id);

--- a/src/NServiceBus.PersistenceTests/Sagas/When_completing_a_saga_with_correlation_property.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_completing_a_saga_with_correlation_property.cs
@@ -15,12 +15,12 @@
 
             const string correlatedPropertyName = nameof(SagaWithCorrelationPropertyData.CorrelatedProperty);
             var context = configuration.GetContextBagForSagaStorage();
-            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context, default))
+            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context))
             {
-                var sagaData = await configuration.SagaStorage.Get<SagaWithCorrelationPropertyData>(correlatedPropertyName, correlationPropertyData, completeSession, context, default);
+                var sagaData = await configuration.SagaStorage.Get<SagaWithCorrelationPropertyData>(correlatedPropertyName, correlationPropertyData, completeSession, context);
 
-                await configuration.SagaStorage.Complete(sagaData, completeSession, context, default);
-                await completeSession.CompleteAsync(default);
+                await configuration.SagaStorage.Complete(sagaData, completeSession, context);
+                await completeSession.CompleteAsync();
             }
 
             var completedSaga = await GetByCorrelationProperty<SagaWithCorrelationPropertyData>(correlatedPropertyName, correlationPropertyData);

--- a/src/NServiceBus.PersistenceTests/Sagas/When_completing_saga_with_no_mapping_loaded_by_id.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_completing_saga_with_no_mapping_loaded_by_id.cs
@@ -24,12 +24,12 @@
             await SaveSaga(saga);
 
             var context = configuration.GetContextBagForSagaStorage();
-            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context, default))
+            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context))
             {
-                var sagaData = await configuration.SagaStorage.Get<SagaWithoutCorrelationPropertyData>(saga.Id, completeSession, context, default);
+                var sagaData = await configuration.SagaStorage.Get<SagaWithoutCorrelationPropertyData>(saga.Id, completeSession, context);
 
-                await configuration.SagaStorage.Complete(sagaData, completeSession, context, default);
-                await completeSession.CompleteAsync(default);
+                await configuration.SagaStorage.Complete(sagaData, completeSession, context);
+                await completeSession.CompleteAsync();
             }
 
             var result = await GetById<SagaWithoutCorrelationPropertyData>(saga.Id);
@@ -64,7 +64,7 @@
 
         public class CustomFinder : IFindSagas<SagaWithoutCorrelationPropertyData>.Using<SagaWithoutCorrelationPropertyStartingMessage>
         {
-            public Task<SagaWithoutCorrelationPropertyData> FindBy(SagaWithoutCorrelationPropertyStartingMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken)
+            public Task<SagaWithoutCorrelationPropertyData> FindBy(SagaWithoutCorrelationPropertyStartingMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken = default)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.PersistenceTests/Sagas/When_concurrent_update_exceed_lock_request_timeout_pessimistic.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_concurrent_update_exceed_lock_request_timeout_pessimistic.cs
@@ -28,34 +28,34 @@
             async Task FirstSession()
             {
                 var firstSessionContext = configuration.GetContextBagForSagaStorage();
-                using (var firstSaveSession = await configuration.SynchronizedStorage.OpenSession(firstSessionContext, default))
+                using (var firstSaveSession = await configuration.SynchronizedStorage.OpenSession(firstSessionContext))
                 {
-                    var record = await persister.Get<TestSagaData>(saga.Id, firstSaveSession, firstSessionContext, default);
+                    var record = await persister.Get<TestSagaData>(saga.Id, firstSaveSession, firstSessionContext);
                     firstSessionGetDone.SetResult(true);
 
                     await Task.Delay(1000).ConfigureAwait(false);
                     await secondSessionGetDone.Task.ConfigureAwait(false);
 
                     record.SagaProperty = "session 1 value";
-                    await persister.Update(record, firstSaveSession, firstSessionContext, default);
-                    await firstSaveSession.CompleteAsync(default);
+                    await persister.Update(record, firstSaveSession, firstSessionContext);
+                    await firstSaveSession.CompleteAsync();
                 }
             }
 
             async Task SecondSession()
             {
                 var secondContext = configuration.GetContextBagForSagaStorage();
-                using (var secondSession = await configuration.SynchronizedStorage.OpenSession(secondContext, default))
+                using (var secondSession = await configuration.SynchronizedStorage.OpenSession(secondContext))
                 {
                     await firstSessionGetDone.Task.ConfigureAwait(false);
 
-                    var recordTask = persister.Get<TestSagaData>(saga.Id, secondSession, secondContext, default);
+                    var recordTask = persister.Get<TestSagaData>(saga.Id, secondSession, secondContext);
                     secondSessionGetDone.SetResult(true);
 
                     var record = await recordTask.ConfigureAwait(false);
                     record.SagaProperty = "session 2 value";
-                    await persister.Update(record, secondSession, secondContext, default);
-                    await secondSession.CompleteAsync(default);
+                    await persister.Update(record, secondSession, secondContext);
+                    await secondSession.CompleteAsync();
                 }
             }
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
@@ -29,19 +29,19 @@
                     transportTransaction.Set(Transaction.Current);
 
                     var unenlistedContextBag = configuration.GetContextBagForSagaStorage();
-                    using (var unenlistedSession = await configuration.SynchronizedStorage.OpenSession(unenlistedContextBag, default))
+                    using (var unenlistedSession = await configuration.SynchronizedStorage.OpenSession(unenlistedContextBag))
                     {
                         var enlistedContextBag = configuration.GetContextBagForSagaStorage();
-                        var enlistedSession = await storageAdapter.TryAdapt(transportTransaction, enlistedContextBag, default);
+                        var enlistedSession = await storageAdapter.TryAdapt(transportTransaction, enlistedContextBag);
 
-                        var unenlistedRecord = await persister.Get<TestSagaData>(generatedSagaId, unenlistedSession, unenlistedContextBag, default);
+                        var unenlistedRecord = await persister.Get<TestSagaData>(generatedSagaId, unenlistedSession, unenlistedContextBag);
 
-                        var enlistedRecord = await persister.Get<TestSagaData>(generatedSagaId, enlistedSession, enlistedContextBag, default);
+                        var enlistedRecord = await persister.Get<TestSagaData>(generatedSagaId, enlistedSession, enlistedContextBag);
 
-                        await persister.Update(unenlistedRecord, unenlistedSession, unenlistedContextBag, default);
-                        await persister.Update(enlistedRecord, enlistedSession, enlistedContextBag, default);
+                        await persister.Update(unenlistedRecord, unenlistedSession, unenlistedContextBag);
+                        await persister.Update(enlistedRecord, enlistedSession, enlistedContextBag);
 
-                        await unenlistedSession.CompleteAsync(default);
+                        await unenlistedSession.CompleteAsync();
                     }
 
                     tx.Complete();

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_no_mapping.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_no_mapping.cs
@@ -56,7 +56,7 @@
 
         public class CustomFinder : IFindSagas<SagaWithoutCorrelationPropertyData>.Using<SagaWithoutCorrelationPropertyStartingMessage>
         {
-            public Task<SagaWithoutCorrelationPropertyData> FindBy(SagaWithoutCorrelationPropertyStartingMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken)
+            public Task<SagaWithoutCorrelationPropertyData> FindBy(SagaWithoutCorrelationPropertyStartingMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken = default)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_a_completed_saga.cs
@@ -17,26 +17,26 @@
 
             await SaveSaga(saga1);
             var context1 = configuration.GetContextBagForSagaStorage();
-            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context1, default))
+            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context1))
             {
-                var sagaData = await persister.Get<SagaWithCorrelationPropertyData>(nameof(saga1.CorrelatedProperty), correlationPropertyData, completeSession, context1, default);
+                var sagaData = await persister.Get<SagaWithCorrelationPropertyData>(nameof(saga1.CorrelatedProperty), correlationPropertyData, completeSession, context1);
                 Assert.AreEqual(saga1.DataProperty, sagaData.DataProperty);
 
-                await persister.Complete(sagaData, completeSession, context1, default);
-                await completeSession.CompleteAsync(default);
+                await persister.Complete(sagaData, completeSession, context1);
+                await completeSession.CompleteAsync();
             }
 
             Assert.IsNull(await GetById<SagaWithCorrelationPropertyData>(saga1.Id));
 
             await SaveSaga(saga2);
             var context2 = configuration.GetContextBagForSagaStorage();
-            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context2, default))
+            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context2))
             {
-                var sagaData = await persister.Get<SagaWithCorrelationPropertyData>(nameof(saga2.CorrelatedProperty), correlationPropertyData, completeSession, context2, default);
+                var sagaData = await persister.Get<SagaWithCorrelationPropertyData>(nameof(saga2.CorrelatedProperty), correlationPropertyData, completeSession, context2);
                 Assert.AreEqual(saga2.DataProperty, sagaData.DataProperty);
 
-                await persister.Complete(sagaData, completeSession, context2, default);
-                await completeSession.CompleteAsync(default);
+                await persister.Complete(sagaData, completeSession, context2);
+                await completeSession.CompleteAsync();
             }
 
             Assert.IsNull(await GetById<SagaWithCorrelationPropertyData>(saga2.Id));

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_the_same_unique_property_as_another_saga.cs
@@ -22,19 +22,19 @@
             };
 
             var winningContextBag = configuration.GetContextBagForSagaStorage();
-            using (var winningSession = await configuration.SynchronizedStorage.OpenSession(winningContextBag, default))
+            using (var winningSession = await configuration.SynchronizedStorage.OpenSession(winningContextBag))
             {
                 await SaveSagaWithSession(saga1, winningSession, winningContextBag);
-                await winningSession.CompleteAsync(default);
+                await winningSession.CompleteAsync();
             }
 
             var losingContextBag = configuration.GetContextBagForSagaStorage();
-            using (var losingSession = await configuration.SynchronizedStorage.OpenSession(losingContextBag, default))
+            using (var losingSession = await configuration.SynchronizedStorage.OpenSession(losingContextBag))
             {
                 Assert.That(async () =>
                 {
                     await SaveSagaWithSession(saga2, losingSession, losingContextBag);
-                    await losingSession.CompleteAsync(default);
+                    await losingSession.CompleteAsync();
                 }, Throws.InstanceOf<Exception>());
             }
         }

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_different_sagas_with_same_correlation_property_value.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_different_sagas_with_same_correlation_property_value.cs
@@ -22,20 +22,20 @@
 
             var persister = configuration.SagaStorage;
             var savingContextBag = configuration.GetContextBagForSagaStorage();
-            using (var session = await configuration.SynchronizedStorage.OpenSession(savingContextBag, default))
+            using (var session = await configuration.SynchronizedStorage.OpenSession(savingContextBag))
             {
                 await SaveSagaWithSession(saga1, session, savingContextBag);
                 await SaveSagaWithSession(saga2, session, savingContextBag);
 
-                await session.CompleteAsync(default);
+                await session.CompleteAsync();
             }
 
             var readContextBag = configuration.GetContextBagForSagaStorage();
-            using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag, default))
+            using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
             {
-                var saga1Result = await persister.Get<SagaWithCorrelationPropertyData>(nameof(SagaWithCorrelationPropertyData.CorrelatedProperty), saga1.CorrelatedProperty, readSession, readContextBag, default);
+                var saga1Result = await persister.Get<SagaWithCorrelationPropertyData>(nameof(SagaWithCorrelationPropertyData.CorrelatedProperty), saga1.CorrelatedProperty, readSession, readContextBag);
 
-                var saga2Result = await persister.Get<AnotherSagaWithCorrelatedPropertyData>(nameof(AnotherSagaWithCorrelatedPropertyData.CorrelatedProperty), saga2.CorrelatedProperty, readSession, readContextBag, default);
+                var saga2Result = await persister.Get<AnotherSagaWithCorrelatedPropertyData>(nameof(AnotherSagaWithCorrelatedPropertyData.CorrelatedProperty), saga2.CorrelatedProperty, readSession, readContextBag);
 
                 Assert.AreEqual(saga1.CorrelatedProperty, saga1Result.CorrelatedProperty);
                 Assert.AreEqual(saga2.CorrelatedProperty, saga2Result.CorrelatedProperty);

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_different_sagas_without_mapping.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_different_sagas_without_mapping.cs
@@ -27,19 +27,19 @@
             };
 
             var savingContextBag = configuration.GetContextBagForSagaStorage();
-            using (var session = await configuration.SynchronizedStorage.OpenSession(savingContextBag, default))
+            using (var session = await configuration.SynchronizedStorage.OpenSession(savingContextBag))
             {
                 await SaveSagaWithSession(saga1, session, savingContextBag);
                 await SaveSagaWithSession(saga2, session, savingContextBag);
-                await session.CompleteAsync(default);
+                await session.CompleteAsync();
             }
 
             var readContextBag = configuration.GetContextBagForSagaStorage();
-            using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag, default))
+            using (var readSession = await configuration.SynchronizedStorage.OpenSession(readContextBag))
             {
-                var saga1Result = await configuration.SagaStorage.Get<SagaWithoutCorrelationPropertyData>(saga1.Id, readSession, readContextBag, default);
+                var saga1Result = await configuration.SagaStorage.Get<SagaWithoutCorrelationPropertyData>(saga1.Id, readSession, readContextBag);
 
-                var saga2Result = await configuration.SagaStorage.Get<AnotherSagaWithoutCorrelationPropertyData>(saga2.Id, readSession, readContextBag, default);
+                var saga2Result = await configuration.SagaStorage.Get<AnotherSagaWithoutCorrelationPropertyData>(saga2.Id, readSession, readContextBag);
 
                 Assert.AreEqual(saga1.FoundByFinderProperty, saga1Result.FoundByFinderProperty);
                 Assert.AreEqual(saga2.FoundByFinderProperty, saga2Result.FoundByFinderProperty);
@@ -62,7 +62,7 @@
 
         public class CustomFinder : IFindSagas<SagaWithoutCorrelationPropertyData>.Using<SagaWithoutCorrelationPropertyStartingMessage>
         {
-            public Task<SagaWithoutCorrelationPropertyData> FindBy(SagaWithoutCorrelationPropertyStartingMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken)
+            public Task<SagaWithoutCorrelationPropertyData> FindBy(SagaWithoutCorrelationPropertyStartingMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken = default)
             {
                 throw new NotImplementedException();
             }
@@ -96,7 +96,7 @@
 
         public class AnotherCustomFinder : IFindSagas<AnotherSagaWithoutCorrelationPropertyData>.Using<AnotherSagaWithoutCorrelationPropertyStartingMessage>
         {
-            public Task<AnotherSagaWithoutCorrelationPropertyData> FindBy(AnotherSagaWithoutCorrelationPropertyStartingMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken)
+            public Task<AnotherSagaWithoutCorrelationPropertyData> FindBy(AnotherSagaWithoutCorrelationPropertyStartingMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken = default)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.PersistenceTests/Sagas/When_rolling_back_storage_session.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_rolling_back_storage_session.cs
@@ -17,12 +17,12 @@
             await SaveSaga(sagaData);
 
             var contextBag = configuration.GetContextBagForSagaStorage();
-            using (var session = await configuration.SynchronizedStorage.OpenSession(contextBag, default))
+            using (var session = await configuration.SynchronizedStorage.OpenSession(contextBag))
             {
-                var sagaFromStorage = await configuration.SagaStorage.Get<TestSagaData>(sagaData.Id, session, contextBag, default);
+                var sagaFromStorage = await configuration.SagaStorage.Get<TestSagaData>(sagaData.Id, session, contextBag);
                 sagaFromStorage.SomethingWeCareAbout = "Particular.Platform";
 
-                await configuration.SagaStorage.Update(sagaFromStorage, session, contextBag, default);
+                await configuration.SagaStorage.Update(sagaFromStorage, session, contextBag);
 
                 // Do not complete
             }
@@ -43,7 +43,7 @@
             };
 
             var contextBag = configuration.GetContextBagForSagaStorage();
-            using (var session = await configuration.SynchronizedStorage.OpenSession(contextBag, default))
+            using (var session = await configuration.SynchronizedStorage.OpenSession(contextBag))
             {
                 await SaveSagaWithSession(sagaData, session, contextBag);
                 // Do not complete
@@ -66,11 +66,11 @@
             await SaveSaga(sagaData);
 
             var contextBag = configuration.GetContextBagForSagaStorage();
-            using (var session = await configuration.SynchronizedStorage.OpenSession(contextBag, default))
+            using (var session = await configuration.SynchronizedStorage.OpenSession(contextBag))
             {
-                var sagaFromStorage = await configuration.SagaStorage.Get<TestSagaData>(sagaData.Id, session, contextBag, default);
+                var sagaFromStorage = await configuration.SagaStorage.Get<TestSagaData>(sagaData.Id, session, contextBag);
 
-                await configuration.SagaStorage.Complete(sagaFromStorage, session, contextBag, default);
+                await configuration.SagaStorage.Complete(sagaFromStorage, session, contextBag);
 
                 // Do not complete
             }

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_on_same_thread.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_on_same_thread.cs
@@ -24,25 +24,25 @@
             var persister = configuration.SagaStorage;
 
             var winningContext = configuration.GetContextBagForSagaStorage();
-            using (var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext, default))
+            using (var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext))
             {
-                var record = await persister.Get<TestSagaData>(generatedSagaId, winningSaveSession, winningContext, default);
+                var record = await persister.Get<TestSagaData>(generatedSagaId, winningSaveSession, winningContext);
 
                 losingContext = configuration.GetContextBagForSagaStorage();
-                losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingContext, default);
-                staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingContext, default);
+                losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingContext);
+                staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingContext);
 
                 record.DateTimeProperty = DateTime.UtcNow;
-                await persister.Update(record, winningSaveSession, winningContext, default);
-                await winningSaveSession.CompleteAsync(default);
+                await persister.Update(record, winningSaveSession, winningContext);
+                await winningSaveSession.CompleteAsync();
             }
 
             try
             {
                 Assert.CatchAsync<Exception>(async () =>
                 {
-                    await persister.Update(staleRecord, losingSaveSession, losingContext, default);
-                    await losingSaveSession.CompleteAsync(default);
+                    await persister.Update(staleRecord, losingSaveSession, losingContext);
+                    await losingSaveSession.CompleteAsync();
                 });
             }
             finally

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_twice_on_the_same_thread.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_twice_on_the_same_thread.cs
@@ -23,19 +23,19 @@
             var persister = configuration.SagaStorage;
 
             var winningContext1 = configuration.GetContextBagForSagaStorage();
-            var winningSaveSession1 = await configuration.SynchronizedStorage.OpenSession(winningContext1, default);
+            var winningSaveSession1 = await configuration.SynchronizedStorage.OpenSession(winningContext1);
 
             try
             {
-                var record1 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession1, winningContext1, default);
+                var record1 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession1, winningContext1);
 
                 losingContext1 = configuration.GetContextBagForSagaStorage();
-                losingSaveSession1 = await configuration.SynchronizedStorage.OpenSession(losingContext1, default);
-                staleRecord1 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession1, losingContext1, default);
+                losingSaveSession1 = await configuration.SynchronizedStorage.OpenSession(losingContext1);
+                staleRecord1 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession1, losingContext1);
 
                 record1.DateTimeProperty = DateTime.UtcNow;
-                await persister.Update(record1, winningSaveSession1, winningContext1, default);
-                await winningSaveSession1.CompleteAsync(default);
+                await persister.Update(record1, winningSaveSession1, winningContext1);
+                await winningSaveSession1.CompleteAsync();
             }
             finally
             {
@@ -46,8 +46,8 @@
             {
                 Assert.That(async () =>
                 {
-                    await persister.Update(staleRecord1, losingSaveSession1, losingContext1, default);
-                    await losingSaveSession1.CompleteAsync(default);
+                    await persister.Update(staleRecord1, losingSaveSession1, losingContext1);
+                    await losingSaveSession1.CompleteAsync();
                 }, Throws.InstanceOf<Exception>());
             }
             finally
@@ -60,18 +60,18 @@
             TestSagaData staleRecord2;
 
             var winningContext2 = configuration.GetContextBagForSagaStorage();
-            var winningSaveSession2 = await configuration.SynchronizedStorage.OpenSession(winningContext2, default);
+            var winningSaveSession2 = await configuration.SynchronizedStorage.OpenSession(winningContext2);
             try
             {
-                var record2 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession2, winningContext2, default);
+                var record2 = await persister.Get<TestSagaData>(saga.Id, winningSaveSession2, winningContext2);
 
                 losingContext2 = configuration.GetContextBagForSagaStorage();
-                losingSaveSession2 = await configuration.SynchronizedStorage.OpenSession(losingContext2, default);
-                staleRecord2 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession2, losingContext2, default);
+                losingSaveSession2 = await configuration.SynchronizedStorage.OpenSession(losingContext2);
+                staleRecord2 = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession2, losingContext2);
 
                 record2.DateTimeProperty = DateTime.UtcNow;
-                await persister.Update(record2, winningSaveSession2, winningContext2, default);
-                await winningSaveSession2.CompleteAsync(default);
+                await persister.Update(record2, winningSaveSession2, winningContext2);
+                await winningSaveSession2.CompleteAsync();
             }
             finally
             {
@@ -82,8 +82,8 @@
             {
                 Assert.That(async () =>
                  {
-                     await persister.Update(staleRecord2, losingSaveSession2, losingContext2, default);
-                     await losingSaveSession2.CompleteAsync(default);
+                     await persister.Update(staleRecord2, losingSaveSession2, losingContext2);
+                     await losingSaveSession2.CompleteAsync();
                  }, Throws.InstanceOf<Exception>());
             }
             finally

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_found_by_correlation_property.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_found_by_correlation_property.cs
@@ -22,14 +22,14 @@
             var context = configuration.GetContextBagForSagaStorage();
             var correlatedPropertyName = nameof(SagaWithCorrelationPropertyData.CorrelatedProperty);
             var persister = configuration.SagaStorage;
-            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context, default))
+            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context))
             {
-                var sagaData = await persister.Get<SagaWithCorrelationPropertyData>(correlatedPropertyName, correlationPropertyData, completeSession, context, default);
+                var sagaData = await persister.Get<SagaWithCorrelationPropertyData>(correlatedPropertyName, correlationPropertyData, completeSession, context);
 
                 sagaData.SomeProperty = updatedValue;
 
-                await persister.Update(sagaData, completeSession, context, default);
-                await completeSession.CompleteAsync(default);
+                await persister.Update(sagaData, completeSession, context);
+                await completeSession.CompleteAsync();
             }
 
             var updatedSagaData = await GetByCorrelationProperty<SagaWithCorrelationPropertyData>(correlatedPropertyName, correlationPropertyData);

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_found_by_id.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_found_by_id.cs
@@ -21,14 +21,14 @@
             var updatedValue = "bar";
             var context = configuration.GetContextBagForSagaStorage();
             var persister = configuration.SagaStorage;
-            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context, default))
+            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context))
             {
-                var sagaData = await persister.Get<SagaWithCorrelationPropertyData>(saga1.Id, completeSession, context, default);
+                var sagaData = await persister.Get<SagaWithCorrelationPropertyData>(saga1.Id, completeSession, context);
 
                 sagaData.SomeProperty = updatedValue;
 
-                await persister.Update(sagaData, completeSession, context, default);
-                await completeSession.CompleteAsync(default);
+                await persister.Update(sagaData, completeSession, context);
+                await completeSession.CompleteAsync();
             }
 
             var updatedSagaData = await GetById<SagaWithCorrelationPropertyData>(saga1.Id);

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_with_no_mapping_found_by_finder.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_with_no_mapping_found_by_finder.cs
@@ -23,15 +23,15 @@
 
             var updateValue = Guid.NewGuid().ToString();
             var context = configuration.GetContextBagForSagaStorage();
-            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context, default))
+            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context))
             {
                 // the saga won't be loaded via a persister.Get operation in this case
                 var customFinder = new CustomFinder(saga);
-                var sagaData = await customFinder.FindBy(new SagaWithoutCorrelationPropertyStartingMessage(), completeSession, context, default);
+                var sagaData = await customFinder.FindBy(new SagaWithoutCorrelationPropertyStartingMessage(), completeSession, context);
                 sagaData.SomeSagaProperty = updateValue;
 
-                await configuration.SagaStorage.Update(sagaData, completeSession, context, default);
-                await completeSession.CompleteAsync(default);
+                await configuration.SagaStorage.Update(sagaData, completeSession, context);
+                await completeSession.CompleteAsync();
             }
 
             var result = await GetById<SagaWithoutCorrelationPropertyData>(saga.Id);
@@ -62,7 +62,7 @@
                 this.sagaToFind = sagaToFind;
             }
 
-            public Task<SagaWithoutCorrelationPropertyData> FindBy(SagaWithoutCorrelationPropertyStartingMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken)
+            public Task<SagaWithoutCorrelationPropertyData> FindBy(SagaWithoutCorrelationPropertyStartingMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken = default)
             {
                 return Task.FromResult(sagaToFind);
             }

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_with_no_mapping_found_by_id.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_with_no_mapping_found_by_id.cs
@@ -24,13 +24,13 @@
 
             var updateValue = Guid.NewGuid().ToString();
             var context = configuration.GetContextBagForSagaStorage();
-            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context, default))
+            using (var completeSession = await configuration.SynchronizedStorage.OpenSession(context))
             {
-                sagaData = await configuration.SagaStorage.Get<SagaWithoutCorrelationPropertyData>(sagaData.Id, completeSession, context, default);
+                sagaData = await configuration.SagaStorage.Get<SagaWithoutCorrelationPropertyData>(sagaData.Id, completeSession, context);
                 sagaData.SomeSagaProperty = updateValue;
 
-                await configuration.SagaStorage.Update(sagaData, completeSession, context, default);
-                await completeSession.CompleteAsync(default);
+                await configuration.SagaStorage.Update(sagaData, completeSession, context);
+                await completeSession.CompleteAsync();
             }
 
             var result = await GetById<SagaWithoutCorrelationPropertyData>(sagaData.Id);
@@ -55,7 +55,7 @@
 
         public class CustomFinder : IFindSagas<SagaWithoutCorrelationPropertyData>.Using<SagaWithoutCorrelationPropertyStartingMessage>
         {
-            public Task<SagaWithoutCorrelationPropertyData> FindBy(SagaWithoutCorrelationPropertyStartingMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken)
+            public Task<SagaWithoutCorrelationPropertyData> FindBy(SagaWithoutCorrelationPropertyStartingMessage message, SynchronizedStorageSession storageSession, ReadOnlyContextBag context, CancellationToken cancellationToken = default)
             {
                 throw new NotImplementedException();
             }

--- a/src/NServiceBus.PersistenceTests/Sagas/When_worker_tries_to_complete_saga_update_by_another_optimistic.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_worker_tries_to_complete_saga_update_by_another_optimistic.cs
@@ -25,18 +25,18 @@
             TestSagaData staleRecord;
 
             var winningContext = configuration.GetContextBagForSagaStorage();
-            var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext, default);
+            var winningSaveSession = await configuration.SynchronizedStorage.OpenSession(winningContext);
             try
             {
-                var record = await persister.Get<TestSagaData>(saga.Id, winningSaveSession, winningContext, default);
+                var record = await persister.Get<TestSagaData>(saga.Id, winningSaveSession, winningContext);
 
                 losingContext = configuration.GetContextBagForSagaStorage();
-                losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingContext, default);
-                staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingContext, default);
+                losingSaveSession = await configuration.SynchronizedStorage.OpenSession(losingContext);
+                staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingContext);
 
                 record.DateTimeProperty = DateTime.UtcNow;
-                await persister.Update(record, winningSaveSession, winningContext, default);
-                await winningSaveSession.CompleteAsync(default);
+                await persister.Update(record, winningSaveSession, winningContext);
+                await winningSaveSession.CompleteAsync();
             }
             finally
             {
@@ -47,8 +47,8 @@
             {
                 Assert.That(async () =>
                 {
-                    await persister.Complete(staleRecord, losingSaveSession, losingContext, default);
-                    await losingSaveSession.CompleteAsync(default);
+                    await persister.Complete(staleRecord, losingSaveSession, losingContext);
+                    await losingSaveSession.CompleteAsync();
                 }, Throws.InstanceOf<Exception>());
             }
             finally

--- a/src/NServiceBus.PersistenceTests/Sagas/When_worker_tries_to_complete_saga_update_by_another_pessimistic.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_worker_tries_to_complete_saga_update_by_another_pessimistic.cs
@@ -25,32 +25,32 @@
             async Task FirstSession()
             {
                 var firstContent = configuration.GetContextBagForSagaStorage();
-                using (var firstSaveSession = await configuration.SynchronizedStorage.OpenSession(firstContent, default))
+                using (var firstSaveSession = await configuration.SynchronizedStorage.OpenSession(firstContent))
                 {
-                    var record = await persister.Get<TestSagaData>(saga.Id, firstSaveSession, firstContent, default);
+                    var record = await persister.Get<TestSagaData>(saga.Id, firstSaveSession, firstContent);
                     firstSessionGetDone.SetResult(true);
 
                     record.DateTimeProperty = firstSessionDateTimeValue;
-                    await persister.Update(record, firstSaveSession, firstContent, default);
+                    await persister.Update(record, firstSaveSession, firstContent);
                     await secondSessionGetDone.Task.ConfigureAwait(false);
-                    await firstSaveSession.CompleteAsync(default);
+                    await firstSaveSession.CompleteAsync();
                 }
             }
 
             async Task SecondSession()
             {
                 var secondContext = configuration.GetContextBagForSagaStorage();
-                using (var secondSession = await configuration.SynchronizedStorage.OpenSession(secondContext, default))
+                using (var secondSession = await configuration.SynchronizedStorage.OpenSession(secondContext))
                 {
                     await firstSessionGetDone.Task.ConfigureAwait(false);
 
-                    var recordTask = Task.Run(() => persister.Get<TestSagaData>(saga.Id, secondSession, secondContext, default));
+                    var recordTask = Task.Run(() => persister.Get<TestSagaData>(saga.Id, secondSession, secondContext));
                     secondSessionGetDone.SetResult(true);
 
                     var record = await recordTask.ConfigureAwait(false);
                     record.DateTimeProperty = secondSessionDateTimeValue;
-                    await persister.Update(record, secondSession, secondContext, default);
-                    await secondSession.CompleteAsync(default);
+                    await persister.Update(record, secondSession, secondContext);
+                    await secondSession.CompleteAsync();
                 }
             }
 

--- a/src/NServiceBus.TransportTests/ConfigureLearningTransportInfrastructure.cs
+++ b/src/NServiceBus.TransportTests/ConfigureLearningTransportInfrastructure.cs
@@ -17,7 +17,7 @@ class ConfigureLearningTransportInfrastructure : IConfigureTransportInfrastructu
         };
     }
 
-    public async Task<TransportInfrastructure> Configure(TransportDefinition transportDefinition, HostSettings hostSettings, string inputQueueName, string errorQueueName, CancellationToken cancellationToken)
+    public async Task<TransportInfrastructure> Configure(TransportDefinition transportDefinition, HostSettings hostSettings, string inputQueueName, string errorQueueName, CancellationToken cancellationToken = default)
     {
         var mainReceiverSettings = new ReceiveSettings(
             "mainReceiver",
@@ -35,7 +35,7 @@ class ConfigureLearningTransportInfrastructure : IConfigureTransportInfrastructu
         return transportInfrastructure;
     }
 
-    public Task Cleanup(CancellationToken cancellationToken)
+    public Task Cleanup(CancellationToken cancellationToken = default)
     {
         if (Directory.Exists(storageDir))
         {

--- a/src/NServiceBus.TransportTests/IConfigureTransportInfrastructure.cs
+++ b/src/NServiceBus.TransportTests/IConfigureTransportInfrastructure.cs
@@ -18,13 +18,13 @@ namespace NServiceBus.TransportTests
         /// <summary>
         /// Gives the transport a chance to configure before the test starts.
         /// </summary>
-        Task<TransportInfrastructure> Configure(TransportDefinition transportDefinition, HostSettings hostSettings, string inputQueueName, string errorQueueName, CancellationToken cancellationToken);
+        Task<TransportInfrastructure> Configure(TransportDefinition transportDefinition, HostSettings hostSettings, string inputQueueName, string errorQueueName, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gives the transport chance to clean up after the test is complete. Implementations of this class may store
         /// private variables during Configure to use during the cleanup phase.
         /// </summary>
         /// <returns>An async Task.</returns>
-        Task Cleanup(CancellationToken cancellationToken);
+        Task Cleanup(CancellationToken cancellationToken = default);
     }
 }

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -67,9 +67,9 @@
         public void TearDown()
         {
             testCancellationTokenSource?.Dispose();
-            StopPump(default).GetAwaiter().GetResult();
-            transportInfrastructure?.Shutdown(default).GetAwaiter().GetResult();
-            configurer?.Cleanup(default).GetAwaiter().GetResult();
+            StopPump().GetAwaiter().GetResult();
+            transportInfrastructure?.Shutdown().GetAwaiter().GetResult();
+            configurer?.Cleanup().GetAwaiter().GetResult();
         }
 
         protected async Task StartPump(OnMessage onMessage, OnError onError, TransportTransactionMode transactionMode, Action<string, Exception, CancellationToken> onCriticalError = null, OnCompleted onComplete = null)
@@ -100,7 +100,7 @@
             IgnoreUnsupportedTransactionModes(transport, transactionMode);
             transport.TransportTransactionMode = transactionMode;
 
-            transportInfrastructure = await configurer.Configure(transport, hostSettings, InputQueueName, ErrorQueueName, default);
+            transportInfrastructure = await configurer.Configure(transport, hostSettings, InputQueueName, ErrorQueueName);
 
             receiver = transportInfrastructure.Receivers.Single().Value;
             await receiver.Initialize(
@@ -134,10 +134,10 @@
                 },
                 default);
 
-            await receiver.StartReceive(default);
+            await receiver.StartReceive();
         }
 
-        protected async Task StopPump(CancellationToken cancellationToken)
+        protected async Task StopPump(CancellationToken cancellationToken = default)
         {
             if (receiver == null)
             {
@@ -188,7 +188,7 @@
 
             var transportOperation = new TransportOperation(message, new UnicastAddressTag(address), dispatchProperties, dispatchConsistency);
 
-            return transportInfrastructure.Dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction, default);
+            return transportInfrastructure.Dispatcher.Dispatch(new TransportOperations(transportOperation), transportTransaction);
         }
 
         protected void OnTestTimeout(Action onTimeoutAction)

--- a/src/NServiceBus.TransportTests/When_op_cancelled_on_error.cs
+++ b/src/NServiceBus.TransportTests/When_op_cancelled_on_error.cs
@@ -39,7 +39,7 @@
 
             await Task.Delay(TimeSpan.FromSeconds(1));
 
-            await StopPump(default);
+            await StopPump();
 
             Assert.True(criticalErrorInvoked);
         }

--- a/src/NServiceBus.TransportTests/When_op_cancelled_on_message.cs
+++ b/src/NServiceBus.TransportTests/When_op_cancelled_on_message.cs
@@ -44,7 +44,7 @@
 
             await Task.Delay(TimeSpan.FromSeconds(1));
 
-            await StopPump(default);
+            await StopPump();
 
             Assert.True(recoverabilityInvoked);
         }

--- a/src/NServiceBus.TransportTests/When_stopping.cs
+++ b/src/NServiceBus.TransportTests/When_stopping.cs
@@ -46,7 +46,7 @@
 
             _ = await messageProcessingStarted.Task;
 
-            await StopPump(default);
+            await StopPump();
 
             Assert.False(await messageProcessingCancelled.Task);
         }


### PR DESCRIPTION
As it turns out, making CancellationToken parameters mandatory causes a lot of noise in tests, and takes away the power of [CA2016](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2016) to find where you're forgetting to forward the token.