### PR TITLE
Obsolete MachineNameAction

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -51,7 +51,7 @@
 
                 if (!string.IsNullOrEmpty(configuration.CustomMachineName))
                 {
-                    endpointConfiguration.UniquelyIdentifyRunningInstance().OverrideHostName(configuration.CustomMachineName);
+                    endpointConfiguration.UniquelyIdentifyRunningInstance().UsingHostName(configuration.CustomMachineName);
                 }
 
                 endpointBehavior.CustomConfig.ForEach(customAction => customAction(endpointConfiguration, scenarioContext));

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -8,7 +8,6 @@
     using Configuration.AdvancedExtensibility;
     using Faults;
     using Logging;
-    using NServiceBus.Support;
     using Transport;
 
     public class EndpointRunner : ComponentRunner
@@ -41,11 +40,6 @@
                 configuration = endpointBehavior.EndpointBuilder.Get();
                 configuration.EndpointName = endpointName;
 
-                if (!string.IsNullOrEmpty(configuration.CustomMachineName))
-                {
-                    RuntimeEnvironment.MachineNameAction = () => configuration.CustomMachineName;
-                }
-
                 //apply custom config settings
                 if (configuration.GetConfiguration == null)
                 {
@@ -54,6 +48,11 @@
                 var endpointConfiguration = await configuration.GetConfiguration(run).ConfigureAwait(false);
                 RegisterInheritanceHierarchyOfContextInSettings(scenarioContext, endpointConfiguration);
                 TrackFailingMessages(endpointName, endpointConfiguration);
+
+                if (!string.IsNullOrEmpty(configuration.CustomMachineName))
+                {
+                    endpointConfiguration.UniquelyIdentifyRunningInstance().OverrideHostName(configuration.CustomMachineName);
+                }
 
                 endpointBehavior.CustomConfig.ForEach(customAction => customAction(endpointConfiguration, scenarioContext));
 

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -448,9 +448,9 @@ namespace NServiceBus
     }
     public class HostInfoSettings
     {
-        public NServiceBus.HostInfoSettings OverrideHostName(string hostName) { }
         public NServiceBus.HostInfoSettings UsingCustomDisplayName(string displayName) { }
         public NServiceBus.HostInfoSettings UsingCustomIdentifier(System.Guid id) { }
+        public NServiceBus.HostInfoSettings UsingHostName(string hostName) { }
         public NServiceBus.HostInfoSettings UsingInstalledFilePath() { }
         public NServiceBus.HostInfoSettings UsingNames(string instanceName, string hostName) { }
     }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -448,6 +448,7 @@ namespace NServiceBus
     }
     public class HostInfoSettings
     {
+        public NServiceBus.HostInfoSettings OverrideHostName(string hostName) { }
         public NServiceBus.HostInfoSettings UsingCustomDisplayName(string displayName) { }
         public NServiceBus.HostInfoSettings UsingCustomIdentifier(System.Guid id) { }
         public NServiceBus.HostInfoSettings UsingInstalledFilePath() { }
@@ -2384,6 +2385,8 @@ namespace NServiceBus.Support
     public static class RuntimeEnvironment
     {
         public static string MachineName { get; }
+        [System.Obsolete("Use `HostInfoSettings.OverrideHostName` instead. Will be treated as an error from" +
+            " version 9.0.0. Will be removed in version 10.0.0.", false)]
         public static System.Func<string> MachineNameAction { get; set; }
     }
 }

--- a/src/NServiceBus.Core.Tests/Hosting/HostInfoSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Hosting/HostInfoSettingsTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.Core.Tests.Host
 {
     using System;
+    using NServiceBus.Support;
     using NUnit.Framework;
 
     [TestFixture]
@@ -27,6 +28,17 @@
 
             var configuredId = busConfig.Settings.Get<HostingComponent.Settings>().HostId;
             Assert.AreEqual(DeterministicGuid.Create("Instance", "Host"), configuredId);
+        }
+
+        [Test]
+        public void It_overrides_the_machine_name()
+        {
+            var busConfig = new EndpointConfiguration("myendpoint");
+
+            busConfig.UniquelyIdentifyRunningInstance().OverrideHostName("overridenhostname");
+
+            var hostName = RuntimeEnvironment.MachineName;
+            Assert.AreEqual("overridenhostname", hostName);
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Hosting/HostInfoSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Hosting/HostInfoSettingsTests.cs
@@ -35,7 +35,7 @@
         {
             var busConfig = new EndpointConfiguration("myendpoint");
 
-            busConfig.UniquelyIdentifyRunningInstance().OverrideHostName("overridenhostname");
+            busConfig.UniquelyIdentifyRunningInstance().UsingHostName("overridenhostname");
 
             var hostName = RuntimeEnvironment.MachineName;
             Assert.AreEqual("overridenhostname", hostName);

--- a/src/NServiceBus.Core/Hosting/HostInfoSettings.cs
+++ b/src/NServiceBus.Core/Hosting/HostInfoSettings.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using Hosting;
+    using NServiceBus.Support;
 
     /// <summary>
     /// Configuration class for <see cref="HostInformation" /> settings.
@@ -64,6 +65,16 @@ namespace NServiceBus
         {
             Guard.AgainstNullAndEmpty(nameof(displayName), displayName);
             config.Settings.Get<HostingComponent.Settings>().DisplayName = displayName;
+            return this;
+        }
+
+        /// <summary>
+        /// Allows overriding the host name of the endpoint.
+        /// </summary>
+        public HostInfoSettings OverrideHostName(string hostName)
+        {
+            Guard.AgainstNullAndEmpty(nameof(hostName), hostName);
+            RuntimeEnvironment.SetMachineName(hostName);
             return this;
         }
 

--- a/src/NServiceBus.Core/Hosting/HostInfoSettings.cs
+++ b/src/NServiceBus.Core/Hosting/HostInfoSettings.cs
@@ -71,7 +71,7 @@ namespace NServiceBus
         /// <summary>
         /// Allows overriding the host name of the endpoint.
         /// </summary>
-        public HostInfoSettings OverrideHostName(string hostName)
+        public HostInfoSettings UsingHostName(string hostName)
         {
             Guard.AgainstNullAndEmpty(nameof(hostName), hostName);
             RuntimeEnvironment.SetMachineName(hostName);

--- a/src/NServiceBus.Core/Support/RuntimeEnvironment.cs
+++ b/src/NServiceBus.Core/Support/RuntimeEnvironment.cs
@@ -23,6 +23,15 @@
         /// <summary>
         /// Get the machine name, allows for overrides.
         /// </summary>
+        [ObsoleteEx(
+            ReplacementTypeOrMember = "HostInfoSettings.OverrideHostName",
+            TreatAsErrorFromVersion = "9.0",
+            RemoveInVersion = "10.0")]
         public static Func<string> MachineNameAction { get; set; }
+
+        internal static void SetMachineName(string machineName)
+        {
+            MachineNameAction = () => machineName;
+        }
     }
 }


### PR DESCRIPTION
There are 2 mechanisms to set the hostname;

- [override host ID](https://docs.particular.net/nservicebus/hosting/override-hostid)
- [override machine name](https://docs.particular.net/nservicebus/hosting/override-machine-name)

The `MachineNameAction` override happens in a different timeframe to the HostID, meaning the behaviour is different which causes support cases.

This PR obsoletes the `MachineNameAction` and introduces a new API on the `HostInfoSettings` class to unify the approach and make the time that each is applied uniform.

Usage example:
```c#
endpointConfiguration
    .UniquelyIdentifyRunningInstance()
    .OverrideHostName(Dns.GetHostEntry(Environment.MachineName).HostName);
```