### PR TITLE
Do not try to load assemblies with no name

### DIFF
--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -92,7 +92,7 @@ namespace NServiceBus.Hosting.Helpers
 
             var platformAssembliesString = (string)AppDomain.CurrentDomain.GetData("TRUSTED_PLATFORM_ASSEMBLIES");
 
-            if (platformAssembliesString != null)
+            if (!string.IsNullOrEmpty(platformAssembliesString))
             {
                 var platformAssemblies = platformAssembliesString.Split(Path.PathSeparator);
 


### PR DESCRIPTION
### Symptoms

Endpoints deployed using `.net5.0` [single file deployments](https://docs.microsoft.com/en-us/dotnet/core/deploying/single-file) fail on startup with:


```
System.ArgumentException: Empty path name is not legal. (Parameter 'path')
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)
   at System.IO.File.OpenRead(String path)
   at NServiceBus.AssemblyValidator.ValidateAssemblyFile(String assemblyPath, Boolean& shouldLoad, String& reason)
   at NServiceBus.Hosting.Helpers.AssemblyScanner.TryLoadScannableAssembly(String assemblyPath, AssemblyScannerResults results, Assembly& assembly)
   at NServiceBus.Hosting.Helpers.AssemblyScanner.GetScannableAssemblies()
   at NServiceBus.AssemblyScanningComponent.Initialize(Configuration configuration, SettingsHolder settings)
   at NServiceBus.HostCreator.CreateWithInternallyManagedContainer(EndpointConfiguration endpointConfiguration)
   at NServiceBus.Endpoint.Start(EndpointConfiguration configuration)
```

### Who's affected

All users of NServiceBus v7.4 and below deploying their application as a single file.

### Root cause

The assembly scanner assumes that [`AppDomain.CurrentDomain.GetData("TRUSTED_PLATFORM_ASSEMBLIES");`](https://docs.microsoft.com/en-us/dotnet/core/dependency-loading/default-probing#host-configured-probing-properties) can't contain an empty string.