### PR TITLE
Split incoming and outgoing activities in pipeline context

### DIFF
--- a/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageConnectorTests.cs
@@ -113,7 +113,7 @@
 
             using var pipelineActivity = new Activity("test activity");
             pipelineActivity.Start();
-            context.Extensions.SetPipelineActitvity(pipelineActivity);
+            context.Extensions.SetIncomingPipelineActitvity(pipelineActivity);
 
             await Invoke(context);
 
@@ -127,7 +127,7 @@
 
             using var pipelineActivity = new Activity("test activity");
             pipelineActivity.Start();
-            context.Extensions.SetPipelineActitvity(pipelineActivity);
+            context.Extensions.SetIncomingPipelineActitvity(pipelineActivity);
 
             await Invoke(context, c =>
             {
@@ -154,7 +154,7 @@
 
             using var pipelineActivity = new Activity("test activity");
             pipelineActivity.Start();
-            context.Extensions.SetPipelineActitvity(pipelineActivity);
+            context.Extensions.SetIncomingPipelineActitvity(pipelineActivity);
 
             await Invoke(context);
 

--- a/src/NServiceBus.Core/Diagnostics/ActivityExtensions.cs
+++ b/src/NServiceBus.Core/Diagnostics/ActivityExtensions.cs
@@ -7,11 +7,17 @@ using Extensibility;
 static class ActivityExtensions
 {
     public const string OutgoingActivityKey = "NServiceBus.Diagnostics.Activity.Outgoing";
+    public const string IncomingActivityKey = "NServiceBus.Diagnostics.Activity.Incoming";
 
-    public static bool TryGetRecordingPipelineActivity(this ContextBag pipelineContext, out Activity activity)
+    public static bool TryGetRecordingOutgoingPipelineActivity(this ContextBag pipelineContext, out Activity activity)
+        => pipelineContext.TryGetRecordingPipelineActivity(OutgoingActivityKey, out activity);
+    public static bool TryGetRecordingIncomingPipelineActivity(this ContextBag pipelineContext, out Activity activity)
+        => pipelineContext.TryGetRecordingPipelineActivity(IncomingActivityKey, out activity);
+
+    static bool TryGetRecordingPipelineActivity(this ContextBag pipelineContext, string activityKey, out Activity activity)
     {
         if (Activity.Current != null // Cheaper to check than searching the pipeline context to start with. If there is no ambient activity, there can't be a context in the context.
-            && pipelineContext.TryGet(OutgoingActivityKey, out activity)  // Search activity in context bag
+            && pipelineContext.TryGet(activityKey, out activity)  // Search activity in context bag
             && activity.IsAllDataRequested) // do not apply "expensive" work on non-recording activities
         {
             return true;
@@ -21,7 +27,8 @@ static class ActivityExtensions
         return false;
     }
 
-    public static void SetPipelineActitvity(this ContextBag pipelineContext, Activity activity) => pipelineContext.Set(OutgoingActivityKey, activity);
+    public static void SetOutgoingPipelineActitvity(this ContextBag pipelineContext, Activity activity) => pipelineContext.Set(OutgoingActivityKey, activity);
+    public static void SetIncomingPipelineActitvity(this ContextBag pipelineContext, Activity activity) => pipelineContext.Set(IncomingActivityKey, activity);
 
     public static void SetErrorStatus(this Activity activity, Exception ex)
     {

--- a/src/NServiceBus.Core/Diagnostics/ActivityFactory.cs
+++ b/src/NServiceBus.Core/Diagnostics/ActivityFactory.cs
@@ -63,7 +63,7 @@ class ActivityFactory : IActivityFactory
             activity.DisplayName = displayName;
             activity.Start();
 
-            outgoingContext.Extensions.SetPipelineActitvity(activity);
+            outgoingContext.Extensions.SetOutgoingPipelineActitvity(activity);
         }
 
         return activity;

--- a/src/NServiceBus.Core/Diagnostics/SubscribeDiagnosticsBehavior.cs
+++ b/src/NServiceBus.Core/Diagnostics/SubscribeDiagnosticsBehavior.cs
@@ -8,7 +8,7 @@ class SubscribeDiagnosticsBehavior : IBehavior<ISubscribeContext, ISubscribeCont
 {
     public Task Invoke(ISubscribeContext context, Func<ISubscribeContext, Task> next)
     {
-        if (context.Extensions.TryGetRecordingPipelineActivity(out var activity))
+        if (context.Extensions.TryGetRecordingOutgoingPipelineActivity(out var activity))
         {
             //TODO should the tag name change between 1 or multiple event subscriptions? Currently only autosubscribe can register multiple events at once
             activity?.SetTag("nservicebus.event_types", string.Join(",", (object[])context.EventTypes));

--- a/src/NServiceBus.Core/Diagnostics/UnsubscribeDiagnosticsBehavior.cs
+++ b/src/NServiceBus.Core/Diagnostics/UnsubscribeDiagnosticsBehavior.cs
@@ -8,7 +8,7 @@ class UnsubscribeDiagnosticsBehavior : IBehavior<IUnsubscribeContext, IUnsubscri
 {
     public Task Invoke(IUnsubscribeContext context, Func<IUnsubscribeContext, Task> next)
     {
-        if (context.Extensions.TryGetRecordingPipelineActivity(out var activity))
+        if (context.Extensions.TryGetRecordingOutgoingPipelineActivity(out var activity))
         {
             //TODO unsubscribe is always a single event type, should the tag name reflect that?
             activity?.SetTag("nservicebus.event_types", context.EventType.FullName);

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
@@ -45,7 +45,7 @@ namespace NServiceBus
             }
             else
             {
-                context.Extensions.TryGetRecordingPipelineActivity(out var activity);
+                context.Extensions.TryGetRecordingIncomingPipelineActivity(out var activity);
                 activity?.AddTag("nservicebus.outbox.deduplicate-message", true);
                 ConvertToPendingOperations(deduplicationEntry, pendingTransportOperations);
             }
@@ -54,7 +54,7 @@ namespace NServiceBus
             {
                 var batchDispatchContext = this.CreateBatchDispatchContext(pendingTransportOperations.Operations, physicalMessageContext);
 
-                if (context.Extensions.TryGetRecordingPipelineActivity(out var activity))
+                if (context.Extensions.TryGetRecordingIncomingPipelineActivity(out var activity))
                 {
                     var activityTagsCollection = new ActivityTagsCollection { { "message-count", batchDispatchContext.Operations.Count } };
                     activity?.AddEvent(new ActivityEvent("Start dispatching", tags: activityTagsCollection));

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -36,7 +36,7 @@ namespace NServiceBus
 
                 if (activity != null)
                 {
-                    transportReceiveContext.SetPipelineActitvity(activity);
+                    transportReceiveContext.SetIncomingPipelineActitvity(activity);
                 }
 
                 try

--- a/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/RoutingToDispatchConnector.cs
@@ -38,7 +38,7 @@
             }
 
             // HINT: These tags get applied to the outgoing message activity, if present.
-            if (context.Extensions.TryGetRecordingPipelineActivity(out var activity))
+            if (context.Extensions.TryGetRecordingOutgoingPipelineActivity(out var activity))
             {
                 ActivityDecorator.PromoteHeadersToTags(activity, context.Message.Headers);
             }


### PR DESCRIPTION
splits the APIs by using different access keys in the ContextBag. Alternatively, we can remain on a single key that should probably be renamed. In this case, there would be no way to access the incoming pipeline activity from a sending behavior. I'm not sure that would be abig deal though so that might be simpler but less flexible option?.