### PR TITLE
Port extendable options leak fix to master

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_setting_ttbr_in_outer_publish.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_setting_ttbr_in_outer_publish.cs
@@ -1,0 +1,129 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Pipeline
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+    using Performance.TimeToBeReceived;
+
+    public class When_setting_ttbr_in_outer_publish : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_not_apply_ttbr_to_inner_publish()
+        {
+            Requires.NativePubSubSupport();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<PublisherWithTtbr>(e => e
+                    .When(s => s.Publish(new OuterEvent())))
+                .WithEndpoint<Subscriber>()
+                .Done(c => c.OuterEventReceived && c.InnerEventReceived)
+                .Run();
+
+            Assert.IsNotNull(context.OuterEventTtbr, "Outer event should have TTBR settings applied");
+            Assert.IsNull(context.InnerEventTtbr, "Inner event should not have TTBR settings applied");
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool InnerEventReceived { get; set; }
+            public bool OuterEventReceived { get; set; }
+            public DiscardIfNotReceivedBefore OuterEventTtbr { get; set; }
+            public DiscardIfNotReceivedBefore InnerEventTtbr { get; set; }
+        }
+
+        class PublisherWithTtbr : EndpointConfigurationBuilder
+        {
+            public PublisherWithTtbr()
+            {
+                EndpointSetup<DefaultServer>((c, r) =>
+                {
+                    c.Pipeline.Register(new InnerPublishBehavior(), "publishes an additional event when publishing an OuterEvent");
+                    c.Pipeline.Register(new TtbrObserver((Context)r.ScenarioContext), "Checks outgoing messages for their TTBR setting");
+                });
+            }
+
+            // Behavior needs to be in the OutgoingPhysical stage as the TTBR settings are applied in the OutgoingLogical stage
+            class InnerPublishBehavior : Behavior<IOutgoingPhysicalMessageContext>
+            {
+                public override async Task Invoke(IOutgoingPhysicalMessageContext context, Func<Task> next)
+                {
+                    await next();
+
+                    if (context.Extensions.Get<OutgoingLogicalMessage>().MessageType == typeof(OuterEvent))
+                    {
+                        await context.Publish(new InnerEvent());
+                    }
+                }
+            }
+
+            class TtbrObserver : Behavior<IDispatchContext>
+            {
+                Context testContext;
+
+                public TtbrObserver(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public override Task Invoke(IDispatchContext context, Func<Task> next)
+                {
+                    var outgoingMessage = context.Extensions.Get<OutgoingLogicalMessage>();
+                    if (outgoingMessage.MessageType == typeof(OuterEvent))
+                    {
+                        testContext.OuterEventTtbr = context.Operations.Single().Properties.DiscardIfNotReceivedBefore;
+                    }
+
+                    if (outgoingMessage.MessageType == typeof(InnerEvent))
+                    {
+                        testContext.InnerEventTtbr = context.Operations.Single().Properties.DiscardIfNotReceivedBefore;
+                    }
+
+                    return next();
+                }
+            }
+        }
+
+        class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class EventHandler : IHandleMessages<OuterEvent>, IHandleMessages<InnerEvent>
+            {
+                Context testContext;
+
+                public EventHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(OuterEvent message, IMessageHandlerContext context)
+                {
+                    testContext.OuterEventReceived = true;
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(InnerEvent message, IMessageHandlerContext context)
+                {
+                    testContext.InnerEventReceived = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        [TimeToBeReceived("00:30:00")]
+        public class OuterEvent : IEvent
+        {
+        }
+
+        public class InnerEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_skipping_serialization_with_nested_send.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_skipping_serialization_with_nested_send.cs
@@ -1,0 +1,113 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Pipeline
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    public class When_skipping_serialization_with_nested_send : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_not_skip_serialization_for_nested_send()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(e => e
+                    .When(s => s.Send(new MessageWithoutSerialization { SomeProperty = "Some property value" })))
+                .WithEndpoint<Receiver>()
+                .Done(c => c.NestedMessageReceived)
+                .Run(TimeSpan.FromSeconds(15));
+
+            Assert.IsTrue(context.NestedMessageReceived, "the serialization should the nested message should not be skipped");
+            Assert.AreEqual("Some property value for NestedMessage", context.NestedMessagePropertyValue, "the message sould be correctly serialized");
+            Assert.IsFalse(context.MessageWithSkippedSerializationReceived, "NServiceBus should discard messages without a body");
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool MessageWithSkippedSerializationReceived { get; set; }
+            public bool NestedMessageReceived { get; set; }
+            public string NestedMessagePropertyValue { get; set; }
+        }
+
+        class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.ConfigureRouting().RouteToEndpoint(typeof(NestedMessage).Assembly, Conventions.EndpointNamingConvention(typeof(Receiver)));
+                    c.Pipeline.Register(new SkipSerializationBehavior(), $"Skips serialization for {nameof(MessageWithoutSerialization)}");
+                    c.Pipeline.Register(new NestedSendBehavior(), $"Sends a {nameof(NestedMessage)} from the outgoing pipeline");
+                });
+            }
+
+            class SkipSerializationBehavior : Behavior<IOutgoingLogicalMessageContext>
+            {
+                public override Task Invoke(IOutgoingLogicalMessageContext context, Func<Task> next)
+                {
+                    if (context.Message.MessageType == typeof(MessageWithoutSerialization))
+                    {
+                        context.SkipSerialization();
+                    }
+
+                    return next();
+                }
+            }
+
+            class NestedSendBehavior : Behavior<IOutgoingPhysicalMessageContext>
+            {
+                public override async Task Invoke(IOutgoingPhysicalMessageContext context, Func<Task> next)
+                {
+                    var logicalMessage = context.Extensions.Get<OutgoingLogicalMessage>();
+                    if (logicalMessage.MessageType != typeof(NestedMessage))
+                    {
+                        await context.Send(new NestedMessage { SomeProperty = "Some property value for NestedMessage" });
+                    }
+
+                    await next();
+                }
+            }
+        }
+
+        class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver() => EndpointSetup<DefaultServer>();
+
+            class MessageHandler : IHandleMessages<MessageWithoutSerialization>, IHandleMessages<NestedMessage>
+            {
+                Context testContext;
+
+                public MessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(MessageWithoutSerialization message, IMessageHandlerContext context)
+                {
+                    testContext.MessageWithSkippedSerializationReceived = true;
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(NestedMessage message, IMessageHandlerContext context)
+                {
+                    testContext.NestedMessageReceived = true;
+                    testContext.NestedMessagePropertyValue = message.SomeProperty;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MessageWithoutSerialization : IMessage
+        {
+            public string SomeProperty { get; set; }
+        }
+
+        public class NestedMessage : IMessage
+        {
+            public string SomeProperty { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_inner_send_with_outer_immediate_dispatch.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_inner_send_with_outer_immediate_dispatch.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Threading.Tasks;
     using AcceptanceTesting;
-    using AcceptanceTesting.Customization;
+    using NServiceBus.AcceptanceTesting.Customization;
     using EndpointTemplates;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
@@ -38,8 +38,8 @@
             {
                 EndpointSetup<DefaultServer>(c =>
                 {
-                    c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MessageToEndpointB), typeof(EndpointB));
-                    c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MessageToEndpointC), typeof(EndpointC));
+                    c.ConfigureRouting().RouteToEndpoint(typeof(MessageToEndpointB), typeof(EndpointB));
+                    c.ConfigureRouting().RouteToEndpoint(typeof(MessageToEndpointC), typeof(EndpointC));
                     c.Pipeline.Register(new OutgoingBehaviorWithSend(), "sends a message as part of an incoming message pipeline");
                 });
             }

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_inner_send_with_outer_immediate_dispatch.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_inner_send_with_outer_immediate_dispatch.cs
@@ -1,0 +1,121 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Routing
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    public class When_inner_send_with_outer_immediate_dispatch : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_not_apply_immediate_dispatch_to_inner_send()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointA>(c => c
+                    .DoNotFailOnErrorMessages()
+                    .When(s => s.SendLocal(new TriggerMessage())))
+                .WithEndpoint<EndpointB>()
+                .WithEndpoint<EndpointC>()
+                .Done(c => c.MessageBReceived)
+                .Run(TimeSpan.FromSeconds(15));
+
+            Assert.IsTrue(context.MessageBReceived);
+            Assert.IsFalse(context.MessageCReceived);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool MessageBReceived { get; set; }
+            public bool MessageCReceived { get; set; }
+        }
+
+        class EndpointA : EndpointConfigurationBuilder
+        {
+            public EndpointA()
+            {
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MessageToEndpointB), typeof(EndpointB));
+                    c.ConfigureTransport().Routing().RouteToEndpoint(typeof(MessageToEndpointC), typeof(EndpointC));
+                    c.Pipeline.Register(new OutgoingBehaviorWithSend(), "sends a message as part of an incoming message pipeline");
+                });
+            }
+
+            class TriggerMessageHandler : IHandleMessages<TriggerMessage>
+            {
+                public Task Handle(TriggerMessage message, IMessageHandlerContext context)
+                {
+                    // "outer send"
+                    var sendOptions = new SendOptions();
+                    sendOptions.RequireImmediateDispatch();
+                    return context.Send(new MessageToEndpointB(), sendOptions);
+                }
+            }
+
+            class OutgoingBehaviorWithSend : Behavior<IOutgoingLogicalMessageContext>
+            {
+                public override async Task Invoke(IOutgoingLogicalMessageContext context, Func<Task> next)
+                {
+                    await next();
+                    if (context.Message.MessageType == typeof(MessageToEndpointB))
+                    {
+                        // "inner send"
+                        await context.Send(new MessageToEndpointC()); // no immediate dispatch
+                        throw new Exception(); // batching should prevent message C from being dispatched.
+                    }
+                }
+            }
+        }
+
+        class EndpointB : EndpointConfigurationBuilder
+        {
+            public EndpointB() => EndpointSetup<DefaultServer>();
+
+            public class EndpointBHandler : IHandleMessages<MessageToEndpointB>
+            {
+                Context testContext;
+
+                public EndpointBHandler(Context testContext) => this.testContext = testContext;
+
+                public Task Handle(MessageToEndpointB message, IMessageHandlerContext context)
+                {
+                    testContext.MessageBReceived = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        class EndpointC : EndpointConfigurationBuilder
+        {
+            public EndpointC() => EndpointSetup<DefaultServer>();
+
+            public class EndpointCHandler : IHandleMessages<MessageToEndpointC>
+            {
+                Context testContext;
+
+                public EndpointCHandler(Context testContext) => this.testContext = testContext;
+
+                public Task Handle(MessageToEndpointC message, IMessageHandlerContext context)
+                {
+                    testContext.MessageCReceived = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class MessageToEndpointB : IMessage
+        {
+        }
+
+        public class MessageToEndpointC : IMessage
+        {
+        }
+
+        public class TriggerMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_sending_from_outgoing_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_sending_from_outgoing_pipeline.cs
@@ -1,0 +1,126 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Routing
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    public class When_sending_from_outgoing_pipeline : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_use_default_routing_when_empty_send_options()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointA>(e => e
+                    .CustomConfig(c =>
+                    {
+                        c.Pipeline.Register(new SendingBehaviorUsingDefaultRouting(), "outgoing pipeline behavior sending messages");
+                        c.ConfigureTransport().Routing().RouteToEndpoint(typeof(BehaviorMessage), typeof(EndpointB));
+                    })
+                    .When(s => s.SendLocal(new LocalMessage())))
+                .WithEndpoint<EndpointB>()
+                .Done(c => c.LocalMessageReceived && c.BehaviorMessageReceived)
+                .Run(TimeSpan.FromSeconds(15));
+
+            Assert.True(context.LocalMessageReceived);
+            Assert.True(context.BehaviorMessageReceived);
+        }
+
+        [Test]
+        public async Task Should_apply_send_options_routing()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointA>(e => e
+                    .CustomConfig(c =>
+                    {
+                        c.Pipeline.Register(new SendingBehaviorUsingRoutingOverride(), "outgoing pipeline behavior sending messages");
+                    })
+                    .When(s => s.SendLocal(new LocalMessage())))
+                .WithEndpoint<EndpointB>()
+                .Done(c => c.LocalMessageReceived && c.BehaviorMessageReceived)
+                .Run(TimeSpan.FromSeconds(15));
+
+            Assert.True(context.LocalMessageReceived);
+            Assert.True(context.BehaviorMessageReceived);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public bool BehaviorMessageReceived { get; set; }
+            public bool LocalMessageReceived { get; set; }
+        }
+
+        public class EndpointA : EndpointConfigurationBuilder
+        {
+            public EndpointA() => EndpointSetup<DefaultServer>();
+
+            public class LocalMessageHandler : IHandleMessages<LocalMessage>
+            {
+                Context testContext;
+
+                public LocalMessageHandler(Context testContext) => this.testContext = testContext;
+
+                public Task Handle(LocalMessage message, IMessageHandlerContext context)
+                {
+                    testContext.LocalMessageReceived = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class EndpointB : EndpointConfigurationBuilder
+        {
+            public EndpointB() => EndpointSetup<DefaultServer>();
+
+            public class BehaviorMessageHandler : IHandleMessages<BehaviorMessage>
+            {
+                Context testContext;
+
+                public BehaviorMessageHandler(Context testContext) => this.testContext = testContext;
+
+                public Task Handle(BehaviorMessage message, IMessageHandlerContext context)
+                {
+                    testContext.BehaviorMessageReceived = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class SendingBehaviorUsingDefaultRouting : Behavior<IOutgoingLogicalMessageContext>
+        {
+            public override async Task Invoke(IOutgoingLogicalMessageContext context, Func<Task> next)
+            {
+                await next();
+                if (context.Message.MessageType != typeof(BehaviorMessage)) // prevent infinite loop
+                {
+                    await context.Send(new BehaviorMessage(), new SendOptions()); // use empty SendOptions
+                }
+            }
+        }
+
+        public class SendingBehaviorUsingRoutingOverride : Behavior<IOutgoingLogicalMessageContext>
+        {
+            public override async Task Invoke(IOutgoingLogicalMessageContext context, Func<Task> next)
+            {
+                await next();
+                if (context.Message.MessageType != typeof(BehaviorMessage)) // prevent infinite loop
+                {
+                    var sendOptions = new SendOptions();
+                    sendOptions.SetDestination(Conventions.EndpointNamingConvention(typeof(EndpointB))); // Configure routing on SendOptions
+                    await context.Send(new BehaviorMessage(), sendOptions);
+                }
+            }
+        }
+
+        public class LocalMessage : IMessage
+        {
+        }
+
+        public class BehaviorMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_sending_from_outgoing_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_sending_from_outgoing_pipeline.cs
@@ -18,7 +18,7 @@
                     .CustomConfig(c =>
                     {
                         c.Pipeline.Register(new SendingBehaviorUsingDefaultRouting(), "outgoing pipeline behavior sending messages");
-                        c.ConfigureTransport().Routing().RouteToEndpoint(typeof(BehaviorMessage), typeof(EndpointB));
+                        c.ConfigureRouting().RouteToEndpoint(typeof(BehaviorMessage), typeof(EndpointB));
                     })
                     .When(s => s.SendLocal(new LocalMessage())))
                 .WithEndpoint<EndpointB>()

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_using_ReplyToOriginator_and_outgoing_behavior.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_using_ReplyToOriginator_and_outgoing_behavior.cs
@@ -56,7 +56,7 @@ namespace NServiceBus.AcceptanceTests.Core.Sagas
             {
                 c.LimitMessageProcessingConcurrencyTo(1); // This test only works if the endpoints processes messages sequentially
                 c.Pipeline.Register(new OutgoingPipelineBehaviorSendingMessages(), "behavior sending messages from the outgoing pipeline");
-                c.ConfigureTransport().Routing().RouteToEndpoint(typeof(BehaviorMessage), Conventions.EndpointNamingConvention(typeof(EndpointB)));
+                c.ConfigureRouting().RouteToEndpoint(typeof(BehaviorMessage), Conventions.EndpointNamingConvention(typeof(EndpointB)));
             });
 
             class MessageHandler : IHandleMessages<ReplyToOriginatorMessage>

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_using_ReplyToOriginator_and_outgoing_behavior.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_using_ReplyToOriginator_and_outgoing_behavior.cs
@@ -1,0 +1,174 @@
+namespace NServiceBus.AcceptanceTests.Core.Sagas
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+    using AcceptanceTesting.Customization;
+
+    public class When_using_ReplyToOriginator_and_outgoing_behavior : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_not_leak_correlation_context()
+        {
+            Requires.NativePubSubSupport();
+            var context = await Scenario.Define<Context>(c => { c.Id = Guid.NewGuid(); })
+                .WithEndpoint<EndPointA>(b =>
+                {
+                    b.When((session, ctx) => session.SendLocal(new StartSagaMessage
+                    {
+                        SomeId = ctx.Id
+                    }));
+                    b.When(ctx => ctx.StartSagaMessageReceived, (session, c) => session.SendLocal(new ContinueSagaMessage
+                    {
+                        SomeId = c.Id
+                    }));
+                })
+                .WithEndpoint<EndpointB>()
+                .Done(c => c.SagaContinued && c.ReplyToOriginatorReceived && c.BehaviorMessageReceived && c.BehaviorEventReceived)
+                .Run();
+
+            Assert.AreEqual(context.StartingSagaCorrId, context.ReplyToOriginatorReceivedCorrId, "When using ReplyToOriginator, the correlationId should be the same of the message that originally started the saga");
+            Assert.AreEqual(context.ContinueSagaMessageCorrId, context.HandlingBehaviorMessageCorrId, "When ReplyToOriginator is used, it shouldn't leak the CorrId to new messages sent from a behavior");
+            Assert.AreEqual(context.ContinueSagaMessageCorrId, context.HandlingBehaviorEventCorrId, "When ReplyToOriginator is used, it shouldn't leak the CorrId to new events published from a behavior");
+        }
+
+        public class Context : ScenarioContext
+        {
+            public Guid Id { get; set; }
+            public bool StartSagaMessageReceived { get; set; }
+            public bool SagaContinued { get; set; }
+            public string HandlingBehaviorMessageCorrId { get; set; }
+            public bool BehaviorMessageReceived { get; set; }
+            public string ContinueSagaMessageCorrId { get; set; }
+            public string StartingSagaCorrId { get; set; }
+            public string ReplyToOriginatorReceivedCorrId { get; set; }
+            public bool ReplyToOriginatorReceived { get; set; }
+            public string HandlingBehaviorEventCorrId { get; set; }
+            public bool BehaviorEventReceived { get; set; }
+        }
+
+        public class EndPointA : EndpointConfigurationBuilder
+        {
+            public EndPointA() => EndpointSetup<DefaultServer>(c =>
+            {
+                c.LimitMessageProcessingConcurrencyTo(1); // This test only works if the endpoints processes messages sequentially
+                c.Pipeline.Register(new OutgoingPipelineBehaviorSendingMessages(), "behavior sending messages from the outgoing pipeline");
+                c.ConfigureTransport().Routing().RouteToEndpoint(typeof(BehaviorMessage), Conventions.EndpointNamingConvention(typeof(EndpointB)));
+            });
+
+            class MessageHandler : IHandleMessages<ReplyToOriginatorMessage>
+            {
+                Context testContext;
+
+                public MessageHandler(Context testContext) => this.testContext = testContext;
+
+                public Task Handle(ReplyToOriginatorMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ReplyToOriginatorReceivedCorrId = context.MessageHeaders[Headers.CorrelationId];
+                    testContext.ReplyToOriginatorReceived = true;
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class TestSaga : Saga<TestSagaData>,
+                IAmStartedByMessages<StartSagaMessage>,
+                IHandleMessages<ContinueSagaMessage>
+            {
+                Context testContext;
+
+                public TestSaga(Context testContext) => this.testContext = testContext;
+
+                public Task Handle(StartSagaMessage message, IMessageHandlerContext context)
+                {
+                    testContext.StartingSagaCorrId = context.MessageHeaders[Headers.CorrelationId];
+                    testContext.StartSagaMessageReceived = true;
+
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(ContinueSagaMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ContinueSagaMessageCorrId = context.MessageHeaders[Headers.CorrelationId];
+                    testContext.SagaContinued = true;
+                    return ReplyToOriginator(context, new ReplyToOriginatorMessage());
+                }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<StartSagaMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                    mapper.ConfigureMapping<ContinueSagaMessage>(m => m.SomeId)
+                        .ToSaga(s => s.SomeId);
+                }
+            }
+
+            public class TestSagaData : ContainSagaData
+            {
+                public virtual Guid SomeId { get; set; }
+            }
+            class OutgoingPipelineBehaviorSendingMessages : Behavior<IOutgoingLogicalMessageContext>
+            {
+                public override async Task Invoke(IOutgoingLogicalMessageContext context, Func<Task> next)
+                {
+                    await next();
+                    if (context.Message.MessageType == typeof(ReplyToOriginatorMessage))
+                    {
+                        await context.Send(new BehaviorMessage());
+                        await context.Publish(new BehaviorEvent());
+                    }
+                }
+            }
+        }
+
+        class EndpointB : EndpointConfigurationBuilder
+        {
+            public EndpointB() => EndpointSetup<DefaultServer>();
+
+            public class BehaviorMessageHandler : IHandleMessages<BehaviorMessage>, IHandleMessages<BehaviorEvent>
+            {
+                Context testContext;
+
+                public BehaviorMessageHandler(Context testContext) => this.testContext = testContext;
+
+                public Task Handle(BehaviorMessage message, IMessageHandlerContext context)
+                {
+                    testContext.HandlingBehaviorMessageCorrId = context.MessageHeaders[Headers.CorrelationId];
+                    testContext.BehaviorMessageReceived = true;
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(BehaviorEvent message, IMessageHandlerContext context)
+                {
+                    testContext.HandlingBehaviorEventCorrId = context.MessageHeaders[Headers.CorrelationId];
+                    testContext.BehaviorEventReceived = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class StartSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+
+        public class ContinueSagaMessage : ICommand
+        {
+            public Guid SomeId { get; set; }
+        }
+
+        public class BehaviorMessage : IMessage
+        {
+        }
+
+        public class ReplyToOriginatorMessage : IMessage
+        {
+        }
+
+        public class BehaviorEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_outer_send.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_outer_send.cs
@@ -1,0 +1,103 @@
+﻿namespace NServiceBus.AcceptanceTests.DelayedDelivery
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    public class When_deferring_outer_send : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_not_defer_inner_send()
+        {
+            Requires.DelayedDelivery();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SenderWithNestedSend>(e => e
+                    .When(s =>
+                    {
+                        var sendOptions = new SendOptions();
+                        sendOptions.DelayDeliveryWith(TimeSpan.FromSeconds(2));
+                        return s.Send(new DelayedMessage(), sendOptions);
+                    }))
+                .WithEndpoint<Receiver>()
+                .Done(c => c.ReceivedNonDelayedMessage && c.ReceivedDelayedMessage)
+                .Run();
+
+            Assert.IsTrue(context.DelayedMessageDelayed, "should delay the message sent with 'DelayDeliveryWith'");
+            Assert.IsFalse(context.NonDelayedMessageDelayed, "should not delay the message sent with default options");
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool DelayedMessageDelayed { get; set; }
+            public bool NonDelayedMessageDelayed { get; set; }
+
+            public bool ReceivedNonDelayedMessage { get; set; }
+            public bool ReceivedDelayedMessage { get; set; }
+        }
+
+        class SenderWithNestedSend : EndpointConfigurationBuilder
+        {
+            public SenderWithNestedSend() => EndpointSetup<DefaultServer>((c, r) =>
+            {
+                c.Pipeline.Register(new NestedSendBehavior(), "Sends an additional message when sending a delayed message");
+                c.ConfigureRouting().RouteToEndpoint(typeof(DelayedMessage).Assembly, Conventions.EndpointNamingConvention(typeof(Receiver)));
+            });
+
+            class NestedSendBehavior : Behavior<IOutgoingSendContext>
+            {
+                public override async Task Invoke(IOutgoingSendContext context, Func<Task> next)
+                {
+                    await next();
+                    if (context.Message.MessageType == typeof(DelayedMessage))
+                    {
+                        await context.Send(new NonDelayedMessage()); // use default options
+                    }
+                }
+            }
+        }
+
+        class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver() => EndpointSetup<DefaultServer>();
+
+            class DelayedMessageHandler : IHandleMessages<DelayedMessage>, IHandleMessages<NonDelayedMessage>
+            {
+                Context testContext;
+
+                public DelayedMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(DelayedMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedDelayedMessage = true;
+                    testContext.DelayedMessageDelayed = context.MessageHeaders.TryGetValue(Headers.DeliverAt, out var _); // header value not set when routing to timeout manager
+
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(NonDelayedMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedNonDelayedMessage = true;
+                    testContext.NonDelayedMessageDelayed = context.MessageHeaders.TryGetValue(Headers.DeliverAt, out var _); // header value not set when routing to timeout manager
+
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class DelayedMessage : IMessage
+        {
+        }
+
+        public class NonDelayedMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Routing/When_nested_send_with_outer_replyTo_routing.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_nested_send_with_outer_replyTo_routing.cs
@@ -1,0 +1,99 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Routing
+{
+    using System;
+    using System.Reflection;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    public class When_nested_send_with_outer_replyTo_routing : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_apply_default_reply_in_inner_send()
+        {
+            const string customReplyAddress = "Tatooine";
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SenderEndpoint>(c => c
+                    .When(s =>
+                    {
+                        var sendOptions = new SendOptions();
+                        sendOptions.RouteReplyTo(customReplyAddress);
+                        return s.Send(new OuterMessage(), sendOptions);
+                    }))
+                .WithEndpoint<ReplyEndpoint>()
+                .Done(c => c.OuterMessageReceived && c.InnerMessageReceived)
+                .Run();
+
+            Assert.AreEqual(customReplyAddress, context.OuterMessageReplyAddress);
+            Assert.AreEqual(Conventions.EndpointNamingConvention(typeof(SenderEndpoint)), context.InnerMessageReplyAddress);
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool OuterMessageReceived { get; set; }
+            public bool InnerMessageReceived { get; set; }
+            public string OuterMessageReplyAddress { get; set; }
+            public string InnerMessageReplyAddress { get; set; }
+        }
+
+        class SenderEndpoint : EndpointConfigurationBuilder
+        {
+            public SenderEndpoint() => EndpointSetup<DefaultServer>(c =>
+            {
+                c.ConfigureTransport().Routing().RouteToEndpoint(Assembly.GetExecutingAssembly(), Conventions.EndpointNamingConvention(typeof(ReplyEndpoint)));
+                c.Pipeline.Register(new InnerSendBehavior(), "sends an inner message on send operations");
+            });
+
+            class InnerSendBehavior : Behavior<IOutgoingLogicalMessageContext>
+            {
+                public override async Task Invoke(IOutgoingLogicalMessageContext context, Func<Task> next)
+                {
+                    await next();
+
+                    if (context.Message.MessageType == typeof(OuterMessage))
+                    {
+                        await context.Send(new InnerMessage());
+                    }
+                }
+            }
+        }
+
+        class ReplyEndpoint : EndpointConfigurationBuilder
+        {
+            public ReplyEndpoint() => EndpointSetup<DefaultServer>();
+
+            class MessageHandler : IHandleMessages<OuterMessage>, IHandleMessages<InnerMessage>
+            {
+                Context testContext;
+
+                public MessageHandler(Context testContext) => this.testContext = testContext;
+
+                public Task Handle(OuterMessage message, IMessageHandlerContext context)
+                {
+                    testContext.OuterMessageReceived = true;
+                    testContext.OuterMessageReplyAddress = context.ReplyToAddress;
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(InnerMessage message, IMessageHandlerContext context)
+                {
+                    testContext.InnerMessageReceived = true;
+                    testContext.InnerMessageReplyAddress = context.ReplyToAddress;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        public class OuterMessage : IMessage
+        {
+        }
+
+        public class InnerMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Routing/When_nested_send_with_outer_replyTo_routing.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_nested_send_with_outer_replyTo_routing.cs
@@ -44,7 +44,7 @@
         {
             public SenderEndpoint() => EndpointSetup<DefaultServer>(c =>
             {
-                c.ConfigureTransport().Routing().RouteToEndpoint(Assembly.GetExecutingAssembly(), Conventions.EndpointNamingConvention(typeof(ReplyEndpoint)));
+                c.ConfigureRouting().RouteToEndpoint(Assembly.GetExecutingAssembly(), Conventions.EndpointNamingConvention(typeof(ReplyEndpoint)));
                 c.Pipeline.Register(new InnerSendBehavior(), "sends an inner message on send operations");
             });
 

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1438,6 +1438,10 @@ namespace NServiceBus.Extensibility
     {
         public static NServiceBus.Transport.DispatchProperties GetDispatchProperties(this NServiceBus.Extensibility.ExtendableOptions options) { }
         public static NServiceBus.Extensibility.ContextBag GetExtensions(this NServiceBus.Extensibility.ExtendableOptions options) { }
+        public static NServiceBus.Extensibility.ReadOnlyContextBag GetOperationProperties(this NServiceBus.Pipeline.IOutgoingContext behaviorContext) { }
+        public static NServiceBus.Extensibility.ReadOnlyContextBag GetOperationProperties(this NServiceBus.Pipeline.IUnsubscribeContext behaviorContext) { }
+        public static NServiceBus.Extensibility.ReadOnlyContextBag GetOperationProperties(this NServiceBus.Pipeline.ISubscribeContext behaviorContext) { }
+        public static NServiceBus.Extensibility.ReadOnlyContextBag GetOperationProperties(this NServiceBus.Pipeline.IRoutingContext behaviorContext) { }
     }
     public interface IExtendable
     {

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1438,10 +1438,10 @@ namespace NServiceBus.Extensibility
     {
         public static NServiceBus.Transport.DispatchProperties GetDispatchProperties(this NServiceBus.Extensibility.ExtendableOptions options) { }
         public static NServiceBus.Extensibility.ContextBag GetExtensions(this NServiceBus.Extensibility.ExtendableOptions options) { }
-        public static NServiceBus.Extensibility.ReadOnlyContextBag GetOperationProperties(this NServiceBus.Pipeline.IOutgoingContext behaviorContext) { }
-        public static NServiceBus.Extensibility.ReadOnlyContextBag GetOperationProperties(this NServiceBus.Pipeline.IUnsubscribeContext behaviorContext) { }
-        public static NServiceBus.Extensibility.ReadOnlyContextBag GetOperationProperties(this NServiceBus.Pipeline.ISubscribeContext behaviorContext) { }
-        public static NServiceBus.Extensibility.ReadOnlyContextBag GetOperationProperties(this NServiceBus.Pipeline.IRoutingContext behaviorContext) { }
+        public static NServiceBus.Extensibility.IReadOnlyContextBag GetOperationProperties(this NServiceBus.Pipeline.IOutgoingContext behaviorContext) { }
+        public static NServiceBus.Extensibility.IReadOnlyContextBag GetOperationProperties(this NServiceBus.Pipeline.IRoutingContext behaviorContext) { }
+        public static NServiceBus.Extensibility.IReadOnlyContextBag GetOperationProperties(this NServiceBus.Pipeline.ISubscribeContext behaviorContext) { }
+        public static NServiceBus.Extensibility.IReadOnlyContextBag GetOperationProperties(this NServiceBus.Pipeline.IUnsubscribeContext behaviorContext) { }
     }
     public interface IExtendable
     {

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingPublishContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingPublishContextTests.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.Core.Tests.Pipeline.Outgoing
 {
+    using System.Collections.Generic;
+    using Extensibility;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
 
@@ -39,6 +41,44 @@
             var valueFound = parentContext.TryGet("someKey", out string _);
 
             Assert.IsFalse(valueFound);
+        }
+
+        [Test]
+        public void ShouldExposePublishOptionsExtensionsAsOperationProperties()
+        {
+            var message = new OutgoingLogicalMessage(typeof(object), new object());
+            var parentContext = new FakeRootContext(); // exact parent context doesn't matter
+            var options = new ContextBag();
+            options.Set("some key", "some value");
+
+            var publishContext = new OutgoingPublishContext(message, "message-id", new Dictionary<string, string>(), options, parentContext);
+
+            var operationProperties = publishContext.GetOperationProperties();
+            Assert.AreEqual("some value", operationProperties.Get<string>("some key"));
+        }
+
+        [Test]
+        public void ShouldNotLeakParentsOperationProperties()
+        {
+            var outerOptions = new ContextBag();
+            outerOptions.Set("outer key", "outer value");
+            outerOptions.Set("shared key", "outer shared value");
+            var parentContext = new OutgoingPublishContext(new OutgoingLogicalMessage(typeof(object), new object()), "message-id", new Dictionary<string, string>(), outerOptions, new FakeRootContext());
+
+            var innerOptions = new ContextBag();
+            innerOptions.Set("inner key", "inner value");
+            innerOptions.Set("shared key", "inner shared value");
+            var innerContext = new OutgoingPublishContext(new OutgoingLogicalMessage(typeof(object), new object()), "message-id", new Dictionary<string, string>(), innerOptions, parentContext);
+
+            var innerOperationProperties = innerContext.GetOperationProperties();
+            Assert.AreEqual("inner value", innerOperationProperties.Get<string>("inner key"));
+            Assert.AreEqual("inner shared value", innerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(innerOperationProperties.TryGet("outer key", out string _));
+
+            var outerOperationProperties = parentContext.GetOperationProperties();
+            Assert.AreEqual("outer value", outerOperationProperties.Get<string>("outer key"));
+            Assert.AreEqual("outer shared value", outerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(outerOperationProperties.TryGet("inner key", out string _));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingReplyContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingReplyContextTests.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.Core.Tests.Pipeline.Outgoing
 {
+    using System.Collections.Generic;
+    using Extensibility;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
 
@@ -40,6 +42,44 @@
             var valueFound = parentContext.TryGet("someKey", out string _);
 
             Assert.IsFalse(valueFound);
+        }
+
+        [Test]
+        public void ShouldExposeSendOptionsExtensionsAsOperationProperties()
+        {
+            var message = new OutgoingLogicalMessage(typeof(object), new object());
+            var parentContext = new FakeRootContext(); // exact parent context doesn't matter
+            var options = new ContextBag();
+            options.Set("some key", "some value");
+
+            var context = new OutgoingReplyContext(message, "message-id", new Dictionary<string, string>(), options, parentContext);
+
+            var operationProperties = context.GetOperationProperties();
+            Assert.AreEqual("some value", operationProperties.Get<string>("some key"));
+        }
+
+        [Test]
+        public void ShouldNotLeakParentsOperationProperties()
+        {
+            var outerOptions = new ContextBag();
+            outerOptions.Set("outer key", "outer value");
+            outerOptions.Set("shared key", "outer shared value");
+            var parentContext = new OutgoingReplyContext(new OutgoingLogicalMessage(typeof(object), new object()), "message-id", new Dictionary<string, string>(), outerOptions, new FakeRootContext());
+
+            var innerOptions = new ContextBag();
+            innerOptions.Set("inner key", "inner value");
+            innerOptions.Set("shared key", "inner shared value");
+            var innerContext = new OutgoingReplyContext(new OutgoingLogicalMessage(typeof(object), new object()), "message-id", new Dictionary<string, string>(), innerOptions, parentContext);
+
+            var innerOperationProperties = innerContext.GetOperationProperties();
+            Assert.AreEqual("inner value", innerOperationProperties.Get<string>("inner key"));
+            Assert.AreEqual("inner shared value", innerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(innerOperationProperties.TryGet("outer key", out string _));
+
+            var outerOperationProperties = parentContext.GetOperationProperties();
+            Assert.AreEqual("outer value", outerOperationProperties.Get<string>("outer key"));
+            Assert.AreEqual("outer shared value", outerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(outerOperationProperties.TryGet("inner key", out string _));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingSendContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingSendContextTests.cs
@@ -1,5 +1,7 @@
 ﻿namespace NServiceBus.Core.Tests.Pipeline.Outgoing
 {
+    using System.Collections.Generic;
+    using Extensibility;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
 
@@ -39,6 +41,44 @@
             var valueFound = parentContext.TryGet("someKey", out string _);
 
             Assert.IsFalse(valueFound);
+        }
+
+        [Test]
+        public void ShouldExposeSendOptionsExtensionsAsOperationProperties()
+        {
+            var message = new OutgoingLogicalMessage(typeof(object), new object());
+            var parentContext = new FakeRootContext(); // exact parent context doesn't matter
+            var options = new ContextBag();
+            options.Set("some key", "some value");
+
+            var context = new OutgoingSendContext(message, "message-id", new Dictionary<string, string>(), options, parentContext);
+
+            var operationProperties = context.GetOperationProperties();
+            Assert.AreEqual("some value", operationProperties.Get<string>("some key"));
+        }
+
+        [Test]
+        public void ShouldNotLeakParentsOperationProperties()
+        {
+            var outerOptions = new ContextBag();
+            outerOptions.Set("outer key", "outer value");
+            outerOptions.Set("shared key", "outer shared value");
+            var parentContext = new OutgoingSendContext(new OutgoingLogicalMessage(typeof(object), new object()), "message-id", new Dictionary<string, string>(), outerOptions, new FakeRootContext());
+
+            var innerOptions = new ContextBag();
+            innerOptions.Set("inner key", "inner value");
+            innerOptions.Set("shared key", "inner shared value");
+            var innerContext = new OutgoingSendContext(new OutgoingLogicalMessage(typeof(object), new object()), "message-id", new Dictionary<string, string>(), innerOptions, parentContext);
+
+            var innerOperationProperties = innerContext.GetOperationProperties();
+            Assert.AreEqual("inner value", innerOperationProperties.Get<string>("inner key"));
+            Assert.AreEqual("inner shared value", innerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(innerOperationProperties.TryGet("outer key", out string _));
+
+            var outerOperationProperties = parentContext.GetOperationProperties();
+            Assert.AreEqual("outer value", outerOperationProperties.Get<string>("outer key"));
+            Assert.AreEqual("outer shared value", outerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(outerOperationProperties.TryGet("inner key", out string _));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/Routers/ReplyConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/ReplyConnectorTests.cs
@@ -11,8 +11,13 @@
         public async Task Should_set_messageintent_to_reply()
         {
             var router = new ReplyConnector();
-            var context = new TestableOutgoingReplyContext();
-            context.Extensions.Set(new ReplyConnector.State { ExplicitDestination = "Fake" });
+            var replyOptions = new ReplyOptions();
+            replyOptions.SetDestination("Fake");
+
+            var context = new TestableOutgoingReplyContext()
+            {
+                Extensions = replyOptions.Context
+            };
 
             await router.Invoke(context, ctx => Task.CompletedTask);
 

--- a/src/NServiceBus.Core.Tests/Routing/SubscribeContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SubscribeContextTests.cs
@@ -13,7 +13,7 @@
             var context = new ContextBag();
             context.Set("someKey", "someValue");
 
-            var testee = new SubscribeContext(new FakeRootContext(), new Type[0], context);
+            var testee = new SubscribeContext(new FakeRootContext(), Type.EmptyTypes, context);
             testee.Extensions.Set("someKey", "updatedValue");
             testee.Extensions.Set("anotherKey", "anotherValue");
             context.TryGet("someKey", out string value);
@@ -33,11 +33,48 @@
 
             var parentContext = new FakeRootContext();
 
-            new SubscribeContext(parentContext, new Type[0], context);
+            new SubscribeContext(parentContext, Type.EmptyTypes, context);
 
             var valueFound = parentContext.TryGet("someKey", out string _);
 
             Assert.IsFalse(valueFound);
+        }
+
+        [Test]
+        public void ShouldExposeSendOptionsExtensionsAsOperationProperties()
+        {
+            var parentContext = new FakeRootContext(); // exact parent context doesn't matter
+            var options = new ContextBag();
+            options.Set("some key", "some value");
+
+            var context = new SubscribeContext(parentContext, Type.EmptyTypes, options);
+
+            var operationProperties = context.GetOperationProperties();
+            Assert.AreEqual("some value", operationProperties.Get<string>("some key"));
+        }
+
+        [Test]
+        public void ShouldNotLeakParentsOperationProperties()
+        {
+            var outerOptions = new ContextBag();
+            outerOptions.Set("outer key", "outer value");
+            outerOptions.Set("shared key", "outer shared value");
+            var parentContext = new SubscribeContext(new FakeRootContext(), Type.EmptyTypes, outerOptions);
+
+            var innerOptions = new ContextBag();
+            innerOptions.Set("inner key", "inner value");
+            innerOptions.Set("shared key", "inner shared value");
+            var innerContext = new SubscribeContext(parentContext, Type.EmptyTypes, innerOptions);
+
+            var innerOperationProperties = innerContext.GetOperationProperties();
+            Assert.AreEqual("inner value", innerOperationProperties.Get<string>("inner key"));
+            Assert.AreEqual("inner shared value", innerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(innerOperationProperties.TryGet("outer key", out string _));
+
+            var outerOperationProperties = parentContext.GetOperationProperties();
+            Assert.AreEqual("outer value", outerOperationProperties.Get<string>("outer key"));
+            Assert.AreEqual("outer shared value", outerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(outerOperationProperties.TryGet("inner key", out string _));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/UnsubscribeContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnsubscribeContextTests.cs
@@ -38,5 +38,42 @@
 
             Assert.IsFalse(valueFound);
         }
+
+        [Test]
+        public void ShouldExposeSendOptionsExtensionsAsOperationProperties()
+        {
+            var parentContext = new FakeRootContext(); // exact parent context doesn't matter
+            var options = new ContextBag();
+            options.Set("some key", "some value");
+
+            var context = new UnsubscribeContext(parentContext, typeof(object), options);
+
+            var operationProperties = context.GetOperationProperties();
+            Assert.AreEqual("some value", operationProperties.Get<string>("some key"));
+        }
+
+        [Test]
+        public void ShouldNotLeakParentsOperationProperties()
+        {
+            var outerOptions = new ContextBag();
+            outerOptions.Set("outer key", "outer value");
+            outerOptions.Set("shared key", "outer shared value");
+            var parentContext = new UnsubscribeContext(new FakeRootContext(), typeof(object), outerOptions);
+
+            var innerOptions = new ContextBag();
+            innerOptions.Set("inner key", "inner value");
+            innerOptions.Set("shared key", "inner shared value");
+            var innerContext = new UnsubscribeContext(parentContext, typeof(object), innerOptions);
+
+            var innerOperationProperties = innerContext.GetOperationProperties();
+            Assert.AreEqual("inner value", innerOperationProperties.Get<string>("inner key"));
+            Assert.AreEqual("inner shared value", innerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(innerOperationProperties.TryGet("outer key", out string _));
+
+            var outerOperationProperties = parentContext.GetOperationProperties();
+            Assert.AreEqual("outer value", outerOperationProperties.Get<string>("outer key"));
+            Assert.AreEqual("outer shared value", outerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(outerOperationProperties.TryGet("inner key", out string _));
+        }
     }
 }

--- a/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
+++ b/src/NServiceBus.Core/Causation/AttachCausationHeadersBehavior.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
+    using Extensibility;
     using Pipeline;
     using Transport;
 
@@ -38,7 +39,7 @@ namespace NServiceBus
             var hasIncomingMessageConversationId = incomingMessage != null && incomingMessage.Headers.TryGetValue(Headers.ConversationId, out conversationIdFromCurrentMessageContext);
             var hasUserDefinedConversationId = context.Headers.TryGetValue(Headers.ConversationId, out var userDefinedConversationId);
 
-            if (context.Extensions.TryGet<string>(NewConversationId, out var newConversationId))
+            if (context.GetOperationProperties().TryGet<string>(NewConversationId, out var newConversationId))
             {
                 if (hasUserDefinedConversationId)
                 {

--- a/src/NServiceBus.Core/Correlation/AttachCorrelationIdBehavior.cs
+++ b/src/NServiceBus.Core/Correlation/AttachCorrelationIdBehavior.cs
@@ -2,13 +2,18 @@
 {
     using System;
     using System.Threading.Tasks;
+    using NServiceBus.Extensibility;
     using Pipeline;
 
     class AttachCorrelationIdBehavior : IBehavior<IOutgoingLogicalMessageContext, IOutgoingLogicalMessageContext>
     {
         public Task Invoke(IOutgoingLogicalMessageContext context, Func<IOutgoingLogicalMessageContext, Task> next)
         {
-            var correlationId = context.Extensions.GetOrCreate<State>().CustomCorrelationId;
+            string correlationId = null;
+            if (context.GetOperationProperties().TryGet(out State state))
+            {
+                correlationId = state.CustomCorrelationId;
+            }
 
             //if we don't have a explicit correlation id set
             if (string.IsNullOrEmpty(correlationId))

--- a/src/NServiceBus.Core/Extensibility/ExtendableOptions.cs
+++ b/src/NServiceBus.Core/Extensibility/ExtendableOptions.cs
@@ -11,6 +11,8 @@ namespace NServiceBus.Extensibility
     /// </remarks>
     public abstract class ExtendableOptions
     {
+        internal const string OperationPropertiesKey = "NServiceBus.OperationProperties";
+
         /// <summary>
         /// Creates an instance of an extendable option.
         /// </summary>

--- a/src/NServiceBus.Core/Extensibility/ExtendableOptionsExtensions.cs
+++ b/src/NServiceBus.Core/Extensibility/ExtendableOptionsExtensions.cs
@@ -25,28 +25,28 @@ namespace NServiceBus.Extensibility
             Guard.AgainstNull(nameof(options), options);
             return options.DispatchProperties;
         }
-        
-        /// <summary>
-        /// Get readonly access to the <see cref="ContextBag"/> used by the <see cref="ExtendableOptions"/> to capture any operation properties.
-        /// </summary>
-        public static ReadOnlyContextBag GetOperationProperties(this IOutgoingContext behaviorContext) => GetOperationPropertiesInternal(behaviorContext);
 
         /// <summary>
         /// Get readonly access to the <see cref="ContextBag"/> used by the <see cref="ExtendableOptions"/> to capture any operation properties.
         /// </summary>
-        public static ReadOnlyContextBag GetOperationProperties(this IUnsubscribeContext behaviorContext) => GetOperationPropertiesInternal(behaviorContext);
+        public static IReadOnlyContextBag GetOperationProperties(this IOutgoingContext behaviorContext) => GetOperationPropertiesInternal(behaviorContext);
 
         /// <summary>
         /// Get readonly access to the <see cref="ContextBag"/> used by the <see cref="ExtendableOptions"/> to capture any operation properties.
         /// </summary>
-        public static ReadOnlyContextBag GetOperationProperties(this ISubscribeContext behaviorContext) => GetOperationPropertiesInternal(behaviorContext);
+        public static IReadOnlyContextBag GetOperationProperties(this IUnsubscribeContext behaviorContext) => GetOperationPropertiesInternal(behaviorContext);
 
         /// <summary>
         /// Get readonly access to the <see cref="ContextBag"/> used by the <see cref="ExtendableOptions"/> to capture any operation properties.
         /// </summary>
-        public static ReadOnlyContextBag GetOperationProperties(this IRoutingContext behaviorContext) => GetOperationPropertiesInternal(behaviorContext);
+        public static IReadOnlyContextBag GetOperationProperties(this ISubscribeContext behaviorContext) => GetOperationPropertiesInternal(behaviorContext);
 
-        static ReadOnlyContextBag GetOperationPropertiesInternal(this IBehaviorContext behaviorContext)
+        /// <summary>
+        /// Get readonly access to the <see cref="ContextBag"/> used by the <see cref="ExtendableOptions"/> to capture any operation properties.
+        /// </summary>
+        public static IReadOnlyContextBag GetOperationProperties(this IRoutingContext behaviorContext) => GetOperationPropertiesInternal(behaviorContext);
+
+        static IReadOnlyContextBag GetOperationPropertiesInternal(this IBehaviorContext behaviorContext)
         {
             Guard.AgainstNull(nameof(behaviorContext), behaviorContext);
             if (!behaviorContext.Extensions.TryGet(ExtendableOptions.OperationPropertiesKey, out ContextBag context))

--- a/src/NServiceBus.Core/Extensibility/ExtendableOptionsExtensions.cs
+++ b/src/NServiceBus.Core/Extensibility/ExtendableOptionsExtensions.cs
@@ -1,6 +1,7 @@
 namespace NServiceBus.Extensibility
 {
     using Transport;
+    using Pipeline;
 
     /// <summary>
     /// Provides hidden access to the extension context.
@@ -9,7 +10,7 @@ namespace NServiceBus.Extensibility
     {
         /// <summary>
         /// Gets access to a "bucket" that allows the developer to pass information from extension methods down to behaviors.
-        /// </summary>
+        /// </summary>        
         public static ContextBag GetExtensions(this ExtendableOptions options)
         {
             Guard.AgainstNull(nameof(options), options);
@@ -23,6 +24,37 @@ namespace NServiceBus.Extensibility
         {
             Guard.AgainstNull(nameof(options), options);
             return options.DispatchProperties;
+        }
+        
+        /// <summary>
+        /// Get readonly access to the <see cref="ContextBag"/> used by the <see cref="ExtendableOptions"/> to capture any operation properties.
+        /// </summary>
+        public static ReadOnlyContextBag GetOperationProperties(this IOutgoingContext behaviorContext) => GetOperationPropertiesInternal(behaviorContext);
+
+        /// <summary>
+        /// Get readonly access to the <see cref="ContextBag"/> used by the <see cref="ExtendableOptions"/> to capture any operation properties.
+        /// </summary>
+        public static ReadOnlyContextBag GetOperationProperties(this IUnsubscribeContext behaviorContext) => GetOperationPropertiesInternal(behaviorContext);
+
+        /// <summary>
+        /// Get readonly access to the <see cref="ContextBag"/> used by the <see cref="ExtendableOptions"/> to capture any operation properties.
+        /// </summary>
+        public static ReadOnlyContextBag GetOperationProperties(this ISubscribeContext behaviorContext) => GetOperationPropertiesInternal(behaviorContext);
+
+        /// <summary>
+        /// Get readonly access to the <see cref="ContextBag"/> used by the <see cref="ExtendableOptions"/> to capture any operation properties.
+        /// </summary>
+        public static ReadOnlyContextBag GetOperationProperties(this IRoutingContext behaviorContext) => GetOperationPropertiesInternal(behaviorContext);
+
+        static ReadOnlyContextBag GetOperationPropertiesInternal(this IBehaviorContext behaviorContext)
+        {
+            Guard.AgainstNull(nameof(behaviorContext), behaviorContext);
+            if (!behaviorContext.Extensions.TryGet(ExtendableOptions.OperationPropertiesKey, out ContextBag context))
+            {
+                return behaviorContext.Extensions; // fallback behavior, e.g. when invoking the outgoing pipeline without using MessageOperation API.
+            }
+
+            return context;
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPublishContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPublishContext.cs
@@ -16,6 +16,8 @@
             Message = message;
 
             Merge(extensions);
+            Set(ExtendableOptions.OperationPropertiesKey, extensions);
+
         }
 
         public OutgoingLogicalMessage Message { get; }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingReplyContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingReplyContext.cs
@@ -16,6 +16,7 @@
             Message = message;
 
             Merge(extensions);
+            Set(ExtendableOptions.OperationPropertiesKey, extensions);
         }
 
         public OutgoingLogicalMessage Message { get; }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingSendContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingSendContext.cs
@@ -16,6 +16,7 @@
             Message = message;
 
             Merge(extensions);
+            Set(ExtendableOptions.OperationPropertiesKey, extensions);
         }
 
         public OutgoingLogicalMessage Message { get; }

--- a/src/NServiceBus.Core/Routing/ApplyReplyToAddressBehavior.cs
+++ b/src/NServiceBus.Core/Routing/ApplyReplyToAddressBehavior.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
+    using Extensibility;
     using Pipeline;
 
     class ApplyReplyToAddressBehavior : IBehavior<IOutgoingLogicalMessageContext, IOutgoingLogicalMessageContext>
@@ -23,7 +24,11 @@
 
         public Task Invoke(IOutgoingLogicalMessageContext context, Func<IOutgoingLogicalMessageContext, Task> next)
         {
-            var state = context.Extensions.GetOrCreate<State>();
+            if (!context.GetOperationProperties().TryGet(out State state))
+            {
+                state = new State();
+            }
+
             if (state.Option == RouteOption.RouteReplyToThisInstance && instanceSpecificQueue == null)
             {
                 throw new InvalidOperationException("Cannot route a reply to a specific instance because an endpoint instance discriminator was not configured for the destination endpoint. It can be specified via EndpointConfiguration.MakeInstanceUniquelyAddressable(string discriminator).");

--- a/src/NServiceBus.Core/Routing/Routers/ReplyConnector.cs
+++ b/src/NServiceBus.Core/Routing/Routers/ReplyConnector.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Threading.Tasks;
+    using Extensibility;
     using Pipeline;
     using Routing;
     using Unicast.Queuing;
@@ -10,9 +11,11 @@ namespace NServiceBus
     {
         public override async Task Invoke(IOutgoingReplyContext context, Func<IOutgoingLogicalMessageContext, Task> stage)
         {
-            var state = context.Extensions.GetOrCreate<State>();
-
-            var replyToAddress = state.ExplicitDestination;
+            string replyToAddress = null;
+            if (context.GetOperationProperties().TryGet(out State state))
+            {
+                replyToAddress = state.ExplicitDestination;
+            }
 
             if (string.IsNullOrEmpty(replyToAddress))
             {

--- a/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
+++ b/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
@@ -164,7 +164,7 @@
         }
 
         /// <summary>
-        /// Indicates whether <see cref="RouteReplyToThisInstance(SendOptions)" /> has been called on this options.
+        /// Indicates whether <see cref="RouteReplyToThisInstance(NServiceBus.SendOptions)" /> has been called on this options.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         public static bool IsRoutingReplyToThisInstance(this SendOptions options)
@@ -192,7 +192,7 @@
         }
 
         /// <summary>
-        /// Indicates whether <see cref="RouteReplyToAnyInstance(SendOptions)" /> has been called on this options.
+        /// Indicates whether <see cref="RouteReplyToAnyInstance(NServiceBus.SendOptions)" /> has been called on this options.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         public static bool IsRoutingReplyToAnyInstance(this SendOptions options)
@@ -220,7 +220,7 @@
         }
 
         /// <summary>
-        /// Indicates whether <see cref="RouteReplyToThisInstance(ReplyOptions)" /> has been called on this options.
+        /// Indicates whether <see cref="RouteReplyToThisInstance(NServiceBus.ReplyOptions)" /> has been called on this options.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         public static bool IsRoutingReplyToThisInstance(this ReplyOptions options)
@@ -248,7 +248,7 @@
         }
 
         /// <summary>
-        /// Indicates whether <see cref="RouteReplyToAnyInstance(ReplyOptions)" /> has been called on this options.
+        /// Indicates whether <see cref="RouteReplyToAnyInstance(NServiceBus.ReplyOptions)" /> has been called on this options.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         public static bool IsRoutingReplyToAnyInstance(this ReplyOptions options)
@@ -279,7 +279,7 @@
         }
 
         /// <summary>
-        /// Returns the configured route by <see cref="RouteReplyTo(ReplyOptions,string)" />.
+        /// Returns the configured route by <see cref="RouteReplyTo(NServiceBus.ReplyOptions,string)" />.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         /// <returns>The configured reply to address or <c>null</c> when no address configured.</returns>
@@ -311,7 +311,7 @@
         }
 
         /// <summary>
-        /// Returns the configured route by <see cref="RouteReplyTo(SendOptions,string)" />.
+        /// Returns the configured route by <see cref="RouteReplyTo(NServiceBus.SendOptions,string)" />.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         /// <returns>The configured reply to address or <c>null</c> when no address configured.</returns>

--- a/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
+++ b/src/NServiceBus.Core/Routing/RoutingOptionExtensions.cs
@@ -164,7 +164,7 @@
         }
 
         /// <summary>
-        /// Indicates whether <see cref="RouteReplyToThisInstance(NServiceBus.SendOptions)" /> has been called on this options.
+        /// Indicates whether <see cref="RouteReplyToThisInstance(SendOptions)" /> has been called on this options.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         public static bool IsRoutingReplyToThisInstance(this SendOptions options)
@@ -192,7 +192,7 @@
         }
 
         /// <summary>
-        /// Indicates whether <see cref="RouteReplyToAnyInstance(NServiceBus.SendOptions)" /> has been called on this options.
+        /// Indicates whether <see cref="RouteReplyToAnyInstance(SendOptions)" /> has been called on this options.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         public static bool IsRoutingReplyToAnyInstance(this SendOptions options)
@@ -220,7 +220,7 @@
         }
 
         /// <summary>
-        /// Indicates whether <see cref="RouteReplyToThisInstance(NServiceBus.ReplyOptions)" /> has been called on this options.
+        /// Indicates whether <see cref="RouteReplyToThisInstance(ReplyOptions)" /> has been called on this options.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         public static bool IsRoutingReplyToThisInstance(this ReplyOptions options)
@@ -248,7 +248,7 @@
         }
 
         /// <summary>
-        /// Indicates whether <see cref="RouteReplyToAnyInstance(NServiceBus.ReplyOptions)" /> has been called on this options.
+        /// Indicates whether <see cref="RouteReplyToAnyInstance(ReplyOptions)" /> has been called on this options.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         public static bool IsRoutingReplyToAnyInstance(this ReplyOptions options)
@@ -279,7 +279,7 @@
         }
 
         /// <summary>
-        /// Returns the configured route by <see cref="RouteReplyTo(NServiceBus.ReplyOptions,string)" />.
+        /// Returns the configured route by <see cref="RouteReplyTo(ReplyOptions,string)" />.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         /// <returns>The configured reply to address or <c>null</c> when no address configured.</returns>
@@ -311,7 +311,7 @@
         }
 
         /// <summary>
-        /// Returns the configured route by <see cref="RouteReplyTo(NServiceBus.SendOptions,string)" />.
+        /// Returns the configured route by <see cref="RouteReplyTo(SendOptions,string)" />.
         /// </summary>
         /// <param name="options">Option being extended.</param>
         /// <returns>The configured reply to address or <c>null</c> when no address configured.</returns>

--- a/src/NServiceBus.Core/Routing/SubscribeContext.cs
+++ b/src/NServiceBus.Core/Routing/SubscribeContext.cs
@@ -15,6 +15,7 @@
             Guard.AgainstNull(nameof(extensions), extensions);
 
             Merge(extensions);
+            Set(ExtendableOptions.OperationPropertiesKey, extensions);
 
             EventTypes = eventTypes;
         }

--- a/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastSendRouter.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Linq;
+    using Extensibility;
     using Pipeline;
     using Routing;
     using Transport;
@@ -40,7 +41,11 @@ namespace NServiceBus
 
         public virtual UnicastRoutingStrategy Route(IOutgoingSendContext context)
         {
-            var state = context.Extensions.GetOrCreate<State>();
+            if (!context.GetOperationProperties().TryGet(out State state))
+            {
+                state = new State();
+            }
+
             var route = SelectRoute(state, context);
             return ResolveRoute(route, context);
         }

--- a/src/NServiceBus.Core/Routing/UnsubscribeContext.cs
+++ b/src/NServiceBus.Core/Routing/UnsubscribeContext.cs
@@ -14,6 +14,7 @@
             Guard.AgainstNull(nameof(extensions), extensions);
 
             Merge(extensions);
+            Set(ExtendableOptions.OperationPropertiesKey, extensions);
 
             EventType = eventType;
         }

--- a/src/NServiceBus.Core/Sagas/PopulateAutoCorrelationHeadersForRepliesBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/PopulateAutoCorrelationHeadersForRepliesBehavior.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
+    using Extensibility;
     using Pipeline;
 
     class PopulateAutoCorrelationHeadersForRepliesBehavior : IBehavior<IOutgoingReplyContext, IOutgoingReplyContext>
@@ -20,7 +21,7 @@
                 incomingMessage.Headers.TryGetValue(Headers.OriginatingSagaId, out var sagaId);
                 incomingMessage.Headers.TryGetValue(Headers.OriginatingSagaType, out var sagaType);
 
-                if (context.Extensions.TryGet(out State state))
+                if (context.GetOperationProperties().TryGet(out State state))
                 {
                     sagaId = state.SagaIdToUse;
                     sagaType = state.SagaTypeToUse;

--- a/src/NServiceBus.Core/Sagas/Saga.cs
+++ b/src/NServiceBus.Core/Sagas/Saga.cs
@@ -109,7 +109,7 @@ namespace NServiceBus
             }
 
             options.SetDestination(Entity.Originator);
-            context.Extensions.Set(new AttachCorrelationIdBehavior.State { CustomCorrelationId = Entity.OriginalMessageId });
+            options.Context.Set(new AttachCorrelationIdBehavior.State { CustomCorrelationId = Entity.OriginalMessageId });
 
             //until we have metadata we just set this to null to avoid our own saga id being set on outgoing messages since
             //that would cause the saga that started us (if it was a saga) to not be found. When we have metadata available in the future we'll set the correct id and type

--- a/src/NServiceBus.Core/Serialization/SerializationContextExtensions.cs
+++ b/src/NServiceBus.Core/Serialization/SerializationContextExtensions.cs
@@ -18,7 +18,9 @@ namespace NServiceBus
         public static void SkipSerialization(this IOutgoingLogicalMessageContext context)
         {
             Guard.AgainstNull(nameof(context), context);
-            context.Extensions.Set("MessageSerialization.Skip", true);
+
+            // Prefix the setting key with the current message id to prevent the setting from leaking to nested send operations for different messages
+            context.Extensions.Set($"{context.MessageId}:MessageSerialization.Skip", true);
         }
 
         /// <summary>
@@ -27,7 +29,7 @@ namespace NServiceBus
         public static bool ShouldSkipSerialization(this IOutgoingLogicalMessageContext context)
         {
             Guard.AgainstNull(nameof(context), context);
-            if (context.Extensions.TryGet("MessageSerialization.Skip", out bool shouldSkipSerialization))
+            if (context.Extensions.TryGet($"{context.MessageId}:MessageSerialization.Skip", out bool shouldSkipSerialization))
             {
                 return shouldSkipSerialization;
             }


### PR DESCRIPTION
releated to #6223

Ports the PRs to fix these issues from the 7.7 release branch into master:
* https://github.com/Particular/NServiceBus/pull/6316
* https://github.com/Particular/NServiceBus/pull/6361
* https://github.com/Particular/NServiceBus/pull/6356

Not all changes have been ported 1:1 since `DeliveryConstraints` have been obsoleted and replaced by `DispatchProperties`.