### PR TITLE
Reset session timeout after test

### DIFF
--- a/src/NServiceBus.PersistenceTests/Sagas/When_concurrent_update_exceed_lock_request_timeout_pessimistic.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_concurrent_update_exceed_lock_request_timeout_pessimistic.cs
@@ -6,14 +6,26 @@
 
     public class When_concurrent_update_exceed_lock_request_timeout_pessimistic : SagaPersisterTests
     {
+        bool resetSessionTimeout;
+
         public override async Task OneTimeSetUp()
         {
             if (!param.SessionTimeout.HasValue)
             {
+                resetSessionTimeout = true;
                 param.SessionTimeout = TimeSpan.FromMilliseconds(500);
             }
             configuration = new PersistenceTestsConfiguration(param);
             await configuration.Configure();
+        }
+
+        public override async Task OneTimeTearDown()
+        {
+            if (resetSessionTimeout)
+            {
+                param.SessionTimeout = null;
+            }
+            await base.OneTimeTearDown();
         }
 
         [Test]


### PR DESCRIPTION
This test sets the Session Timeout to 500ms but because the underlying test infrastructure is static and shared across all tests it changes it for all tests that run afterwards. This change resets the value back to null after the test.

NOTE: This solves it for one test but it's easy for any test to cause the same issue. [This alternative PR](https://github.com/Particular/NServiceBus/pull/6303) solves it for all tests by cloning the test parameters for each test.