### PR TITLE
Add preflight get to outbox test

### DIFF
--- a/src/NServiceBus.PersistenceTests/Outbox/OutboxStorageTests.cs
+++ b/src/NServiceBus.PersistenceTests/Outbox/OutboxStorageTests.cs
@@ -35,6 +35,8 @@
             var ctx = configuration.GetContextBagForOutbox();
 
             string messageId = Guid.NewGuid().ToString();
+            await storage.Get(messageId, ctx);
+
             var messageToStore = new OutboxMessage(messageId, new[] { new TransportOperation("x", null, null, null) });
             using (var transaction = await storage.BeginTransaction(ctx))
             {


### PR DESCRIPTION
because some persisters (NH and Azure table) require get requests before storing saga data.