### PR TITLE
Take an explicit reference to System.Text.Json 7.0.3 for all the supported TFMs

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -14,13 +14,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
     <PackageReference Include="System.Memory" Version="4.5.5" />
-    <PackageReference Include="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup Label="Public dependencies">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="7.0.1" />
+    <PackageReference Include="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
 
   <ItemGroup Label="Private dependencies">


### PR DESCRIPTION
Follow up for #6771 and the discussion in https://github.com/Particular/NServiceBus/pull/6749#pullrequestreview-1464490349

@andreasohlund and I discussed this again, and we believe the same minimum version of System.Text.Json should be used for all supported TFMs to avoid confusion for us and the customer. As an example, today if we would leverage internally the source generation to speed up serialization for existing types you could use the new `.Default` property in nNET472 but not on NET6.

Additionally, from an end-user perspective, you could be using `JsonDerivedTypedAttribute` to support polymorphic serialization, but you have to take an extra step in NET 6 by adding an explicit reference to System.Text.Json 7.0 and higher. 

Once we remove support for .NET 6 we can move the reference back to .NET Framework only.