### PR TITLE
Move ToTransportAddress to TransportInfrastructure

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransport.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransport.cs
@@ -25,32 +25,6 @@
             return infrastructure;
         }
 
-        public override string ToTransportAddress(QueueAddress address)
-        {
-            var baseAddress = address.BaseAddress;
-            PathChecker.ThrowForBadPath(baseAddress, "endpoint name");
-
-            var discriminator = address.Discriminator;
-
-            if (!string.IsNullOrEmpty(discriminator))
-            {
-                PathChecker.ThrowForBadPath(discriminator, "endpoint discriminator");
-
-                baseAddress += "-" + discriminator;
-            }
-
-            var qualifier = address.Qualifier;
-
-            if (!string.IsNullOrEmpty(qualifier))
-            {
-                PathChecker.ThrowForBadPath(qualifier, "address qualifier");
-
-                baseAddress += "-" + qualifier;
-            }
-
-            return baseAddress;
-        }
-
         public override IReadOnlyCollection<TransportTransactionMode> GetSupportedTransactionModes()
         {
             return new[]

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransportInfrastructure.cs
@@ -42,6 +42,32 @@
             }
         }
 
+        public override string ToTransportAddress(QueueAddress address)
+        {
+            var baseAddress = address.BaseAddress;
+            PathChecker.ThrowForBadPath(baseAddress, "endpoint name");
+
+            var discriminator = address.Discriminator;
+
+            if (!string.IsNullOrEmpty(discriminator))
+            {
+                PathChecker.ThrowForBadPath(discriminator, "endpoint discriminator");
+
+                baseAddress += "-" + discriminator;
+            }
+
+            var qualifier = address.Qualifier;
+
+            if (!string.IsNullOrEmpty(qualifier))
+            {
+                PathChecker.ThrowForBadPath(qualifier, "address qualifier");
+
+                baseAddress += "-" + qualifier;
+            }
+
+            return baseAddress;
+        }
+
         public async Task ConfigureReceivers()
         {
             var receivers = new Dictionary<string, IMessageReceiver>();
@@ -64,9 +90,9 @@
             ISubscriptionManager subscriptionManager = null;
             if (receiveSettings.UsePublishSubscribe && transportSettings.SupportsPublishSubscribe)
             {
-                subscriptionManager = new LearningTransportSubscriptionManager(storagePath, settings.Name, receiveSettings.ReceiveAddress);
+                subscriptionManager = new LearningTransportSubscriptionManager(storagePath, settings.Name, ToTransportAddress(receiveSettings.ReceiveAddress));
             }
-            var pump = new LearningTransportMessagePump(receiveSettings.Id, storagePath, settings.CriticalErrorAction, subscriptionManager, receiveSettings, transportSettings.TransportTransactionMode);
+            var pump = new LearningTransportMessagePump(receiveSettings.Id, storagePath, ToTransportAddress(receiveSettings.ReceiveAddress), settings.CriticalErrorAction, subscriptionManager, receiveSettings, transportSettings.TransportTransactionMode);
             return Task.FromResult<IMessageReceiver>(pump);
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransport.cs
@@ -25,14 +25,9 @@
             infrastructure.ConfigureSendInfrastructure();
             infrastructure.ConfigureReceiveInfrastructure();
 
-            OnTransportInitialize((receivers.Select(r => r.ReceiveAddress).ToArray(), sendingAddresses, hostSettings.SetupInfrastructure));
+            OnTransportInitialize((receivers.Select(r => r.ReceiveAddress.BaseAddress).ToArray(), sendingAddresses, hostSettings.SetupInfrastructure));
 
             return Task.FromResult<TransportInfrastructure>(infrastructure);
-        }
-
-        public override string ToTransportAddress(QueueAddress address)
-        {
-            return new LearningTransport().ToTransportAddress(address);
         }
 
         public override IReadOnlyCollection<TransportTransactionMode> GetSupportedTransactionModes()

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/FakeTransportInfrastructure.cs
@@ -49,5 +49,29 @@
 
             return Task.CompletedTask;
         }
+
+        /// <inheritdoc />
+        public override string ToTransportAddress(QueueAddress queueAddress)
+        {
+            var address = queueAddress.BaseAddress;
+
+            var discriminator = queueAddress.Discriminator;
+
+            if (!string.IsNullOrEmpty(discriminator))
+            {
+
+                address += "-" + discriminator;
+            }
+
+            var qualifier = queueAddress.Qualifier;
+
+            if (!string.IsNullOrEmpty(qualifier))
+            {
+
+                address += "-" + qualifier;
+            }
+
+            return address;
+        }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/ProcessingOptimizations/When_using_concurrency_limit.cs
@@ -81,11 +81,6 @@
                 return Task.FromResult<TransportInfrastructure>(new FakeTransportInfrastructure(receivers));
             }
 
