### PR TITLE
CriticalError.Raise allow null exception

### DIFF
--- a/src/NServiceBus.Core/CriticalError/CriticalError.cs
+++ b/src/NServiceBus.Core/CriticalError/CriticalError.cs
@@ -39,9 +39,7 @@ namespace NServiceBus
         public virtual void Raise(string errorMessage, Exception exception = null, CancellationToken cancellationToken = default)
         {
             Guard.AgainstNullAndEmpty(nameof(errorMessage), errorMessage);
-            
             var logger = LogManager.GetLogger("NServiceBus");
-            
             if (exception != null)
             {
                 logger.Fatal(errorMessage, exception);

--- a/src/NServiceBus.Core/CriticalError/CriticalError.cs
+++ b/src/NServiceBus.Core/CriticalError/CriticalError.cs
@@ -36,11 +36,20 @@ namespace NServiceBus
         ///     cref="ConfigureCriticalErrorAction.DefineCriticalErrorAction(EndpointConfiguration, Func{ICriticalErrorContext, CancellationToken, Task})" />
         /// .
         /// </summary>
-        public virtual void Raise(string errorMessage, Exception exception, CancellationToken cancellationToken = default)
+        public virtual void Raise(string errorMessage, Exception exception = null, CancellationToken cancellationToken = default)
         {
             Guard.AgainstNullAndEmpty(nameof(errorMessage), errorMessage);
-            Guard.AgainstNull(nameof(exception), exception);
-            LogManager.GetLogger("NServiceBus").Fatal(errorMessage, exception);
+            
+            var logger = LogManager.GetLogger("NServiceBus");
+            
+            if (exception != null)
+            {
+                logger.Fatal(errorMessage, exception);
+            }
+            else
+            {
+                logger.Fatal(errorMessage);
+            }
 
             lock (endpointCriticalLock)
             {

--- a/src/NServiceBus.Core/CriticalError/CriticalError.cs
+++ b/src/NServiceBus.Core/CriticalError/CriticalError.cs
@@ -36,7 +36,7 @@ namespace NServiceBus
         ///     cref="ConfigureCriticalErrorAction.DefineCriticalErrorAction(EndpointConfiguration, Func{ICriticalErrorContext, CancellationToken, Task})" />
         /// .
         /// </summary>
-        public virtual void Raise(string errorMessage, Exception exception = null, CancellationToken cancellationToken = default)
+        public virtual void Raise(string errorMessage, Exception exception = default, CancellationToken cancellationToken = default)
         {
             Guard.AgainstNullAndEmpty(nameof(errorMessage), errorMessage);
             var logger = LogManager.GetLogger("NServiceBus");


### PR DESCRIPTION
The current API assumes there is always an exception. If a critical error is not trigger based on an exception then we should be able to invoke a critical error raise too.

For example, raising a critical based on a timer.

Currently requires passing `new Exception()` which feels wrong.