### PR TITLE
Add basic outbox loading persistence test

### DIFF
--- a/src/NServiceBus.PersistenceTests/Outbox/OutboxStorageTests.cs
+++ b/src/NServiceBus.PersistenceTests/Outbox/OutboxStorageTests.cs
@@ -43,11 +43,11 @@
                 await transaction.Commit();
             }
 
-            var getResult = await storage.Get(messageId, configuration.GetContextBagForOutbox());
+            var message = await storage.Get(messageId, configuration.GetContextBagForOutbox());
 
-            Assert.IsNotNull(getResult);
-            Assert.AreEqual(messageId, getResult.MessageId);
-            Assert.AreEqual(1, getResult.TransportOperations.Length);
+            Assert.IsNotNull(message);
+            Assert.AreEqual(messageId, message.MessageId);
+            Assert.AreEqual(1, message.TransportOperations.Length);
         }
 
         [Test]

--- a/src/NServiceBus.PersistenceTests/Outbox/OutboxStorageTests.cs
+++ b/src/NServiceBus.PersistenceTests/Outbox/OutboxStorageTests.cs
@@ -27,6 +27,30 @@
         }
 
         [Test]
+        public async Task Should_find_existing_outbox_data()
+        {
+            configuration.RequiresOutboxSupport();
+
+            var storage = configuration.OutboxStorage;
+            var ctx = configuration.GetContextBagForOutbox();
+
+            string messageId = Guid.NewGuid().ToString();
+            var messageToStore = new OutboxMessage(messageId, new[] { new TransportOperation("x", null, null, null) });
+            using (var transaction = await storage.BeginTransaction(ctx))
+            {
+                await storage.Store(messageToStore, transaction, ctx);
+
+                await transaction.Commit();
+            }
+
+            var getResult = await storage.Get(messageId, configuration.GetContextBagForOutbox());
+
+            Assert.IsNotNull(getResult);
+            Assert.AreEqual(messageId, getResult.MessageId);
+            Assert.AreEqual(1, getResult.TransportOperations.Length);
+        }
+
+        [Test]
         public async Task Should_clear_operations_on_dispatched_messages()
         {
             configuration.RequiresOutboxSupport();

--- a/src/NServiceBus.PersistenceTests/Sagas/When_concurrently_persisting_sagas_with_same_correlation_prop.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_concurrently_persisting_sagas_with_same_correlation_prop.cs
@@ -4,7 +4,7 @@
     using System.Threading.Tasks;
     using NUnit.Framework;
 
-    public class Persist_saga_same_unique_prop_as_saga : SagaPersisterTests
+    public class When_concurrently_persisting_sagas_with_same_correlation_prop : SagaPersisterTests
     {
         [Test]
         public async Task It_should_enforce_uniqueness()
@@ -68,7 +68,7 @@
             public string CorrelatedProperty { get; set; }
         }
 
-        public Persist_saga_same_unique_prop_as_saga(TestVariant param) : base(param)
+        public When_concurrently_persisting_sagas_with_same_correlation_prop(TestVariant param) : base(param)
         {
         }
     }

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_the_same_unique_prop_as_another_saga.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_the_same_unique_prop_as_another_saga.cs
@@ -4,7 +4,7 @@
     using System.Threading.Tasks;
     using NUnit.Framework;
 
-    public class Persist_sagas_same_correlation_prop_val : SagaPersisterTests
+    public class When_persisting_a_saga_with_the_same_unique_prop_as_another_saga : SagaPersisterTests
     {
         [Test]
         public async Task It_should_persist_successfully()
@@ -94,7 +94,7 @@
             public string CorrelatedProperty { get; set; }
         }
 
-        public Persist_sagas_same_correlation_prop_val(TestVariant param) : base(param)
+        public When_persisting_a_saga_with_the_same_unique_prop_as_another_saga(TestVariant param) : base(param)
         {
         }
     }


### PR DESCRIPTION
* Adds a basic test verifying that loading an existing outbox record contains the same message id as the id passed into the query.
* Renames some saga tests that have been renamed by https://github.com/Particular/NServiceBus/pull/6117 and don't align with the overall naming convention in the project