### PR TITLE
Increase deserialization test time

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Serialization/When_disabling_serializer_type_inference.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_disabling_serializer_type_inference.cs
@@ -23,7 +23,7 @@
                     .DoNotFailOnErrorMessages()
                     .When(s => s.SendLocal(new MessageWithoutTypeHeader())))
                 .Done(c => c.IncomingMessageReceived)
-                .Run(TimeSpan.FromSeconds(20));
+                .Run(TimeSpan.FromSeconds(35));
 
             Assert.IsFalse(context.HandlerInvoked);
             Assert.AreEqual(1, context.FailedMessages.Single().Value.Count);
@@ -40,7 +40,7 @@
                     .DoNotFailOnErrorMessages()
                     .When(s => s.SendLocal(new UnknownMessage())))
                 .Done(c => c.IncomingMessageReceived)
-                .Run(TimeSpan.FromSeconds(20));
+                .Run(TimeSpan.FromSeconds(35));
 
             Assert.IsFalse(context.HandlerInvoked);
             Assert.AreEqual(1, context.FailedMessages.Single().Value.Count);


### PR DESCRIPTION
This test fails on Linux for the AmazonSQS transport as it takes roughly 31 seconds for the test to complete in that environment.