### PR TITLE
Add dedicated Installer APIs

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Installers/InstallationOnlyComponent.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Installers/InstallationOnlyComponent.cs
@@ -1,0 +1,53 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Installers;
+
+using System.Threading;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using AcceptanceTesting.Customization;
+using AcceptanceTesting.Support;
+using Configuration.AdvancedExtensibility;
+using Installation;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Custom test component that uses the <see cref="Installer.Setup"/> API instead of fully starting the endpoint.
+/// </summary>
+public class InstallationOnlyComponent<TConfigurationFactory> : IComponentBehavior
+    where TConfigurationFactory : IEndpointConfigurationFactory, new()
+{
+    public async Task<ComponentRunner> CreateRunner(RunDescriptor run)
+    {
+        var configurationFactory = new TConfigurationFactory();
+        var customizationConfiguration = configurationFactory.Get();
+        customizationConfiguration.EndpointName = Conventions.EndpointNamingConvention(configurationFactory.GetType());
+        var endpointConfiguration = await customizationConfiguration.GetConfiguration(run);
+        RegisterScenarioContext(endpointConfiguration, run.ScenarioContext);
+        return new InstallationRunner(endpointConfiguration);
+    }
+
+    void RegisterScenarioContext(EndpointConfiguration endpointConfiguration, ScenarioContext scenarioContext)
+    {
+        var type = scenarioContext.GetType();
+        while (type != typeof(object))
+        {
+            var currentType = type;
+            endpointConfiguration.GetSettings().Set(currentType.FullName, scenarioContext);
+            endpointConfiguration.RegisterComponents(serviceCollection => serviceCollection.AddSingleton(currentType, scenarioContext));
+            type = type.BaseType;
+        }
+    }
+
+    public class InstallationRunner : ComponentRunner
+    {
+        EndpointConfiguration endpointConfiguration;
+
+        public InstallationRunner(EndpointConfiguration endpointConfiguration)
+        {
+            this.endpointConfiguration = endpointConfiguration;
+        }
+
+        public override string Name => "Installation only runner";
+
+        public override Task Start(CancellationToken cancellationToken = default) => Installer.Setup(endpointConfiguration, cancellationToken);
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Core/Installers/When_installing_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Installers/When_installing_endpoint.cs
@@ -22,12 +22,12 @@ public class When_installing_endpoint : NServiceBusAcceptanceTest
 
         Assert.IsTrue(context.InstallerCalled, "Should run installers");
         Assert.IsTrue(context.FeatureSetupCalled, "Should initialize Features");
-        Assert.IsFalse(context.FeatureStartupTaskCalled, "should not start FeatureStartupTasks");
+        Assert.IsFalse(context.FeatureStartupTaskCalled, "Should not start FeatureStartupTasks");
         CollectionAssert.AreEqual(context.TransportStartupSequence, new string[]
         {
             $"{nameof(TransportDefinition)}.{nameof(TransportDefinition.Initialize)}",
             $"{nameof(IMessageReceiver)}.{nameof(IMessageReceiver.Initialize)} for receiver Main",
-        }, "should not start the receivers");
+        }, "Should not start the receivers");
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Installers/When_installing_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Installers/When_installing_endpoint.cs
@@ -1,0 +1,104 @@
+﻿namespace NServiceBus.AcceptanceTests.Core.Installers;
+
+using System.Threading;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using EndpointTemplates;
+using FakeTransport;
+using Features;
+using Installation;
+using Configuration.AdvancedExtensibility;
+using NUnit.Framework;
+using Transport;
+
+public class When_installing_endpoint : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_only_execute_setup_and_complete()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithComponent(new InstallationOnlyComponent<EndpointWithInstaller>())
+            .Run();
+
+        Assert.IsTrue(context.InstallerCalled, "Should run installers");
+        Assert.IsTrue(context.FeatureSetupCalled, "Should initialize Features");
+        Assert.IsFalse(context.FeatureStartupTaskCalled, "should not start FeatureStartupTasks");
+        CollectionAssert.AreEqual(context.TransportStartupSequence, new string[]
+        {
+            $"{nameof(TransportDefinition)}.{nameof(TransportDefinition.Initialize)}",
+            $"{nameof(IMessageReceiver)}.{nameof(IMessageReceiver.Initialize)} for receiver Main",
+        }, "should not start the receivers");
+    }
+
+    class Context : ScenarioContext
+    {
+        public bool InstallerCalled { get; set; }
+        public bool FeatureSetupCalled { get; set; }
+        public bool FeatureStartupTaskCalled { get; set; }
+        public FakeTransport.StartUpSequence TransportStartupSequence { get; set; }
+    }
+
+    class EndpointWithInstaller : EndpointConfigurationBuilder
+    {
+        public EndpointWithInstaller()
+        {
+            EndpointSetup<DefaultServer>((c, r) =>
+            {
+                // Disable installers (enabled by default in DefaultServer)
+                c.GetSettings().Set("Installers.Enable", true);
+
+                c.EnableFeature<CustomFeature>();
+
+                // Register FakeTransport to track transport seam usage during installation
+                var fakeTransport = new FakeTransport();
+                c.UseTransport(fakeTransport);
+                ((Context)r.ScenarioContext).TransportStartupSequence = fakeTransport.StartupSequence;
+            });
+        }
+
+        class CustomInstaller : INeedToInstallSomething
+        {
+            Context testContext;
+
+            public CustomInstaller(Context testContext)
+            {
+                this.testContext = testContext;
+            }
+
+            public Task Install(string identity, CancellationToken cancellationToken = default)
+            {
+                testContext.InstallerCalled = true;
+                return Task.CompletedTask;
+            }
+        }
+
+        class CustomFeature : Feature
+        {
+            protected override void Setup(FeatureConfigurationContext context)
+            {
+                var testContext = context.Settings.Get<Context>();
+                testContext.FeatureSetupCalled = true;
+
+                context.RegisterStartupTask(new CustomFeatureStartupTask(testContext));
+            }
+
+            class CustomFeatureStartupTask : FeatureStartupTask
+            {
+                readonly Context testContext;
+
+                public CustomFeatureStartupTask(Context testContext)
+                {
+                    this.testContext = testContext;
+                }
+
+                protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
+                {
+                    testContext.FeatureStartupTaskCalled = true;
+                    return Task.CompletedTask;
+                }
+
+                protected override Task OnStop(IMessageSession session, CancellationToken cancellationToken = default) => Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1706,6 +1706,15 @@ namespace NServiceBus.Installation
     {
         System.Threading.Tasks.Task Install(string identity, System.Threading.CancellationToken cancellationToken = default);
     }
+    public static class Installer
+    {
+        public static NServiceBus.Installation.InstallerWithExternallyManagedContainer CreateInstallerWithExternallyManagedContainer(NServiceBus.EndpointConfiguration configuration, Microsoft.Extensions.DependencyInjection.IServiceCollection serviceCollection) { }
+        public static System.Threading.Tasks.Task Setup(NServiceBus.EndpointConfiguration configuration, System.Threading.CancellationToken cancellationToken = default) { }
+    }
+    public class InstallerWithExternallyManagedContainer
+    {
+        public System.Threading.Tasks.Task Setup(System.IServiceProvider builder, System.Threading.CancellationToken cancellationToken = default) { }
+    }
 }
 namespace NServiceBus.Logging
 {

--- a/src/NServiceBus.Core/Installation/Installer.cs
+++ b/src/NServiceBus.Core/Installation/Installer.cs
@@ -1,0 +1,51 @@
+﻿namespace NServiceBus.Installation;
+
+using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;
+using System.Threading;
+
+/// <summary>
+/// Provides methods to setup an NServiceBus endpoint.
+/// </summary>
+public static class Installer
+{
+
+    /// <summary>
+    /// Executes all the installers and transport configuration without starting the endpoint.
+    /// <see cref="Setup"/> always runs installers, even if <see cref="InstallConfigExtensions.EnableInstallers"/> has not been configured.
+    /// </summary>
+    public static async Task Setup(EndpointConfiguration configuration, CancellationToken cancellationToken = default)
+    {
+        Guard.AgainstNull(nameof(configuration), configuration);
+
+        // does not overwrite installer usernames configured by the user.
+        configuration.EnableInstallers();
+
+        var serviceCollection = new ServiceCollection();
+        var endpointCreator = EndpointCreator.Create(configuration, serviceCollection);
+
+        var serviceProvider = serviceCollection.BuildServiceProvider();
+        await using (serviceProvider.ConfigureAwait(false))
+        {
+            var endpoint = endpointCreator.CreateStartableEndpoint(serviceProvider, true);
+            await endpoint.RunInstallers(cancellationToken).ConfigureAwait(false);
+            await endpoint.Setup(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Creates an instance of <see cref="InstallerWithExternallyManagedContainer"/> that can be used to setup an NServiceBus when access to externally registered container dependencies are required.
+    /// </summary>
+    public static InstallerWithExternallyManagedContainer CreateInstallerWithExternallyManagedContainer(EndpointConfiguration configuration, IServiceCollection serviceCollection)
+    {
+        Guard.AgainstNull(nameof(configuration), configuration);
+        Guard.AgainstNull(nameof(serviceCollection), serviceCollection);
+
+        // does not overwrite installer usernames configured by the user.
+        configuration.EnableInstallers();
+
+        var endpointCreator = EndpointCreator.Create(configuration, serviceCollection);
+
+        return new InstallerWithExternallyManagedContainer(endpointCreator);
+    }
+}

--- a/src/NServiceBus.Core/Installation/InstallerWithExternallyManagedContainer.cs
+++ b/src/NServiceBus.Core/Installation/InstallerWithExternallyManagedContainer.cs
@@ -1,0 +1,29 @@
+﻿namespace NServiceBus.Installation;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Provides methods to setup an NServiceBus endpoint with an externally managed dependency injection container.
+/// </summary>
+public class InstallerWithExternallyManagedContainer
+{
+    readonly EndpointCreator endpointCreator;
+
+    internal InstallerWithExternallyManagedContainer(EndpointCreator endpointCreator)
+    {
+        this.endpointCreator = endpointCreator;
+    }
+
+    /// <summary>
+    /// Executes all the installers and transport configuration without starting the endpoint.
+    /// Installers are always run, even if <see cref="InstallConfigExtensions.EnableInstallers"/> has not been configured.
+    /// </summary>
+    public async Task Setup(IServiceProvider builder, CancellationToken cancellationToken = default)
+    {
+        var endpoint = endpointCreator.CreateStartableEndpoint(builder, false);
+        await endpoint.RunInstallers(cancellationToken).ConfigureAwait(false);
+        await endpoint.Setup(cancellationToken).ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
Based on #6549, this PR adds new installation APIs that can be used to run installation separately with or without an externally managed container without starting the endpoint.

This goes further than `Endpoint.Create` as it also initializes the transport seam and allows endpoints with an externally managed container to execute setup/installation logic without starting the endpoint (currently not possible)

docs PR: https://github.com/Particular/docs.particular.net/pull/5882
