### PR TITLE
Optimize the CombGuid generation strategy

### DIFF
--- a/src/NServiceBus.Core.Tests/IdGeneration/IdGenerationTests.cs
+++ b/src/NServiceBus.Core.Tests/IdGeneration/IdGenerationTests.cs
@@ -1,0 +1,117 @@
+﻿namespace NServiceBus.Core.Tests.IdGeneration
+{
+    using System;
+    using System.Buffers.Binary;
+    using System.Collections.Generic;
+    using NUnit.Framework;
+#if NETFRAMEWORK
+    using System.Runtime.InteropServices;
+#endif
+
+    [TestFixture]
+    public class IdGenerationTests
+    {
+        [TestCaseSource(nameof(RandomizedInput))]
+        public void Should_return_same_result_for_same_input(Guid guid, DateTime now)
+        {
+            var oldCombGuid = LocalCopyOfCombGuid.GenerateOld(guid, now);
+            var improvedCombGuid = LocalCopyOfCombGuid.GenerateImproved(guid, now);
+
+            Assert.AreEqual(oldCombGuid, improvedCombGuid);
+        }
+
+        static readonly Random Random = new Random();
+
+        static IEnumerable<object[]> RandomizedInput
+        {
+            get
+            {
+                for (int i = 0; i < 20; i++)
+                {
+                    yield return new object[]
+                    {
+                        Guid.NewGuid(),
+                        DateTime.UtcNow.AddDays(Random.Next(0, 30)).AddHours(Random.Next(0, 24)).AddMinutes(Random.Next(0, 60)).AddSeconds(Random.Next(0, 60))
+                    };
+                }
+            }
+        }
+
+        class LocalCopyOfCombGuid
+        {
+            // Only slightly modified copy of the original algorithm
+            public static Guid GenerateOld(Guid input, DateTime nowInput)
+            {
+                var guidArray = input.ToByteArray();
+
+                var now = nowInput; // Internal use, no need for DateTimeOffset
+
+                // Get the days and milliseconds which will be used to build the byte string
+                var days = new TimeSpan(now.Ticks - BaseDateTicks);
+                var timeOfDay = now.TimeOfDay;
+
+                // Convert to a byte array
+                // Note that SQL Server is accurate to 1/300th of a millisecond so we divide by 3.333333
+                var daysArray = BitConverter.GetBytes(days.Days);
+                var millisecondArray = BitConverter.GetBytes((long)(timeOfDay.TotalMilliseconds / 3.333333));
+
+                // Reverse the bytes to match SQL Servers ordering
+                Array.Reverse(daysArray);
+                Array.Reverse(millisecondArray);
+
+                // Copy the bytes into the guid
+                Array.Copy(daysArray, daysArray.Length - 2, guidArray, guidArray.Length - 6, 2);
+                Array.Copy(millisecondArray, millisecondArray.Length - 4, guidArray, guidArray.Length - 4, 4);
+
+                return new Guid(guidArray);
+            }
+
+            public static Guid GenerateImproved(Guid input, DateTime nowInput)
+            {
+                var newGuid = input;
+                Span<byte> guidArray = stackalloc byte[16];
+#if NETCOREAPP
+                if (!newGuid.TryWriteBytes(guidArray))
+#elif NETFRAMEWORK
+                if (!MemoryMarshal.TryWrite(guidArray, ref newGuid))
+#endif
+                {
+
+                    guidArray = newGuid.ToByteArray();
+                }
+
+                var now = nowInput; // Internal use, no need for DateTimeOffset
+
+                // Get the days and milliseconds which will be used to build the byte string
+                var days = new TimeSpan(now.Ticks - BaseDateTicks);
+                var timeOfDay = now.TimeOfDay;
+
+                // Convert to a byte array
+                Span<byte> daysArray = stackalloc byte[sizeof(int)];
+                // Reverse the bytes to match SQL Servers ordering
+                BinaryPrimitives.WriteInt32BigEndian(daysArray, days.Days);
+                Span<byte> milliSecondsArray = stackalloc byte[sizeof(long)];
+                // Reverse the bytes to match SQL Servers ordering
+                // Note that SQL Server is accurate to 1/300th of a millisecond so we divide by 3.333333
+                BinaryPrimitives.WriteInt64BigEndian(milliSecondsArray, (long)(timeOfDay.TotalMilliseconds / 3.333333));
+
+                // // Copy the bytes into the guid
+                daysArray.Slice(daysArray.Length - 2).CopyTo(guidArray.Slice(10, 2));
+                milliSecondsArray.Slice(milliSecondsArray.Length - 4).CopyTo(guidArray.Slice(12, 4));
+
+#if NETCOREAPP
+                return new Guid(guidArray);
+#elif NETFRAMEWORK
+                if (!MemoryMarshal.TryRead(guidArray, out Guid readGuid))
+                {
+                    readGuid = new Guid(guidArray.ToArray());
+                }
+
+                return readGuid;
+#endif
+            }
+
+            static readonly long BaseDateTicks = new DateTime(1900, 1, 1).Ticks;
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/IdGeneration/IdGenerationTests.cs
+++ b/src/NServiceBus.Core.Tests/IdGeneration/IdGenerationTests.cs
@@ -1,12 +1,8 @@
 ﻿namespace NServiceBus.Core.Tests.IdGeneration
 {
     using System;
-    using System.Buffers.Binary;
     using System.Collections.Generic;
     using NUnit.Framework;
-#if NETFRAMEWORK
-    using System.Runtime.InteropServices;
-#endif
 
     [TestFixture]
     public class IdGenerationTests
@@ -15,7 +11,7 @@
         public void Should_return_same_result_for_same_input(Guid guid, DateTime now)
         {
             var oldCombGuid = LocalCopyOfCombGuid.GenerateOld(guid, now);
-            var improvedCombGuid = LocalCopyOfCombGuid.GenerateImproved(guid, now);
+            var improvedCombGuid = CombGuid.Generate(guid, now);
 
             Assert.AreEqual(oldCombGuid, improvedCombGuid);
         }
@@ -64,51 +60,6 @@
                 Array.Copy(millisecondArray, millisecondArray.Length - 4, guidArray, guidArray.Length - 4, 4);
 
                 return new Guid(guidArray);
-            }
-
-            public static Guid GenerateImproved(Guid input, DateTime nowInput)
-            {
-                var newGuid = input;
-                Span<byte> guidArray = stackalloc byte[16];
-#if NETCOREAPP
-                if (!newGuid.TryWriteBytes(guidArray))
-#elif NETFRAMEWORK
-                if (!MemoryMarshal.TryWrite(guidArray, ref newGuid))
-#endif
-                {
-
-                    guidArray = newGuid.ToByteArray();
-                }
-
-                var now = nowInput; // Internal use, no need for DateTimeOffset
-
-                // Get the days and milliseconds which will be used to build the byte string
-                var days = new TimeSpan(now.Ticks - BaseDateTicks);
-                var timeOfDay = now.TimeOfDay;
-
-                // Convert to a byte array
-                Span<byte> daysArray = stackalloc byte[sizeof(int)];
-                // Reverse the bytes to match SQL Servers ordering
-                BinaryPrimitives.WriteInt32BigEndian(daysArray, days.Days);
-                Span<byte> milliSecondsArray = stackalloc byte[sizeof(long)];
-                // Reverse the bytes to match SQL Servers ordering
-                // Note that SQL Server is accurate to 1/300th of a millisecond so we divide by 3.333333
-                BinaryPrimitives.WriteInt64BigEndian(milliSecondsArray, (long)(timeOfDay.TotalMilliseconds / 3.333333));
-
-                // // Copy the bytes into the guid
-                daysArray.Slice(daysArray.Length - 2).CopyTo(guidArray.Slice(10, 2));
-                milliSecondsArray.Slice(milliSecondsArray.Length - 4).CopyTo(guidArray.Slice(12, 4));
-
-#if NETCOREAPP
-                return new Guid(guidArray);
-#elif NETFRAMEWORK
-                if (!MemoryMarshal.TryRead(guidArray, out Guid readGuid))
-                {
-                    readGuid = new Guid(guidArray.ToArray());
-                }
-
-                return readGuid;
-#endif
             }
 
             static readonly long BaseDateTicks = new DateTime(1900, 1, 1).Ticks;

--- a/src/NServiceBus.Core/IdGeneration/CombGuid.cs
+++ b/src/NServiceBus.Core/IdGeneration/CombGuid.cs
@@ -77,8 +77,6 @@ namespace NServiceBus
 #endif
         }
 
-        // Represents new DateTime(1900, 1, 1).Ticks, while this would be more readable having a const here instead of
-        // a static field the less readable version slightly improves the throughput
-        const long BaseDateTicks = 599266080000000000; // new DateTime(1900, 1, 1).Ticks
+        static readonly long BaseDateTicks = new DateTime(1900, 1, 1).Ticks;
     }
 }

