### PR TITLE
Pass the saga type so that "SagaNotFound" knows which saga wasn't invoked

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
@@ -66,7 +66,7 @@
                     return Task.FromResult(0);
                 }
 
-                public Task Handle(object message, IMessageProcessingContext context)
+                public Task Handle(object message, IMessageProcessingContext context, Type sagaType)
                 {
                     testContext.NotFoundHandlerCalled = true;
                     return Task.FromResult(0);

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_multiple_timeouts.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_multiple_timeouts.cs
@@ -122,7 +122,7 @@
             {
                 public Context TestContext { get; set; }
 
-                public Task Handle(object message, IMessageProcessingContext context)
+                public Task Handle(object message, IMessageProcessingContext context, Type sagaType)
                 {
                     if (((dynamic)message).ContextId != TestContext.Id)
                     {

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_reply_from_saga_not_found_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_reply_from_saga_not_found_handler.cs
@@ -92,7 +92,7 @@
 
             public class SagaNotFound : IHandleSagaNotFound
             {
-                public Task Handle(object message, IMessageProcessingContext context)
+                public Task Handle(object message, IMessageProcessingContext context, Type sagaType)
                 {
                     return context.Reply(new Reply());
                 }

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
@@ -20,7 +20,7 @@
                 .Done(c => c.Done)
                 .Run();
 
-            Assert.AreEqual(1, context.TimesFired);
+            Assert.AreEqual(2, context.TimesFired, "NotFound invocations");
         }
 
         [Test]
@@ -34,7 +34,7 @@
                 .Done(c => c.Done)
                 .Run();
 
-            Assert.AreEqual(0, context.TimesFired);
+            Assert.AreEqual(1, context.TimesFired, "NotFound invocations");
         }
 
         public class Context : ScenarioContext
@@ -109,7 +109,7 @@
                     testContext = context;
                 }
 
-                public Task Handle(object message, IMessageProcessingContext context)
+                public Task Handle(object message, IMessageProcessingContext context, Type sagaType)
                 {
                     testContext.TimesFired++;
                     testContext.Done = true;
@@ -196,7 +196,7 @@
                     testContext = context;
                 }
 
-                public Task Handle(object message, IMessageProcessingContext context)
+                public Task Handle(object message, IMessageProcessingContext context, Type sagaType)
                 {
                     testContext.TimesFired++;
                     return Task.FromResult(0);

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_timeout_hit_not_found_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_timeout_hit_not_found_saga.cs
@@ -68,7 +68,7 @@
                     return Task.FromResult(0);
                 }
 
-                public Task Handle(object message, IMessageProcessingContext context)
+                public Task Handle(object message, IMessageProcessingContext context, Type sagaType)
                 {
                     if (message is SomeOtherMessage)
                     {

--- a/src/NServiceBus.Core.Tests/Sagas/InvokeSagaNotFoundBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/InvokeSagaNotFoundBehaviorTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Core.Tests.Sagas
 {
+    using System;
     using NServiceBus.Pipeline;
     using NServiceBus.Sagas;
     using NUnit.Framework;
@@ -43,7 +44,7 @@
 
         static Task SetSagaNotFound(IIncomingLogicalMessageContext context)
         {
-            context.Extensions.Get<SagaInvocationResult>().SagaNotFound();
+            context.Extensions.Get<SagaInvocationResult>().SagaNotFound(typeof(object));
             return Task.CompletedTask;
         }
 
@@ -52,7 +53,7 @@
 
         class HandleSagaNotFoundReturnsNull1 : IHandleSagaNotFound
         {
-            public Task Handle(object message, IMessageProcessingContext context)
+            public Task Handle(object message, IMessageProcessingContext context, Type sagaType)
             {
                 return null;
             }
@@ -62,7 +63,7 @@
         {
             public bool Handled { get; private set; }
 
-            public Task Handle(object message, IMessageProcessingContext context)
+            public Task Handle(object message, IMessageProcessingContext context, Type sagaType)
             {
                 Handled = true;
 

--- a/src/NServiceBus.Core/Sagas/IHandleSagaNotFound.cs
+++ b/src/NServiceBus.Core/Sagas/IHandleSagaNotFound.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Sagas
 {
+    using System;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -14,6 +15,6 @@ namespace NServiceBus.Sagas
         /// to send responses to the client who sent the message.
         /// </summary>
         /// <exception cref="System.Exception">This exception will be thrown if <code>null</code> is returned. Return a Task or mark the method as <code>async</code>.</exception>
-        Task Handle(object message, IMessageProcessingContext context);
+        Task Handle(object message, IMessageProcessingContext context, Type sagaType);
     }
 }

--- a/src/NServiceBus.Core/Sagas/SagaInvocationResult.cs
+++ b/src/NServiceBus.Core/Sagas/SagaInvocationResult.cs
@@ -1,27 +1,24 @@
 namespace NServiceBus
 {
+    using System;
+    using System.Collections.Generic;
+
     class SagaInvocationResult
     {
-        public bool WasFound => state != State.SagaNotFound;
-
-        public void SagaFound()
+        public void SagaFound(Type type)
         {
-            state = State.SagaFound;
+            Results[type] = State.SagaFound;
         }
 
-        public void SagaNotFound()
+        public void SagaNotFound(Type type)
         {
-            if (state == State.Unknown)
-            {
-                state = State.SagaNotFound;
-            }
+            Results[type] = State.SagaNotFound;
         }
 
-        State state;
+        public Dictionary<Type, State> Results { get; set; } = new Dictionary<Type, State>();
 
-        enum State
+        public enum State
         {
-            Unknown,
             SagaFound,
             SagaNotFound
         }

--- a/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
@@ -80,7 +80,7 @@
             {
                 if (IsMessageAllowedToStartTheSaga(context, currentSagaMetadata))
                 {
-                    context.Extensions.Get<SagaInvocationResult>().SagaFound();
+                    context.Extensions.Get<SagaInvocationResult>().SagaFound(currentSagaMetadata.SagaType);
                     sagaInstanceState.AttachNewEntity(CreateNewSagaEntity(currentSagaMetadata, context));
                 }
                 else
@@ -99,18 +99,18 @@
                     //we don't invoke not found handlers for timeouts
                     if (isTimeoutMessage)
                     {
-                        context.Extensions.Get<SagaInvocationResult>().SagaFound();
+                        context.Extensions.Get<SagaInvocationResult>().SagaFound(currentSagaMetadata.SagaType);
                         logger.InfoFormat("No saga found for timeout message {0}, ignoring since the saga has been marked as complete before the timeout fired", context.MessageId);
                     }
                     else
                     {
-                        context.Extensions.Get<SagaInvocationResult>().SagaNotFound();
+                        context.Extensions.Get<SagaInvocationResult>().SagaNotFound(currentSagaMetadata.SagaType);
                     }
                 }
             }
             else
             {
-                context.Extensions.Get<SagaInvocationResult>().SagaFound();
+                context.Extensions.Get<SagaInvocationResult>().SagaFound(currentSagaMetadata.SagaType);
                 sagaInstanceState.AttachExistingEntity(loadedEntity);
             }
 


### PR DESCRIPTION
Change the behavior that `ISagaNotFound` gets an additional argument that identifies the saga type that wasn't invoked.

This is now also invoked if at least one, but not all sagas have been invoked.