### PR TITLE
Fixes for logfile retrieval for a certain date

### DIFF
--- a/src/NServiceBus.Core/Logging/RollingLogger.cs
+++ b/src/NServiceBus.Core/Logging/RollingLogger.cs
@@ -93,7 +93,7 @@ namespace NServiceBus
 
         internal static LogFile GetTodaysNewest(IEnumerable<LogFile> logFiles, DateTimeOffset today)
         {
-            return logFiles.Where(x => x.DatePart == today)
+            return logFiles.Where(x => x.DatePart.Date == today.Date)
                 .OrderByDescending(x => x.SequenceNumber)
                 .FirstOrDefault();
         }


### PR DESCRIPTION
The introduction of DateTimeOffset throughout our APIs introduced an issue when finding the logfiles for a specific day.

