### PR TITLE
Trace handler invocations

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Diagnostics/TestingActivityListener.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/TestingActivityListener.cs
@@ -49,5 +49,6 @@
         public static List<Activity> GetIncomingActivities(this ConcurrentQueue<Activity> activities) => activities.Where(a => a.OperationName == "NServiceBus.Diagnostics.IncomingMessage" && !Convert.ToBoolean(a.GetTagItem("nservicebus.control_message"))).ToList();
         public static List<Activity> GetOutgoingActivities(this ConcurrentQueue<Activity> activities) => activities.Where(a => a.OperationName == "NServiceBus.Diagnostics.OutgoingMessage").ToList(); //TODO rename to alight with the event method
         public static List<Activity> GetOutgoingEventActivities(this ConcurrentQueue<Activity> activities) => activities.Where(a => a.OperationName == "NServiceBus.Diagnostics.PublishMessage").ToList();
+        public static List<Activity> GetInvokedHandlerActivities(this ConcurrentQueue<Activity> activities) => activities.Where(a => a.OperationName == "NServiceBus.Diagnostics.InvokeHandler").ToList();
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Diagnostics/When_ambient_trace_in_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/When_ambient_trace_in_pipeline.cs
@@ -25,14 +25,13 @@
                 .Done(c => c.MessageReceived)
                 .Run();
 
-            var incomingMessageActiviy = activityListener.CompletedActivities.GetIncomingActivities().First();
+            var handlerActivity = activityListener.CompletedActivities.GetInvokedHandlerActivities().First();
             var sendFromHandlerActivity = activityListener.CompletedActivities.GetOutgoingActivities().Last();
             Assert.AreEqual(context.AmbientActivityId, sendFromHandlerActivity.ParentId, "the outgoing message should be connected to the ambient span");
             Assert.AreEqual(context.AmbientActivityRootId, sendFromHandlerActivity.RootId, "outgoing and ambient activity should belong to same trace");
             Assert.AreEqual(ExpectedTraceState, sendFromHandlerActivity.TraceStateString, "outgoing activity should capture ambient trace state");
-            // TODO: Determine if this is still needed. The introduction of a handler invocation span breaks this because now it's Incoming->Handler Invocation->Ambient->Outgoing
-            // Assert.AreEqual(incomingMessageActiviy.Id, context.AmbientActivityParentId, "the ambient activity should be connected to the incoming pipeline span");
-            Assert.AreEqual(incomingMessageActiviy.RootId, context.AmbientActivityRootId, "incoming and ambient activity should belong to same trace");
+            Assert.AreEqual(handlerActivity.Id, context.AmbientActivityParentId, "the ambient activity should be connected to the handler span");
+            Assert.AreEqual(handlerActivity.RootId, context.AmbientActivityRootId, "handler and ambient activity should belong to same trace");
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Diagnostics/When_ambient_trace_in_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/When_ambient_trace_in_pipeline.cs
@@ -30,7 +30,8 @@
             Assert.AreEqual(context.AmbientActivityId, sendFromHandlerActivity.ParentId, "the outgoing message should be connected to the ambient span");
             Assert.AreEqual(context.AmbientActivityRootId, sendFromHandlerActivity.RootId, "outgoing and ambient activity should belong to same trace");
             Assert.AreEqual(ExpectedTraceState, sendFromHandlerActivity.TraceStateString, "outgoing activity should capture ambient trace state");
-            Assert.AreEqual(incomingMessageActiviy.Id, context.AmbientActivityParentId, "the ambient activity should be connected to the incoming pipeline span");
+            // TODO: Determine if this is still needed. The introduction of a handler invocation span breaks this because now it's Incoming->Handler Invocation->Ambient->Outgoing
+            // Assert.AreEqual(incomingMessageActiviy.Id, context.AmbientActivityParentId, "the ambient activity should be connected to the incoming pipeline span");
             Assert.AreEqual(incomingMessageActiviy.RootId, context.AmbientActivityRootId, "incoming and ambient activity should belong to same trace");
         }
 

--- a/src/NServiceBus.AcceptanceTests/Diagnostics/When_incoming_message_has_trace.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/When_incoming_message_has_trace.cs
@@ -37,7 +37,8 @@
 
             Assert.AreEqual(sendRequest.Id, receiveRequest.ParentId, "first incoming message is correlated to the first send operation");
             Assert.AreEqual(sendRequest.RootId, receiveRequest.RootId, "first send operation is the root activity");
