### PR TITLE
Improve OT spans display names for pipelines

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Diagnostics/When_processing_incoming_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/When_processing_incoming_message.cs
@@ -33,7 +33,7 @@
 
             Assert.AreEqual(ActivityStatusCode.Ok, incomingActivity.Status);
             var destination = AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(ReceivingEndpoint));
-            Assert.AreEqual($"process", incomingActivity.DisplayName);
+            Assert.AreEqual("process message", incomingActivity.DisplayName);
 
             var incomingActivityTags = incomingActivity.Tags.ToImmutableDictionary();
 

--- a/src/NServiceBus.AcceptanceTests/Diagnostics/When_publishing_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/When_publishing_messages.cs
@@ -37,7 +37,7 @@
 
             var publishedMessage = outgoingEventActivities.Single();
             publishedMessage.VerifyUniqueTags();
-            Assert.AreEqual("publish", publishedMessage.DisplayName);
+            Assert.AreEqual("publish event", publishedMessage.DisplayName);
             Assert.IsNull(publishedMessage.ParentId, "publishes without ambient span should start a new trace");
 
             var sentMessageTags = publishedMessage.Tags.ToImmutableDictionary();

--- a/src/NServiceBus.AcceptanceTests/Diagnostics/When_sending_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/When_sending_messages.cs
@@ -35,7 +35,7 @@
             Assert.IsNull(sentMessage.ParentId, "sends without ambient span should start a new trace");
             // TODO: is this correct? it seems like this needs to be filled by the transport
             var destination = Conventions.EndpointNamingConvention(typeof(TestEndpoint));
-            Assert.AreEqual("send", sentMessage.DisplayName);
+            Assert.AreEqual("send message", sentMessage.DisplayName);
 
             var sentMessageTags = sentMessage.Tags.ToImmutableDictionary();
             // TODO: Verify whether we want to keep this. messaging.message_id is from the spec

--- a/src/NServiceBus.AcceptanceTests/Diagnostics/When_subscribing.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/When_subscribing.cs
@@ -65,7 +65,7 @@ public class When_subscribing : NServiceBusAcceptanceTest
 
         var subscribeActivity = subscribeActivities.Single();
         subscribeActivity.VerifyUniqueTags();
-        Assert.AreEqual("subscribe", subscribeActivity.DisplayName);
+        Assert.AreEqual("subscribe event", subscribeActivity.DisplayName);
         var subscribeActivityTags = subscribeActivity.Tags.ToImmutableDictionary();
         subscribeActivityTags.VerifyTag("nservicebus.event_types", typeof(DemoEvent).FullName);
 

--- a/src/NServiceBus.AcceptanceTests/Diagnostics/When_subscribing.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/When_subscribing.cs
@@ -32,7 +32,7 @@ public class When_subscribing : NServiceBusAcceptanceTest
 
         var subscribeActivity = subscribeActivities.Single();
         subscribeActivity.VerifyUniqueTags();
-        Assert.AreEqual("subscribe", subscribeActivity.DisplayName);
+        Assert.AreEqual("subscribe event", subscribeActivity.DisplayName);
         var subscribeActivityTags = subscribeActivity.Tags.ToImmutableDictionary();
         subscribeActivityTags.VerifyTag("nservicebus.event_types", typeof(DemoEvent).FullName);
 

--- a/src/NServiceBus.AcceptanceTests/Diagnostics/When_unsubscribing.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/When_unsubscribing.cs
@@ -31,7 +31,7 @@ public class When_unsubscribing : NServiceBusAcceptanceTest
 
         var unsubscribeActivity = unsubscribeActivities.Single();
         unsubscribeActivity.VerifyUniqueTags();
-        Assert.AreEqual("unsubscribe", unsubscribeActivity.DisplayName);
+        Assert.AreEqual("unsubscribe event", unsubscribeActivity.DisplayName);
 
         var unsubscribeActivityTags = unsubscribeActivity.Tags.ToImmutableDictionary();
         unsubscribeActivityTags.VerifyTag("nservicebus.event_types", typeof(DemoEvent).FullName);

--- a/src/NServiceBus.AcceptanceTests/Diagnostics/When_unsubscribing.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/When_unsubscribing.cs
@@ -62,7 +62,7 @@ public class When_unsubscribing : NServiceBusAcceptanceTest
 
         var unsubscribeActivity = unsubscribeActivities.Single();
         unsubscribeActivity.VerifyUniqueTags();
-        Assert.AreEqual("unsubscribe", unsubscribeActivity.DisplayName);
+        Assert.AreEqual("unsubscribe event", unsubscribeActivity.DisplayName);
 
         var unsubscribeActivityTags = unsubscribeActivity.Tags.ToImmutableDictionary();
         unsubscribeActivityTags.VerifyTag("nservicebus.event_types", typeof(DemoEvent).FullName);

--- a/src/NServiceBus.Core.Tests/Diagnostics/MessageOperationsTests.cs
+++ b/src/NServiceBus.Core.Tests/Diagnostics/MessageOperationsTests.cs
@@ -41,7 +41,7 @@ public class MessageOperationsTests
         Assert.AreEqual(activity.RootId, activity.TraceId.ToString());
 
         Assert.AreEqual(ActivityNames.OutgoingMessageActivityName, activity.OperationName);
