### PR TITLE
Register ScenarioContext in pipeline context

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioContextRegistration.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioContextRegistration.cs
@@ -1,0 +1,45 @@
+﻿namespace NServiceBus.AcceptanceTesting
+{
+    using System;
+    using System.Threading.Tasks;
+    using Features;
+    using Microsoft.Extensions.DependencyInjection;
+    using Pipeline;
+
+    public class ScenarioContextRegistration : Feature
+    {
+        protected internal override void Setup(FeatureConfigurationContext context)
+        {
+            var scenarioContext = context.Settings.Get<ScenarioContext>();
+
+            // register the ScenarioContext in the DI container
+            var type = scenarioContext.GetType();
+            while (type != typeof(object))
+            {
+                context.Container.AddSingleton(type, scenarioContext);
+                type = type.BaseType;
+            }
+
+            // register the ScenarioContext in the pipeline context
+            context.Pipeline.Register(new RegisterTestContextBehavior(scenarioContext), "Stores the test context into the pipeline extensions.");
+        }
+    }
+    class RegisterTestContextBehavior : Behavior<ITransportReceiveContext>
+    {
+        readonly ScenarioContext testContext;
+
+        public RegisterTestContextBehavior(ScenarioContext testContext) => this.testContext = testContext;
+
+        public override Task Invoke(ITransportReceiveContext context, Func<Task> next)
+        {
+            context.Extensions.Set(testContext);
+
+            return next();
+        }
+    }
+
+    public static class TestContextExtensions
+    {
+        public static T GetTestContext<T>(this IPipelineContext behavior) where T : ScenarioContext => behavior.Extensions.Get<ScenarioContext>() as T;
+    }
+}

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioContextRegistration.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioContextRegistration.cs
@@ -16,7 +16,7 @@
             var type = scenarioContext.GetType();
             while (type != typeof(object))
             {
-                context.Container.AddSingleton(type, scenarioContext);
+                context.Services.AddSingleton(type, scenarioContext);
                 type = type.BaseType;
             }
 
@@ -24,6 +24,7 @@
             context.Pipeline.Register(new RegisterTestContextBehavior(scenarioContext), "Stores the test context into the pipeline extensions.");
         }
     }
