### PR TITLE
fixup! Introduce OnCompleted to the transport seam (#5936)

### DIFF
--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -329,10 +329,6 @@
             }
             catch (OperationCanceledException ex) when (messageProcessingCancellationToken.IsCancellationRequested)
             {
-                // a handler may have just thrown an OperationCanceledException
-                // and messageProcessingCancellationToken.IsCancellationRequested may just happen to be also true
-                onMessageFailed = true;
-
                 log.Info("Message processing cancelled. Rolling back transaction.", ex);
                 transaction.Rollback();
 


### PR DESCRIPTION
I had second thoughts about this.

The scenario described in the comment is an edge case. Most of the time, when we get an `OperationCanceledException` it will be because `messageProcessingCancellationToken.IsCancellationRequested == true`. In the edge case, we are cancelling anyway, so let's just cancel and take that to be the result of the `onMessage` invocation, rather than it failing. Also, what does explicitly throwing an `OperationCanceledException` in a handler (or behaviour) convey? It conveys that the operation is being cancelled, so let's just roll with that. Anything else is probably reduced to a corner case. In any case, our `when` condition allows recoverability to kick in when message processing is not being cancelled, so the corner case is probably reduced even further to a race-condition dependent... needle-point case?