### PR TITLE
Persistence Tests - Make sure stale records are modified before save

### DIFF
--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_on_same_thread.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_on_same_thread.cs
@@ -44,6 +44,7 @@
             {
                 Assert.CatchAsync<Exception>(async () =>
                 {
+                    staleRecord.DateTimeProperty = DateTime.UtcNow;
                     await persister.Update(staleRecord, losingSaveSession, losingContext);
                     await losingSaveSession.CompleteAsync();
                 });

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_on_same_thread.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_on_same_thread.cs
@@ -42,9 +42,9 @@
 
             try
             {
+                staleRecord.DateTimeProperty = DateTime.UtcNow.AddHours(1);
                 Assert.CatchAsync<Exception>(async () =>
                 {
-                    staleRecord.DateTimeProperty = DateTime.UtcNow;
                     await persister.Update(staleRecord, losingSaveSession, losingContext);
                     await losingSaveSession.CompleteAsync();
                 });

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_twice_on_the_same_thread.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_twice_on_the_same_thread.cs
@@ -49,6 +49,7 @@
             {
                 Assert.That(async () =>
                 {
+                    staleRecord1.DateTimeProperty = DateTime.UtcNow;
                     await persister.Update(staleRecord1, losingSaveSession1, losingContext1);
                     await losingSaveSession1.CompleteAsync();
                 }, Throws.InstanceOf<Exception>());
@@ -88,6 +89,7 @@
             {
                 Assert.That(async () =>
                  {
+                     staleRecord2.DateTimeProperty = DateTime.UtcNow;
                      await persister.Update(staleRecord2, losingSaveSession2, losingContext2);
                      await losingSaveSession2.CompleteAsync();
                  }, Throws.InstanceOf<Exception>());

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_twice_on_the_same_thread.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_twice_on_the_same_thread.cs
@@ -47,9 +47,9 @@
 
             try
             {
+                staleRecord1.DateTimeProperty = DateTime.UtcNow.AddHours(1);
                 Assert.That(async () =>
                 {
-                    staleRecord1.DateTimeProperty = DateTime.UtcNow;
                     await persister.Update(staleRecord1, losingSaveSession1, losingContext1);
                     await losingSaveSession1.CompleteAsync();
                 }, Throws.InstanceOf<Exception>());
@@ -87,9 +87,9 @@
 
             try
             {
+                staleRecord2.DateTimeProperty = DateTime.UtcNow.AddHours(1);
                 Assert.That(async () =>
                  {
-                     staleRecord2.DateTimeProperty = DateTime.UtcNow;
                      await persister.Update(staleRecord2, losingSaveSession2, losingContext2);
                      await losingSaveSession2.CompleteAsync();
                  }, Throws.InstanceOf<Exception>());


### PR DESCRIPTION
This PR aligns

- `When_updating_saga_concurrently_on_same_thread`
- `When_updating_saga_concurrently_twice_on_the_same_thread`

with `When_updating_saga_concurrently_on_different_thread` [which already does update a property of the saga](https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_on_different_threads.cs#L55). 

It is required to update something on the saga otherwise persisters like RavenDB that can discover whether something has change or not will simply not execute any side effect because the document hasn't been updated which then also doesn't trigger a concurrency conflict.

## Backported to

- [Release 8.0](TBD)
- [Release 7.8](TBD)