### PR TITLE
Remove unnecessary Task.Run from persistence tests

### DIFF
--- a/src/NServiceBus.PersistenceTests/Sagas/When_worker_tries_to_complete_saga_update_by_another_pessimistic.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_worker_tries_to_complete_saga_update_by_another_pessimistic.cs
@@ -44,7 +44,7 @@
                 {
                     await firstSessionGetDone.Task.ConfigureAwait(false);
 
-                    var recordTask = Task.Run(() => persister.Get<TestSagaData>(saga.Id, secondSession, secondContext));
+                    var recordTask = persister.Get<TestSagaData>(saga.Id, secondSession, secondContext);
                     secondSessionGetDone.SetResult(true);
 
                     var record = await recordTask.ConfigureAwait(false);


### PR DESCRIPTION
Small improvement. Couldn't see why the offloading would be necessary there but I might be missing something