### PR TITLE
Validate if implementation of `ISagaNotFound` isn't a saga type

### DIFF
--- a/src/NServiceBus.Core/Sagas/InvokeSagaNotFoundBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/InvokeSagaNotFoundBehavior.cs
@@ -28,6 +28,11 @@ namespace NServiceBus
 
             foreach (var handler in context.Builder.GetServices<IHandleSagaNotFound>())
             {
+                if (handler is Saga)
+                {
+                    throw new InvalidOperationException("It is not allowed to inherit `IHandleSagaNotFound` on a Saga type.");
+                }
+
                 logger.DebugFormat("Invoking SagaNotFoundHandler ('{0}')", handler.GetType().FullName);
 
                 foreach (var sagaType in sagaTypes)

--- a/src/NServiceBus.Core/Sagas/InvokeSagaNotFoundBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/InvokeSagaNotFoundBehavior.cs
@@ -30,7 +30,7 @@ namespace NServiceBus
             {
                 if (handler is Saga)
                 {
-                    throw new InvalidOperationException("It is not allowed to inherit `IHandleSagaNotFound` on a Saga type.");
+                    throw new InvalidOperationException("Saga types can't implement `IHandleSagaNotFound`. The not found handlers are not bound to a specific saga type and are invoked if none of the sagas mapped to a given message is found.");
                 }
 
                 logger.DebugFormat("Invoking SagaNotFoundHandler ('{0}')", handler.GetType().FullName);


### PR DESCRIPTION
As `ISagaNotFound` can be implementation on a Saga type a user might think that this method would only be invoked if an instance for THAT saga type isn't found which is incorrect.

This check prevents such false assumptions by not allowing to implement `ISagaNotFound` on a saga.