### PR TITLE
Add props file to package for implicit global usings support

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -39,6 +39,7 @@
   <PropertyGroup>
     <PackageId>NServiceBus</PackageId>
     <Description>The most popular open-source service bus for .NET</Description>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);AddPropsFileToPackage</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
 
   <ItemGroup>
@@ -46,6 +47,12 @@
     <None Include="..\NServiceBus.Core.Analyzer\bin\$(Configuration)\**\NServiceBus.Core.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/cs/NServiceBus.Core.Analyzer.dll" Link="NServiceBus.Core.Analyzer.dll" Visible="false" />
     <None Include="..\NServiceBus.Core.Analyzer\tools\*.ps1" Pack="true" PackagePath="tools" Visible="false" />
   </ItemGroup>
+
+  <Target Name="AddPropsFileToPackage">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="NServiceBus.props" PackagePath="build/$(TargetFramework)" />
+    </ItemGroup>
+  </Target>
 
   <ItemGroup>
     <InternalsVisibleTo Include="NServiceBus.AcceptanceTesting" Key="$(NServiceBusKey)" />

--- a/src/NServiceBus.Core/NServiceBus.props
+++ b/src/NServiceBus.Core/NServiceBus.props
@@ -1,0 +1,7 @@
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup Condition="'$(Language)' == 'C#' AND ('$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable')">
+    <Using Include="NServiceBus" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This adds the `NServiceBus` namespace automatically when a project has [implicit global usings](https://docs.microsoft.com/en-us/dotnet/core/project-sdk/overview#implicit-using-directives) enabled by having `<ImplicitUsings>enable</ImplicitUsings>` in the project file. 

NOTE: This feature does require using the .NET 6 SDK to work, but does not cause problems if used with an older SDK.