### PR TITLE
Use custom message body type

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Audit/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_a_message_is_audited.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Audit
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
@@ -26,7 +27,7 @@
             Assert.AreEqual(context.OriginalBodyChecksum, context.AuditChecksum, "The body of the message sent to audit should be the same as the original message coming off the queue");
         }
 
-        public static byte Checksum(byte[] data)
+        public static byte Checksum(IReadOnlyCollection<byte> data)
         {
             var longSum = data.Sum(x => (long)x);
             return unchecked((byte)longSum);
@@ -65,13 +66,10 @@
                     testContext.OriginalBodyChecksum = Checksum(originalBody);
 
                     // modifying the body by adding a line break
-                    var modifiedBody = new byte[originalBody.Length + 1];
-
-                    Buffer.BlockCopy(originalBody, 0, modifiedBody, 0, originalBody.Length);
-
+                    var modifiedBody = originalBody.Concat(new byte[1]).ToArray();
                     modifiedBody[modifiedBody.Length - 1] = 13;
 
-                    context.Body = modifiedBody;
+                    context.UpdateMessage(modifiedBody);
                     return Task.FromResult(0);
                 }
 

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_failing_mutated_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_failing_mutated_message.cs
@@ -5,9 +5,9 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using Features;
     using MessageMutator;
     using NUnit.Framework;
