### PR TITLE
XmlSerializer SanitizeInput and SkipWrappingRawXml settings use same configuration key

### DIFF
--- a/src/NServiceBus.Core/Serializers/XML/XmlSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlSerializer.cs
@@ -48,6 +48,6 @@
 
         internal const string CustomNamespaceConfigurationKey = "XmlSerializer.CustomNamespace";
         internal const string SkipWrappingRawXml = "XmlSerializer.SkipWrappingRawXml";
-        internal const string SanitizeInput = "XmlSerializer.SkipWrappingRawXml";
+        internal const string SanitizeInput = "XmlSerializer.SanitizeInput";
     }
 }


### PR DESCRIPTION
Backport of #6615 to the release-8.0 branch