-        Assert.AreEqual("send", activity.DisplayName);
+        Assert.AreEqual("send message", activity.DisplayName);
 
         //TODO: verify message intent tag == send
 
@@ -63,7 +63,7 @@ public class MessageOperationsTests
         Assert.AreEqual(activity.RootId, activity.TraceId.ToString());
 
         Assert.AreEqual(ActivityNames.OutgoingEventActivityName, activity.OperationName);
-        Assert.AreEqual("publish", activity.DisplayName);
+        Assert.AreEqual("publish event", activity.DisplayName);
 
         //TODO: verify message intent tag == publish
 
@@ -107,7 +107,7 @@ public class MessageOperationsTests
         Assert.AreEqual(activity.RootId, activity.TraceId.ToString());
 
         Assert.AreEqual(ActivityNames.SubscribeActivityName, activity.OperationName);
-        Assert.AreEqual("subscribe", activity.DisplayName);
+        Assert.AreEqual("subscribe event", activity.DisplayName);
 
         //TODO: verify message intent tag == subscribe
 
@@ -129,7 +129,7 @@ public class MessageOperationsTests
         Assert.AreEqual(activity.RootId, activity.TraceId.ToString());
 
         Assert.AreEqual(ActivityNames.UnsubscribeActivityName, activity.OperationName);
-        Assert.AreEqual("unsubscribe", activity.DisplayName);
+        Assert.AreEqual("unsubscribe event", activity.DisplayName);
 
         //TODO: verify message intent tag == subscribe
 

--- a/src/NServiceBus.Core.Tests/Pipeline/MainPipelineExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MainPipelineExecutorTests.cs
@@ -38,7 +38,7 @@
 
             Assert.NotNull(receivePipeline.PipelineAcitivty);
             Assert.AreEqual(ActivityNames.IncomingMessageActivityName, receivePipeline.PipelineAcitivty.OperationName);
-            Assert.AreEqual("process", receivePipeline.PipelineAcitivty.DisplayName);
+            Assert.AreEqual("process message", receivePipeline.PipelineAcitivty.DisplayName);
         }
 
         [Test]

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -98,7 +98,7 @@ namespace NServiceBus
 
             if (activity != null)
             {
-                activity.DisplayName = "process";
+                activity.DisplayName = "process message";
                 activity.SetIdFormat(ActivityIdFormat.W3C);
                 activity.AddTag("nservicebus.native_message_id", context.NativeMessageId);
                 activity.Start();

--- a/src/NServiceBus.Core/Unicast/MessageOperations.cs
+++ b/src/NServiceBus.Core/Unicast/MessageOperations.cs
@@ -63,7 +63,7 @@ namespace NServiceBus
 
             MergeDispatchProperties(publishContext, options.DispatchProperties);
 
-            return InvokePipelineWithTracing(ActivityNames.OutgoingEventActivityName, "publish", publishContext, publishPipeline);
+            return InvokePipelineWithTracing(ActivityNames.OutgoingEventActivityName, "publish event", publishContext, publishPipeline);
         }
 
         public Task Subscribe(IBehaviorContext context, Type eventType, SubscribeOptions options)
@@ -80,7 +80,7 @@ namespace NServiceBus
 
             MergeDispatchProperties(subscribeContext, options.DispatchProperties);
 
-            return InvokePipelineWithTracing(ActivityNames.SubscribeActivityName, "subscribe", subscribeContext, subscribePipeline);
+            return InvokePipelineWithTracing(ActivityNames.SubscribeActivityName, "subscribe event", subscribeContext, subscribePipeline);
         }
 
         public Task Unsubscribe(IBehaviorContext context, Type eventType, UnsubscribeOptions options)
@@ -92,7 +92,7 @@ namespace NServiceBus
 
             MergeDispatchProperties(unsubscribeContext, options.DispatchProperties);
 
-            return InvokePipelineWithTracing(ActivityNames.UnsubscribeActivityName, "unsubscribe", unsubscribeContext, unsubscribePipeline);
+            return InvokePipelineWithTracing(ActivityNames.UnsubscribeActivityName, "unsubscribe event", unsubscribeContext, unsubscribePipeline);
         }
 
         public Task Send<T>(IBehaviorContext context, Action<T> messageConstructor, SendOptions options)
@@ -124,7 +124,7 @@ namespace NServiceBus
 
             MergeDispatchProperties(outgoingContext, options.DispatchProperties);
 
-            return InvokePipelineWithTracing(ActivityNames.OutgoingMessageActivityName, "send", outgoingContext, sendPipeline);
+            return InvokePipelineWithTracing(ActivityNames.OutgoingMessageActivityName, "send message", outgoingContext, sendPipeline);
         }
 
         public Task Reply(IBehaviorContext context, object message, ReplyOptions options)


### PR DESCRIPTION
improves the span's display name with a bit more precision in the context of all the spans to be more clear this is about messages/events