### PR TITLE
prevent loading assemblies when name is empty

### DIFF
--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -95,7 +95,7 @@ namespace NServiceBus.Hosting.Helpers
 
             var platformAssembliesString = (string)AppDomain.CurrentDomain.GetData("TRUSTED_PLATFORM_ASSEMBLIES");
 
-            if (platformAssembliesString != null)
+            if (!string.IsNullOrEmpty(platformAssembliesString))
             {
                 var platformAssemblies = platformAssembliesString.Split(Path.PathSeparator);
 


### PR DESCRIPTION
As specified in this [issue](https://github.com/Particular/NServiceBus/issues/5935) and the solution mentioned by @bording, here is the corresponding PR.