### PR TITLE
Make GetAllMessages public

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -2979,6 +2979,7 @@ namespace NServiceBus.Unicast.Messages
     }
     public class MessageMetadataRegistry
     {
+        public NServiceBus.Unicast.Messages.MessageMetadata[] GetAllMessages() { }
         public NServiceBus.Unicast.Messages.MessageMetadata GetMessageMetadata(string messageTypeIdentifier) { }
         public NServiceBus.Unicast.Messages.MessageMetadata GetMessageMetadata(System.Type messageType) { }
     }

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -127,7 +127,10 @@
             return null;
         }
 
-        internal MessageMetadata[] GetAllMessages() => messages.Values.ToArray();
+        /// <summary>
+        /// Get all known messages metadata
+        /// </summary>
+        public MessageMetadata[] GetAllMessages() => messages.Values.ToArray();
 
         internal void RegisterMessageTypesFoundIn(IList<Type> availableTypes)
         {


### PR DESCRIPTION
Similarly to #6448, library authors may need to access message types metadata. Otherwise, they are forced to use either reflection or reinvent the wheel by adding custom assembly scanning.

For example: https://github.com/mauroservienti/NServiceBus.AttributeRouting/blob/master/src/NServiceBus.AttributeRouting/MessageMetadataRegistryExtensions.cs