### PR TITLE
Disable instead of throwing an exception

### DIFF
--- a/src/NServiceBus.Core/Performance/Metrics/MessagingMetricsFeature.cs
+++ b/src/NServiceBus.Core/Performance/Metrics/MessagingMetricsFeature.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus
 {
-    using System;
     using System.Diagnostics.Metrics;
     using Features;
 
@@ -13,17 +12,10 @@ namespace NServiceBus
             NServiceBusDiagnosticsInfo.InstrumentationName,
             NServiceBusDiagnosticsInfo.InstrumentationVersion);
 
-        /// <inheritdoc />
-        protected internal override void Setup(FeatureConfigurationContext context)
-        {
-            var isSendOnly = context.Receiving.IsSendOnlyEndpoint;
-            if (isSendOnly)
-            {
-                throw new Exception("Metrics are not supported on send only endpoints.");
-            }
+        public MessagingMetricsFeature() => Prerequisite(c => !c.Receiving.IsSendOnlyEndpoint, "Processing metrics are not supported on send-only endpoints");
 
-            RegisterBehavior(context);
-        }
+        /// <inheritdoc />
+        protected internal override void Setup(FeatureConfigurationContext context) => RegisterBehavior(context);
 
         static void RegisterBehavior(FeatureConfigurationContext context)
         {


### PR DESCRIPTION
Disabled the metrics feature "silently" instead of throwing an exception. I think this makes more sense because diagnostics-related configuration/behavior should not prevent endpoints from starting or running. We could even leave the feature completely enabled since the registered behavior would do nothing on a send-only feature but I think disabling it gives a bit more insights in case the user looks at the diagnostics file (this might change anyway if we add any non-processing related metrics?).