### PR TITLE
Add additional outbox+saga persistence tests

### DIFF
--- a/src/NServiceBus.PersistenceTests/Sagas/When_multiple_sagas_in_outbox_transaction.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_multiple_sagas_in_outbox_transaction.cs
@@ -1,0 +1,231 @@
+﻿namespace NServiceBus.PersistenceTesting.Sagas
+{
+    using NUnit.Framework;
+    using System.Threading.Tasks;
+    using System;
+
+    public class When_multiple_sagas_in_outbox_transaction : SagaPersisterTests
+    {
+        [Test]
+        public async Task Should_create_new_sagas_when_committed()
+        {
+            configuration.RequiresOutboxSupport();
+
+            var saga1 = new Saga1.Saga1Data { CorrelationId = Guid.NewGuid().ToString() };
+            var saga2 = new Saga2.Saga2Data { CorrelationId = Guid.NewGuid().ToString() };
+
+            var context = configuration.GetContextBagForOutbox();
+            using (var outboxTransaction = await configuration.OutboxStorage.BeginTransaction(context))
+            {
+                using (var saga1Session = configuration.CreateStorageSession())
+                {
+                    await saga1Session.TryOpen(outboxTransaction, context);
+                    var get = await configuration.SagaStorage.Get<Saga1.Saga1Data>(nameof(Saga1.Saga1Data.CorrelationId),
+                        saga1.CorrelationId, saga1Session, context);
+                    Assert.IsNull(get);
+
+                    await SaveSagaWithSession(saga1, saga1Session, context);
+
+                    await saga1Session.CompleteAsync();
+                }
+
+                using (var saga2Session = configuration.CreateStorageSession())
+                {
+                    await saga2Session.TryOpen(outboxTransaction, context);
+                    var get = await configuration.SagaStorage.Get<Saga2.Saga2Data>(nameof(Saga2.Saga2Data.CorrelationId),
+                        saga2.CorrelationId, saga2Session, context);
+                    Assert.IsNull(get);
+
+                    await SaveSagaWithSession(saga2, saga2Session, context);
+
+                    await saga2Session.CompleteAsync();
+                }
+
+                await outboxTransaction.Commit();
+            }
+
+            var s1 = await GetById<Saga1.Saga1Data>(saga1.Id);
+            Assert.NotNull(s1);
+            Assert.AreEqual(saga1.CorrelationId, s1.CorrelationId);
+            var s2 = await GetById<Saga2.Saga2Data>(saga2.Id);
+            Assert.NotNull(s2);
+            Assert.AreEqual(saga2.CorrelationId, s2.CorrelationId);
+        }
+
+        [Test]
+        public async Task Should_not_create_new_sagas_when_not_committed()
+        {
+            configuration.RequiresOutboxSupport();
+
+            var saga1 = new Saga1.Saga1Data { CorrelationId = Guid.NewGuid().ToString() };
+            var saga2 = new Saga2.Saga2Data { CorrelationId = Guid.NewGuid().ToString() };
+
+            var context = configuration.GetContextBagForOutbox();
+            using (var outboxTransaction = await configuration.OutboxStorage.BeginTransaction(context))
+            {
+                using (var saga1Session = configuration.CreateStorageSession())
+                {
+                    await saga1Session.TryOpen(outboxTransaction, context);
+                    var get = await configuration.SagaStorage.Get<Saga1.Saga1Data>(nameof(Saga1.Saga1Data.CorrelationId),
+                        saga1.CorrelationId, saga1Session, context);
+                    Assert.IsNull(get);
+
+                    await SaveSagaWithSession(saga1, saga1Session, context);
+
+                    await saga1Session.CompleteAsync();
+                }
+
+                using (var saga2Session = configuration.CreateStorageSession())
+                {
+                    await saga2Session.TryOpen(outboxTransaction, context);
+                    var get = await configuration.SagaStorage.Get<Saga2.Saga2Data>(nameof(Saga2.Saga2Data.CorrelationId),
+                        saga2.CorrelationId, saga2Session, context);
+                    Assert.IsNull(get);
+
+                    await SaveSagaWithSession(saga2, saga2Session, context);
+
+                    await saga2Session.CompleteAsync();
+                }
+
+                // no commit
+            }
+
+            var s1 = await GetById<Saga1.Saga1Data>(saga1.Id);
+            Assert.IsNull(s1);
+            var s2 = await GetById<Saga2.Saga2Data>(saga2.Id);
+            Assert.IsNull(s2);
+        }
+
+        [Test]
+        public async Task Should_update_existing_sagas_when_committed()
+        {
+            configuration.RequiresOutboxSupport();
+
+            var saga1 = new Saga1.Saga1Data { CorrelationId = Guid.NewGuid().ToString(), SomeSaga1Data = "saga 1 before update" };
+            await SaveSaga(saga1);
+            var saga2 = new Saga2.Saga2Data { CorrelationId = Guid.NewGuid().ToString(), SomeSaga2Data = "saga 2 before update" };
+            await SaveSaga(saga2);
+
+            var context = configuration.GetContextBagForOutbox();
+            using (var outboxTransaction = await configuration.OutboxStorage.BeginTransaction(context))
+            {
+                using (var saga1Session = configuration.CreateStorageSession())
+                {
+                    await saga1Session.TryOpen(outboxTransaction, context);
+
+                    var existingSaga1 = await configuration.SagaStorage.Get<Saga1.Saga1Data>(saga1.Id, saga1Session, context);
+                    existingSaga1.SomeSaga1Data = "saga 1 after update";
+
+                    await configuration.SagaStorage.Update(existingSaga1, saga1Session, context);
+
+                    await saga1Session.CompleteAsync();
+                }
+
+                using (var saga2Session = configuration.CreateStorageSession())
+                {
+                    await saga2Session.TryOpen(outboxTransaction, context);
+
+                    var existingSaga2 = await configuration.SagaStorage.Get<Saga2.Saga2Data>(saga2.Id, saga2Session, context);
+                    existingSaga2.SomeSaga2Data = "saga 2 after update";
+
+                    await configuration.SagaStorage.Update(existingSaga2, saga2Session, context);
+
+                    await saga2Session.CompleteAsync();
+                }
+
+                await outboxTransaction.Commit();
+            }
+
+            var saga1AfterUpdate = await GetById<Saga1.Saga1Data>(saga1.Id);
+            Assert.NotNull(saga1AfterUpdate);
+            Assert.AreEqual("saga 1 after update", saga1AfterUpdate.SomeSaga1Data);
+            var saga2AfterUpdate = await GetById<Saga2.Saga2Data>(saga2.Id);
+            Assert.NotNull(saga2AfterUpdate);
+            Assert.AreEqual("saga 2 after update", saga2AfterUpdate.SomeSaga2Data);
+        }
+
+        [Test]
+        public async Task Should_not_update_existing_sagas_when_not_committed()
+        {
+            configuration.RequiresOutboxSupport();
+
+            var saga1 = new Saga1.Saga1Data { CorrelationId = Guid.NewGuid().ToString(), SomeSaga1Data = "saga 1 before update" };
+            await SaveSaga(saga1);
+            var saga2 = new Saga2.Saga2Data { CorrelationId = Guid.NewGuid().ToString(), SomeSaga2Data = "saga 2 before update" };
+            await SaveSaga(saga2);
+
+            var context = configuration.GetContextBagForOutbox();
+            using (var outboxTransaction = await configuration.OutboxStorage.BeginTransaction(context))
+            {
+                using (var saga1Session = configuration.CreateStorageSession())
+                {
+                    await saga1Session.TryOpen(outboxTransaction, context);
+
+                    var existingSaga1 = await configuration.SagaStorage.Get<Saga1.Saga1Data>(saga1.Id, saga1Session, context);
+                    existingSaga1.SomeSaga1Data = "saga 1 after update";
+
+                    await configuration.SagaStorage.Update(existingSaga1, saga1Session, context);
+
+                    await saga1Session.CompleteAsync();
+                }
+
+                using (var saga2Session = configuration.CreateStorageSession())
+                {
+                    await saga2Session.TryOpen(outboxTransaction, context);
+
+                    var existingSaga2 = await configuration.SagaStorage.Get<Saga2.Saga2Data>(saga2.Id, saga2Session, context);
+                    existingSaga2.SomeSaga2Data = "saga 2 after update";
+
+                    await configuration.SagaStorage.Update(existingSaga2, saga2Session, context);
+
+                    await saga2Session.CompleteAsync();
+                }
+
+                // no commit
+            }
+
+            var saga1AfterUpdate = await GetById<Saga1.Saga1Data>(saga1.Id);
+            Assert.NotNull(saga1AfterUpdate);
+            Assert.AreEqual("saga 1 before update", saga1AfterUpdate.SomeSaga1Data);
+            var saga2AfterUpdate = await GetById<Saga2.Saga2Data>(saga2.Id);
+            Assert.NotNull(saga2AfterUpdate);
+            Assert.AreEqual("saga 2 before update", saga2AfterUpdate.SomeSaga2Data);
+        }
+
+        public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartTestSagaMessage>
+        {
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper) => mapper.ConfigureMapping<StartTestSagaMessage>(m => m.CorrelationProperty).ToSaga(s => s.CorrelationId);
+
+            public Task Handle(StartTestSagaMessage message, IMessageHandlerContext context) => throw new NotImplementedException();
+
+            public class Saga1Data : ContainSagaData
+            {
+                public string CorrelationId { get; set; }
+                public string SomeSaga1Data { get; set; }
+            }
+        }
+
+        public class Saga2 : Saga<Saga2.Saga2Data>, IAmStartedByMessages<StartTestSagaMessage>
+        {
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga2Data> mapper) => mapper.ConfigureMapping<StartTestSagaMessage>(m => m.CorrelationProperty).ToSaga(s => s.CorrelationId);
+
+            public Task Handle(StartTestSagaMessage message, IMessageHandlerContext context) => throw new NotImplementedException();
+
+            public class Saga2Data : ContainSagaData
+            {
+                public string CorrelationId { get; set; }
+                public string SomeSaga2Data { get; set; }
+            }
+        }
+
+
+        public class StartTestSagaMessage : IMessage
+        {
+            public string CorrelationProperty { get; set; }
+        }
+
+        public When_multiple_sagas_in_outbox_transaction(TestVariant param) : base(param)
+        {
+        }
+    }
+}

