### PR TITLE
Manual feature and handler registration

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Feature/When_enabling_feature_not_scanned.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Feature/When_enabling_feature_not_scanned.cs
@@ -1,0 +1,76 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Feature
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Features;
+    using Microsoft.Extensions.DependencyInjection;
+    using NUnit.Framework;
+
+    public class When_enabling_feature_not_scanned : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_enable_feature()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithoutAssemblyScanning>()
+                .Done(c => c.EndpointsStarted)
+                .Run();
+
+            Assert.IsTrue(context.FeatureSetupCalled);
+            Assert.IsTrue(context.FeatureStartupTaskCalled);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool FeatureSetupCalled { get; set; }
+            public bool FeatureStartupTaskCalled { get; set; }
+        }
+
+        class EndpointWithoutAssemblyScanning : EndpointConfigurationBuilder
+        {
+            public EndpointWithoutAssemblyScanning()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.AssemblyScanner().ScanAssembliesInNestedDirectories = false;
+                    c.AssemblyScanner().ScanAppDomainAssemblies = false;
+
+                    c.EnableFeature<CustomFeature>();
+                }).ExcludeType<CustomFeature>();
+            }
+
+            public class CustomFeature : Feature
+            {
+                public CustomFeature() => EnableByDefault();
+
+                protected override void Setup(FeatureConfigurationContext context)
+                {
+                    var testContext = context.Settings.Get<ScenarioContext>() as Context;
+                    testContext.FeatureSetupCalled = true;
+
+                    context.RegisterStartupTask(sp => new CustomFeatureStartupTask(sp.GetRequiredService<Context>()));
+                }
+
+                class CustomFeatureStartupTask : FeatureStartupTask
+                {
+                    Context testContext;
+
+                    public CustomFeatureStartupTask(Context testContext)
+                    {
+                        this.testContext = testContext;
+                    }
+
+                    protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
+                    {
+                        testContext.FeatureStartupTaskCalled = true;
+                        return Task.CompletedTask;
+                    }
+
+                    protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
+                }
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_registering_handler_not_scanned.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_registering_handler_not_scanned.cs
@@ -1,0 +1,58 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Pipeline
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_registering_handler_not_scanned : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_invoke_handler()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithoutAssemblyScanning>(e => e
+                    .When(s => s.SendLocal(new IncomingMessage())))
+                .Done(c => c.HandlerInvoked)
+                .Run(TimeSpan.FromSeconds(15));
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool HandlerInvoked { get; set; }
+        }
+
+        class EndpointWithoutAssemblyScanning : EndpointConfigurationBuilder
+        {
+            public EndpointWithoutAssemblyScanning() =>
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.AssemblyScanner().ScanAppDomainAssemblies = false;
+                    c.AssemblyScanner().ScanFileSystemAssemblies = false;
+                    c.RegisterMessageHandlers(typeof(RegisteredHandler));
+
+                }).ExcludeType<RegisteredHandler>().ExcludeType<IncomingMessage>();
+
+            public class RegisteredHandler : IHandleMessages<IncomingMessage>
+            {
+                Context testContext;
+
+                public RegisteredHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(IncomingMessage message, IMessageHandlerContext context)
+                {
+                    testContext.HandlerInvoked = true;
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        public class IncomingMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core/Features/EndpointConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Features/EndpointConfigurationExtensions.cs
@@ -1,7 +1,10 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using Features;
+    using Settings;
 
     /// <summary>
     /// Extension methods declarations.
@@ -28,6 +31,8 @@
             Guard.AgainstNull(nameof(config), config);
             Guard.AgainstNull(nameof(featureType), featureType);
 
+            var features = config.Settings.GetOrCreate<HashSet<Type>>(RegisteredFeaturesKey);
+            features.Add(featureType);
             config.Settings.EnableFeature(featureType);
         }
 
@@ -53,5 +58,17 @@
 
             config.Settings.DisableFeature(featureType);
         }
