### PR TITLE
Allow Outbox to run in SendsAtomicWithReceives

### DIFF
--- a/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
@@ -1,7 +1,7 @@
 ﻿namespace NServiceBus.Features
 {
-    using ConsistencyGuarantees;
     using System;
+    using ConsistencyGuarantees;
     using Transport;
 
     /// <summary>
@@ -30,10 +30,11 @@
                 throw new Exception("The selected persistence doesn't have support for outbox storage. Select another persistence or disable the outbox feature using endpointConfiguration.DisableFeature<Outbox>()");
             }
 
-            if (context.Settings.GetRequiredTransactionModeForReceives() != TransportTransactionMode.ReceiveOnly)
+            var transactionMode = context.Settings.GetRequiredTransactionModeForReceives();
+            if (transactionMode != TransportTransactionMode.ReceiveOnly && transactionMode != TransportTransactionMode.SendsAtomicWithReceive)
             {
                 throw new Exception(
-                    $"Outbox requires transport to be running in ${nameof(TransportTransactionMode.ReceiveOnly)} mode. Use ${nameof(TransportDefinition.TransportTransactionMode)} property on the transport definition to specify the transaction mode.");
+                    $"Outbox requires the transport to be running in '{nameof(TransportTransactionMode.ReceiveOnly)}' or '{nameof(TransportTransactionMode.SendsAtomicWithReceive)}' mode. Use the '{nameof(TransportDefinition.TransportTransactionMode)}' property on the transport definition to specify the transaction mode.");
             }
 
             //note: in the future we should change the persister api to give us a "outbox factory" so that we can register it in DI here instead of relying on the persister to do it


### PR DESCRIPTION
Outbox should not have been limited to only ReceiveOnly mode.

Consider Azure Service Bus that has a SendsAtomicWithReceives mode. The point of Outbox is to gain consistency between messaging operations and database operations. ASB already has consistency between the incoming & outgoing messages, it doesn't make sense to sabotage that in order to get the consistency with data. The result is that running in SendsAtomic, ASB can limit the number of duplicate messages to start with, and therefore the system can run more efficiently and at lower cost.

TransportTransactionMode.None is still out, or else Outbox doesn't work.

TransactionScope is still out, because then you have the DTC transaction to keep your messaging consistent with data and Outbox isn't needed. It *is* possible to use a DTC transaction on the persistence side, for example, to use RabbitMQ (which only supports ReceiveOnly) but have a handler touch 2 different SQL databases. In that case, the DTC transaction is governed by the Outbox persistence, such as [with SQL Persistence Outbox API](https://docs.particular.net/persistence/sql/outbox#transaction-type). In that case the **transport** is still ReceiveOnly or SendsAtomicWithReceives.