### PR TITLE
Serializer resolving resiliency

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Serialization/When_defining_serializer_with_no_content_type.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_defining_serializer_with_no_content_type.cs
@@ -1,0 +1,44 @@
+﻿namespace NServiceBus.AcceptanceTests.Serialization
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using MessageInterfaces;
+    using NServiceBus.Serialization;
+    using NUnit.Framework;
+    using Settings;
+
+    public class When_defining_serializer_with_no_content_type : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public void Should_fail_endpoint_startup()
+        {
+            var exception = Assert.ThrowsAsync<ArgumentException>(() => Scenario.Define<ScenarioContext>()
+                .WithEndpoint<EndpointWithInvalidSerializer>()
+                .Done(c => c.EndpointsStarted)
+                .Run());
+
+            StringAssert.Contains($"Serializer '{nameof(InvalidSerializer)}' defines no content type. Ensure the 'ContentType' property of the serializer has a value.", exception.Message);
+        }
+
+        class EndpointWithInvalidSerializer : EndpointConfigurationBuilder
+        {
+            public EndpointWithInvalidSerializer()
+            {
+                EndpointSetup<DefaultServer>(c => c.UseSerialization<InvalidSerializer>());
+            }
+        }
+
+        class InvalidSerializer : SerializationDefinition, IMessageSerializer
+        {
+            public string ContentType => null; // equal to not setting a value at all
+            public override Func<IMessageMapper, IMessageSerializer> Configure(IReadOnlySettings settings) => _ => this;
+
+            public void Serialize(object message, Stream stream) => throw new NotImplementedException();
+
+            public object[] Deserialize(ReadOnlyMemory<byte> body, IList<Type> messageTypes = null) => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Serializers/MessageDeserializerResolverTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/MessageDeserializerResolverTests.cs
@@ -61,6 +61,24 @@
             Assert.AreEqual(defaultSerializer, serializer);
         }
 
+        [TestCase(null)]
+        [TestCase("")]
+        public void EmptylContentTypeFallsBackToDefaultSerialization(string headerValue)
+        {
+            var defaultSerializer = new FakeSerializer(ContentTypes.Xml);
+            var resolver = new MessageDeserializerResolver(defaultSerializer, new IMessageSerializer[]
+            {
+                new FakeSerializer(ContentTypes.Json)
+            });
+
+            var serializer = resolver.Resolve(new Dictionary<string, string>()
+            {
+                { Headers.ContentType, headerValue}
+            });
+
+            Assert.AreEqual(defaultSerializer, serializer);
+        }
+
         [Test]
         public void MultipleDeserializersWithSameContentTypeShouldThrowException()
         {

--- a/src/NServiceBus.Core.Tests/Serializers/MessageDeserializerResolverTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/MessageDeserializerResolverTests.cs
@@ -63,7 +63,7 @@
 
         [TestCase(null)]
         [TestCase("")]
-        public void EmptylContentTypeFallsBackToDefaultSerialization(string headerValue)
+        public void EmptyContentTypeFallsBackToDefaultSerialization(string headerValue)
         {
             var defaultSerializer = new FakeSerializer(ContentTypes.Xml);
             var resolver = new MessageDeserializerResolver(defaultSerializer, new IMessageSerializer[]

--- a/src/NServiceBus.Core/Serialization/SerializationFeature.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationFeature.cs
@@ -81,6 +81,12 @@
 
             var serializerFactory = definition.Configure(deserializerSettings);
             var serializer = serializerFactory(mapper);
+
+            if (serializer.ContentType == null)
+            {
+                throw new ArgumentException($"Serializer '{definition.GetType().Name}' defines no content type. Ensure the '{nameof(serializer.ContentType)}' property of the serializer has a value.");
+            }
+
             return serializer;
         }
 

--- a/src/NServiceBus.Core/Serialization/SerializationFeature.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationFeature.cs
@@ -82,7 +82,7 @@
             var serializerFactory = definition.Configure(deserializerSettings);
             var serializer = serializerFactory(mapper);
 
-            if (serializer.ContentType == null)
+            if (string.IsNullOrWhiteSpace(serializer.ContentType))
             {
                 throw new ArgumentException($"Serializer '{definition.GetType().Name}' defines no content type. Ensure the '{nameof(serializer.ContentType)}' property of the serializer has a value.");
             }

--- a/src/NServiceBus.Core/Serializers/MessageDeserializerResolver.cs
+++ b/src/NServiceBus.Core/Serializers/MessageDeserializerResolver.cs
@@ -25,7 +25,7 @@
         {
             if (headers.TryGetValue(Headers.ContentType, out var contentType))
             {
-                if (serializersMap.TryGetValue(contentType, out var serializer))
+                if (serializersMap.TryGetValue(contentType ?? string.Empty, out var serializer))
                 {
                     return serializer;
                 }

--- a/src/NServiceBus.Core/Serializers/MessageDeserializerResolver.cs
+++ b/src/NServiceBus.Core/Serializers/MessageDeserializerResolver.cs
@@ -25,7 +25,7 @@
         {
             if (headers.TryGetValue(Headers.ContentType, out var contentType))
             {
-                if (serializersMap.TryGetValue(contentType ?? string.Empty, out var serializer))
+                if (contentType != null && serializersMap.TryGetValue(contentType, out var serializer))
                 {
                     return serializer;
                 }


### PR DESCRIPTION
A small fix and additional checks to prevent some edge cases where serializer resolving would fail.
If the header `NServiceBus.ContentType` is set but has no value (`null`) the dictionary fails due to an invalid `null` argument. This PR prevents null-arguments by falling back to the default serializer in this case.

Since handling of `string.Empty` would be a bit unexpected if it would be allowed in this case (e.g. define an additional deserializer with `string.Empty` as the content type could in the default serializer be resolved, depending on how the transport handles header serialization), this PR also strictly prevents any deserializer definition that doesn't specify a content type.