+    using Transport;
 
     public class When_failing_mutated_message : NServiceBusAcceptanceTest
     {
@@ -30,7 +30,7 @@
 
         class Context : ScenarioContext
         {
-            public byte[] OriginalBody { get; set; }
+            public MessageBody OriginalBody { get; set; }
         }
 
         public class RetryEndpoint : EndpointConfigurationBuilder
@@ -54,13 +54,12 @@
 
                 public Task MutateIncoming(MutateIncomingTransportMessageContext transportMessage)
                 {
-                    var originalBody = transportMessage.Body;
-                    testContext.OriginalBody = originalBody;
-                    var newBody = new byte[originalBody.Length];
-                    Buffer.BlockCopy(originalBody, 0, newBody, 0, originalBody.Length);
+                    testContext.OriginalBody = transportMessage.Body;
+
+                    var newBody = transportMessage.Body.CreateCopy();
                     //corrupt
                     newBody[1]++;
-                    transportMessage.Body = newBody;
+                    transportMessage.UpdateMessage(newBody);
                     return Task.FromResult(0);
                 }
 

--- a/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties.cs
+++ b/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties.cs
@@ -82,7 +82,7 @@
             {
                 public Task MutateIncoming(MutateIncomingTransportMessageContext context)
                 {
-                    if (context.Body.Length > PayloadSize)
+                    if (context.Body.Count > PayloadSize)
                     {
                         throw new Exception("The message body is too large, which means the DataBus was not used to transfer the payload.");
                     }

--- a/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties_with_unobtrusive.cs
+++ b/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties_with_unobtrusive.cs
@@ -91,7 +91,7 @@
         {
             public Task MutateIncoming(MutateIncomingTransportMessageContext context)
             {
-                if (context.Body.Length > PayloadSize)
+                if (context.Body.Count > PayloadSize)
                 {
                     throw new Exception("The message body is too large, which means the DataBus was not used to transfer the payload.");
                 }

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_configuring_custom_xml_namespace.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_configuring_custom_xml_namespace.cs
@@ -66,7 +66,7 @@
 
                 public Task MutateIncoming(MutateIncomingTransportMessageContext context)
                 {
-                    var document = XDocument.Parse(Encoding.UTF8.GetString(context.Body));
+                    var document = XDocument.Parse(Encoding.UTF8.GetString(context.Body.CreateCopy()));
                     var defaultNamespace = document.Root?.GetDefaultNamespace();
                     scenarioContext.MessageNamespace = defaultNamespace?.NamespaceName;
                     return Task.FromResult(0);

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_sanitizing_xml_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_sanitizing_xml_messages.cs
@@ -63,10 +63,10 @@
             {
                 public Task MutateIncoming(MutateIncomingTransportMessageContext context)
                 {
-                    var body = Encoding.UTF8.GetString(context.Body);
+                    var body = Encoding.UTF8.GetString(context.Body.CreateCopy());
                     var invalidChar = char.ConvertFromUtf32(0x8);
 
-                    context.Body = Encoding.UTF8.GetBytes(body.Replace("Hello World!", $"{invalidChar}Hello {invalidChar}World!{invalidChar}"));
+                    context.UpdateMessage(Encoding.UTF8.GetBytes(body.Replace("Hello World!", $"{invalidChar}Hello {invalidChar}World!{invalidChar}")));
 
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_skip_wrapping_xml.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_skip_wrapping_xml.cs
@@ -75,7 +75,7 @@
 
                 public Task MutateIncoming(MutateIncomingTransportMessageContext context)
                 {
-                    testContext.XmlMessage = XDocument.Parse(Encoding.UTF8.GetString(context.Body));
+                    testContext.XmlMessage = XDocument.Parse(Encoding.UTF8.GetString(context.Body.CreateCopy()));
 
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_wrapping_is_not_skipped.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_wrapping_is_not_skipped.cs
@@ -77,7 +77,7 @@
 
                 public Task MutateIncoming(MutateIncomingTransportMessageContext context)
                 {
-                    testContext.XmlMessage = XDocument.Parse(Encoding.UTF8.GetString(context.Body));
+                    testContext.XmlMessage = XDocument.Parse(Encoding.UTF8.GetString(context.Body.CreateCopy()));
 
                     return Task.FromResult(0);
                 }

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1417,8 +1417,8 @@ namespace NServiceBus.Faults
 {
     public class DelayedRetryMessage
     {
-        public DelayedRetryMessage(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, System.Exception exception, int retryAttempt) { }
-        public byte[] Body { get; }
+        public DelayedRetryMessage(string messageId, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.Transport.MessageBody body, System.Exception exception, int retryAttempt) { }
+        public NServiceBus.Transport.MessageBody Body { get; }
         public System.Exception Exception { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public string MessageId { get; }
@@ -1445,8 +1445,8 @@ namespace NServiceBus.Faults
     }
     public class FailedMessage
     {
-        public FailedMessage(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, System.Exception exception, string errorQueue) { }
-        public byte[] Body { get; }
+        public FailedMessage(string messageId, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.Transport.MessageBody body, System.Exception exception, string errorQueue) { }
+        public NServiceBus.Transport.MessageBody Body { get; }
         public string ErrorQueue { get; }
         public System.Exception Exception { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
@@ -1458,8 +1458,8 @@ namespace NServiceBus.Faults
     }
     public class ImmediateRetryMessage
     {
-        public ImmediateRetryMessage(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, System.Exception exception, int retryAttempt) { }
-        public byte[] Body { get; }
+        public ImmediateRetryMessage(string messageId, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.Transport.MessageBody body, System.Exception exception, int retryAttempt) { }
+        public NServiceBus.Transport.MessageBody Body { get; }
         public System.Exception Exception { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public string MessageId { get; }
@@ -1734,9 +1734,10 @@ namespace NServiceBus.MessageMutator
     public class MutateIncomingTransportMessageContext : NServiceBus.ICancellableContext
     {
         public MutateIncomingTransportMessageContext(NServiceBus.Transport.MessageBody body, System.Collections.Generic.Dictionary<string, string> headers, System.Threading.CancellationToken cancellationToken = default) { }
-        public byte[] Body { get; set; }
+        public NServiceBus.Transport.MessageBody Body { get; }
         public System.Threading.CancellationToken CancellationToken { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
+        public void UpdateMessage(byte[] messageBody) { }
     }
     public class MutateOutgoingMessageContext : NServiceBus.ICancellableContext
     {
@@ -2577,6 +2578,7 @@ namespace NServiceBus.Transport
     {
         public MessageBody(byte[] body) { }
         public int Count { get; }
+        public byte[] CreateCopy() { }
         public System.Collections.Generic.IEnumerator<byte> GetEnumerator() { }
     }
     public class MessageContext : NServiceBus.Extensibility.IExtendable

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2580,6 +2580,7 @@ namespace NServiceBus.Transport
         public int Count { get; }
         public byte[] CreateCopy() { }
         public System.Collections.Generic.IEnumerator<byte> GetEnumerator() { }
+        public System.IO.Stream GetStream() { }
     }
     public class MessageContext : NServiceBus.Extensibility.IExtendable
     {

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1733,7 +1733,7 @@ namespace NServiceBus.MessageMutator
     }
     public class MutateIncomingTransportMessageContext : NServiceBus.ICancellableContext
     {
-        public MutateIncomingTransportMessageContext(byte[] body, System.Collections.Generic.Dictionary<string, string> headers, System.Threading.CancellationToken cancellationToken = default) { }
+        public MutateIncomingTransportMessageContext(NServiceBus.Transport.MessageBody body, System.Collections.Generic.Dictionary<string, string> headers, System.Threading.CancellationToken cancellationToken = default) { }
         public byte[] Body { get; set; }
         public System.Threading.CancellationToken CancellationToken { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
@@ -2556,8 +2556,8 @@ namespace NServiceBus.Transport
     }
     public class IncomingMessage
     {
-        public IncomingMessage(string nativeMessageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body) { }
-        public byte[] Body { get; }
+        public IncomingMessage(string nativeMessageId, System.Collections.Generic.Dictionary<string, string> headers, NServiceBus.Transport.MessageBody body) { }
+        public NServiceBus.Transport.MessageBody Body { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public string MessageId { get; }
         public string NativeMessageId { get; }
@@ -2573,6 +2573,12 @@ namespace NServiceBus.Transport
             " a NotImplementedException. Will be removed in version 9.0.0.", true)]
         public static string GetTransportAddress(this NServiceBus.Settings.ReadOnlySettings settings, NServiceBus.LogicalAddress logicalAddress) { }
     }
+    public class MessageBody : System.Collections.Generic.IEnumerable<byte>, System.Collections.Generic.IReadOnlyCollection<byte>, System.Collections.IEnumerable
+    {
+        public MessageBody(byte[] body) { }
+        public int Count { get; }
+        public System.Collections.Generic.IEnumerator<byte> GetEnumerator() { }
+    }
     public class MessageContext : NServiceBus.Extensibility.IExtendable
     {
         public MessageContext(string nativeMessageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, NServiceBus.Extensibility.ContextBag context) { }
@@ -2580,7 +2586,7 @@ namespace NServiceBus.Transport
             "ion, ContextBag)` instead. The member currently throws a NotImplementedException" +
             ". Will be removed in version 9.0.0.", true)]
         public MessageContext(string messageId, System.Collections.Generic.Dictionary<string, string> headers, byte[] body, NServiceBus.Transport.TransportTransaction transportTransaction, System.Threading.CancellationTokenSource receiveCancellationTokenSource, NServiceBus.Extensibility.ContextBag context) { }
-        public byte[] Body { get; }
+        public NServiceBus.Transport.MessageBody Body { get; }
         public NServiceBus.Extensibility.ContextBag Extensions { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         [System.Obsolete("Use `NativeMessageId` instead. Will be removed in version 9.0.0.", true)]

--- a/src/NServiceBus.Core.Tests/Causation/AttachCausationHeadersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Causation/AttachCausationHeadersBehaviorTests.cs
@@ -34,7 +34,7 @@
             var transportMessage = new IncomingMessage("xyz", new Dictionary<string, string>
             {
                 {Headers.ConversationId, incomingConversationId}
-            }, new byte[0]);
+            }, new MessageBody(new byte[0]));
             context.Extensions.Set(transportMessage);
 
             await behavior.Invoke(context, ctx => Task.CompletedTask);
@@ -78,7 +78,7 @@
             var transportMessage = new IncomingMessage("xyz", new Dictionary<string, string>
             {
                 {Headers.ConversationId, incomingConversationId}
-            }, new byte[0]);
+            }, new MessageBody(new byte[0]));
             context.Extensions.Set(transportMessage);
 
             var exception = Assert.ThrowsAsync<Exception>(() => behavior.Invoke(context, ctx => Task.CompletedTask));
@@ -92,7 +92,7 @@
             var behavior = new AttachCausationHeadersBehavior(ReturnDefaultConversationId);
             var context = new TestableOutgoingLogicalMessageContext();
 
-            context.Extensions.Set(new IncomingMessage("the message id", new Dictionary<string, string>(), new byte[0]));
+            context.Extensions.Set(new IncomingMessage("the message id", new Dictionary<string, string>(), new MessageBody(new byte[0])));
 
             await behavior.Invoke(context, ctx => Task.CompletedTask);
 

--- a/src/NServiceBus.Core.Tests/MessageMutators/MutateInstanceMessage/MutateOutgoingMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageMutators/MutateInstanceMessage/MutateOutgoingMessageBehaviorTests.cs
@@ -68,7 +68,7 @@
             var behavior = new MutateOutgoingMessageBehavior(new HashSet<IMutateOutgoingMessages>());
 
             var context = new TestableOutgoingLogicalMessageContext();
-            context.Extensions.Set(new IncomingMessage("messageId", new Dictionary<string, string>(), new byte[0]));
+            context.Extensions.Set(new IncomingMessage("messageId", new Dictionary<string, string>(), new MessageBody(new byte[0])));
             context.Extensions.Set(new LogicalMessage(null, null));
             context.Services.AddTransient<IMutateOutgoingMessages>(sp => new MutateOutgoingMessagesReturnsNull());
 

--- a/src/NServiceBus.Core.Tests/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehaviorTests.cs
@@ -158,7 +158,7 @@
         {
             public Task MutateIncoming(MutateIncomingTransportMessageContext context)
             {
-                context.Body = new byte[0];
+                context.UpdateMessage(new byte[0]);
 
                 return Task.CompletedTask;
             }

--- a/src/NServiceBus.Core.Tests/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehaviorTests.cs
@@ -77,13 +77,13 @@
         {
             var behavior = new MutateIncomingTransportMessageBehavior(new HashSet<IMutateIncomingTransportMessages>());
 
-            var context = new InterceptUpdateMessageIncomingPhysicalMessageContext();
+            var context = new TestableIncomingPhysicalMessageContext();
 
             context.Services.AddTransient<IMutateIncomingTransportMessages>(sp => new MutatorWhichDoesNotMutateTheBody());
 
             await behavior.Invoke(context, ctx => Task.CompletedTask);
 
-            Assert.False(context.UpdateMessageBodyCalled);
+            Assert.AreSame(context.Message.OriginalMessageBody, context.Message.Body);
         }
 
         [Test]
@@ -91,13 +91,13 @@
         {
             var behavior = new MutateIncomingTransportMessageBehavior(new HashSet<IMutateIncomingTransportMessages>());
 
-            var context = new InterceptUpdateMessageIncomingPhysicalMessageContext();
+            var context = new TestableIncomingPhysicalMessageContext();
 
             context.Services.AddTransient(sp => new IMutateIncomingTransportMessages[] { });
 
             await behavior.Invoke(context, ctx => Task.CompletedTask);
 
-            Assert.False(context.UpdateMessageBodyCalled);
+            Assert.AreSame(context.Message.OriginalMessageBody, context.Message.Body);
         }
 
         [Test]
@@ -105,25 +105,13 @@
         {
             var behavior = new MutateIncomingTransportMessageBehavior(new HashSet<IMutateIncomingTransportMessages>());
 
-            var context = new InterceptUpdateMessageIncomingPhysicalMessageContext();
+            var context = new TestableIncomingPhysicalMessageContext();
 
             context.Services.AddTransient<IMutateIncomingTransportMessages>(sp => new MutatorWhichMutatesTheBody());
 
             await behavior.Invoke(context, ctx => Task.CompletedTask);
 
-            Assert.True(context.UpdateMessageBodyCalled);
-        }
-
-        class InterceptUpdateMessageIncomingPhysicalMessageContext : TestableIncomingPhysicalMessageContext
-        {
-            public bool UpdateMessageBodyCalled { get; private set; }
-
-            public override void UpdateMessage(byte[] body)
-            {
-                base.UpdateMessage(body);
-
-                UpdateMessageBodyCalled = true;
-            }
+            Assert.AreNotSame(context.Message.OriginalMessageBody, context.Message.Body);
         }
 
         class MutatorThatIndicatesIfItWasCalled : IMutateIncomingTransportMessages

--- a/src/NServiceBus.Core.Tests/Recoverability/DelayedRetryExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/DelayedRetryExecutorTests.cs
@@ -91,7 +91,7 @@
 
         IncomingMessage CreateMessage(Dictionary<string, string> headers = null)
         {
-            return new IncomingMessage("messageId", headers ?? new Dictionary<string, string>(), new byte[0]);
+            return new IncomingMessage("messageId", headers ?? new Dictionary<string, string>(), new MessageBody(new byte[0]));
         }
 
         DelayedRetryExecutor CreateExecutor()

--- a/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
@@ -24,7 +24,7 @@
         {
             var customErrorQueue = "random_error_queue";
             var transportTransaction = new TransportTransaction();
-            var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), new byte[0]);
+            var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), new MessageBody(new byte[0]));
 
             await moveToErrorsExecutor.MoveToErrorQueue(customErrorQueue, incomingMessage, new Exception(), transportTransaction);
 
@@ -46,7 +46,7 @@
                 {"key2", "value2"}
             };
 
-            var incomingMessage = new IncomingMessage("messageId", incomingMessageHeaders, new byte[0]);
+            var incomingMessage = new IncomingMessage("messageId", incomingMessageHeaders, new MessageBody(new byte[0]));
 
             await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, new Exception(), new TransportTransaction());
 
@@ -62,7 +62,7 @@
                 {Headers.ImmediateRetries, "42"},
                 {Headers.DelayedRetries, "21"}
             };
-            var incomingMessage = new IncomingMessage("messageId", retryHeaders, new byte[0]);
+            var incomingMessage = new IncomingMessage("messageId", retryHeaders, new MessageBody(new byte[0]));
 
             await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, new Exception(), new TransportTransaction());
 
@@ -74,7 +74,7 @@
         [Test]
         public async Task MoveToErrorQueue_should_add_exception_headers()
         {
-            var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), new byte[0]);
+            var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), new MessageBody(new byte[0]));
             var exception = new InvalidOperationException("test exception");
 
             await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, exception, new TransportTransaction());
@@ -92,7 +92,7 @@
         public async Task MoveToErrorQueue_should_add_static_fault_info_to_headers()
         {
             staticFaultMetadata.Add("staticFaultMetadataKey", "staticFaultMetadataValue");
-            var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), new byte[0]);
+            var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), new MessageBody(new byte[0]));
 
             await moveToErrorsExecutor.MoveToErrorQueue(ErrorQueueAddress, incomingMessage, new Exception(), new TransportTransaction());
 
