### PR TITLE
Added DeliverAt to message header for auditing and metrics

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netframework.approved.txt
@@ -396,6 +396,7 @@ namespace NServiceBus
         public const string CorrelationId = "NServiceBus.CorrelationId";
         public const string DelayedRetries = "NServiceBus.Retries";
         public const string DelayedRetriesTimestamp = "NServiceBus.Retries.Timestamp";
+        public const string DeliverAt = "NServiceBus.DeliverAt";
         public const string DestinationSites = "NServiceBus.DestinationSites";
         public const string EnclosedMessageTypes = "NServiceBus.EnclosedMessageTypes";
         public const string HasLicenseExpired = "$.diagnostics.license.expired";

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.netstandard.approved.txt
@@ -396,6 +396,7 @@ namespace NServiceBus
         public const string CorrelationId = "NServiceBus.CorrelationId";
         public const string DelayedRetries = "NServiceBus.Retries";
         public const string DelayedRetriesTimestamp = "NServiceBus.Retries.Timestamp";
+        public const string DeliverAt = "NServiceBus.DeliverAt";
         public const string DestinationSites = "NServiceBus.DestinationSites";
         public const string EnclosedMessageTypes = "NServiceBus.EnclosedMessageTypes";
         public const string HasLicenseExpired = "$.diagnostics.license.expired";

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/AttachSenderRelatedInfoOnMessageTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/AttachSenderRelatedInfoOnMessageTests.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using Extensibility;
     using NServiceBus.Routing;
     using NUnit.Framework;
     using Testing;
@@ -55,12 +56,58 @@
             Assert.AreEqual(nsbVersion, message.Headers[Headers.NServiceBusVersion]);
         }
 
-        static async Task<OutgoingMessage> InvokeBehavior(Dictionary<string, string> headers = null)
+        [Test]
+        public async Task Should_set_deliver_At_header_when_delay_delivery_with_setAsync()
+        {
+            var options = new SendOptions();
+            var delayTime = TimeSpan.FromSeconds(2);
+            options.DelayDeliveryWith(delayTime);
+            var message = await InvokeBehavior(null, options);
+            var expectedTime = DateTimeExtensions.ToUtcDateTime(message.Headers[Headers.TimeSent]).Add(delayTime);
+
+            Assert.True(message.Headers.ContainsKey(Headers.DeliverAt));
+            Assert.AreEqual(DateTimeExtensions.ToWireFormattedString(expectedTime), message.Headers[Headers.DeliverAt]);
+        }
+
+        [Test]
+        public async Task Should_set_deliver_At_header_when_do_not_deliver_before_setAsync()
+        {
+            var options = new SendOptions();
+            var doNotDeliverBefore = DateTimeOffset.UtcNow;
+            options.DoNotDeliverBefore(doNotDeliverBefore);
+            var message = await InvokeBehavior(null, options);
+
+            Assert.True(message.Headers.ContainsKey(Headers.DeliverAt));
+            Assert.AreEqual(DateTimeExtensions.ToWireFormattedString(doNotDeliverBefore.UtcDateTime), message.Headers[Headers.DeliverAt]);
+        }
+
+        [Test]
+        public async Task Should_not_override_deliver_at_headerAsync()
+        {
+            var options = new SendOptions();
+            var doNotDeliverBefore = DateTimeOffset.UtcNow;
+            options.DelayDeliveryWith(TimeSpan.FromSeconds(2));
+            var message = await InvokeBehavior(new Dictionary<string, string>
+            {
+                {Headers.DeliverAt, DateTimeExtensions.ToWireFormattedString(doNotDeliverBefore.UtcDateTime)}
+            }, options);
+
+            Assert.True(message.Headers.ContainsKey(Headers.DeliverAt));
+            Assert.AreEqual(DateTimeExtensions.ToWireFormattedString(doNotDeliverBefore.UtcDateTime), message.Headers[Headers.DeliverAt]);
+        }
+
+        static async Task<OutgoingMessage> InvokeBehavior(Dictionary<string, string> headers = null, SendOptions options = null)
         {
             var message = new OutgoingMessage("id", headers ?? new Dictionary<string, string>(), null);
+            var stash = new ContextBag();
+
+            if (options != null)
+            {
+                stash.Set(options);
+            }
 
             await new AttachSenderRelatedInfoOnMessageBehavior()
-                .Invoke(new TestableRoutingContext { Message = message, RoutingStrategies = new List<UnicastRoutingStrategy> { new UnicastRoutingStrategy("_") } }, _ => TaskEx.CompletedTask);
+                .Invoke(new TestableRoutingContext { Message = message, Extensions = stash, RoutingStrategies = new List<UnicastRoutingStrategy> { new UnicastRoutingStrategy("_") } }, _ => TaskEx.CompletedTask);
 
             return message;
         }

