### PR TITLE
Move LearningTransport message pump logging out of loop

### DIFF
--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -166,12 +166,12 @@
         [DebuggerNonUserCode]
         async Task PumpMessagesAndSwallowExceptions(CancellationToken messagePumpCancellationToken)
         {
+            log.Debug($"Started polling for new messages in {messagePumpBasePath}");
+
             while (!messagePumpCancellationToken.IsCancellationRequested)
             {
                 try
                 {
-                    log.Debug($"Started polling for new messages in {messagePumpBasePath}");
-
                     await PumpMessages(messagePumpCancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex) when (ex.IsCausedBy(messagePumpCancellationToken))


### PR DESCRIPTION
During some refactorings (I think from the cancellation token TF), the debug logging was moved inside the while loop. This now causes the log output to be completely spammed when debug logging is enabled. Before that, this was logged once, at the start of the pump.