-            Assert.AreEqual(receiveRequest.Id, sendReply.ParentId, "second send operation is correlated to the first incoming message");
+            // TODO: Determine if this is still needed. Introduction of a handler invocation trace breaks this. Incoming->Handler Invocation->Outgoing
+            // Assert.AreEqual(receiveRequest.Id, sendReply.ParentId, "second send operation is correlated to the first incoming message");
             Assert.AreEqual(sendRequest.RootId, sendReply.RootId, "first send operation is the root activity");
             Assert.AreEqual(sendReply.Id, receiveReply.ParentId, "second incoming message is correlated to the second send operation");
             Assert.AreEqual(sendRequest.RootId, receiveReply.RootId, "first send operation is the root activity");

--- a/src/NServiceBus.AcceptanceTests/Diagnostics/When_incoming_message_has_trace.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/When_incoming_message_has_trace.cs
@@ -35,10 +35,8 @@
             var sendReply = outgoingMessageActivities[1];
             var receiveReply = incomingMessageActivities[1];
 
-            Assert.AreEqual(sendRequest.Id, receiveRequest.ParentId, "first incoming message is correlated to the first send operation");
             Assert.AreEqual(sendRequest.RootId, receiveRequest.RootId, "first send operation is the root activity");
-            // TODO: Determine if this is still needed. Introduction of a handler invocation trace breaks this. Incoming->Handler Invocation->Outgoing
-            // Assert.AreEqual(receiveRequest.Id, sendReply.ParentId, "second send operation is correlated to the first incoming message");
+            Assert.AreEqual(sendRequest.Id, receiveRequest.ParentId, "first incoming message is correlated to the first send operation");
             Assert.AreEqual(sendRequest.RootId, sendReply.RootId, "first send operation is the root activity");
             Assert.AreEqual(sendReply.Id, receiveReply.ParentId, "second incoming message is correlated to the second send operation");
             Assert.AreEqual(sendRequest.RootId, receiveReply.RootId, "first send operation is the root activity");

