### PR TITLE
make TransportDefinition.ToTransportAddress async

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/AcceptanceTestingTransactionalStorageFeature.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/AcceptanceTestingTransactionalStorageFeature.cs
@@ -3,13 +3,16 @@
     using Features;
     using Persistence;
     using Microsoft.Extensions.DependencyInjection;
+    using System.Threading.Tasks;
+    using System.Threading;
 
     class AcceptanceTestingTransactionalStorageFeature : Feature
     {
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             context.Services.AddSingleton<ISynchronizedStorage, AcceptanceTestingSynchronizedStorage>();
             context.Services.AddSingleton<ISynchronizedStorageAdapter, AcceptanceTestingTransactionalSynchronizedStorageAdapter>();
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/Outbox/AcceptanceTestingOutboxPersistence.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/Outbox/AcceptanceTestingOutboxPersistence.cs
@@ -15,13 +15,15 @@
             Defaults(s => s.EnableFeature(typeof(AcceptanceTestingTransactionalStorageFeature)));
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             var outboxStorage = new AcceptanceTestingOutboxStorage();
 
             context.Services.AddSingleton(typeof(IOutboxStorage), outboxStorage);
 
             context.RegisterStartupTask(new OutboxCleaner(outboxStorage, TimeSpan.FromDays(5)));
+
+            return Task.CompletedTask;
         }
 
         class OutboxCleaner : FeatureStartupTask

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/SagaPersister/AcceptanceTestingSagaPersistence.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/SagaPersister/AcceptanceTestingSagaPersistence.cs
@@ -3,6 +3,8 @@
     using Features;
     using Sagas;
     using Microsoft.Extensions.DependencyInjection;
+    using System.Threading.Tasks;
+    using System.Threading;
 
     class AcceptanceTestingSagaPersistence : Feature
     {
@@ -12,9 +14,10 @@
             Defaults(s => s.EnableFeature(typeof(AcceptanceTestingTransactionalStorageFeature)));
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             context.Services.AddSingleton<ISagaPersister, AcceptanceTestingSagaPersister>();
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/SubscriptionStorage/AcceptanceTestingSubscriptionPersistence.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/SubscriptionStorage/AcceptanceTestingSubscriptionPersistence.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTesting
 {
+    using System.Threading.Tasks;
+    using System.Threading;
     using Features;
     using Microsoft.Extensions.DependencyInjection;
     using Unicast.Subscriptions.MessageDrivenSubscriptions;
@@ -13,9 +15,10 @@
 #pragma warning restore CS0618
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             context.Services.AddSingleton<ISubscriptionStorage, AcceptanceTestingSubscriptionStorage>();
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransport.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransport.cs
@@ -25,7 +25,7 @@
             return infrastructure;
         }
 
-        public override string ToTransportAddress(QueueAddress address)
+        public override Task<string> ToTransportAddress(QueueAddress address, CancellationToken cancellationToken = default)
         {
             var baseAddress = address.BaseAddress;
             PathChecker.ThrowForBadPath(baseAddress, "endpoint name");
@@ -48,7 +48,7 @@
                 baseAddress += "-" + qualifier;
             }
 
-            return baseAddress;
+            return Task.FromResult(baseAddress);
         }
 
         public override IReadOnlyCollection<TransportTransactionMode> GetSupportedTransactionModes()

--- a/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_at_startup.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_at_startup.cs
@@ -73,9 +73,10 @@
 
         class CriticalErrorStartup : Feature
         {
-            protected override void Setup(FeatureConfigurationContext context)
+            protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
             {
                 context.RegisterStartupTask(b => new CriticalErrorStartupFeatureTask(b.GetService<CriticalError>(), b.GetService<TestContext>()));
+                return Task.CompletedTask;
             }
 
             class CriticalErrorStartupFeatureTask : FeatureStartupTask

--- a/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_from_a_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_from_a_handler.cs
@@ -83,9 +83,10 @@
 
         class CriticalErrorStartup : Feature
         {
-            protected override void Setup(FeatureConfigurationContext context)
+            protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
             {
                 context.RegisterStartupTask(b => new CriticalErrorStartupFeatureTask(b.GetService<CriticalError>(), b.GetService<TestContext>()));
+                return Task.CompletedTask;
             }
 
             class CriticalErrorStartupFeatureTask : FeatureStartupTask

--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_endpoint_is_warmed_up.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_endpoint_is_warmed_up.cs
@@ -22,7 +22,7 @@
                 .WithEndpoint<StartedEndpoint>(b =>
                 {
                     b.ToCreateInstance(
-                        endpointConfiguration => Task.FromResult(EndpointWithExternallyManagedContainer.Create(endpointConfiguration, serviceCollection)),
+                        endpointConfiguration => EndpointWithExternallyManagedContainer.Create(endpointConfiguration, serviceCollection),
                         startableEndpoint =>
                         {
                             spyContainer = new SpyConainer(serviceCollection);

--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_overriding_services_in_registercomponents.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_overriding_services_in_registercomponents.cs
@@ -21,8 +21,7 @@
                         config =>
                         {
                             serviceCollection.AddSingleton<IDependencyBeforeEndpointConfiguration, OriginallyDefinedDependency>();
-                            var configuredEndpoint = EndpointWithExternallyManagedContainer.Create(config, serviceCollection);
-                            return Task.FromResult(configuredEndpoint);
+                            return EndpointWithExternallyManagedContainer.Create(config, serviceCollection);
                         },
                         configured =>
                         {
@@ -65,12 +64,14 @@
                     EnableByDefault();
                 }
 
-                protected override void Setup(FeatureConfigurationContext context)
+                protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
                 {
                     context.Services.AddSingleton<IDependencyFromFeature, OriginallyDefinedDependency>();
 
                     context.Services.AddTransient<StartupFeatureWithDependencies>();
                     context.RegisterStartupTask(sp => sp.GetRequiredService<StartupFeatureWithDependencies>());
+
+                    return Task.CompletedTask;
                 }
 
                 public class StartupFeatureWithDependencies : FeatureStartupTask

--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_using_externally_managed_container.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_using_externally_managed_container.cs
@@ -23,11 +23,7 @@
                 IStartableEndpointWithExternallyManagedContainer configuredEndpoint = null;
 
                 b.ToCreateInstance(
-                        config =>
-                        {
-                            configuredEndpoint = EndpointWithExternallyManagedContainer.Create(config, serviceCollection);
-                            return Task.FromResult(configuredEndpoint);
-                        },
+                        async config => configuredEndpoint = await EndpointWithExternallyManagedContainer.Create(config, serviceCollection),
                         configured => configured.Start(serviceCollection.BuildServiceProvider())
                     )
                     .When((e, c) =>

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransport.cs
@@ -30,9 +30,9 @@
             return Task.FromResult<TransportInfrastructure>(infrastructure);
         }
 
-        public override string ToTransportAddress(QueueAddress address)
+        public override Task<string> ToTransportAddress(QueueAddress address, CancellationToken cancellationToken = default)
         {
-            return new LearningTransport().ToTransportAddress(address);
+            return new LearningTransport().ToTransportAddress(address, cancellationToken);
         }
 
         public override IReadOnlyCollection<TransportTransactionMode> GetSupportedTransactionModes()

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -81,9 +81,9 @@
                 return Task.FromResult<TransportInfrastructure>(new FakeTransportInfrastructure(receivers));
             }
 
-            public override string ToTransportAddress(QueueAddress address)
+            public override Task<string> ToTransportAddress(QueueAddress address, CancellationToken cancellationToken = default)
             {
-                return address.ToString();
+                return Task.FromResult(address.ToString());
             }
 
             public override IReadOnlyCollection<TransportTransactionMode> GetSupportedTransactionModes()

--- a/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_feature.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_feature.cs
@@ -49,10 +49,12 @@
                 DependsOn<DependencyFeature>();
             }
 
-            protected override void Setup(FeatureConfigurationContext context)
+            protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
             {
                 context.Services.AddSingleton<Runner>();
                 context.RegisterStartupTask(b => b.GetService<Runner>());
+
+                return Task.CompletedTask;
             }
 
             class Runner : FeatureStartupTask
@@ -79,11 +81,13 @@
 
         public class DependencyFeature : Feature
         {
-            protected override void Setup(FeatureConfigurationContext context)
+            protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
             {
                 context.Services.AddSingleton<Dependency>();
                 context.Services.AddSingleton<Runner>();
                 context.RegisterStartupTask(b => b.GetService<Runner>());
+
+                return Task.CompletedTask;
             }
 
             class Runner : FeatureStartupTask

--- a/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_typed_feature.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_typed_feature.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Core.Feature
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -58,18 +59,18 @@
                 DependsOn<DependencyFeature>();
             }
 
-            protected override void Setup(FeatureConfigurationContext context)
+            protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
             {
                 var testContext = (Context)context.Settings.Get<ScenarioContext>();
                 testContext.TypedDependencyFeatureSetUp = true;
+
+                return Task.CompletedTask;
             }
         }
 
         public class DependencyFeature : Feature
         {
-            protected override void Setup(FeatureConfigurationContext context)
-            {
-            }
+            protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default) => Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_untyped_feature.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_untyped_feature.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.AcceptanceTests.Core.Feature
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -59,18 +60,17 @@ namespace NServiceBus.AcceptanceTests.Core.Feature
                 DependsOn(featureTypeFullName);
             }
 
-            protected override void Setup(FeatureConfigurationContext context)
+            protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
             {
                 var testContext = (Context)context.Settings.Get<ScenarioContext>();
                 testContext.UntypedDependencyFeatureSetUp = true;
+                return Task.CompletedTask;
             }
         }
 
         public class DependencyFeature : Feature
         {
-            protected override void Setup(FeatureConfigurationContext context)
-            {
-            }
+            protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default) => Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Core/Feature/When_feature_startup_task_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Feature/When_feature_startup_task_fails.cs
@@ -27,9 +27,10 @@
 
             class FeatureWithStartupTask : Feature
             {
-                protected override void Setup(FeatureConfigurationContext context)
+                protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
                 {
                     context.RegisterStartupTask(new FailingStartupTask());
+                    return Task.CompletedTask;
                 }
             }
 

--- a/src/NServiceBus.AcceptanceTests/Core/Feature/When_registering_a_startup_task.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Feature/When_registering_a_startup_task.cs
@@ -48,9 +48,10 @@
                     EnableByDefault();
                 }
 
