### PR TITLE
Update to latest licensing package

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="5.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup Label="Public dependencies">

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="5.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup Label="Public dependencies">
@@ -30,7 +30,7 @@
     <PackageReference Include="Fody" Version="6.5.1" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.8.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="3.6.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="3.7.0-downgrade-system-crypto-xml.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="1.3.0" PrivateAssets="All" />
     <PackageReference Include="SimpleJson" Version="0.38.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="4.7.0" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="Public dependencies">
@@ -30,7 +30,7 @@
     <PackageReference Include="Fody" Version="6.5.1" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.8.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="3.7.0-downgrade-system-crypto-xml.1" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="3.7.0-alpha.3" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="1.3.0" PrivateAssets="All" />
     <PackageReference Include="SimpleJson" Version="0.38.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
This version downgrades `System.Security.Cryptography.Xml` from 5.0 to 4.7 and therefore also requires the project dependencies to be adjusted.