### PR TITLE
Minor cleanup

### DIFF
--- a/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
@@ -38,7 +38,7 @@
             }
 
             //note: in the future we should change the persister api to give us a "outbox factory" so that we can register it in DI here instead of relying on the persister to do it
-            context.Pipeline.Register("ForceBatchDispatchToBeIsolated", new ForceBatchDispatchToBeIsolatedBehavior(), "Makes sure that we dispatch straight to the transport so that we can safely set the outbox record to dispatched one the dispatch pipeline returns.");
+            context.Pipeline.Register("ForceBatchDispatchToBeIsolated", new ForceBatchDispatchToBeIsolatedBehavior(), "Makes sure that we dispatch straight to the transport so that we can safely set the outbox record to dispatched once the dispatch pipeline returns.");
         }
         internal const string TimeToKeepDeduplicationEntries = "Outbox.TimeToKeepDeduplicationEntries";
     }


### PR DESCRIPTION
Some test cleanup to remove an unused behavior and put the `RetryId` on the test context so it can be inspected and compared if the test fails.