@@ -106,7 +106,7 @@
         public async Task MoveToErrorQueue_should_apply_header_customizations_before_dispatch()
         {
             staticFaultMetadata.Add("staticFaultMetadataKey", "staticFaultMetadataValue");
-            var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), new byte[0]);
+            var incomingMessage = new IncomingMessage("messageId", new Dictionary<string, string>(), new MessageBody(new byte[0]));
             var exception = new InvalidOperationException("test exception");
 
             Dictionary<string, string> passedInHeaders = null;

--- a/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageConnectorTests.cs
@@ -106,7 +106,7 @@
         {
             var context = new TestableTransportReceiveContext
             {
-                Message = new IncomingMessage(messageId, new Dictionary<string, string>(), new byte[0])
+                Message = new IncomingMessage(messageId, new Dictionary<string, string>(), new MessageBody(new byte[0]))
             };
 
             context.Extensions.Set<IPipelineCache>(new FakePipelineCache(pipeline));

--- a/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
@@ -26,7 +26,7 @@
                 {
                     {Headers.ReplyToAddress, "ReplyAddressOfIncomingMessage"}
                 },
-                new byte[0]));
+                new MessageBody(new byte[0])));
 
             UnicastAddressTag addressTag = null;
             await behavior.Invoke(context, c =>
@@ -48,7 +48,7 @@
             context.Extensions.Set(new IncomingMessage(
                 "id",
                 new Dictionary<string, string>(),
-                new byte[0]));
+                new MessageBody(new byte[0])));
 
             Assert.That(async () => await behavior.Invoke(context, _ => Task.CompletedTask), Throws.InstanceOf<Exception>().And.Message.Contains(typeof(MyReply).FullName));
         }