--- a/src/NServiceBus.Core/Headers.cs
+++ b/src/NServiceBus.Core/Headers.cs
@@ -121,6 +121,11 @@
         public const string TimeSent = "NServiceBus.TimeSent";
 
         /// <summary>
+        /// The time this message should be delivered to the endpoint to start processing.
+        /// </summary>
+        public const string DeliverAt = "NServiceBus.DeliverAt";
+
+        /// <summary>
         /// Id of the message that caused this message to be sent.
         /// </summary>
         public const string RelatedTo = "NServiceBus.RelatedTo";

--- a/src/NServiceBus.Core/Pipeline/Outgoing/AttachSenderRelatedInfoOnMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/AttachSenderRelatedInfoOnMessageBehavior.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
+    using DelayedDelivery;
     using Pipeline;
 
     class AttachSenderRelatedInfoOnMessageBehavior : IBehavior<IRoutingContext, IRoutingContext>
@@ -9,6 +10,10 @@ namespace NServiceBus
         public Task Invoke(IRoutingContext context, Func<IRoutingContext, Task> next)
         {
             var message = context.Message;
+            var utcNow = DateTime.UtcNow;
+
+            // This behavior executes in the case of auditing as well, so assuming there are no delayed delivery constraints set,
+            // no existing header should be overwritten, otherwise the message being audited would be modified improperly.
 
             if (!message.Headers.ContainsKey(Headers.NServiceBusVersion))
             {
@@ -17,7 +22,24 @@ namespace NServiceBus
 
             if (!message.Headers.ContainsKey(Headers.TimeSent))
             {
-                message.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(DateTime.UtcNow);
+                message.Headers[Headers.TimeSent] = DateTimeExtensions.ToWireFormattedString(utcNow);
+            }
+
+            if (!message.Headers.ContainsKey(Headers.DeliverAt))
+            {
+                if (context.Extensions.TryGet<SendOptions>(out var options))
+                {
+                    if (options.DelayedDeliveryConstraint is DelayDeliveryWith delayDeliveryWith)
+                    {
+                        var timeDelay = delayDeliveryWith.Delay;
+                        message.Headers[Headers.DeliverAt] = DateTimeExtensions.ToWireFormattedString(utcNow.Add(timeDelay));
+                    }
+                    else if (options.DelayedDeliveryConstraint is DoNotDeliverBefore doNotDeliverBefore)
+                    {
+                        var deliverAt = doNotDeliverBefore.At;
+                        message.Headers[Headers.DeliverAt] = DateTimeExtensions.ToWireFormattedString(deliverAt);
+                    }
+                }
             }
             return next(context);
         }


### PR DESCRIPTION
This is related to #5893

Currently, critical time in NServiceBus.Metrics and ServiceControl is being calculated based on the `TimeSent` header in a message.  However, this does not take into account that there could be a delayed delivery set for a message, which can cause the critical time that is displayed in ServicePulse to appear inaccurate especially for messages that could be set far into the future.  Critical time should be measured as the time between when a message should be delivered to an endpoint and when the message is finished processing.

This PR adds `DeliverAt` to the header of a message.  The `DeliverAt` value is calculated by either taking the `TimeSent` value and adding the `DelayDeliveryWith` time span or setting `DeliverAt` to the value of `DoNotDeliverBefore` DateTimeOffset.