### PR TITLE
Update allowed language version

### DIFF
--- a/guidelines/coding-guidelines.md
+++ b/guidelines/coding-guidelines.md
@@ -1,5 +1,6 @@
 ## Language Features
-It is acceptable to use language features from C# 10 and lower versions.
+
+It is acceptable to use language features for the given `LangVersion` defined in the project that compile successfully against all targeted TFMs. Note that all language features later than C# 7.3 are not officially supported for .NET Framework so compatibility varies on a feature by feature level. This can result in some language features to cause compiler errors or slower performance.
 
 ## Performance related
 

--- a/guidelines/coding-guidelines.md
+++ b/guidelines/coding-guidelines.md
@@ -1,5 +1,5 @@
 ## Language Features
-It is acceptable to use language features in C# 7.3 and lower versions.
+It is acceptable to use language features from C# 10 and lower versions.
 
 ## Performance related
 


### PR DESCRIPTION
Since the language version has been updated in https://github.com/Particular/NServiceBus/pull/6389.

Not sure whether to completely remove this section instead. It would probably be more helpful to state some guidance about what version is allowed in a way without documenting a specific version so that this document won't fall out of date again. Any suggestions @bording ?