### PR TITLE
Prevent generic saga from crashing saga analyzer code fix

### DIFF
--- a/src/NServiceBus.Core.Analyzer/Sagas/RewriteConfigureHowToFindSagaFixer.cs
+++ b/src/NServiceBus.Core.Analyzer/Sagas/RewriteConfigureHowToFindSagaFixer.cs
@@ -62,7 +62,7 @@
                     var isHeader = bool.Parse(diagnostic.Properties[i.ToString()]);
 
                     var messageType = root.FindToken(msgTypeLocation.SourceSpan.Start)
-                        .Parent.AncestorsAndSelf().OfType<IdentifierNameSyntax>().First();
+                        .Parent.AncestorsAndSelf().OfType<SimpleNameSyntax>().First();
                     var mappingExpression = root.FindToken(mappingExpressionLocation.SourceSpan.Start)
                         .Parent.AncestorsAndSelf().OfType<ArgumentSyntax>().First();
 


### PR DESCRIPTION
`SimpleNameSyntax` is a base class for both `IdentifierNameSyntax` and `GenericNameSyntax` which is why the generic message type failed.

Regardless of whether mapping a generic message type is supported by saga infrastructure (see [designing messages](https://docs.particular.net/nservicebus/messaging/messages-events-commands#designing-messages) in docs) it shouldn't cause a code fix to throw an error.

Fixes a bug reported in https://github.com/Particular/NServiceBus/issues/6399