### PR TITLE
Additional pipeline events/tags

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Diagnostics/When_sending_messages_from_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/When_sending_messages_from_pipeline.cs
@@ -26,11 +26,10 @@ public class When_sending_messages_from_pipeline : NServiceBusAcceptanceTest
         var sentMessage = outgoingMessageActivities.First();
 
         Assert.IsNotEmpty(sentMessage.Events);
-        var startDispatchingEvent = sentMessage.Events.Single(e => e.Name == "Start dispatching");
-        Assert.NotNull(startDispatchingEvent, "should raise dispatch start event");
-        Assert.AreEqual(1, startDispatchingEvent.Tags.ToImmutableDictionary()["message-count"]);
-        var dispatchFinishedEvent = sentMessage.Events.Single(e => e.Name == "Finished dispatching");
-        Assert.NotNull(dispatchFinishedEvent, "should raise dispatch finished event");
+        var startDispatchingEvents = sentMessage.Events.Where(e => e.Name == "Start dispatching").ToArray();
+        Assert.AreEqual(1, startDispatchingEvents.Length, "should raise dispatch start event");
+        Assert.AreEqual(1, startDispatchingEvents.Single().Tags.ToImmutableDictionary()["message-count"]);
+        Assert.AreEqual(1, sentMessage.Events.Count(e => e.Name == "Finished dispatching"), "should raise dispatch completed event");
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Diagnostics/When_sending_messages_from_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Diagnostics/When_sending_messages_from_pipeline.cs
@@ -1,0 +1,69 @@
+﻿namespace NServiceBus.AcceptanceTests.Diagnostics;
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using EndpointTemplates;
+using NUnit.Framework;
+
+[NonParallelizable] // Ensure only activities for the current test are captured
+public class When_sending_messages_from_pipeline : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_add_batch_dispatch_events()
+    {
+        using var activityListener = TestingActivityListener.SetupNServiceBusDiagnosticListener();
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<TestEndpoint>(b => b
+                .When(s => s.SendLocal(new TriggerMessage())))
+            .Done(c => c.OutgoingMessageReceived)
+            .Run();
+
+        Assert.AreEqual(activityListener.CompletedActivities.Count, activityListener.StartedActivities.Count, "all activities should be completed");
+
+        var outgoingMessageActivities = activityListener.CompletedActivities.GetIncomingActivities();
+        var sentMessage = outgoingMessageActivities.First();
+
+        Assert.IsNotEmpty(sentMessage.Events);
+        var startDispatchingEvent = sentMessage.Events.Single(e => e.Name == "Start dispatching");
+        Assert.NotNull(startDispatchingEvent, "should raise dispatch start event");
+        Assert.AreEqual(1, startDispatchingEvent.Tags.ToImmutableDictionary()["message-count"]);
+        var dispatchFinishedEvent = sentMessage.Events.Single(e => e.Name == "Finished dispatching");
+        Assert.NotNull(dispatchFinishedEvent, "should raise dispatch finished event");
+    }
+
+    class Context : ScenarioContext
+    {
+        public bool OutgoingMessageReceived { get; set; }
+    }
+
+    class TestEndpoint : EndpointConfigurationBuilder
+    {
+        public TestEndpoint() => EndpointSetup<DefaultServer>();
+
+        class MessageHandler : IHandleMessages<OutgoingMessage>, IHandleMessages<TriggerMessage>
+        {
+            readonly Context testContext;
+
+            public MessageHandler(Context testContext) => this.testContext = testContext;
+
+            public Task Handle(TriggerMessage message, IMessageHandlerContext context) => context.SendLocal(new OutgoingMessage());
+
+            public Task Handle(OutgoingMessage message, IMessageHandlerContext context)
+            {
+                testContext.OutgoingMessageReceived = true;
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class TriggerMessage : IMessage
+    {
+
+    }
+
+    public class OutgoingMessage : IMessage
+    {
+    }
+}

--- a/src/NServiceBus.Core.Tests/Reliability/Outbox/FakeOutboxStorage.cs
+++ b/src/NServiceBus.Core.Tests/Reliability/Outbox/FakeOutboxStorage.cs
@@ -3,6 +3,7 @@
     using System.Threading;
     using System.Threading.Tasks;
     using Extensibility;
+    using Fakes;
     using NServiceBus.Outbox;
 
     class FakeOutboxStorage : IOutboxStorage
@@ -34,9 +35,7 @@
             return Task.CompletedTask;
         }
 
-        public Task<IOutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken = default)
-        {
-            throw new System.NotImplementedException();
-        }
+        public Task<IOutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken = default) =>
+            Task.FromResult<IOutboxTransaction>(new FakeOutboxTransaction());
     }
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
@@ -2,6 +2,7 @@ namespace NServiceBus
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Threading.Tasks;
     using Outbox;
     using Pipeline;

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
@@ -44,6 +44,8 @@ namespace NServiceBus
             }
             else
             {
+                context.Extensions.TryGetRecordingPipelineActivity(out var activity);
+                activity?.AddTag("nservicebus.outbox.deduplicate-message", true);
                 ConvertToPendingOperations(deduplicationEntry, pendingTransportOperations);
             }
 

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -34,6 +34,11 @@ namespace NServiceBus
 
                 var transportReceiveContext = new TransportReceiveContext(message, messageContext.TransportTransaction, rootContext);
 
+                if (activity != null)
+                {
+                    transportReceiveContext.SetPipelineActitvity(activity);
+                }
+
                 try
                 {
                     await receivePipeline.Invoke(transportReceiveContext).ConfigureAwait(false);


### PR DESCRIPTION
Paired up with @lailabougria to play around some ideas to add events or tags that might be of interest for the activities.

* Adds 2 events for the dispatching "phase": A more lightweight alternative instead of creating a custom span (might still be done by the transport when needed) and making the batch dispatch behavior a little bit more visible with some additional details on the number of messages that are being dispatched.
* Adds a special tag when the outbox has already a record for the incoming message and therefore "deduplicates" the message (not invoke message handler) and re-dispatches any remaining messages if needed. This might help identify cases where the outbox comes into play but where it's not immediately clear to users.