### PR TITLE
Correctly set parent activity for ReceiveMessage activity as remote

### DIFF
--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
@@ -27,7 +27,10 @@ class ActivityFactory : IActivityFactory
         }
         else if (context.Headers.TryGetValue(Headers.DiagnosticsTraceParent, out var sendSpanId) && ActivityContext.TryParse(sendSpanId, null, out var sendSpanContext)) // otherwise directly create child from logical send
         {
-            activity = ActivitySources.Main.CreateActivity(name: ActivityNames.IncomingMessageActivityName, ActivityKind.Consumer, sendSpanContext);
+            // TryParse doesn't have an overload that supports changing the isRemote setting yet
+            // This can be removed with .NET 7, see https://github.com/dotnet/runtime/issues/42575
+            var remoteParentActivityContext = new ActivityContext(sendSpanContext.TraceId, sendSpanContext.SpanId, sendSpanContext.TraceFlags, sendSpanContext.TraceState, isRemote: true);
+            activity = ActivitySources.Main.CreateActivity(name: ActivityNames.IncomingMessageActivityName, ActivityKind.Consumer, remoteParentActivityContext);
         }
         else // otherwise start new trace
         {


### PR DESCRIPTION
Parsing the `ActivityContext` currently always sets `isRemote` false. This can cause sampler behavior to be incorrect as some samplers, e.g. [`ParentBasedSampler`](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry/Trace/ParentBasedSampler.cs#L122) (default sampler) can use this property to adjust the sampling behavior. The default behavior isn't impacted by the current implementation as both remote and local parent fall back to not sampling, but a user-defined configuration might behave differently.

This PR changes the implementation to correctly set the `isRemote` flag on the parent context. This needs to be done via a workaround until .NET 7 which will contain a proper API for this, see https://github.com/dotnet/runtime/issues/42575

Note that this can't be easily unit testing without intercepting the sampler at the moment. .NET 7 will have a [`Activity.HasRemoteParent`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity.hasremoteparent?view=net-7.0#system-diagnostics-activity-hasremoteparent) property that should allow easier unit testing. For now this has been verified manually:
![image](https://user-images.githubusercontent.com/3524870/199580439-8ff9de63-5b7d-4347-871d-d9bc83ef2302.png)

TODO once merged:
* [ ] Raise follow-up issue to replace with the proper API and add a unit test assertion once we target .NET 7