### PR TITLE
better wording for the obsolete message

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -694,17 +694,18 @@ namespace NServiceBus
         [System.Obsolete("Use `QueueAddress.Qualifier` instead. The member currently throws a NotImplemente" +
             "dException. Will be removed in version 9.0.0.", true)]
         public string Qualifier { get; }
-        [System.Obsolete("Use `QueueAddress` instead. The member currently throws a NotImplementedException" +
-            ". Will be removed in version 9.0.0.", true)]
+        [System.Obsolete("Directly construct a QueueAddress with the discriminator. The member currently th" +
+            "rows a NotImplementedException. Will be removed in version 9.0.0.", true)]
         public NServiceBus.LogicalAddress CreateIndividualizedAddress(string discriminator) { }
-        [System.Obsolete("Use `QueueAddress` instead. The member currently throws a NotImplementedException" +
-            ". Will be removed in version 9.0.0.", true)]
+        [System.Obsolete("Directly construct a QueueAddress with the qualifier. The member currently throws" +
+            " a NotImplementedException. Will be removed in version 9.0.0.", true)]
         public NServiceBus.LogicalAddress CreateQualifiedAddress(string qualifier) { }
-        [System.Obsolete("Use `QueueAddress` instead. The member currently throws a NotImplementedException" +
-            ". Will be removed in version 9.0.0.", true)]
+        [System.Obsolete("Directly construct a QueueAddress with the queueName as the BaseAddress. The memb" +
+            "er currently throws a NotImplementedException. Will be removed in version 9.0.0." +
+            "", true)]
         public static NServiceBus.LogicalAddress CreateLocalAddress(string queueName, System.Collections.Generic.IReadOnlyDictionary<string, string> properties) { }
-        [System.Obsolete("Use `QueueAddress` instead. The member currently throws a NotImplementedException" +
-            ". Will be removed in version 9.0.0.", true)]
+        [System.Obsolete("Directly construct a QueueAddress. The member currently throws a NotImplementedEx" +
+            "ception. Will be removed in version 9.0.0.", true)]
         public static NServiceBus.LogicalAddress CreateRemoteAddress(NServiceBus.Routing.EndpointInstance endpointInstance) { }
     }
     public static class MessageCausationConfigurationExtensions

--- a/src/NServiceBus.Core/obsoletes-v8.cs
+++ b/src/NServiceBus.Core/obsoletes-v8.cs
@@ -1202,7 +1202,7 @@ namespace NServiceBus
         [ObsoleteEx(
             RemoveInVersion = "9",
             TreatAsErrorFromVersion = "8",
-            ReplacementTypeOrMember = nameof(QueueAddress))]
+            Message = "Directly construct a QueueAddress.")]
         public static LogicalAddress CreateRemoteAddress(EndpointInstance endpointInstance)
         {
             throw new NotImplementedException();
@@ -1211,7 +1211,7 @@ namespace NServiceBus
         [ObsoleteEx(
             RemoveInVersion = "9",
             TreatAsErrorFromVersion = "8",
-            ReplacementTypeOrMember = nameof(QueueAddress))]
+            Message = "Directly construct a QueueAddress with the queueName as the BaseAddress.")]
         public static LogicalAddress CreateLocalAddress(string queueName, IReadOnlyDictionary<string, string> properties)
         {
             throw new NotImplementedException();
@@ -1220,7 +1220,7 @@ namespace NServiceBus
         [ObsoleteEx(
             RemoveInVersion = "9",
             TreatAsErrorFromVersion = "8",
-            ReplacementTypeOrMember = nameof(QueueAddress))]
+            Message = "Directly construct a QueueAddress with the qualifier.")]
         public LogicalAddress CreateQualifiedAddress(string qualifier)
         {
             throw new NotImplementedException();
@@ -1229,7 +1229,7 @@ namespace NServiceBus
         [ObsoleteEx(
             RemoveInVersion = "9",
             TreatAsErrorFromVersion = "8",
-            ReplacementTypeOrMember = nameof(QueueAddress))]
+            Message = "Directly construct a QueueAddress with the discriminator.")]
         public LogicalAddress CreateIndividualizedAddress(string discriminator)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
Clarify the obsolete message for the `LogicalAddress`.