### PR TITLE
Specify dotnet quality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           dotnet-version: |
             7.0.x
             6.0.x
+          dotnet-quality: 'ga'  
       - name: Build
         run: dotnet build src --configuration Release
       - name: Upload packages


### PR DESCRIPTION
According to

> A.B or A.B.x (e.g. 3.1, 3.1.x) - installs the latest patch version of .NET SDK on the channel 3.1, including prerelease versions (preview, rc)

https://github.com/actions/setup-dotnet/tree/v3.0.3#supported-version-syntax

the current way how we define the dotnet-version can also pull in previews. This is what seems to happen with the PRs that are currently failing:

> MSBuild version 17.5.0-preview-23061-01+040e2a90e for .NET

