### PR TITLE
Register ScenarioContext setting and DI in EndpointRunner

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/AcceptanceTestingTransportServer.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/AcceptanceTestingTransportServer.cs
@@ -29,8 +29,6 @@
             await transportConfiguration.Configure(endpointConfiguration.EndpointName, configuration, runDescriptor.Settings, endpointConfiguration.PublisherMetadata);
             runDescriptor.OnTestCompleted(_ => transportConfiguration.Cleanup());
 
-            configuration.RegisterComponentsAndInheritanceHierarchy(runDescriptor);
-
             var persistenceConfiguration = new ConfigureEndpointAcceptanceTestingPersistence();
             await persistenceConfiguration.Configure(endpointConfiguration.EndpointName, configuration, runDescriptor.Settings, endpointConfiguration.PublisherMetadata);
             runDescriptor.OnTestCompleted(_ => persistenceConfiguration.Cleanup());

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ConfigureExtensions.cs
@@ -4,7 +4,6 @@
     using Transport;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting.Support;
-    using Microsoft.Extensions.DependencyInjection;
 
     public static class ConfigureExtensions
     {
@@ -44,21 +43,6 @@
         {
             await persistenceConfiguration.Configure(endpointCustomizationConfiguration.EndpointName, config, runDescriptor.Settings, endpointCustomizationConfiguration.PublisherMetadata);
             runDescriptor.OnTestCompleted(_ => persistenceConfiguration.Cleanup());
-        }
-
-        public static void RegisterComponentsAndInheritanceHierarchy(this EndpointConfiguration builder, RunDescriptor runDescriptor)
-        {
-            builder.RegisterComponents(r => { RegisterInheritanceHierarchyOfContextOnContainer(runDescriptor, r); });
-        }
-
-        static void RegisterInheritanceHierarchyOfContextOnContainer(RunDescriptor runDescriptor, IServiceCollection r)
-        {
-            var type = runDescriptor.ScenarioContext.GetType();
-            while (type != typeof(object))
-            {
-                r.AddSingleton(type, runDescriptor.ScenarioContext);
-                type = type.BaseType;
-            }
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/ServerWithNoDefaultPersistenceDefinitions.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/ServerWithNoDefaultPersistenceDefinitions.cs
@@ -21,8 +21,6 @@
 
             await builder.DefineTransport(TransportConfiguration, runDescriptor, endpointConfiguration).ConfigureAwait(false);
 
-            builder.RegisterComponentsAndInheritanceHierarchy(runDescriptor);
-
             await configurationBuilderCustomization(builder).ConfigureAwait(false);
 
             // scan types at the end so that all types used by the configuration have been loaded into the AppDomain


### PR DESCRIPTION
replaces https://github.com/Particular/NServiceBus/pull/6380

Simplifies the registration of the ScenarioContext in the settings and DI by doing it in a single place and by default so that this doesn't have to be replicated on custom endpoint templates.