### PR TITLE
Do not autosubscribe without events

### DIFF
--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -56,6 +56,7 @@
 
                 if (eventsToSubscribe.Length == 0)
                 {
+                    Logger.Debug("Auto-subscribe found no event types to subscribe.");
                     return;
                 }
 

--- a/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
+++ b/src/NServiceBus.Core/Routing/AutomaticSubscriptions/AutoSubscribe.cs
@@ -63,6 +63,11 @@
 
             protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
             {
+                if (messagesHandledByThisEndpoint.Length == 0)
+                {
+                    return;
+                }
+
                 try
                 {
                     var messageSession = session as MessageSession;


### PR DESCRIPTION
Noticed that Autosubscribe is currently always invoking the subscription pipeline, even when there is no event being handled.

Added some small refactoring to resolve the event types to subscribe at the FST start time instead inside the instance factory.