### PR TITLE
Clarify what we want user to do on missing await

### DIFF
--- a/src/NServiceBus.Core.Analyzer/AwaitOrCaptureTasksAnalyzer.cs
+++ b/src/NServiceBus.Core.Analyzer/AwaitOrCaptureTasksAnalyzer.cs
@@ -59,8 +59,8 @@ namespace NServiceBus.Core.Analyzer
 
         static readonly DiagnosticDescriptor diagnostic = new DiagnosticDescriptor(
             DiagnosticId,
-            "Await or assign Task",
-            "A Task returned by an NServiceBus method is not awaited or assigned to a variable.",
+            "Await Task",
+            "A Task returned by an async NServiceBus method is not awaited.",
             "NServiceBus.Code",
             DiagnosticSeverity.Error,
             true,


### PR DESCRIPTION
Have seen reports of some users just assigning tasks to variables and then not doing anything else with those variables, because that's what the message currently suggests and that's the easiest way (at least in their minds at the time) to get rid of the diagnostic. This makes the primary message drive right to the heart of what needs to be done: whether or not you assign the task to a variable first, **the task needs to be awaited**.

The more nuanced version continues to exist in the diagnostic description - you might need to expand the diff view down a bit to see it.