### PR TITLE
Prevent DeliveryConstraints from leaking in nested operations

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_setting_ttbr_in_outer_publish.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_setting_ttbr_in_outer_publish.cs
@@ -12,7 +12,7 @@
     public class When_setting_ttbr_in_outer_publish : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_not_apply_ttbr_to_inner_operation()
+        public async Task Should_not_apply_ttbr_to_inner_publish()
         {
             Requires.NativePubSubSupport();
 

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_setting_ttbr_in_outer_publish.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_setting_ttbr_in_outer_publish.cs
@@ -1,0 +1,129 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Pipeline
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using DeliveryConstraints;
+    using EndpointTemplates;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+    using Performance.TimeToBeReceived;
+
+    public class When_setting_ttbr_in_outer_publish : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_not_apply_ttbr_to_inner_operation()
+        {
+            Requires.NativePubSubSupport();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<PublisherWithTtbr>(e => e
+                    .When(s => s.Publish(new OuterEvent())))
+                .WithEndpoint<Subscriber>()
+                .Done(c => c.OuterEventReceived && c.InnerEventReceived)
+                .Run();
+
+            Assert.IsTrue(context.OuterEventHasTtbr, "Outer event should have TTBR settings applied");
+            Assert.IsFalse(context.InnerEventHasTtbr, "Inner event should not have TTBR settings applied");
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool InnerEventReceived { get; set; }
+            public bool OuterEventReceived { get; set; }
+            public bool OuterEventHasTtbr { get; set; }
+            public bool InnerEventHasTtbr { get; set; }
+        }
+
+        class PublisherWithTtbr : EndpointConfigurationBuilder
+        {
+            public PublisherWithTtbr()
+            {
+                EndpointSetup<DefaultServer>((c, r) =>
+                {
+                    c.Pipeline.Register(new InnerPublishBehavior(), "publishes an additional event when publishing an OuterEvent");
+                    c.Pipeline.Register(new TtbrObserver((Context)r.ScenarioContext), "Checks outgoing messages for their TTBR setting");
+                });
+            }
+
+            // Behavior needs to be in the OutgoingPhysical stage as the TTBR settings are applied in the OutgoingLogical stage
+            class InnerPublishBehavior : Behavior<IOutgoingPhysicalMessageContext>
+            {
+                public override async Task Invoke(IOutgoingPhysicalMessageContext context, Func<Task> next)
+                {
+                    await next();
+
+                    if (context.Extensions.Get<OutgoingLogicalMessage>().MessageType == typeof(OuterEvent))
+                    {
+                        await context.Publish(new InnerEvent());
+                    }
+                }
+            }
+
+            class TtbrObserver : Behavior<IDispatchContext>
+            {
+                Context testContext;
+
+                public TtbrObserver(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public override Task Invoke(IDispatchContext context, Func<Task> next)
+                {
+                    var outgoingMessage = context.Extensions.Get<OutgoingLogicalMessage>();
+                    if (outgoingMessage.MessageType == typeof(OuterEvent))
+                    {
+                        testContext.OuterEventHasTtbr = context.Extensions.TryGetDeliveryConstraint<DiscardIfNotReceivedBefore>(out var _);
+                    }
+
+                    if (outgoingMessage.MessageType == typeof(InnerEvent))
+                    {
+                        testContext.InnerEventHasTtbr = context.Extensions.TryGetDeliveryConstraint<DiscardIfNotReceivedBefore>(out var _);
+                    }
+
+                    return next();
+                }
+            }
+        }
+
+        class Subscriber : EndpointConfigurationBuilder
+        {
+            public Subscriber()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            class EventHandler : IHandleMessages<OuterEvent>, IHandleMessages<InnerEvent>
+            {
+                Context testContext;
+
+                public EventHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(OuterEvent message, IMessageHandlerContext context)
+                {
+                    testContext.OuterEventReceived = true;
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(InnerEvent message, IMessageHandlerContext context)
+                {
+                    testContext.InnerEventReceived = true;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        [TimeToBeReceived("00:30:00")]
+        class OuterEvent : IEvent
+        {
+        }
+
+        class InnerEvent : IEvent
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_setting_ttbr_in_outer_publish.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_setting_ttbr_in_outer_publish.cs
@@ -118,11 +118,11 @@
         }
 
         [TimeToBeReceived("00:30:00")]
-        class OuterEvent : IEvent
+        public class OuterEvent : IEvent
         {
         }
 
-        class InnerEvent : IEvent
+        public class InnerEvent : IEvent
         {
         }
     }

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_outer_send.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_outer_send.cs
@@ -1,15 +1,11 @@
 ﻿namespace NServiceBus.AcceptanceTests.DelayedDelivery
 {
     using System;
-    using System.Linq;
-    using System.Threading;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using EndpointTemplates;
-    using Extensibility;
     using Features;
-    using NServiceBus.DelayedDelivery;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
 
@@ -92,7 +88,7 @@
                     {
                         testContext.DelayedMessageDelayed = context.MessageHeaders.TryGetValue("NServiceBus.Timeout.RouteExpiredTimeoutTo", out var _); // header value when routing to timeout manager queue
                     }
-                    
+
                     return Task.FromResult(0);
                 }
 

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_outer_send.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_outer_send.cs
@@ -91,11 +91,11 @@
             }
         }
 
-        class DelayedMessage : IMessage
+        public class DelayedMessage : IMessage
         {
         }
 
-        class NonDelayedMessage : IMessage
+        public class NonDelayedMessage : IMessage
         {
         }
     }

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_outer_send.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_outer_send.cs
@@ -1,0 +1,102 @@
+﻿namespace NServiceBus.AcceptanceTests.DelayedDelivery
+{
+    using System;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using NServiceBus.DelayedDelivery;
+    using NServiceBus.Pipeline;
+    using NUnit.Framework;
+
+    public class When_deferring_outer_send : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_not_defer_inner_send()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<SenderWithNestedSend>(e => e
+                    .When(s =>
+                    {
+                        var sendOptions = new SendOptions();
+                        sendOptions.DelayDeliveryWith(TimeSpan.FromSeconds(2));
+                        return s.Send(new DelayedMessage(), sendOptions);
+                    }))
+                .WithEndpoint<Receiver>()
+                .Done(c => c.ReceivedNonDelayedMessage && c.ReceivedDelayedMessage)
+                .Run();
+
+            Assert.IsTrue(context.DelayedMessageDelayed, "should delay the message sent with 'DelayDeliveryWith'");
+            Assert.IsFalse(context.NonDelayedMessageDelayed, "should not delay the message sent with default options");
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool DelayedMessageDelayed { get; set; }
+            public bool NonDelayedMessageDelayed { get; set; }
+
+            public bool ReceivedNonDelayedMessage { get; set; }
+            public bool ReceivedDelayedMessage { get; set; }
+        }
+
+        class SenderWithNestedSend : EndpointConfigurationBuilder
+        {
+            public SenderWithNestedSend() => EndpointSetup<DefaultServer>((c, r) =>
+            {
+                c.Pipeline.Register(new NestedSendBehavior(), "Sends an additional message when sending a delayed message");
+                c.ConfigureTransport().Routing().RouteToEndpoint(typeof(DelayedMessage).Assembly, Conventions.EndpointNamingConvention(typeof(Receiver)));
+            });
+
+            class NestedSendBehavior : Behavior<IOutgoingSendContext>
+            {
+                public override async Task Invoke(IOutgoingSendContext context, Func<Task> next)
+                {
+                    await next();
+                    if (context.Message.MessageType == typeof(DelayedMessage))
+                    {
+                        await context.Send(new NonDelayedMessage()); // use default options
+                    }
+                }
+            }
+        }
+
+        class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver() => EndpointSetup<DefaultServer>();
+
+            class DelayedMessageHandler : IHandleMessages<DelayedMessage>, IHandleMessages<NonDelayedMessage>
+            {
+                Context testContext;
+
+                public DelayedMessageHandler(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                public Task Handle(DelayedMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedDelayedMessage = true;
+                    testContext.DelayedMessageDelayed = context.MessageHeaders.TryGetValue(Headers.DeliverAt, out var _);
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(NonDelayedMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedNonDelayedMessage = true;
+                    testContext.NonDelayedMessageDelayed = context.MessageHeaders.TryGetValue(Headers.DeliverAt, out var _);
+                    return Task.FromResult(0);
+                }
+            }
+        }
+
+        class DelayedMessage : IMessage
+        {
+        }
+
+        class NonDelayedMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingPublishContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingPublishContextTests.cs
@@ -1,7 +1,11 @@
 ﻿namespace NServiceBus.Core.Tests.Pipeline.Outgoing
 {
+    using System.Collections.Generic;
+    using DeliveryConstraints;
+    using Extensibility;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
+    using Testing;
 
     [TestFixture]
     public class OutgoingPublishContextTests
@@ -39,6 +43,57 @@
             var valueFound = parentContext.TryGet("someKey", out string _);
 
             Assert.IsFalse(valueFound);
+        }
+
+        [Test]
+        public void ShouldExposePublishOptionsExtensionsAsOperationProperties()
+        {
+            var message = new OutgoingLogicalMessage(typeof(object), new object());
+            var parentContext = new FakeRootContext(); // exact parent context doesn't matter
+            var options = new ContextBag();
+            options.Set("some key", "some value");
+
+            var publishContext = new OutgoingPublishContext(message, "message-id", new Dictionary<string, string>(), options, parentContext);
+
+            var operationProperties = publishContext.GetOperationProperties();
+            Assert.AreEqual("some value", operationProperties.Get<string>("some key"));
+        }
+
+        [Test]
+        public void ShouldNotLeakParentsOperationProperties()
+        {
+            var outerOptions = new ContextBag();
+            outerOptions.Set("outer key", "outer value");
+            outerOptions.Set("shared key", "outer shared value");
+            var parentContext = new OutgoingPublishContext(new OutgoingLogicalMessage(typeof(object), new object()), "message-id", new Dictionary<string, string>(), outerOptions, new FakeRootContext());
+
+            var innerOptions = new ContextBag();
+            innerOptions.Set("inner key", "inner value");
+            innerOptions.Set("shared key", "inner shared value");
+            var innerContext = new OutgoingPublishContext(new OutgoingLogicalMessage(typeof(object), new object()), "message-id", new Dictionary<string, string>(), innerOptions, parentContext);
+
+            var innerOperationProperties = innerContext.GetOperationProperties();
+            Assert.AreEqual("inner value", innerOperationProperties.Get<string>("inner key"));
+            Assert.AreEqual("inner shared value", innerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(innerOperationProperties.TryGet("outer key", out string _));
+
+            var outerOperationProperties = parentContext.GetOperationProperties();
+            Assert.AreEqual("outer value", outerOperationProperties.Get<string>("outer key"));
+            Assert.AreEqual("outer shared value", outerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(outerOperationProperties.TryGet("inner key", out string _));
+        }
+
+        [Test]
+        public void ShouldNotLeakParentsDeliveryConstraints()
+        {
+            var message = new OutgoingLogicalMessage(typeof(object), new object());
+            var publishOptions = new ContextBag();
+            var parentContext = new FakeRootContext();
+            parentContext.Extensions.AddDeliveryConstraint(new NonDurableDelivery());
+
+            var publishContext = new OutgoingPublishContext(message, "message-id", new Dictionary<string, string>(), publishOptions, parentContext);
+
+            Assert.IsFalse(publishContext.TryGetDeliveryConstraint(out NonDurableDelivery _));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingReplyContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingReplyContextTests.cs
@@ -1,5 +1,8 @@
 ﻿namespace NServiceBus.Core.Tests.Pipeline.Outgoing
 {
+    using System.Collections.Generic;
+    using DeliveryConstraints;
+    using Extensibility;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
 
@@ -40,6 +43,57 @@
             var valueFound = parentContext.TryGet("someKey", out string _);
 
             Assert.IsFalse(valueFound);
+        }
+
+        [Test]
+        public void ShouldExposeSendOptionsExtensionsAsOperationProperties()
+        {
+            var message = new OutgoingLogicalMessage(typeof(object), new object());
+            var parentContext = new FakeRootContext(); // exact parent context doesn't matter
+            var options = new ContextBag();
+            options.Set("some key", "some value");
+
+            var context = new OutgoingReplyContext(message, "message-id", new Dictionary<string, string>(), options, parentContext);
+
+            var operationProperties = context.GetOperationProperties();
+            Assert.AreEqual("some value", operationProperties.Get<string>("some key"));
+        }
+
+        [Test]
+        public void ShouldNotLeakParentsOperationProperties()
+        {
+            var outerOptions = new ContextBag();
+            outerOptions.Set("outer key", "outer value");
+            outerOptions.Set("shared key", "outer shared value");
+            var parentContext = new OutgoingReplyContext(new OutgoingLogicalMessage(typeof(object), new object()), "message-id", new Dictionary<string, string>(), outerOptions, new FakeRootContext());
+
+            var innerOptions = new ContextBag();
+            innerOptions.Set("inner key", "inner value");
+            innerOptions.Set("shared key", "inner shared value");
+            var innerContext = new OutgoingReplyContext(new OutgoingLogicalMessage(typeof(object), new object()), "message-id", new Dictionary<string, string>(), innerOptions, parentContext);
+
+            var innerOperationProperties = innerContext.GetOperationProperties();
+            Assert.AreEqual("inner value", innerOperationProperties.Get<string>("inner key"));
+            Assert.AreEqual("inner shared value", innerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(innerOperationProperties.TryGet("outer key", out string _));
+
+            var outerOperationProperties = parentContext.GetOperationProperties();
+            Assert.AreEqual("outer value", outerOperationProperties.Get<string>("outer key"));
+            Assert.AreEqual("outer shared value", outerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(outerOperationProperties.TryGet("inner key", out string _));
+        }
+
+        [Test]
+        public void ShouldNotLeakParentsDeliveryConstraints()
+        {
+            var message = new OutgoingLogicalMessage(typeof(object), new object());
+            var options = new ContextBag();
+            var parentContext = new FakeRootContext();
+            parentContext.Extensions.AddDeliveryConstraint(new NonDurableDelivery());
+
+            var context = new OutgoingReplyContext(message, "message-id", new Dictionary<string, string>(), options, parentContext);
+
+            Assert.IsFalse(context.TryGetDeliveryConstraint(out NonDurableDelivery _));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingSendContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingSendContextTests.cs
@@ -1,7 +1,11 @@
 ﻿namespace NServiceBus.Core.Tests.Pipeline.Outgoing
 {
+    using System.Collections.Generic;
+    using DeliveryConstraints;
+    using Extensibility;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
+    using Testing;
 
     [TestFixture]
     public class OutgoingSendContextTests
@@ -39,6 +43,57 @@
             var valueFound = parentContext.TryGet("someKey", out string _);
 
             Assert.IsFalse(valueFound);
+        }
+
+        [Test]
+        public void ShouldExposeSendOptionsExtensionsAsOperationProperties()
+        {
+            var message = new OutgoingLogicalMessage(typeof(object), new object());
+            var parentContext = new FakeRootContext(); // exact parent context doesn't matter
+            var options = new ContextBag();
+            options.Set("some key", "some value");
+
+            var context = new OutgoingSendContext(message, "message-id", new Dictionary<string, string>(), options, parentContext);
+
+            var operationProperties = context.GetOperationProperties();
+            Assert.AreEqual("some value", operationProperties.Get<string>("some key"));
+        }
+
+        [Test]
+        public void ShouldNotLeakParentsOperationProperties()
+        {
+            var outerOptions = new ContextBag();
+            outerOptions.Set("outer key", "outer value");
+            outerOptions.Set("shared key", "outer shared value");
+            var parentContext = new OutgoingSendContext(new OutgoingLogicalMessage(typeof(object), new object()), "message-id", new Dictionary<string, string>(), outerOptions, new FakeRootContext());
+
+            var innerOptions = new ContextBag();
+            innerOptions.Set("inner key", "inner value");
+            innerOptions.Set("shared key", "inner shared value");
+            var innerContext = new OutgoingSendContext(new OutgoingLogicalMessage(typeof(object), new object()), "message-id", new Dictionary<string, string>(), innerOptions, parentContext);
+
+            var innerOperationProperties = innerContext.GetOperationProperties();
+            Assert.AreEqual("inner value", innerOperationProperties.Get<string>("inner key"));
+            Assert.AreEqual("inner shared value", innerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(innerOperationProperties.TryGet("outer key", out string _));
+
+            var outerOperationProperties = parentContext.GetOperationProperties();
+            Assert.AreEqual("outer value", outerOperationProperties.Get<string>("outer key"));
+            Assert.AreEqual("outer shared value", outerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(outerOperationProperties.TryGet("inner key", out string _));
+        }
+
+        [Test]
+        public void ShouldNotLeakParentsDeliveryConstraints()
+        {
+            var message = new OutgoingLogicalMessage(typeof(object), new object());
+            var options = new ContextBag();
+            var parentContext = new FakeRootContext();
+            parentContext.Extensions.AddDeliveryConstraint(new NonDurableDelivery());
+
+            var context = new OutgoingSendContext(message, "message-id", new Dictionary<string, string>(), options, parentContext);
+
+            Assert.IsFalse(context.TryGetDeliveryConstraint(out NonDurableDelivery _));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/UnsubscribeContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnsubscribeContextTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Core.Tests.Routing
 {
+    using DeliveryConstraints;
     using Extensibility;
     using NUnit.Framework;
 
@@ -37,6 +38,55 @@
             var valueFound = parentContext.TryGet("someKey", out string _);
 
             Assert.IsFalse(valueFound);
+        }
+
+        [Test]
+        public void ShouldExposeSendOptionsExtensionsAsOperationProperties()
+        {
+            var parentContext = new FakeRootContext(); // exact parent context doesn't matter
+            var options = new ContextBag();
+            options.Set("some key", "some value");
+
+            var context = new UnsubscribeContext(parentContext, typeof(object), options);
+
+            var operationProperties = context.GetOperationProperties();
+            Assert.AreEqual("some value", operationProperties.Get<string>("some key"));
+        }
+
+        [Test]
+        public void ShouldNotLeakParentsOperationProperties()
+        {
+            var outerOptions = new ContextBag();
+            outerOptions.Set("outer key", "outer value");
+            outerOptions.Set("shared key", "outer shared value");
+            var parentContext = new UnsubscribeContext(new FakeRootContext(), typeof(object), outerOptions);
+
+            var innerOptions = new ContextBag();
+            innerOptions.Set("inner key", "inner value");
+            innerOptions.Set("shared key", "inner shared value");
+            var innerContext = new UnsubscribeContext(parentContext, typeof(object), innerOptions);
+
+            var innerOperationProperties = innerContext.GetOperationProperties();
+            Assert.AreEqual("inner value", innerOperationProperties.Get<string>("inner key"));
+            Assert.AreEqual("inner shared value", innerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(innerOperationProperties.TryGet("outer key", out string _));
+
+            var outerOperationProperties = parentContext.GetOperationProperties();
+            Assert.AreEqual("outer value", outerOperationProperties.Get<string>("outer key"));
+            Assert.AreEqual("outer shared value", outerOperationProperties.Get<string>("shared key"));
+            Assert.IsFalse(outerOperationProperties.TryGet("inner key", out string _));
+        }
+
+        [Test]
+        public void ShouldNotLeakParentsDeliveryConstraints()
+        {
+            var options = new ContextBag();
+            var parentContext = new FakeRootContext();
+            parentContext.Extensions.AddDeliveryConstraint(new NonDurableDelivery());
+
+            var context = new UnsubscribeContext(parentContext, typeof(object), options);
+
+            Assert.IsFalse(context.TryGetDeliveryConstraint(out NonDurableDelivery _));
         }
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPublishContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingPublishContext.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System.Collections.Generic;
+    using DeliveryConstraints;
     using Extensibility;
     using Pipeline;
 
@@ -17,7 +18,7 @@
 
             Merge(extensions);
             Set(ExtendableOptions.OperationPropertiesKey, extensions);
-
+            Set(new List<DeliveryConstraint>(0)); // set empty delivery constraint to prevent leaking nested constraints collections.
         }
 
         public OutgoingLogicalMessage Message { get; }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingReplyContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingReplyContext.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System.Collections.Generic;
+    using DeliveryConstraints;
     using Extensibility;
     using Pipeline;
 
@@ -17,6 +18,7 @@
 
             Merge(extensions);
             Set(ExtendableOptions.OperationPropertiesKey, extensions);
+            Set(new List<DeliveryConstraint>(0)); // set empty delivery constraint to prevent leaking nested constraints collections.
         }
 
         public OutgoingLogicalMessage Message { get; }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingSendContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/OutgoingSendContext.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus
 {
     using System.Collections.Generic;
+    using DeliveryConstraints;
     using Extensibility;
     using Pipeline;
 
@@ -17,6 +18,7 @@
 
             Merge(extensions);
             Set(ExtendableOptions.OperationPropertiesKey, extensions);
+            Set(new List<DeliveryConstraint>(0)); // set empty delivery constraint to prevent leaking nested constraints collections.
         }
 
         public OutgoingLogicalMessage Message { get; }

--- a/src/NServiceBus.Core/Routing/SubscribeContext.cs
+++ b/src/NServiceBus.Core/Routing/SubscribeContext.cs
@@ -1,6 +1,8 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
+    using DeliveryConstraints;
     using Extensibility;
     using Pipeline;
 
@@ -15,6 +17,7 @@
 
             Merge(extensions);
             Set(ExtendableOptions.OperationPropertiesKey, extensions);
+            Set(new List<DeliveryConstraint>(0)); // set empty delivery constraint to prevent leaking nested constraints collections.
 
             EventType = eventType;
         }

--- a/src/NServiceBus.Core/Routing/UnsubscribeContext.cs
+++ b/src/NServiceBus.Core/Routing/UnsubscribeContext.cs
@@ -1,6 +1,8 @@
 ﻿namespace NServiceBus
 {
     using System;
+    using System.Collections.Generic;
+    using DeliveryConstraints;
     using Extensibility;
     using Pipeline;
 
@@ -15,6 +17,7 @@
 
             Merge(extensions);
             Set(ExtendableOptions.OperationPropertiesKey, extensions);
+            Set(new List<DeliveryConstraint>(0)); // set empty delivery constraint to prevent leaking nested constraints collections.
 
             EventType = eventType;
         }


### PR DESCRIPTION
The `DeliveryConstraint`s are managed via a mutable collection that is created directly on the behavior context rather than on the extendable option's context bag to prevent "sideway" leaks from reusing send options. Since they are accessed directly from the context and are only created when values have been defined, they are also affected in a very similar behavior to the options leak described in #6223 as the delivery constraint's from an "outer" operation might be found and applied.

With this behavior, delivery constraint's set in the incoming pipeline are always hidden (ignored) but I couldn't find any usage  like this.