### PR TITLE
Added usefull guidance to RegisterComponents obsoletes

### DIFF
--- a/src/NServiceBus.Core/obsoletes-v8.cs
+++ b/src/NServiceBus.Core/obsoletes-v8.cs
@@ -200,6 +200,7 @@ namespace NServiceBus.ObjectBuilder
         void ConfigureComponent(Type concreteComponent, DependencyLifecycle dependencyLifecycle);
 
         [ObsoleteEx(
+            Message = "Ensure to explicitly register all interfaces of a specific type as this will no longer be done automatically."
             ReplacementTypeOrMember = "IServiceCollection.ConfigureComponent",
             TreatAsErrorFromVersion = "8.0",
             RemoveInVersion = "9.0")]


### PR DESCRIPTION
Added 

> Ensure to explicitly register all interfaces of a given type. 

That hopefully prevents users from converting:

    configuration.RegisterComponents(c => c.ConfigureComponent<StatisticsUoW>(DependencyLifecycle.SingleInstance));

into:

    configuration.RegisterComponents(c => c.AddSingleton<IManageUnitsOfWork, StatisticsUoW>());

and not into:

    configuration.RegisterComponents(c => c.AddSingleton<StatisticsUoW>());