+
+        internal static IEnumerable<Type> GetExplicitlyEnabledFeatures(this SettingsHolder settings)
+        {
+            if (settings.TryGet(RegisteredFeaturesKey, out HashSet<Type> features))
+            {
+                return features;
+            }
+
+            return Enumerable.Empty<Type>();
+        }
+
+        const string RegisteredFeaturesKey = "RegisteredFeatures";
     }
 }

--- a/src/NServiceBus.Core/Settings/SettingsHolder.cs
+++ b/src/NServiceBus.Core/Settings/SettingsHolder.cs
@@ -173,12 +173,16 @@ namespace NServiceBus.Settings
         /// Gets the requested value, a new one will be created and added if needed.
         /// </summary>
         public T GetOrCreate<T>()
+            where T : class, new() =>
+            GetOrCreate<T>(typeof(T).FullName);
+
+        internal T GetOrCreate<T>(string key)
             where T : class, new()
         {
-            if (!TryGet(out T value))
+            if (!TryGet(key, out T value))
             {
                 value = new T();
-                Set(value);
+                Set(key, value);
             }
             return value;
         }

--- a/src/NServiceBus.Core/Unicast/Config/LoadMessageHandlersExtensions.cs
+++ b/src/NServiceBus.Core/Unicast/Config/LoadMessageHandlersExtensions.cs
@@ -9,6 +9,20 @@ namespace NServiceBus
     public static class LoadMessageHandlersExtensions
     {
         /// <summary>
+        /// Registers the provided types as message handlers. The handlers will automatically be registered with the DI container. Handlers registered via this API are executed before message handlers that are detected via assembly scanning. This setting cannot be combined with <see cref="ExecuteTheseHandlersFirst(EndpointConfiguration,IEnumerable{Type})"/>. 
+        /// </summary>
+        /// <param name="config">The <see cref="EndpointConfiguration" /> instance to apply the settings to.</param>
+        /// <param name="handlerTypes">The handler type to register. The provided type must implement <see cref="IHandleMessages{T}"/>.</param>
+        public static void RegisterMessageHandlers(this EndpointConfiguration config, params Type[] handlerTypes) => ExecuteTheseHandlersFirst(config, (IEnumerable<Type>)handlerTypes);
+
+        /// <summary>
+        /// Registers the provided types as message handlers. The handlers will automatically be registered with the DI container. Handlers registered via this API are executed before message handlers that are detected via assembly scanning. This setting cannot be combined with <see cref="ExecuteTheseHandlersFirst(EndpointConfiguration,IEnumerable{Type})"/>. 
+        /// </summary>
+        /// <param name="config">The <see cref="EndpointConfiguration" /> instance to apply the settings to.</param>
+        /// <param name="handlerTypes">The handler type to register. The provided type must implement <see cref="IHandleMessages{T}"/>.</param>
+        public static void RegisterMessageHandlers(this EndpointConfiguration config, IEnumerable<Type> handlerTypes) => ExecuteTheseHandlersFirst(config, handlerTypes);
+
+        /// <summary>
         /// Loads all message handler assemblies in the runtime directory
         /// and specifies that the handlers in the given 'order' are to
         /// run before all others and in the order specified.


### PR DESCRIPTION
With these changes, features and message handlers can be explicitly registered, without the need to rely on assembly scanning. Essentially allowing usage of features and handlers while assembly scanning is completely disabled.

For features, this enhances the existing `EnableFeature` API which already specifies the specific feature type but didn't register it so for (only the expected "enabled state").

For handlers, the `ExecuteTheseHandlersFirst` API basically already does exactly what we need but feels weird from a naming perspective, so I've added a different alias for this API.

for example, the following will successfully work:

```
var endpointConfiguration = new EndpointConfiguration(...);

// completely disable assembly scanning:
endpointConfiguration .AssemblyScanner().ScanAppDomainAssemblies = false;
endpointConfiguration .AssemblyScanner().ScanFileSystemAssemblies = false;

c.RegisterMessageHandlers(typeof(MyHandler));
c.EnableFeature<MyFeature>();
```