### PR TITLE
Stop exposing error context on the recoverability pipeline

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2056,13 +2056,19 @@ namespace NServiceBus.Pipeline
     }
     public interface IRecoverabilityActionContext : NServiceBus.Extensibility.IExtendable, NServiceBus.ICancellableContext, NServiceBus.Pipeline.IBehaviorContext
     {
-        NServiceBus.Transport.ErrorContext ErrorContext { get; }
+        System.Exception Exception { get; }
+        NServiceBus.Transport.IncomingMessage FailedMessage { get; }
+        int ImmediateProcessingFailures { get; }
         System.Collections.Generic.IReadOnlyDictionary<string, string> Metadata { get; }
+        string ReceiveAddress { get; }
     }
     public interface IRecoverabilityContext : NServiceBus.Extensibility.IExtendable, NServiceBus.ICancellableContext, NServiceBus.Pipeline.IBehaviorContext
     {
-        NServiceBus.Transport.ErrorContext ErrorContext { get; }
+        System.Exception Exception { get; }
+        NServiceBus.Transport.IncomingMessage FailedMessage { get; }
+        int ImmediateProcessingFailures { get; }
         System.Collections.Generic.Dictionary<string, string> Metadata { get; }
+        string ReceiveAddress { get; }
         NServiceBus.RecoverabilityAction RecoverabilityAction { get; set; }
         NServiceBus.RecoverabilityConfig RecoverabilityConfiguration { get; }
         NServiceBus.Pipeline.IRecoverabilityActionContext PreventChanges();

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2056,6 +2056,7 @@ namespace NServiceBus.Pipeline
     }
     public interface IRecoverabilityActionContext : NServiceBus.Extensibility.IExtendable, NServiceBus.ICancellableContext, NServiceBus.Pipeline.IBehaviorContext
     {
+        int DelayedDeliveriesPerformed { get; }
         System.Exception Exception { get; }
         NServiceBus.Transport.IncomingMessage FailedMessage { get; }
         int ImmediateProcessingFailures { get; }
@@ -2064,6 +2065,7 @@ namespace NServiceBus.Pipeline
     }
     public interface IRecoverabilityContext : NServiceBus.Extensibility.IExtendable, NServiceBus.ICancellableContext, NServiceBus.Pipeline.IBehaviorContext
     {
+        int DelayedDeliveriesPerformed { get; }
         System.Exception Exception { get; }
         NServiceBus.Transport.IncomingMessage FailedMessage { get; }
         int ImmediateProcessingFailures { get; }

--- a/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/RecoverabilityExecutorTests.cs
@@ -1,8 +1,5 @@
 ﻿namespace NServiceBus.Core.Tests.Recoverability
 {
-    using System;
-    using System.Collections.Generic;
-    using NServiceBus.Extensibility;
     using NUnit.Framework;
     using Testing;
     using Transport;
@@ -14,8 +11,7 @@
         public void Discard_action_should_discard_message()
         {
             var discardAction = new Discard("not needed anymore");
-            var errorContext = new ErrorContext(new Exception(""), new Dictionary<string, string>(), "some-id", Array.Empty<byte>(), new TransportTransaction(), 1, "my-endpoint", new ContextBag());
-            var actionContext = new TestableRecoverabilityContext { ErrorContext = errorContext };
+            var actionContext = new TestableRecoverabilityContext();
 
             var routingContexts = discardAction.GetRoutingContexts(actionContext);
 

--- a/src/NServiceBus.Core/Recoverability/DelayedRetry.cs
+++ b/src/NServiceBus.Core/Recoverability/DelayedRetry.cs
@@ -39,7 +39,7 @@
 
             var outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body);
 
-            var currentDelayedRetriesAttempt = message.GetDelayedDeliveriesPerformed() + 1;
+            var currentDelayedRetriesAttempt = context.DelayedDeliveriesPerformed + 1;
 
             if (context is IRecoverabilityActionContextNotifications notifications)
             {

--- a/src/NServiceBus.Core/Recoverability/DelayedRetry.cs
+++ b/src/NServiceBus.Core/Recoverability/DelayedRetry.cs
@@ -32,10 +32,10 @@
         /// <inheritdoc />
         public override IReadOnlyCollection<IRoutingContext> GetRoutingContexts(IRecoverabilityActionContext context)
         {
-            var errorContext = context.ErrorContext;
-            var message = errorContext.Message;
+            var message = context.FailedMessage;
+            var exception = context.Exception;
 
-            Logger.Warn($"Delayed Retry will reschedule message '{message.MessageId}' after a delay of {Delay} because of an exception:", errorContext.Exception);
+            Logger.Warn($"Delayed Retry will reschedule message '{message.MessageId}' after a delay of {Delay} because of an exception:", exception);
 
             var outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body);
 
@@ -47,13 +47,14 @@
                     attempt: currentDelayedRetriesAttempt,
                     delay: Delay,
                     immediateRetry: false,
-                    errorContext: errorContext));
+                    message,
+                    exception));
             }
 
             outgoingMessage.SetCurrentDelayedDeliveries(currentDelayedRetriesAttempt);
             outgoingMessage.SetDelayedDeliveryTimestamp(DateTimeOffset.UtcNow);
 
