### PR TITLE
Update Particular/push-octopus-package-action to 1.0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,6 @@ jobs:
           path: nugets/*
           retention-days: 1
       - name: Deploy
-        uses: Particular/push-octopus-package-action@v1.0.0
+        uses: Particular/push-octopus-package-action@v1.0.1
         with:
           octopus-deploy-api-key: ${{ secrets.OCTOPUS_DEPLOY_API_KEY }}


### PR DESCRIPTION
Bug in 1.0.0 version of the action because trying to copy from a non-existant folder (`assets` in this case) in powershell is an error, not a no-op. Fixed in https://github.com/Particular/push-octopus-package-action/pull/1.