### PR TITLE
remove LightInject.Source package ref

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -28,7 +28,6 @@
   <ItemGroup Label="Private dependencies">
     <PackageReference Include="Fody" Version="6.3.0" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.8.0" PrivateAssets="All" />
-    <PackageReference Include="LightInject.Source" Version="5.0.3" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Licensing.Sources" Version="3.5.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="1.1.0" PrivateAssets="All" />


### PR DESCRIPTION
As far as I can see, this package ref has had no effect since we switched to an SDK style project, since the source files are contained in the package's `/content` folder, which only works with the old-style csproj. The new style csproj requires files in `/contentFiles`. Newer versions of the package have the source files in `/contentFiles`.

However, instead of relying on the package ref, we have committed the source files to `/src/NServiceBus.Core/ObjectBuilder/LightInject/`. We have also modified them. Regardless of the modifications, we have to keep doing this, because we need `LightInject.Microsoft.DependencyInjection.Source.cs`, which is no longer provided as a package. At one time it was, but [it has not been updated](https://www.nuget.org/packages/LightInject.Microsoft.DependencyInjection.Source/) since `2.x`.

This erroneous package reference means that dependabot is raising [PR's](https://github.com/Particular/NServiceBus/pull/5812) to upgrade to the latest version which do not work as intended. I've raised a [separate PR](https://github.com/Particular/NServiceBus/pull/5950) to do the upgrade properly.