--- a/src/NServiceBus.Core.Tests/Transports/IncomingMessageTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/IncomingMessageTests.cs
@@ -11,7 +11,7 @@
         public void Should_assign_transport_message_id_when_NServiceBus_message_id_header_is_missing()
         {
             var headers = new Dictionary<string, string>();
-            var message = new IncomingMessage("nativeId", headers, new byte[] { });
+            var message = new IncomingMessage("nativeId", headers, new MessageBody(new byte[0]));
 
             Assert.AreEqual("nativeId", message.NativeMessageId);
             Assert.AreEqual("nativeId", message.MessageId);
@@ -25,7 +25,7 @@
             {
                 { Headers.MessageId, "coreId" }
             };
-            var message = new IncomingMessage("nativeId", headers, new byte[] { });
+            var message = new IncomingMessage("nativeId", headers, new MessageBody(new byte[0]));
 
             Assert.AreEqual("nativeId", message.NativeMessageId);
             Assert.AreEqual("coreId", message.MessageId);
@@ -38,7 +38,7 @@
             {
                 { Headers.MessageId, "" }
             };
-            var message = new IncomingMessage("nativeId", headers, new byte[] { });
+            var message = new IncomingMessage("nativeId", headers, new MessageBody(new byte[0]));
 
             Assert.AreEqual("nativeId", message.NativeMessageId);
             Assert.AreEqual("nativeId", message.MessageId);

--- a/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
@@ -17,7 +17,6 @@
         {
             await next(context).ConfigureAwait(false);
 
-            //TODO consider change the Body type of OutgoingMessage as well
             var processedMessage = new OutgoingMessage(context.Message.MessageId, new Dictionary<string, string>(context.Message.Headers), context.Message.OriginalMessageBody.CreateCopy());
 
             var auditContext = this.CreateAuditContext(processedMessage, auditAddress, context);

--- a/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
@@ -15,12 +15,10 @@
 
         public async Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
         {
-            var originalMessageBody = context.Message.Body;
-
             await next(context).ConfigureAwait(false);
 
             //TODO consider change the Body type of OutgoingMessage as well
-            var processedMessage = new OutgoingMessage(context.Message.MessageId, new Dictionary<string, string>(context.Message.Headers), originalMessageBody.CreateCopy());
+            var processedMessage = new OutgoingMessage(context.Message.MessageId, new Dictionary<string, string>(context.Message.Headers), context.Message.OriginalMessageBody.CreateCopy());
 
             var auditContext = this.CreateAuditContext(processedMessage, auditAddress, context);
 

--- a/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading.Tasks;
     using Pipeline;
     using Transport;
@@ -16,11 +15,12 @@
 
         public async Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
         {
+            var originalMessageBody = context.Message.Body;
+
             await next(context).ConfigureAwait(false);
 
-            context.Message.RevertToOriginalBodyIfNeeded();
-
-            var processedMessage = new OutgoingMessage(context.Message.MessageId, new Dictionary<string, string>(context.Message.Headers), context.Message.Body.ToArray());
+            //TODO consider change the Body type of OutgoingMessage as well
+            var processedMessage = new OutgoingMessage(context.Message.MessageId, new Dictionary<string, string>(context.Message.Headers), originalMessageBody.CreateCopy());
 
             var auditContext = this.CreateAuditContext(processedMessage, auditAddress, context);
 

--- a/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
+++ b/src/NServiceBus.Core/Audit/InvokeAuditPipelineBehavior.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading.Tasks;
     using Pipeline;
     using Transport;
@@ -19,7 +20,7 @@
 
             context.Message.RevertToOriginalBodyIfNeeded();
 
-            var processedMessage = new OutgoingMessage(context.Message.MessageId, new Dictionary<string, string>(context.Message.Headers), context.Message.Body);
+            var processedMessage = new OutgoingMessage(context.Message.MessageId, new Dictionary<string, string>(context.Message.Headers), context.Message.Body.ToArray());
 
             var auditContext = this.CreateAuditContext(processedMessage, auditAddress, context);
 

--- a/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
@@ -54,7 +54,7 @@
 
             if (mutatorContext.MessageBodyChanged)
             {
-                context.UpdateMessage(mutatorContext.Body.Bytes);
+                context.Message.Body = mutatorContext.Body;
             }
 
             await next(context).ConfigureAwait(false);

--- a/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
@@ -54,7 +54,7 @@
 
             if (mutatorContext.MessageBodyChanged)
             {
-                context.UpdateMessage(mutatorContext.Body);
+                context.UpdateMessage(mutatorContext.Body.Bytes);
             }
 
             await next(context).ConfigureAwait(false);

--- a/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
@@ -60,7 +60,6 @@
             await next(context).ConfigureAwait(false);
         }
 
-
         volatile bool hasIncomingTransportMessageMutators = true;
         HashSet<IMutateIncomingTransportMessages> mutators;
     }

--- a/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
@@ -60,6 +60,7 @@
             await next(context).ConfigureAwait(false);
         }
 
+
         volatile bool hasIncomingTransportMessageMutators = true;
         HashSet<IMutateIncomingTransportMessages> mutators;
     }

--- a/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageContext.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageContext.cs
@@ -18,26 +18,15 @@ namespace NServiceBus.MessageMutator
             Guard.AgainstNull(nameof(body), body);
             Headers = headers;
 
