### PR TITLE
Startup task runner for acceptance tests

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointRunner.cs
@@ -54,6 +54,8 @@
                     endpointConfiguration.UniquelyIdentifyRunningInstance().UsingHostName(configuration.CustomMachineName);
                 }
 
+                endpointConfiguration.EnableFeature<FeatureStartupTaskRunner>();
+
                 endpointBehavior.CustomConfig.ForEach(customAction => customAction(endpointConfiguration, scenarioContext));
 
                 startable = await createCallback(endpointConfiguration).ConfigureAwait(false);

--- a/src/NServiceBus.AcceptanceTesting/Support/FeatureStartupTaskRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/FeatureStartupTaskRunner.cs
@@ -1,0 +1,63 @@
+﻿namespace NServiceBus.AcceptanceTesting
+{
+    using System;
+    using System.Collections.Generic;
+    using Features;
+    using Microsoft.Extensions.DependencyInjection;
+
+    /// <summary>
+    /// Simple feature that allows registration of <see cref="FeatureStartupTask"/> without having to define a <see cref="Feature"/> beforehand.
+    /// </summary>
+    class FeatureStartupTaskRunner : Feature
+    {
+        public const string ConfigKey = "FeatureStartupTaskRunner.StartupTasks";
+        public FeatureStartupTaskRunner() => EnableByDefault();
+
+        protected internal override void Setup(FeatureConfigurationContext context)
+        {
+            if (context.Settings.TryGet<List<Func<IServiceProvider, FeatureStartupTask>>>(ConfigKey, out var startupTasks))
+            {
+                foreach (var startupTaskRegistration in startupTasks)
+                {
+                    context.RegisterStartupTask(startupTaskRegistration);
+                }
+            }
+        }
+    }
+
+    public static class StartupTaskRunnerExtensions
+    {
+        public static void RegisterStartupTask(this EndpointConfiguration endpointConfiguration, Func<IServiceProvider, FeatureStartupTask> factory)
+        {
+            var startupTasks = GetStartupTaskRegistrations(endpointConfiguration);
+
+            startupTasks.Add(factory);
+        }
+
+        public static void RegisterStartupTask<TStartupTask>(this EndpointConfiguration endpointConfiguration) where TStartupTask : FeatureStartupTask
+        {
+            var startupTasks = GetStartupTaskRegistrations(endpointConfiguration);
+
+            endpointConfiguration.RegisterComponents(s => s.AddTransient(typeof(TStartupTask)));
+            startupTasks.Add(sp => sp.GetRequiredService<TStartupTask>());
+        }
+
+        public static void RegisterStartupTask<TStartupTask>(this EndpointConfiguration endpointConfiguration, TStartupTask startupTask) where TStartupTask : FeatureStartupTask
+        {
+            var startupTasks = GetStartupTaskRegistrations(endpointConfiguration);
+
+            startupTasks.Add(sp => startupTask);
+        }
+
+        static List<Func<IServiceProvider, FeatureStartupTask>> GetStartupTaskRegistrations(EndpointConfiguration endpointConfiguration)
+        {
+            if (!endpointConfiguration.Settings.TryGet<List<Func<IServiceProvider, FeatureStartupTask>>>(FeatureStartupTaskRunner.ConfigKey, out var startupTasks))
+            {
+                startupTasks = new List<Func<IServiceProvider, FeatureStartupTask>>();
+                endpointConfiguration.Settings.Set(FeatureStartupTaskRunner.ConfigKey, startupTasks);
+            }
+
+            return startupTasks;
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_from_a_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_from_a_handler.cs
@@ -80,49 +80,41 @@
                 TestContext testContext;
             }
         }
-
-        class CriticalErrorStartup : Feature
+        class CriticalErrorStartupFeatureTask : FeatureStartupTask
         {
-            protected override void Setup(FeatureConfigurationContext context)
+            public CriticalErrorStartupFeatureTask(CriticalError criticalError, TestContext testContext)
             {
-                context.RegisterStartupTask(b => new CriticalErrorStartupFeatureTask(b.GetService<CriticalError>(), b.GetService<TestContext>()));
+                this.criticalError = criticalError;
+                this.testContext = testContext;
             }
 
-            class CriticalErrorStartupFeatureTask : FeatureStartupTask
+            protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
             {
-                public CriticalErrorStartupFeatureTask(CriticalError criticalError, TestContext testContext)
-                {
-                    this.criticalError = criticalError;
-                    this.testContext = testContext;
-                }
+                criticalError.Raise("critical error 1", new SimulatedException(), cancellationToken);
+                testContext.CriticalErrorsRaised++;
 
-                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
-                {
-                    criticalError.Raise("critical error 1", new SimulatedException(), cancellationToken);
-                    testContext.CriticalErrorsRaised++;
+                criticalError.Raise("critical error 2", new SimulatedException(), cancellationToken);
+                testContext.CriticalErrorsRaised++;
 
-                    criticalError.Raise("critical error 2", new SimulatedException(), cancellationToken);
-                    testContext.CriticalErrorsRaised++;
-
-                    return Task.FromResult(0);
-                }
-
-                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
-                {
-                    return Task.FromResult(0);
-                }
-
-                readonly TestContext testContext;
-
-                CriticalError criticalError;
+                return Task.FromResult(0);
             }
+
+            protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default)
+            {
+                return Task.FromResult(0);
+            }
+
+            readonly TestContext testContext;
+
+            CriticalError criticalError;
         }
 
         public class EndpointWithCriticalErrorStartup : EndpointConfigurationBuilder
         {
             public EndpointWithCriticalErrorStartup()
             {
-                EndpointSetup<DefaultServer>(c => c.EnableFeature<CriticalErrorStartup>());
+                EndpointSetup<DefaultServer>(c => c
+                    .RegisterStartupTask(b => new CriticalErrorStartupFeatureTask(b.GetService<CriticalError>(), b.GetService<TestContext>())));
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_configuring_subscription_authorizer.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_configuring_subscription_authorizer.cs
@@ -75,7 +75,7 @@
                 EndpointSetup(defaultServer, (endpointConfiguration, descriptor) =>
                 {
                     endpointConfiguration.UsePersistence<FakePersistence>();
-                    endpointConfiguration.EnableFeature<StorageAccessorFeature>();
+                    endpointConfiguration.RegisterStartupTask<StorageAccessor>();
                     endpointConfiguration.OnEndpointSubscribed<Context>((args, ctx) =>
                     {
                         if (args.MessageType.Contains(typeof(AllowedEvent).FullName))
@@ -98,25 +98,16 @@
                     });
                 });
             }
-
-            class StorageAccessorFeature : Feature
+            class StorageAccessor : FeatureStartupTask
             {
-                protected override void Setup(FeatureConfigurationContext context) =>
-                    context.RegisterStartupTask(
-                        sp => new StorageAccessor(sp.GetRequiredService<ISubscriptionStorage>(),
-                            sp.GetRequiredService<Context>()));
-
-                class StorageAccessor : FeatureStartupTask
+                public StorageAccessor(ISubscriptionStorage subscriptionStorage, Context testContext)
                 {
-                    public StorageAccessor(ISubscriptionStorage subscriptionStorage, Context testContext)
-                    {
-                        testContext.SubscriptionStorage = (FakePersistence.FakeSubscriptionStorage)subscriptionStorage;
-                    }
-
-                    protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
-
-                    protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
+                    testContext.SubscriptionStorage = (FakePersistence.FakeSubscriptionStorage)subscriptionStorage;
                 }
+
+                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Feature/When_purging_queues.cs
+++ b/src/NServiceBus.AcceptanceTests/Feature/When_purging_queues.cs
@@ -31,8 +31,11 @@
         {
             public EndpointWithStartupTask()
             {
-                EndpointSetup<DefaultServer>(c => c
-                    .PurgeOnStartup(true));
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.RegisterStartupTask<StartupTask>();
+                    c.PurgeOnStartup(true);
+                });
             }
 
             class MessageHandler : IHandleMessages<LocalMessage>
@@ -50,23 +53,14 @@
                     return Task.CompletedTask;
                 }
             }