--- a/src/NServiceBus.AcceptanceTests/Diagnostics/When_processing_message_with_multiple_handlers.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/When_processing_message_with_multiple_handlers.cs
@@ -1,0 +1,94 @@
+﻿namespace NServiceBus.AcceptanceTests.Diagnostics
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    [NonParallelizable] // Ensure only activities for the current test are captured
+    public class When_processing_message_with_multiple_handlers : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_create_message_handler_spans()
+        {
+            using var activityListener = TestingActivityListener.SetupNServiceBusDiagnosticListener();
+            TestContext.WriteLine($"Created listener {activityListener.GetHashCode()}");
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<ReceivingEndpoint>(b =>
+                    b.When(session => session.SendLocal(new SomeMessage()))
+                )
+                .Done(c => c.FirstHandlerRun && c.SecondHandlerRun)
+                .Run();
+
+            Assert.AreEqual(activityListener.CompletedActivities.Count, activityListener.StartedActivities.Count, "all activities should be completed");
+
+            var invokedHandlerActivities = activityListener.CompletedActivities.GetInvokedHandlerActivities();
+
+            Assert.AreEqual(2, invokedHandlerActivities.Count, "Two handlers should be invoked");
+
+            var recordedHandlerTypes = new HashSet<string>();
+
+            foreach (var invokedHandlerActivity in invokedHandlerActivities)
+            {
+                var handlerType = invokedHandlerActivity.GetTagItem("nservicebus.handler_type") as string;
+                Assert.NotNull(handlerType, "Handler type tag should be set");
+                recordedHandlerTypes.Add(handlerType);
+            }
+
+            Assert.True(recordedHandlerTypes.Contains(typeof(ReceivingEndpoint.HandlerOne).FullName), "invocation of handler one should be traced");
+            Assert.True(recordedHandlerTypes.Contains(typeof(ReceivingEndpoint.HandlerTwo).FullName), "invocation of handler two should be traced");
+        }
+
+        class ReceivingEndpoint : EndpointConfigurationBuilder
+        {
+            public ReceivingEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class HandlerOne : IHandleMessages<SomeMessage>
+            {
+                Context scenarioContext;
+
+                public HandlerOne(Context context)
+                {
+                    scenarioContext = context;
+                }
+
+                public Task Handle(SomeMessage message, IMessageHandlerContext context)
+                {
+                    scenarioContext.FirstHandlerRun = true;
+                    return Task.CompletedTask;
+                }
+            }
+
+            public class HandlerTwo : IHandleMessages<SomeMessage>
+            {
+                Context scenarioContext;
+
+                public HandlerTwo(Context context)
+                {
+                    scenarioContext = context;
+                }
+
+                public Task Handle(SomeMessage message, IMessageHandlerContext context)
+                {
+                    scenarioContext.SecondHandlerRun = true;
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        class SomeMessage : IMessage
+        {
+
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool FirstHandlerRun { get; set; }
+            public bool SecondHandlerRun { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Diagnostics/When_processing_message_with_multiple_handlers.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/When_processing_message_with_multiple_handlers.cs
@@ -80,7 +80,7 @@
             }
         }
 
-        class SomeMessage : IMessage
+        public class SomeMessage : IMessage
         {
 
         }

--- a/src/NServiceBus.AcceptanceTests/Diagnostics/When_processing_message_with_saga_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/When_processing_message_with_saga_handler.cs
@@ -33,7 +33,7 @@
 
             var handlerType = invokedSagaActivity.GetTagItem("nservicebus.handler_type");
             Assert.NotNull(handlerType, "Handler type tag should be set");
-            Assert.AreEqual(handlerType, typeof(TestEndpoint.MySaga).FullName, "invocation of saga should be recorded");
+            Assert.AreEqual(handlerType, typeof(TestEndpoint.TracedSaga).FullName, "invocation of saga should be recorded");
 
             var sagaId = invokedSagaActivity.GetTagItem("nservicebus.saga_id");
             Assert.NotNull(sagaId, "Saga Id tag should be set");
@@ -47,13 +47,13 @@
                 EndpointSetup<DefaultServer>();
             }
 
-            public class MySaga : Saga<MySaga.SagaData>, IAmStartedByMessages<SomeMessage>
+            public class TracedSaga : Saga<TracedSaga.TracedSagaData>, IAmStartedByMessages<SomeMessage>
             {
                 Context scenarioContext;
 
-                public MySaga(Context scenarioContext) => this.scenarioContext = scenarioContext;
+                public TracedSaga(Context scenarioContext) => this.scenarioContext = scenarioContext;
 
-                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TracedSagaData> mapper)
                     => mapper.MapSaga(saga => saga.BusinessId)
                             .ToMessage<SomeMessage>(msg => msg.BusinessId);
 
@@ -64,9 +64,9 @@
                     return Task.CompletedTask;
                 }
 
-                public class SagaData : ContainSagaData
+                public class TracedSagaData : ContainSagaData
                 {
-                    public Guid BusinessId { get; set; }
+                    public virtual Guid BusinessId { get; set; }
                 }
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Diagnostics/When_processing_message_with_saga_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/When_processing_message_with_saga_handler.cs
@@ -1,0 +1,85 @@
+﻿namespace NServiceBus.AcceptanceTests.Diagnostics
+{
+    using System;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    [NonParallelizable] // Ensure only activities for the current test are captured
+    public class When_processing_message_with_saga_handler : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_trace_saga_id()
+        {
+            using var activityListener = TestingActivityListener.SetupNServiceBusDiagnosticListener();
+            var businessId = Guid.NewGuid();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<TestEndpoint>(b =>
+                    b.When(session => session.SendLocal(new SomeMessage { BusinessId = businessId }))
+                )
+                .Done(ctx => ctx.MessageHandled)
+                .Run();
+
+            Assert.AreEqual(activityListener.CompletedActivities.Count, activityListener.StartedActivities.Count, "all activities should be completed");
+
+            var invokedHandlerActivities = activityListener.CompletedActivities.GetInvokedHandlerActivities();
+
+            Assert.AreEqual(1, invokedHandlerActivities.Count, "One handlers should be invoked");
+
+            var invokedSagaActivity = invokedHandlerActivities.Single();
+
+            var handlerType = invokedSagaActivity.GetTagItem("nservicebus.handler_type");
+            Assert.NotNull(handlerType, "Handler type tag should be set");
+            Assert.AreEqual(handlerType, typeof(TestEndpoint.MySaga).FullName, "invocation of saga should be recorded");
+
+            var sagaId = invokedSagaActivity.GetTagItem("nservicebus.saga_id");
+            Assert.NotNull(sagaId, "Saga Id tag should be set");
+            Assert.AreEqual(context.SagaId, sagaId, "Saga Id does not match");
+        }
+
+        public class TestEndpoint : EndpointConfigurationBuilder
+        {
+            public TestEndpoint()
+            {
+                EndpointSetup<DefaultServer>();
+            }
+
+            public class MySaga : Saga<MySaga.SagaData>, IAmStartedByMessages<SomeMessage>
+            {
+                Context scenarioContext;
+
+                public MySaga(Context scenarioContext) => this.scenarioContext = scenarioContext;
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
+                    => mapper.MapSaga(saga => saga.BusinessId)
+                            .ToMessage<SomeMessage>(msg => msg.BusinessId);
+
+                public Task Handle(SomeMessage message, IMessageHandlerContext context)
+                {
+                    scenarioContext.MessageHandled = true;
+                    scenarioContext.SagaId = Data.Id.ToString();
+                    return Task.CompletedTask;
+                }
+
+                public class SagaData : ContainSagaData
+                {
+                    public Guid BusinessId { get; set; }
+                }
+            }
+        }
+
+        public class SomeMessage : IMessage
+        {
+            public Guid BusinessId { get; set; }
+        }
+
+        public class Context : ScenarioContext
+        {
+            public string SagaId { get; set; }
+            public bool MessageHandled { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Core/Diagnostics/ActivityDecorator.cs
+++ b/src/NServiceBus.Core/Diagnostics/ActivityDecorator.cs
@@ -87,10 +87,13 @@ namespace NServiceBus
 
         public static void SetInvokeHandlerTags(Activity activity, MessageHandler messageHandler, ActiveSagaInstance saga)
         {
-            activity?.AddTag("nservicebus.handler_type", messageHandler.HandlerType.FullName);
-            if (saga != null)
+            if (activity != null)
             {
-                activity?.AddTag("nservicebus.saga_id", saga.SagaId);
+                activity.AddTag("nservicebus.handler_type", messageHandler.HandlerType.FullName);
+                if (saga != null)
+                {
+                    activity.AddTag("nservicebus.saga_id", saga.SagaId);
+                }
             }
         }
 

--- a/src/NServiceBus.Core/Diagnostics/ActivityDecorator.cs
+++ b/src/NServiceBus.Core/Diagnostics/ActivityDecorator.cs
@@ -4,6 +4,8 @@ namespace NServiceBus
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Sagas;
     using Routing;
     using Transport;
 
@@ -81,6 +83,15 @@ namespace NServiceBus
 
             var destination = string.Join(", ", destinations);
             activity.AddTag("messaging.destination", destination);
+        }
+
+        public static void SetInvokeHandlerTags(Activity activity, MessageHandler messageHandler, ActiveSagaInstance saga)
+        {
+            activity?.AddTag("nservicebus.handler_type", messageHandler.HandlerType.FullName);
+            if (saga != null)
+            {
+                activity?.AddTag("nservicebus.saga_id", saga.SagaId);
+            }
         }
 
         public static void Initialize(string receiveAddress)

--- a/src/NServiceBus.Core/Diagnostics/ActivityNames.cs
+++ b/src/NServiceBus.Core/Diagnostics/ActivityNames.cs
@@ -8,6 +8,7 @@ namespace NServiceBus
         public const string OutgoingEventActivityName = "NServiceBus.Diagnostics.PublishMessage";
         public const string SubscribeActivityName = "NServiceBus.Diagnostics.Subscribe";
         public const string UnsubscribeActivityName = "NServiceBus.Diagnostics.Unsubscribe";
+        public const string InvokeHandlerActivityName = "NServiceBus.Diagnostics.InvokeHandler";
     }
 
     class DiagnosticsKeys

--- a/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs
@@ -14,6 +14,9 @@
                 return;
             }
 
+            using var activity = ActivitySources.Main.StartActivity(ActivityNames.InvokeHandlerActivityName);
+            ActivityDecorator.SetInvokeHandlerTags(activity, context.MessageHandler, saga);
+
             var messageHandler = context.MessageHandler;
 
             // Might as well abort before invoking the handler if we're shutting down

--- a/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs
@@ -14,6 +14,7 @@
                 return;
             }
 
+            //TODO set activity status
             using var activity = ActivitySources.Main.StartActivity(ActivityNames.InvokeHandlerActivityName);
             ActivityDecorator.SetInvokeHandlerTags(activity, context.MessageHandler, saga);
 


### PR DESCRIPTION
Built on top of #6410

This adds a trace for each handler invocation. It creates two tags:

- `nservicebus.handler_type` contains the full type name of the handler being invoked
- `nservicebus.saga_id` gets filled in if the handler is a saga instance