### PR TITLE
Add AnalyzerTargetFramework property

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -1,0 +1,7 @@
+<Project>
+
+  <PropertyGroup>
+    <AnalyzerTargetFramework>netstandard2.0</AnalyzerTargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/NServiceBus.Core.Analyzer/NServiceBus.Core.Analyzer.csproj
+++ b/src/NServiceBus.Core.Analyzer/NServiceBus.Core.Analyzer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>$(AnalyzerTargetFramework)</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
     <IsPackable>false</IsPackable>

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -45,7 +45,7 @@
 
   <ItemGroup>
     <None Include="..\..\packaging\nuget\tools\init.ps1" Pack="true" PackagePath="tools" Visible="false" />
-    <None Include="..\NServiceBus.Core.Analyzer\bin\$(Configuration)\**\NServiceBus.Core.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/cs/NServiceBus.Core.Analyzer.dll" Link="NServiceBus.Core.Analyzer.dll" Visible="false" />
+    <None Include="..\NServiceBus.Core.Analyzer\bin\$(Configuration)\$(AnalyzerTargetFramework)\NServiceBus.Core.Analyzer.dll" Pack="true" PackagePath="analyzers/dotnet/cs/NServiceBus.Core.Analyzer.dll" Link="NServiceBus.Core.Analyzer.dll" Visible="false" />
   </ItemGroup>
 
   <Target Name="AddPropsFileToPackage">

--- a/src/NServiceBus.sln
+++ b/src/NServiceBus.sln
@@ -25,6 +25,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.TransportTests"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E3BC3CE8-9EA6-41BE-89AD-23876257B740}"
 	ProjectSection(SolutionItems) = preProject
+		Custom.Build.props = Custom.Build.props
 		Directory.Build.props = Directory.Build.props
 		..\GitVersion.yml = ..\GitVersion.yml
 	EndProjectSection
@@ -39,7 +40,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.PersistenceTest
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Learning.AcceptanceTests", "NServiceBus.Learning.AcceptanceTests\NServiceBus.Learning.AcceptanceTests.csproj", "{360438BD-AEDE-48AC-BE75-FBB6BF2F004D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Core.Analyzer.Tests.Roslyn4", "NServiceBus.Core.Analyzer.Tests.Roslyn4\NServiceBus.Core.Analyzer.Tests.Roslyn4.csproj", "{71330321-DA6D-4199-89C4-FB36F92E77C2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Core.Analyzer.Tests.Roslyn4", "NServiceBus.Core.Analyzer.Tests.Roslyn4\NServiceBus.Core.Analyzer.Tests.Roslyn4.csproj", "{71330321-DA6D-4199-89C4-FB36F92E77C2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
This adds an `AnalyzerTargetFramework` property that can be used in both projects that need to sync the TFM used to get the analyzer assembly in the package.

