### PR TITLE
Simplify noisy default endpoint setup in acceptance tests

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -62,17 +62,17 @@ namespace NServiceBus.AcceptanceTesting
             return (TContext)runDescriptor.ScenarioContext;
         }
 
-        public IScenarioWithEndpointBehavior<TContext> WithEndpoint<T>() where T : EndpointConfigurationBuilder
+        public IScenarioWithEndpointBehavior<TContext> WithEndpoint<T>() where T : IEndpointConfigurationFactory
         {
             return WithEndpoint<T>(b => { });
         }
 
-        public IScenarioWithEndpointBehavior<TContext> WithEndpoint<T>(Action<EndpointBehaviorBuilder<TContext>> defineBehavior) where T : EndpointConfigurationBuilder
+        public IScenarioWithEndpointBehavior<TContext> WithEndpoint<T>(Action<EndpointBehaviorBuilder<TContext>> defineBehavior) where T : IEndpointConfigurationFactory
         {
             return WithEndpoint(Activator.CreateInstance<T>(), defineBehavior);
         }
 
-        public IScenarioWithEndpointBehavior<TContext> WithEndpoint(EndpointConfigurationBuilder endpointConfigurationBuilder, Action<EndpointBehaviorBuilder<TContext>> defineBehavior)
+        public IScenarioWithEndpointBehavior<TContext> WithEndpoint(IEndpointConfigurationFactory endpointConfigurationBuilder, Action<EndpointBehaviorBuilder<TContext>> defineBehavior)
         {
             var builder = new EndpointBehaviorBuilder<TContext>(endpointConfigurationBuilder);
             defineBehavior(builder);

--- a/src/NServiceBus.AcceptanceTesting/Support/IScenarioWithEndpointBehavior.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/IScenarioWithEndpointBehavior.cs
@@ -5,11 +5,11 @@
 
     public interface IScenarioWithEndpointBehavior<TContext> where TContext : ScenarioContext
     {
-        IScenarioWithEndpointBehavior<TContext> WithEndpoint<T>() where T : EndpointConfigurationBuilder;
+        IScenarioWithEndpointBehavior<TContext> WithEndpoint<T>() where T : IEndpointConfigurationFactory;
 
-        IScenarioWithEndpointBehavior<TContext> WithEndpoint<T>(Action<EndpointBehaviorBuilder<TContext>> behavior) where T : EndpointConfigurationBuilder;
+        IScenarioWithEndpointBehavior<TContext> WithEndpoint<T>(Action<EndpointBehaviorBuilder<TContext>> behavior) where T : IEndpointConfigurationFactory;
 
-        IScenarioWithEndpointBehavior<TContext> WithEndpoint(EndpointConfigurationBuilder endpointConfigurationBuilder, Action<EndpointBehaviorBuilder<TContext>> defineBehavior);
+        IScenarioWithEndpointBehavior<TContext> WithEndpoint(IEndpointConfigurationFactory endpointConfigurationBuilder, Action<EndpointBehaviorBuilder<TContext>> defineBehavior);
 
         IScenarioWithEndpointBehavior<TContext> WithComponent(IComponentBehavior componentBehavior);
 

--- a/src/NServiceBus.AcceptanceTests/Audit/When_a_replymessage_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_a_replymessage_is_audited.cs
@@ -39,13 +39,8 @@
             public string HeaderValue { get; set; }
         }
 
-        public class Server : EndpointConfigurationBuilder
+        public class Server : EndpointFromTemplate<DefaultServer>
         {
-            public Server()
-            {
-                EndpointSetup<DefaultServer>();
-            }
-
             class RequestHandler : IHandleMessages<Request>
             {
                 public Task Handle(Request message, IMessageHandlerContext context)

--- a/src/NServiceBus.AcceptanceTests/Audit/When_audit_is_overridden_in_code.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_audit_is_overridden_in_code.cs
@@ -19,11 +19,11 @@
             Assert.True(context.MessageAudited);
         }
 
-        public class UserEndpoint : EndpointConfigurationBuilder
+        public class UserEndpoint : EndpointFromTemplate<DefaultServer>
         {
             public UserEndpoint()
             {
-                EndpointSetup<DefaultServer>(c => c.AuditProcessedMessagesTo("audit_with_code_target"));
+                EndpointSetup(c => c.AuditProcessedMessagesTo("audit_with_code_target"));
             }
 
             class Handler : IHandleMessages<MessageToBeAudited>

--- a/src/NServiceBus.AcceptanceTests/Audit/When_auditing.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_auditing.cs
@@ -39,14 +39,14 @@
             public bool IsMessageHandledByTheAuditEndpoint { get; set; }
         }
 
-        public class EndpointWithAuditOff : EndpointConfigurationBuilder
+        public class EndpointWithAuditOff : EndpointFromTemplate<DefaultServer>
         {
             public EndpointWithAuditOff()
             {
                 // Although the AuditProcessedMessagesTo seems strange here, this test tries to fake the scenario where
                 // even though the user has specified audit config, because auditing is explicitly turned
                 // off, no messages should be audited.
-                EndpointSetup<DefaultServer>(c =>
+                EndpointSetup(c =>
                 {
                     c.DisableFeature<Audit>();
                     c.AuditProcessedMessagesTo<EndpointThatHandlesAuditMessages>();
@@ -70,12 +70,9 @@
             }
         }
 
-        public class EndpointWithAuditOn : EndpointConfigurationBuilder
+        public class EndpointWithAuditOn : EndpointFromTemplate<DefaultServer>
         {
-            public EndpointWithAuditOn()
-            {
-                EndpointSetup<DefaultServer>(c => c.AuditProcessedMessagesTo<EndpointThatHandlesAuditMessages>());
-            }
+            public EndpointWithAuditOn() => EndpointSetup(c => c.AuditProcessedMessagesTo<EndpointThatHandlesAuditMessages>());
 
             class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
             {
@@ -94,13 +91,8 @@
             }
         }
 
-        public class EndpointThatHandlesAuditMessages : EndpointConfigurationBuilder
+        public class EndpointThatHandlesAuditMessages : EndpointFromTemplate<DefaultServer>
         {
-            public EndpointThatHandlesAuditMessages()
-            {
-                EndpointSetup<DefaultServer>();
-            }
-
             class AuditMessageHandler : IHandleMessages<MessageToBeAudited>
             {
                 public AuditMessageHandler(Context context)

--- a/src/NServiceBus.AcceptanceTests/Audit/When_auditing_message_with_TimeToBeReceived.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_auditing_message_with_TimeToBeReceived.cs
@@ -33,12 +33,9 @@
             public bool TTBRHasExpiredAndMessageIsStillInAuditQueue { get; set; }
         }
 
-        class EndpointWithAuditOn : EndpointConfigurationBuilder
+        class EndpointWithAuditOn : EndpointFromTemplate<DefaultServer>
         {
-            public EndpointWithAuditOn()
-            {
-                EndpointSetup<DefaultServer>(c => c.AuditProcessedMessagesTo<EndpointThatHandlesAuditMessages>());
-            }
+            public EndpointWithAuditOn() => EndpointSetup(c => c.AuditProcessedMessagesTo<EndpointThatHandlesAuditMessages>());
 
             class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
             {

--- a/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_starting_an_endpoint_with_autosubscribe_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_starting_an_endpoint_with_autosubscribe_disabled.cs
@@ -28,11 +28,11 @@
             public ConcurrentBag<Type> SubscribedEvents { get; set; } = new ConcurrentBag<Type>();
         }
 
-        class Subscriber : EndpointConfigurationBuilder
+        class Subscriber : EndpointFromTemplate<DefaultServer>
         {
             public Subscriber()
             {
-                EndpointSetup<DefaultServer>(c =>
+                EndpointSetup(c =>
                 {
                     c.DisableFeature<AutoSubscribe>();
                     c.Pipeline.Register(typeof(SubscribeSpy), "Inspects all subscribe operations");

--- a/src/NServiceBus.AcceptanceTests/Core/BestPractices/When_injecting_message_session_into_handlers.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/BestPractices/When_injecting_message_session_into_handlers.cs
@@ -19,13 +19,8 @@
             StringAssert.Contains("IMessageSession", exception.ToString());
         }
 
-        public class StartedEndpoint : EndpointConfigurationBuilder
+        public class StartedEndpoint : EndpointFromTemplate<DefaultServer>
         {
-            public StartedEndpoint()
-            {
-                EndpointSetup<DefaultServer>();
-            }
-
             class MyHandler : IHandleMessages<MyMessage>
             {
                 //not supported

--- a/src/NServiceBus.AcceptanceTests/Core/BestPractices/When_publishing_command.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/BestPractices/When_publishing_command.cs
@@ -36,12 +36,8 @@
             public Exception Exception { get; set; }
         }
 
-        public class Endpoint : EndpointConfigurationBuilder
+        public class Endpoint : EndpointFromTemplate<DefaultServer>
         {
-            public Endpoint()
-            {
-                EndpointSetup<DefaultServer>();
-            }
         }
 
         public class MyCommand : ICommand

--- a/src/NServiceBus.AcceptanceTests/Core/BestPractices/When_sending_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/BestPractices/When_sending_event.cs
@@ -36,12 +36,8 @@
             public Exception Exception { get; set; }
         }
 
-        public class Endpoint : EndpointConfigurationBuilder
+        public class Endpoint : EndpointFromTemplate<DefaultServer>
         {
-            public Endpoint()
-            {
-                EndpointSetup<DefaultServer>();
-            }
         }
 
         public class MyEvent : IEvent

--- a/src/NServiceBus.AcceptanceTests/Core/BestPractices/When_subscribing_to_command.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/BestPractices/When_subscribing_to_command.cs
@@ -36,12 +36,8 @@
             public Exception Exception { get; set; }
         }
 
-        public class Endpoint : EndpointConfigurationBuilder
+        public class Endpoint : EndpointFromTemplate<DefaultServer>
         {
-            public Endpoint()
-            {
-                EndpointSetup<DefaultServer>();
-            }
         }
 
         public class MyCommand : ICommand

--- a/src/NServiceBus.AcceptanceTests/Core/BestPractices/When_unsubscribing_to_command.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/BestPractices/When_unsubscribing_to_command.cs
@@ -36,12 +36,8 @@
             public Exception Exception { get; set; }
         }
 
-        public class Endpoint : EndpointConfigurationBuilder
+        public class Endpoint : EndpointFromTemplate<DefaultServer>
         {
-            public Endpoint()
-            {
-                EndpointSetup<DefaultServer>();
-            }
         }
 
         public class MyCommand : ICommand

--- a/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_at_startup.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_at_startup.cs
@@ -39,13 +39,8 @@
             public int CriticalErrorsRaised { get; set; }
         }
 
-        public class EndpointWithCriticalError : EndpointConfigurationBuilder
+        public class EndpointWithCriticalError : EndpointFromTemplate<DefaultServer>
         {
-            public EndpointWithCriticalError()
-            {
-                EndpointSetup<DefaultServer>();
-            }
-
             public class CriticalHandler : IHandleMessages<Message>
             {
                 public CriticalHandler(CriticalError criticalError, TestContext testContext)

--- a/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_from_a_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_from_a_handler.cs
@@ -50,13 +50,8 @@
             public int CriticalErrorsRaised { get; set; }
         }
 
-        public class EndpointWithCriticalError : EndpointConfigurationBuilder
+        public class EndpointWithCriticalError : EndpointFromTemplate<DefaultServer>
         {
-            public EndpointWithCriticalError()
-            {
-                EndpointSetup<DefaultServer>();
-            }
-
             public class CriticalHandler : IHandleMessages<Message>
             {
                 public CriticalHandler(CriticalError criticalError, TestContext testContext)

--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/When_delayed_delivery_is_not_supported.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/When_delayed_delivery_is_not_supported.cs
@@ -39,13 +39,8 @@
             public bool SecondMessageReceived { get; set; }
         }
 
-        public class Endpoint : EndpointConfigurationBuilder
+        public class Endpoint : EndpointFromTemplate<DefaultServer>
         {
-            public Endpoint()
-            {
-                EndpointSetup<DefaultServer>();
-            }
-
             public class MyMessageHandler : IHandleMessages<MyMessage>, IHandleMessages<MyOtherMessage>
             {
                 public MyMessageHandler(Context testContext)

--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_endpoint_is_warmed_up.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_endpoint_is_warmed_up.cs
@@ -77,13 +77,8 @@
             public bool GotTheMessage { get; set; }
         }
 
-        public class StartedEndpoint : EndpointConfigurationBuilder
+        public class StartedEndpoint : EndpointFromTemplate<DefaultServer>
         {
-            public StartedEndpoint()
-            {
-                EndpointSetup<DefaultServer>();
-            }
-
             class SomeMessageHandler : IHandleMessages<SomeMessage>
             {
                 public SomeMessageHandler(Context context)

--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_using_externally_managed_container.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_using_externally_managed_container.cs
@@ -50,13 +50,8 @@
             public MyComponent CustomService { get; set; }
         }
 
-        public class ExternallyManagedContainerEndpoint : EndpointConfigurationBuilder
+        public class ExternallyManagedContainerEndpoint : EndpointFromTemplate<DefaultServer>
         {
-            public ExternallyManagedContainerEndpoint()
-            {
-                EndpointSetup<DefaultServer>();
-            }
-
             class SomeMessageHandler : IHandleMessages<SomeMessage>
             {
                 public SomeMessageHandler(Context context, MyComponent component, IServiceProvider serviceProvider)

--- a/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_a_message_is_audited.cs
@@ -49,13 +49,8 @@
             }
         }
 
-        class AuditSpyEndpoint : EndpointConfigurationBuilder
+        class AuditSpyEndpoint : EndpointFromTemplate<DefaultServer>
         {
-            public AuditSpyEndpoint()
-            {
-                EndpointSetup<DefaultServer>();
-            }
-
             public class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
             {
                 public MessageToBeAuditedHandler(Context context)

--- a/src/NServiceBus.AcceptanceTests/Core/Hosting/When_custom_host_id_is_configured.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Hosting/When_custom_host_id_is_configured.cs
@@ -26,12 +26,8 @@ namespace NServiceBus.AcceptanceTests.Core.Hosting
             Assert.AreEqual(context.CustomHostId, context.HostIdObserved);
         }
 
-        public class MyEndpoint : EndpointConfigurationBuilder
+        public class MyEndpoint : EndpointFromTemplate<DefaultServer>
         {
-            public MyEndpoint()
-            {
-                EndpointSetup<DefaultServer>();
-            }
         }
 
         public class MyFeatureThatOverridesHostInformationDefaults : Feature

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_extending_the_publish_api.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_extending_the_publish_api.cs
@@ -91,11 +91,17 @@
                 EndpointSetup<DefaultServer>(builder => builder.DisableFeature<AutoSubscribe>(), metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
             }
 
-            public class MyHandler : IHandleMessages<MyEvent>
+            public class BaseHandler<TContext>
             {
-                public MyHandler(Context context)
+                protected TContext testContext;
+
+                public BaseHandler(TContext testContext) => this.testContext = testContext;
+            }
+
+            public class MyHandler : BaseHandler<Context>, IHandleMessages<MyEvent>
+            {
+                public MyHandler(Context testContext) : base(testContext)
                 {
-                    testContext = context;
                 }
 
                 public Task Handle(MyEvent messageThatIsEnlisted, IMessageHandlerContext context)
@@ -103,8 +109,6 @@
                     testContext.Subscriber1GotTheEvent = true;
                     return Task.FromResult(0);
                 }
-
-                Context testContext;
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_using_custom_conversation_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_using_custom_conversation_id.cs
@@ -33,13 +33,8 @@
             public string ReceivedConversationId { get; set; }
         }
 
-        class ReceivingEndpoint : EndpointConfigurationBuilder
+        class ReceivingEndpoint : EndpointFromTemplate<DefaultServer>
         {
-            public ReceivingEndpoint()
-            {
-                EndpointSetup<DefaultServer>();
-            }
-
             public class ConversationIdMessageHandler : IHandleMessages<MessageWithConversationId>
             {
                 Context testContext;

--- a/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_used_with_transport_scopes.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_used_with_transport_scopes.cs
@@ -30,12 +30,8 @@
             Assert.True(exception.Message.Contains("A Transaction scope unit of work can't be used when the transport already uses a scope"));
         }
 
-        public class ScopeEndpoint : EndpointConfigurationBuilder
+        public class ScopeEndpoint : EndpointFromTemplate<DefaultServer>
         {
-            public ScopeEndpoint()
-            {
-                EndpointSetup<DefaultServer>();
-            }
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_to_non_local.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_to_non_local.cs
@@ -5,7 +5,6 @@
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using EndpointTemplates;
-    using Features;
     using NUnit.Framework;
 
     public class When_deferring_to_non_local : NServiceBusAcceptanceTest
@@ -42,24 +41,17 @@
             public DateTimeOffset ReceivedAt { get; set; }
         }
 
-        public class Endpoint : EndpointConfigurationBuilder
+        public class Endpoint : EndpointFromTemplate<DefaultServer>
         {
-            public Endpoint()
-            {
-                EndpointSetup<DefaultServer>(config =>
+            public Endpoint() =>
+                EndpointSetup(config =>
                 {
                     config.ConfigureRouting().RouteToEndpoint(typeof(MyMessage), typeof(Receiver));
                 });
-            }
         }
 
-        public class Receiver : EndpointConfigurationBuilder
+        public class Receiver : EndpointFromTemplate<DefaultServer>
         {
-            public Receiver()
-            {
-                EndpointSetup<DefaultServer>();
-            }
-
             public class MyMessageHandler : IHandleMessages<MyMessage>
             {
                 public MyMessageHandler(Context context)

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_custom_policy_moves_to_overridden_error_queue.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_custom_policy_moves_to_overridden_error_queue.cs
@@ -54,13 +54,8 @@ namespace NServiceBus.AcceptanceTests.Recoverability
             }
         }
 
-        class ErrorSpy : EndpointConfigurationBuilder
+        class ErrorSpy : EndpointFromTemplate<DefaultServer>
         {
-            public ErrorSpy()
-            {
-                EndpointSetup<DefaultServer>();
-            }
-
             class InitiatingMessageHandler : IHandleMessages<InitiatingMessage>
             {
                 public InitiatingMessageHandler(Context context)

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_message_fails_retries.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_message_fails_retries.cs
@@ -29,13 +29,8 @@
                 .StartsWith($"Moving message '{testContext.PhysicalMessageId}' to the error queue 'error' because processing failed due to an exception:")));
         }
 
-        public class RetryEndpoint : EndpointConfigurationBuilder
+        public class RetryEndpoint : EndpointFromTemplate<DefaultServer>
         {
-            public RetryEndpoint()
-            {
-                EndpointSetup<DefaultServer>();
-            }
-
             class MessageHandler : IHandleMessages<MessageWhichFailsRetries>
             {
                 public MessageHandler(Context context)

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Missing_pub_info.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Missing_pub_info.cs
@@ -28,13 +28,8 @@
             StringAssert.Contains($"No publisher address could be found for message type '{typeof(MyEvent).FullName}'.", log.Message);
         }
 
-        public class Subscriber : EndpointConfigurationBuilder
+        public class Subscriber : EndpointFromTemplate<DefaultServer>
         {
-            public Subscriber()
-            {
-                EndpointSetup<DefaultServer>();
-            }
-
             public class MyHandler : IHandleMessages<MyEvent>
             {
                 public Task Handle(MyEvent @event, IMessageHandlerContext context)

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Sub_to_multiple_pubs.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Sub_to_multiple_pubs.cs
@@ -57,12 +57,8 @@
             }
         }
 
-        class Publisher : EndpointConfigurationBuilder
+        class Publisher : EndpointFromTemplate<DefaultServer>
         {
-            public Publisher()
-            {
-                EndpointSetup<DefaultServer>();
-            }
         }
 
         public class SomeEvent : IEvent

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/MultiSubscribeToPolymorphicEvent.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/MultiSubscribeToPolymorphicEvent.cs
@@ -37,29 +37,16 @@
             public bool SubscriberGotMyEvent2 { get; set; }
         }
 
-        public class Publisher1 : EndpointConfigurationBuilder
+        public class Publisher1 : EndpointFromTemplate<DefaultPublisher>
         {
-            public Publisher1()
-            {
-                EndpointSetup<DefaultPublisher>();
-            }
         }
 
-        public class Publisher2 : EndpointConfigurationBuilder
+        public class Publisher2 : EndpointFromTemplate<DefaultPublisher>
         {
-            public Publisher2()
-            {
-                EndpointSetup<DefaultPublisher>();
-            }
         }
 
-        public class Subscriber : EndpointConfigurationBuilder
+        public class Subscriber : EndpointFromTemplate<DefaultServer>
         {
-            public Subscriber()
-            {
-                EndpointSetup<DefaultServer>();
-            }
-
             public class MyHandler : IHandleMessages<IMyEvent>
             {
                 public MyHandler(Context context)


### PR DESCRIPTION
The configuration for an endpoint in the acceptance testing framework is quite noisy if the endpoint doesn't require any specific setup. By passing the endpoint template in the `EndpointConfigurationBuilder` type, we could save a lot of unnecessary lines of code.

I've spiked this in a non-breaking way to minimize migration effort. The API might be further improved for cases where some configuration customization is necessary, in those cases the change doesn't change much as you still need to define a ctor and call `EndpointSetup` but it might be enough benefit to remove all the "useless" ctors for the simple cases.

This PR doesn't replace all usages of the "useless" ctors, it just migrates a few to showcase the API changes.

thoughts?