### PR TITLE
Deep copy test parameters

### DIFF
--- a/src/NServiceBus.PersistenceTests/NServiceBus.PersistenceTests.csproj
+++ b/src/NServiceBus.PersistenceTests/NServiceBus.PersistenceTests.csproj
@@ -32,6 +32,7 @@
   <ItemGroup>
     <AddSourceFileToPackage Include="..\NServiceBus.Core\IdGeneration\CombGuid.cs" />
     <AddSourceFileToPackage Include="..\NServiceBus.Core\Sagas\DefaultSagaIdGenerator.cs" />
+    <AddSourceFileToPackage Include="..\NServiceBus.Core\DeepCopy.cs" />
     <RemoveSourceFileFromPackage Include="PersistenceTestsConfiguration.cs" />
   </ItemGroup>
 

--- a/src/NServiceBus.PersistenceTests/Outbox/OutboxStorageTests.cs
+++ b/src/NServiceBus.PersistenceTests/Outbox/OutboxStorageTests.cs
@@ -10,7 +10,7 @@
     {
         public OutboxStorageTests(TestVariant param)
         {
-            this.param = param;
+            this.param = ObjectExtensions.DeepCopy(param);
         }
 
         [OneTimeSetUp]

--- a/src/NServiceBus.PersistenceTests/Outbox/OutboxStorageTests.cs
+++ b/src/NServiceBus.PersistenceTests/Outbox/OutboxStorageTests.cs
@@ -10,7 +10,7 @@
     {
         public OutboxStorageTests(TestVariant param)
         {
-            this.param = ObjectExtensions.DeepCopy(param);
+            this.param = param.DeepCopy();
         }
 
         [OneTimeSetUp]

--- a/src/NServiceBus.PersistenceTests/Sagas/SagaPersisterTests.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/SagaPersisterTests.cs
@@ -13,7 +13,7 @@
     {
         public SagaPersisterTests(TestVariant param)
         {
-            this.param = ObjectExtensions.DeepCopy(param);
+            this.param = param.DeepCopy();
         }
 
         [OneTimeSetUp]

--- a/src/NServiceBus.PersistenceTests/Sagas/SagaPersisterTests.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/SagaPersisterTests.cs
@@ -13,7 +13,7 @@
     {
         public SagaPersisterTests(TestVariant param)
         {
-            this.param = param;
+            this.param = ObjectExtensions.DeepCopy(param);
         }
 
         [OneTimeSetUp]


### PR DESCRIPTION
This is an alternative fix to #6302

By deep copying the test parameters we ensure that tests can't interfere with each other.