### PR TITLE
Persistence Tests - Make sure stale records are modified before save - Backporting of #6603

### DIFF
--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_on_same_thread.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_on_same_thread.cs
@@ -42,6 +42,7 @@
 
             try
             {
+                staleRecord.DateTimeProperty = DateTime.UtcNow.AddHours(1);
                 Assert.CatchAsync<Exception>(async () =>
                 {
                     await persister.Update(staleRecord, losingSaveSession, losingContext);

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_twice_on_the_same_thread.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_twice_on_the_same_thread.cs
@@ -47,6 +47,7 @@
 
             try
             {
+                staleRecord1.DateTimeProperty = DateTime.UtcNow.AddHours(1);
                 Assert.That(async () =>
                 {
                     await persister.Update(staleRecord1, losingSaveSession1, losingContext1);
@@ -86,6 +87,7 @@
 
             try
             {
+                staleRecord2.DateTimeProperty = DateTime.UtcNow.AddHours(1);
                 Assert.That(async () =>
                  {
                      await persister.Update(staleRecord2, losingSaveSession2, losingContext2);


### PR DESCRIPTION
Backport #6603 to `release-8.0`