### PR TITLE
Make IEndpointInstance IAsyncDisposable

### DIFF
--- a/src/NServiceBus.Core/IEndpointInstance.cs
+++ b/src/NServiceBus.Core/IEndpointInstance.cs
@@ -1,5 +1,9 @@
 namespace NServiceBus
 {
+#if NETCOREAPP
+    using System;
+#endif
+
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -7,10 +11,17 @@ namespace NServiceBus
     /// Represents an endpoint in the running phase.
     /// </summary>
     public interface IEndpointInstance : IMessageSession
+#if NETCOREAPP
+    , IAsyncDisposable
+#endif
     {
         /// <summary>
         /// Stops the endpoint.
         /// </summary>
         Task Stop(CancellationToken cancellationToken = default);
+
+#if NETCOREAPP
+        ValueTask IAsyncDisposable.DisposeAsync() => new ValueTask(Stop(CancellationToken.None));
+#endif
     }
 }


### PR DESCRIPTION
Alternative approach to #6240  that doesn't require user-opt-in via a dedicated API

only when targeting .NET Core. Might have more direct impact due to some analyzers maybe not happy that endpoint isn't being disposed now.