--- a/src/NServiceBus.PersistenceTests/Sagas/When_multiple_sagas_in_outbox_transaction.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_multiple_sagas_in_outbox_transaction.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.PersistenceTesting.Sagas
+namespace NServiceBus.PersistenceTesting.Sagas
 {
     using NUnit.Framework;
     using System.Threading.Tasks;
@@ -11,18 +11,20 @@
         {
             configuration.RequiresOutboxSupport();
 
-            var saga1 = new Saga1.Saga1Data { CorrelationId = Guid.NewGuid().ToString() };
-            var saga2 = new Saga2.Saga2Data { CorrelationId = Guid.NewGuid().ToString() };
+            var saga1 = new Saga1Data { CorrelationId = Guid.NewGuid().ToString() };
+            var saga2 = new Saga2Data { CorrelationId = Guid.NewGuid().ToString() };
 
             var context = configuration.GetContextBagForOutbox();
+            var outboxMessage = await configuration.OutboxStorage.Get(Guid.NewGuid().ToString(), context);
+            Assert.IsNull(outboxMessage);
             using (var outboxTransaction = await configuration.OutboxStorage.BeginTransaction(context))
             {
                 using (var saga1Session = configuration.CreateStorageSession())
                 {
                     await saga1Session.TryOpen(outboxTransaction, context);
-                    var get = await configuration.SagaStorage.Get<Saga1.Saga1Data>(nameof(Saga1.Saga1Data.CorrelationId),
+                    var saga1Data = await configuration.SagaStorage.Get<Saga1Data>(nameof(Saga1Data.CorrelationId),
                         saga1.CorrelationId, saga1Session, context);
-                    Assert.IsNull(get);
+                    Assert.IsNull(saga1Data);
 
                     await SaveSagaWithSession(saga1, saga1Session, context);
 
@@ -32,9 +34,9 @@
                 using (var saga2Session = configuration.CreateStorageSession())
                 {
                     await saga2Session.TryOpen(outboxTransaction, context);
-                    var get = await configuration.SagaStorage.Get<Saga2.Saga2Data>(nameof(Saga2.Saga2Data.CorrelationId),
+                    var saga2Data = await configuration.SagaStorage.Get<Saga2Data>(nameof(Saga2Data.CorrelationId),
                         saga2.CorrelationId, saga2Session, context);
-                    Assert.IsNull(get);
+                    Assert.IsNull(saga2Data);
 
                     await SaveSagaWithSession(saga2, saga2Session, context);
 
@@ -44,12 +46,12 @@
                 await outboxTransaction.Commit();
             }
 
-            var s1 = await GetById<Saga1.Saga1Data>(saga1.Id);
-            Assert.NotNull(s1);
-            Assert.AreEqual(saga1.CorrelationId, s1.CorrelationId);
-            var s2 = await GetById<Saga2.Saga2Data>(saga2.Id);
-            Assert.NotNull(s2);
-            Assert.AreEqual(saga2.CorrelationId, s2.CorrelationId);
+            var sagaData1 = await GetById<Saga1Data>(saga1.Id);
+            Assert.NotNull(sagaData1);
+            Assert.AreEqual(saga1.CorrelationId, sagaData1.CorrelationId);
+            var sagaData2 = await GetById<Saga2Data>(saga2.Id);
+            Assert.NotNull(sagaData2);
+            Assert.AreEqual(saga2.CorrelationId, sagaData2.CorrelationId);
         }
 
         [Test]
@@ -57,18 +59,20 @@
         {
             configuration.RequiresOutboxSupport();
 
-            var saga1 = new Saga1.Saga1Data { CorrelationId = Guid.NewGuid().ToString() };
-            var saga2 = new Saga2.Saga2Data { CorrelationId = Guid.NewGuid().ToString() };
+            var saga1 = new Saga1Data { CorrelationId = Guid.NewGuid().ToString() };
+            var saga2 = new Saga2Data { CorrelationId = Guid.NewGuid().ToString() };
 
             var context = configuration.GetContextBagForOutbox();
+            var outboxMessage = await configuration.OutboxStorage.Get(Guid.NewGuid().ToString(), context);
+            Assert.IsNull(outboxMessage);
             using (var outboxTransaction = await configuration.OutboxStorage.BeginTransaction(context))
             {
                 using (var saga1Session = configuration.CreateStorageSession())
                 {
                     await saga1Session.TryOpen(outboxTransaction, context);
-                    var get = await configuration.SagaStorage.Get<Saga1.Saga1Data>(nameof(Saga1.Saga1Data.CorrelationId),
+                    var saga1Data = await configuration.SagaStorage.Get<Saga1Data>(nameof(Saga1Data.CorrelationId),
                         saga1.CorrelationId, saga1Session, context);
-                    Assert.IsNull(get);
+                    Assert.IsNull(saga1Data);
 
                     await SaveSagaWithSession(saga1, saga1Session, context);
 
@@ -78,9 +82,9 @@
                 using (var saga2Session = configuration.CreateStorageSession())
                 {
                     await saga2Session.TryOpen(outboxTransaction, context);
-                    var get = await configuration.SagaStorage.Get<Saga2.Saga2Data>(nameof(Saga2.Saga2Data.CorrelationId),
+                    var saga2Data = await configuration.SagaStorage.Get<Saga2Data>(nameof(Saga2Data.CorrelationId),
                         saga2.CorrelationId, saga2Session, context);
-                    Assert.IsNull(get);
+                    Assert.IsNull(saga2Data);
 
                     await SaveSagaWithSession(saga2, saga2Session, context);
 
@@ -90,10 +94,10 @@
                 // no commit
             }
 
-            var s1 = await GetById<Saga1.Saga1Data>(saga1.Id);
-            Assert.IsNull(s1);
-            var s2 = await GetById<Saga2.Saga2Data>(saga2.Id);
-            Assert.IsNull(s2);
+            var sagaData1 = await GetById<Saga1Data>(saga1.Id);
+            Assert.IsNull(sagaData1);
+            var sagaData2 = await GetById<Saga2Data>(saga2.Id);
+            Assert.IsNull(sagaData2);
         }
 
         [Test]
@@ -101,19 +105,21 @@
         {
             configuration.RequiresOutboxSupport();
 
-            var saga1 = new Saga1.Saga1Data { CorrelationId = Guid.NewGuid().ToString(), SomeSaga1Data = "saga 1 before update" };
+            var saga1 = new Saga1Data { CorrelationId = Guid.NewGuid().ToString(), SomeSaga1Data = "saga 1 before update" };
             await SaveSaga(saga1);
-            var saga2 = new Saga2.Saga2Data { CorrelationId = Guid.NewGuid().ToString(), SomeSaga2Data = "saga 2 before update" };
+            var saga2 = new Saga2Data { CorrelationId = Guid.NewGuid().ToString(), SomeSaga2Data = "saga 2 before update" };
             await SaveSaga(saga2);
 
             var context = configuration.GetContextBagForOutbox();
+            var outboxMessage = await configuration.OutboxStorage.Get(Guid.NewGuid().ToString(), context);
+            Assert.IsNull(outboxMessage);
             using (var outboxTransaction = await configuration.OutboxStorage.BeginTransaction(context))
             {
                 using (var saga1Session = configuration.CreateStorageSession())
                 {
                     await saga1Session.TryOpen(outboxTransaction, context);
 
-                    var existingSaga1 = await configuration.SagaStorage.Get<Saga1.Saga1Data>(saga1.Id, saga1Session, context);
+                    var existingSaga1 = await configuration.SagaStorage.Get<Saga1Data>(saga1.Id, saga1Session, context);
                     existingSaga1.SomeSaga1Data = "saga 1 after update";
 
                     await configuration.SagaStorage.Update(existingSaga1, saga1Session, context);
@@ -125,7 +131,7 @@
                 {
                     await saga2Session.TryOpen(outboxTransaction, context);
 
-                    var existingSaga2 = await configuration.SagaStorage.Get<Saga2.Saga2Data>(saga2.Id, saga2Session, context);
+                    var existingSaga2 = await configuration.SagaStorage.Get<Saga2Data>(saga2.Id, saga2Session, context);
                     existingSaga2.SomeSaga2Data = "saga 2 after update";
 
                     await configuration.SagaStorage.Update(existingSaga2, saga2Session, context);
@@ -136,10 +142,10 @@
                 await outboxTransaction.Commit();
             }
 
-            var saga1AfterUpdate = await GetById<Saga1.Saga1Data>(saga1.Id);
+            var saga1AfterUpdate = await GetById<Saga1Data>(saga1.Id);
             Assert.NotNull(saga1AfterUpdate);
             Assert.AreEqual("saga 1 after update", saga1AfterUpdate.SomeSaga1Data);
-            var saga2AfterUpdate = await GetById<Saga2.Saga2Data>(saga2.Id);
+            var saga2AfterUpdate = await GetById<Saga2Data>(saga2.Id);
             Assert.NotNull(saga2AfterUpdate);
             Assert.AreEqual("saga 2 after update", saga2AfterUpdate.SomeSaga2Data);
         }
@@ -149,19 +155,21 @@
         {
             configuration.RequiresOutboxSupport();
 
-            var saga1 = new Saga1.Saga1Data { CorrelationId = Guid.NewGuid().ToString(), SomeSaga1Data = "saga 1 before update" };
+            var saga1 = new Saga1Data { CorrelationId = Guid.NewGuid().ToString(), SomeSaga1Data = "saga 1 before update" };
             await SaveSaga(saga1);
-            var saga2 = new Saga2.Saga2Data { CorrelationId = Guid.NewGuid().ToString(), SomeSaga2Data = "saga 2 before update" };
+            var saga2 = new Saga2Data { CorrelationId = Guid.NewGuid().ToString(), SomeSaga2Data = "saga 2 before update" };
             await SaveSaga(saga2);
 
             var context = configuration.GetContextBagForOutbox();
+            var outboxMessage = await configuration.OutboxStorage.Get(Guid.NewGuid().ToString(), context);
+            Assert.IsNull(outboxMessage);
             using (var outboxTransaction = await configuration.OutboxStorage.BeginTransaction(context))
             {
                 using (var saga1Session = configuration.CreateStorageSession())
                 {
                     await saga1Session.TryOpen(outboxTransaction, context);
 
-                    var existingSaga1 = await configuration.SagaStorage.Get<Saga1.Saga1Data>(saga1.Id, saga1Session, context);
+                    var existingSaga1 = await configuration.SagaStorage.Get<Saga1Data>(saga1.Id, saga1Session, context);
                     existingSaga1.SomeSaga1Data = "saga 1 after update";
 
                     await configuration.SagaStorage.Update(existingSaga1, saga1Session, context);
@@ -173,7 +181,7 @@
                 {
                     await saga2Session.TryOpen(outboxTransaction, context);
 
-                    var existingSaga2 = await configuration.SagaStorage.Get<Saga2.Saga2Data>(saga2.Id, saga2Session, context);
+                    var existingSaga2 = await configuration.SagaStorage.Get<Saga2Data>(saga2.Id, saga2Session, context);
                     existingSaga2.SomeSaga2Data = "saga 2 after update";
 
                     await configuration.SagaStorage.Update(existingSaga2, saga2Session, context);
@@ -184,40 +192,39 @@
                 // no commit
             }
 
-            var saga1AfterUpdate = await GetById<Saga1.Saga1Data>(saga1.Id);
+            var saga1AfterUpdate = await GetById<Saga1Data>(saga1.Id);
             Assert.NotNull(saga1AfterUpdate);
             Assert.AreEqual("saga 1 before update", saga1AfterUpdate.SomeSaga1Data);
-            var saga2AfterUpdate = await GetById<Saga2.Saga2Data>(saga2.Id);
+            var saga2AfterUpdate = await GetById<Saga2Data>(saga2.Id);
             Assert.NotNull(saga2AfterUpdate);
             Assert.AreEqual("saga 2 before update", saga2AfterUpdate.SomeSaga2Data);
         }
 
-        public class Saga1 : Saga<Saga1.Saga1Data>, IAmStartedByMessages<StartTestSagaMessage>
+        public class Saga1 : Saga<Saga1Data>, IAmStartedByMessages<StartTestSagaMessage>
         {
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga1Data> mapper) => mapper.ConfigureMapping<StartTestSagaMessage>(m => m.CorrelationProperty).ToSaga(s => s.CorrelationId);
 
             public Task Handle(StartTestSagaMessage message, IMessageHandlerContext context) => throw new NotImplementedException();
-
-            public class Saga1Data : ContainSagaData
-            {
-                public string CorrelationId { get; set; }
-                public string SomeSaga1Data { get; set; }
-            }
         }
 
-        public class Saga2 : Saga<Saga2.Saga2Data>, IAmStartedByMessages<StartTestSagaMessage>
+        public class Saga1Data : ContainSagaData
+        {
+            public string CorrelationId { get; set; }
+            public string SomeSaga1Data { get; set; }
+        }
+
+        public class Saga2 : Saga<Saga2Data>, IAmStartedByMessages<StartTestSagaMessage>
         {
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<Saga2Data> mapper) => mapper.ConfigureMapping<StartTestSagaMessage>(m => m.CorrelationProperty).ToSaga(s => s.CorrelationId);
 
             public Task Handle(StartTestSagaMessage message, IMessageHandlerContext context) => throw new NotImplementedException();
-
-            public class Saga2Data : ContainSagaData
-            {
-                public string CorrelationId { get; set; }
-                public string SomeSaga2Data { get; set; }
-            }
         }
 
+        public class Saga2Data : ContainSagaData
+        {
+            public string CorrelationId { get; set; }
+            public string SomeSaga2Data { get; set; }
+        }
 
         public class StartTestSagaMessage : IMessage
         {

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_in_outbox_transaction.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_in_outbox_transaction.cs
@@ -1,0 +1,67 @@
+﻿namespace NServiceBus.PersistenceTesting.Sagas
+{
+    using System;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    public class When_updating_saga_in_outbox_transaction : SagaPersisterTests
+    {
+        [Test]
+        public async Task Should_save_saga_only_when_outbox_tx_committed()
+        {
+            configuration.RequiresOutboxSupport();
+            configuration.RequiresOptimisticConcurrencySupport();
+
+            var contextBag = configuration.GetContextBagForOutbox();
+
+            var sagaData = new TestSagaData { SomeId = Guid.NewGuid().ToString() };
+            using (var outboxTransaction = await configuration.OutboxStorage.BeginTransaction(contextBag))
+            {
+                using (var synchronizedStorageSession = configuration.CreateStorageSession())
+                {
+                    var sessionCreated = await synchronizedStorageSession.TryOpen(outboxTransaction, contextBag);
+                    Assert.IsTrue(sessionCreated);
+
+                    var readBeforeCreate = await configuration.SagaStorage.Get<TestSagaData>(nameof(TestSagaData.SomeId),
+                        sagaData.SomeId, synchronizedStorageSession, contextBag);
+                    Assert.IsNull(readBeforeCreate);
+
+                    await SaveSagaWithSession(sagaData, synchronizedStorageSession, contextBag);
+
+                    await synchronizedStorageSession.CompleteAsync();
+                }
+
+                // outbox transaction not yet committed
+                var readBeforeOutboxCommit = await GetById<TestSagaData>(sagaData.Id);
+                Assert.IsNull(readBeforeOutboxCommit);
+
+                await outboxTransaction.Commit();
+            }
+
+            var readAfterOutboxCommit = await GetById<TestSagaData>(sagaData.Id);
+            Assert.NotNull(readAfterOutboxCommit);
+            Assert.AreEqual(sagaData.SomeId, readAfterOutboxCommit.SomeId);
+        }
+
+        public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartTestSagaMessage>
+        {
+            protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TestSagaData> mapper) => mapper.ConfigureMapping<StartTestSagaMessage>(m => m.SomeId).ToSaga(s => s.SomeId);
+
+            public Task Handle(StartTestSagaMessage message, IMessageHandlerContext context) => throw new NotImplementedException();
+        }
+
+        public class TestSagaData : ContainSagaData
+        {
+            public string SomeId { get; set; } = "Test";
+        }
+
+        public class StartTestSagaMessage : IMessage
+        {
+            public string SomeId { get; set; }
+        }
+
+        public When_updating_saga_in_outbox_transaction(TestVariant param) : base(param)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Adds a set of tests that test the combination of the outbox transaction and the saga persister, specifically:
* Verifies that multiple saga modifications can be handled properly within a single outbox transaction
* Verifies that commits are correctly moved to the outbox transaction session

These tests have been tested to work on the persisters via:
* https://github.com/Particular/NServiceBus.Persistence.CosmosDB/pull/543 ✅ 
* https://github.com/Particular/NServiceBus.Storage.MongoDB/pull/475 ✅ 
* https://github.com/Particular/NServiceBus.Persistence.Sql/pull/1167 ✅ 
* https://github.com/Particular/NServiceBus.Persistence.AzureTable/pull/751 ✅ 
* https://github.com/Particular/NServiceBus.RavenDB/pull/1126 ✅ 
* https://github.com/Particular/NServiceBus.NHibernate/pull/962 ✅ 