### PR TITLE
Allow dispatch behaviors to modify message bodies

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Audit/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Audit/When_a_message_is_audited.cs
@@ -1,0 +1,101 @@
+﻿namespace NServiceBus.AcceptanceTests.Audit
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using MessageMutator;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Routing;
+    using NUnit.Framework;
+
+    public class When_a_message_is_being_audited : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_allow_body_to_be_sent_separately()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithSeparateBodyStorage>(b => b.When((session, c) => session.SendLocal(new MessageToBeAudited())))
+                .WithEndpoint<AuditSpyEndpoint>()
+                .Done(c => c.AuditMessageReceived)
+                .Run();
+
+            Assert.True(context.BodyWasEmpty);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool AuditMessageReceived { get; set; }
+            public bool BodyWasEmpty { get; set; }
+        }
+
+        public class EndpointWithSeparateBodyStorage : EndpointConfigurationBuilder
+        {
+            public EndpointWithSeparateBodyStorage()
+            {
+                EndpointSetup<DefaultServer, Context>((config, context) =>
+                 {
+                     config.AuditProcessedMessagesTo<AuditSpyEndpoint>();
+                     config.Pipeline.Register(typeof(AuditBodyStorageBehavior), "Simulate writing the body to a separate storage and pass a null body to the transport");
+                 });
+            }
+
+            public class AuditBodyStorageBehavior : Behavior<IDispatchContext>
+            {
+                public override Task Invoke(IDispatchContext context, Func<Task> next)
+                {
+                    foreach (var operation in context.Operations)
+                    {
+                        var unicastAddress = operation.AddressTag as UnicastAddressTag;
+
+                        if (unicastAddress?.Destination != Conventions.EndpointNamingConvention(typeof(AuditSpyEndpoint)))
+                        {
+                            continue;
+                        }
+
+                        operation.Message.UpdateBody(null); //TODO: Would ReadOnlyMemory<byte>.Empty be better?
+                    }
+                    return next();
+                }
+            }
+
+            public class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Task Handle(MessageToBeAudited message, IMessageHandlerContext context)
+                {
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        class AuditSpyEndpoint : EndpointConfigurationBuilder
+        {
+            public AuditSpyEndpoint()
+            {
+                EndpointSetup<DefaultServer, Context>((config, context) => config.RegisterMessageMutator(new BodySpy(context)));
+            }
+
+            class BodySpy : IMutateIncomingTransportMessages
+            {
+                public BodySpy(Context context)
+                {
+                    this.context = context;
+                }
+
+                public Task MutateIncoming(MutateIncomingTransportMessageContext transportMessage)
+                {
+                    context.BodyWasEmpty = transportMessage.Body.Length == 0;
+                    context.AuditMessageReceived = true;
+                    return Task.FromResult(0);
+                }
+
+                Context context;
+            }
+        }
+
+        public class MessageToBeAudited : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/Audit/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Audit/When_a_message_is_audited.cs
@@ -54,7 +54,7 @@
                             continue;
                         }
 
-                        operation.Message.UpdateBody(null); //TODO: Would ReadOnlyMemory<byte>.Empty be better?
+                        operation.Message.UpdateBody(ReadOnlyMemory<byte>.Empty);
                     }
                     return next();
                 }

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -18,9 +18,9 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" PrivateAssets="All" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" PrivateAssets="All" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Packaging" Version="1.4.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="1.3.0" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -32,9 +32,7 @@
 
   <ItemGroup>
     <RemoveSourceFileFromPackage Include="Core\**\*.cs" />
-    <RemoveSourceFileFromPackage Remove="Core\Recoverability\When_messages_never_succeed.cs" />
-    <RemoveSourceFileFromPackage Remove="Core\Recoverability\When_messages_never_succeed_with_delays_specified.cs" />
-    <RemoveSourceFileFromPackage Remove="Core\Recoverability\When_messages_succeed_after_throttling.cs" />
+    <RemoveSourceFileFromPackage Remove="Core\Audit\When_a_message_is_audited.cs" />
     <RemoveSourceFileFromPackage Include="AssemblyInfo.cs" />
   </ItemGroup>
 

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -18,9 +18,9 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" PrivateAssets="All" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0" PrivateAssets="All" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Approvals" Version="0.3.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Packaging" Version="1.3.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="1.4.0" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -32,7 +32,6 @@
 
   <ItemGroup>
     <RemoveSourceFileFromPackage Include="Core\**\*.cs" />
-    <RemoveSourceFileFromPackage Remove="Core\Audit\When_a_message_is_audited.cs" />
     <RemoveSourceFileFromPackage Include="AssemblyInfo.cs" />
   </ItemGroup>
 

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2647,6 +2647,7 @@ namespace NServiceBus.Transport
         public System.ReadOnlyMemory<byte> Body { get; }
         public System.Collections.Generic.Dictionary<string, string> Headers { get; }
         public string MessageId { get; }
+        public void UpdateBody(System.ReadOnlyMemory<byte> updatedBody) { }
     }
     public class PushRuntimeSettings
     {

--- a/src/NServiceBus.Core/Transports/IncomingMessage.cs
+++ b/src/NServiceBus.Core/Transports/IncomingMessage.cs
@@ -59,7 +59,7 @@ namespace NServiceBus.Transport
         public ReadOnlyMemory<byte> Body { get; private set; }
 
         /// <summary>
-        /// Use this method to update the body if this message.
+        /// Use this method to update the body of this message.
         /// </summary>
         internal void UpdateBody(ReadOnlyMemory<byte> updatedBody)
         {

--- a/src/NServiceBus.Core/Transports/OutgoingMessage.cs
+++ b/src/NServiceBus.Core/Transports/OutgoingMessage.cs
@@ -24,7 +24,7 @@ namespace NServiceBus.Transport
         /// <summary>
         /// The body to be sent.
         /// </summary>
-        public ReadOnlyMemory<byte> Body { get; }
+        public ReadOnlyMemory<byte> Body { get; private set; }
 
 
         /// <summary>
@@ -36,5 +36,13 @@ namespace NServiceBus.Transport
         /// The headers for the message.
         /// </summary>
         public Dictionary<string, string> Headers { get; }
+
+        /// <summary>
+        /// Use this method to update the body of this message.
+        /// </summary>
+        public void UpdateBody(ReadOnlyMemory<byte> updatedBody)
+        {
+            Body = updatedBody;
+        }
     }
 }


### PR DESCRIPTION
This allows things like storing the message body separate from the headers and audit metadata