### PR TITLE
OpenTelemetry opt-in API

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/OpenTelemetryEnabledEndpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/OpenTelemetryEnabledEndpoint.cs
@@ -1,0 +1,19 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.OpenTelemetry;
+
+using System;
+using System.Threading.Tasks;
+using AcceptanceTesting.Support;
+using EndpointTemplates;
+using NServiceBus.OpenTelemetry;
+
+public class OpenTelemetryEnabledEndpoint : DefaultServer
+{
+    public override Task<EndpointConfiguration> GetConfiguration(RunDescriptor runDescriptor,
+        EndpointCustomizationConfiguration endpointConfiguration,
+        Func<EndpointConfiguration, Task> configurationBuilderCustomization) =>
+        base.GetConfiguration(runDescriptor, endpointConfiguration, configuration =>
+        {
+            configuration.EnableOpenTelemetry();
+            return configurationBuilderCustomization(configuration);
+        });
+}

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/OpenTelemetryEnabledEndpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/OpenTelemetryEnabledEndpoint.cs
@@ -4,7 +4,6 @@ using System;
 using System.Threading.Tasks;
 using AcceptanceTesting.Support;
 using EndpointTemplates;
-using NServiceBus.OpenTelemetry;
 
 public class OpenTelemetryEnabledEndpoint : DefaultServer
 {

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_ambient_trace_in_message_session.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_ambient_trace_in_message_session.cs
@@ -4,7 +4,6 @@
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
     public class When_ambient_trace_in_message_session : OpenTelemetryAcceptanceTest
@@ -55,7 +54,7 @@
 
         class EndpointWithAmbientActivity : EndpointConfigurationBuilder
         {
-            public EndpointWithAmbientActivity() => EndpointSetup<DefaultServer>();
+            public EndpointWithAmbientActivity() => EndpointSetup<OpenTelemetryEnabledEndpoint>();
 
             public class MessageHandler : IHandleMessages<LocalMessage>
             {

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_ambient_trace_in_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_ambient_trace_in_pipeline.cs
@@ -5,7 +5,6 @@
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
     public class When_ambient_trace_in_pipeline : OpenTelemetryAcceptanceTest
@@ -43,7 +42,7 @@
 
         class EndpointWithAmbientActivity : EndpointConfigurationBuilder
         {
-            public EndpointWithAmbientActivity() => EndpointSetup<DefaultServer>();
+            public EndpointWithAmbientActivity() => EndpointSetup<OpenTelemetryEnabledEndpoint>();
 
             class MessageHandler : IHandleMessages<TriggerMessage>, IHandleMessages<MessageFromAmbientTrace>
             {

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_incoming_event_has_trace.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_incoming_event_has_trace.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using NServiceBus.AcceptanceTesting;
 using NServiceBus.AcceptanceTesting.Customization;
-using NServiceBus.AcceptanceTests.EndpointTemplates;
 using NUnit.Framework;
 
 public class When_incoming_event_has_trace : OpenTelemetryAcceptanceTest
@@ -49,7 +48,7 @@ public class When_incoming_event_has_trace : OpenTelemetryAcceptanceTest
     class Publisher : EndpointConfigurationBuilder
     {
         public Publisher() =>
-            EndpointSetup<DefaultPublisher>(b =>
+            EndpointSetup<OpenTelemetryEnabledEndpoint>(b =>
             {
                 b.OnEndpointSubscribed<Context>((s, context) =>
                 {
@@ -81,7 +80,7 @@ public class When_incoming_event_has_trace : OpenTelemetryAcceptanceTest
     public class Subscriber : EndpointConfigurationBuilder
     {
         public Subscriber() =>
-            EndpointSetup<DefaultServer>(_ =>
+            EndpointSetup<OpenTelemetryEnabledEndpoint>(_ =>
                 {
                 },
                 metadata =>

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_incoming_message_has_baggage_header.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_incoming_message_has_baggage_header.cs
@@ -3,7 +3,6 @@
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
     public class When_incoming_message_has_baggage_header : OpenTelemetryAcceptanceTest
@@ -41,7 +40,7 @@
 
         class TestEndpoint : EndpointConfigurationBuilder
         {
-            public TestEndpoint() => EndpointSetup<DefaultServer>();
+            public TestEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>();
 
             public class SomeMessageHandler : IHandleMessages<SomeMessage>
             {

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_incoming_message_has_no_trace.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_incoming_message_has_no_trace.cs
@@ -4,7 +4,6 @@
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NServiceBus.Pipeline;
     using NServiceBus.Transport;
     using NUnit.Framework;
@@ -31,7 +30,7 @@
 
         class ReceivingEndpoint : EndpointConfigurationBuilder
         {
-            public ReceivingEndpoint() => EndpointSetup<DefaultServer>(c => c
+            public ReceivingEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>(c => c
                 .Pipeline.Register(new StopTraceBehavior(), "removes tracing headers from outgoing messages"));
 
             class StopTraceBehavior : Behavior<IDispatchContext>

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_incoming_message_has_trace.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_incoming_message_has_trace.cs
@@ -52,7 +52,7 @@
 
         class ReceivingEndpoint : EndpointConfigurationBuilder
         {
-            public ReceivingEndpoint() => EndpointSetup<DefaultServer>();
+            public ReceivingEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>();
 
             class MessageHandler : IHandleMessages<IncomingMessage>
             {
@@ -71,7 +71,7 @@
 
         class ReplyingEndpoint : EndpointConfigurationBuilder
         {
-            public ReplyingEndpoint() => EndpointSetup<DefaultServer>();
+            public ReplyingEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>();
 
             class MessageHandler : IHandleMessages<IncomingMessage>
             {
@@ -90,7 +90,7 @@
 
         class TestEndpoint : EndpointConfigurationBuilder
         {
-            public TestEndpoint() => EndpointSetup<DefaultServer>();
+            public TestEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>();
 
             class MessageHandler : IHandleMessages<ReplyMessage>
             {

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_messages_processed_successfully.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_messages_processed_successfully.cs
@@ -4,7 +4,6 @@ namespace NServiceBus.AcceptanceTests.Core.OpenTelemetry
     using System.Threading.Tasks;
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
     using Conventions = AcceptanceTesting.Customization.Conventions;
 
@@ -49,7 +48,7 @@ namespace NServiceBus.AcceptanceTests.Core.OpenTelemetry
 
         class EndpointWithMetrics : EndpointConfigurationBuilder
         {
-            public EndpointWithMetrics() => EndpointSetup<DefaultServer>();
+            public EndpointWithMetrics() => EndpointSetup<OpenTelemetryEnabledEndpoint>();
 
             class MessageHandler : IHandleMessages<OutgoingMessage>
             {

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_outgoing_activity_has_baggage.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_outgoing_activity_has_baggage.cs
@@ -3,7 +3,6 @@
     using System.Diagnostics;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
     public class When_outgoing_activity_has_baggage : OpenTelemetryAcceptanceTest
@@ -40,10 +39,7 @@
 
         class TestEndpoint : EndpointConfigurationBuilder
         {
-            public TestEndpoint()
-            {
-                EndpointSetup<DefaultServer>();
-            }
+            public TestEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>();
 
             class SomeMessageHandler : IHandleMessages<SomeMessage>
             {
@@ -65,7 +61,6 @@
 
         public class SomeMessage : IMessage
         {
-
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_processing_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_processing_fails.cs
@@ -6,7 +6,6 @@
     using System.Threading.Tasks;
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
     public class When_processing_fails : OpenTelemetryAcceptanceTest
@@ -63,7 +62,7 @@
 
         class FailingEndpoint : EndpointConfigurationBuilder
         {
-            public FailingEndpoint() => EndpointSetup<DefaultServer>();
+            public FailingEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>();
 
             class FailingMessageHandler : IHandleMessages<FailingMessage>
             {

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_processing_incoming_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_processing_incoming_message.cs
@@ -59,7 +59,7 @@
 
         class ReceivingEndpoint : EndpointConfigurationBuilder
         {
-            public ReceivingEndpoint() => EndpointSetup<DefaultServer>();
+            public ReceivingEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>();
 
             class MessageHandler : IHandleMessages<IncomingMessage>
             {

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_processing_message_with_multiple_handlers.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_processing_message_with_multiple_handlers.cs
@@ -4,7 +4,6 @@
     using System.Diagnostics;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
     public class When_processing_message_with_multiple_handlers : OpenTelemetryAcceptanceTest
@@ -48,7 +47,7 @@
 
         class ReceivingEndpoint : EndpointConfigurationBuilder
         {
-            public ReceivingEndpoint() => EndpointSetup<DefaultServer>();
+            public ReceivingEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>();
 
             public class HandlerOne : IHandleMessages<SomeMessage>
             {

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_processing_message_with_saga_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_processing_message_with_saga_handler.cs
@@ -5,7 +5,6 @@
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
     public class When_processing_message_with_saga_handler : OpenTelemetryAcceptanceTest
@@ -39,7 +38,7 @@
 
         public class TestEndpoint : EndpointConfigurationBuilder
         {
-            public TestEndpoint() => EndpointSetup<DefaultServer>();
+            public TestEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>();
 
             public class TracedSaga : Saga<TracedSaga.TracedSagaData>, IAmStartedByMessages<SomeMessage>
             {

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_publishing_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_publishing_messages.cs
@@ -5,7 +5,6 @@
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTesting.Customization;
-    using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
     public class When_publishing_messages : OpenTelemetryAcceptanceTest
@@ -53,7 +52,7 @@
         class Publisher : EndpointConfigurationBuilder
         {
             public Publisher() =>
-                EndpointSetup<DefaultPublisher>(b =>
+                EndpointSetup<OpenTelemetryEnabledEndpoint>(b =>
                 {
                     b.OnEndpointSubscribed<Context>((s, context) =>
                     {
@@ -70,16 +69,14 @@
 
         public class Subscriber : EndpointConfigurationBuilder
         {
-            public Subscriber()
-            {
-                EndpointSetup<DefaultServer>(c =>
+            public Subscriber() =>
+                EndpointSetup<OpenTelemetryEnabledEndpoint>(c =>
                     {
                     },
                     metadata =>
                     {
                         metadata.RegisterPublisherFor<ThisIsAnEvent>(typeof(Publisher));
                     });
-            }
 
             public class ThisHandlesSomethingHandler : IHandleMessages<ThisIsAnEvent>
             {

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_retrying_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_retrying_messages.cs
@@ -4,7 +4,6 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using NServiceBus.AcceptanceTesting;
-using NServiceBus.AcceptanceTests.EndpointTemplates;
 using NUnit.Framework;
 
 public class When_retrying_messages : OpenTelemetryAcceptanceTest
@@ -64,7 +63,7 @@ public class When_retrying_messages : OpenTelemetryAcceptanceTest
     {
         public RetryingEndpoint()
         {
-            EndpointSetup<DefaultServer>();
+            EndpointSetup<OpenTelemetryEnabledEndpoint>();
         }
 
         class Handler : IHandleMessages<FailingMessage>

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_sending_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_sending_messages.cs
@@ -6,7 +6,6 @@
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
     public class When_sending_messages : OpenTelemetryAcceptanceTest
@@ -50,7 +49,7 @@
 
         class TestEndpoint : EndpointConfigurationBuilder
         {
-            public TestEndpoint() => EndpointSetup<DefaultServer>();
+            public TestEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>();
 
             class MessageHandler : IHandleMessages<OutgoingMessage>
             {

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_sending_messages_from_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_sending_messages_from_pipeline.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using NServiceBus.AcceptanceTesting;
-using NServiceBus.AcceptanceTests.EndpointTemplates;
 using NUnit.Framework;
 
 public class When_sending_messages_from_pipeline : OpenTelemetryAcceptanceTest
@@ -35,7 +34,7 @@ public class When_sending_messages_from_pipeline : OpenTelemetryAcceptanceTest
 
     class TestEndpoint : EndpointConfigurationBuilder
     {
-        public TestEndpoint() => EndpointSetup<DefaultServer>();
+        public TestEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>();
 
         class MessageHandler : IHandleMessages<OutgoingMessage>, IHandleMessages<TriggerMessage>
         {

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_sending_replies.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_sending_replies.cs
@@ -36,7 +36,7 @@ namespace NServiceBus.AcceptanceTests.Core.OpenTelemetry
 
         class TestEndpoint : EndpointConfigurationBuilder
         {
-            public TestEndpoint() => EndpointSetup<DefaultServer>();
+            public TestEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>();
 
             class MessageHandler : IHandleMessages<IncomingMessage>,
                 IHandleMessages<OutgoingReply>

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_subscribing.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_subscribing.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using NServiceBus.AcceptanceTesting;
-using NServiceBus.AcceptanceTests.EndpointTemplates;
 using NServiceBus.Features;
 using NUnit.Framework;
 
@@ -72,14 +71,14 @@ public class When_subscribing : OpenTelemetryAcceptanceTest
 
     class SubscribingEndpoint : EndpointConfigurationBuilder
     {
-        public SubscribingEndpoint() => EndpointSetup<DefaultServer>(
+        public SubscribingEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>(
             c => c.DisableFeature<AutoSubscribe>(),
             p => p.RegisterPublisherFor<DemoEvent>(typeof(PublishingEndpoint)));
     }
 
     class PublishingEndpoint : EndpointConfigurationBuilder
     {
-        public PublishingEndpoint() => EndpointSetup<DefaultServer>(c =>
+        public PublishingEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>(c =>
         {
             c.DisableFeature<AutoSubscribe>();
             c.OnEndpointSubscribed<Context>((e, ctx) =>

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_unsubscribing.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_unsubscribing.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using NServiceBus.AcceptanceTesting;
-using NServiceBus.AcceptanceTests.EndpointTemplates;
 using NServiceBus.Features;
 using NUnit.Framework;
 
@@ -71,14 +70,14 @@ public class When_unsubscribing : OpenTelemetryAcceptanceTest
 
     class SubscriberEndpoint : EndpointConfigurationBuilder
     {
-        public SubscriberEndpoint() => EndpointSetup<DefaultServer>(
+        public SubscriberEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>(
             c => c.DisableFeature<AutoSubscribe>(),
             p => p.RegisterPublisherFor<DemoEvent>(typeof(PublishingEndpoint)));
     }
 
     class PublishingEndpoint : EndpointConfigurationBuilder
     {
-        public PublishingEndpoint() => EndpointSetup<DefaultServer>(c =>
+        public PublishingEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>(c =>
         {
             c.DisableFeature<AutoSubscribe>();
             c.OnEndpointUnsubscribed<Context>((e, ctx) =>

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -831,6 +831,10 @@ namespace NServiceBus
         public NServiceBus.Faults.ErrorsNotifications Errors { get; }
     }
     public delegate System.Threading.Tasks.Task OnSatelliteMessage(System.IServiceProvider serviceProvider, NServiceBus.Transport.MessageContext messageContext, System.Threading.CancellationToken cancellationToken = default);
+    public static class OpenTelemetryConfigurationExtensions
+    {
+        public static void EnableOpenTelemetry(this NServiceBus.EndpointConfiguration endpointConfiguration) { }
+    }
     public static class OutboxConfigExtensions
     {
         public static NServiceBus.Outbox.OutboxSettings EnableOutbox(this NServiceBus.EndpointConfiguration config) { }
@@ -1922,13 +1926,6 @@ namespace NServiceBus.ObjectBuilder
         [System.Obsolete("The Release method is not supported. The member currently throws a NotImplemented" +
             "Exception. Will be removed in version 9.0.0.", true)]
         public static void Release(this System.IServiceProvider serviceProvider, object instance) { }
-    }
-}
-namespace NServiceBus.OpenTelemetry
-{
-    public static class OpenTelemetryConfigurationExtensions
-    {
-        public static void EnableOpenTelemetry(this NServiceBus.EndpointConfiguration endpointConfiguration) { }
     }
 }
 namespace NServiceBus.Outbox

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1924,6 +1924,13 @@ namespace NServiceBus.ObjectBuilder
         public static void Release(this System.IServiceProvider serviceProvider, object instance) { }
     }
 }
+namespace NServiceBus.OpenTelemetry
+{
+    public static class OpenTelemetryConfigurationExtensions
+    {
+        public static void EnableOpenTelemetry(this NServiceBus.EndpointConfiguration endpointConfiguration) { }
+    }
+}
 namespace NServiceBus.Outbox
 {
     public interface IOutboxStorage

--- a/src/NServiceBus.Core/Hosting/HostingComponent.Configuration.cs
+++ b/src/NServiceBus.Core/Hosting/HostingComponent.Configuration.cs
@@ -28,7 +28,7 @@
                 settings.InstallationUserName,
                 settings.ShouldRunInstallers,
                 settings.UserRegistrations,
-                ActivitySources.Main.HasListeners() ? new ActivityFactory() : new NoOpActivityFactory());
+                settings.EnableOpenTelemetry ? new ActivityFactory() : new NoOpActivityFactory());
 
             return configuration;
         }

--- a/src/NServiceBus.Core/Hosting/HostingComponent.Settings.cs
+++ b/src/NServiceBus.Core/Hosting/HostingComponent.Settings.cs
@@ -89,6 +89,8 @@
                 set => settings.Set("Installers.Enable", value);
             }
 
+            public bool EnableOpenTelemetry { get; set; }
+
             internal void ApplyHostIdDefaultIfNeeded()
             {
                 // We don't want to do settings.SetDefault() all the time, because the default uses MD5 which runs afoul of FIPS in such a way that cannot be worked around.

--- a/src/NServiceBus.Core/OpenTelemetry/Metrics/MessagingMetricsFeature.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Metrics/MessagingMetricsFeature.cs
@@ -7,14 +7,7 @@ namespace NServiceBus
     /// </summary>
     class MessagingMetricsFeature : Feature
     {
-        static bool HasMetricsListener => Meters.TotalProcessedSuccessfully.Enabled || Meters.TotalFetched.Enabled || Meters.TotalFailures.Enabled;
-
-        public MessagingMetricsFeature()
-        {
-            EnableByDefault();
-            Prerequisite(c => HasMetricsListener, "No subscribers for messaging metrics");
-            Prerequisite(c => !c.Receiving.IsSendOnlyEndpoint, "Processing metrics are not supported on send-only endpoints");
-        }
+        public MessagingMetricsFeature() => Prerequisite(c => !c.Receiving.IsSendOnlyEndpoint, "Processing metrics are not supported on send-only endpoints");
 
         /// <inheritdoc />
         protected internal override void Setup(FeatureConfigurationContext context)

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.OpenTelemetry;
+﻿namespace NServiceBus;
 
 /// <summary>
 /// Contains configuration extensions for OpenTelemetry support.

--- a/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/OpenTelemetryConfigurationExtensions.cs
@@ -1,0 +1,18 @@
+﻿namespace NServiceBus.OpenTelemetry;
+
+/// <summary>
+/// Contains configuration extensions for OpenTelemetry support.
+/// </summary>
+public static class OpenTelemetryConfigurationExtensions
+{
+    /// <summary>
+    /// Enables the OpenTelemetry instrumentation in NServiceBus.
+    /// </summary>
+    public static void EnableOpenTelemetry(this EndpointConfiguration endpointConfiguration)
+    {
+        Guard.AgainstNull(nameof(endpointConfiguration), endpointConfiguration);
+
+        endpointConfiguration.Settings.Get<HostingComponent.Settings>().EnableOpenTelemetry = true;
+        endpointConfiguration.EnableFeature<MessagingMetricsFeature>();
+    }
+}


### PR DESCRIPTION
Alternative to #6444 that instead changes the API to an explicit opt-in API for both traces and metrics.

When enabled, OT instrumentation will always be "enabled", slightly decreasing endpoint performance due to the overhead (although it is minimal), regardless whether listeners for metrics and or traces have been registered.

This approach avoids all potential race conditions with the registration of OpenTelemetry listeners and would even allow runtime subscriptions.

downside of this approach:
* users need to double-opt-in into OpenTelemetry instrumentation via the `AddSource` and the `EnableOpenTelemetry` API.
* Currently a single API controlling both metrics and traces. Maybe a more granular API would be better to let users decide which parts of the instrumentation should be added.