### PR TITLE
When shutting down throw OperationCancelledException before handler invocation

### DIFF
--- a/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs
@@ -16,6 +16,9 @@
 
             var messageHandler = context.MessageHandler;
 
+            // Might as well abort before invoking the handler if we're shutting down
+            context.CancellationToken.ThrowIfCancellationRequested();
+
             var startTime = DateTimeOffset.UtcNow;
             try
             {


### PR DESCRIPTION
In case handler code does not handle cancellation, provide opportunity to abort immediately before invoking handler