-            // Intentionally assign to field to not set the MessageBodyChanged flag.
-            this.body = body.Bytes;
+            Body = body;
 
             CancellationToken = cancellationToken;
         }
 
-        //TODO what to expose here?
         /// <summary>
         /// The body of the message.
         /// </summary>
-        public byte[] Body
-        {
-            get => body;
-            set
-            {
-                Guard.AgainstNull(nameof(value), value);
-                MessageBodyChanged = true;
-                body = value;
-            }
-        }
+        public MessageBody Body { get; private set; }
 
         /// <summary>
         /// The current incoming headers.
@@ -49,7 +38,15 @@ namespace NServiceBus.MessageMutator
         /// </summary>
         public CancellationToken CancellationToken { get; }
 
-        byte[] body;
+        /// <summary>
+        /// Replace the message body
+        /// </summary>
+        /// <param name="messageBody"></param>
+        public void UpdateMessage(byte[] messageBody)
+        {
+            MessageBodyChanged = true;
+            Body = new MessageBody(messageBody);
+        }
 
         internal bool MessageBodyChanged;
     }

--- a/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageContext.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageContext.cs
@@ -39,9 +39,8 @@ namespace NServiceBus.MessageMutator
         public CancellationToken CancellationToken { get; }
 
         /// <summary>
-        /// Replace the message body
+        /// Replace the current message body.
         /// </summary>
