### PR TITLE
Use native TransactionManager.MaxTimeout API

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <Reference Include="System.Transactions" />
-    <Reference Include="System.Configuration" />
     <Reference Include="System.Security" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
   </ItemGroup>

--- a/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWork.cs
+++ b/src/NServiceBus.Core/UnitOfWork/TransactionScopes/TransactionScopeUnitOfWork.cs
@@ -25,12 +25,9 @@
                 var isolationLevel = IsolationLevel.ReadCommitted;
                 if (requestedTimeout.HasValue)
                 {
-                    var maxTimeout = GetMaxTimeout();
-
-                    if (requestedTimeout.Value > maxTimeout)
+                    if (requestedTimeout.Value > TransactionManager.MaximumTimeout)
                     {
-                        throw new Exception(
-                            "Timeout requested is longer than the maximum value for this machine. Override using the maxTimeout setting of the system.transactions section in machine.config");
+                        throw new Exception("Timeout requested is longer than the maximum value for this machine. Override using the maxTimeout setting of the system.transactions section in machine.config");
                     }
 
                     timeout = requestedTimeout.Value;
@@ -49,23 +46,6 @@
             }
 
             public TransactionOptions TransactionOptions { get; }
-
-            static TimeSpan GetMaxTimeout()
-            {
-                //default is always 10 minutes
-                var maxTimeout = TimeSpan.FromMinutes(10);
-#if NETFRAMEWORK
-                var systemTransactionsGroup = System.Configuration.ConfigurationManager.OpenMachineConfiguration()
-                    .GetSectionGroup("system.transactions");
-
-                if (systemTransactionsGroup?.Sections.Get("machineSettings") is System.Transactions.Configuration.MachineSettingsSection machineSettings)
-                {
-                    maxTimeout = machineSettings.MaxTimeout;
-                }
-#endif
-
-                return maxTimeout;
-            }
         }
     }
 }


### PR DESCRIPTION
After [refactoring to use the native API for the MSMQ transport](https://github.com/Particular/NServiceBus.Transport.Msmq/pull/381) I discovered that Core has the same code.