### PR TITLE
fix: net6 SYSLIB0021: Derived cryptographic types are obsolete

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_overriding_saga_id_creation.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_overriding_saga_id_creation.cs
@@ -54,7 +54,7 @@
                 static Guid ToGuid(string src)
                 {
                     var stringbytes = Encoding.UTF8.GetBytes(src);
-                    using (var provider = new SHA1CryptoServiceProvider())
+                    using (var provider = SHA1.Create())
                     {
                         var hashedBytes = provider.ComputeHash(stringbytes);
                         Array.Resize(ref hashedBytes, 16);

--- a/src/NServiceBus.AcceptanceTests/DeterministicGuid.cs
+++ b/src/NServiceBus.AcceptanceTests/DeterministicGuid.cs
@@ -9,7 +9,7 @@
         public static Guid Create(params object[] data)
         {
             // use MD5 hash to get a 16-byte hash of the string
-            using (var provider = new MD5CryptoServiceProvider())
+            using (var provider = MD5.Create())
             {
                 var inputBytes = Encoding.Default.GetBytes(string.Concat(data));
                 var hashBytes = provider.ComputeHash(inputBytes);


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/46934

Cherry pick as a result of https://github.com/Particular/NServiceBus/pull/6108