### PR TITLE
Complete acceptance test when messages are discarded

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/CaptureRecoverabilityActionBehavior.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/CaptureRecoverabilityActionBehavior.cs
@@ -1,0 +1,67 @@
+﻿namespace NServiceBus.AcceptanceTesting.Support
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Faults;
+    using Pipeline;
+
+    class CaptureRecoverabilityActionBehavior : IBehavior<IRecoverabilityContext, IRecoverabilityContext>
+    {
+        readonly string endpointName;
+        readonly ScenarioContext scenarioContext;
+
+        public CaptureRecoverabilityActionBehavior(string endpointName, ScenarioContext scenarioContext)
+        {
+            this.endpointName = endpointName;
+            this.scenarioContext = scenarioContext;
+        }
+
+        public async Task Invoke(IRecoverabilityContext context, Func<IRecoverabilityContext, Task> next)
+        {
+            await next(context).ConfigureAwait(false);
+
+            switch (context.RecoverabilityAction)
+            {
+                case MoveToError moveToErrorAction:
+                    {
+                        var failedMessage = new FailedMessage(
+                            context.FailedMessage.MessageId,
+                            new Dictionary<string, string>(context.FailedMessage.Headers),
+                            context.FailedMessage.Body,
+                            context.Exception,
+                            moveToErrorAction.ErrorQueue);
+
+                        scenarioContext.FailedMessages.AddOrUpdate(
+                            endpointName,
+                            new[]
+                            {
+                                failedMessage
+                            },
+                            (i, failed) =>
+                            {
+                                var result = failed.ToList();
+                                result.Add(failedMessage);
+                                return result;
+                            });
+
+                        MarkMessageAsCompleted();
+                        break;
+                    }
+                case Discard discardAction:
+                    MarkMessageAsCompleted();
+                    break;
+                default:
+                    break;
+            }
+
+            void MarkMessageAsCompleted()
+            {
+                scenarioContext.UnfinishedFailedMessages.AddOrUpdate(context.FailedMessage.MessageId,
+                    id => false,
+                    (id, value) => false);
+            }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/ApprovalFiles/When_pipelines_are_built.Should_preserve_order.approved.txt
+++ b/src/NServiceBus.AcceptanceTests/ApprovalFiles/When_pipelines_are_built.Should_preserve_order.approved.txt
@@ -66,8 +66,9 @@
                                         (IIncomingLogicalMessageContext context10) => LoadHandlersConnector.Invoke(context10, 
                                             (IInvokeHandlerContext context11) => InvokeHandlerTerminator.Invoke(context11))
 
-(IRecoverabilityContext context0) => RecoverabilityRoutingConnector.Invoke(context0, 
-    (IRoutingContext context1) => ThrowIfCannotDeferMessageBehavior.Invoke(context1, 
-        (IRoutingContext context2) => AttachSenderRelatedInfoOnMessageBehavior.Invoke(context2, 
-            (IRoutingContext context3) => RoutingToDispatchConnector.Invoke(context3, 
-                (IDispatchContext context4) => ImmediateDispatchTerminator.Invoke(context4))
+(IRecoverabilityContext context0) => CaptureRecoverabilityActionBehavior.Invoke(context0, 
+    (IRecoverabilityContext context1) => RecoverabilityRoutingConnector.Invoke(context1, 
+        (IRoutingContext context2) => ThrowIfCannotDeferMessageBehavior.Invoke(context2, 
+            (IRoutingContext context3) => AttachSenderRelatedInfoOnMessageBehavior.Invoke(context3, 
+                (IRoutingContext context4) => RoutingToDispatchConnector.Invoke(context4, 
+                    (IDispatchContext context5) => ImmediateDispatchTerminator.Invoke(context5))

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_custom_policy_discards_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_custom_policy_discards_message.cs
@@ -1,0 +1,56 @@
+﻿namespace NServiceBus.AcceptanceTests.Recoverability
+{
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_custom_policy_discards_failed_message : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_consume_message_without_retries()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<EndpointWithDiscardPolicy>(e => e
+                    .When(s => s.SendLocal(new FailingMessage())))
+                .Done(c => c.HandlerInvoked >= 1)
+                .Run();
+
+            Assert.IsEmpty(context.FailedMessages, "the message should not be moved to the error queue");
+            Assert.AreEqual(1, context.HandlerInvoked, "the discarded message should not be retried");
+        }
+
+        class Context : ScenarioContext
+        {
+            public int HandlerInvoked { get; set; }
+        }
+
+        class EndpointWithDiscardPolicy : EndpointConfigurationBuilder
+        {
+            public EndpointWithDiscardPolicy() =>
+                EndpointSetup<DefaultServer>(c => c
+                    .Recoverability()
+                    .CustomPolicy((config, context) => RecoverabilityAction.Discard("discard on purpose")));
+        }
+
+        class FailingMessageHandler : IHandleMessages<FailingMessage>
+        {
+            Context testContext;
+
+            public FailingMessageHandler(Context testContext)
+            {
+                this.testContext = testContext;
+            }
+
+            public Task Handle(FailingMessage message, IMessageHandlerContext context)
+            {
+                testContext.HandlerInvoked++;
+                throw new SimulatedException();
+            }
+        }
+
+        public class FailingMessage : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.Learning.AcceptanceTests/ApprovalFiles/When_pipelines_are_built.Should_preserve_order.approved.txt
+++ b/src/NServiceBus.Learning.AcceptanceTests/ApprovalFiles/When_pipelines_are_built.Should_preserve_order.approved.txt
@@ -62,7 +62,8 @@
                                     (IIncomingLogicalMessageContext context9) => LoadHandlersConnector.Invoke(context9, 
                                         (IInvokeHandlerContext context10) => InvokeHandlerTerminator.Invoke(context10))
 
-(IRecoverabilityContext context0) => RecoverabilityRoutingConnector.Invoke(context0, 
-    (IRoutingContext context1) => AttachSenderRelatedInfoOnMessageBehavior.Invoke(context1, 
-        (IRoutingContext context2) => RoutingToDispatchConnector.Invoke(context2, 
-            (IDispatchContext context3) => ImmediateDispatchTerminator.Invoke(context3))
+(IRecoverabilityContext context0) => CaptureRecoverabilityActionBehavior.Invoke(context0, 
+    (IRecoverabilityContext context1) => RecoverabilityRoutingConnector.Invoke(context1, 
+        (IRoutingContext context2) => AttachSenderRelatedInfoOnMessageBehavior.Invoke(context2, 
+            (IRoutingContext context3) => RoutingToDispatchConnector.Invoke(context3, 
+                (IDispatchContext context4) => ImmediateDispatchTerminator.Invoke(context4))


### PR DESCRIPTION
The acceptance testing framework tracks all pipeline exceptions and keeps the test running until the message has processed successfully or has been moved to the error queue. However, when using the `Discard` recoverability action, the test would run into a timeout and show the error message `Some failed messages were not handled by the recoverability feature.`

This PR changes the acceptance testing framework to track discarded messages as "completed" messages too so that the test no longer times out in such cases.

Since we don't have any public notification APIs for discarded messages (probably a separate issue to raise), a custom behavior is used to inspect the applied recoverability action which is now possible due to the recoverability pipeline extensibility. Along with that, I also moved the tracking of error queue messages from the notification API to the behavior to use the same approach and have it in the same place.