### PR TITLE
Allow setting headers on ReplyToOriginator

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_using_ReplyToOriginator_with_headers.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_using_ReplyToOriginator_with_headers.cs
@@ -1,0 +1,89 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Sagas
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_using_ReplyToOriginator_with_headers : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_send_headers()
+        {
+            var customeHeaderValue = Guid.NewGuid();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Endpoint>(b => b.When(session => session.SendLocal(new InitiateRequestingSaga
+                {
+                    CustomHeaderValue = customeHeaderValue
+                })))
+                .Done(c => c.CustomHeaderOnReply != null)
+                .Run();
+
+            Assert.AreEqual(customeHeaderValue.ToString(), context.CustomHeaderOnReply, "Header values should be forwarded");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public string CustomHeaderOnReply { get; set; }
+        }
+
+        public class Endpoint : EndpointConfigurationBuilder
+        {
+            public Endpoint()
+            {
+                EndpointSetup<DefaultServer>(config =>
+                        config.LimitMessageProcessingConcurrencyTo(1) //to avoid race conditions with the start and second message
+                );
+            }
+
+            public class RequestingSaga : Saga<RequestingSaga.RequestingSagaData>,
+                IAmStartedByMessages<InitiateRequestingSaga>
+            {
+                public Task Handle(InitiateRequestingSaga message, IMessageHandlerContext context)
+                {
+                    var customHeaders = new Dictionary<string, string> { { "CustomHeader", Data.CustomHeaderValue.ToString() } };
+                    return ReplyToOriginator(context, new MyReplyToOriginator(), customHeaders);
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RequestingSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<InitiateRequestingSaga>(m => m.CustomHeaderValue)
+                        .ToSaga(s => s.CustomHeaderValue);
+                }
+
+                public class RequestingSagaData : ContainSagaData
+                {
+                    public virtual Guid CustomHeaderValue { get; set; }
+                }
+            }
+
+            class MyReplyToOriginatorHandler : IHandleMessages<MyReplyToOriginator>
+            {
+                public MyReplyToOriginatorHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MyReplyToOriginator message, IMessageHandlerContext context)
+                {
+                    testContext.CustomHeaderOnReply = context.MessageHeaders["CustomHeader"];
+                    return Task.FromResult(0);
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class InitiateRequestingSaga : ICommand
+        {
+            public Guid CustomHeaderValue { get; set; }
+        }
+
+        public class MyReplyToOriginator : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_using_ReplyToOriginator_with_headers.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_using_ReplyToOriginator_with_headers.cs
@@ -39,7 +39,7 @@
                 );
             }
 
-            public class RequestingSaga : Saga<RequestingSaga.RequestingSagaData>,
+            public class ReplyingSaga : Saga<ReplyingSaga.ReplyingSagaData>,
                 IAmStartedByMessages<InitiateRequestingSaga>
             {
                 public Task Handle(InitiateRequestingSaga message, IMessageHandlerContext context)
@@ -48,13 +48,13 @@
                     return ReplyToOriginator(context, new MyReplyToOriginator(), customHeaders);
                 }
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<RequestingSagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<ReplyingSagaData> mapper)
                 {
                     mapper.ConfigureMapping<InitiateRequestingSaga>(m => m.CustomHeaderValue)
                         .ToSaga(s => s.CustomHeaderValue);
                 }
 
