### PR TITLE
Make system json handle payloads with BOM

### DIFF
--- a/src/NServiceBus.Core.Tests/Serializers/SystemTextJson/SystemJsonSerializerTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/SystemTextJson/SystemJsonSerializerTests.cs
@@ -224,7 +224,7 @@
         }
 
         [Test]
-        public void Should_be_able_to_serialize_payloads_with_BOM()
+        public void Should_be_able_to_deserialize_payloads_with_BOM()
         {
             var payload = JsonSerializer.Serialize(new SomeMessage());
 

--- a/src/NServiceBus.Core.Tests/Serializers/SystemTextJson/SystemJsonSerializerTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/SystemTextJson/SystemJsonSerializerTests.cs
@@ -230,7 +230,7 @@
 
             using (var stream = new MemoryStream())
             {
-                using (var sw = new StreamWriter(stream, new UTF8Encoding(true)))
+                using (var sw = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: true)))
                 {
                     sw.WriteLine(payload);
                     sw.Flush();

--- a/src/NServiceBus.Core.Tests/Serializers/SystemTextJson/SystemJsonSerializerTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/SystemTextJson/SystemJsonSerializerTests.cs
@@ -226,7 +226,7 @@
         [Test]
         public void Should_be_able_to_serialize_payloads_with_BOM()
         {
-            var payload = JsonSerializer.Serialize(new SomeMessage { MyProperty = 23 });
+            var payload = JsonSerializer.Serialize(new SomeMessage());
 
             using (var stream = new MemoryStream())
             {
@@ -306,6 +306,5 @@
 
     class SomeMessage
     {
-        public int MyProperty { get; set; }
     }
 }

--- a/src/NServiceBus.Core/Serializers/SystemJson/JsonMessageSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/SystemJson/JsonMessageSerializer.cs
@@ -104,6 +104,6 @@ namespace NServiceBus.Serializers.SystemJson
         readonly JsonReaderOptions readerOptions;
         readonly IMessageMapper messageMapper;
 
-        static byte[] utf8Preamble = Encoding.UTF8.GetPreamble();
+        static readonly byte[] utf8Preamble = Encoding.UTF8.GetPreamble();
     }
 }

--- a/src/NServiceBus.Core/Serializers/SystemJson/JsonMessageSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/SystemJson/JsonMessageSerializer.cs
@@ -5,6 +5,7 @@ namespace NServiceBus.Serializers.SystemJson
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Text;
     using System.Text.Json;
     using NServiceBus.MessageInterfaces;
     using NServiceBus.Serialization;
@@ -54,6 +55,13 @@ namespace NServiceBus.Serializers.SystemJson
         object Deserialize(ReadOnlyMemory<byte> body, Type type)
         {
             var actualType = GetMappedType(type);
+
+            // Get rid of the BOM if present since system json can't handle it
+            if (body.Span.StartsWith(utf8Preamble))
+            {
+                body = body.Slice(utf8Preamble.Length);
+            }
+
             var reader = new Utf8JsonReader(body.Span, readerOptions);
             return JsonSerializer.Deserialize(ref reader, actualType, serializerOptions)!;
         }
@@ -95,5 +103,7 @@ namespace NServiceBus.Serializers.SystemJson
         readonly JsonWriterOptions writerOptions;
         readonly JsonReaderOptions readerOptions;
         readonly IMessageMapper messageMapper;
+
+        static byte[] utf8Preamble = Encoding.UTF8.GetPreamble();
     }
 }


### PR DESCRIPTION
This makes it compatible with Newtonsoft which adds the BOM by default, see https://docs.particular.net/nservicebus/serialization/newtonsoft#usage-custom-writer