### PR TITLE
Don't configure auditing or create audit queue if endpoint is SendOnly

### DIFF
--- a/src/NServiceBus.Core/Audit/Audit.cs
+++ b/src/NServiceBus.Core/Audit/Audit.cs
@@ -16,6 +16,8 @@
                 settings.Set(AuditConfigReader.GetConfiguredAuditQueue(settings));
             });
             Prerequisite(config => config.Settings.GetOrDefault<AuditConfigReader.Result>() != null, "No configured audit queue was found");
+            Prerequisite(context => !context.Settings.GetOrDefault<bool>("Endpoint.SendOnly"),
+                "Auditing is only relevant for endpoints receiving messages.");
         }
 
 


### PR DESCRIPTION
The changes to the NServiceBus 8 transport seam treat all queues the same and pass them as a collection to the transport, and transports create them. Becuase the Audit feature was not dependent upon whether the endpoint was send-only, this means that the audit queue was also being created, as well as other unnecessary stuff like the diagnostics entry, logging, and adding behaviors to the receive pipeline.

This PR adds a prerequisite so that the Audit feature will not run if the endpoint is send only.

This is a fix for https://github.com/Particular/NServiceBus/issues/6736.