### PR TITLE
Move disposal of cancellation source to after shutdown

### DIFF
--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -66,10 +66,10 @@
         [TearDown]
         public void TearDown()
         {
-            testCancellationTokenSource?.Dispose();
             StopPump().GetAwaiter().GetResult();
             transportInfrastructure?.Shutdown().GetAwaiter().GetResult();
             configurer?.Cleanup().GetAwaiter().GetResult();
+            testCancellationTokenSource?.Dispose();
         }
 
         protected async Task StartPump(OnMessage onMessage, OnError onError, TransportTransactionMode transactionMode, Action<string, Exception, CancellationToken> onCriticalError = null)


### PR DESCRIPTION
Disposing the token source could cause a critical error in a test that is shutting down to encounter an exception while the pump is shutting down. Disposal of the token source should come last.