### PR TITLE
Fix/improve 2 transport tests

### DIFF
--- a/src/NServiceBus.TransportTests/When_on_error_throws.cs
+++ b/src/NServiceBus.TransportTests/When_on_error_throws.cs
@@ -64,7 +64,8 @@
             Assert.AreEqual($"Failed to execute recoverability policy for message with native ID: `{nativeMessageId}`", criticalErrorMessage);
             Assert.AreEqual(exceptionFromOnError, criticalErrorException);
 
-            Assert.False(LogFactory.LogItems.Any(item => item.Level > LogLevel.Info), "Transport should not log anything above LogLevel.Info");
+            var logItemsAboveInfo = LogFactory.LogItems.Where(item => item.Level > LogLevel.Info).Select(log => $"{log.Level}: {log.Message}").ToArray();
+            Assert.AreEqual(0, logItemsAboveInfo.Length, "Transport should not log anything above LogLevel.Info:" + string.Join(Environment.NewLine, logItemsAboveInfo));
         }
     }
 }

--- a/src/NServiceBus.TransportTests/When_transaction_level_TransactionScope.cs
+++ b/src/NServiceBus.TransportTests/When_transaction_level_TransactionScope.cs
@@ -24,7 +24,11 @@
                     return Task.CompletedTask;
                 },
                 (_, __) => Task.FromResult(ErrorHandleResult.Handled),
-                (_, __) => Task.CompletedTask,
+                (_, __) =>
+                {
+                    completed.SetResult(true);
+                    return Task.CompletedTask;
+                },
                 transactionMode);
 
             await SendMessage(InputQueueName);


### PR DESCRIPTION
* The test that asserts no logging above info may be a heisenbug. If it fails we need to know what was output.
* Impossible for When_transaction_level_TransactionScope to pass, it never sets completed, it will time out every time.