### PR TITLE
Reduce logging output on test completion

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -128,15 +128,6 @@ namespace NServiceBus.AcceptanceTesting
                 TestContext.WriteLine("     - {0}", endpoint);
             }
 
-            if (runResult.Failed)
-            {
-                TestContext.WriteLine("Scenario failed: {0}", runResult.Exception.SourceException);
-            }
-            else
-            {
-                TestContext.WriteLine("Result: Successful - Duration: {0}", runResult.TotalTime);
-            }
-
             //dump trace and context regardless since asserts outside the should could still fail the test
             TestContext.WriteLine();
             TestContext.WriteLine("Context:");


### PR DESCRIPTION
When an acceptance tests fails, the exception is logged ~4 times for the failing test. Some of this seems to be part of nUnit which already logs exceptions thrown anyway. This removes one of the exception dumps since there are already enough stack traces dumped to the text context and log.

A potential case where this might be an issue could be when the exception from `Scenario.Run` is caught by the test code. In this case, the stack trace might not be dumped except for the log entries but that seems acceptable.