### PR TITLE
obsolete ServiceCollectionExtensions

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1010,6 +1010,8 @@ namespace NServiceBus
         public static bool ShouldSkipSerialization(this NServiceBus.Pipeline.IOutgoingLogicalMessageContext context) { }
         public static void SkipSerialization(this NServiceBus.Pipeline.IOutgoingLogicalMessageContext context) { }
     }
+    [System.Obsolete("Use methods on IServiceCollection instead. Will be treated as an error from versi" +
+        "on 9.0.0. Will be removed in version 10.0.0.", false)]
     public static class ServiceCollectionExtensions
     {
         [System.Obsolete("Use `IServiceCollection.Add` instead. Will be treated as an error from version 9." +

--- a/src/NServiceBus.Core/ObjectBuilder/ServiceCollectionExtensions.cs
+++ b/src/NServiceBus.Core/ObjectBuilder/ServiceCollectionExtensions.cs
@@ -8,6 +8,10 @@
     /// <summary>
     /// Contains extension methods for <see cref="IServiceCollection"/> that were formerly provided by <see cref="IConfigureComponents"/>.
     /// </summary>
+    [ObsoleteEx(
+        Message = "Use methods on IServiceCollection instead.",
+        TreatAsErrorFromVersion = "9.0",
+        RemoveInVersion = "10.0")]
     public static class ServiceCollectionExtensions
     {
         /// <summary>


### PR DESCRIPTION
I realise that it's unlikely that the type is used explicitly, since all the methods are extension methods, but it's not immediately obvious that the entire type is obsolete. It requires scanning through all the methods and noticing that that they are all obsolete.