### PR TITLE
Removing the wildcard from the analyzer reference some builds will generate multiple netstandard folders which then leads to NU5118

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -44,7 +44,7 @@
 
   <ItemGroup>
     <None Include="..\..\packaging\nuget\tools\init.ps1" Pack="true" PackagePath="tools" Visible="false" />
-    <None Include="..\NServiceBus.Core.Analyzer\bin\$(Configuration)\**\NServiceBus.Core.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/cs/NServiceBus.Core.Analyzer.dll" Link="NServiceBus.Core.Analyzer.dll" Visible="false" />
+    <None Include="..\NServiceBus.Core.Analyzer\bin\$(Configuration)\netstandard2.0\NServiceBus.Core.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/cs/NServiceBus.Core.Analyzer.dll" Link="NServiceBus.Core.Analyzer.dll" Visible="false" />
   </ItemGroup>
 
   <Target Name="AddPropsFileToPackage">


### PR DESCRIPTION
This switches the analyzer reference to be no longer a wildcard but directly referencing the output in the netstandard2.0 folder. When you switch between branches without doing a `git clean -xdf` the output folder may contain for example `netstandard1.1` as well as `netstandard2.0` and then if the `netstandard1.1` is picked up by the wild card first the `netstandard2.0` version cannot be added to the package because it already contains the analyzer which then leads to NU5118 build failures.