### PR TITLE
Clarifying the wording for people who "do not wish to release the source"

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -5,6 +5,6 @@ Your license to Particular Software source code and/or binaries is governed by t
 
 https://www.opensource.org/licenses/rpl1.5.txt
 
-If you do not wish to release the source of software you build using Particular Software source code and/or binaries, you may use Particular Software source code and/or binaries under the License Agreement described here:
+If you do not wish to release the source of software you build using Particular Software source code and/or binaries under the terms above, you may use Particular Software source code and/or binaries under the License Agreement described here:
 
 https://particular.net/LicenseAgreement


### PR DESCRIPTION
The text currently states:

> If you do not wish to release the source of software you build using Particular Software source code and/or binaries

This is may be unclear to people who are willing to release the source of the software they build, but do not wish to do so under the RPL stated in the previous section.

This PR should help clarify the intent.

This PR is being withdrawn and in its place, this other PR is continuing the same work, for the reasons mentioned by Andreas in his comment below.