--- a/src/NServiceBus.Core/IdGeneration/CombGuid.cs
+++ b/src/NServiceBus.Core/IdGeneration/CombGuid.cs
@@ -38,33 +38,32 @@ namespace NServiceBus
             var days = new TimeSpan(now.Ticks - BaseDateTicks);
             var timeOfDay = now.TimeOfDay;
 
-            // Allocate a scratch buffer that is large enough to hold an int and a long so that we can reuse
-            Span<byte> scratchArray = stackalloc byte[sizeof(long)];
+            // Convert to a byte array
+            Span<byte> daysArray = stackalloc byte[sizeof(int)];
             // Reverse the bytes to match SQL Servers ordering
             if (BitConverter.IsLittleEndian)
             {
-                BinaryPrimitives.WriteInt32BigEndian(scratchArray, days.Days);
+                BinaryPrimitives.WriteInt32BigEndian(daysArray, days.Days);
             }
             else
             {
-                BinaryPrimitives.WriteInt32LittleEndian(scratchArray, days.Days);
+                BinaryPrimitives.WriteInt32LittleEndian(daysArray, days.Days);
             }
-            // Copy the two last bytes into the array slice
-            scratchArray.Slice(2, 2).CopyTo(guidArray.Slice(10, 2));
-            // No need to clear the scratch array because the writing the long will overwrite all bytes in the scratch array
-
+            Span<byte> milliSecondsArray = stackalloc byte[sizeof(long)];
             // Reverse the bytes to match SQL Servers ordering
             // Note that SQL Server is accurate to 1/300th of a millisecond so we divide by 3.333333
             if (BitConverter.IsLittleEndian)
             {
-                BinaryPrimitives.WriteInt64BigEndian(scratchArray, (long)(timeOfDay.TotalMilliseconds / 3.333333));
+                BinaryPrimitives.WriteInt64BigEndian(milliSecondsArray, (long)(timeOfDay.TotalMilliseconds / 3.333333));
             }
             else
             {
-                BinaryPrimitives.WriteInt64LittleEndian(scratchArray, (long)(timeOfDay.TotalMilliseconds / 3.333333));
+                BinaryPrimitives.WriteInt64LittleEndian(milliSecondsArray, (long)(timeOfDay.TotalMilliseconds / 3.333333));
             }
