### PR TITLE
support cancellation during feature startup

### DIFF
--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -70,22 +70,11 @@ namespace NServiceBus.Features
                     {
                         await taskController.Start(builder, session, cancellationToken).ConfigureAwait(false);
                     }
-                    catch (Exception startException)
+                    catch (Exception)
                     {
-                        var exceptions = new List<Exception> { startException };
+                        await Task.WhenAll(startedTaskControllers.Select(controller => controller.Stop(cancellationToken))).ConfigureAwait(false);
 
-                        var stop = Task.WhenAll(startedTaskControllers.Select(controller => controller.Stop(cancellationToken)));
-
-                        try
-                        {
-                            await stop.ConfigureAwait(false);
-                        }
-                        catch (Exception ex) when (stop.Exception?.InnerException == ex)
-                        {
-                            exceptions.AddRange(stop.Exception.InnerExceptions);
-                        }
-
-                        throw new AggregateException(exceptions);
+                        throw;
                     }
 
                     startedTaskControllers.Add(taskController);


### PR DESCRIPTION
@DavidBoike — @andreasohlund and me sync'd on this and we came to the conclusion that adding a cancellation token to `StartFeatures` implies that the method supports cancellation (er... rather obviously), regardless of https://github.com/Particular/NServiceBus/issues/6015, and so it should indeed do whatever is required to honour that.

If this change also solves https://github.com/Particular/NServiceBus/issues/6015, it's coincidental.
