### PR TITLE
Remove unnecessary RevertToOriginalBodyIfNeeded call

### DIFF
--- a/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using NUnit.Framework;
@@ -53,19 +52,6 @@
 
             var outgoingMessage = dispatcher.TransportOperations.UnicastTransportOperations.Single();
             Assert.That(incomingMessage.Headers, Is.SubsetOf(outgoingMessage.Message.Headers));
-        }
-
-        [Test]
-        public async Task MoveToErrorQueue_should_dispatch_original_message_body()
-        {
-            var originalMessageBody = Encoding.UTF8.GetBytes("message body");
-            var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), originalMessageBody);
-            incomingMessage.UpdateBody(Encoding.UTF8.GetBytes("new body"));
-
-            await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, new Exception(), new TransportTransaction());
-
-            var outgoingMessage = dispatcher.TransportOperations.UnicastTransportOperations.Single();
-            Assert.That(outgoingMessage.Message.Body, Is.EqualTo(originalMessageBody));
         }
 
         [Test]

--- a/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
@@ -18,8 +18,6 @@
 
         public Task MoveToErrorQueue(string errorQueueAddress, IncomingMessage message, Exception exception, TransportTransaction transportTransaction, CancellationToken cancellationToken = default)
         {
-            message.RevertToOriginalBodyIfNeeded();
-
             var outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body);
 
             var headers = outgoingMessage.Headers;


### PR DESCRIPTION
It seems this call to `RevertToOriginalBodyIfNeeded ` in the `MoveToErrorsExecutor` doesn't really seem to be necessary, as there should never be a body modification that needs to be reverted.

The only way to do body modifications that can be reverted, is by calling `IncomingMessage.UpdateBody` which is `internal`, therefore not accessible to users. The only place this update body method is called from, and made accessible to users, is in `IncomingPhysicalMessageContext.UpdateBody`. The "baseline" body for the `IncomingMessage` available in the recoverability logic (e.g. custom policy), and therefore to the errors executor, [is set when a new `ErrorContext` is created](https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.Core/Transports/ErrorContext.cs#L33). There is no code path that allows updating the message body on the `ErrorContext.Message`'s body, so this could shouldn't be necessary.