### PR TITLE
Add receivers transport test for send-only endpoints

### DIFF
--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -32,8 +32,7 @@
             testCancellationTokenSource = null;
             receiver = null;
         }
-
-        static IConfigureTransportInfrastructure CreateConfigurer()
+        protected static IConfigureTransportInfrastructure CreateConfigurer()
         {
             var transportToUse = EnvironmentHelper.GetEnvironmentVariable("Transport_UseSpecific");
 
@@ -206,7 +205,7 @@
             return source;
         }
 
-        static string GetTestName()
+        protected static string GetTestName()
         {
             var index = 1;
             var frame = new StackFrame(index);

--- a/src/NServiceBus.TransportTests/When_creating_send_only_transport.cs
+++ b/src/NServiceBus.TransportTests/When_creating_send_only_transport.cs
@@ -1,0 +1,29 @@
+﻿namespace NServiceBus.TransportTests
+{
+    using System;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using Transport;
+
+    public class When_creating_send_only_transport : NServiceBusTransportTest
+    {
+        [Test]
+        public async Task Should_have_empty_receivers()
+        {
+            var configurer = CreateConfigurer();
+            var transportDefinition = configurer.CreateTransportDefinition();
+
+            var hostSettings = new HostSettings(
+                GetTestName(),
+                string.Empty,
+                new StartupDiagnosticEntries(),
+                (_, __, ___) => { },
+                true);
+
+            var transport = await transportDefinition.Initialize(hostSettings, Array.Empty<ReceiveSettings>(), Array.Empty<string>());
+
+            Assert.IsNotNull(transport.Receivers);
+            Assert.IsEmpty(transport.Receivers);
+        }
+    }
+}


### PR DESCRIPTION
To test that the receivers property is never null but at least an empty collection for easier handling by consumers of the transport API.

Some helper methods had to be made more accessible, as those could so far only be called when using tests that start a working pump, so there was no way to create a send-only endpoint before