### PR TITLE
Fix ForwardCancellationTokenAnalyzer bug on default parameter values

### DIFF
--- a/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/AnalyzerTestFixture.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/AnalyzerTestFixture.cs
@@ -110,6 +110,8 @@
                 MetadataReference.CreateFromFile(typeof(System.Linq.Expressions.Expression).GetTypeInfo().Assembly.Location),
 #if NET
                 MetadataReference.CreateFromFile(Assembly.Load("System.Runtime").Location),
+                MetadataReference.CreateFromFile(Assembly.Load("System.Console").Location),
+                MetadataReference.CreateFromFile(Assembly.Load("System.Private.CoreLib").Location),
 #endif
                 MetadataReference.CreateFromFile(typeof(EndpointConfiguration).GetTypeInfo().Assembly.Location),
                 MetadataReference.CreateFromFile(typeof(IUniformSession).GetTypeInfo().Assembly.Location));

--- a/src/NServiceBus.Core.Analyzer/ForwardCancellationTokenAnalyzer.cs
+++ b/src/NServiceBus.Core.Analyzer/ForwardCancellationTokenAnalyzer.cs
@@ -177,20 +177,46 @@
                 }
             }
 
-            if (expression is ObjectCreationExpressionSyntax objectCreation &&
-                objectCreation.Type is IdentifierNameSyntax objectCreationTypeName &&
-                objectCreationTypeName.Identifier.ValueText == "CancellationToken")
+            // new CancellationToken(...)
+            if (expression is ObjectCreationExpressionSyntax objectCreation && TypeSyntaxLooksLikeCancellationToken(objectCreation.Type))
             {
                 return true;
             }
 
+            // default(CancellationToken)
+            if (expression is DefaultExpressionSyntax defaultSyntax && TypeSyntaxLooksLikeCancellationToken(defaultSyntax.Type))
+            {
+                return true;
+            }
+
+            // Note: `default` on its own is a LiteralExpressionSyntax, not a DefaultExpressionSyntax, so when this is used
+            // as a parameter we can't tell whether it's a CancellationToken at the lexical level and must allow IsCancellationToken
+            // to make the determination by consulting the semantic model
             return false;
         }
 
+        static bool TypeSyntaxLooksLikeCancellationToken(TypeSyntax typeSyntax) =>
+            typeSyntax is IdentifierNameSyntax identifierSyntax && identifierSyntax.Identifier.ValueText == "CancellationToken";
+
         static bool IsCancellationToken(ExpressionSyntax expressionSyntax, SyntaxNodeAnalysisContext context, INamedTypeSymbol cancellationTokenType)
         {
-            var expressionSymbol = context.SemanticModel.GetSymbolInfo(expressionSyntax, context.CancellationToken).Symbol;
-            return expressionSymbol.GetTypeSymbolOrDefault()?.Equals(cancellationTokenType, SymbolEqualityComparer.IncludeNullability) ?? false;
+            var typeSymbol = GetTypeSymbolFromExpression(expressionSyntax, context);
+            return typeSymbol?.Equals(cancellationTokenType, SymbolEqualityComparer.IncludeNullability) ?? false;
+        }
+
+        static ITypeSymbol GetTypeSymbolFromExpression(ExpressionSyntax expression, SyntaxNodeAnalysisContext context)
+        {
+            if (expression is LiteralExpressionSyntax) // `default` as a parameter
+            {
+                var typeInfo = context.SemanticModel.GetTypeInfo(expression, context.CancellationToken);
+                return typeInfo.Type;
+            }
+            else
+            {
+                var symbolInfo = context.SemanticModel.GetSymbolInfo(expression, context.CancellationToken);
+                var expressionSymbol = symbolInfo.Symbol;
+                return expressionSymbol.GetTypeSymbolOrDefault();
+            }
         }
 
         static IMethodSymbol GetRecommendedMethod(
@@ -247,7 +273,7 @@
 
         // if adding a cancellation token to the args will not put it in the right place
         static string GetRequiredArgName(IMethodSymbol recommendedMethod, IParameterSymbol extraParam, SeparatedSyntaxList<ArgumentSyntax> args) =>
-            !recommendedMethod.Parameters[args.Count].Equals(extraParam, SymbolEqualityComparer.IncludeNullability) ? extraParam.Name : null;
+            args.Count < recommendedMethod.Parameters.Length && !recommendedMethod.Parameters[args.Count].Equals(extraParam, SymbolEqualityComparer.IncludeNullability) ? extraParam.Name : null;
 
         static INamedTypeSymbol GetCalledType(InvocationExpressionSyntax call, IMethodSymbol calledMethod, SyntaxNodeAnalysisContext context)
         {

--- a/src/NServiceBus.Core.Analyzer/ForwardCancellationTokenAnalyzer.cs
+++ b/src/NServiceBus.Core.Analyzer/ForwardCancellationTokenAnalyzer.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
+    using System.Threading;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/src/NServiceBus.Core.Analyzer/ForwardCancellationTokenAnalyzer.cs
+++ b/src/NServiceBus.Core.Analyzer/ForwardCancellationTokenAnalyzer.cs
@@ -165,12 +165,12 @@
                     var memberName = memberAccess.Name.Identifier.ValueText;
 
                     // Is context.CancellationToken
-                    if (refName == callerCancellableContextParam && memberName == "CancellationToken")
+                    if (refName == callerCancellableContextParam && memberName == nameof(CancellationToken))
                     {
                         return true;
                     }
 
-                    if (refName == "CancellationToken" && memberName == "None")
+                    if (refName == nameof(CancellationToken) && memberName == "None")
                     {
                         return true;
                     }
@@ -196,7 +196,7 @@
         }
 
         static bool TypeSyntaxLooksLikeCancellationToken(TypeSyntax typeSyntax) =>
-            typeSyntax is IdentifierNameSyntax identifierSyntax && identifierSyntax.Identifier.ValueText == "CancellationToken";
+            typeSyntax is IdentifierNameSyntax identifierSyntax && identifierSyntax.Identifier.ValueText == nameof(CancellationToken);
 
         static bool IsCancellationToken(ExpressionSyntax expressionSyntax, SyntaxNodeAnalysisContext context, INamedTypeSymbol cancellationTokenType)
         {


### PR DESCRIPTION
This fixes a bug discovered in the ForwardCancellationTokenAnalyzer and adds several more test cases.

The analyzer is supposed to ignore when you pass `CancellationToken.None`, but throwing an exception when doing the same thing but by using a default operator or literal which were introduced between C# 7 and 8:

```csharp
// OK
await Task.Delay(100, CancellationToken.None);

// Throwing exceptions in 8.0.0
await Task.Delay(100, default(CancellationToken));
await Task.Delay(100, default);
```

This requires better analysis to make sure the presence of `default` doesn't throw it off:

```csharp
public async Task SomeMethod(int a, string b, CancellationToken token = default) { }

// Would pass the 0 and null but not provide a token:
await SomeMethod(default, default);
```

This PR also introduces several test cases around the use of `await foreach…` when using async enumerables.

---

*Backported to release-8.0 in https://github.com/Particular/NServiceBus/pull/6617*