### PR TITLE
Add additional information to DI approval tests

### DIFF
--- a/src/NServiceBus.AcceptanceTests/ApprovalFiles/When_endpoint_is_warmed_up.Make_sure_things_are_in_DI.approved.txt
+++ b/src/NServiceBus.AcceptanceTests/ApprovalFiles/When_endpoint_is_warmed_up.Make_sure_things_are_in_DI.approved.txt
@@ -1,17 +1,13 @@
------------ Used registrations (Find ways to stop accessing them)-----------
-NServiceBus.InferredMessageTypeEnricherBehavior - Transient
+----------- Public registrations used by Core -----------
 NServiceBus.Persistence.ISynchronizedStorage - Singleton
 NServiceBus.Persistence.ISynchronizedStorageAdapter - Singleton
 NServiceBus.ReceiveAddresses - Singleton
-NServiceBus.SubscriptionReceiverBehavior - Transient
-NServiceBus.SubscriptionRouter - Singleton
 NServiceBus.Transport.IMessageDispatcher - Singleton
 NServiceBus.Transport.ITransportAddressResolver - Singleton
 NServiceBus.Unicast.MessageHandlerRegistry - Singleton
 NServiceBus.Unicast.Messages.MessageMetadataRegistry - Singleton
 NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.ISubscriptionStorage - Singleton
-NServiceBus.UnicastSendRouter - Singleton
------------ Registrations not used by the core, can be removed in next major if downstreams have been confirmed to not use it -----------
+----------- Public registrations not used by Core -----------
 NServiceBus.CriticalError - Singleton
 NServiceBus.Hosting.HostInformation - Singleton
 NServiceBus.IHandleMessages`1[[NServiceBus.AcceptanceTests.Core.DependencyInjection.When_endpoint_is_warmed_up+SomeMessage, NServiceBus.AcceptanceTests, Version=8.0.0.0, Culture=neutral, PublicKeyToken=null]] - Scoped
@@ -24,3 +20,9 @@ NServiceBus.Pipeline.IBehavior`2[[NServiceBus.Pipeline.IIncomingPhysicalMessageC
 NServiceBus.Pipeline.LogicalMessageFactory - Singleton
 NServiceBus.Settings.IReadOnlySettings - Singleton
 NServiceBus.Transport.ISubscriptionManager - Singleton
+----------- Private registrations used by Core-----------
+NServiceBus.InferredMessageTypeEnricherBehavior - Transient
+NServiceBus.SubscriptionReceiverBehavior - Transient
+NServiceBus.SubscriptionRouter - Singleton
+NServiceBus.UnicastSendRouter - Singleton
+----------- Private registrations not used by Core -----------

--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_endpoint_is_warmed_up.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_endpoint_is_warmed_up.cs
@@ -38,16 +38,33 @@
                 .OrderBy(c => c.Type.FullName)
                 .ToList();
 
-            builder.AppendLine("----------- Used registrations (Find ways to stop accessing them)-----------");
+            var privateComponents = coreComponents.Where(c => !c.Type.IsPublic);
+            var publicComponents = coreComponents.Where(c => c.Type.IsPublic);
 
-            foreach (var component in coreComponents.Where(c => c.WasResolved))
+            builder.AppendLine("----------- Public registrations used by Core -----------");
+
+            foreach (var component in publicComponents.Where(c => c.WasResolved))
             {
                 builder.AppendLine(component.ToString());
             }
 
-            builder.AppendLine("----------- Registrations not used by the core, can be removed in next major if downstreams have been confirmed to not use it -----------");
+            builder.AppendLine("----------- Public registrations not used by Core -----------");
 
-            foreach (var component in coreComponents.Where(c => !c.WasResolved))
+            foreach (var component in publicComponents.Where(c => !c.WasResolved))
+            {
+                builder.AppendLine(component.ToString());
+            }
+
+            builder.AppendLine("----------- Private registrations used by Core-----------");
+
+            foreach (var component in privateComponents.Where(c => c.WasResolved))
+            {
+                builder.AppendLine(component.ToString());
+            }
+
+            builder.AppendLine("----------- Private registrations not used by Core -----------");
+
+            foreach (var component in privateComponents.Where(c => !c.WasResolved))
             {
                 builder.AppendLine(component.ToString());
             }

--- a/src/NServiceBus.Learning.AcceptanceTests/ApprovalFiles/When_endpoint_is_warmed_up.Make_sure_things_are_in_DI.approved.txt
+++ b/src/NServiceBus.Learning.AcceptanceTests/ApprovalFiles/When_endpoint_is_warmed_up.Make_sure_things_are_in_DI.approved.txt
@@ -1,12 +1,10 @@
------------ Used registrations (Find ways to stop accessing them)-----------
-NServiceBus.InferredMessageTypeEnricherBehavior - Transient
+----------- Public registrations used by Core -----------
 NServiceBus.ReceiveAddresses - Singleton
 NServiceBus.Transport.IMessageDispatcher - Singleton
 NServiceBus.Transport.ISubscriptionManager - Singleton
 NServiceBus.Unicast.MessageHandlerRegistry - Singleton
 NServiceBus.Unicast.Messages.MessageMetadataRegistry - Singleton
-NServiceBus.UnicastSendRouter - Singleton
------------ Registrations not used by the core, can be removed in next major if downstreams have been confirmed to not use it -----------
+----------- Public registrations not used by Core -----------
 NServiceBus.CriticalError - Singleton
 NServiceBus.Hosting.HostInformation - Singleton
 NServiceBus.IHandleMessages`1[[NServiceBus.AcceptanceTests.Core.DependencyInjection.When_endpoint_is_warmed_up+SomeMessage, NServiceBus.Learning.AcceptanceTests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]] - Scoped
@@ -18,3 +16,7 @@ NServiceBus.Pipeline.IBehavior`2[[NServiceBus.Pipeline.IIncomingLogicalMessageCo
 NServiceBus.Pipeline.LogicalMessageFactory - Singleton
 NServiceBus.Settings.IReadOnlySettings - Singleton
 NServiceBus.Transport.ITransportAddressResolver - Singleton
+----------- Private registrations used by Core-----------
+NServiceBus.InferredMessageTypeEnricherBehavior - Transient
+NServiceBus.UnicastSendRouter - Singleton
+----------- Private registrations not used by Core -----------


### PR DESCRIPTION
Change the structure of the DI approval test slightly to give better indication whether types registered and used from DI are public or private.