-            // Copy the last four bytes into the array slice
-            scratchArray.Slice(3, 4).CopyTo(guidArray.Slice(12, 4));
+
+            // // Copy the bytes into the guid
+            daysArray.Slice(daysArray.Length - 2).CopyTo(guidArray.Slice(10, 2));
+            milliSecondsArray.Slice(milliSecondsArray.Length - 4).CopyTo(guidArray.Slice(12, 4));
 
 #if NETCOREAPP
             return new Guid(guidArray);

--- a/src/NServiceBus.Core/IdGeneration/CombGuid.cs
+++ b/src/NServiceBus.Core/IdGeneration/CombGuid.cs
@@ -77,6 +77,8 @@ namespace NServiceBus
 #endif
         }
 
-        static readonly long BaseDateTicks = new DateTime(1900, 1, 1).Ticks;
+        // Represents new DateTime(1900, 1, 1).Ticks, while this would be more readable having a const here instead of
+        // a static field the less readable version slightly improves the throughput
+        const long BaseDateTicks = 599266080000000000; // new DateTime(1900, 1, 1).Ticks
     }
 }

--- a/src/NServiceBus.Core/IdGeneration/CombGuid.cs
+++ b/src/NServiceBus.Core/IdGeneration/CombGuid.cs
@@ -1,21 +1,32 @@
 namespace NServiceBus
 {
     using System;
+    using System.Buffers.Binary;
+#if NETFRAMEWORK
+    using System.Runtime.InteropServices;
+#endif
 
     /// <summary>
     /// Generates a Guid using http://www.informit.com/articles/article.asp?p=25862
     /// The Comb algorithm is designed to make the use of <see cref="Guid"/>s as Primary Keys, Foreign Keys, and Indexes nearly as efficient
     /// as <see cref="int"/>.
     /// </summary>
-    /// <remarks>Source: https://github.com/nhibernate/nhibernate-core/blob/4.0.4.GA/src/NHibernate/Id/GuidCombGenerator.cs</remarks>
+    /// <remarks>Original Source: https://github.com/nhibernate/nhibernate-core/blob/4.0.4.GA/src/NHibernate/Id/GuidCombGenerator.cs</remarks>
     static class CombGuid
     {
-        /// <summary>
-        /// Generate a new <see cref="Guid" /> using the comb algorithm.
-        /// </summary>
         public static Guid Generate()
         {
-            var guidArray = Guid.NewGuid().ToByteArray();
+            var newGuid = Guid.NewGuid();
+            Span<byte> guidArray = stackalloc byte[16];
+#if NETCOREAPP
+            if (!newGuid.TryWriteBytes(guidArray))
+#elif NETFRAMEWORK
+            if (!MemoryMarshal.TryWrite(guidArray, ref newGuid))
+#endif
+            {
+
+                guidArray = newGuid.ToByteArray();
+            }
 
             var now = DateTime.UtcNow; // Internal use, no need for DateTimeOffset
 
@@ -23,20 +34,27 @@ namespace NServiceBus
             var days = new TimeSpan(now.Ticks - BaseDateTicks);
             var timeOfDay = now.TimeOfDay;
 
-            // Convert to a byte array
-            // Note that SQL Server is accurate to 1/300th of a millisecond so we divide by 3.333333
-            var daysArray = BitConverter.GetBytes(days.Days);
-            var millisecondArray = BitConverter.GetBytes((long)(timeOfDay.TotalMilliseconds / 3.333333));
-
+            Span<byte> daysArray = stackalloc byte[sizeof(int)];
             // Reverse the bytes to match SQL Servers ordering
-            Array.Reverse(daysArray);
-            Array.Reverse(millisecondArray);
+            BinaryPrimitives.WriteInt32BigEndian(daysArray, days.Days);
+            Span<byte> milliSecondsArray = stackalloc byte[sizeof(long)];
+            // Reverse the bytes to match SQL Servers ordering
+            // Note that SQL Server is accurate to 1/300th of a millisecond so we divide by 3.333333
+            BinaryPrimitives.WriteInt64BigEndian(milliSecondsArray, (long)(timeOfDay.TotalMilliseconds / 3.333333));
 
-            // Copy the bytes into the guid
-            Array.Copy(daysArray, daysArray.Length - 2, guidArray, guidArray.Length - 6, 2);
-            Array.Copy(millisecondArray, millisecondArray.Length - 4, guidArray, guidArray.Length - 4, 4);
+            // // Copy the bytes into the guid
+            daysArray.Slice(daysArray.Length - 2).CopyTo(guidArray.Slice(10, 2));
+            milliSecondsArray.Slice(milliSecondsArray.Length - 4).CopyTo(guidArray.Slice(12, 4));
 
+#if NETCOREAPP
             return new Guid(guidArray);
+#elif NETFRAMEWORK
+            if (!MemoryMarshal.TryRead(guidArray, out Guid readGuid))
+            {
+                readGuid = new Guid(guidArray.ToArray());
+            }
+            return readGuid;
+#endif
         }
 
         static readonly long BaseDateTicks = new DateTime(1900, 1, 1).Ticks;

--- a/src/NServiceBus.Core/IdGeneration/CombGuid.cs
+++ b/src/NServiceBus.Core/IdGeneration/CombGuid.cs
@@ -76,6 +76,8 @@ namespace NServiceBus
 #endif
         }
 
-        static readonly long BaseDateTicks = new DateTime(1900, 1, 1).Ticks;
+        // Represents new DateTime(1900, 1, 1).Ticks, while this would be more readable having a const here instead of
+        // a static field the less readable version slightly improves the throughput
+        const long BaseDateTicks = 599266080000000000; // new DateTime(1900, 1, 1).Ticks
     }
 }


### PR DESCRIPTION
This PR modernizes slight the CombGuid code that we haven't touched for ages. Now that we target platforms directly, we can leverage some more specific APIs. With CSharp 8 and Spans we can leverage stack allocations to have the buffers allocated on the local stack to reduce the memory allocations during the GUID generation. This code is involved on the hot path (for example during saga creation) and it is worth optimizing allocations away. 

![image](https://user-images.githubusercontent.com/174258/151128041-848bd433-8897-4ad3-b953-24d665e3c3fc.png)

[Benchmark](https://github.com/danielmarbach/MicroBenchmarks/commit/589835fff565842dd83b95c1baedd2e1ad268115)