### PR TITLE
obsolete ServiceCollectionExtensions

### DIFF
--- a/src/NServiceBus.Core/ObjectBuilder/ServiceCollectionExtensions.cs
+++ b/src/NServiceBus.Core/ObjectBuilder/ServiceCollectionExtensions.cs
@@ -8,6 +8,10 @@
     /// <summary>
     /// Contains extension methods for <see cref="IServiceCollection"/> that were formerly provided by <see cref="IConfigureComponents"/>.
     /// </summary>
+    [ObsoleteEx(
+        Message = "Use methods on IServiceCollection instead.",
+        TreatAsErrorFromVersion = "9.0",
+        RemoveInVersion = "10.0")]
     public static class ServiceCollectionExtensions
     {
         /// <summary>


### PR DESCRIPTION
I realise that it's unlikely that the type is used explicitly, since all the methods are extension methods, but it's not immediately obvious that the entire type is obsolete. It requires scanning through all the methods and noticing that that they are all obsolete.