### PR TITLE
Make test output quieter by default

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -46,7 +46,7 @@ namespace NServiceBus.AcceptanceTesting
 
             await runDescriptor.RaiseOnTestCompleted(runSummary).ConfigureAwait(false);
 
-            TestContext.WriteLine("Test {0}: Scenario completed in {2:0.0}s", TestContext.CurrentContext.Test.FullName, sw.Elapsed.TotalSeconds);
+            TestContext.WriteLine("Test {0}: Scenario completed in {1:0.0}s", TestContext.CurrentContext.Test.FullName, sw.Elapsed.TotalSeconds);
 
             if (runSummary.Result.Failed || ScenarioRunner.VerboseLogging)
             {

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -46,8 +46,11 @@ namespace NServiceBus.AcceptanceTesting
 
             await runDescriptor.RaiseOnTestCompleted(runSummary).ConfigureAwait(false);
 
-            DisplayRunResult(runSummary);
-            TestContext.WriteLine("Total time for testrun: {0}", sw.Elapsed);
+            TestContext.WriteLine("Test {0}: {1} in: {1:0.0}s", TestContext.CurrentContext.Test.FullName, TestContext.CurrentContext.Result, sw.Elapsed.TotalSeconds);
+            if (runSummary.Result.Failed || ScenarioRunner.VerboseLogging)
+            {
+                DisplayRunResult(runSummary);
+            }
 
             if (runSummary.Result.Failed)
             {

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -46,8 +46,8 @@ namespace NServiceBus.AcceptanceTesting
 
             await runDescriptor.RaiseOnTestCompleted(runSummary).ConfigureAwait(false);
 
-            var statusLabel = runSummary.Result.Failed ? "Failed" : "Passed";
-            TestContext.WriteLine("Test {0}: {1} in: {2:0.0}s", TestContext.CurrentContext.Test.FullName, statusLabel, sw.Elapsed.TotalSeconds);
+            TestContext.WriteLine("Test {0}: Scenario completed in {2:0.0}s", TestContext.CurrentContext.Test.FullName, sw.Elapsed.TotalSeconds);
+
             if (runSummary.Result.Failed || ScenarioRunner.VerboseLogging)
             {
                 DisplayRunResult(runSummary);

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -46,7 +46,8 @@ namespace NServiceBus.AcceptanceTesting
 
             await runDescriptor.RaiseOnTestCompleted(runSummary).ConfigureAwait(false);
 
-            TestContext.WriteLine("Test {0}: {1} in: {1:0.0}s", TestContext.CurrentContext.Test.FullName, TestContext.CurrentContext.Result, sw.Elapsed.TotalSeconds);
+            var statusLabel = runSummary.Result.Failed ? "Failed" : "Passed";
+            TestContext.WriteLine("Test {0}: {1} in: {2:0.0}s", TestContext.CurrentContext.Test.FullName, statusLabel, sw.Elapsed.TotalSeconds);
             if (runSummary.Result.Failed || ScenarioRunner.VerboseLogging)
             {
                 DisplayRunResult(runSummary);

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -210,7 +210,8 @@
             }
         }
 
-        internal static readonly bool VerboseLogging = Environment.GetEnvironmentVariable("VERBOSE_TEST_LOGGING")?.ToLower() == "true";
+        internal static readonly bool VerboseLogging = Environment.GetEnvironmentVariable("CI") != "true"
+            || Environment.GetEnvironmentVariable("VERBOSE_TEST_LOGGING")?.ToLower() == "true";
     }
 
     public class RunResult

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -16,12 +16,18 @@
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Code", "PS0023:Use DateTime.UtcNow or DateTimeOffset.UtcNow", Justification = "Test logging")]
         public static async Task<RunSummary> Run(RunDescriptor runDescriptor, List<IComponentBehavior> behaviorDescriptors, Func<ScenarioContext, Task<bool>> done)
         {
-            TestContext.WriteLine("current context: " + runDescriptor.ScenarioContext.GetType().FullName);
-            TestContext.WriteLine("Started test @ {0}", DateTime.Now.ToString(CultureInfo.InvariantCulture));
+            if (VerboseLogging)
+            {
+                TestContext.WriteLine("current context: " + runDescriptor.ScenarioContext.GetType().FullName);
+                TestContext.WriteLine("Started test @ {0}", DateTime.Now.ToString(CultureInfo.InvariantCulture));
+            }
 
             var runResult = await PerformTestRun(behaviorDescriptors, runDescriptor, done).ConfigureAwait(false);
 
-            TestContext.WriteLine("Finished test @ {0}", DateTime.Now.ToString(CultureInfo.InvariantCulture));
+            if (VerboseLogging)
+            {
+                TestContext.WriteLine("Finished test @ {0}", DateTime.Now.ToString(CultureInfo.InvariantCulture));
+            }
 
             return new RunSummary
             {
@@ -167,13 +173,19 @@
             return endpoints.Select(async endpoint =>
             {
                 await Task.Yield(); // ensure all endpoints are stopped even if a synchronous implementation throws
-                TestContext.WriteLine("Stopping endpoint: {0}", endpoint.Name);
+                if (VerboseLogging)
+                {
+                    TestContext.WriteLine("Stopping endpoint: {0}", endpoint.Name);
+                }
                 var stopwatch = Stopwatch.StartNew();
                 try
                 {
                     await endpoint.Stop().ConfigureAwait(false);
                     stopwatch.Stop();
-                    TestContext.WriteLine("Endpoint: {0} stopped ({1}s)", endpoint.Name, stopwatch.Elapsed);
+                    if (VerboseLogging)
+                    {
+                        TestContext.WriteLine("Endpoint: {0} stopped ({1}s)", endpoint.Name, stopwatch.Elapsed);
+                    }
                 }
                 catch (Exception)
                 {
@@ -197,6 +209,8 @@
                 throw;
             }
         }
+
+        internal static readonly bool VerboseLogging = Environment.GetEnvironmentVariable("VERBOSE_TEST_LOGGING")?.ToLower() == "true";
     }
 
     public class RunResult

--- a/src/NServiceBus.Core.Analyzer.Tests.Common/ForwardCancellationToken/ForwardFromPipelineTests.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Common/ForwardCancellationToken/ForwardFromPipelineTests.cs
@@ -107,9 +107,6 @@ public class TestTimeout {}";
                 code = code.Replace("public Task", "public override Task");
             }
 
-            TestContext.WriteLine($"Source Code for test case: {type.FullName}:");
-            TestContext.WriteLine(code);
-
             return Assert(ForwardCancellationTokenAnalyzer.DiagnosticId, code);
         }
 

--- a/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/AnalyzerTestFixture.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/AnalyzerTestFixture.cs
@@ -61,6 +61,11 @@
 
         protected static async Task WriteCode(Project project)
         {
+            if (!VerboseLogging)
+            {
+                return;
+            }
+
             foreach (var document in project.Documents)
             {
                 Console.WriteLine(document.Name);
@@ -116,6 +121,11 @@
 
         protected static void WriteCompilerDiagnostics(IEnumerable<Diagnostic> diagnostics)
         {
+            if (VerboseLogging)
+            {
+                return;
+            }
+
             Console.WriteLine("Compiler diagnostics:");
 
             foreach (var diagnostic in diagnostics)
@@ -126,6 +136,11 @@
 
         protected static void WriteAnalyzerDiagnostics(IEnumerable<Diagnostic> diagnostics)
         {
+            if (VerboseLogging)
+            {
+                return;
+            }
+
             Console.WriteLine("Analyzer diagnostics:");
 
             foreach (var diagnostic in diagnostics)
@@ -191,5 +206,8 @@
 
             return (documents, markupSpans);
         }
+
+        protected static readonly bool VerboseLogging = Environment.GetEnvironmentVariable("CI") != "true"
+            || Environment.GetEnvironmentVariable("VERBOSE_TEST_LOGGING")?.ToLower() == "true";
     }
 }

--- a/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/AnalyzerTestFixture.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/AnalyzerTestFixture.cs
@@ -121,7 +121,7 @@
 
         protected static void WriteCompilerDiagnostics(IEnumerable<Diagnostic> diagnostics)
         {
-            if (VerboseLogging)
+            if (!VerboseLogging)
             {
                 return;
             }
@@ -136,7 +136,7 @@
 
         protected static void WriteAnalyzerDiagnostics(IEnumerable<Diagnostic> diagnostics)
         {
-            if (VerboseLogging)
+            if (!VerboseLogging)
             {
                 return;
             }

--- a/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/CodeFixTestFixture.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/CodeFixTestFixture.cs
@@ -68,7 +68,7 @@
                 return codeFiles;
             }
 
-            if (VerboseLogging)
+            if (!VerboseLogging)
             {
                 Console.WriteLine("Applying code fix actions...");
             }

--- a/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/CodeFixTestFixture.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/CodeFixTestFixture.cs
@@ -68,7 +68,7 @@
                 return codeFiles;
             }
 
-            if (!VerboseLogging)
+            if (VerboseLogging)
             {
                 Console.WriteLine("Applying code fix actions...");
             }

--- a/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/CodeFixTestFixture.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/CodeFixTestFixture.cs
@@ -68,7 +68,10 @@
                 return codeFiles;
             }
 
-            Console.WriteLine("Applying code fix actions...");
+            if (VerboseLogging)
+            {
+                Console.WriteLine("Applying code fix actions...");
+            }
 
             var projectDocuments = project.Documents.ToArray();
 


### PR DESCRIPTION
If `env:CI != "true"` (i.e. local development) then nothing really changes.

If `env:CI == "true"` then by default the test output will be much quieter, because:

* Do not output a lot of gunk for acceptance tests unless `runSummary.Result.Failed` is true. Which is a bit weird, because that means the **scenario** failed, not that the test failed. But it is what it is.
  * This will also help out with too much verbosity in other repos that use AcceptanceTesting framework.
* Analyzer tests will not pump out source code and diagnostic information.

If `env:VERBOSE_TEST_LOGGING == "true"` then it will be just as noisy as before. It would be possible to add a parameter to [run-tests-action](https://github.com/Particular/run-tests-action) to easily support this.

Results before and after change on the Windows/Linux "Run tests" step. (Keep in mind Windows has an extra `net472` framework to deal with:

* [Build without changes (control)](https://github.com/Particular/NServiceBus/actions/runs/2041046147)
  * Windows: Truncated at 104,148 lines
  * Linux: Truncated at 100,029 lines
* [Build with changes (this PR)](https://github.com/Particular/NServiceBus/actions/runs/2055036388)
  * Windows: 39,268 lines
  * Linux: 23,702 lines

The difference in how quickly the log lines populate in the log viewer is _**stark**_.