### PR TITLE
Split out the learning persistence tests similar to the learning acceptance tests for better separation

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -55,7 +55,7 @@
     <InternalsVisibleTo Include="NServiceBus.AcceptanceTesting" Key="$(NServiceBusKey)" />
     <InternalsVisibleTo Include="NServiceBus.ContainerTests" Key="$(NServiceBusTestsKey)" />
     <InternalsVisibleTo Include="NServiceBus.Core.Tests" Key="$(NServiceBusTestsKey)" />
-    <InternalsVisibleTo Include="NServiceBus.PersistenceTests" Key="$(NServiceBusTestsKey)" />
+    <InternalsVisibleTo Include="NServiceBus.Learning.PersistenceTests" Key="$(NServiceBusTestsKey)" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.Learning.PersistenceTests/NServiceBus.Learning.PersistenceTests.csproj
+++ b/src/NServiceBus.Learning.PersistenceTests/NServiceBus.Learning.PersistenceTests.csproj
@@ -20,7 +20,6 @@
         <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
-        <PackageReference Include="Particular.Approvals" Version="0.4.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NServiceBus.Learning.PersistenceTests/NServiceBus.Learning.PersistenceTests.csproj
+++ b/src/NServiceBus.Learning.PersistenceTests/NServiceBus.Learning.PersistenceTests.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
+        <LangVersion>10.0</LangVersion>
+        <SignAssembly>true</SignAssembly>
+        <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\NServiceBus.AcceptanceTesting\NServiceBus.AcceptanceTesting.csproj" />
+        <ProjectReference Include="..\NServiceBus.Core\NServiceBus.Core.csproj" />
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+        <Reference Include="System.Transactions" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+        <PackageReference Include="Particular.Approvals" Version="0.4.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Compile Include="../NServiceBus.PersistenceTests/**/*.cs" Exclude="../NServiceBus.PersistenceTests/obj/**/*.*" />
+        <Compile Remove="../NServiceBus.PersistenceTests/PersistenceTestsConfiguration.cs" />
+    </ItemGroup>
+
+</Project>

--- a/src/NServiceBus.PersistenceTests/NServiceBus.PersistenceTests.csproj
+++ b/src/NServiceBus.PersistenceTests/NServiceBus.PersistenceTests.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -30,10 +29,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\NServiceBus.Core\IdGeneration\CombGuid.cs" />
+    <Compile Include="..\NServiceBus.Core\Sagas\DefaultSagaIdGenerator.cs" />
+    <Compile Include="..\NServiceBus.Core\DeepCopy.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <AddSourceFileToPackage Include="..\NServiceBus.Core\IdGeneration\CombGuid.cs" />
     <AddSourceFileToPackage Include="..\NServiceBus.Core\Sagas\DefaultSagaIdGenerator.cs" />
     <AddSourceFileToPackage Include="..\NServiceBus.Core\DeepCopy.cs" />
-    <RemoveSourceFileFromPackage Include="PersistenceTestsConfiguration.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/NServiceBus.sln
+++ b/src/NServiceBus.sln
@@ -40,6 +40,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Learning.Accept
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.Core.Analyzer.Tests.Roslyn4", "NServiceBus.Core.Analyzer.Tests.Roslyn4\NServiceBus.Core.Analyzer.Tests.Roslyn4.csproj", "{71330321-DA6D-4199-89C4-FB36F92E77C2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NServiceBus.Learning.PersistenceTests", "NServiceBus.Learning.PersistenceTests\NServiceBus.Learning.PersistenceTests.csproj", "{A259E9F5-E052-4BE1-9BE3-8F23FA592329}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -94,6 +96,10 @@ Global
 		{71330321-DA6D-4199-89C4-FB36F92E77C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{71330321-DA6D-4199-89C4-FB36F92E77C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{71330321-DA6D-4199-89C4-FB36F92E77C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A259E9F5-E052-4BE1-9BE3-8F23FA592329}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A259E9F5-E052-4BE1-9BE3-8F23FA592329}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A259E9F5-E052-4BE1-9BE3-8F23FA592329}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A259E9F5-E052-4BE1-9BE3-8F23FA592329}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -110,6 +116,7 @@ Global
 		{157D1894-BAE7-45B2-9906-0445B38F3A97} = {2904B75F-8F07-4C07-BABC-BC42533B3E75}
 		{360438BD-AEDE-48AC-BE75-FBB6BF2F004D} = {2904B75F-8F07-4C07-BABC-BC42533B3E75}
 		{71330321-DA6D-4199-89C4-FB36F92E77C2} = {2904B75F-8F07-4C07-BABC-BC42533B3E75}
+		{A259E9F5-E052-4BE1-9BE3-8F23FA592329} = {2904B75F-8F07-4C07-BABC-BC42533B3E75}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A32A19A8-C700-4AC8-8A34-1D56DA9CDF95}


### PR DESCRIPTION
Discovered while reviewing #6725 

This makes sure we no longer have to have internals visible to on the persistence project and all the dependencies that are required from a source perspective are explicitly linked (otherwise it doesn't compile).