+
     class RegisterTestContextBehavior : Behavior<ITransportReceiveContext>
     {
         readonly ScenarioContext testContext;

--- a/src/NServiceBus.AcceptanceTests/Audit/When_a_replymessage_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_a_replymessage_is_audited.cs
@@ -41,10 +41,7 @@
 
         public class Server : EndpointConfigurationBuilder
         {
-            public Server()
-            {
-                EndpointSetup<DefaultServer>();
-            }
+            public Server() => EndpointSetup<DefaultServer>();
 
             class RequestHandler : IHandleMessages<Request>
             {
@@ -61,40 +58,29 @@
 
         public class EndpointWithAuditOn : EndpointConfigurationBuilder
         {
-            public EndpointWithAuditOn()
-            {
+            public EndpointWithAuditOn() =>
                 EndpointSetup<DefaultServer>(c =>
                 {
                     c.DisableFeature<Outbox>();
                     c.AuditProcessedMessagesTo<AuditSpyEndpoint>();
                     c.ConfigureRouting().RouteToEndpoint(typeof(Request), typeof(Server));
                 });
-            }
 
             public class MessageToBeAuditedHandler : IHandleMessages<ResponseToBeAudited>
             {
-                public MessageToBeAuditedHandler(Context context)
-                {
-                    testContext = context;
-                }
-
                 public Task Handle(ResponseToBeAudited message, IMessageHandlerContext context)
                 {
+                    var testContext = context.GetTestContext<Context>();
                     testContext.HeaderValue = context.MessageHeaders["MyHeader"];
                     testContext.MessageProcessed = true;
                     return Task.FromResult(0);
                 }
-
-                Context testContext;
             }
         }
 
         class AuditSpyEndpoint : EndpointConfigurationBuilder
         {
-            public AuditSpyEndpoint()
-            {
-                EndpointSetup<DefaultServer, Context>((config, context) => config.RegisterMessageMutator(new BodySpy(context)));
-            }
+            public AuditSpyEndpoint() => EndpointSetup<DefaultServer, Context>((config, context) => config.RegisterMessageMutator(new BodySpy(context)));
 
             class BodySpy : IMutateIncomingTransportMessages
             {

--- a/src/NServiceBus.AcceptanceTests/Audit/When_audit_is_overridden_in_code.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_audit_is_overridden_in_code.cs
@@ -28,10 +28,7 @@
 
             class Handler : IHandleMessages<MessageToBeAudited>
             {
-                public Task Handle(MessageToBeAudited message, IMessageHandlerContext context)
-                {
-                    return Task.FromResult(0);
-                }
+                public Task Handle(MessageToBeAudited message, IMessageHandlerContext context) => Task.FromResult(0);
             }
         }
 
@@ -45,18 +42,12 @@
 
             class AuditMessageHandler : IHandleMessages<MessageToBeAudited>
             {
-                public AuditMessageHandler(Context context)
-                {
-                    testContext = context;
-                }
-
                 public Task Handle(MessageToBeAudited message, IMessageHandlerContext context)
                 {
+                    var testContext = context.GetTestContext<Context>();
                     testContext.MessageAudited = true;
                     return Task.FromResult(0);
                 }
-
-                Context testContext;
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Audit/When_auditing.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_auditing.cs
@@ -55,18 +55,12 @@
 
             class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
             {
-                public MessageToBeAuditedHandler(Context context)
-                {
-                    testContext = context;
-                }
-
                 public Task Handle(MessageToBeAudited message, IMessageHandlerContext context)
                 {
+                    var testContext = context.GetTestContext<Context>();
                     testContext.IsMessageHandlingComplete = true;
                     return Task.FromResult(0);
                 }
-
-                Context testContext;
             }
         }
 
@@ -79,18 +73,12 @@
 
             class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
             {
-                public MessageToBeAuditedHandler(Context context)
-                {
-                    testContext = context;
-                }
-
                 public Task Handle(MessageToBeAudited message, IMessageHandlerContext context)
                 {
+                    var testContext = context.GetTestContext<Context>();
                     testContext.IsMessageHandlingComplete = true;
                     return Task.FromResult(0);
                 }
-
-                Context testContext;
             }
         }
 
@@ -103,18 +91,12 @@
 
             class AuditMessageHandler : IHandleMessages<MessageToBeAudited>
             {
-                public AuditMessageHandler(Context context)
-                {
-                    testContext = context;
-                }
-
                 public Task Handle(MessageToBeAudited message, IMessageHandlerContext context)
                 {
+                    var testContext = context.GetTestContext<Context>();
                     testContext.IsMessageHandledByTheAuditEndpoint = true;
                     return Task.FromResult(0);
                 }
-
-                Context testContext;
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Audit/When_auditing_message_with_TimeToBeReceived.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_auditing_message_with_TimeToBeReceived.cs
@@ -42,18 +42,12 @@
 
             class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
             {
-                public MessageToBeAuditedHandler(Context testContext)
-                {
-                    this.testContext = testContext;
-                }
-
                 public Task Handle(MessageToBeAudited message, IMessageHandlerContext context)
                 {
+                    var testContext = context.GetTestContext<Context>();
                     testContext.IsMessageHandlingComplete = true;
                     return Task.FromResult(0);
                 }
-
-                Context testContext;
             }
         }
 
@@ -66,16 +60,13 @@
 
             class AuditMessageHandler : IHandleMessages<MessageToBeAudited>
             {
-                public AuditMessageHandler(Context textContext)
-                {
-                    this.textContext = textContext;
-                }
-
                 public async Task Handle(MessageToBeAudited message, IMessageHandlerContext context)
                 {
-                    if (textContext.AuditRetries > 0)
+                    var testContext = context.GetTestContext<Context>();
+
+                    if (testContext.AuditRetries > 0)
                     {
-                        textContext.TTBRHasExpiredAndMessageIsStillInAuditQueue = true;
+                        testContext.TTBRHasExpiredAndMessageIsStillInAuditQueue = true;
                         return;
                     }
 
@@ -84,11 +75,9 @@
                     await Task.Delay(ttbr.Add(TimeSpan.FromSeconds(1)));
 
                     // enforce message retry
-                    Interlocked.Increment(ref textContext.AuditRetries);
+                    Interlocked.Increment(ref testContext.AuditRetries);
                     throw new Exception("retry message");
                 }
-
-                Context textContext;
             }
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/AcceptanceTestingTransportServer.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/AcceptanceTestingTransportServer.cs
@@ -29,8 +29,6 @@
             await transportConfiguration.Configure(endpointConfiguration.EndpointName, configuration, runDescriptor.Settings, endpointConfiguration.PublisherMetadata);
             runDescriptor.OnTestCompleted(_ => transportConfiguration.Cleanup());
 
-            configuration.RegisterComponentsAndInheritanceHierarchy(runDescriptor);
-
             var persistenceConfiguration = new ConfigureEndpointAcceptanceTestingPersistence();
             await persistenceConfiguration.Configure(endpointConfiguration.EndpointName, configuration, runDescriptor.Settings, endpointConfiguration.PublisherMetadata);
             runDescriptor.OnTestCompleted(_ => persistenceConfiguration.Cleanup());

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -4,7 +4,6 @@
     using Transport;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting.Support;
-    using Microsoft.Extensions.DependencyInjection;
 
     public static class ConfigureExtensions
     {
@@ -44,21 +43,6 @@
         {
             await persistenceConfiguration.Configure(endpointCustomizationConfiguration.EndpointName, config, runDescriptor.Settings, endpointCustomizationConfiguration.PublisherMetadata);
             runDescriptor.OnTestCompleted(_ => persistenceConfiguration.Cleanup());
-        }
-
-        public static void RegisterComponentsAndInheritanceHierarchy(this EndpointConfiguration builder, RunDescriptor runDescriptor)
-        {
-            builder.RegisterComponents(r => { RegisterInheritanceHierarchyOfContextOnContainer(runDescriptor, r); });
-        }
-
-        static void RegisterInheritanceHierarchyOfContextOnContainer(RunDescriptor runDescriptor, IServiceCollection r)
-        {
-            var type = runDescriptor.ScenarioContext.GetType();
-            while (type != typeof(object))
-            {
-                r.AddSingleton(type, runDescriptor.ScenarioContext);
-                type = type.BaseType;
-            }
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ServerWithNoDefaultPersistenceDefinitions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ServerWithNoDefaultPersistenceDefinitions.cs
@@ -2,8 +2,10 @@
 {
     using System;
     using System.Threading.Tasks;
+    using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using AcceptanceTesting.Support;
+    using NServiceBus.Pipeline;
 
     public class ServerWithNoDefaultPersistenceDefinitions : IEndpointSetupTemplate
     {
@@ -19,6 +21,8 @@
                 .Immediate(immediate => immediate.NumberOfRetries(0));
             builder.SendFailedMessagesTo("error");
 
+            builder.Pipeline.Register(new RegisterTestContextBehavior(runDescriptor.ScenarioContext), "Stores the test context into the pipeline extensions.");
+
             await builder.DefineTransport(TransportConfiguration, runDescriptor, endpointConfiguration).ConfigureAwait(false);
 
             builder.RegisterComponentsAndInheritanceHierarchy(runDescriptor);
@@ -29,6 +33,35 @@
             builder.TypesToIncludeInScan(endpointConfiguration.GetTypesScopedByTestClass());
 
             return builder;
+        }
+    }
+
+    class RegisterTestContextBehavior : Behavior<ITransportReceiveContext>
+    {
+        readonly ScenarioContext testContext;
+
+        public RegisterTestContextBehavior(ScenarioContext testContext)
+        {
+            this.testContext = testContext;
+        }
+
+        public override Task Invoke(ITransportReceiveContext context, Func<Task> next)
+        {
+            context.Extensions.Set(testContext);
+            return next();
+        }
+    }
+
+    public static class TestContextExtensions
+    {
+        public static T GetTestContext<T>(this IPipelineContext behavior) where T : ScenarioContext
+        {
+            //if (behavior is ITransportReceiveContext)
+            //{
+            //    throw new InvalidOperationException("cannot call on transport receive context");
+            //}
+
+            return behavior.Extensions.Get<ScenarioContext>() as T;
         }
     }
 }


### PR DESCRIPTION
Another spike in an attempt to reduce boilerplate code when writing acceptance tests. It's very common to require the `ScenarioContext` in message handlers and behaviors. The test context needs to be resolved via DI container which forces every usage to define a ctor and assign it to a field. For behaviors it also requires the proper setup of the registration for the DI to work.

By registering the `ScnearioContext` in the pipeline context, it can be made accessible using extension methods, saving some boiler-plate code.