### PR TITLE
Relax address assertion

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Routing/When_nested_send_with_outer_replyTo_routing.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_nested_send_with_outer_replyTo_routing.cs
@@ -28,8 +28,8 @@
                 .Done(c => c.OuterMessageReceived && c.InnerMessageReceived)
                 .Run();
 
-            Assert.AreEqual(customReplyAddress, context.OuterMessageReplyAddress);
-            Assert.AreEqual(Conventions.EndpointNamingConvention(typeof(SenderEndpoint)), context.InnerMessageReplyAddress);
+            Assert.AreEqual(customReplyAddress, context.OuterMessageReplyAddress, "it should apply the configured custom replyTo address.");
+            Assert.AreNotEqual(customReplyAddress, context.InnerMessageReplyAddress, "it should apply the default replyTo address"); // it's difficult to verify the default replyTo address across transports as transport address translation makes it difficult to define the expected default value.
         }
 
         class Context : ScenarioContext


### PR DESCRIPTION
The actual reply address can vary, depending on the transport that runs this test. E.g. this fails on MSMQ (see https://github.com/Particular/NServiceBus.Transport.Msmq/actions/runs/2159281452 because MSMQ adds the machine name to the return address which is not taken into account by the conventions helper class.)