-            public override string ToTransportAddress(QueueAddress address)
-            {
-                return address.ToString();
-            }
-
             public override IReadOnlyCollection<TransportTransactionMode> GetSupportedTransactionModes()
             {
                 return new[]
@@ -111,6 +106,11 @@
             public override Task Shutdown(CancellationToken cancellationToken = default)
             {
                 return Task.CompletedTask;
+            }
+
+            public override string ToTransportAddress(QueueAddress address)
+            {
+                return address.ToString();
             }
         }
     }

--- a/src/NServiceBus.AcceptanceTests/Core/Installers/When_creating_queues.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Installers/When_creating_queues.cs
@@ -118,7 +118,7 @@
                 protected override void Setup(FeatureConfigurationContext context)
                 {
                     context.AddSatelliteReceiver("MySatellite",
-                        "MySatelliteAddress",
+                        new QueueAddress("MySatelliteReceiver", null, null, null),
                         PushRuntimeSettings.Default,
                         (_, __) => throw new NotImplementedException(),
                         (_, __, ___) => throw new NotImplementedException());

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_using_discriminator.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_using_discriminator.cs
@@ -43,7 +43,7 @@
 
                 protected override void Setup(FeatureConfigurationContext context)
                 {
-                    context.Settings.Get<Context>().InstanceDescriminatorFromSettingsExtensions = context.Settings.InstanceSpecificQueue();
+                    context.Settings.Get<Context>().InstanceDescriminatorFromSettingsExtensions = context.Settings.InstanceSpecificQueue().Discriminator;
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
+++ b/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
@@ -14,7 +14,7 @@
         public async Task Should_receive_the_message()
         {
             var context = await Scenario.Define<Context>()
-                .WithEndpoint<Endpoint>(b => b.When((session, c) => session.Send(Endpoint.MySatelliteFeature.Address, new MyMessage())))
+                .WithEndpoint<Endpoint>(b => b.When((session, c) => session.Send(@"¯\_(ツ)_/¯", new MyMessage())))
                 .Done(c => c.MessageReceived)
                 .Run();
 
@@ -51,9 +51,7 @@
                     var endpointQueueName = context.Settings.EndpointQueueName();
                     var queueAddress = new QueueAddress(endpointQueueName, null, null, "MySatellite");
 
-                    var satelliteAddress = context.Settings.Get<TransportDefinition>().ToTransportAddress(queueAddress);
-
-                    context.AddSatelliteReceiver("Test satellite", satelliteAddress, PushRuntimeSettings.Default,
+                    context.AddSatelliteReceiver("Test satellite", queueAddress, PushRuntimeSettings.Default,
                         (c, ec) => RecoverabilityAction.MoveToError(c.Failed.ErrorQueue),
                         (builder, messageContext, cancellationToken) =>
                         {
@@ -62,11 +60,7 @@
                             testContext.TransportTransactionAddedToContext = ReferenceEquals(messageContext.Extensions.Get<TransportTransaction>(), messageContext.TransportTransaction);
                             return Task.FromResult(true);
                         });
-
-                    Address = satelliteAddress;
                 }
-
-                public static string Address;
             }
         }
 

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -64,7 +64,6 @@ namespace NServiceBus
 
             var routingComponent = RoutingComponent.Initialize(
                 routingConfiguration,
-                transportSeam,
                 receiveConfiguration,
                 settings.Get<Conventions>(),
                 pipelineSettings);

--- a/src/NServiceBus.Core/Features/FeatureConfigurationContext.cs
+++ b/src/NServiceBus.Core/Features/FeatureConfigurationContext.cs
@@ -66,10 +66,10 @@
         /// <param name="runtimeSettings">Transport runtime settings.</param>
         /// <param name="recoverabilityPolicy">Recoverability policy to be if processing fails.</param>
         /// <param name="onMessage">The message func.</param>
-        public void AddSatelliteReceiver(string name, string transportAddress, PushRuntimeSettings runtimeSettings, Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> recoverabilityPolicy, OnSatelliteMessage onMessage)
+        public void AddSatelliteReceiver(string name, QueueAddress transportAddress, PushRuntimeSettings runtimeSettings, Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> recoverabilityPolicy, OnSatelliteMessage onMessage)
         {
             Guard.AgainstNullAndEmpty(nameof(name), name);
-            Guard.AgainstNullAndEmpty(nameof(transportAddress), transportAddress);
+            Guard.AgainstNull(nameof(transportAddress), transportAddress);
             Guard.AgainstNull(nameof(runtimeSettings), runtimeSettings);
             Guard.AgainstNull(nameof(recoverabilityPolicy), recoverabilityPolicy);
             Guard.AgainstNull(nameof(onMessage), onMessage);

--- a/src/NServiceBus.Core/Pipeline/Outgoing/SendComponent.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/SendComponent.cs
@@ -19,7 +19,7 @@
             pipelineSettings.Register("AuditHostInformation", new AuditHostInformationBehavior(hostingConfiguration.HostInformation, hostingConfiguration.EndpointName), "Adds audit host information");
             pipelineSettings.Register("AddHostInfoHeaders", new AddHostInfoHeadersBehavior(hostingConfiguration.HostInformation, hostingConfiguration.EndpointName), "Adds host info headers to outgoing headers");
 
-            pipelineSettings.Register("UnicastSendRouterConnector", new SendConnector(routingComponent.UnicastSendRouter), "Determines how the message being sent should be routed");
+            pipelineSettings.Register("UnicastSendRouterConnector", b => new SendConnector(routingComponent.UnicastSendRouter, b.GetRequiredService<TransportInfrastructure>()), "Determines how the message being sent should be routed");
             pipelineSettings.Register("UnicastReplyRouterConnector", new ReplyConnector(), "Determines how replies should be routed");
 
 

--- a/src/NServiceBus.Core/Pipeline/SatelliteDefinition.cs
+++ b/src/NServiceBus.Core/Pipeline/SatelliteDefinition.cs
@@ -5,7 +5,7 @@
 
     class SatelliteDefinition
     {
-        public SatelliteDefinition(string name, string receiveAddress, PushRuntimeSettings runtimeSettings, Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> recoverabilityPolicy, OnSatelliteMessage onMessage)
+        public SatelliteDefinition(string name, QueueAddress receiveAddress, PushRuntimeSettings runtimeSettings, Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> recoverabilityPolicy, OnSatelliteMessage onMessage)
         {
             Name = name;
             ReceiveAddress = receiveAddress;
@@ -16,7 +16,7 @@
 
         public string Name { get; }
 
-        public string ReceiveAddress { get; }
+        public QueueAddress ReceiveAddress { get; }
 
         public PushRuntimeSettings RuntimeSettings { get; }
 

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.Configuration.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.Configuration.cs
@@ -22,19 +22,19 @@ namespace NServiceBus
             var purgeOnStartup = settings.PurgeOnStartup;
 
             var transportDefinition = transportSeam.TransportDefinition;
-            var localAddress = transportDefinition.ToTransportAddress(new QueueAddress(queueNameBase, null, null, null));
+            var localAddress2 = new QueueAddress(queueNameBase, null, null, null);
 
-            string instanceSpecificQueue = null;
+            QueueAddress instanceSpecificQueue = null;
             if (discriminator != null)
             {
-                instanceSpecificQueue = transportDefinition.ToTransportAddress(new QueueAddress(queueNameBase, discriminator, null, null));
+                instanceSpecificQueue = new QueueAddress(queueNameBase, discriminator, null, null);
             }
 
             var pushRuntimeSettings = settings.PushRuntimeSettings;
 
             var receiveConfiguration = new Configuration(
                 queueNameBase,
-                localAddress,
+                localAddress2,
                 instanceSpecificQueue,
                 pushRuntimeSettings,
                 purgeOnStartup,
@@ -56,8 +56,8 @@ namespace NServiceBus
         {
             public Configuration(
                 string queueNameBase,
-                string localAddress,
-                string instanceSpecificQueue,
+                QueueAddress localAddress,
+                QueueAddress instanceSpecificQueue,
                 PushRuntimeSettings pushRuntimeSettings,
                 bool purgeOnStartup,
                 Notification<ReceivePipelineCompleted> pipelineCompletedSubscribers,
@@ -83,9 +83,9 @@ namespace NServiceBus
                 this.transportSeam = transportSeam;
             }
 
-            public string LocalAddress { get; }
+            public QueueAddress LocalAddress { get; }
 
-            public string InstanceSpecificQueue { get; }
+            public QueueAddress InstanceSpecificQueue { get; }
 
             public PushRuntimeSettings PushRuntimeSettings { get; }
 
@@ -103,7 +103,7 @@ namespace NServiceBus
 
             public Conventions Conventions { get; }
 
-            public void AddSatelliteReceiver(string name, string transportAddress, PushRuntimeSettings runtimeSettings, Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> recoverabilityPolicy, OnSatelliteMessage onMessage)
+            public void AddSatelliteReceiver(string name, QueueAddress transportAddress, PushRuntimeSettings runtimeSettings, Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> recoverabilityPolicy, OnSatelliteMessage onMessage)
             {
                 var satelliteDefinition = new SatelliteDefinition(name, transportAddress, runtimeSettings, recoverabilityPolicy, onMessage);
 

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -78,7 +78,7 @@ namespace NServiceBus
             };
 
 
-            if (!string.IsNullOrWhiteSpace(configuration.InstanceSpecificQueue))
+            if (configuration.InstanceSpecificQueue != null)
             {
                 receiveSettings.Add(new ReceiveSettings(
                     InstanceSpecificReceiverId,
@@ -95,6 +95,7 @@ namespace NServiceBus
                 configuration.PurgeOnStartup,
                 errorQueue)));
 
+            //TODO this could be made easier by resolving transportinfrastructure instead of using the ugly event
             hostingConfiguration.Services.ConfigureComponent(() => receiveComponent.mainReceiverSubscriptionManager, DependencyLifecycle.SingleInstance);
             // get a reference to the subscription manager as soon as the transport has been created:
             configuration.transportSeam.TransportInfrastructureCreated += (_, infrastructure) =>

--- a/src/NServiceBus.Core/Recoverability/DelayedRetryExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/DelayedRetryExecutor.cs
@@ -10,7 +10,7 @@
 
     class DelayedRetryExecutor
     {
-        public DelayedRetryExecutor(string endpointInputQueue, IMessageDispatcher dispatcher)
+        public DelayedRetryExecutor(QueueAddress endpointInputQueue, IMessageDispatcher dispatcher)
         {
             this.dispatcher = dispatcher;
             this.endpointInputQueue = endpointInputQueue;
@@ -29,7 +29,8 @@
             {
                 DelayDeliveryWith = new DelayDeliveryWith(delay)
             };
-            var messageDestination = new UnicastAddressTag(endpointInputQueue);
+            //TODO need to inject TI somehow and translate address
+            var messageDestination = new UnicastAddressTag(endpointInputQueue.ToString());
 
             var transportOperations = new TransportOperations(new TransportOperation(outgoingMessage, messageDestination, dispatchProperties));
 
@@ -39,6 +40,6 @@
         }
 
         IMessageDispatcher dispatcher;
-        string endpointInputQueue;
+        QueueAddress endpointInputQueue;
     }
 }

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityComponent.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityComponent.cs
@@ -74,11 +74,12 @@
             var delayedRetriesAvailable = transactionsOn && transportSeam.TransportDefinition.SupportsDelayedDelivery;
             var immediateRetriesAvailable = transactionsOn;
 
-            Func<string, MoveToErrorsExecutor> moveToErrorsExecutorFactory = localAddress =>
+            Func<QueueAddress, MoveToErrorsExecutor> moveToErrorsExecutorFactory = localAddress =>
             {
+                //TODO how to get TI here to translate the address?
                 var staticFaultMetadata = new Dictionary<string, string>
                 {
-                    {FaultsHeaderKeys.FailedQ, localAddress},
+                    {FaultsHeaderKeys.FailedQ, "localAddress"},
                     {Headers.ProcessingMachine, RuntimeEnvironment.MachineName},
                     {Headers.ProcessingEndpoint, settings.EndpointName()},
                     {Headers.HostId, hostInformation.HostId.ToString("N")},
@@ -90,7 +91,7 @@
                 return new MoveToErrorsExecutor(builder.GetRequiredService<IMessageDispatcher>(), staticFaultMetadata, headerCustomizations);
             };
 
-            Func<string, DelayedRetryExecutor> delayedRetryExecutorFactory = localAddress =>
+            Func<QueueAddress, DelayedRetryExecutor> delayedRetryExecutorFactory = localAddress =>
             {
                 if (delayedRetriesAvailable)
                 {

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityExecutorFactory.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityExecutorFactory.cs
@@ -8,8 +8,8 @@
         public RecoverabilityExecutorFactory(
             Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> defaultRecoverabilityPolicy,
             RecoverabilityConfig configuration,
-            Func<string, DelayedRetryExecutor> delayedRetryExecutorFactory,
-            Func<string, MoveToErrorsExecutor> moveToErrorsExecutorFactory,
+            Func<QueueAddress, DelayedRetryExecutor> delayedRetryExecutorFactory,
+            Func<QueueAddress, MoveToErrorsExecutor> moveToErrorsExecutorFactory,
             bool immediateRetriesAvailable,
             bool delayedRetriesAvailable,
             INotificationSubscriptions<MessageToBeRetried> messageRetryNotification,
@@ -25,17 +25,17 @@
             this.messageFaultedNotification = messageFaultedNotification;
         }
 
-        public RecoverabilityExecutor CreateDefault(string localAddress)
+        public RecoverabilityExecutor CreateDefault(QueueAddress localAddress)
         {
             return Create(defaultRecoverabilityPolicy, localAddress, raiseNotifications: true);
         }
 
-        public RecoverabilityExecutor Create(Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> customRecoverabilityPolicy, string localAddress)
+        public RecoverabilityExecutor Create(Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> customRecoverabilityPolicy, QueueAddress localAddress)
         {
             return Create(customRecoverabilityPolicy, localAddress, raiseNotifications: false);
         }
 
-        RecoverabilityExecutor Create(Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> customRecoverabilityPolicy, string localAddress, bool raiseNotifications)
+        RecoverabilityExecutor Create(Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> customRecoverabilityPolicy, QueueAddress localAddress, bool raiseNotifications)
         {
             var delayedRetryExecutor = delayedRetryExecutorFactory(localAddress);
             var moveToErrorsExecutor = moveToErrorsExecutorFactory(localAddress);
@@ -58,8 +58,8 @@
         readonly INotificationSubscriptions<MessageFaulted> messageFaultedNotification;
 
         Func<RecoverabilityConfig, ErrorContext, RecoverabilityAction> defaultRecoverabilityPolicy;
-        Func<string, DelayedRetryExecutor> delayedRetryExecutorFactory;
-        Func<string, MoveToErrorsExecutor> moveToErrorsExecutorFactory;
+        Func<QueueAddress, DelayedRetryExecutor> delayedRetryExecutorFactory;
+        Func<QueueAddress, MoveToErrorsExecutor> moveToErrorsExecutorFactory;
         RecoverabilityConfig configuration;
     }
 }

--- a/src/NServiceBus.Core/Routing/DistributionContext.cs
+++ b/src/NServiceBus.Core/Routing/DistributionContext.cs
@@ -1,9 +1,9 @@
 namespace NServiceBus.Routing
 {
-    using System;
     using System.Collections.Generic;
     using Extensibility;
     using Pipeline;
+    using Transport;
 
     /// <summary>
     /// The context for custom <see cref="DistributionStrategy" /> implementations.
@@ -13,9 +13,9 @@ namespace NServiceBus.Routing
         /// <summary>
         /// Creates a new distribution context.
         /// </summary>
-        public DistributionContext(string[] receiverAddresses, OutgoingLogicalMessage message, string messageId, Dictionary<string, string> headers, Func<EndpointInstance, string> addressTranslation, ContextBag extensions)
+        public DistributionContext(string[] receiverAddresses, OutgoingLogicalMessage message, string messageId, Dictionary<string, string> headers, TransportInfrastructure transportInfrastructure, ContextBag extensions)
         {
-            this.addressTranslation = addressTranslation;
+            this.transportInfrastructure = transportInfrastructure;
             ReceiverAddresses = receiverAddresses;
             Message = message;
             MessageId = messageId;
@@ -56,9 +56,9 @@ namespace NServiceBus.Routing
         public string ToTransportAddress(EndpointInstance endpointInstance)
         {
             Guard.AgainstNull(nameof(endpointInstance), endpointInstance);
-            return addressTranslation(endpointInstance);
+            return transportInfrastructure.ToTransportAddress(new QueueAddress(endpointInstance.Endpoint, endpointInstance.Discriminator, endpointInstance.Properties, null));
         }
 
-        Func<EndpointInstance, string> addressTranslation;
+        TransportInfrastructure transportInfrastructure;
     }
 }

--- a/src/NServiceBus.Core/Routing/EndpointInstance.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstance.cs
@@ -115,7 +115,7 @@
             {
                 return true;
             }
-            return obj is EndpointInstance && Equals((EndpointInstance)obj);
+            return obj is EndpointInstance instance && Equals(instance);
         }
 
         /// <summary>

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionRouter.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/SubscriptionRouter.cs
@@ -4,14 +4,15 @@
     using System.Collections.Generic;
     using Routing;
     using Routing.MessageDrivenSubscriptions;
+    using Transport;
 
     class SubscriptionRouter
     {
-        public SubscriptionRouter(Publishers publishers, EndpointInstances endpointInstances, Func<EndpointInstance, string> transportAddressTranslation)
+        public SubscriptionRouter(Publishers publishers, EndpointInstances endpointInstances, TransportInfrastructure transportInfrastructure)
         {
             this.publishers = publishers;
             this.endpointInstances = endpointInstances;
-            this.transportAddressTranslation = transportAddressTranslation;
+            this.transportInfrastructure = transportInfrastructure;
         }
 
         public List<string> GetAddressesForEventType(Type messageType)
@@ -25,13 +26,13 @@
                 {
                     publisherTransportAddresses = new List<string>();
                 }
-                publisherTransportAddresses.AddRange(publisherAddress.Resolve(e => endpointInstances.FindInstances(e), i => transportAddressTranslation(i)));
+                publisherTransportAddresses.AddRange(publisherAddress.Resolve(e => endpointInstances.FindInstances(e), i => transportInfrastructure.ToTransportAddress(new QueueAddress(i.Endpoint, i.Discriminator, i.Properties, null))));
             }
             return publisherTransportAddresses ?? noAddresses;
         }
 
         EndpointInstances endpointInstances;
-        Func<EndpointInstance, string> transportAddressTranslation;
+        readonly TransportInfrastructure transportInfrastructure;
         static List<string> noAddresses = new List<string>(0);
 
         Publishers publishers;

--- a/src/NServiceBus.Core/Routing/Routers/SendConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/SendConnector.cs
@@ -3,18 +3,20 @@ namespace NServiceBus
     using System;
     using System.Threading.Tasks;
     using Pipeline;
+    using Transport;
     using Unicast.Queuing;
 
     class SendConnector : StageConnector<IOutgoingSendContext, IOutgoingLogicalMessageContext>
     {
-        public SendConnector(UnicastSendRouter unicastSendRouter)
+        public SendConnector(UnicastSendRouter unicastSendRouter, TransportInfrastructure transportInfrastructure)
         {
             this.unicastSendRouter = unicastSendRouter;
+            this.transportInfrastructure = transportInfrastructure;
         }
 
         public override async Task Invoke(IOutgoingSendContext context, Func<IOutgoingLogicalMessageContext, Task> stage)
         {
-            var routingStrategy = unicastSendRouter.Route(context);
+            var routingStrategy = unicastSendRouter.Route(context, transportInfrastructure);
             context.Headers[Headers.MessageIntent] = MessageIntentEnum.Send.ToString();
             var logicalMessageContext = this.CreateOutgoingLogicalMessageContext(context.Message, new[] { routingStrategy }, context);
 
@@ -29,5 +31,6 @@ namespace NServiceBus
         }
 
         readonly UnicastSendRouter unicastSendRouter;
+        readonly TransportInfrastructure transportInfrastructure;
     }
 }

--- a/src/NServiceBus.Core/Routing/RoutingComponent.cs
+++ b/src/NServiceBus.Core/Routing/RoutingComponent.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus
 {
-    using Transport;
     using Pipeline;
 
     partial class RoutingComponent
@@ -17,7 +16,6 @@ namespace NServiceBus
 
         public static RoutingComponent Initialize(
             Configuration configuration,
-            TransportSeam transportSeam,
             ReceiveComponent.Configuration receiveConfiguration,
             Conventions conventions,
             PipelineSettings pipelineSettings)
@@ -36,22 +34,22 @@ namespace NServiceBus
             var isSendOnlyEndpoint = receiveConfiguration.IsSendOnlyEndpoint;
             if (!isSendOnlyEndpoint)
             {
+                //TODO: translate address at resolve time
                 pipelineSettings.Register(
                     new ApplyReplyToAddressBehavior(
-                        receiveConfiguration.LocalAddress,
-                        receiveConfiguration.InstanceSpecificQueue,
+                        "receiveConfiguration.LocalAddress",
+                        "receiveConfiguration.InstanceSpecificQueue",
                         configuration.PublicReturnAddress),
                     "Applies the public reply to address to outgoing messages");
             }
 
             var sendRouter = new UnicastSendRouter(
                 isSendOnlyEndpoint,
-                receiveConfiguration?.QueueNameBase,
+                receiveConfiguration?.QueueNameBase, // shouldn't this be LocalAddress?
                 receiveConfiguration?.InstanceSpecificQueue,
                 distributionPolicy,
                 unicastRoutingTable,
-                endpointInstances,
-                i => transportSeam.TransportDefinition.ToTransportAddress(new QueueAddress(i.Endpoint, i.Discriminator, i.Properties, null)));
+                endpointInstances);
 
             if (configuration.EnforceBestPractices)
             {

--- a/src/NServiceBus.Core/Routing/UnicastRoute.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRoute.cs
@@ -1,5 +1,7 @@
 namespace NServiceBus.Routing
 {
+    using Transport;
+
     /// <summary>
     /// A destination of address routing.
     /// </summary>
@@ -14,10 +16,15 @@ namespace NServiceBus.Routing
         /// </summary>
         public string Endpoint { get; private set; }
 
+        /////// <summary>
+        /////// The endpoint instance if present.
+        /////// </summary>
+        ////public EndpointInstance Instance { get; private set; }
+
         /// <summary>
-        /// The endpoint instance if present.
+        /// TODO
         /// </summary>
-        public EndpointInstance Instance { get; private set; }
+        public QueueAddress QueueAddress { get; set; }
 
         /// <summary>
         /// The physical address if present.
@@ -39,17 +46,24 @@ namespace NServiceBus.Routing
         }
 
         /// <summary>
+        /// TODO
+        /// </summary>
+        /// <param name="queueAddress"></param>
+        /// <returns></returns>
+        public static UnicastRoute CreateFromQueueAddress(QueueAddress queueAddress)
+        {
+            return new UnicastRoute { QueueAddress = queueAddress };
+        }
+
+        /// <summary>
         /// Creates a destination based on the name of the endpoint instance.
         /// </summary>
         /// <param name="instance">Destination instance name.</param>
         /// <returns>The new destination route.</returns>
         public static UnicastRoute CreateFromEndpointInstance(EndpointInstance instance)
         {
-            Guard.AgainstNull(nameof(instance), instance);
-            return new UnicastRoute
-            {
-                Instance = instance
-            };
+            return CreateFromQueueAddress(new QueueAddress(instance.Endpoint, instance.Discriminator, instance.Properties,
+                null));
         }
 
         /// <summary>
@@ -66,6 +80,7 @@ namespace NServiceBus.Routing
             };
         }
 
+        //TODO:implement ToString in QueueAddress
         /// <summary>Returns a string that represents the current object.</summary>
         /// <returns>A string that represents the current object.</returns>
         public override string ToString()
@@ -74,9 +89,9 @@ namespace NServiceBus.Routing
             {
                 return Endpoint;
             }
-            if (Instance != null)
+            if (QueueAddress != null)
             {
-                return $"[{Instance}]";
+                return $"[{QueueAddress}]";
             }
             return $"<{PhysicalAddress}>";
         }

--- a/src/NServiceBus.Core/SettingsExtensions.cs
+++ b/src/NServiceBus.Core/SettingsExtensions.cs
@@ -3,6 +3,7 @@ namespace NServiceBus
     using System;
     using System.Collections.Generic;
     using Settings;
+    using Transport;
 
     /// <summary>
     /// Provides extensions to the settings holder.
@@ -27,10 +28,11 @@ namespace NServiceBus
             return settings.Get<string>("NServiceBus.Routing.EndpointName");
         }
 
+        //TODO this one might be a big breaking change
         /// <summary>
         /// Returns the transport specific address of the shared queue name of this endpoint.
         /// </summary>
-        public static string LocalAddress(this ReadOnlySettings settings)
+        public static QueueAddress LocalAddress(this ReadOnlySettings settings)
         {
             Guard.AgainstNull(nameof(settings), settings);
 
@@ -60,7 +62,7 @@ namespace NServiceBus
         /// <summary>
         /// Returns the instance-specific queue name of this endpoint.
         /// </summary>
-        public static string InstanceSpecificQueue(this ReadOnlySettings settings)
+        public static QueueAddress InstanceSpecificQueue(this ReadOnlySettings settings)
         {
             Guard.AgainstNull(nameof(settings), settings);
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransport.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransport.cs
@@ -35,32 +35,7 @@
             return Task.FromResult<TransportInfrastructure>(learningTransportInfrastructure);
         }
 
-        /// <inheritdoc />
-        public override string ToTransportAddress(QueueAddress queueAddress)
-        {
-            var address = queueAddress.BaseAddress;
-            PathChecker.ThrowForBadPath(address, "endpoint name");
 
-            var discriminator = queueAddress.Discriminator;
-
-            if (!string.IsNullOrEmpty(discriminator))
-            {
-                PathChecker.ThrowForBadPath(discriminator, "endpoint discriminator");
-
-                address += "-" + discriminator;
-            }
-
-            var qualifier = queueAddress.Qualifier;
-
-            if (!string.IsNullOrEmpty(qualifier))
-            {
-                PathChecker.ThrowForBadPath(qualifier, "address qualifier");
-
-                address += "-" + qualifier;
-            }
-
-            return address;
-        }
 
         /// <inheritdoc />
         public override IReadOnlyCollection<TransportTransactionMode> GetSupportedTransactionModes()

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -14,6 +14,7 @@
     {
         public LearningTransportMessagePump(string id,
             string basePath,
+            string receiveAddress,
             Action<string, Exception, CancellationToken> criticalErrorAction,
             ISubscriptionManager subscriptionManager,
             ReceiveSettings receiveSettings,
@@ -21,6 +22,7 @@
         {
             Id = id;
             this.basePath = basePath;
+            this.receiveAddress = receiveAddress;
             this.criticalErrorAction = criticalErrorAction;
             Subscriptions = subscriptionManager;
             this.receiveSettings = receiveSettings;
@@ -29,9 +31,9 @@
 
         public void Init()
         {
-            PathChecker.ThrowForBadPath(receiveSettings.ReceiveAddress, "InputQueue");
+            //PathChecker.ThrowForBadPath(receiveSettings.ReceiveAddress, "InputQueue");
 
-            messagePumpBasePath = Path.Combine(basePath, receiveSettings.ReceiveAddress);
+            messagePumpBasePath = Path.Combine(basePath, receiveAddress);
             bodyDir = Path.Combine(messagePumpBasePath, BodyDirName);
             delayedDir = Path.Combine(messagePumpBasePath, DelayedDirName);
 
@@ -362,6 +364,7 @@
         ConcurrentDictionary<string, int> retryCounts = new ConcurrentDictionary<string, int>();
         string messagePumpBasePath;
         string basePath;
+        readonly string receiveAddress;
         DelayedMessagePoller delayedMessagePoller;
         int maxConcurrency;
         string bodyDir;

--- a/src/NServiceBus.Core/Transports/QueueAddress.cs
+++ b/src/NServiceBus.Core/Transports/QueueAddress.cs
@@ -10,6 +10,8 @@ namespace NServiceBus.Transport
     {
         static readonly IReadOnlyDictionary<string, string> EmptyProperties = new ReadOnlyDictionary<string, string>(new Dictionary<string, string>(0));
 
+
+        //TODO remove qualifier from public API?
         /// <summary>
         /// Creates a new instance of <see cref="QueueAddress"/>.
         /// </summary>

--- a/src/NServiceBus.Core/Transports/ReceiveSettings.cs
+++ b/src/NServiceBus.Core/Transports/ReceiveSettings.cs
@@ -8,7 +8,7 @@
         /// <summary>
         /// Creates a new instance of <see cref="ReceiveSettings"/>.
         /// </summary>
-        public ReceiveSettings(string id, string receiveAddress, bool usePublishSubscribe, bool purgeOnStartup, string errorQueue)
+        public ReceiveSettings(string id, QueueAddress receiveAddress, bool usePublishSubscribe, bool purgeOnStartup, string errorQueue)
         {
             Id = id;
             ReceiveAddress = receiveAddress;
@@ -25,7 +25,7 @@
         /// <summary>
         /// The queue address the <see cref="IMessageReceiver"/> should receive messages from.
         /// </summary>
-        public string ReceiveAddress { get; set; }
+        public QueueAddress ReceiveAddress { get; set; }
 
         /// <summary>
         /// A flag indicating whether events will be subscribed to this receiver's queue.

--- a/src/NServiceBus.Core/Transports/TransportDefinition.cs
+++ b/src/NServiceBus.Core/Transports/TransportDefinition.cs
@@ -32,12 +32,6 @@ namespace NServiceBus.Transport
         /// </summary>
         public abstract Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken = default);
 
-
-        /// <summary>
-        /// Translates a <see cref="QueueAddress"/> object into a transport specific queue address-string.
-        /// </summary>
-        public abstract string ToTransportAddress(QueueAddress address);
-
         /// <summary>
         /// Returns a list of all supported transaction modes of this transport.
         /// </summary>

--- a/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/TransportInfrastructure.cs
@@ -23,5 +23,10 @@ namespace NServiceBus.Transport
         /// Disposes all transport internal resources.
         /// </summary>
         public abstract Task Shutdown(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Translates a <see cref="QueueAddress"/> object into a transport specific queue address-string.
+        /// </summary>
+        public abstract string ToTransportAddress(QueueAddress address);
     }
 }

--- a/src/NServiceBus.Core/Transports/TransportSeam.cs
+++ b/src/NServiceBus.Core/Transports/TransportSeam.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Extensions.DependencyInjection;
     using Settings;
     using Transport;
 
@@ -48,6 +49,7 @@
 
             var transportSeam = new TransportSeam(transportDefinition, settings, transportSeamSettings.QueueBindings);
 
+            hostingConfiguration.Services.AddTransient(_ => transportSeam.TransportInfrastructure);
             hostingConfiguration.Services.ConfigureComponent(() => transportSeam.TransportInfrastructure.Dispatcher, DependencyLifecycle.SingleInstance);
 
             return transportSeam;

--- a/src/NServiceBus.TransportTests/ConfigureLearningTransportInfrastructure.cs
+++ b/src/NServiceBus.TransportTests/ConfigureLearningTransportInfrastructure.cs
@@ -21,7 +21,7 @@ class ConfigureLearningTransportInfrastructure : IConfigureTransportInfrastructu
     {
         var mainReceiverSettings = new ReceiveSettings(
             "mainReceiver",
-            inputQueueName,
+            new QueueAddress(inputQueueName, null, null, null),
             transportDefinition.SupportsPublishSubscribe,
             true,
             errorQueueName);


### PR DESCRIPTION
Rough spike to test moving `ToTransportAddress` from `TransportDefinition` to `TransportInfrastructure`

Some issues with this approach:
* ToTransportAddress is hard to access as TransportDefinition isn't really accessible for many of the code paths that require it
  * This would require registering `TransportInfrastructure` (or a more specialized abstraction) with the DI container.
* We need to pass a queue name on the `ReceiveSettings` when initializing the transport but we can't call `ToTransportAddress` before, so we need to think more clearly about what we pass here. Should we pass a logical address (`QueueAddress`) or do we expect that a "raw address string" is passed as Core only ever passes a plain endpoint name or combines it with the discriminator and expect that the transport can fill in the rest (e.g. Catalog name, schema name) itself?
* There seems two aspects handled by `ToTransportAddress`:
  * "sanitization" logic that defines how to combine endpoint name and instance discriminator (and formerly qualifier) in a transport compatible way. This logic should never involve any state/IO.
  * enhancing the "address" by additional, transport specific information like machine name (MSMQ), schema & catalog (SQLT)
* Some settings based extension methods give users access to transport addresses of the main & instance specific queue. Removing those (because those might not be available anymore at configuration time) could be a potential big breaking change. Working with `QueueAddress` is difficult e.g. if the user wants to find out the local endpoints address to send messages to it.
* `EndpointInstance` and `QueueAddress` are very similar if we drop the Qualifier field. The qualifier should not be used by users and was only used for endpoint-specific satellite queues which are not around anymore (TimeoutManager).
* It's not clear how to pass/use the TransportInfrastructure on all paths that use address translation, especially on the recoverability side.