### PR TITLE
Nullable default for acceptance test transport transaction mode

### DIFF
--- a/src/NServiceBus.AcceptanceTests/ConfigureEndpointAcceptanceTestingTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureEndpointAcceptanceTestingTransport.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 
 public class ConfigureEndpointAcceptanceTestingTransport : IConfigureEndpointTestExecution
 {
-    public ConfigureEndpointAcceptanceTestingTransport(bool useNativePubSub, bool useNativeDelayedDelivery, TransportTransactionMode transactionMode = TransportTransactionMode.ReceiveOnly)
+    public ConfigureEndpointAcceptanceTestingTransport(bool useNativePubSub, bool useNativeDelayedDelivery, TransportTransactionMode? transactionMode = null)
     {
         this.useNativePubSub = useNativePubSub;
         this.useNativeDelayedDelivery = useNativeDelayedDelivery;
@@ -47,8 +47,13 @@ public class ConfigureEndpointAcceptanceTestingTransport : IConfigureEndpointTes
             enableNativePublishSubscribe: useNativePubSub)
         {
             StorageLocation = storageDir,
-            TransportTransactionMode = transactionMode
         };
+
+        if (transactionMode.HasValue)
+        {
+            acceptanceTestingTransport.TransportTransactionMode = transactionMode.Value;
+        }
+
         var routing = configuration.UseTransport(acceptanceTestingTransport);
 
         if (!useNativePubSub)
@@ -68,7 +73,7 @@ public class ConfigureEndpointAcceptanceTestingTransport : IConfigureEndpointTes
 
     readonly bool useNativePubSub;
     readonly bool useNativeDelayedDelivery;
-    readonly TransportTransactionMode transactionMode;
+    readonly TransportTransactionMode? transactionMode;
 
     string storageDir;
 }


### PR DESCRIPTION
I think I made a mistake in https://github.com/Particular/NServiceBus/pull/5976 by making the default ReceiveOnly, when a non-choice should allow the transport to do its thing normally, which in the case of the AcceptanceTestingTransport would be to go to its highest supported mode of SendsAtomicWithReceive. So downstreams that weren't making a selection were being forced into ReceiveOnly.