### PR TITLE
Expose possibility to add conventions on the conventions class

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -146,6 +146,7 @@ namespace NServiceBus
     public class Conventions
     {
         public Conventions() { }
+        public void Add(NServiceBus.IMessageConvention messageConvention) { }
         public void AddSystemMessagesConventions(System.Func<System.Type, bool> definesMessageType) { }
         public bool IsCommandType(System.Type t) { }
         public bool IsDataBusProperty(System.Reflection.PropertyInfo property) { }

--- a/src/NServiceBus.Core/Conventions/Conventions.cs
+++ b/src/NServiceBus.Core/Conventions/Conventions.cs
@@ -194,6 +194,12 @@
             }
         }
 
+        /// <summary>
+        /// Adds a message convention implementation to the list of conventions.
+        /// </summary>
+        /// <param name="messageConvention">The message convention.</param>
+        public void Add(IMessageConvention messageConvention) => conventions.Add(messageConvention);
+
         internal bool CustomMessageTypeConventionUsed => defaultMessageConvention.ConventionModified || conventions.Count > 1;
 
         internal string[] RegisteredConventions => conventions.Select(x => x.Name).ToArray();
@@ -234,10 +240,7 @@
             defaultMessageConvention.DefiningEventsAs(definesEventType);
         }
 
-        internal void Add(IMessageConvention messageConvention)
-        {
-            conventions.Add(messageConvention);
-        }
+
 
         internal Func<PropertyInfo, bool> IsDataBusPropertyAction = p => typeof(IDataBusProperty).IsAssignableFrom(p.PropertyType) && typeof(IDataBusProperty) != p.PropertyType;
 

--- a/src/NServiceBus.Core/Conventions/Conventions.cs
+++ b/src/NServiceBus.Core/Conventions/Conventions.cs
@@ -226,21 +226,13 @@
         }
 
         internal void DefineMessageTypeConvention(Func<Type, bool> definesMessageType)
-        {
-            defaultMessageConvention.DefiningMessagesAs(definesMessageType);
-        }
+            => defaultMessageConvention.DefiningMessagesAs(definesMessageType);
 
         internal void DefineCommandTypeConventions(Func<Type, bool> definesCommandType)
-        {
-            defaultMessageConvention.DefiningCommandsAs(definesCommandType);
-        }
+            => defaultMessageConvention.DefiningCommandsAs(definesCommandType);
 
         internal void DefineEventTypeConventions(Func<Type, bool> definesEventType)
-        {
-            defaultMessageConvention.DefiningEventsAs(definesEventType);
-        }
-
-
+            => defaultMessageConvention.DefiningEventsAs(definesEventType);
 
         internal Func<PropertyInfo, bool> IsDataBusPropertyAction = p => typeof(IDataBusProperty).IsAssignableFrom(p.PropertyType) && typeof(IDataBusProperty) != p.PropertyType;
 
@@ -260,14 +252,9 @@
         class ConventionCache
         {
             public bool ApplyConvention(Type type, Func<RuntimeTypeHandle, bool> action)
-            {
-                return cache.GetOrAdd(type.TypeHandle, action);
-            }
+                => cache.GetOrAdd(type.TypeHandle, action);
 
-            public void Reset()
-            {
-                cache.Clear();
-            }
+            public void Reset() => cache.Clear();
 
             ConcurrentDictionary<RuntimeTypeHandle, bool> cache = new ConcurrentDictionary<RuntimeTypeHandle, bool>();
         }


### PR DESCRIPTION
Currently, it is not possible to call `Add` on the Conventions class to add implementations of `IMessageConvention`. It is only possible to add implementations of that interface by calling

```csharp
endpointConfiguration.Conventions().Add()
```

This makes it not possible for features to add their own implementations of `IMessageConvention` directly and forces authors of packages that provide conventions to make sure users call a method on the endpoint configuration level instead of having the possibility to directly do everything from a feature.

@mauroservienti has been suffering through this as an author of the AttributeRouting packages. I'm currently working on a prototype to enable AsyncApi specifications and I also need the ability to add conventions.

Given that conventions are already accessible via the settings inside features I see no reason why we need to hide the add method.