### PR TITLE
Exclude nunit.engine related assemblies

### DIFF
--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -445,6 +445,9 @@ namespace NServiceBus.Hosting.Helpers
             "nunit",
             "nunit.framework",
             "nunit.applicationdomain",
+            "nunit.engine",
+            "nunit.engine.api",
+            "nunit.engine.core",
 
             // NSB OSS Dependencies
             "nlog",


### PR DESCRIPTION
Under .NET Core these additional assemblies are loaded from nunit and might fail depending on the test runner. Since we already track exclusions for nunit adding those doesn't hurt