### PR TITLE
Remove unnecessary allocations of PipelineRootContext

### DIFF
--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveContext.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveContext.cs
@@ -1,18 +1,21 @@
 ﻿namespace NServiceBus
 {
+    using System;
+    using System.Threading;
+    using Extensibility;
     using Pipeline;
     using Transport;
 
     /// <summary>
     /// Context containing a physical message.
     /// </summary>
-    partial class TransportReceiveContext : BehaviorContext, ITransportReceiveContext
+    partial class TransportReceiveContext : PipelineRootContext, ITransportReceiveContext
     {
         /// <summary>
         /// Creates a new transport receive context.
         /// </summary>
-        public TransportReceiveContext(IncomingMessage receivedMessage, TransportTransaction transportTransaction, PipelineRootContext rootContext)
-            : base(rootContext)
+        public TransportReceiveContext(IServiceProvider serviceProvider, MessageOperations messageOperations, IPipelineCache pipelineCache, IncomingMessage receivedMessage, TransportTransaction transportTransaction, ContextBag parentContext, CancellationToken cancellationToken)
+            : base(serviceProvider, messageOperations, pipelineCache, cancellationToken, parentContext)
         {
             Message = receivedMessage;
             Set(Message);

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -30,9 +30,14 @@ namespace NServiceBus
             {
                 var message = new IncomingMessage(messageContext.NativeMessageId, messageContext.Headers, messageContext.Body);
 
-                var rootContext = new PipelineRootContext(childScope.ServiceProvider, messageOperations, pipelineCache, cancellationToken, messageContext.Extensions);
-
-                var transportReceiveContext = new TransportReceiveContext(message, messageContext.TransportTransaction, rootContext);
+                var transportReceiveContext = new TransportReceiveContext(
+                    childScope.ServiceProvider,
+                    messageOperations,
+                    pipelineCache,
+                    message,
+                    messageContext.TransportTransaction,
+                    messageContext.Extensions,
+                    cancellationToken);
 
                 if (activity != null)
                 {

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityContext.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityContext.cs
@@ -4,17 +4,23 @@
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
+    using Extensibility;
     using NServiceBus.Transport;
     using Pipeline;
 
-    class RecoverabilityContext : BehaviorContext, IRecoverabilityContext, IRecoverabilityActionContext, IRecoverabilityActionContextNotifications
+    class RecoverabilityContext : PipelineRootContext, IRecoverabilityContext, IRecoverabilityActionContext, IRecoverabilityActionContextNotifications
     {
         public RecoverabilityContext(
+            IServiceProvider serviceProvider,
+            MessageOperations messageOperations,
+            IPipelineCache pipelineCache,
             ErrorContext errorContext,
             RecoverabilityConfig recoverabilityConfig,
             Dictionary<string, string> metadata,
             RecoverabilityAction recoverabilityAction,
-            IBehaviorContext parent) : base(parent)
+            ContextBag parent,
+            CancellationToken cancellationToken) : base(serviceProvider, messageOperations, pipelineCache, cancellationToken, parent)
         {
             FailedMessage = errorContext.Message;
             Exception = errorContext.Exception;

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityPipelineExecutor.cs
@@ -34,18 +34,20 @@
             var childScope = serviceProvider.CreateAsyncScope();
             await using (childScope.ConfigureAwait(false))
             {
-                var rootContext = new PipelineRootContext(childScope.ServiceProvider, messageOperations, pipelineCache, cancellationToken, errorContext.Extensions);
-
                 var recoverabilityAction = recoverabilityPolicy(errorContext, state);
 
                 var metadata = faultMetadataExtractor.Extract(errorContext);
 
                 var recoverabilityContext = new RecoverabilityContext(
+                    childScope.ServiceProvider,
+                    messageOperations,
+                    pipelineCache,
                     errorContext,
                     recoverabilityConfig,
                     metadata,
                     recoverabilityAction,
-                    rootContext);
+                    errorContext.Extensions,
+                    cancellationToken);
 
                 await recoverabilityPipeline.Invoke(recoverabilityContext).ConfigureAwait(false);
 


### PR DESCRIPTION
Just a rough version to show the potential for removing allocations of the `PipelineRootContext` class for the main and recoverability pipelines fairly easily. The root context is just used as an intermediary class that is directly passed to a new context.

The ctors of the `TransportReceiveContext` and `RecoverabilityContext` look a lot uglier though, so I'm not sure it's really worthwhile pursuing this idea but it could safe a few allocations, especially when thinking about the `ContextBag`'s internal data structure.

I haven't changed the instances of `PipelineRootContext` on the `IMessageSession` operations as this would require more parameters rippling through more method calls, making the code a lot messier without some other refactoring to counter that smell.