### PR TITLE
Fixed how the DeliverAt header is assigned

### DIFF
--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/AttachSenderRelatedInfoOnMessageTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/AttachSenderRelatedInfoOnMessageTests.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using DeliveryConstraints;
     using Extensibility;
     using NServiceBus.Routing;
     using NUnit.Framework;
@@ -103,7 +104,7 @@
 
             if (options != null)
             {
-                stash.Set(options);
+                stash.AddDeliveryConstraint(options.DelayedDeliveryConstraint);
             }
 
             await new AttachSenderRelatedInfoOnMessageBehavior()

--- a/src/NServiceBus.Core/Pipeline/Outgoing/AttachSenderRelatedInfoOnMessageBehavior.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/AttachSenderRelatedInfoOnMessageBehavior.cs
@@ -3,6 +3,7 @@ namespace NServiceBus
     using System;
     using System.Threading.Tasks;
     using DelayedDelivery;
+    using NServiceBus.DeliveryConstraints;
     using Pipeline;
 
     class AttachSenderRelatedInfoOnMessageBehavior : IBehavior<IRoutingContext, IRoutingContext>
@@ -27,14 +28,14 @@ namespace NServiceBus
 
             if (!message.Headers.ContainsKey(Headers.DeliverAt))
             {
-                if (context.Extensions.TryGet<SendOptions>(out var options))
+                if (context.Extensions.TryGetDeliveryConstraint<DelayedDeliveryConstraint>(out var delayedDeliveryConstraint))
                 {
-                    if (options.DelayedDeliveryConstraint is DelayDeliveryWith delayDeliveryWith)
+                    if (delayedDeliveryConstraint is DelayDeliveryWith delayDeliveryWith)
                     {
                         var timeDelay = delayDeliveryWith.Delay;
                         message.Headers[Headers.DeliverAt] = DateTimeExtensions.ToWireFormattedString(utcNow.Add(timeDelay));
                     }
-                    else if (options.DelayedDeliveryConstraint is DoNotDeliverBefore doNotDeliverBefore)
+                    else if (delayedDeliveryConstraint is DoNotDeliverBefore doNotDeliverBefore)
                     {
                         var deliverAt = doNotDeliverBefore.At;
                         message.Headers[Headers.DeliverAt] = DateTimeExtensions.ToWireFormattedString(deliverAt);


### PR DESCRIPTION
Since `DelayedDeliveryConstraint` cannot be directly added to the `SendOptions` `contextBag`, in order to assign the `DeliverAt` header the `TryGetDeliveryConstraint` method needs to be used.