### PR TITLE
Allow acceptance tests to easily select transport transaction mode

### DIFF
--- a/src/NServiceBus.AcceptanceTests/ConfigureEndpointAcceptanceTestingTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureEndpointAcceptanceTestingTransport.cs
@@ -7,10 +7,11 @@ using NUnit.Framework;
 
 public class ConfigureEndpointAcceptanceTestingTransport : IConfigureEndpointTestExecution
 {
-    public ConfigureEndpointAcceptanceTestingTransport(bool useNativePubSub, bool useNativeDelayedDelivery)
+    public ConfigureEndpointAcceptanceTestingTransport(bool useNativePubSub, bool useNativeDelayedDelivery, TransportTransactionMode transactionMode = TransportTransactionMode.ReceiveOnly)
     {
         this.useNativePubSub = useNativePubSub;
         this.useNativeDelayedDelivery = useNativeDelayedDelivery;
+        this.transactionMode = transactionMode;
     }
 
     public Task Cleanup()
@@ -45,7 +46,8 @@ public class ConfigureEndpointAcceptanceTestingTransport : IConfigureEndpointTes
             enableNativeDelayedDelivery: useNativeDelayedDelivery,
             enableNativePublishSubscribe: useNativePubSub)
         {
-            StorageLocation = storageDir
+            StorageLocation = storageDir,
+            TransportTransactionMode = transactionMode
         };
         var routing = configuration.UseTransport(acceptanceTestingTransport);
 
@@ -66,6 +68,7 @@ public class ConfigureEndpointAcceptanceTestingTransport : IConfigureEndpointTes
 
     readonly bool useNativePubSub;
     readonly bool useNativeDelayedDelivery;
+    readonly TransportTransactionMode transactionMode;
 
     string storageDir;
 }


### PR DESCRIPTION
No downstream is going to want to use TransportTransactionMode.None as the default for acceptance tests. Persisters, for instance, must use ReceiveOnly for Outbox tests to work.

This defaults to ReceiveOnly but provides an optional param to be used from `TestSuiteConstraints.cs` to select the transaction mode without needing to call (and knowing you need to include `using NServiceBus.AcceptanceTests.EndpointTemplates;` to find) this:

```
var transport = configuration.ConfigureTransport<AcceptanceTestingTransport>();
transport.TransportTransactionMode = TransportTransactionMode.ReceiveOnly;
```

That's appropriate in a specific test that needs a specific transaction mode for that test but isn't a good thing to force every downstream to have to do.