### PR TITLE
Create ContextBag stash lazily

### DIFF
--- a/src/NServiceBus.Core/Extensibility/ContextBag.cs
+++ b/src/NServiceBus.Core/Extensibility/ContextBag.cs
@@ -48,7 +48,7 @@ namespace NServiceBus.Extensibility
         public bool TryGet<T>(string key, out T result)
         {
             Guard.AgainstNullAndEmpty(nameof(key), key);
-            if (stash.TryGetValue(key, out var value))
+            if (stash?.TryGetValue(key, out var value) == true)
             {
                 result = (T)value;
                 return true;
@@ -121,7 +121,7 @@ namespace NServiceBus.Extensibility
         public void Remove(string key)
         {
             Guard.AgainstNullAndEmpty(nameof(key), key);
-            stash.Remove(key);
+            _ = stash?.Remove(key);
         }
 
         /// <summary>
@@ -130,7 +130,7 @@ namespace NServiceBus.Extensibility
         public void Set<T>(string key, T t)
         {
             Guard.AgainstNullAndEmpty(nameof(key), key);
-            stash[key] = t;
+            GetOrCreateStash()[key] = t;
         }
 
         /// <summary>
@@ -139,10 +139,25 @@ namespace NServiceBus.Extensibility
         /// <param name="context">The source context.</param>
         internal void Merge(ContextBag context)
         {
+            if (context.stash == null)
+            {
+                return;
+            }
+
+            var targetStash = GetOrCreateStash();
             foreach (var kvp in context.stash)
             {
-                stash[kvp.Key] = kvp.Value;
+                targetStash[kvp.Key] = kvp.Value;
             }
+        }
+        Dictionary<string, object> GetOrCreateStash()
+        {
+            if (stash == null)
+            {
+                stash = new Dictionary<string, object>();
+            }
+
+            return stash;
         }
 
         /// <summary>
@@ -153,6 +168,6 @@ namespace NServiceBus.Extensibility
         internal IBehavior[] Behaviors { get; set; }
 
         ContextBag parentBag;
-        Dictionary<string, object> stash = new Dictionary<string, object>();
+        Dictionary<string, object> stash; // might be null!
     }
 }


### PR DESCRIPTION
Only creates the internal settings collection of the `ContextBag` when it is actually used to set values on this bag, otherwise, it avoids the allocation. Since many stages don't contain their own settings but rely primarily on the hierarchy, this can safe quite a few unnecessary allocations.

In a test sending and receiving 10k messages, this reduced the total memory allocated for the test from 867,3 MB and 6,38M objects to 859,9 MB and 6,3M objects, which is about 1% reduction in total memory usage and object allocations. In worst-case scenarios, the memory used shouldn't change from the current state.