### PR TITLE
Don't create handler activity when incoming message activity isn't set

### DIFF
--- a/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityFactoryTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityFactoryTests.cs
@@ -222,9 +222,22 @@ public class ActivityFactoryTests
     class StartHandlerActivity : ActivityFactoryTests
     {
         [Test]
+        public void Should_not_start_activity_when_no_parent_activity_exists()
+        {
+            Type handlerType = typeof(StartHandlerActivity);
+            var activity = activityFactory.StartHandlerActivity(new MessageHandler((_, _, _) => Task.CompletedTask, handlerType), null);
+
+            Assert.IsNull(activity, "should not start handler activity when no parent activity exists");
+        }
+
+        [Test]
         public void Should_set_handler_type_as_tag()
         {
             Type handlerType = typeof(StartHandlerActivity);
+
+            using var ambientActivity = new Activity("ambient activity");
+            ambientActivity.Start();
+
             var activity = activityFactory.StartHandlerActivity(new MessageHandler((_, _, _) => Task.CompletedTask, handlerType), null);
 
             Assert.IsNotNull(activity);
@@ -236,6 +249,9 @@ public class ActivityFactoryTests
         public void Should_set_saga_id_when_saga()
         {
             var sagaInstance = new ActiveSagaInstance(null, null, () => DateTimeOffset.UtcNow) { SagaId = Guid.NewGuid().ToString() };
+
+            using var ambientActivity = new Activity("ambient activity");
+            ambientActivity.Start();
 
             var activity = activityFactory.StartHandlerActivity(new MessageHandler((_, _, _) => Task.CompletedTask, typeof(StartHandlerActivity)), sagaInstance);
 

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
@@ -70,6 +70,12 @@ class ActivityFactory : IActivityFactory
 
     public Activity StartHandlerActivity(MessageHandler messageHandler, ActiveSagaInstance saga)
     {
+        if (Activity.Current == null)
+        {
+            // don't call StartActivity if we haven't started an activity from the incoming pipeline to avoid the handlers being sampled although the incoming message isn't.
+            return null;
+        }
+
         var activity = ActivitySources.Main.StartActivity(ActivityNames.InvokeHandlerActivityName);
 
         if (activity != null)


### PR DESCRIPTION
Due to hard-to-predict sampler behavior, it might be that the incoming message activity is not created although we have a listener registered. When invoking handler, the `Activity.Current` can be `null` in such cases which means that the `StartActivity` call for the handler span will be run through the sampler again and might be created. This can cause handler spans being created but not properly connected which is especially weird when multiple handlers for a single message exist. If the incoming message activity hasn't been created (or no other user-defined ambient activity exists), the handler activity should never be created.