### PR TITLE
Allow the session timeout to be controlled per permutation

### DIFF
--- a/src/NServiceBus.PersistenceTests/IPersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.PersistenceTests/IPersistenceTestsConfiguration.cs
@@ -47,9 +47,9 @@
     // Consumers of this source package have to implement the remaining properties via partial class to configure the tests infrastructure.
     public partial class PersistenceTestsConfiguration : IPersistenceTestsConfiguration
     {
-        public PersistenceTestsConfiguration(TestVariant variant, TimeSpan? sessionTimeout = null)
+        public PersistenceTestsConfiguration(TestVariant variant)
         {
-            SessionTimeout = sessionTimeout;
+            SessionTimeout = variant.SessionTimeout;
             Variant = variant;
         }
 

--- a/src/NServiceBus.PersistenceTests/TestVariant.cs
+++ b/src/NServiceBus.PersistenceTests/TestVariant.cs
@@ -1,17 +1,15 @@
 ﻿namespace NServiceBus.PersistenceTesting
 {
+    using System;
+
     public class TestVariant
     {
         public object[] Values { get; }
 
-        public TestVariant(params object[] values)
-        {
-            this.Values = values;
-        }
+        public TimeSpan? SessionTimeout { get; set; }
 
-        public override string ToString()
-        {
-            return string.Join(" ", Values);
-        }
+        public TestVariant(params object[] values) => Values = values;
+
+        public override string ToString() => string.Join(" ", Values);
     }
 }


### PR DESCRIPTION
Related to https://github.com/Particular/NServiceBus.RavenDB/pull/822/commits/9217110e26a2dde12e6c2d591d8d12416b97a434

During implementing cluster wide transaction support for the RavenDB persistence, we realized having a short time cause to be problematic, since even settling a compare exchange value in the cluster can take some time. This can then cause operations to the cluster to timeout immediately, throwing an `OperationCanceledException`.

With this change, the session timeout can be overridden by the test variant without having to copy the test locally.

Ideally, we would also need this for 7.x branch later