-        /// <param name="messageBody"></param>
         public void UpdateMessage(byte[] messageBody)
         {
             MessageBodyChanged = true;

--- a/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageContext.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageContext.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.MessageMutator
 {
     using System.Collections.Generic;
     using System.Threading;
+    using Transport;
 
     /// <summary>
     /// Context class for <see cref="IMutateIncomingTransportMessages" />.
@@ -11,18 +12,19 @@ namespace NServiceBus.MessageMutator
         /// <summary>
         /// Initializes a new instance of <see cref="MutateOutgoingTransportMessageContext" />.
         /// </summary>
-        public MutateIncomingTransportMessageContext(byte[] body, Dictionary<string, string> headers, CancellationToken cancellationToken = default)
+        public MutateIncomingTransportMessageContext(MessageBody body, Dictionary<string, string> headers, CancellationToken cancellationToken = default)
         {
             Guard.AgainstNull(nameof(headers), headers);
             Guard.AgainstNull(nameof(body), body);
             Headers = headers;
 
             // Intentionally assign to field to not set the MessageBodyChanged flag.
-            this.body = body;
+            this.body = body.Bytes;
 
             CancellationToken = cancellationToken;
         }
 
+        //TODO what to expose here?
         /// <summary>
         /// The body of the message.
         /// </summary>

--- a/src/NServiceBus.Core/Pipeline/Incoming/DeserializeMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/DeserializeMessageConnector.cs
@@ -60,7 +60,7 @@
                 return NoMessagesFound;
             }
 
-            if (physicalMessage.Body == null || physicalMessage.Body.Length == 0)
+            if (physicalMessage.Body.Bytes == null || physicalMessage.Body.Count == 0)
             {
                 log.Debug("Received a message without body. Skipping deserialization.");
                 return NoMessagesFound;
@@ -104,7 +104,7 @@
             // add the default content type
             physicalMessage.Headers[Headers.ContentType] = messageSerializer.ContentType;
 
-            using (var stream = new MemoryStream(physicalMessage.Body))
+            using (var stream = new MemoryStream(physicalMessage.Body.Bytes))
             {
                 var deserializedMessages = messageSerializer.Deserialize(stream, messageTypes);
                 var logicalMessages = new LogicalMessage[deserializedMessages.Length];

--- a/src/NServiceBus.Core/Pipeline/Incoming/DeserializeMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/DeserializeMessageConnector.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using System.Threading.Tasks;
     using Logging;
@@ -104,7 +103,7 @@
             // add the default content type
             physicalMessage.Headers[Headers.ContentType] = messageSerializer.ContentType;
 
-            using (var stream = new MemoryStream(physicalMessage.Body.Bytes))
+            using (var stream = physicalMessage.Body.GetStream())
             {
                 var deserializedMessages = messageSerializer.Deserialize(stream, messageTypes);
                 var logicalMessages = new LogicalMessage[deserializedMessages.Length];

--- a/src/NServiceBus.Core/Pipeline/Incoming/IIncomingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IIncomingPhysicalMessageContext.cs
@@ -11,5 +11,10 @@
         /// The physical message being processed.
         /// </summary>
         IncomingMessage Message { get; }
+
+        /// <summary>
+        /// Updates the message with the given body.
+        /// </summary>
+        void UpdateMessage(byte[] body);
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/IIncomingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IIncomingPhysicalMessageContext.cs
@@ -11,10 +11,5 @@
         /// The physical message being processed.
         /// </summary>
         IncomingMessage Message { get; }
-
-        /// <summary>
-        /// Updates the message with the given body.
-        /// </summary>
-        void UpdateMessage(byte[] body);
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/IncomingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IncomingPhysicalMessageContext.cs
@@ -15,7 +15,7 @@
 
         public void UpdateMessage(byte[] body)
         {
-            Message.UpdateBody(body);
+            Message.UpdateBody(new MessageBody(body));
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/IncomingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/IncomingPhysicalMessageContext.cs
@@ -15,7 +15,7 @@
 
         public void UpdateMessage(byte[] body)
         {
-            Message.UpdateBody(new MessageBody(body));
+            Message.Body = new MessageBody(body);
         }
     }
 }

--- a/src/NServiceBus.Core/Recoverability/DelayedRetries/DelayedRetryMessage.cs
+++ b/src/NServiceBus.Core/Recoverability/DelayedRetries/DelayedRetryMessage.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Faults
 {
     using System;
     using System.Collections.Generic;
+    using Transport;
 
     /// <summary>
     /// Delayed Retry event data.
@@ -16,7 +17,7 @@ namespace NServiceBus.Faults
         /// <param name="body">Message body.</param>
         /// <param name="exception">Exception thrown.</param>
         /// <param name="retryAttempt">Number of retry attempt.</param>
-        public DelayedRetryMessage(string messageId, Dictionary<string, string> headers, byte[] body, Exception exception, int retryAttempt)
+        public DelayedRetryMessage(string messageId, Dictionary<string, string> headers, MessageBody body, Exception exception, int retryAttempt)
         {
             Headers = headers;
             Body = body;
@@ -38,7 +39,7 @@ namespace NServiceBus.Faults
         /// <summary>
         /// Gets a byte array to the body content of the message.
         /// </summary>
-        public byte[] Body { get; }
+        public MessageBody Body { get; }
 
         /// <summary>
         /// The exception that caused this message to fail.

--- a/src/NServiceBus.Core/Recoverability/DelayedRetryExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/DelayedRetryExecutor.cs
@@ -18,7 +18,7 @@
 
         public async Task<int> Retry(IncomingMessage message, TimeSpan delay, TransportTransaction transportTransaction, CancellationToken cancellationToken = default)
         {
-            var outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body);
+            var outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body.Bytes);
 
             var currentDelayedRetriesAttempt = message.GetDelayedDeliveriesPerformed() + 1;
 

--- a/src/NServiceBus.Core/Recoverability/Faults/FailedMessage.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/FailedMessage.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Faults
 {
     using System;
     using System.Collections.Generic;
+    using Transport;
 
     /// <summary>
     /// Error message event data.
@@ -16,7 +17,7 @@ namespace NServiceBus.Faults
         /// <param name="body">Message body.</param>
         /// <param name="exception">Exception thrown.</param>
         /// <param name="errorQueue">Error queue address.</param>
-        public FailedMessage(string messageId, Dictionary<string, string> headers, byte[] body, Exception exception, string errorQueue)
+        public FailedMessage(string messageId, Dictionary<string, string> headers, MessageBody body, Exception exception, string errorQueue)
         {
             MessageId = messageId;
             Headers = headers;
@@ -33,7 +34,7 @@ namespace NServiceBus.Faults
         /// <summary>
         /// Gets a byte array to the body content of the message.
         /// </summary>
-        public byte[] Body { get; }
+        public MessageBody Body { get; }
 
         /// <summary>
         /// The exception that caused this message to fail.

--- a/src/NServiceBus.Core/Recoverability/ImmediateRetries/ImmediateRetryMessage.cs
+++ b/src/NServiceBus.Core/Recoverability/ImmediateRetries/ImmediateRetryMessage.cs
@@ -2,6 +2,7 @@ namespace NServiceBus.Faults
 {
     using System;
     using System.Collections.Generic;
+    using Transport;
 
     /// <summary>
     /// Immediate Retry event data.
@@ -16,7 +17,7 @@ namespace NServiceBus.Faults
         /// <param name="body">Message body.</param>
         /// <param name="exception">Exception thrown.</param>
         /// <param name="retryAttempt">Number of retry attempt.</param>
-        public ImmediateRetryMessage(string messageId, Dictionary<string, string> headers, byte[] body, Exception exception, int retryAttempt)
+        public ImmediateRetryMessage(string messageId, Dictionary<string, string> headers, MessageBody body, Exception exception, int retryAttempt)
         {
             Guard.AgainstNullAndEmpty(nameof(messageId), messageId);
             Guard.AgainstNull(nameof(headers), headers);
@@ -43,7 +44,7 @@ namespace NServiceBus.Faults
         /// <summary>
         /// Gets a byte array to the body content of the message.
         /// </summary>
-        public byte[] Body { get; }
+        public MessageBody Body { get; }
 
         /// <summary>
         /// The exception that caused this message to fail.

--- a/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Routing;
@@ -18,7 +19,7 @@
 
         public Task MoveToErrorQueue(string errorQueueAddress, IncomingMessage message, Exception exception, TransportTransaction transportTransaction, CancellationToken cancellationToken = default)
         {
-            var outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body);
+            var outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body.ToArray());
 
             var headers = outgoingMessage.Headers;
             headers.Remove(Headers.DelayedRetries);

--- a/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/MoveToErrorsExecutor.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Routing;
@@ -19,7 +18,7 @@
 
         public Task MoveToErrorQueue(string errorQueueAddress, IncomingMessage message, Exception exception, TransportTransaction transportTransaction, CancellationToken cancellationToken = default)
         {
-            var outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body.ToArray());
+            var outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body.Bytes);
 
             var headers = outgoingMessage.Headers;
             headers.Remove(Headers.DelayedRetries);

--- a/src/NServiceBus.Core/Recoverability/Settings/DelayedRetriesSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/DelayedRetriesSettings.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Configuration.AdvancedExtensibility;
@@ -57,7 +58,7 @@ namespace NServiceBus
                 }
 
                 var headerCopy = new Dictionary<string, string>(retry.Message.Headers);
-                var bodyCopy = retry.Message.Body.Copy();
+                var bodyCopy = retry.Message.Body.ToArray();
                 return notificationCallback(new DelayedRetryMessage(retry.Message.MessageId, headerCopy, bodyCopy, retry.Exception, retry.Attempt), cancellationToken);
             });
 

--- a/src/NServiceBus.Core/Recoverability/Settings/DelayedRetriesSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/DelayedRetriesSettings.cs
@@ -2,7 +2,6 @@ namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Configuration.AdvancedExtensibility;
@@ -58,8 +57,7 @@ namespace NServiceBus
                 }
 
                 var headerCopy = new Dictionary<string, string>(retry.Message.Headers);
-                var bodyCopy = retry.Message.Body.ToArray();
-                return notificationCallback(new DelayedRetryMessage(retry.Message.MessageId, headerCopy, bodyCopy, retry.Exception, retry.Attempt), cancellationToken);
+                return notificationCallback(new DelayedRetryMessage(retry.Message.MessageId, headerCopy, retry.Message.Body, retry.Exception, retry.Attempt), cancellationToken);
             });
 
             return this;

--- a/src/NServiceBus.Core/Recoverability/Settings/ImmediateRetriesSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/ImmediateRetriesSettings.cs
@@ -2,7 +2,6 @@ namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Configuration.AdvancedExtensibility;
@@ -46,8 +45,7 @@ namespace NServiceBus
                 }
 
                 var headerCopy = new Dictionary<string, string>(retry.Message.Headers);
-                var bodyCopy = retry.Message.Body.ToArray();
-                return notificationCallback(new ImmediateRetryMessage(retry.Message.MessageId, headerCopy, bodyCopy, retry.Exception, retry.Attempt), cancellationToken);
+                return notificationCallback(new ImmediateRetryMessage(retry.Message.MessageId, headerCopy, retry.Message.Body, retry.Exception, retry.Attempt), cancellationToken);
             });
 
             return this;

--- a/src/NServiceBus.Core/Recoverability/Settings/ImmediateRetriesSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/ImmediateRetriesSettings.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Configuration.AdvancedExtensibility;
@@ -45,7 +46,7 @@ namespace NServiceBus
                 }
 
                 var headerCopy = new Dictionary<string, string>(retry.Message.Headers);