-                public class RequestingSagaData : ContainSagaData
+                public class ReplyingSagaData : ContainSagaData
                 {
                     public virtual Guid CustomHeaderValue { get; set; }
                 }

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_using_ReplyToOriginator_with_headers.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_using_ReplyToOriginator_with_headers.cs
@@ -12,17 +12,17 @@
         [Test]
         public async Task Should_send_headers()
         {
-            var customeHeaderValue = Guid.NewGuid();
+            var customHeaderValue = Guid.NewGuid();
 
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<Endpoint>(b => b.When(session => session.SendLocal(new InitiateRequestingSaga
                 {
-                    CustomHeaderValue = customeHeaderValue
+                    CustomHeaderValue = customHeaderValue
                 })))
                 .Done(c => c.CustomHeaderOnReply != null)
                 .Run();
 
-            Assert.AreEqual(customeHeaderValue.ToString(), context.CustomHeaderOnReply, "Header values should be forwarded");
+            Assert.AreEqual(customHeaderValue.ToString(), context.CustomHeaderOnReply, "Header values should be forwarded");
         }
 
         public class Context : ScenarioContext

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -953,7 +953,7 @@ namespace NServiceBus
         public NServiceBus.IContainSagaData Entity { get; set; }
         protected abstract void ConfigureHowToFindSaga(NServiceBus.IConfigureHowToFindSagaWithMessage sagaMessageFindingConfiguration);
         protected void MarkAsComplete() { }
-        protected System.Threading.Tasks.Task ReplyToOriginator(NServiceBus.IMessageHandlerContext context, object message) { }
+        protected System.Threading.Tasks.Task ReplyToOriginator(NServiceBus.IMessageHandlerContext context, object message, System.Collections.Generic.IReadOnlyDictionary<string, string> outgoingHeaders = null) { }
         protected System.Threading.Tasks.Task RequestTimeout<TTimeoutMessageType>(NServiceBus.IMessageHandlerContext context, System.DateTimeOffset at)
             where TTimeoutMessageType : new() { }
         protected System.Threading.Tasks.Task RequestTimeout<TTimeoutMessageType>(NServiceBus.IMessageHandlerContext context, System.TimeSpan within)

--- a/src/NServiceBus.Core/Sagas/Saga.cs
+++ b/src/NServiceBus.Core/Sagas/Saga.cs
@@ -1,6 +1,8 @@
 namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using Extensibility;
 
@@ -92,7 +94,7 @@ namespace NServiceBus
         /// <summary>
         /// Sends the <paramref name="message" /> using the bus to the endpoint that caused this saga to start.
         /// </summary>
-        protected Task ReplyToOriginator(IMessageHandlerContext context, object message)
+        protected Task ReplyToOriginator(IMessageHandlerContext context, object message, IReadOnlyDictionary<string, string> outgoingHeaders = null)
         {
             if (string.IsNullOrEmpty(Entity.Originator))
             {
@@ -100,6 +102,11 @@ namespace NServiceBus
             }
 
             var options = new ReplyOptions();
+
+            foreach (var keyValuePair in outgoingHeaders ?? Enumerable.Empty<KeyValuePair<string, string>>())
+            {
+                options.OutgoingHeaders.Add(keyValuePair.Key, keyValuePair.Value);
+            }
 
             options.SetDestination(Entity.Originator);
             context.Extensions.Set(new AttachCorrelationIdBehavior.State { CustomCorrelationId = Entity.OriginalMessageId });


### PR DESCRIPTION
Closes #5982
https://discuss.particular.net/t/saga-replytooriginator-using-headers-impossible/2317

So instead of forcing users to do this ugly hack

```c#
protected Task ReplyToOriginatorCustom(IMessageHandlerContext context, object message)
{
    if (string.IsNullOrEmpty(Entity.Originator))
    {
        throw new Exception("Entity.Originator cannot be null. Perhaps the sender is a SendOnly endpoint.");
    }

    var options = new ReplyOptions();

    options.SetDestination(Entity.Originator);
    dynamic correlationIdState = Activator.CreateInstance(Type.GetType("NServiceBus.AttachCorrelationIdBehavior+State"), true);
    correlationIdState.CustomCorrelationId = Entity.OriginalMessageId;
    context.Extensions.Set(correlationIdState);

    var correlationHeaderState = Activator.CreateInstance(Type.GetType("NServiceBus.PopulateAutoCorrelationHeadersForRepliesBehavior+State"), true);
    options.Context.Set(correlationHeaderState);

    return context.Reply(message, options);
}
```

We can add the possibility to set outgoing headers to the saga method