### PR TITLE
New headers to correlate message processing instead of sending

### DIFF
--- a/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
+++ b/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
@@ -30,6 +30,7 @@ namespace NServiceBus
             }
 
             context.Headers[Headers.RelatedTo] = incomingMessage.MessageId;
+            context.Headers[Headers.RelatedTo2] = context.Extensions.Get<string>(Headers.ProcessingId);
         }
 
         void SetConversationIdHeader(IOutgoingLogicalMessageContext context, IncomingMessage incomingMessage)

--- a/src/NServiceBus.Core/Headers.cs
+++ b/src/NServiceBus.Core/Headers.cs
@@ -218,5 +218,15 @@
         /// of the message can be known.
         /// </summary>
         public const string TimeToBeReceived = "NServiceBus.TimeToBeReceived";
+
+        /// <summary>
+        /// Identifies one specific processing attempt of a received message.
+        /// </summary>
+        public const string ProcessingId = "NServiceBus.ProcessingId";
+
+        /// <summary>
+        /// Processing Id of the message processing attempt that caused this message to be sent.
+        /// </summary>
+        public const string RelatedTo2 = "NServiceBus.RelatesTo";
     }
 }

--- a/src/NServiceBus.Core/Hosting/AuditHostInformationBehavior.cs
+++ b/src/NServiceBus.Core/Hosting/AuditHostInformationBehavior.cs
@@ -21,6 +21,7 @@
 
             context.AuditMetadata[Headers.ProcessingMachine] = RuntimeEnvironment.MachineName;
             context.AuditMetadata[Headers.ProcessingEndpoint] = endpoint;
+            context.AuditMetadata[Headers.ProcessingId] = context.Extensions.Get<string>(Headers.ProcessingId);
 
             return next(context);
         }

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -28,6 +28,7 @@ namespace NServiceBus
 
                 var rootContext = new RootContext(childScope.ServiceProvider, messageOperations, pipelineCache, cancellationToken);
                 rootContext.Extensions.Merge(messageContext.Extensions);
+                rootContext.Set(Headers.ProcessingId, Guid.NewGuid().ToString("N"));
 
                 var transportReceiveContext = new TransportReceiveContext(message, messageContext.TransportTransaction, rootContext);
 


### PR DESCRIPTION
Our current `RelatedTo` header is based on *sending*. This is problematic as an even for example has one publisher but can have multiple subscribers. The issue is that if a subscribers sends a message its `RelatedTo` is set to the ID of the event which. This creates a chain of send messages.

This has the limitation that it cannot directly be used for visualization within ServiceInsight in the message flow that shows the *processing* of messages. It uses a "hack"  using the `OriginatingEndpoint`, and `ProcessingEndpoint` headers.

This is an improvement to base chaining on *processing*. 

1. Each time a message is processed Core creates a `ProcessingId`.
2. Audit messages get this `ProcessingId` appended in its headers.
3. Sends/Published get a `RelatedTo2` header containing this `ProcessingId`.

It uses `RelatedTo2` and not `RelatedTo` to not break backwardscompatibility. A better name could maybe be created but this was is a quick spike.

It also has the benefit that each processing attempt is identified. 

ReceiveOnly or immediate dispatch issue:

ReceiveOnly or immediate dispatch could result in messages with a `RelatedTo2` value that currently cannot be correlated as auditing only happens for successful messages. Ideally we should have a new "audit" message that would get all current audit headers and link to the readonly incoming messages or just always send an audit messages via "immediate dispatch". Making the incoming message fully read-only. But there is still the fallback to correlate on sends as old headers still exist.