-                protected override void Setup(FeatureConfigurationContext context)
+                protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
                 {
                     context.RegisterStartupTask(b => new MyTask(b.GetService<Context>()));
+                    return Task.CompletedTask;
                 }
 
                 public class MyTask : FeatureStartupTask

--- a/src/NServiceBus.AcceptanceTests/Core/Hosting/When_custom_host_id_is_configured.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Hosting/When_custom_host_id_is_configured.cs
@@ -3,6 +3,7 @@ namespace NServiceBus.AcceptanceTests.Core.Hosting
     using System;
     using System.Collections.Concurrent;
     using System.Reflection;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -51,9 +52,7 @@ namespace NServiceBus.AcceptanceTests.Core.Hosting
                 });
             }
 
-            protected override void Setup(FeatureConfigurationContext context)
-            {
-            }
+            protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default) => Task.CompletedTask;
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Installers/When_creating_queues.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Installers/When_creating_queues.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using Configuration.AdvancedExtensibility;
@@ -115,13 +116,15 @@
                     EnableByDefault();
                 }
 
-                protected override void Setup(FeatureConfigurationContext context)
+                protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
                 {
                     context.AddSatelliteReceiver("MySatellite",
                         "MySatelliteAddress",
                         PushRuntimeSettings.Default,
                         (_, __) => throw new NotImplementedException(),
                         (_, __, ___) => throw new NotImplementedException());
+
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_configuring_subscription_authorizer.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_configuring_subscription_authorizer.cs
@@ -101,10 +101,14 @@
 
             class StorageAccessorFeature : Feature
             {
-                protected override void Setup(FeatureConfigurationContext context) =>
+                protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
+                {
                     context.RegisterStartupTask(
                         sp => new StorageAccessor(sp.GetRequiredService<ISubscriptionStorage>(),
                             sp.GetRequiredService<Context>()));
+
+                    return Task.CompletedTask;
+                }
 
                 class StorageAccessor : FeatureStartupTask
                 {
@@ -137,9 +141,10 @@
 
             class SubscriptionStorageFeature : Feature
             {
-                protected override void Setup(FeatureConfigurationContext context)
+                protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
                 {
                     context.Services.AddSingleton<ISubscriptionStorage>(new FakeSubscriptionStorage());
+                    return Task.CompletedTask;
                 }
             }
 

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_extending_command_routing_with_thisinstance.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_extending_command_routing_with_thisinstance.cs
@@ -92,10 +92,10 @@ namespace NServiceBus.AcceptanceTests.Core.Routing
                     this.testContext = testContext;
                 }
 
-                public override string SelectDestination(DistributionContext context)
+                public override Task<string> SelectDestination(DistributionContext context, CancellationToken cancellationToken = default)
                 {
                     testContext.StrategyCalled = true;
-                    return context.ReceiverAddresses[0];
+                    return Task.FromResult(context.ReceiverAddresses[0]);
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_using_discriminator.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_using_discriminator.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Routing
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -41,9 +42,10 @@
                     EnableByDefault();
                 }
 
-                protected override void Setup(FeatureConfigurationContext context)
+                protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
                 {
                     context.Settings.Get<Context>().InstanceDescriminatorFromSettingsExtensions = context.Settings.InstanceSpecificQueue();
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Core/Stopping/When_feature_startup_task_throws_on_stop.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Stopping/When_feature_startup_task_throws_on_stop.cs
@@ -43,9 +43,10 @@ namespace NServiceBus.AcceptanceTests.Core.Stopping
                     EnableByDefault();
                 }
 
-                protected override void Setup(FeatureConfigurationContext context)
+                protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
                 {
                     context.RegisterStartupTask(new CustomTask());
+                    return Task.CompletedTask;
                 }
 
                 class CustomTask : FeatureStartupTask

--- a/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_configuring_transport.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_configuring_transport.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Core.TransportSeam
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -34,10 +35,12 @@
 
             class FeatureAccessingInfrastructure : Feature
             {
-                protected override void Setup(FeatureConfigurationContext context)
+                protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
                 {
                     var testContext = (Context)context.Settings.Get<ScenarioContext>();
                     testContext.TransportDefinition = context.Settings.Get<TransportDefinition>();
+
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_querying_for_transaction_mode.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_querying_for_transaction_mode.cs
@@ -6,6 +6,7 @@
     using Features;
     using ConsistencyGuarantees;
     using NUnit.Framework;
+    using System.Threading;
 
     public class When_querying_for_transaction_mode : NServiceBusAcceptanceTest
     {
@@ -40,9 +41,10 @@
             {
                 public Context TestContext { get; set; }
 
-                protected override void Setup(FeatureConfigurationContext context)
+                protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
                 {
                     context.Settings.Get<Context>().TransactionModeFromSettingsExtensions = context.Settings.GetRequiredTransactionModeForReceives();
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Feature/When_purging_queues.cs
+++ b/src/NServiceBus.AcceptanceTests/Feature/When_purging_queues.cs
@@ -55,8 +55,11 @@
             {
                 public FeatureWithStartupTask() => EnableByDefault();
 
-                protected override void Setup(FeatureConfigurationContext context) =>
+                protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
+                {
                     context.RegisterStartupTask(new StartupTask());
+                    return Task.CompletedTask;
+                }
 
                 class StartupTask : FeatureStartupTask
                 {

--- a/src/NServiceBus.AcceptanceTests/Feature/When_subscribing_in_FST.cs
+++ b/src/NServiceBus.AcceptanceTests/Feature/When_subscribing_in_FST.cs
@@ -84,8 +84,11 @@
             {
                 public FeatureWithStartupTask() => EnableByDefault();
 
-                protected override void Setup(FeatureConfigurationContext context) =>
+                protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
+                {
                     context.RegisterStartupTask(new StartupTask());
+                    return Task.CompletedTask;
+                }
 
                 class StartupTask : FeatureStartupTask
                 {

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_publishing_from_sendonly.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/When_publishing_from_sendonly.cs
@@ -90,9 +90,10 @@
 
         public class HardCodedPersistenceFeature : Feature
         {
-            protected override void Setup(FeatureConfigurationContext context)
+            protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
             {
                 context.Services.AddSingleton(typeof(ISubscriptionStorage), typeof(HardcodedSubscriptionManager));
+                return Task.CompletedTask;
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/When_extending_command_routing.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_extending_command_routing.cs
@@ -68,9 +68,9 @@
                 {
                 }
 
-                public override string SelectDestination(DistributionContext context)
+                public override async Task<string> SelectDestination(DistributionContext context, CancellationToken cancellationToken = default)
                 {
-                    var address = context.ToTransportAddress(new EndpointInstance(ReceiverEndpoint, "XYZ"));
+                    var address = await context.ToTransportAddress(new EndpointInstance(ReceiverEndpoint, "XYZ"), cancellationToken).ConfigureAwait(false);
                     return context.ReceiverAddresses.First(x => x == address);
                 }
             }

--- a/src/NServiceBus.AcceptanceTests/Routing/When_using_custom_routing_strategy.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_using_custom_routing_strategy.cs
@@ -76,11 +76,11 @@
                 {
                 }
 
-                public override string SelectDestination(DistributionContext context)
+                public override async Task<string> SelectDestination(DistributionContext context, CancellationToken cancellationToken = default)
                 {
                     if (context.Message.Instance is MyCommand message)
                     {
-                        var address = context.ToTransportAddress(new EndpointInstance(Endpoint, message.Instance));
+                        var address = await context.ToTransportAddress(new EndpointInstance(Endpoint, message.Instance), cancellationToken);
                         return context.ReceiverAddresses.Single(a => a.Contains(address));
                     }
                     throw new InvalidOperationException("Unable to route!");

--- a/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
+++ b/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTests.Satellites
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -46,16 +47,16 @@
                     EnableByDefault();
                 }
 
-                protected override void Setup(FeatureConfigurationContext context)
+                protected override async Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
                 {
                     var endpointQueueName = context.Settings.EndpointQueueName();
                     var queueAddress = new QueueAddress(endpointQueueName, null, null, "MySatellite");
 
-                    var satelliteAddress = context.Settings.Get<TransportDefinition>().ToTransportAddress(queueAddress);
+                    var satelliteAddress = await context.Settings.Get<TransportDefinition>().ToTransportAddress(queueAddress, cancellationToken);
 
                     context.AddSatelliteReceiver("Test satellite", satelliteAddress, PushRuntimeSettings.Default,
                         (c, ec) => RecoverabilityAction.MoveToError(c.Failed.ErrorQueue),
-                        (builder, messageContext, cancellationToken) =>
+                        (builder, messageContext, _) =>
                         {
                             var testContext = builder.GetService<Context>();
                             testContext.MessageReceived = true;

--- a/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired.cs
+++ b/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired.cs
@@ -27,9 +27,10 @@
 
         class DelayReceiverFromStarting : Feature
         {
-            protected override void Setup(FeatureConfigurationContext context)
+            protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
             {
                 context.RegisterStartupTask(b => new DelayReceiverFromStartingTask());
+                return Task.CompletedTask;
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired_convention.cs
+++ b/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired_convention.cs
@@ -27,9 +27,10 @@
 
         class DelayReceiverFromStarting : Feature
         {
-            protected override void Setup(FeatureConfigurationContext context)
+            protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
             {
                 context.RegisterStartupTask(b => new DelayReceiverFromStartingTask());
+                return Task.CompletedTask;
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_used_with_unobtrusive_mode.cs
+++ b/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_used_with_unobtrusive_mode.cs
@@ -27,9 +27,10 @@
 
         class SendMessageAndDelayStart : Feature
         {
-            protected override void Setup(FeatureConfigurationContext context)
+            protected override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
             {
                 context.RegisterStartupTask(b => new SendMessageAndDelayStartTask());
+                return Task.CompletedTask;
             }
         }
 

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -342,7 +342,7 @@ namespace NServiceBus
     }
     public static class EndpointWithExternallyManagedContainer
     {
-        public static NServiceBus.IStartableEndpointWithExternallyManagedContainer Create(NServiceBus.EndpointConfiguration configuration, Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) { }
+        public static System.Threading.Tasks.Task<NServiceBus.IStartableEndpointWithExternallyManagedContainer> Create(NServiceBus.EndpointConfiguration configuration, Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public static class ErrorQueueSettings
     {
@@ -677,7 +677,7 @@ namespace NServiceBus
         public string StorageDirectory { get; set; }
         public override System.Collections.Generic.IReadOnlyCollection<NServiceBus.TransportTransactionMode> GetSupportedTransactionModes() { }
         public override System.Threading.Tasks.Task<NServiceBus.Transport.TransportInfrastructure> Initialize(NServiceBus.Transport.HostSettings hostSettings, NServiceBus.Transport.ReceiveSettings[] receivers, string[] sendingAddresses, System.Threading.CancellationToken cancellationToken = default) { }
-        public override string ToTransportAddress(NServiceBus.Transport.QueueAddress queueAddress) { }
+        public override System.Threading.Tasks.Task<string> ToTransportAddress(NServiceBus.Transport.QueueAddress queueAddress, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public static class LearningTransportApiExtensions
     {
@@ -1444,15 +1444,15 @@ namespace NServiceBus.Features
 {
     public class Audit : NServiceBus.Features.Feature
     {
-        protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected override System.Threading.Tasks.Task Setup(NServiceBus.Features.FeatureConfigurationContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public class AutoSubscribe : NServiceBus.Features.Feature
     {
-        protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected override System.Threading.Tasks.Task Setup(NServiceBus.Features.FeatureConfigurationContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public class DataBus : NServiceBus.Features.Feature
     {
-        protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected override System.Threading.Tasks.Task Setup(NServiceBus.Features.FeatureConfigurationContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public abstract class Feature
     {
@@ -1473,7 +1473,7 @@ namespace NServiceBus.Features
             where T : NServiceBus.Features.Feature { }
         protected void EnableByDefault() { }
         protected void Prerequisite(System.Func<NServiceBus.Features.FeatureConfigurationContext, bool> condition, string description) { }
-        protected abstract void Setup(NServiceBus.Features.FeatureConfigurationContext context);
+        protected abstract System.Threading.Tasks.Task Setup(NServiceBus.Features.FeatureConfigurationContext context, System.Threading.CancellationToken cancellationToken = default);
         public override string ToString() { }
     }
     public class FeatureConfigurationContext
@@ -1514,15 +1514,15 @@ namespace NServiceBus.Features
     [System.Obsolete(@"It's not recommended to disable the MessageDrivenSubscriptions feature and this option will be removed in future versions. Use 'TransportExtensions<T>.DisablePublishing()' to avoid the need for a subscription storage if this endpoint does not publish events. Will be treated as an error from version 9.0.0. Will be removed in version 10.0.0.", false)]
     public class MessageDrivenSubscriptions : NServiceBus.Features.Feature
     {
-        protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected override System.Threading.Tasks.Task Setup(NServiceBus.Features.FeatureConfigurationContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public class Outbox : NServiceBus.Features.Feature
     {
-        protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected override System.Threading.Tasks.Task Setup(NServiceBus.Features.FeatureConfigurationContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public class Sagas : NServiceBus.Features.Feature
     {
-        protected override void Setup(NServiceBus.Features.FeatureConfigurationContext context) { }
+        protected override System.Threading.Tasks.Task Setup(NServiceBus.Features.FeatureConfigurationContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
     [System.Obsolete("The built-in scheduler is no longer supported, see our upgrade guide for details " +
         "on how to migrate to plain .NET Timers. Will be removed in version 9.0.0.", true)]
@@ -2076,20 +2076,20 @@ namespace NServiceBus.Routing
     }
     public class DistributionContext : NServiceBus.Extensibility.IExtendable
     {
-        public DistributionContext(string[] receiverAddresses, NServiceBus.Pipeline.OutgoingLogicalMessage message, string messageId, System.Collections.Generic.Dictionary<string, string> headers, System.Func<NServiceBus.Routing.EndpointInstance, string> addressTranslation, NServiceBus.Extensibility.ContextBag extensions) { }
+        public DistributionContext(string[] receiverAddresses, NServiceBus.Pipeline.OutgoingLogicalMessage message, string messageId, System.Collections.Generic.Dictionary<string, string> headers, System.Func<NServiceBus.Routing.EndpointInstance, System.Threading.CancellationToken, System.Threading.Tasks.Task<string>> addressTranslation, NServiceBus.Extensibility.ContextBag extensions) { }
         public NServiceBus.Extensibility.ContextBag Extensions { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public NServiceBus.Pipeline.OutgoingLogicalMessage Message { get; }
         public string MessageId { get; }
         public string[] ReceiverAddresses { get; }
-        public string ToTransportAddress(NServiceBus.Routing.EndpointInstance endpointInstance) { }
+        public System.Threading.Tasks.Task<string> ToTransportAddress(NServiceBus.Routing.EndpointInstance endpointInstance, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public abstract class DistributionStrategy
     {
         protected DistributionStrategy(string endpoint, NServiceBus.DistributionStrategyScope scope) { }
         public string Endpoint { get; }
         public NServiceBus.DistributionStrategyScope Scope { get; }
-        public abstract string SelectDestination(NServiceBus.Routing.DistributionContext context);
+        public abstract System.Threading.Tasks.Task<string> SelectDestination(NServiceBus.Routing.DistributionContext context, System.Threading.CancellationToken cancellationToken = default);
     }
     public sealed class EndpointInstance
     {
@@ -2135,7 +2135,7 @@ namespace NServiceBus.Routing
     public class SingleInstanceRoundRobinDistributionStrategy : NServiceBus.Routing.DistributionStrategy
     {
         public SingleInstanceRoundRobinDistributionStrategy(string endpoint, NServiceBus.DistributionStrategyScope scope) { }
-        public override string SelectDestination(NServiceBus.Routing.DistributionContext context) { }
+        public override System.Threading.Tasks.Task<string> SelectDestination(NServiceBus.Routing.DistributionContext context, System.Threading.CancellationToken cancellationToken = default) { }
     }
     public class UnicastAddressTag : NServiceBus.Routing.AddressTag
     {
@@ -2667,7 +2667,7 @@ namespace NServiceBus.Transport
         public virtual NServiceBus.TransportTransactionMode TransportTransactionMode { get; set; }
         public abstract System.Collections.Generic.IReadOnlyCollection<NServiceBus.TransportTransactionMode> GetSupportedTransactionModes();
         public abstract System.Threading.Tasks.Task<NServiceBus.Transport.TransportInfrastructure> Initialize(NServiceBus.Transport.HostSettings hostSettings, NServiceBus.Transport.ReceiveSettings[] receivers, string[] sendingAddresses, System.Threading.CancellationToken cancellationToken = default);
-        public abstract string ToTransportAddress(NServiceBus.Transport.QueueAddress address);
+        public abstract System.Threading.Tasks.Task<string> ToTransportAddress(NServiceBus.Transport.QueueAddress address, System.Threading.CancellationToken cancellationToken = default);
     }
     public abstract class TransportInfrastructure
     {

--- a/src/NServiceBus.Core.Tests/Features/FeatureDifferingOnlyByNamespaceTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDifferingOnlyByNamespaceTests.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.Features;
     using NUnit.Framework;
     using Settings;
@@ -10,7 +11,7 @@
     public class FeatureDifferingOnlyByNamespaceTests
     {
         [Test]
-        public void Should_activate_upstream_dependencies_first()
+        public async Task Should_activate_upstream_dependencies_first()
         {
             var order = new List<Feature>();
 
@@ -31,7 +32,7 @@
 
             settings.EnableFeatureByDefault<NamespaceA.MyFeature>();
 
-            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
+            await featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             Assert.True(dependingFeature.IsActive);
 

--- a/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
@@ -25,7 +25,7 @@
 
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
+            await featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             await featureSettings.StartFeatures(null, null);
             await featureSettings.StopFeatures();
@@ -42,7 +42,7 @@
             featureSettings.Add(new FeatureWithStartupTaskWithDependency(orderBuilder));
             featureSettings.Add(new FeatureWithStartupThatAnotherFeatureDependsOn(orderBuilder));
 
-            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
+            await featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             await featureSettings.StartFeatures(null, null);
             await featureSettings.StopFeatures();
@@ -63,7 +63,7 @@
 
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
+            await featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             await featureSettings.StartFeatures(null, null);
             await featureSettings.StopFeatures();
@@ -72,14 +72,14 @@
         }
 
         [Test]
-        public void Should_not_throw_when_feature_task_fails_on_start_and_abort_starting()
+        public async Task Should_not_throw_when_feature_task_fails_on_start_and_abort_starting()
         {
             var feature1 = new FeatureWithStartupTaskThatThrows(throwOnStart: true, throwOnStop: false);
             var feature2 = new FeatureWithStartupTaskThatThrows(throwOnStart: false, throwOnStop: false);
             featureSettings.Add(feature1);
             featureSettings.Add(feature2);
 
-            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
+            await featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             Assert.ThrowsAsync<InvalidOperationException>(async () => await featureSettings.StartFeatures(null, null));
 
@@ -95,7 +95,7 @@
             featureSettings.Add(feature1);
             featureSettings.Add(feature2);
 
-            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
+            await featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             await featureSettings.StartFeatures(null, null);
 
@@ -110,7 +110,7 @@
             var feature = new FeatureWithStartupTaskThatThrows(throwOnStart: false, throwOnStop: true);
             featureSettings.Add(feature);
 
-            featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
+            await featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
             await featureSettings.StartFeatures(null, null);
 
@@ -131,9 +131,10 @@
                 this.orderBuilder = orderBuilder;
             }
 
-            protected internal override void Setup(FeatureConfigurationContext context)
+            protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
             {
                 context.RegisterStartupTask(new Runner(orderBuilder));
+                return Task.CompletedTask;
             }
 
             class Runner : FeatureStartupTask
@@ -170,9 +171,10 @@
                 this.orderBuilder = orderBuilder;
             }
 
-            protected internal override void Setup(FeatureConfigurationContext context)
+            protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
             {
                 context.RegisterStartupTask(new Runner(orderBuilder));
+                return Task.CompletedTask;
             }
 
             class Runner : FeatureStartupTask
@@ -210,9 +212,10 @@
             public bool TaskStarted { get; private set; }
             public bool TaskStopped { get; private set; }
 
-            protected internal override void Setup(FeatureConfigurationContext context)
+            protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
             {
                 context.RegisterStartupTask(new Runner(this));
+                return Task.CompletedTask;
             }
 
             public class Runner : FeatureStartupTask
@@ -252,9 +255,10 @@
             public bool TaskStopped { get; private set; }
             public bool TaskDisposed { get; private set; }
 
-            protected internal override void Setup(FeatureConfigurationContext context)
+            protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
             {
                 context.RegisterStartupTask(new Runner(this));
+                return Task.CompletedTask;
             }
 
             bool throwOnStart;
@@ -305,9 +309,10 @@
 
             public bool TaskDisposed { get; private set; }
 
-            protected internal override void Setup(FeatureConfigurationContext context)
+            protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
             {
                 context.RegisterStartupTask(new Runner(this));
+                return Task.CompletedTask;
             }
 
             public class Runner : FeatureStartupTask, IDisposable

--- a/src/NServiceBus.Core.Tests/Routing/DistributionPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DistributionPolicyTests.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.Core.Tests.Routing
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using NServiceBus.Routing;
     using NUnit.Framework;
 
@@ -50,9 +52,9 @@
             {
             }
 
-            public override string SelectDestination(DistributionContext context)
+            public override Task<string> SelectDestination(DistributionContext context, CancellationToken cancellationToken = default)
             {
-                return null;
+                return Task.FromResult<string>(null);
             }
         }
     }

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
@@ -20,7 +20,7 @@
         {
             publishers = new Publishers();
             publishers.AddOrReplacePublishers("A", new List<PublisherTableEntry> { new PublisherTableEntry(typeof(object), PublisherAddress.CreateFromPhysicalAddresses("publisher1")) });
-            router = new SubscriptionRouter(publishers, new EndpointInstances(), i => i.ToString());
+            router = new SubscriptionRouter(publishers, new EndpointInstances(), (i, _) => Task.FromResult(i.ToString()));
             dispatcher = new FakeDispatcher();
             subscribeTerminator = new MessageDrivenSubscribeTerminator(router, "replyToAddress", "Endpoint", dispatcher);
         }

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensionsTests.cs
@@ -171,7 +171,7 @@ namespace NServiceBus.Core.Tests.Routing.MessageDrivenSubscriptions
             throw new NotImplementedException();
         }
 
-        public override string ToTransportAddress(QueueAddress address)
+        public override Task<string> ToTransportAddress(QueueAddress address, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
@@ -24,7 +24,7 @@
         {
             var publishers = new Publishers();
             publishers.AddOrReplacePublishers("A", new List<PublisherTableEntry> { new PublisherTableEntry(typeof(object), PublisherAddress.CreateFromPhysicalAddresses("publisher1")) });
-            router = new SubscriptionRouter(publishers, new EndpointInstances(), i => i.ToString());
+            router = new SubscriptionRouter(publishers, new EndpointInstances(), (i, _) => Task.FromResult(i.ToString()));
             dispatcher = new FakeDispatcher();
             terminator = new MessageDrivenUnsubscribeTerminator(router, "replyToAddress", "Endpoint", dispatcher);
         }

--- a/src/NServiceBus.Core.Tests/Routing/Routers/SendConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/SendConnectorTests.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
@@ -83,10 +84,7 @@
 
             public UnicastRoutingStrategy FixedDestination { get; set; }
 
-            public override UnicastRoutingStrategy Route(IOutgoingSendContext context)
-            {
-                return FixedDestination;
-            }
+            public override Task<UnicastRoutingStrategy> Route(IOutgoingSendContext context) => Task.FromResult(FixedDestination);
         }
 
         class MyMessage

--- a/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingPolicyTests.cs
@@ -1,6 +1,8 @@
 namespace NServiceBus.Core.Tests.Routing
 {
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using NServiceBus.Routing;
     using NUnit.Framework;
 
@@ -8,7 +10,7 @@ namespace NServiceBus.Core.Tests.Routing
     public class RoutingPolicyTests
     {
         [Test]
-        public void ShouldScopeDistributionToEndpointName()
+        public async Task ShouldScopeDistributionToEndpointName()
         {
             var endpointA = "endpointA";
             var policy = new DistributionPolicy();
@@ -27,10 +29,10 @@ namespace NServiceBus.Core.Tests.Routing
 
             var result = new List<string>
             {
-                InvokeDistributionStrategy(policy, endpointA, endpointAInstances),
-                InvokeDistributionStrategy(policy, endpointB, endpointBInstances),
-                InvokeDistributionStrategy(policy, endpointA, endpointAInstances),
-                InvokeDistributionStrategy(policy, endpointB, endpointBInstances)
+                await InvokeDistributionStrategy(policy, endpointA, endpointAInstances),
+                await InvokeDistributionStrategy(policy, endpointB, endpointBInstances),
+                await InvokeDistributionStrategy(policy, endpointA, endpointAInstances),
+                await InvokeDistributionStrategy(policy, endpointB, endpointBInstances)
             };
 
             Assert.That(result.Count, Is.EqualTo(4));
@@ -40,9 +42,9 @@ namespace NServiceBus.Core.Tests.Routing
             Assert.That(result, Has.Exactly(1).EqualTo(endpointBInstances[1]));
         }
 
-        static string InvokeDistributionStrategy(IDistributionPolicy policy, string endpointName, string[] instanceAddress)
+        static Task<string> InvokeDistributionStrategy(IDistributionPolicy policy, string endpointName, string[] instanceAddress, CancellationToken cancellationToken = default)
         {
-            return policy.GetDistributionStrategy(endpointName, DistributionStrategyScope.Send).SelectDestination(new DistributionContext(instanceAddress, null, null, null, null, null));
+            return policy.GetDistributionStrategy(endpointName, DistributionStrategyScope.Send).SelectDestination(new DistributionContext(instanceAddress, null, null, null, null, null), cancellationToken);
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using NServiceBus.Routing;
     using NUnit.Framework;
 
@@ -9,7 +10,7 @@
     public class SingleInstanceRoundRobinDistributionStrategyTests
     {
         [Test]
-        public void ShouldRoundRobinOverAllProvidedInstances()
+        public async Task ShouldRoundRobinOverAllProvidedInstances()
         {
             var strategy = new SingleInstanceRoundRobinDistributionStrategy("endpointA", DistributionStrategyScope.Send);
 
@@ -23,9 +24,9 @@
             var distributionContext = new DistributionContext(instances, null, null, null, null, null);
             var result = new List<string>
             {
-                strategy.SelectDestination(distributionContext),
-                strategy.SelectDestination(distributionContext),
-                strategy.SelectDestination(distributionContext)
+                await strategy.SelectDestination(distributionContext),
+                await strategy.SelectDestination(distributionContext),
+                await strategy.SelectDestination(distributionContext)
             };
 
             Assert.That(result.Count, Is.EqualTo(3));
@@ -35,7 +36,7 @@
         }
 
         [Test]
-        public void ShouldRestartAtFirstInstance()
+        public async Task ShouldRestartAtFirstInstance()
         {
             var strategy = new SingleInstanceRoundRobinDistributionStrategy("endpointA", DistributionStrategyScope.Send);
 
@@ -49,17 +50,17 @@
             var distributionContext = new DistributionContext(instances, null, null, null, null, null);
             var result = new List<string>
             {
-                strategy.SelectDestination(distributionContext),
-                strategy.SelectDestination(distributionContext),
-                strategy.SelectDestination(distributionContext),
-                strategy.SelectDestination(distributionContext)
+                await strategy.SelectDestination(distributionContext),
+                await strategy.SelectDestination(distributionContext),
+                await strategy.SelectDestination(distributionContext),
+                await strategy.SelectDestination(distributionContext)
             };
 
             Assert.That(result.Last(), Is.EqualTo(result.First()));
         }
 
         [Test]
-        public void WhenNewInstancesAdded_ShouldIncludeAllInstancesInDistribution()
+        public async Task WhenNewInstancesAdded_ShouldIncludeAllInstancesInDistribution()
         {
             var strategy = new SingleInstanceRoundRobinDistributionStrategy("endpointA", DistributionStrategyScope.Send);
 
@@ -72,12 +73,12 @@
             var distributionContext = new DistributionContext(instances, null, null, null, null, null);
             var result = new List<string>
             {
-                strategy.SelectDestination(distributionContext),
-                strategy.SelectDestination(distributionContext)
+                await strategy.SelectDestination(distributionContext),
+                await strategy.SelectDestination(distributionContext)
             };
             instances = instances.Concat(new[] { "3" }).ToArray(); // add new instance
             distributionContext = new DistributionContext(instances, null, null, null, null, null);
-            result.Add(strategy.SelectDestination(distributionContext));
+            result.Add(await strategy.SelectDestination(distributionContext));
 
             Assert.That(result.Count, Is.EqualTo(3));
             Assert.That(result, Has.Exactly(1).EqualTo(instances[0]));
@@ -86,7 +87,7 @@
         }
 
         [Test]
-        public void WhenInstancesRemoved_ShouldOnlyDistributeAcrossRemainingInstances()
+        public async Task WhenInstancesRemoved_ShouldOnlyDistributeAcrossRemainingInstances()
         {
             var strategy = new SingleInstanceRoundRobinDistributionStrategy("endpointA", DistributionStrategyScope.Send);
 
@@ -100,12 +101,12 @@
             var distributionContext = new DistributionContext(instances, null, null, null, null, null);
             var result = new List<string>
             {
-                strategy.SelectDestination(distributionContext),
-                strategy.SelectDestination(distributionContext)
+                await strategy.SelectDestination(distributionContext),
+                await strategy.SelectDestination(distributionContext)
             };
             instances = instances.Take(2).ToArray(); // remove last instance.
             distributionContext = new DistributionContext(instances, null, null, null, null, null);
-            result.Add(strategy.SelectDestination(distributionContext));
+            result.Add(await strategy.SelectDestination(distributionContext));
 
             Assert.That(result.Count, Is.EqualTo(3));
             Assert.That(result, Has.Exactly(2).EqualTo(instances[0]));

--- a/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
@@ -130,7 +130,7 @@
             subscriptionStorage = new FakeSubscriptionStorage();
             router = new UnicastPublishRouter(
                 metadataRegistry,
-                i => string.Empty,
+                (i, _) => Task.FromResult(string.Empty),
                 subscriptionStorage);
 
             logStatements.Clear();

--- a/src/NServiceBus.Core/Audit/Audit.cs
+++ b/src/NServiceBus.Core/Audit/Audit.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using Logging;
     using Transport;
 
@@ -22,7 +24,7 @@
         /// <summary>
         /// See <see cref="Feature.Setup" />.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             var auditConfig = context.Settings.Get<AuditConfigReader.Result>();
 
@@ -38,6 +40,8 @@
             });
 
             logger.InfoFormat($"Auditing processed messages to '{auditConfig.Address}'");
+
+            return Task.CompletedTask;
         }
 
         static readonly ILog logger = LogManager.GetLogger<Audit>();

--- a/src/NServiceBus.Core/Causation/MessageCausation.cs
+++ b/src/NServiceBus.Core/Causation/MessageCausation.cs
@@ -1,6 +1,8 @@
 ﻿namespace NServiceBus.Features
 {
     using System;
+    using System.Threading.Tasks;
+    using System.Threading;
     using Pipeline;
     using Settings;
 
@@ -11,11 +13,13 @@
             EnableByDefault();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             var newIdGenerator = GetIdStrategy(context.Settings);
 
             context.Pipeline.Register("AttachCausationHeaders", new AttachCausationHeadersBehavior(newIdGenerator), "Adds related to and conversation id headers to outgoing messages");
+
+            return Task.CompletedTask;
         }
 
         static Func<IOutgoingLogicalMessageContext, string> GetIdStrategy(ReadOnlySettings settings)

--- a/src/NServiceBus.Core/Correlation/MessageCorrelation.cs
+++ b/src/NServiceBus.Core/Correlation/MessageCorrelation.cs
@@ -1,5 +1,8 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Threading.Tasks;
+    using System.Threading;
+
     class MessageCorrelation : Feature
     {
         public MessageCorrelation()
@@ -7,9 +10,10 @@
             EnableByDefault();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             context.Pipeline.Register("AttachCorrelationId", new AttachCorrelationIdBehavior(), "Makes sure that outgoing messages have a correlation id header set");
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.Core/DataBus/CustomIDataBus.cs
+++ b/src/NServiceBus.Core/DataBus/CustomIDataBus.cs
@@ -1,6 +1,8 @@
 ﻿namespace NServiceBus.Features
 {
     using System;
+    using System.Threading.Tasks;
+    using System.Threading;
 
     class CustomIDataBus : Feature
     {
@@ -9,9 +11,10 @@
             DependsOn<DataBus>();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             context.Container.ConfigureComponent(context.Settings.Get<Type>("CustomDataBusType"), DependencyLifecycle.SingleInstance);
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.Core/DataBus/DataBus.cs
+++ b/src/NServiceBus.Core/DataBus/DataBus.cs
@@ -30,7 +30,7 @@ namespace NServiceBus.Features
         /// <summary>
         /// Called when the features is activated.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             if (!context.Container.HasComponent<IDataBusSerializer>())
             {
@@ -42,6 +42,8 @@ namespace NServiceBus.Features
             var conventions = context.Settings.Get<Conventions>();
             context.Pipeline.Register(new DataBusReceiveBehavior.Registration(conventions));
             context.Pipeline.Register(new DataBusSendBehavior.Registration(conventions));
+
+            return Task.CompletedTask;
         }
 
         class IDataBusInitializer : FeatureStartupTask

--- a/src/NServiceBus.Core/DataBus/DataBusFileBased.cs
+++ b/src/NServiceBus.Core/DataBus/DataBusFileBased.cs
@@ -1,6 +1,8 @@
 namespace NServiceBus.Features
 {
     using System;
+    using System.Threading.Tasks;
+    using System.Threading;
     using Microsoft.Extensions.DependencyInjection;
     using NServiceBus.DataBus;
 
@@ -14,7 +16,7 @@ namespace NServiceBus.Features
         /// <summary>
         /// See <see cref="Feature.Setup" />
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             if (!context.Settings.TryGet("FileShareDataBusPath", out string basePath))
             {
@@ -23,6 +25,8 @@ namespace NServiceBus.Features
             var dataBus = new FileShareDataBusImplementation(basePath);
 
             context.Container.AddSingleton(typeof(IDataBus), dataBus);
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.Core/DelayedDelivery/DelayedDeliveryFeature.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/DelayedDeliveryFeature.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Threading.Tasks;
+    using System.Threading;
     using Transport;
 
     class DelayedDeliveryFeature : Feature
@@ -9,7 +11,7 @@
             EnableByDefault();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             var transportHasNativeDelayedDelivery = context.Settings.Get<TransportDefinition>().SupportsDelayedDelivery;
 
@@ -17,6 +19,8 @@
             {
                 context.Pipeline.Register("ThrowIfCannotDeferMessage", new ThrowIfCannotDeferMessageBehavior(), "Throws an exception if an attempt is made to defer a message without infrastructure support.");
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.Core/EndpointWithExternallyManagedContainer.cs
+++ b/src/NServiceBus.Core/EndpointWithExternallyManagedContainer.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
 
     /// <summary>
@@ -10,13 +12,13 @@
         /// <summary>
         /// Creates a new startable endpoint based on the provided configuration that uses an externally managed container.
         /// </summary>
-        public static IStartableEndpointWithExternallyManagedContainer Create(EndpointConfiguration configuration, IServiceCollection serviceCollection)
+        public static async Task<IStartableEndpointWithExternallyManagedContainer> Create(EndpointConfiguration configuration, IServiceCollection serviceCollection, CancellationToken cancellationToken = default)
         {
             Guard.AgainstNull(nameof(configuration), configuration);
             Guard.AgainstNull(nameof(serviceCollection), serviceCollection);
 
-            return HostCreator
-                .CreateWithExternallyManagedContainer(configuration, serviceCollection);
+            return await HostCreator
+                .CreateWithExternallyManagedContainer(configuration, serviceCollection, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/NServiceBus.Core/Features/Feature.cs
+++ b/src/NServiceBus.Core/Features/Feature.cs
@@ -3,6 +3,8 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Settings;
 
     /// <summary>
@@ -56,7 +58,7 @@
         /// <summary>
         /// Called when the features is activated.
         /// </summary>
-        protected internal abstract void Setup(FeatureConfigurationContext context);
+        protected internal abstract Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Adds a setup prerequisite condition. If false this feature won't be setup.
@@ -199,9 +201,9 @@
             return status;
         }
 
-        internal void SetupFeature(FeatureConfigurationContext config)
+        internal async Task SetupFeature(FeatureConfigurationContext config, CancellationToken cancellationToken = default)
         {
-            Setup(config);
+            await Setup(config, cancellationToken).ConfigureAwait(false);
 
             IsActive = true;
         }

--- a/src/NServiceBus.Core/Features/FeatureComponent.cs
+++ b/src/NServiceBus.Core/Features/FeatureComponent.cs
@@ -24,9 +24,9 @@
             }
         }
 
-        public void Initalize(FeatureConfigurationContext featureConfigurationContext)
+        public async Task Initalize(FeatureConfigurationContext featureConfigurationContext, CancellationToken cancellationToken = default)
         {
-            var featureStats = featureActivator.SetupFeatures(featureConfigurationContext);
+            var featureStats = await featureActivator.SetupFeatures(featureConfigurationContext, cancellationToken).ConfigureAwait(false);
 
             settings.AddStartupDiagnosticsSection("Features", featureStats);
         }

--- a/src/NServiceBus.Core/Features/RootFeature.cs
+++ b/src/NServiceBus.Core/Features/RootFeature.cs
@@ -1,5 +1,8 @@
 namespace NServiceBus.Features
 {
+    using System.Threading.Tasks;
+    using System.Threading;
+
     /// <summary>
     /// A root feature that is always enabled.
     /// </summary>
@@ -10,8 +13,6 @@ namespace NServiceBus.Features
             EnableByDefault();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
-        {
-        }
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 }

--- a/src/NServiceBus.Core/Hosting/HostCreator.cs
+++ b/src/NServiceBus.Core/Hosting/HostCreator.cs
@@ -10,7 +10,7 @@
 
     class HostCreator
     {
-        public static ExternallyManagedContainerHost CreateWithExternallyManagedContainer(EndpointConfiguration endpointConfiguration, IServiceCollection serviceCollection)
+        public static async Task<ExternallyManagedContainerHost> CreateWithExternallyManagedContainer(EndpointConfiguration endpointConfiguration, IServiceCollection serviceCollection, CancellationToken cancellationToken = default)
         {
             var settings = endpointConfiguration.Settings;
 
@@ -29,7 +29,7 @@
                 Type = "external"
             });
 
-            var endpointCreator = EndpointCreator.Create(settings, hostingConfiguration);
+            var endpointCreator = await EndpointCreator.Create(settings, hostingConfiguration, cancellationToken).ConfigureAwait(false);
             var hostingComponent = HostingComponent.Initialize(hostingConfiguration, serviceCollection, false);
             var externallyManagedContainerHost = new ExternallyManagedContainerHost(endpointCreator, hostingComponent);
 
@@ -55,7 +55,7 @@
                 Type = "internal"
             });
 
-            var endpointCreator = EndpointCreator.Create(settings, hostingConfiguration);
+            var endpointCreator = await EndpointCreator.Create(settings, hostingConfiguration, cancellationToken).ConfigureAwait(false);
 
             var hostingComponent = HostingComponent.Initialize(hostingConfiguration, serviceCollection, true);
 

--- a/src/NServiceBus.Core/Licensing/LicenseReminder.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseReminder.cs
@@ -2,6 +2,8 @@ namespace NServiceBus.Features
 {
     using System;
     using System.Diagnostics;
+    using System.Threading.Tasks;
+    using System.Threading;
     using Logging;
 
     class LicenseReminder : Feature
@@ -14,7 +16,7 @@ namespace NServiceBus.Features
             Defaults(s => s.SetDefault(LicenseFilePathSettingsKey, null));
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             try
             {
@@ -25,7 +27,7 @@ namespace NServiceBus.Features
 
                 if (!licenseManager.HasLicenseExpired)
                 {
-                    return;
+                    return Task.CompletedTask;
                 }
 
                 context.Pipeline.Register("LicenseReminder", new AuditInvalidLicenseBehavior(), "Audits that the message was processed by an endpoint with an expired license");
@@ -40,6 +42,8 @@ namespace NServiceBus.Features
                 //we only log here to prevent licensing issue to abort startup and cause production outages
                 Logger.Fatal("Failed to initialize the license", ex);
             }
+
+            return Task.CompletedTask;
         }
 
         static object GenerateLicenseDiagnostics(LicenseManager licenseManager)

--- a/src/NServiceBus.Core/MessageMutators/Mutators.cs
+++ b/src/NServiceBus.Core/MessageMutators/Mutators.cs
@@ -2,6 +2,8 @@
 {
     using MessageMutator;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using System.Threading;
 
     class Mutators : Feature
     {
@@ -10,7 +12,7 @@
             EnableByDefault();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             var registry = context.Settings.GetOrDefault<RegisteredMutators>() ?? new RegisteredMutators();
 
@@ -18,6 +20,8 @@
             context.Pipeline.Register("MutateIncomingMessages", new MutateIncomingMessageBehavior(registry.IncomingMessage), "Executes IMutateIncomingMessages");
             context.Pipeline.Register("MutateOutgoingMessages", new MutateOutgoingMessageBehavior(registry.OutgoingMessage), "Executes IMutateOutgoingMessages");
             context.Pipeline.Register("MutateOutgoingTransportMessage", new MutateOutgoingTransportMessageBehavior(registry.OutgoingTransportMessage), "Executes IMutateOutgoingTransportMessages");
+
+            return Task.CompletedTask;
         }
 
         public class RegisteredMutators

--- a/src/NServiceBus.Core/Performance/Statistics/ReceiveStatisticsFeature.cs
+++ b/src/NServiceBus.Core/Performance/Statistics/ReceiveStatisticsFeature.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus
 {
+    using System.Threading.Tasks;
+    using System.Threading;
     using Features;
 
     class ReceiveStatisticsFeature : Feature
@@ -9,10 +11,12 @@
             EnableByDefault();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             context.Pipeline.Register("ProcessingStatistics", new ProcessingStatisticsBehavior(), "Collects timing for ProcessingStarted and adds the state to determine ProcessingEnded");
             context.Pipeline.Register("AuditProcessingStatistics", new AuditProcessingStatisticsBehavior(), "Add ProcessingStarted and ProcessingEnded headers");
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.Core/Performance/TimeToBeReceived/TimeToBeReceived.cs
+++ b/src/NServiceBus.Core/Performance/TimeToBeReceived/TimeToBeReceived.cs
@@ -3,6 +3,8 @@
     using Transport;
     using System.Linq;
     using Unicast.Messages;
+    using System.Threading.Tasks;
+    using System.Threading;
 
     class TimeToBeReceived : Feature
     {
@@ -11,11 +13,13 @@
             EnableByDefault();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             var mappings = GetMappings(context);
 
             context.Pipeline.Register("ApplyTimeToBeReceived", new ApplyTimeToBeReceivedBehavior(mappings), "Adds the `DiscardIfNotReceivedBefore` constraint to relevant messages");
+
+            return Task.CompletedTask;
         }
 
         static TimeToBeReceivedMappings GetMappings(FeatureConfigurationContext context)

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/LearningSagaPersistence.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/LearningSagaPersistence.cs
@@ -2,6 +2,8 @@
 {
     using System;
     using System.IO;
+    using System.Threading.Tasks;
+    using System.Threading;
     using NServiceBus.Sagas;
 
     class LearningSagaPersistence : Feature
@@ -13,7 +15,7 @@
             Defaults(s => s.SetDefault(StorageLocationKey, Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ".sagas")));
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             var storageLocation = context.Settings.Get<string>(StorageLocationKey);
 
@@ -25,6 +27,8 @@
             context.Container.ConfigureComponent<LearningStorageAdapter>(DependencyLifecycle.SingleInstance);
 
             context.Container.ConfigureComponent(b => new LearningSagaPersister(), DependencyLifecycle.SingleInstance);
+
+            return Task.CompletedTask;
         }
 
         internal static string StorageLocationKey = "LearningSagaPersistence.StorageLocation";

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.Configuration.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.Configuration.cs
@@ -2,12 +2,14 @@ namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Transport;
     using Unicast;
 
     partial class ReceiveComponent
     {
-        public static Configuration PrepareConfiguration(HostingComponent.Configuration hostingConfiguration, Settings settings, TransportSeam transportSeam)
+        public static async Task<Configuration> PrepareConfiguration(HostingComponent.Configuration hostingConfiguration, Settings settings, TransportSeam transportSeam, CancellationToken cancellationToken = default)
         {
             var isSendOnlyEndpoint = settings.IsSendOnlyEndpoint;
 
@@ -22,12 +24,12 @@ namespace NServiceBus
             var purgeOnStartup = settings.PurgeOnStartup;
 
             var transportDefinition = transportSeam.TransportDefinition;
-            var localAddress = transportDefinition.ToTransportAddress(new QueueAddress(queueNameBase, null, null, null));
+            var localAddress = await transportDefinition.ToTransportAddress(new QueueAddress(queueNameBase, null, null, null), cancellationToken).ConfigureAwait(false);
 
             string instanceSpecificQueue = null;
             if (discriminator != null)
             {
-                instanceSpecificQueue = transportDefinition.ToTransportAddress(new QueueAddress(queueNameBase, discriminator, null, null));
+                instanceSpecificQueue = await transportDefinition.ToTransportAddress(new QueueAddress(queueNameBase, discriminator, null, null), cancellationToken).ConfigureAwait(false);
             }
 
             var pushRuntimeSettings = settings.PushRuntimeSettings;

--- a/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
@@ -2,6 +2,8 @@
 {
     using ConsistencyGuarantees;
     using System;
+    using System.Threading.Tasks;
+    using System.Threading;
     using Transport;
 
     /// <summary>
@@ -23,7 +25,7 @@
         /// <summary>
         /// See <see cref="Feature.Setup" />.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             if (!PersistenceStartup.HasSupportFor<StorageType.Outbox>(context.Settings))
             {
@@ -38,6 +40,8 @@
 
             //note: in the future we should change the persister api to give us a "outbox factory" so that we can register it in DI here instead of relying on the persister to do it
             context.Pipeline.Register("ForceBatchDispatchToBeIsolated", new ForceBatchDispatchToBeIsolatedBehavior(), "Makes sure that we dispatch straight to the transport so that we can safely set the outbox record to dispatched one the dispatch pipeline returns.");
+
+            return Task.CompletedTask;
         }
         internal const string TimeToKeepDeduplicationEntries = "Outbox.TimeToKeepDeduplicationEntries";
     }

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -24,7 +24,7 @@
         /// <summary>
         /// See <see cref="Feature.Setup" />.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             if (!context.Settings.TryGet(out SubscribeSettings settings))
             {
@@ -39,6 +39,8 @@
                 var messageTypesHandled = GetMessageTypesHandledByThisEndpoint(handlerRegistry, conventions, settings);
                 return new ApplySubscriptions(messageTypesHandled);
             });
+
+            return Task.CompletedTask;
         }
 
         static Type[] GetMessageTypesHandledByThisEndpoint(MessageHandlerRegistry handlerRegistry, Conventions conventions, SubscribeSettings settings)

--- a/src/NServiceBus.Core/Routing/DistributionContext.cs
+++ b/src/NServiceBus.Core/Routing/DistributionContext.cs
@@ -2,6 +2,8 @@ namespace NServiceBus.Routing
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Extensibility;
     using Pipeline;
 
@@ -13,7 +15,7 @@ namespace NServiceBus.Routing
         /// <summary>
         /// Creates a new distribution context.
         /// </summary>
-        public DistributionContext(string[] receiverAddresses, OutgoingLogicalMessage message, string messageId, Dictionary<string, string> headers, Func<EndpointInstance, string> addressTranslation, ContextBag extensions)
+        public DistributionContext(string[] receiverAddresses, OutgoingLogicalMessage message, string messageId, Dictionary<string, string> headers, Func<EndpointInstance, CancellationToken, Task<string>> addressTranslation, ContextBag extensions)
         {
             this.addressTranslation = addressTranslation;
             ReceiverAddresses = receiverAddresses;
@@ -52,13 +54,14 @@ namespace NServiceBus.Routing
         /// Converts a given logical address to the transport address.
         /// </summary>
         /// <param name="endpointInstance">The endpoint instance.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe.</param>
         /// <returns>The transport address.</returns>
-        public string ToTransportAddress(EndpointInstance endpointInstance)
+        public Task<string> ToTransportAddress(EndpointInstance endpointInstance, CancellationToken cancellationToken = default)
         {
             Guard.AgainstNull(nameof(endpointInstance), endpointInstance);
-            return addressTranslation(endpointInstance);
+            return addressTranslation(endpointInstance, cancellationToken);
         }
 
-        Func<EndpointInstance, string> addressTranslation;
+        Func<EndpointInstance, CancellationToken, Task<string>> addressTranslation;
     }
 }

--- a/src/NServiceBus.Core/Routing/DistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/DistributionStrategy.cs
@@ -1,5 +1,8 @@
 namespace NServiceBus.Routing
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+
     /// <summary>
     /// Determines which instance of a given endpoint a message is to be sent.
     /// </summary>
@@ -21,7 +24,7 @@ namespace NServiceBus.Routing
         /// <summary>
         /// Selects a destination instance for a message from all known addresses of a logical endpoint.
         /// </summary>
-        public abstract string SelectDestination(DistributionContext context);
+        public abstract Task<string> SelectDestination(DistributionContext context, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// The name of the endpoint this distribution strategy resolves instances for.

--- a/src/NServiceBus.Core/Routing/InferredMessageTypeEnricherFeature.cs
+++ b/src/NServiceBus.Core/Routing/InferredMessageTypeEnricherFeature.cs
@@ -1,5 +1,8 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Threading.Tasks;
+    using System.Threading;
+
     class InferredMessageTypeEnricherFeature : Feature
     {
         public InferredMessageTypeEnricherFeature()
@@ -7,9 +10,10 @@
             EnableByDefault();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             context.Pipeline.Register(typeof(InferredMessageTypeEnricherBehavior), "Adds EnclosedMessageType to the header of the incoming message if it doesn't exist.");
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscribeTerminator.cs
@@ -30,7 +30,7 @@
             {
                 try
                 {
-                    var publisherAddresses = subscriptionRouter.GetAddressesForEventType(eventType);
+                    var publisherAddresses = await subscriptionRouter.GetAddressesForEventType(eventType, context.CancellationToken).ConfigureAwait(false);
                     if (publisherAddresses.Count == 0)
                     {
                         throw new Exception($"No publisher address could be found for message type '{eventType}'. Ensure that a publisher has been configured for the event type and that the configured publisher endpoint has at least one known instance.");

--- a/src/NServiceBus.Core/Routing/NativePublishSubscribeFeature.cs
+++ b/src/NServiceBus.Core/Routing/NativePublishSubscribeFeature.cs
@@ -3,6 +3,8 @@ namespace NServiceBus.Features
     using Microsoft.Extensions.DependencyInjection;
     using Unicast.Messages;
     using Transport;
+    using System.Threading.Tasks;
+    using System.Threading;
 
     class NativePublishSubscribeFeature : Feature
     {
@@ -13,7 +15,7 @@ namespace NServiceBus.Features
             Prerequisite(c => SubscriptionMigrationMode.IsMigrationModeEnabled(c.Settings) == false, "The transport has enabled subscription migration mode");
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             var canReceive = !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly");
 
@@ -29,6 +31,8 @@ namespace NServiceBus.Features
                 context.Pipeline.Register(new SendOnlySubscribeTerminator(), "Throws an exception when trying to subscribe from a send-only endpoint");
                 context.Pipeline.Register(new SendOnlyUnsubscribeTerminator(), "Throws an exception when trying to unsubscribe from a send-only endpoint");
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.Core/Routing/Routers/SendConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/SendConnector.cs
@@ -14,7 +14,7 @@ namespace NServiceBus
 
         public override async Task Invoke(IOutgoingSendContext context, Func<IOutgoingLogicalMessageContext, Task> stage)
         {
-            var routingStrategy = unicastSendRouter.Route(context);
+            var routingStrategy = await unicastSendRouter.Route(context).ConfigureAwait(false);
             context.Headers[Headers.MessageIntent] = MessageIntentEnum.Send.ToString();
             var logicalMessageContext = this.CreateOutgoingLogicalMessageContext(context.Message, new[] { routingStrategy }, context);
 

--- a/src/NServiceBus.Core/Routing/RoutingComponent.cs
+++ b/src/NServiceBus.Core/Routing/RoutingComponent.cs
@@ -51,7 +51,7 @@ namespace NServiceBus
                 distributionPolicy,
                 unicastRoutingTable,
                 endpointInstances,
-                i => transportSeam.TransportDefinition.ToTransportAddress(new QueueAddress(i.Endpoint, i.Discriminator, i.Properties, null)));
+                (i, cancellationToken) => transportSeam.TransportDefinition.ToTransportAddress(new QueueAddress(i.Endpoint, i.Discriminator, i.Properties, null), cancellationToken));
 
             if (configuration.EnforceBestPractices)
             {

--- a/src/NServiceBus.Core/Routing/SingleInstanceRoundRobinDistributionStrategy.cs
+++ b/src/NServiceBus.Core/Routing/SingleInstanceRoundRobinDistributionStrategy.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Routing
 {
     using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Selects a single instance based on a round-robin scheme.
@@ -20,16 +21,16 @@ namespace NServiceBus.Routing
         /// <summary>
         /// Selects a destination instance for a message from all known addresses of a logical endpoint.
         /// </summary>
-        public override string SelectDestination(DistributionContext context)
+        public override Task<string> SelectDestination(DistributionContext context, CancellationToken cancellationToken = default)
         {
             Guard.AgainstNull(nameof(context), context);
             if (context.ReceiverAddresses.Length == 0)
             {
-                return default;
+                return Task.FromResult<string>(default);
             }
             var i = Interlocked.Increment(ref index);
             var result = context.ReceiverAddresses[(int)(i % context.ReceiverAddresses.Length)];
-            return result;
+            return Task.FromResult(result);
         }
 
         // start with -1 so the index will be at 0 after the first increment.

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationSubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationSubscribeTerminator.cs
@@ -54,7 +54,7 @@
             {
                 try
                 {
-                    var publisherAddresses = subscriptionRouter.GetAddressesForEventType(eventType);
+                    var publisherAddresses = await subscriptionRouter.GetAddressesForEventType(eventType, context.CancellationToken).ConfigureAwait(false);
                     if (publisherAddresses.Count == 0)
                     {
                         continue;

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationUnsubscribeTerminator.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/MigrationUnsubscribeTerminator.cs
@@ -33,7 +33,7 @@
             await subscriptionManager.Unsubscribe(eventMetadata, context.Extensions, context.CancellationToken).ConfigureAwait(false);
 
 
-            var publisherAddresses = subscriptionRouter.GetAddressesForEventType(eventType);
+            var publisherAddresses = await subscriptionRouter.GetAddressesForEventType(eventType, context.CancellationToken).ConfigureAwait(false);
             if (publisherAddresses.Count == 0)
             {
                 return;

--- a/src/NServiceBus.Core/Sagas/AutoCorrelationFeature.cs
+++ b/src/NServiceBus.Core/Sagas/AutoCorrelationFeature.cs
@@ -1,5 +1,8 @@
 ﻿namespace NServiceBus.Features
 {
+    using System.Threading.Tasks;
+    using System.Threading;
+
     class AutoCorrelationFeature : Feature
     {
         public AutoCorrelationFeature()
@@ -7,9 +10,10 @@
             EnableByDefault();
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             context.Pipeline.Register("PopulateAutoCorrelationHeadersForReplies", new PopulateAutoCorrelationHeadersForRepliesBehavior(), "Copies existing saga headers from incoming message to outgoing message to facilitate the auto correlation in the saga, when replying to a message that was sent by a saga.");
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.Core/Sagas/Sagas.cs
+++ b/src/NServiceBus.Core/Sagas/Sagas.cs
@@ -3,6 +3,8 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
+    using System.Threading;
     using Microsoft.Extensions.DependencyInjection;
     using NServiceBus.Sagas;
 
@@ -35,7 +37,7 @@
         /// <summary>
         /// See <see cref="Feature.Setup" />.
         /// </summary>
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             if (!PersistenceStartup.HasSupportFor<StorageType.Sagas>(context.Settings))
             {
@@ -68,6 +70,8 @@
             context.Pipeline.Register("InvokeSaga", b => new SagaPersistenceBehavior(b.GetRequiredService<ISagaPersister>(), sagaIdGenerator, sagaMetaModel), "Invokes the saga logic");
             context.Pipeline.Register("InvokeSagaNotFound", new InvokeSagaNotFoundBehavior(), "Invokes saga not found logic");
             context.Pipeline.Register("AttachSagaDetailsToOutGoingMessage", new AttachSagaDetailsToOutGoingMessageBehavior(), "Makes sure that outgoing messages have saga info attached to them");
+
+            return Task.CompletedTask;
         }
 
         static void RegisterCustomFindersInContainer(IServiceCollection container, IEnumerable<SagaMetadata> sagaMetaModel)

--- a/src/NServiceBus.Core/Serialization/SerializationFeature.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationFeature.cs
@@ -3,6 +3,8 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
+    using System.Threading;
     using Features;
     using Logging;
     using MessageInterfaces;
@@ -18,7 +20,7 @@
             EnableByDefault();
         }
 
-        protected internal sealed override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             var mapper = context.Settings.Get<IMessageMapper>();
             var settings = context.Settings;
@@ -70,6 +72,8 @@
                 },
                 AdditionalDeserializers = additionalDeserializerDiagnostics
             });
+
+            return Task.CompletedTask;
         }
 
         static IMessageSerializer CreateMessageSerializer(Tuple<SerializationDefinition, SettingsHolder> definitionAndSettings, IMessageMapper mapper, ReadOnlySettings mainSettings)

--- a/src/NServiceBus.Core/StaticHeaders/StaticHeaders.cs
+++ b/src/NServiceBus.Core/StaticHeaders/StaticHeaders.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus
 {
+    using System.Threading.Tasks;
+    using System.Threading;
     using Features;
 
     class StaticHeaders : Feature
@@ -10,10 +12,12 @@
             Prerequisite(c => c.Settings.HasSetting<CurrentStaticHeaders>(), "No static outgoing headers registered");
         }
 
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             var headers = context.Settings.Get<CurrentStaticHeaders>();
             context.Pipeline.Register("ApplyStaticHeaders", new ApplyStaticHeadersBehavior(headers), "Applies static headers to outgoing messages");
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransport.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransport.cs
@@ -36,7 +36,7 @@
         }
 
         /// <inheritdoc />
-        public override string ToTransportAddress(QueueAddress queueAddress)
+        public override Task<string> ToTransportAddress(QueueAddress queueAddress, CancellationToken cancellationToken = default)
         {
             var address = queueAddress.BaseAddress;
             PathChecker.ThrowForBadPath(address, "endpoint name");
@@ -59,7 +59,7 @@
                 address += "-" + qualifier;
             }
 
-            return address;
+            return Task.FromResult(address);
         }
 
         /// <inheritdoc />

--- a/src/NServiceBus.Core/Transports/TransportDefinition.cs
+++ b/src/NServiceBus.Core/Transports/TransportDefinition.cs
@@ -36,7 +36,7 @@ namespace NServiceBus.Transport
         /// <summary>
         /// Translates a <see cref="QueueAddress"/> object into a transport specific queue address-string.
         /// </summary>
-        public abstract string ToTransportAddress(QueueAddress address);
+        public abstract Task<string> ToTransportAddress(QueueAddress address, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns a list of all supported transaction modes of this transport.

--- a/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWork.cs
+++ b/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWork.cs
@@ -1,12 +1,14 @@
 ﻿namespace NServiceBus.Features
 {
     using System;
+    using System.Threading.Tasks;
+    using System.Threading;
     using System.Transactions;
     using ConsistencyGuarantees;
 
     class TransactionScopeUnitOfWork : Feature
     {
-        protected internal override void Setup(FeatureConfigurationContext context)
+        protected internal override Task Setup(FeatureConfigurationContext context, CancellationToken cancellationToken = default)
         {
             if (context.Settings.GetRequiredTransactionModeForReceives() == TransportTransactionMode.TransactionScope)
             {
@@ -15,6 +17,8 @@
 
             var transactionOptions = context.Settings.Get<Settings>().TransactionOptions;
             context.Pipeline.Register(new TransactionScopeUnitOfWorkBehavior.Registration(transactionOptions));
+
+            return Task.CompletedTask;
         }
 
         public class Settings


### PR DESCRIPTION
To remove [this](https://github.com/Particular/NServiceBus.SqlServer/blob/6e04f96acf10014c2a1cb72a364534c3b09abb65/src/NServiceBus.Transport.SqlServer/SqlServerTransport.cs#L108-L128).

This results in two _user_ API changes:

- `EndpointWithExternallyManagedContainer.Create` becomes async.
  - Note that `Endpoint.Create` is already async, so this is arguably an improvement, since it aligns the two.
- `Feature.Setup` becomes async.
  - I guess this is more controversial, since it will require users to update _all_ features. However, we may be able to revert this change. See [this comment](https://github.com/Particular/NServiceBus/pull/5981#discussion_r593913758).