-            var routingContext = context.CreateRoutingContext(outgoingMessage, new UnicastRoutingStrategy(errorContext.ReceiveAddress));
+            var routingContext = context.CreateRoutingContext(outgoingMessage, new UnicastRoutingStrategy(context.ReceiveAddress));
             routingContext.Extensions.Set(new DispatchProperties
             {
                 DelayDeliveryWith = new DelayDeliveryWith(Delay)

--- a/src/NServiceBus.Core/Recoverability/Discard.cs
+++ b/src/NServiceBus.Core/Recoverability/Discard.cs
@@ -3,8 +3,8 @@ namespace NServiceBus
     using System;
     using System.Collections.Generic;
     using Logging;
-    using Transport;
     using Pipeline;
+    using Transport;
 
     /// <summary>
     /// Indicates recoverability is required to discard/ignore the current message.
@@ -32,8 +32,7 @@ namespace NServiceBus
         /// <inheritdoc />
         public override IReadOnlyCollection<IRoutingContext> GetRoutingContexts(IRecoverabilityActionContext context)
         {
-            var errorContext = context.ErrorContext;
-            Logger.Info($"Discarding message with id '{errorContext.Message.MessageId}'. Reason: {Reason}", errorContext.Exception);
+            Logger.Info($"Discarding message with id '{context.FailedMessage.MessageId}'. Reason: {Reason}", context.Exception);
             return Array.Empty<IRoutingContext>();
         }
 

--- a/src/NServiceBus.Core/Recoverability/Faults/MessageFaulted.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/MessageFaulted.cs
@@ -1,12 +1,13 @@
 namespace NServiceBus
 {
+    using System;
     using Transport;
 
     class MessageFaulted : MessageProcessingFailed
     {
         public string ErrorQueue { get; }
 
-        public MessageFaulted(ErrorContext errorContext, string errorQueue) : base(errorContext)
+        public MessageFaulted(string errorQueue, IncomingMessage failedMessage, Exception exception) : base(failedMessage, exception)
         {
             ErrorQueue = errorQueue;
         }

--- a/src/NServiceBus.Core/Recoverability/Faults/MessageProcessingFailed.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/MessageProcessingFailed.cs
@@ -7,13 +7,11 @@ namespace NServiceBus
     {
         public IncomingMessage Message { get; }
         public Exception Exception { get; }
-        public ErrorContext ErrorContext { get; }
 
-        protected MessageProcessingFailed(ErrorContext errorContext)
+        protected MessageProcessingFailed(IncomingMessage failedMessage, Exception exception)
         {
-            Message = errorContext.Message;
-            Exception = errorContext.Exception;
-            ErrorContext = errorContext;
+            Message = failedMessage;
+            Exception = exception;
         }
     }
 }

--- a/src/NServiceBus.Core/Recoverability/Faults/MessageToBeRetried.cs
+++ b/src/NServiceBus.Core/Recoverability/Faults/MessageToBeRetried.cs
@@ -9,7 +9,7 @@ namespace NServiceBus
         public TimeSpan Delay { get; }
         public bool IsImmediateRetry { get; }
 
-        public MessageToBeRetried(int attempt, TimeSpan delay, bool immediateRetry, ErrorContext errorContext) : base(errorContext)
+        public MessageToBeRetried(int attempt, TimeSpan delay, bool immediateRetry, IncomingMessage failedMessage, Exception exception) : base(failedMessage, exception)
         {
             Attempt = attempt;
             Delay = delay;

--- a/src/NServiceBus.Core/Recoverability/IRecoverabilityActionContext.cs
+++ b/src/NServiceBus.Core/Recoverability/IRecoverabilityActionContext.cs
@@ -30,6 +30,11 @@
         public int ImmediateProcessingFailures { get; }
 
         /// <summary>
+        /// Number of delayed deliveries performed so far.
+        /// </summary>
+        public int DelayedDeliveriesPerformed { get; }
+
+        /// <summary>
         /// Metadata for this message.
         /// </summary>
         IReadOnlyDictionary<string, string> Metadata { get; }

--- a/src/NServiceBus.Core/Recoverability/IRecoverabilityActionContext.cs
+++ b/src/NServiceBus.Core/Recoverability/IRecoverabilityActionContext.cs
@@ -1,7 +1,8 @@
 ﻿namespace NServiceBus.Pipeline
 {
+    using System;
     using System.Collections.Generic;
-    using Transport;
+    using NServiceBus.Transport;
 
     /// <summary>
     /// Provide context to recoverability actions.
@@ -9,9 +10,24 @@
     public interface IRecoverabilityActionContext : IBehaviorContext
     {
         /// <summary>
-        /// Context for the message that failed processing.
+        /// The message that failed processing.
         /// </summary>
-        ErrorContext ErrorContext { get; }
+        public IncomingMessage FailedMessage { get; }
+
+        /// <summary>
+        /// The exception that caused processing to fail.
+        /// </summary>
+        public Exception Exception { get; }
+
+        /// <summary>
+        /// The receive address where this message failed.
+        /// </summary>
+        public string ReceiveAddress { get; }
+
+        /// <summary>
+        /// The number of times the message have been retried immediately but failed.
+        /// </summary>
+        public int ImmediateProcessingFailures { get; }
 
         /// <summary>
         /// Metadata for this message.

--- a/src/NServiceBus.Core/Recoverability/IRecoverabilityContext.cs
+++ b/src/NServiceBus.Core/Recoverability/IRecoverabilityContext.cs
@@ -1,7 +1,8 @@
 ﻿namespace NServiceBus.Pipeline
 {
+    using System;
     using System.Collections.Generic;
-    using Transport;
+    using NServiceBus.Transport;
 
     /// <summary>
     /// Provide context to behaviors on the recoverability pipeline.
@@ -9,9 +10,24 @@
     public interface IRecoverabilityContext : IBehaviorContext
     {
         /// <summary>
-        /// Context for the message that failed processing.
+        /// The message that failed processing.
         /// </summary>
-        ErrorContext ErrorContext { get; }
+        public IncomingMessage FailedMessage { get; }
+
+        /// <summary>
+        /// The exception that caused processing to fail.
+        /// </summary>
+        public Exception Exception { get; }
+
+        /// <summary>
+        /// The receive address where this message failed.
+        /// </summary>
+        public string ReceiveAddress { get; }
+
+        /// <summary>
+        /// The number of times the message have been retried immediately but failed.
+        /// </summary>
+        public int ImmediateProcessingFailures { get; }
 
         /// <summary>
         /// The recoverability configuration for the endpoint.

--- a/src/NServiceBus.Core/Recoverability/IRecoverabilityContext.cs
+++ b/src/NServiceBus.Core/Recoverability/IRecoverabilityContext.cs
@@ -30,6 +30,11 @@
         public int ImmediateProcessingFailures { get; }
 
         /// <summary>
+        /// Number of delayed deliveries performed so far.
+        /// </summary>
+        public int DelayedDeliveriesPerformed { get; }
+
+        /// <summary>
         /// The recoverability configuration for the endpoint.
         /// </summary>
         public RecoverabilityConfig RecoverabilityConfiguration { get; }

--- a/src/NServiceBus.Core/Recoverability/ImmediateRetry.cs
+++ b/src/NServiceBus.Core/Recoverability/ImmediateRetry.cs
@@ -26,16 +26,18 @@
         /// <inheritdoc />
         public override IReadOnlyCollection<IRoutingContext> GetRoutingContexts(IRecoverabilityActionContext context)
         {
-            var errorContext = context.ErrorContext;
+            var message = context.FailedMessage;
+            var exception = context.Exception;
 
-            Logger.Info($"Immediate Retry is going to retry message '{errorContext.Message.MessageId}' because of an exception:", errorContext.Exception);
+            Logger.Info($"Immediate Retry is going to retry message '{message.MessageId}' because of an exception:", exception);
             if (context is IRecoverabilityActionContextNotifications notifications)
             {
                 notifications.Add(new MessageToBeRetried(
-                    attempt: errorContext.ImmediateProcessingFailures - 1,
+                    attempt: context.ImmediateProcessingFailures - 1,
                     delay: TimeSpan.Zero,
                     immediateRetry: true,
-                    errorContext: errorContext));
+                    message,
+                    exception));
             }
             return Array.Empty<IRoutingContext>();
         }

--- a/src/NServiceBus.Core/Recoverability/MoveToError.cs
+++ b/src/NServiceBus.Core/Recoverability/MoveToError.cs
@@ -30,15 +30,15 @@ namespace NServiceBus
         /// <inheritdoc />
         public override IReadOnlyCollection<IRoutingContext> GetRoutingContexts(IRecoverabilityActionContext context)
         {
-            var errorContext = context.ErrorContext;
             var metadata = context.Metadata;
-            var message = errorContext.Message;
+            var message = context.FailedMessage;
+            var exception = context.Exception;
 
-            Logger.Error($"Moving message '{message.MessageId}' to the error queue '{ErrorQueue}' because processing failed due to an exception:", errorContext.Exception);
+            Logger.Error($"Moving message '{message.MessageId}' to the error queue '{ErrorQueue}' because processing failed due to an exception:", exception);
 
             if (context is IRecoverabilityActionContextNotifications notifications)
             {
-                notifications.Add(new MessageFaulted(errorContext, ErrorQueue));
+                notifications.Add(new MessageFaulted(ErrorQueue, message, exception));
             }
 
             var outgoingMessage = new OutgoingMessage(message.MessageId, new Dictionary<string, string>(message.Headers), message.Body);

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityContext.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityContext.cs
@@ -10,26 +10,22 @@
     class RecoverabilityContext : BehaviorContext, IRecoverabilityContext, IRecoverabilityActionContext, IRecoverabilityActionContextNotifications
     {
         public RecoverabilityContext(
-            IncomingMessage failedMessage,
-            Exception exception,
-            string receiveAddress,
-            int immediateProcessingFailures,
-            TransportTransaction transportTransaction,
+            ErrorContext errorContext,
             RecoverabilityConfig recoverabilityConfig,
             Dictionary<string, string> metadata,
             RecoverabilityAction recoverabilityAction,
             IBehaviorContext parent) : base(parent)
         {
-            FailedMessage = failedMessage;
-            Exception = exception;
-            ReceiveAddress = receiveAddress;
-            ImmediateProcessingFailures = immediateProcessingFailures;
+            FailedMessage = errorContext.Message;
+            Exception = errorContext.Exception;
+            ReceiveAddress = errorContext.ReceiveAddress;
+            ImmediateProcessingFailures = errorContext.ImmediateProcessingFailures;
 
             RecoverabilityConfiguration = recoverabilityConfig;
             Metadata = metadata;
             RecoverabilityAction = recoverabilityAction;
 
-            Extensions.Set(transportTransaction);
+            Extensions.Set(errorContext.TransportTransaction);
         }
 
         public IncomingMessage FailedMessage { get; }

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityContext.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityContext.cs
@@ -20,7 +20,7 @@
             Exception = errorContext.Exception;
             ReceiveAddress = errorContext.ReceiveAddress;
             ImmediateProcessingFailures = errorContext.ImmediateProcessingFailures;
-
+            DelayedDeliveriesPerformed = errorContext.DelayedDeliveriesPerformed;
             RecoverabilityConfiguration = recoverabilityConfig;
             Metadata = metadata;
             RecoverabilityAction = recoverabilityAction;
@@ -35,6 +35,8 @@
         public string ReceiveAddress { get; }
 
         public int ImmediateProcessingFailures { get; }
+
+        public int DelayedDeliveriesPerformed { get; }
 
         IReadOnlyDictionary<string, string> IRecoverabilityActionContext.Metadata => Metadata;
 

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityContext.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityContext.cs
@@ -4,26 +4,41 @@
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
+    using NServiceBus.Transport;
     using Pipeline;
-    using Transport;
 
     class RecoverabilityContext : BehaviorContext, IRecoverabilityContext, IRecoverabilityActionContext, IRecoverabilityActionContextNotifications
     {
         public RecoverabilityContext(
-            ErrorContext errorContext,
+            IncomingMessage failedMessage,
+            Exception exception,
+            string receiveAddress,
+            int immediateProcessingFailures,
+            TransportTransaction transportTransaction,
             RecoverabilityConfig recoverabilityConfig,
             Dictionary<string, string> metadata,
             RecoverabilityAction recoverabilityAction,
             IBehaviorContext parent) : base(parent)
         {
-            ErrorContext = errorContext;
+            FailedMessage = failedMessage;
+            Exception = exception;
+            ReceiveAddress = receiveAddress;
+            ImmediateProcessingFailures = immediateProcessingFailures;
+
             RecoverabilityConfiguration = recoverabilityConfig;
             Metadata = metadata;
             RecoverabilityAction = recoverabilityAction;
-            Extensions.Set(errorContext.TransportTransaction);
+
+            Extensions.Set(transportTransaction);
         }
 
-        public ErrorContext ErrorContext { get; }
+        public IncomingMessage FailedMessage { get; }
+
+        public Exception Exception { get; }
+
+        public string ReceiveAddress { get; }
+
+        public int ImmediateProcessingFailures { get; }
 
         IReadOnlyDictionary<string, string> IRecoverabilityActionContext.Metadata => Metadata;
 

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityPipelineExecutor.cs
@@ -41,11 +41,7 @@
                 var metadata = faultMetadataExtractor.Extract(errorContext);
 
                 var recoverabilityContext = new RecoverabilityContext(
-                    errorContext.Message,
-                    errorContext.Exception,
-                    errorContext.ReceiveAddress,
-                    errorContext.ImmediateProcessingFailures,
-                    errorContext.TransportTransaction,
+                    errorContext,
                     recoverabilityConfig,
                     metadata,
                     recoverabilityAction,

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityPipelineExecutor.cs
@@ -41,7 +41,11 @@
                 var metadata = faultMetadataExtractor.Extract(errorContext);
 
                 var recoverabilityContext = new RecoverabilityContext(
-                    errorContext,
+                    errorContext.Message,
+                    errorContext.Exception,
+                    errorContext.ReceiveAddress,
+                    errorContext.ImmediateProcessingFailures,
+                    errorContext.TransportTransaction,
                     recoverabilityConfig,
                     metadata,
                     recoverabilityAction,

--- a/src/NServiceBus.Core/Recoverability/SatelliteRecoverabilityExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/SatelliteRecoverabilityExecutor.cs
@@ -74,6 +74,7 @@
                 Exception = errorContext.Exception;
                 ReceiveAddress = errorContext.ReceiveAddress;
                 ImmediateProcessingFailures = errorContext.ImmediateProcessingFailures;
+                DelayedDeliveriesPerformed = errorContext.DelayedDeliveriesPerformed;
 
                 Metadata = metadata;
                 CancellationToken = cancellationToken;
@@ -87,6 +88,8 @@
             public string ReceiveAddress { get; }
 
             public int ImmediateProcessingFailures { get; }
+
+            public int DelayedDeliveriesPerformed { get; }
 
             public CancellationToken CancellationToken { get; }
 

--- a/src/NServiceBus.Core/Recoverability/SatelliteRecoverabilityExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/SatelliteRecoverabilityExecutor.cs
@@ -31,10 +31,7 @@
             var metadata = faultMetadataExtractor.Extract(errorContext);
 
             var actionContext = new BehaviorActionContext(
-                errorContext.Message,
-                errorContext.Exception,
-                errorContext.ReceiveAddress,
-                errorContext.ImmediateProcessingFailures,
+                errorContext,
                 metadata,
                 serviceProvider,
                 cancellationToken);
@@ -68,18 +65,15 @@
         class BehaviorActionContext : IRecoverabilityActionContext
         {
             public BehaviorActionContext(
-                IncomingMessage failedMessage,
-                Exception exception,
-                string receiveAddress,
-                int immediateProcessingFailures,
+                ErrorContext errorContext,
                 IReadOnlyDictionary<string, string> metadata,
                 IServiceProvider serviceProvider,
                 CancellationToken cancellationToken)
             {
-                FailedMessage = failedMessage;
-                Exception = exception;
-                ReceiveAddress = receiveAddress;
-                ImmediateProcessingFailures = immediateProcessingFailures;
+                FailedMessage = errorContext.Message;
+                Exception = errorContext.Exception;
+                ReceiveAddress = errorContext.ReceiveAddress;
+                ImmediateProcessingFailures = errorContext.ImmediateProcessingFailures;
 
                 Metadata = metadata;
                 CancellationToken = cancellationToken;

--- a/src/NServiceBus.Testing.Fakes/TestableRecoverabilityContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableRecoverabilityContext.cs
@@ -31,6 +31,11 @@
         public int ImmediateProcessingFailures { get; set; }
 
         /// <summary>
+        /// Number of delayed deliveries performed so far.
+        /// </summary>
+        public int DelayedDeliveriesPerformed { get; set; }
+
+        /// <summary>
         /// Metadata for this message.
         /// </summary>
         IReadOnlyDictionary<string, string> IRecoverabilityActionContext.Metadata => Metadata;

--- a/src/NServiceBus.Testing.Fakes/TestableRecoverabilityContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableRecoverabilityContext.cs
@@ -28,7 +28,7 @@
         /// <summary>
         /// The number of times the message have been retried immediately but failed.
         /// </summary>
-        public int ImmediateProcessingFailures { get; set; } = 0;
+        public int ImmediateProcessingFailures { get; set; }
 
         /// <summary>
         /// Metadata for this message.

--- a/src/NServiceBus.Testing.Fakes/TestableRecoverabilityContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableRecoverabilityContext.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using Extensibility;
     using Pipeline;
     using Transport;
 
@@ -14,15 +13,22 @@
         /// <summary>
         /// The message that failed processing.
         /// </summary>
-        public ErrorContext ErrorContext { get; set; } = new ErrorContext(
-            new Exception(),
-            new Dictionary<string, string>(),
-            Guid.NewGuid().ToString(),
-            ReadOnlyMemory<byte>.Empty,
-            new TransportTransaction(),
-            0,
-            "receive-address",
-            new ContextBag());
+        public IncomingMessage FailedMessage { get; set; } = new IncomingMessage(Guid.NewGuid().ToString(), new Dictionary<string, string>(), ReadOnlyMemory<byte>.Empty);
+
+        /// <summary>
+        /// The exception that caused processing to fail.
+        /// </summary>
+        public Exception Exception { get; set; } = new Exception();
+
+        /// <summary>
+        /// The receive address where this message failed.
+        /// </summary>
+        public string ReceiveAddress { get; set; } = "receive-queue";
+
+        /// <summary>
+        /// The number of times the message have been retried immediately but failed.
+        /// </summary>
+        public int ImmediateProcessingFailures { get; set; } = 0;
 
         /// <summary>
         /// Metadata for this message.


### PR DESCRIPTION
To align the design with the incoming pipeline which doesn't expose the message context