### PR TITLE
Report framework version in license URL

### DIFF
--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -4,6 +4,7 @@ namespace NServiceBus
     using System.Diagnostics;
     using System.Runtime.InteropServices;
     using System.Text;
+    using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
     using Logging;
@@ -148,7 +149,8 @@ namespace NServiceBus
             var version = VersionInformation.MajorMinorPatch;
             var isRenewal = result.License.IsExtendedTrial ? "1" : "0";
             var platform = GetPlatformCode();
-            return $"https://particular.net/license/nservicebus?v={version}&t={isRenewal}&p={platform}";
+            var frameworkVersion = GetFrameworkVersion();
+            return $"https://particular.net/license/nservicebus?v={version}&t={isRenewal}&p={platform}&f={frameworkVersion}";
         }
 
         string GetPlatformCode()
@@ -169,6 +171,12 @@ namespace NServiceBus
             }
 
             return "unknown";
+        }
+
+        string GetFrameworkVersion()
+        {
+            var match = Regex.Match(RuntimeInformation.FrameworkDescription, @"\d+");
+            return match.Success ? match.Value : "0";
         }
 
         internal ActiveLicenseFindResult result;


### PR DESCRIPTION
Reports the .NET Framework major version in the licensing URL, using a regular expression on the result of [RuntimeInformation.FrameworkDescription](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.runtimeinformation.frameworkdescription?view=net-6.0).

The regular expression finds the first digit group and returns only that, resulting in the major version.

The values of `FrameworkDescription` found using various versions of LINQPad were found to agree with the documentation:

* .NET 6: `.NET 6.0.5`
* .NET 5: `.NET 5.0.17`
* .NET Core 3.1: `.NET Core 3.1.25`
* .NET Framework 4.8: `.NET Framework 4.8.4470.0`

Given that NServiceBus 8 targets `net472;net6.0` we don't have to worry about any overlap with .NET Framework 3.x and .NET Core 3.1. The only values that should be possible (until .NET 7 is released) are `4` and `6`.