### PR TITLE
stop serializer test from polluting local folder

### DIFF
--- a/src/NServiceBus.Core.Tests/Serializers/XML/SerializerTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/SerializerTests.cs
@@ -787,8 +787,12 @@ namespace NServiceBus.Serializers.XML.Test
 
             sw.Reset();
 
-            File.Delete("a.xml");
-            using (var fs = File.Open("a.xml", FileMode.OpenOrCreate))
+            var fileName = Path.GetTempFileName();
+            Console.Error.WriteLine($"{nameof(fileName)}: {fileName}");
+
+            File.Delete(fileName);
+
+            using (var fs = File.Open(fileName, FileMode.OpenOrCreate))
             {
                 DataContractSerialize(xmlWriterSettings, dataContractSerializer, messages, fs);
             }


### PR DESCRIPTION
This stops the beloved `a.xml` from appearing in the local folder after running tests.

It writes the filename to the console, which appears in the "additional output" in the test runner, in case it is necessary to inspect the contents of the file in the case of failure.