### PR TITLE
Message operation context

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_setting_operation_state_in_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_setting_operation_state_in_pipeline.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests.Core.Routing
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
@@ -33,16 +34,16 @@
 
             Assert.AreEqual(2, context.ExistingSettingValues.Count);
             Assert.IsTrue(context.ExistingSettingValues.All(x => x));
-            Assert.IsTrue(context.NewSettingValues.Any(x => x.HasValue));
+            Assert.IsFalse(context.NewSettingValues.Any(x => x.HasValue));
         }
 
         public class Context : ScenarioContext
         {
             public volatile int MessagesReceived;
 
-            public List<bool> ExistingSettingValues { get; } = new List<bool>();
+            public ConcurrentBag<bool> ExistingSettingValues { get; } = new ConcurrentBag<bool>();
 
-            public List<bool?> NewSettingValues { get; } = new List<bool?>();
+            public ConcurrentBag<bool?> NewSettingValues { get; } = new ConcurrentBag<bool?>();
         }
 
         public class SenderReusingSendOptions : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_setting_operation_state_in_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_setting_operation_state_in_pipeline.cs
@@ -47,7 +47,10 @@
         public class SenderReusingSendOptions : EndpointConfigurationBuilder
         {
             public SenderReusingSendOptions() => EndpointSetup<DefaultServer>((c, r) =>
-                c.Pipeline.Register(new OperationContextModifyingBehavior((Context)r.ScenarioContext), "modifies message operations context values"));
+            {
+                c.Pipeline.Register(new OperationContextModifyingBehavior((Context)r.ScenarioContext), "modifies message operations context values");
+                c.LimitMessageProcessingConcurrencyTo(1);
+            });
 
             public class SimeMessageHandler : IHandleMessages<SimpleMessage>
             {

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_setting_operation_state_in_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_setting_operation_state_in_pipeline.cs
@@ -1,0 +1,91 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Routing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using Extensibility;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    public class When_setting_operation_state_in_pipeline : NServiceBusAcceptanceTest
+    {
+        const string ExistingSettingKey = "NSB.Testing.ExistingSettingKey";
+        const string NewSettingKey = "NSB.Testing.NewSettingKey";
+
+        [Test]
+        public async Task Should_not_leak_up_to_sendoptions()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SenderReusingSendOptions>(c => c.When(async s =>
+                {
+                    var sendOptions = new SendOptions();
+                    sendOptions.RouteToThisEndpoint();
+                    sendOptions.GetMessageOperationExtensions().Set(ExistingSettingKey, true);
+                    await s.Send(new SimpleMessage(), sendOptions);
+                    await s.Send(new SimpleMessage(), sendOptions);
+                }))
+                .Done(c => c.MessagesReceived == 2)
+                .Run();
+
+            Assert.AreEqual(2, context.ExistingSettingValues.Count);
+            Assert.IsTrue(context.ExistingSettingValues.All(x => x));
+            Assert.IsTrue(context.NewSettingValues.Any(x => x.HasValue));
+        }
+
+        public class Context : ScenarioContext
+        {
+            public int MessagesReceived { get; set; }
+
+            public List<bool> ExistingSettingValues { get; } = new List<bool>();
+
+            public List<bool?> NewSettingValues { get; } = new List<bool?>();
+        }
+
+        public class SenderReusingSendOptions : EndpointConfigurationBuilder
+        {
+            public SenderReusingSendOptions() => EndpointSetup<DefaultServer>((c, r) =>
+                c.Pipeline.Register(new OperationContextModifyingBehavior((Context)r.ScenarioContext), "modifies message operations context values"));
+
+            public class SimeMessageHandler : IHandleMessages<SimpleMessage>
+            {
+                Context testContext;
+
+                public SimeMessageHandler(Context testContext) => this.testContext = testContext;
+
+                public Task Handle(SimpleMessage message, IMessageHandlerContext context)
+                {
+                    testContext.MessagesReceived++;
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class OperationContextModifyingBehavior : Behavior<IOutgoingLogicalMessageContext>
+            {
+                Context testContext;
+
+                public OperationContextModifyingBehavior(Context testContext) => this.testContext = testContext;
+
+                public override Task Invoke(IOutgoingLogicalMessageContext context, Func<Task> next)
+                {
+                    ContextBag messageOperationContext = context.GetMessageOperationExtensions();
+
+                    testContext.ExistingSettingValues.Add(messageOperationContext.Get<bool>(ExistingSettingKey)); // should exist and set to true
+                    messageOperationContext.Set(ExistingSettingKey, false);
+
+                    messageOperationContext.TryGet(NewSettingKey, out bool? value); // should not exist
+                    testContext.NewSettingValues.Add(value);
+                    messageOperationContext.Set(NewSettingKey, true);
+
+                    return next();
+                }
+            }
+        }
+
+        public class SimpleMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
+++ b/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
+    using Extensibility;
     using Pipeline;
     using Transport;
 
@@ -38,7 +39,7 @@ namespace NServiceBus
             var hasIncomingMessageConversationId = incomingMessage != null && incomingMessage.Headers.TryGetValue(Headers.ConversationId, out conversationIdFromCurrentMessageContext);
             var hasUserDefinedConversationId = context.Headers.TryGetValue(Headers.ConversationId, out var userDefinedConversationId);
 
-            if (context.Extensions.TryGet<string>(NewConversationId, out var newConversationId))
+            if (context.GetMessageOperationExtensions().TryGet<string>(NewConversationId, out var newConversationId))
             {
                 if (hasUserDefinedConversationId)
                 {

--- a/src/NServiceBus.Core/Causation/ConversationRoutingExtensions.cs
+++ b/src/NServiceBus.Core/Causation/ConversationRoutingExtensions.cs
@@ -12,7 +12,7 @@
         /// <param name="conversationId">The id for the new conversation. If not provided, an id will be generated.</param>
         public static void StartNewConversation(this SendOptions sendOptions, string conversationId = null)
         {
-            sendOptions.Context.Set(AttachCausationHeadersBehavior.NewConversationId, conversationId);
+            sendOptions.MessageOperationContext.Set(AttachCausationHeadersBehavior.NewConversationId, conversationId);
         }
     }
 }

--- a/src/NServiceBus.Core/Extensibility/ExtendableOptions.cs
+++ b/src/NServiceBus.Core/Extensibility/ExtendableOptions.cs
@@ -15,11 +15,15 @@ namespace NServiceBus.Extensibility
         /// </summary>
         protected ExtendableOptions()
         {
+            MessageOperationContext = new ContextBag();
             Context = new ContextBag();
+            Context.Set("MessageOperationContext", MessageOperationContext);
             OutgoingHeaders = new Dictionary<string, string>();
         }
 
         internal ContextBag Context { get; }
+
+        internal ContextBag MessageOperationContext { get; }
 
         internal string UserDefinedMessageId { get; set; }
 

--- a/src/NServiceBus.Core/Extensibility/ExtendableOptionsExtensions.cs
+++ b/src/NServiceBus.Core/Extensibility/ExtendableOptionsExtensions.cs
@@ -27,7 +27,10 @@ namespace NServiceBus.Extensibility
             return options.MessageOperationContext;
         }
 
-        internal static ContextBag GetMessageOperationExtensions(this IBehaviorContext behaviorContext)
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public static ContextBag GetMessageOperationExtensions(this IBehaviorContext behaviorContext)
         {
             if (!behaviorContext.Extensions.TryGet("MessageOperationContext", out ContextBag context))
             {

--- a/src/NServiceBus.Core/Extensibility/ExtendableOptionsExtensions.cs
+++ b/src/NServiceBus.Core/Extensibility/ExtendableOptionsExtensions.cs
@@ -1,5 +1,7 @@
 namespace NServiceBus.Extensibility
 {
+    using Pipeline;
+
     /// <summary>
     /// Provides hidden access to the extension context.
     /// </summary>
@@ -14,6 +16,26 @@ namespace NServiceBus.Extensibility
         {
             Guard.AgainstNull(nameof(options), options);
             return options.Context;
+        }
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public static ContextBag GetMessageOperationExtensions(this ExtendableOptions options)
+        {
+            Guard.AgainstNull(nameof(options), options);
+            return options.MessageOperationContext;
+        }
+
+        internal static ContextBag GetMessageOperationExtensions(this IBehaviorContext behaviorContext)
+        {
+            if (!behaviorContext.Extensions.TryGet("MessageOperationContext", out ContextBag context))
+            {
+                context = new ContextBag();
+                behaviorContext.Extensions.Set("MessageOperationContext", context);
+            }
+
+            return context;
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/ImmediateDispatchOptionExtensions.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/ImmediateDispatchOptionExtensions.cs
@@ -17,7 +17,7 @@ namespace NServiceBus
         {
             Guard.AgainstNull(nameof(options), options);
 
-            options.Context.Set(new RoutingToDispatchConnector.State
+            options.MessageOperationContext.Set(new RoutingToDispatchConnector.State
             {
                 ImmediateDispatch = true
             });
@@ -32,7 +32,7 @@ namespace NServiceBus
         {
             Guard.AgainstNull(nameof(options), options);
 
-            options.Context.TryGet(out RoutingToDispatchConnector.State state);
+            options.MessageOperationContext.TryGet(out RoutingToDispatchConnector.State state);
 
             return state?.ImmediateDispatch ?? false;
         }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
@@ -4,6 +4,7 @@
     using System.Text;
     using System.Threading.Tasks;
     using DeliveryConstraints;
+    using Extensibility;
     using Logging;
     using Pipeline;
     using Routing;
@@ -13,7 +14,7 @@
     {
         public override Task Invoke(IRoutingContext context, Func<IDispatchContext, Task> stage)
         {
-            var state = context.Extensions.GetOrCreate<State>();
+            var state = context.GetMessageOperationExtensions().GetOrCreate<State>();
             var dispatchConsistency = state.ImmediateDispatch ? DispatchConsistency.Isolated : DispatchConsistency.Default;
 
             var operations = new TransportOperation[context.RoutingStrategies.Count];

--- a/src/NServiceBus.Core/PublishOptions.cs
+++ b/src/NServiceBus.Core/PublishOptions.cs
@@ -10,10 +10,5 @@ namespace NServiceBus
     /// </remarks>
     public class PublishOptions : ExtendableOptions
     {
-        /// <inheritdoc />
-        public PublishOptions()
-        {
-            Context.GetOrCreate<AttachCorrelationIdBehavior.State>();
-        }
     }
 }

--- a/src/NServiceBus.Core/Routing/ApplyReplyToAddressBehavior.cs
+++ b/src/NServiceBus.Core/Routing/ApplyReplyToAddressBehavior.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
+    using Extensibility;
     using Pipeline;
 
     class ApplyReplyToAddressBehavior : IBehavior<IOutgoingLogicalMessageContext, IOutgoingLogicalMessageContext>
@@ -23,7 +24,7 @@
 
         public Task Invoke(IOutgoingLogicalMessageContext context, Func<IOutgoingLogicalMessageContext, Task> next)
         {
-            var state = context.Extensions.GetOrCreate<State>();
+            var state = context.GetMessageOperationExtensions().GetOrCreate<State>();
             if (state.Option == RouteOption.RouteReplyToThisInstance && instanceSpecificQueue == null)
             {
                 throw new InvalidOperationException("Cannot route a reply to a specific instance because an endpoint instance discriminator was not configured for the destination endpoint. It can be specified via EndpointConfiguration.MakeInstanceUniquelyAddressable(string discriminator).");

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/BestPracticesOptionExtensions.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/BestPracticesOptionExtensions.cs
@@ -14,7 +14,7 @@
         public static void DoNotEnforceBestPractices(this ExtendableOptions options)
         {
             Guard.AgainstNull(nameof(options), options);
-            options.Context.SetDoNotEnforceBestPractices();
+            options.MessageOperationContext.SetDoNotEnforceBestPractices();
         }
 
         /// <summary>
@@ -24,7 +24,7 @@
         public static bool IgnoredBestPractices(this ExtendableOptions options)
         {
             Guard.AgainstNull(nameof(options), options);
-            options.Context.TryGet(out EnforceBestPracticesOptions bestPracticesOptions);
+            options.MessageOperationContext.TryGet(out EnforceBestPracticesOptions bestPracticesOptions);
             return !(bestPracticesOptions?.Enabled ?? true);
         }
 
@@ -34,7 +34,7 @@
         public static void DoNotEnforceBestPractices(this IOutgoingReplyContext context)
         {
             Guard.AgainstNull(nameof(context), context);
-            context.Extensions.SetDoNotEnforceBestPractices();
+            context.GetMessageOperationExtensions().SetDoNotEnforceBestPractices();
         }
 
         /// <summary>
@@ -43,7 +43,7 @@
         public static void DoNotEnforceBestPractices(this IOutgoingSendContext context)
         {
             Guard.AgainstNull(nameof(context), context);
-            context.Extensions.SetDoNotEnforceBestPractices();
+            context.GetMessageOperationExtensions().SetDoNotEnforceBestPractices();
         }
 
         /// <summary>
@@ -52,7 +52,7 @@
         public static void DoNotEnforceBestPractices(this ISubscribeContext context)
         {
             Guard.AgainstNull(nameof(context), context);
-            context.Extensions.SetDoNotEnforceBestPractices();
+            context.GetMessageOperationExtensions().SetDoNotEnforceBestPractices();
         }
 
         /// <summary>
@@ -61,7 +61,7 @@
         public static void DoNotEnforceBestPractices(this IOutgoingPublishContext context)
         {
             Guard.AgainstNull(nameof(context), context);
-            context.Extensions.SetDoNotEnforceBestPractices();
+            context.GetMessageOperationExtensions().SetDoNotEnforceBestPractices();
         }
 
         /// <summary>
@@ -70,7 +70,7 @@
         public static void DoNotEnforceBestPractices(this IUnsubscribeContext context)
         {
             Guard.AgainstNull(nameof(context), context);
-            context.Extensions.SetDoNotEnforceBestPractices();
+            context.GetMessageOperationExtensions().SetDoNotEnforceBestPractices();
         }
 
         static void SetDoNotEnforceBestPractices(this ContextBag context)

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforcePublishBestPracticesBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforcePublishBestPracticesBehavior.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
+    using Extensibility;
     using Pipeline;
 
     class EnforcePublishBestPracticesBehavior : IBehavior<IOutgoingPublishContext, IOutgoingPublishContext>
@@ -13,7 +14,7 @@
 
         public Task Invoke(IOutgoingPublishContext context, Func<IOutgoingPublishContext, Task> next)
         {
-            if (!context.Extensions.TryGet(out EnforceBestPracticesOptions options) || options.Enabled)
+            if (!context.GetMessageOperationExtensions().TryGet(out EnforceBestPracticesOptions options) || options.Enabled)
             {
                 validations.AssertIsValidForPubSub(context.Message.MessageType);
             }

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceReplyBestPracticesBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceReplyBestPracticesBehavior.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
+    using Extensibility;
     using Pipeline;
 
     class EnforceReplyBestPracticesBehavior : IBehavior<IOutgoingReplyContext, IOutgoingReplyContext>
@@ -13,7 +14,7 @@ namespace NServiceBus
 
         public Task Invoke(IOutgoingReplyContext context, Func<IOutgoingReplyContext, Task> next)
         {
-            if (!context.Extensions.TryGet(out EnforceBestPracticesOptions options) || options.Enabled)
+            if (!context.GetMessageOperationExtensions().TryGet(out EnforceBestPracticesOptions options) || options.Enabled)
             {
                 validations.AssertIsValidForReply(context.Message.MessageType);
             }

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceSendBestPracticesBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceSendBestPracticesBehavior.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
+    using Extensibility;
     using Pipeline;
 
     class EnforceSendBestPracticesBehavior : IBehavior<IOutgoingSendContext, IOutgoingSendContext>
@@ -13,7 +14,7 @@
 
         public Task Invoke(IOutgoingSendContext context, Func<IOutgoingSendContext, Task> next)
         {
-            if (!context.Extensions.TryGet(out EnforceBestPracticesOptions options) || options.Enabled)
+            if (!context.GetMessageOperationExtensions().TryGet(out EnforceBestPracticesOptions options) || options.Enabled)
             {
                 validations.AssertIsValidForSend(context.Message.MessageType);
             }

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceSubscribeBestPracticesBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceSubscribeBestPracticesBehavior.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
+    using Extensibility;
     using Pipeline;
 
     class EnforceSubscribeBestPracticesBehavior : IBehavior<ISubscribeContext, ISubscribeContext>
@@ -13,7 +14,7 @@ namespace NServiceBus
 
         public Task Invoke(ISubscribeContext context, Func<ISubscribeContext, Task> next)
         {
-            if (!context.Extensions.TryGet(out EnforceBestPracticesOptions options) || options.Enabled)
+            if (!context.GetMessageOperationExtensions().TryGet(out EnforceBestPracticesOptions options) || options.Enabled)
             {
                 validations.AssertIsValidForPubSub(context.EventType);
             }

--- a/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceUnsubscribeBestPracticesBehavior.cs
+++ b/src/NServiceBus.Core/Routing/MessagingBestPractices/EnforceUnsubscribeBestPracticesBehavior.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
+    using Extensibility;
     using Pipeline;
 
     class EnforceUnsubscribeBestPracticesBehavior : IBehavior<IUnsubscribeContext, IUnsubscribeContext>
@@ -13,7 +14,7 @@ namespace NServiceBus
 
         public Task Invoke(IUnsubscribeContext context, Func<IUnsubscribeContext, Task> next)
         {
-            if (!context.Extensions.TryGet(out EnforceBestPracticesOptions options) || options.Enabled)
+            if (!context.GetMessageOperationExtensions().TryGet(out EnforceBestPracticesOptions options) || options.Enabled)
             {
                 validations.AssertIsValidForPubSub(context.EventType);
             }

--- a/src/NServiceBus.Core/Routing/Routers/ReplyConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/ReplyConnector.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
+    using Extensibility;
     using Pipeline;
     using Routing;
     using Unicast.Queuing;
@@ -10,7 +11,7 @@ namespace NServiceBus
     {
         public override async Task Invoke(IOutgoingReplyContext context, Func<IOutgoingLogicalMessageContext, Task> stage)
         {
-            var state = context.Extensions.GetOrCreate<State>();
+            var state = context.GetMessageOperationExtensions().GetOrCreate<State>();
 
             var replyToAddress = state.ExplicitDestination;
 

--- a/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
+++ b/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
@@ -15,7 +15,7 @@
             Guard.AgainstNull(nameof(options), options);
             Guard.AgainstNullAndEmpty(nameof(destination), destination);
 
-            var state = options.Context.GetOrCreate<UnicastSendRouter.State>();
+            var state = options.MessageOperationContext.GetOrCreate<UnicastSendRouter.State>();
             state.Option = UnicastSendRouter.RouteOption.ExplicitDestination;
             state.ExplicitDestination = destination;
         }
@@ -31,7 +31,7 @@
             Guard.AgainstNull(nameof(options), options);
             Guard.AgainstNullAndEmpty(nameof(destination), destination);
 
-            options.Context.GetOrCreate<ReplyConnector.State>()
+            options.MessageOperationContext.GetOrCreate<ReplyConnector.State>()
                 .ExplicitDestination = destination;
         }
 
@@ -44,7 +44,7 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            options.Context.TryGet(out ReplyConnector.State state);
+            options.MessageOperationContext.TryGet(out ReplyConnector.State state);
             return state?.ExplicitDestination;
         }
 
@@ -57,7 +57,7 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            options.Context.TryGet(out UnicastSendRouter.State state);
+            options.MessageOperationContext.TryGet(out UnicastSendRouter.State state);
             return state?.ExplicitDestination;
         }
 
@@ -69,7 +69,7 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            options.Context.GetOrCreate<UnicastSendRouter.State>()
+            options.MessageOperationContext.GetOrCreate<UnicastSendRouter.State>()
                 .Option = UnicastSendRouter.RouteOption.RouteToAnyInstanceOfThisEndpoint;
         }
 
@@ -82,7 +82,7 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            if (options.Context.TryGet(out UnicastSendRouter.State state))
+            if (options.MessageOperationContext.TryGet(out UnicastSendRouter.State state))
             {
                 return state.Option == UnicastSendRouter.RouteOption.RouteToAnyInstanceOfThisEndpoint;
             }
@@ -98,7 +98,7 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            options.Context.GetOrCreate<UnicastSendRouter.State>()
+            options.MessageOperationContext.GetOrCreate<UnicastSendRouter.State>()
                 .Option = UnicastSendRouter.RouteOption.RouteToThisInstance;
         }
 
@@ -111,7 +111,7 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            if (options.Context.TryGet(out UnicastSendRouter.State state))
+            if (options.MessageOperationContext.TryGet(out UnicastSendRouter.State state))
             {
                 return state.Option == UnicastSendRouter.RouteOption.RouteToThisInstance;
             }
@@ -129,7 +129,7 @@
             Guard.AgainstNull(nameof(options), options);
             Guard.AgainstNull(nameof(instanceId), instanceId);
 
-            var state = options.Context.GetOrCreate<UnicastSendRouter.State>();
+            var state = options.MessageOperationContext.GetOrCreate<UnicastSendRouter.State>();
             state.Option = UnicastSendRouter.RouteOption.RouteToSpecificInstance;
             state.SpecificInstance = instanceId;
         }
@@ -143,7 +143,7 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            if (options.Context.TryGet(out UnicastSendRouter.State state) && state.Option == UnicastSendRouter.RouteOption.RouteToSpecificInstance)
+            if (options.MessageOperationContext.TryGet(out UnicastSendRouter.State state) && state.Option == UnicastSendRouter.RouteOption.RouteToSpecificInstance)
             {
                 return state.SpecificInstance;
             }
@@ -159,19 +159,19 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            options.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>()
+            options.MessageOperationContext.GetOrCreate<ApplyReplyToAddressBehavior.State>()
                 .Option = ApplyReplyToAddressBehavior.RouteOption.RouteReplyToThisInstance;
         }
 
         /// <summary>
-        /// Indicates whether <see cref="RouteReplyToThisInstance(NServiceBus.SendOptions)" /> has been called on this options.
+        /// Indicates whether <see cref="RouteReplyToThisInstance(SendOptions)" /> has been called on this options.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         public static bool IsRoutingReplyToThisInstance(this SendOptions options)
         {
             Guard.AgainstNull(nameof(options), options);
 
-            if (options.Context.TryGet(out ApplyReplyToAddressBehavior.State state))
+            if (options.MessageOperationContext.TryGet(out ApplyReplyToAddressBehavior.State state))
             {
                 return state.Option == ApplyReplyToAddressBehavior.RouteOption.RouteReplyToThisInstance;
             }
@@ -187,19 +187,19 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            options.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>()
+            options.MessageOperationContext.GetOrCreate<ApplyReplyToAddressBehavior.State>()
                 .Option = ApplyReplyToAddressBehavior.RouteOption.RouteReplyToAnyInstanceOfThisEndpoint;
         }
 
         /// <summary>
-        /// Indicates whether <see cref="RouteReplyToAnyInstance(NServiceBus.SendOptions)" /> has been called on this options.
+        /// Indicates whether <see cref="RouteReplyToAnyInstance(SendOptions)" /> has been called on this options.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         public static bool IsRoutingReplyToAnyInstance(this SendOptions options)
         {
             Guard.AgainstNull(nameof(options), options);
 
-            if (options.Context.TryGet(out ApplyReplyToAddressBehavior.State state))
+            if (options.MessageOperationContext.TryGet(out ApplyReplyToAddressBehavior.State state))
             {
                 return state.Option == ApplyReplyToAddressBehavior.RouteOption.RouteReplyToAnyInstanceOfThisEndpoint;
             }
@@ -215,19 +215,19 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            options.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>()
+            options.MessageOperationContext.GetOrCreate<ApplyReplyToAddressBehavior.State>()
                 .Option = ApplyReplyToAddressBehavior.RouteOption.RouteReplyToThisInstance;
         }
 
         /// <summary>
-        /// Indicates whether <see cref="RouteReplyToThisInstance(NServiceBus.ReplyOptions)" /> has been called on this options.
+        /// Indicates whether <see cref="RouteReplyToThisInstance(ReplyOptions)" /> has been called on this options.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         public static bool IsRoutingReplyToThisInstance(this ReplyOptions options)
         {
             Guard.AgainstNull(nameof(options), options);
 
-            if (options.Context.TryGet(out ApplyReplyToAddressBehavior.State state))
+            if (options.MessageOperationContext.TryGet(out ApplyReplyToAddressBehavior.State state))
             {
                 return state.Option == ApplyReplyToAddressBehavior.RouteOption.RouteReplyToThisInstance;
             }
@@ -243,19 +243,19 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            options.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>()
+            options.MessageOperationContext.GetOrCreate<ApplyReplyToAddressBehavior.State>()
                 .Option = ApplyReplyToAddressBehavior.RouteOption.RouteReplyToAnyInstanceOfThisEndpoint;
         }
 
         /// <summary>
-        /// Indicates whether <see cref="RouteReplyToAnyInstance(NServiceBus.ReplyOptions)" /> has been called on this options.
+        /// Indicates whether <see cref="RouteReplyToAnyInstance(ReplyOptions)" /> has been called on this options.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         public static bool IsRoutingReplyToAnyInstance(this ReplyOptions options)
         {
             Guard.AgainstNull(nameof(options), options);
 
-            if (options.Context.TryGet(out ApplyReplyToAddressBehavior.State state))
+            if (options.MessageOperationContext.TryGet(out ApplyReplyToAddressBehavior.State state))
             {
                 return state.Option == ApplyReplyToAddressBehavior.RouteOption.RouteReplyToAnyInstanceOfThisEndpoint;
             }
@@ -273,13 +273,13 @@
             Guard.AgainstNull(nameof(options), options);
             Guard.AgainstNull(nameof(address), address);
 
-            var state = options.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>();
+            var state = options.MessageOperationContext.GetOrCreate<ApplyReplyToAddressBehavior.State>();
             state.Option = ApplyReplyToAddressBehavior.RouteOption.ExplicitReplyDestination;
             state.ExplicitDestination = address;
         }
 
         /// <summary>
-        /// Returns the configured route by <see cref="RouteReplyTo(NServiceBus.ReplyOptions,string)" />.
+        /// Returns the configured route by <see cref="RouteReplyTo(ReplyOptions,string)" />.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         /// <returns>The configured reply to address or <c>null</c> when no address configured.</returns>
@@ -287,7 +287,7 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            if (options.Context.TryGet(out ApplyReplyToAddressBehavior.State state) && state.Option == ApplyReplyToAddressBehavior.RouteOption.ExplicitReplyDestination)
+            if (options.MessageOperationContext.TryGet(out ApplyReplyToAddressBehavior.State state) && state.Option == ApplyReplyToAddressBehavior.RouteOption.ExplicitReplyDestination)
             {
                 return state.ExplicitDestination;
             }
@@ -305,13 +305,13 @@
             Guard.AgainstNull(nameof(options), options);
             Guard.AgainstNull(nameof(address), address);
 
-            var state = options.Context.GetOrCreate<ApplyReplyToAddressBehavior.State>();
+            var state = options.MessageOperationContext.GetOrCreate<ApplyReplyToAddressBehavior.State>();
             state.Option = ApplyReplyToAddressBehavior.RouteOption.ExplicitReplyDestination;
             state.ExplicitDestination = address;
         }
 
         /// <summary>
-        /// Returns the configured route by <see cref="RouteReplyTo(NServiceBus.SendOptions,string)" />.
+        /// Returns the configured route by <see cref="RouteReplyTo(SendOptions,string)" />.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         /// <returns>The configured reply to address or <c>null</c> when no address configured.</returns>
@@ -319,7 +319,7 @@
         {
             Guard.AgainstNull(nameof(options), options);
 
-            if (options.Context.TryGet(out ApplyReplyToAddressBehavior.State state) && state.Option == ApplyReplyToAddressBehavior.RouteOption.ExplicitReplyDestination)
+            if (options.MessageOperationContext.TryGet(out ApplyReplyToAddressBehavior.State state) && state.Option == ApplyReplyToAddressBehavior.RouteOption.ExplicitReplyDestination)
             {
                 return state.ExplicitDestination;
             }

--- a/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Linq;
+    using Extensibility;
     using Pipeline;
     using Routing;
 
@@ -36,7 +37,7 @@ namespace NServiceBus
 
         public virtual UnicastRoutingStrategy Route(IOutgoingSendContext context)
         {
-            var state = context.Extensions.GetOrCreate<State>();
+            var state = context.GetMessageOperationExtensions().GetOrCreate<State>();
             var route = SelectRoute(state, context);
             return ResolveRoute(route, context);
         }

--- a/src/NServiceBus.Core/Sagas/PopulateAutoCorrelationHeadersForRepliesBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/PopulateAutoCorrelationHeadersForRepliesBehavior.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
+    using Extensibility;
     using Pipeline;
 
     class PopulateAutoCorrelationHeadersForRepliesBehavior : IBehavior<IOutgoingReplyContext, IOutgoingReplyContext>
@@ -20,7 +21,7 @@
                 incomingMessage.Headers.TryGetValue(Headers.OriginatingSagaId, out var sagaId);
                 incomingMessage.Headers.TryGetValue(Headers.OriginatingSagaType, out var sagaType);
 
-                if (context.Extensions.TryGet(out State state))
+                if (context.GetMessageOperationExtensions().TryGet(out State state))
                 {
                     sagaId = state.SagaIdToUse;
                     sagaType = state.SagaTypeToUse;

--- a/src/NServiceBus.Core/Sagas/Saga.cs
+++ b/src/NServiceBus.Core/Sagas/Saga.cs
@@ -112,7 +112,7 @@ namespace NServiceBus
             //until we have metadata we just set this to null to avoid our own saga id being set on outgoing messages since
             //that would cause the saga that started us (if it was a saga) to not be found. When we have metadata available in the future we'll set the correct id and type
             // and get true auto correlation to work between sagas
-            options.Context.Set(new PopulateAutoCorrelationHeadersForRepliesBehavior.State
+            options.MessageOperationContext.Set(new PopulateAutoCorrelationHeadersForRepliesBehavior.State
             {
                 SagaTypeToUse = null,
                 SagaIdToUse = null

--- a/src/NServiceBus.Core/Scheduling/ScheduleBehavior.cs
+++ b/src/NServiceBus.Core/Scheduling/ScheduleBehavior.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
+    using Extensibility;
     using Pipeline;
 
     class ScheduleBehavior : IBehavior<IOutgoingLogicalMessageContext, IOutgoingLogicalMessageContext>
@@ -13,7 +14,7 @@ namespace NServiceBus
 
         public Task Invoke(IOutgoingLogicalMessageContext context, Func<IOutgoingLogicalMessageContext, Task> next)
         {
-            if (context.Extensions.TryGet(out State state))
+            if (context.GetMessageOperationExtensions().TryGet(out State state))
             {
                 scheduler.Schedule(state.TaskDefinition);
             }

--- a/src/NServiceBus.Core/Scheduling/ScheduleExtensions.cs
+++ b/src/NServiceBus.Core/Scheduling/ScheduleExtensions.cs
@@ -72,7 +72,7 @@ namespace NServiceBus
             var options = new SendOptions();
             options.DelayDeliveryWith(taskDefinition.Every);
             options.RouteToThisEndpoint();
-            options.Context.GetOrCreate<ScheduleBehavior.State>().TaskDefinition = taskDefinition;
+            options.MessageOperationContext.GetOrCreate<ScheduleBehavior.State>().TaskDefinition = taskDefinition;
 
             var scheduledTask = new ScheduledTask
             {

--- a/src/NServiceBus.Core/SendOptions.cs
+++ b/src/NServiceBus.Core/SendOptions.cs
@@ -11,14 +11,13 @@ namespace NServiceBus
     /// </remarks>
     public class SendOptions : ExtendableOptions
     {
-        /// <inheritdoc />
-        public SendOptions()
-        {
-            Context.GetOrCreate<UnicastSendRouter.State>();
-            Context.GetOrCreate<RoutingToDispatchConnector.State>(); // this needs to be done for all message options!
-            Context.GetOrCreate<ApplyReplyToAddressBehavior.State>();
-            Context.GetOrCreate<AttachCorrelationIdBehavior.State>();
-        }
+        ///// <inheritdoc />
+        //public SendOptions()
+        //{
+        //    Context.GetOrCreate<UnicastSendRouter.State>();
+        //    Context.GetOrCreate<RoutingToDispatchConnector.State>(); // this needs to be done for all message options!
+        //    Context.GetOrCreate<ApplyReplyToAddressBehavior.State>();
+        //}
 
         internal DelayedDeliveryConstraint DelayedDeliveryConstraint { get; set; }
     }

--- a/src/NServiceBus.Core/SendOptions.cs
+++ b/src/NServiceBus.Core/SendOptions.cs
@@ -11,14 +11,6 @@ namespace NServiceBus
     /// </remarks>
     public class SendOptions : ExtendableOptions
     {
-        ///// <inheritdoc />
-        //public SendOptions()
-        //{
-        //    Context.GetOrCreate<UnicastSendRouter.State>();
-        //    Context.GetOrCreate<RoutingToDispatchConnector.State>(); // this needs to be done for all message options!
-        //    Context.GetOrCreate<ApplyReplyToAddressBehavior.State>();
-        //}
-
         internal DelayedDeliveryConstraint DelayedDeliveryConstraint { get; set; }
     }
 }

--- a/src/NServiceBus.Core/Unicast/MessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperations.cs
@@ -4,6 +4,7 @@ namespace NServiceBus
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using DeliveryConstraints;
+    using Extensibility;
     using MessageInterfaces;
     using Pipeline;
 
@@ -59,6 +60,8 @@ namespace NServiceBus
                 options.Context,
                 context);
 
+            publishContext.Set("MessageOperationContext", new ContextBag(options.MessageOperationContext));
+
             return publishPipeline.Invoke(publishContext);
         }
 
@@ -69,6 +72,8 @@ namespace NServiceBus
                 eventType,
                 options.Context);
 
+            subscribeContext.Set("MessageOperationContext", new ContextBag(options.MessageOperationContext));
+
             return subscribePipeline.Invoke(subscribeContext);
         }
 
@@ -78,6 +83,8 @@ namespace NServiceBus
                 context,
                 eventType,
                 options.Context);
+
+            unsubscribeContext.Set("MessageOperationContext", new ContextBag(options.MessageOperationContext));
 
             return unsubscribePipeline.Invoke(unsubscribeContext);
         }
@@ -108,6 +115,8 @@ namespace NServiceBus
                 headers,
                 options.Context,
                 context);
+
+            outgoingContext.Set("MessageOperationContext", new ContextBag(options.MessageOperationContext));
 
             if (options.DelayedDeliveryConstraint != null)
             {


### PR DESCRIPTION
Potential fix using a dedicated context bag that is added to the pipeline context hierarchy as a property rather than being merged. This ensures that value lookups never travel further through the hierarchy due to the absence of settings.

This requires adjusting all code setting and reading state though. Conceptually it's basically the as `DispatchProperties` in v8 but for the pipeline only (therefore supporting reference types).