### PR TITLE
Persistence tests for .NET 5 record types.

### DIFF
--- a/src/NServiceBus.PersistenceTests/NServiceBus.PersistenceTests.csproj
+++ b/src/NServiceBus.PersistenceTests/NServiceBus.PersistenceTests.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net5.0;net472;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Test.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_record_type.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_record_type.cs
@@ -1,0 +1,106 @@
+﻿namespace NServiceBus.PersistenceTesting.Sagas
+{
+#if NET5_0_OR_GREATER
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    public class When_persisting_a_saga_with_record_type : SagaPersisterTests
+    {
+        [Test]
+        public async Task It_should_get_deep_copy()
+        {
+            var correlationPropertyData = Guid.NewGuid().ToString();
+            var sagaData = new SagaWithRecordTypeEntity
+            {
+                Ints = new List<int> { 1, 2 },
+                CorrelationProperty = correlationPropertyData
+            };
+
+            await SaveSaga(sagaData);
+
+            var retrieved = await GetById<SagaWithRecordTypeEntity>(sagaData.Id);
+
+            CollectionAssert.AreEqual(sagaData.Ints, retrieved.Ints);
+            Assert.False(ReferenceEquals(sagaData.Ints, retrieved.Ints));
+        }
+
+        [Test]
+        public async Task It_Should_Load()
+        {
+            var correlationPropertyData = Guid.NewGuid().ToString();
+            var person = new SagaWithNestedRecordTypeEntity.Person() { FirstName = "John", LastName = "Doe" };
+            var sagaData =
+                new SagaWithNestedRecordTypeEntity { SomePerson = person, CorrelationProperty = correlationPropertyData };
+
+            await SaveSaga(sagaData);
+
+            var retrieved = await GetById<SagaWithNestedRecordTypeEntity>(sagaData.Id);
+
+            Assert.IsNotNull(retrieved);
+            Assert.AreEqual(person, retrieved.SomePerson);
+        }
+
+        public class SagaWithRecordType : Saga<SagaWithRecordTypeEntity>, IAmStartedByMessages<StartMessage>
+        {
+            public Task Handle(StartMessage message, IMessageHandlerContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaWithRecordTypeEntity> mapper)
+            {
+                mapper.ConfigureMapping<StartMessage>(msg => msg.SomeId).ToSaga(saga => saga.CorrelationProperty);
+            }
+        }
+
+        public class SagaWithNestedRecordType : Saga<SagaWithNestedRecordTypeEntity>,
+            IAmStartedByMessages<StartMessage>
+        {
+            public Task Handle(StartMessage message, IMessageHandlerContext context)
+            {
+                throw new NotImplementedException();
+            }
+
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaWithNestedRecordTypeEntity> mapper)
+            {
+                mapper.ConfigureMapping<StartMessage>(msg => msg.SomeId).ToSaga(saga => saga.CorrelationProperty);
+            }
+        }
+
+        public class SagaWithNestedRecordTypeEntity : ContainSagaData
+        {
+            public string CorrelationProperty { get; set; }
+            public Person SomePerson { get; set; }
+
+            //public record Person(string FirstName, string LastName);
+            public record Person
+            {
+                public string FirstName { get; set; }
+                public string LastName { get; set; }
+            };
+        }
+
+        public record SagaWithRecordTypeEntity : IContainSagaData
+        {
+            public Guid Id { get; set; }
+            public string Originator { get; set; }
+            public string OriginalMessageId { get; set; }
+
+            public string CorrelationProperty { get; set; }
+            public List<int> Ints { get; set; }
+        }
+
+        public class StartMessage
+        {
+            public string SomeId { get; set; }
+        }
+
+        public When_persisting_a_saga_with_record_type(TestVariant param) : base(param)
+        {
+
+        }
+    }
+#endif
+}

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_record_type.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_record_type.cs
@@ -74,7 +74,7 @@
             public string CorrelationProperty { get; set; }
             public Person SomePerson { get; set; }
 
-            //public record Person(string FirstName, string LastName);
+            // A mutable record type. Immutable won't deserialize
             public record Person
             {
                 public string FirstName { get; set; }


### PR DESCRIPTION
_Related to https://github.com/Particular/DeveloperExperience/issues/1461_

- Changed language version to 9.0 to be able to make use of `record`.
- Added two tests
  - One that uses `record` for saga data
  - One that has `record` as property