-                var bodyCopy = retry.Message.Body.Copy();
+                var bodyCopy = retry.Message.Body.ToArray();
                 return notificationCallback(new ImmediateRetryMessage(retry.Message.MessageId, headerCopy, bodyCopy, retry.Exception, retry.Attempt), cancellationToken);
             });
 

--- a/src/NServiceBus.Core/Recoverability/Settings/RetryFailedSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/RetryFailedSettings.cs
@@ -2,7 +2,6 @@ namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Configuration.AdvancedExtensibility;
@@ -42,8 +41,7 @@ namespace NServiceBus
             subscriptions.MessageFaultedNotification.Subscribe((faulted, cancellationToken) =>
             {
                 var headerCopy = new Dictionary<string, string>(faulted.Message.Headers);
-                var bodyCopy = faulted.Message.Body.ToArray();
-                return notificationCallback(new FailedMessage(faulted.Message.MessageId, headerCopy, bodyCopy, faulted.Exception, faulted.ErrorQueue), cancellationToken);
+                return notificationCallback(new FailedMessage(faulted.Message.MessageId, headerCopy, faulted.Message.Body, faulted.Exception, faulted.ErrorQueue), cancellationToken);
             });
 
             return this;

--- a/src/NServiceBus.Core/Recoverability/Settings/RetryFailedSettings.cs
+++ b/src/NServiceBus.Core/Recoverability/Settings/RetryFailedSettings.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Configuration.AdvancedExtensibility;
@@ -41,7 +42,7 @@ namespace NServiceBus
             subscriptions.MessageFaultedNotification.Subscribe((faulted, cancellationToken) =>
             {
                 var headerCopy = new Dictionary<string, string>(faulted.Message.Headers);
-                var bodyCopy = faulted.Message.Body.Copy();
+                var bodyCopy = faulted.Message.Body.ToArray();
                 return notificationCallback(new FailedMessage(faulted.Message.MessageId, headerCopy, bodyCopy, faulted.Exception, faulted.ErrorQueue), cancellationToken);
             });
 

--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -30,7 +30,7 @@
             TransportTransaction = transportTransaction;
             ImmediateProcessingFailures = immediateProcessingFailures;
 
-            Message = new IncomingMessage(nativeMessageId, headers, body);
+            Message = new IncomingMessage(nativeMessageId, headers, new MessageBody(body));
 
             DelayedDeliveriesPerformed = Message.GetDelayedDeliveriesPerformed();
             Extensions = context;

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -14,7 +14,7 @@ namespace NServiceBus.Transport
         /// <param name="nativeMessageId">The native message ID.</param>
         /// <param name="headers">The message headers.</param>
         /// <param name="body">The message body.</param>
-        public IncomingMessage(string nativeMessageId, Dictionary<string, string> headers, byte[] body)
+        public IncomingMessage(string nativeMessageId, Dictionary<string, string> headers, MessageBody body)
         {
             Guard.AgainstNullAndEmpty(nameof(nativeMessageId), nativeMessageId);
             Guard.AgainstNull(nameof(body), body);
@@ -56,7 +56,7 @@ namespace NServiceBus.Transport
         /// <summary>
         /// Gets/sets a byte array to the body content of the message.
         /// </summary>
-        public byte[] Body { get; private set; }
+        public MessageBody Body { get; private set; }
 
         /// <summary>
         /// Use this method to update the body if this message.
@@ -64,13 +64,13 @@ namespace NServiceBus.Transport
         internal void UpdateBody(byte[] updatedBody)
         {
             //preserve the original body if needed
-            if (Body != null && originalBody == null)
+            if (Body.Bytes != null && originalBody == null)
             {
-                originalBody = new byte[Body.Length];
-                Buffer.BlockCopy(Body, 0, originalBody, 0, Body.Length);
+                originalBody = new byte[Body.Count];
+                Buffer.BlockCopy(Body.Bytes, 0, originalBody, 0, Body.Bytes.Length);
             }
 
-            Body = updatedBody;
+            Body.Bytes = updatedBody;
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace NServiceBus.Transport
         {
             if (originalBody != null)
             {
-                Body = originalBody;
+                Body.Bytes = originalBody;
             }
         }
 

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -34,7 +34,7 @@ namespace NServiceBus.Transport
 
             Headers = headers;
 
-            Body = body;
+            Body = OriginalMessageBody = body;
         }
 
         /// <summary>
@@ -56,5 +56,7 @@ namespace NServiceBus.Transport
         /// Gets/sets a byte array to the body content of the message.
         /// </summary>
         public MessageBody Body { get; internal set; }
+
+        internal MessageBody OriginalMessageBody { get; }
     }
 }

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus.Transport
 {
-    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -61,29 +60,9 @@ namespace NServiceBus.Transport
         /// <summary>
         /// Use this method to update the body if this message.
         /// </summary>
-        internal void UpdateBody(byte[] updatedBody)
+        internal void UpdateBody(MessageBody updatedBody)
         {
-            //preserve the original body if needed
-            if (Body.Bytes != null && originalBody == null)
-            {
-                originalBody = new byte[Body.Count];
-                Buffer.BlockCopy(Body.Bytes, 0, originalBody, 0, Body.Bytes.Length);
-            }
-
-            Body.Bytes = updatedBody;
+            Body = updatedBody;
         }
-
-        /// <summary>
-        /// Makes sure that the body is reset to the exact state as it was when the message was created.
-        /// </summary>
-        internal void RevertToOriginalBodyIfNeeded()
-        {
-            if (originalBody != null)
-            {
-                Body.Bytes = originalBody;
-            }
-        }
-
-        byte[] originalBody;
     }
 }

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -55,14 +55,6 @@ namespace NServiceBus.Transport
         /// <summary>
         /// Gets/sets a byte array to the body content of the message.
         /// </summary>
-        public MessageBody Body { get; private set; }
-
-        /// <summary>
-        /// Use this method to update the body if this message.
-        /// </summary>
-        internal void UpdateBody(MessageBody updatedBody)
-        {
-            Body = updatedBody;
-        }
+        public MessageBody Body { get; internal set; }
     }
 }

--- a/src/NServiceBus.Core/Transports/MessageBody.cs
+++ b/src/NServiceBus.Core/Transports/MessageBody.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.IO;
 
     /// <summary>
     /// A reference to a read-only message body.
@@ -37,5 +38,10 @@
             Buffer.BlockCopy(Bytes, 0, copy, 0, Bytes.Length);
             return copy;
         }