-
-            class FeatureWithStartupTask : Feature
+            class StartupTask : FeatureStartupTask
             {
-                public FeatureWithStartupTask() => EnableByDefault();
-
-                protected override void Setup(FeatureConfigurationContext context) =>
-                    context.RegisterStartupTask(new StartupTask());
-
-                class StartupTask : FeatureStartupTask
+                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                 {
-                    protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
-                    {
-                        return session.SendLocal(new LocalMessage(), cancellationToken);
-                    }
-
-                    protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
+                    return session.SendLocal(new LocalMessage(), cancellationToken);
                 }
+
+                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Feature/When_subscribing_in_FST.cs
+++ b/src/NServiceBus.AcceptanceTests/Feature/When_subscribing_in_FST.cs
@@ -53,6 +53,7 @@
                 EndpointSetup<DefaultServer>(c =>
                     {
                         c.DisableFeature<AutoSubscribe>();
+                        c.RegisterStartupTask(new StartupTask());
                         c.OnEndpointSubscribed<Context>((args, ctx) =>
                         {
                             if (args.MessageType.Contains(typeof(LocalEvent).FullName))
@@ -80,22 +81,14 @@
                 }
             }
 
-            class FeatureWithStartupTask : Feature
+            class StartupTask : FeatureStartupTask
             {
-                public FeatureWithStartupTask() => EnableByDefault();
-
-                protected override void Setup(FeatureConfigurationContext context) =>
-                    context.RegisterStartupTask(new StartupTask());
-
-                class StartupTask : FeatureStartupTask
+                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                 {
-                    protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
-                    {
-                        return session.Subscribe<LocalEvent>(cancellationToken);
-                    }
-
-                    protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
+                    return session.Subscribe<LocalEvent>(cancellationToken);
                 }
+
+                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_retrying_control_message_from_error_queue.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_retrying_control_message_from_error_queue.cs
@@ -7,7 +7,6 @@
     using AcceptanceTesting.Customization;
     using EndpointTemplates;
     using Features;
-    using Microsoft.Extensions.DependencyInjection;
     using NServiceBus.Pipeline;
     using NServiceBus.Routing;
     using NUnit.Framework;
@@ -44,17 +43,8 @@
         {
             public ProcessingEndpoint() => EndpointSetup<DefaultServer>(c =>
             {
-                c.EnableFeature<ControlMessageFeature>();
+                c.RegisterStartupTask<ControlMessageSender>();
             });
-
-            class ControlMessageFeature : Feature
-            {
-                protected override void Setup(FeatureConfigurationContext context)
-                {
-                    context.RegisterStartupTask(s =>
-                        new ControlMessageSender(s.GetRequiredService<IMessageDispatcher>()));
-                }
-            }
 
             class ControlMessageSender : FeatureStartupTask
             {

--- a/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired.cs
+++ b/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired.cs
@@ -25,14 +25,6 @@
             public bool WasCalled { get; set; }
         }
 
-        class DelayReceiverFromStarting : Feature
-        {
-            protected override void Setup(FeatureConfigurationContext context)
-            {
-                context.RegisterStartupTask(b => new DelayReceiverFromStartingTask());
-            }
-        }
-
         class DelayReceiverFromStartingTask : FeatureStartupTask
         {
             protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
@@ -51,7 +43,7 @@
         {
             public Endpoint()
             {
-                EndpointSetup<DefaultServer>(c => c.EnableFeature<DelayReceiverFromStarting>());
+                EndpointSetup<DefaultServer>(c => c.RegisterStartupTask(new DelayReceiverFromStartingTask()));
             }
 
             public class MyMessageHandler : IHandleMessages<MyMessage>

--- a/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired_convention.cs
+++ b/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_expired_convention.cs
@@ -25,14 +25,6 @@
             public bool WasCalled { get; set; }
         }
 
-        class DelayReceiverFromStarting : Feature
-        {
-            protected override void Setup(FeatureConfigurationContext context)
-            {
-                context.RegisterStartupTask(b => new DelayReceiverFromStartingTask());
-            }
-        }
-
         class DelayReceiverFromStartingTask : FeatureStartupTask
         {
             protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
@@ -53,7 +45,7 @@
             {
                 EndpointSetup<DefaultServer>(c =>
                 {
-                    c.EnableFeature<DelayReceiverFromStarting>();
+                    c.RegisterStartupTask(new DelayReceiverFromStartingTask());
                     c.Conventions().DefiningTimeToBeReceivedAs(messageType =>
                     {
                         if (messageType == typeof(MyMessage))

--- a/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_used_with_unobtrusive_mode.cs
+++ b/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_used_with_unobtrusive_mode.cs
@@ -25,14 +25,6 @@
             public bool WasCalled { get; set; }
         }
 
-        class SendMessageAndDelayStart : Feature
-        {
-            protected override void Setup(FeatureConfigurationContext context)
-            {
-                context.RegisterStartupTask(b => new SendMessageAndDelayStartTask());
-            }
-        }
-
         class SendMessageAndDelayStartTask : FeatureStartupTask
         {
             protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
@@ -63,7 +55,7 @@
                         }
                         return TimeSpan.MaxValue;
                     });
-                    c.EnableFeature<SendMessageAndDelayStart>();
+                    c.RegisterStartupTask(new SendMessageAndDelayStartTask());
                 }).ExcludeType<MyCommand>(); // remove that type from assembly scanning to simulate what would happen with true unobtrusive mode
             }
 


### PR DESCRIPTION
Simple spike that adds a small feature for acceptance tests that allows registration of `FeatureStartupTask` without having to define owning `Feature`s first. This removes unnecessary noisy code and makes writing tests easier and faster.

Might also be a feature to be considered as a public feature in NServiceBus. Mauro already built something very similar but focused on pure startup actions (https://github.com/mauroservienti/NServiceBus.Extensions.EndpointStarted)