+
+        /// <summary>
+        /// Returns a stream of the message body.
+        /// </summary>
+        public Stream GetStream() => new MemoryStream(Bytes);
     }
 }

--- a/src/NServiceBus.Core/Transports/MessageBody.cs
+++ b/src/NServiceBus.Core/Transports/MessageBody.cs
@@ -4,13 +4,15 @@
     using System.Collections;
     using System.Collections.Generic;
 
-    /// <inheritdoc />
+    /// <summary>
+    /// A reference to a read-only message body.
+    /// </summary>
     public class MessageBody : IReadOnlyCollection<byte>
     {
         internal byte[] Bytes;
 
         /// <summary>
-        /// Blabla.
+        /// Creates a new instance of <see cref="MessageBody"/>.
         /// </summary>
         public MessageBody(byte[] body)
         {
@@ -27,7 +29,7 @@
         public int Count => Bytes.Length;
 
         /// <summary>
-        /// Creates a copy of the message body
+        /// Creates a copy of the message body.
         /// </summary>
         public byte[] CreateCopy()
         {

--- a/src/NServiceBus.Core/Transports/MessageBody.cs
+++ b/src/NServiceBus.Core/Transports/MessageBody.cs
@@ -1,9 +1,9 @@
 ﻿namespace NServiceBus.Transport
 {
+    using System;
     using System.Collections;
     using System.Collections.Generic;
 
-    //TODO should this implement ICloneable?
     /// <inheritdoc />
     public class MessageBody : IReadOnlyCollection<byte>
     {
@@ -25,5 +25,15 @@
 
         /// <inheritdoc />
         public int Count => Bytes.Length;
+
+        /// <summary>
+        /// Creates a copy of the message body
+        /// </summary>
+        public byte[] CreateCopy()
+        {
+            var copy = new byte[Bytes.Length];
+            Buffer.BlockCopy(Bytes, 0, copy, 0, Bytes.Length);
+            return copy;
+        }
     }
 }

--- a/src/NServiceBus.Core/Transports/MessageBody.cs
+++ b/src/NServiceBus.Core/Transports/MessageBody.cs
@@ -1,0 +1,29 @@
+﻿namespace NServiceBus.Transport
+{
+    using System.Collections;
+    using System.Collections.Generic;
+
+    //TODO should this implement ICloneable?
+    /// <inheritdoc />
+    public class MessageBody : IReadOnlyCollection<byte>
+    {
+        internal byte[] Bytes;
+
+        /// <summary>
+        /// Blabla.
+        /// </summary>
+        public MessageBody(byte[] body)
+        {
+            Guard.AgainstNull(nameof(body), body);
+            Bytes = body;
+        }
+
+        /// <inheritdoc />
+        public IEnumerator<byte> GetEnumerator() => ((IList<byte>)Bytes).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <inheritdoc />
+        public int Count => Bytes.Length;
+    }
+}

--- a/src/NServiceBus.Core/Transports/MessageContext.cs
+++ b/src/NServiceBus.Core/Transports/MessageContext.cs
@@ -25,7 +25,7 @@
             Guard.AgainstNull(nameof(context), context);
 
             Headers = headers;
-            Body = body;
+            Body = new MessageBody(body);
             NativeMessageId = nativeMessageId;
             Extensions = context;
             TransportTransaction = transportTransaction;
@@ -44,7 +44,7 @@
         /// <summary>
         /// The message body.
         /// </summary>
-        public byte[] Body { get; }
+        public MessageBody Body { get; }
 
         /// <summary>
         /// Transaction (along with connection if applicable) used to receive the message.

--- a/src/NServiceBus.Core/Unicast/IncomingMessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/IncomingMessageOperations.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus
 {
+    using System.Linq;
     using System.Threading.Tasks;
     using Pipeline;
     using Routing;
@@ -13,7 +14,7 @@ namespace NServiceBus
             var outgoingMessage = new OutgoingMessage(
                             messageBeingProcessed.MessageId,
                             messageBeingProcessed.Headers,
-                            messageBeingProcessed.Body);
+                            messageBeingProcessed.Body.ToArray());
 
             var routingContext = new RoutingContext(outgoingMessage, new UnicastRoutingStrategy(destination), context);
 

--- a/src/NServiceBus.Core/Unicast/IncomingMessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/IncomingMessageOperations.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus
 {
-    using System.Linq;
     using System.Threading.Tasks;
     using Pipeline;
     using Routing;
@@ -14,7 +13,7 @@ namespace NServiceBus
             var outgoingMessage = new OutgoingMessage(
                             messageBeingProcessed.MessageId,
                             messageBeingProcessed.Headers,
-                            messageBeingProcessed.Body.ToArray());
+                            messageBeingProcessed.Body.CreateCopy());
 
             var routingContext = new RoutingContext(outgoingMessage, new UnicastRoutingStrategy(destination), context);
 

--- a/src/NServiceBus.Testing.Fakes/TestableIncomingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableIncomingPhysicalMessageContext.cs
@@ -15,7 +15,7 @@
         /// </summary>
         public TestableIncomingPhysicalMessageContext()
         {
-            Message = new IncomingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[] { });
+            Message = new IncomingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new MessageBody(new byte[0]));
         }
 
         /// <summary>
@@ -23,7 +23,7 @@
         /// </summary>
         public virtual void UpdateMessage(byte[] body)
         {
-            Message = new IncomingMessage(Message.MessageId, Message.Headers, body);
+            Message = new IncomingMessage(Message.MessageId, Message.Headers, new MessageBody(body));
         }
 
         /// <summary>

--- a/src/NServiceBus.Testing.Fakes/TestableTransportReceiveContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableTransportReceiveContext.cs
@@ -13,6 +13,6 @@
         /// <summary>
         /// The physical message being processed.
         /// </summary>
-        public IncomingMessage Message { get; set; } = new IncomingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new byte[0]);
+        public IncomingMessage Message { get; set; } = new IncomingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), new MessageBody(new byte[0]));
     }
 }


### PR DESCRIPTION
to prevent manual modification of the body via random-access to the body instead of using the `UpdateBody` API or message mutators

TODO:
- [ ] Consider switching the new `MessageBody` class to a `readonly struct`
- [x] Add a `ToStream/GetStream` method to the new class for better integration with some third party libs
- [ ] Add section to v8 upgrade guide
- [ ] Consider exposing a `ReadOnlySpan<byte>` access to the internal byte array (requires a reference to `System.Memory`) similar to the `GetStream` method.