### PR TITLE
Log additional test information only on failing test case

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -41,9 +41,10 @@ namespace NServiceBus.AcceptanceTesting
             LogManager.UseFactory(Scenario.GetLoggerFactory(scenarioContext));
 
             var sw = new Stopwatch();
+            var scenarioRunner = new ScenarioRunner(runDescriptor, behaviors, done);
 
             sw.Start();
-            var runSummary = await ScenarioRunner.Run(runDescriptor, behaviors, done).ConfigureAwait(false);
+            var runSummary = await scenarioRunner.Run().ConfigureAwait(false);
             sw.Stop();
 
             await runDescriptor.RaiseOnTestCompleted(runSummary).ConfigureAwait(false);

--- a/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
+++ b/src/NServiceBus.AcceptanceTesting/ScenarioWithContext.cs
@@ -3,7 +3,6 @@ namespace NServiceBus.AcceptanceTesting
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Linq;
     using System.Threading.Tasks;
     using Logging;
     using NUnit.Framework;
@@ -36,7 +35,7 @@ namespace NServiceBus.AcceptanceTesting
             var runDescriptor = new RunDescriptor(scenarioContext);
             runDescriptor.Settings.Merge(settings);
 
-            TestExecutionContext.CurrentContext.CurrentTest.Properties.Add("NServiceBus.ScenarioContext", scenarioContext);
+            TestExecutionContext.CurrentContext.AddRunDescriptor(runDescriptor);
             ScenarioContext.Current = scenarioContext;
 
             LogManager.UseFactory(Scenario.GetLoggerFactory(scenarioContext));
@@ -50,11 +49,6 @@ namespace NServiceBus.AcceptanceTesting
             await runDescriptor.RaiseOnTestCompleted(runSummary).ConfigureAwait(false);
 
             TestContext.WriteLine("Test {0}: Scenario completed in {1:0.0}s", TestContext.CurrentContext.Test.FullName, sw.Elapsed.TotalSeconds);
-
-            if (runSummary.Result.Failed || ScenarioRunner.VerboseLogging)
-            {
-                DisplayRunResult(runSummary);
-            }
 
             if (runSummary.Result.Failed)
             {
@@ -99,23 +93,6 @@ namespace NServiceBus.AcceptanceTesting
             done = c => func((TContext)c);
 
             return this;
-        }
-
-        static void DisplayRunResult(RunSummary summary)
-        {
-            var runDescriptor = summary.RunDescriptor;
-            var runResult = summary.Result;
-
-            var scenarioContext = summary.RunDescriptor.ScenarioContext;
-
-            scenarioContext.AddTrace($@"Test settings:
-{string.Join(Environment.NewLine, runDescriptor.Settings.Select(setting => $"   {setting.Key}: {setting.Value}"))}");
-
-            scenarioContext.AddTrace($@"Endpoints:
-{string.Join(Environment.NewLine, runResult.ActiveEndpoints.Select(e => $"     - {e}"))}");
-
-            scenarioContext.AddTrace($@"Context:
-{string.Join(Environment.NewLine, runResult.ScenarioContext.GetType().GetProperties().Select(p => $"{p.Name} = {p.GetValue(runResult.ScenarioContext, null)}"))}");
         }
 
         List<IComponentBehavior> behaviors = new List<IComponentBehavior>();

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -18,7 +18,7 @@
         {
             runDescriptor.ScenarioContext.AddTrace("current context: " + runDescriptor.ScenarioContext.GetType().FullName);
             runDescriptor.ScenarioContext.AddTrace("Started test @ " + DateTime.Now.ToString(CultureInfo.InvariantCulture));
-            
+
             var runResult = await PerformTestRun(behaviorDescriptors, runDescriptor, done).ConfigureAwait(false);
 
             runDescriptor.ScenarioContext.AddTrace("Finished test @ " + DateTime.Now.ToString(CultureInfo.InvariantCulture));

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -178,20 +178,13 @@
             return endpoints.Select(async endpoint =>
             {
                 await Task.Yield(); // ensure all endpoints are stopped even if a synchronous implementation throws
-                //TODO can we remove VerboseLogging?
-                if (VerboseLogging)
-                {
-                    runDescriptor.ScenarioContext.AddTrace($"Stopping endpoint: {endpoint.Name}");
-                }
+                runDescriptor.ScenarioContext.AddTrace($"Stopping endpoint: {endpoint.Name}");
                 var stopwatch = Stopwatch.StartNew();
                 try
                 {
                     await endpoint.Stop().ConfigureAwait(false);
                     stopwatch.Stop();
-                    if (VerboseLogging)
-                    {
-                        runDescriptor.ScenarioContext.AddTrace($"Endpoint: {endpoint.Name} stopped ({stopwatch.Elapsed}s)");
-                    }
+                    runDescriptor.ScenarioContext.AddTrace($"Endpoint: {endpoint.Name} stopped ({stopwatch.Elapsed}s)");
                 }
                 catch (Exception)
                 {
@@ -206,9 +199,6 @@
             var runnerInitializations = behaviorDescriptors.Select(endpointBehavior => endpointBehavior.CreateRunner(runDescriptor)).ToArray();
             return await Task.WhenAll(runnerInitializations).ConfigureAwait(false);
         }
-
-        internal static readonly bool VerboseLogging = Environment.GetEnvironmentVariable("CI") != "true"
-                                                       || Environment.GetEnvironmentVariable("VERBOSE_TEST_LOGGING")?.ToLower() == "true";
     }
 
     public class RunResult

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -16,7 +16,7 @@
         readonly List<IComponentBehavior> behaviorDescriptors;
         readonly Func<ScenarioContext, Task<bool>> done;
 
-        ScenarioRunner(RunDescriptor runDescriptor, List<IComponentBehavior> behaviorDescriptors, Func<ScenarioContext, Task<bool>> done)
+        public ScenarioRunner(RunDescriptor runDescriptor, List<IComponentBehavior> behaviorDescriptors, Func<ScenarioContext, Task<bool>> done)
         {
             this.runDescriptor = runDescriptor;
             this.behaviorDescriptors = behaviorDescriptors;
@@ -24,13 +24,12 @@
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Code", "PS0023:Use DateTime.UtcNow or DateTimeOffset.UtcNow", Justification = "Test logging")]
-        public static async Task<RunSummary> Run(RunDescriptor runDescriptor, List<IComponentBehavior> behaviorDescriptors, Func<ScenarioContext, Task<bool>> done)
+        public async Task<RunSummary> Run()
         {
             runDescriptor.ScenarioContext.AddTrace("current context: " + runDescriptor.ScenarioContext.GetType().FullName);
             runDescriptor.ScenarioContext.AddTrace("Started test @ " + DateTime.Now.ToString(CultureInfo.InvariantCulture));
 
-            var scenarioRunner = new ScenarioRunner(runDescriptor, behaviorDescriptors, done);
-            var runResult = await scenarioRunner.PerformTestRun().ConfigureAwait(false);
+            var runResult = await PerformTestRun().ConfigureAwait(false);
 
             runDescriptor.ScenarioContext.AddTrace("Finished test @ " + DateTime.Now.ToString(CultureInfo.InvariantCulture));
 

--- a/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/ScenarioRunner.cs
@@ -16,18 +16,12 @@
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Code", "PS0023:Use DateTime.UtcNow or DateTimeOffset.UtcNow", Justification = "Test logging")]
         public static async Task<RunSummary> Run(RunDescriptor runDescriptor, List<IComponentBehavior> behaviorDescriptors, Func<ScenarioContext, Task<bool>> done)
         {
-            if (VerboseLogging)
-            {
-                TestContext.WriteLine("current context: " + runDescriptor.ScenarioContext.GetType().FullName);
-                TestContext.WriteLine("Started test @ {0}", DateTime.Now.ToString(CultureInfo.InvariantCulture));
-            }
-
+            runDescriptor.ScenarioContext.AddTrace("current context: " + runDescriptor.ScenarioContext.GetType().FullName);
+            runDescriptor.ScenarioContext.AddTrace("Started test @ " + DateTime.Now.ToString(CultureInfo.InvariantCulture));
+            
             var runResult = await PerformTestRun(behaviorDescriptors, runDescriptor, done).ConfigureAwait(false);
 
-            if (VerboseLogging)
-            {
-                TestContext.WriteLine("Finished test @ {0}", DateTime.Now.ToString(CultureInfo.InvariantCulture));
-            }
+            runDescriptor.ScenarioContext.AddTrace("Finished test @ " + DateTime.Now.ToString(CultureInfo.InvariantCulture));
 
             return new RunSummary
             {

--- a/src/NServiceBus.AcceptanceTesting/Support/TestContextExtensions.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/TestContextExtensions.cs
@@ -1,0 +1,26 @@
+﻿namespace NServiceBus.AcceptanceTesting;
+
+using NUnit.Framework.Internal;
+using Support;
+
+public static class TestContextExtensions
+{
+    static readonly string SettingsKey = typeof(RunDescriptor).FullName;
+
+    public static void AddRunDescriptor(this TestExecutionContext testContext, RunDescriptor runDescriptor)
+    {
+        testContext.CurrentTest.Properties.Add(SettingsKey, runDescriptor);
+    }
+
+    public static bool TryGetRunDescriptor(this TestExecutionContext testContext, out RunDescriptor runDescriptor)
+    {
+        if (testContext.CurrentTest.Properties.ContainsKey(SettingsKey))
+        {
+            runDescriptor = testContext.CurrentTest.Properties.Get(SettingsKey) as RunDescriptor;
+            return true;
+        }
+
+        runDescriptor = null;
+        return false;
+    }
+}

--- a/src/NServiceBus.AcceptanceTesting/Support/TestContextExtensions.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/TestContextExtensions.cs
@@ -1,26 +1,27 @@
-﻿namespace NServiceBus.AcceptanceTesting;
-
-using NUnit.Framework.Internal;
-using Support;
-
-public static class TestContextExtensions
+﻿namespace NServiceBus.AcceptanceTesting
 {
-    static readonly string SettingsKey = typeof(RunDescriptor).FullName;
+    using NUnit.Framework.Internal;
+    using Support;
 
-    public static void AddRunDescriptor(this TestExecutionContext testContext, RunDescriptor runDescriptor)
+    public static class TestContextExtensions
     {
-        testContext.CurrentTest.Properties.Add(SettingsKey, runDescriptor);
-    }
+        static readonly string SettingsKey = typeof(RunDescriptor).FullName;
 
-    public static bool TryGetRunDescriptor(this TestExecutionContext testContext, out RunDescriptor runDescriptor)
-    {
-        if (testContext.CurrentTest.Properties.ContainsKey(SettingsKey))
+        public static void AddRunDescriptor(this TestExecutionContext testContext, RunDescriptor runDescriptor)
         {
-            runDescriptor = testContext.CurrentTest.Properties.Get(SettingsKey) as RunDescriptor;
-            return true;
+            testContext.CurrentTest.Properties.Add(SettingsKey, runDescriptor);
         }
 
-        runDescriptor = null;
-        return false;
+        public static bool TryGetRunDescriptor(this TestExecutionContext testContext, out RunDescriptor runDescriptor)
+        {
+            if (testContext.CurrentTest.Properties.ContainsKey(SettingsKey))
+            {
+                runDescriptor = testContext.CurrentTest.Properties.Get(SettingsKey) as RunDescriptor;
+                return true;
+            }
+
+            runDescriptor = null;
+            return false;
+        }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/NServiceBusAcceptanceTest.cs
+++ b/src/NServiceBus.AcceptanceTests/NServiceBusAcceptanceTest.cs
@@ -4,7 +4,6 @@ namespace NServiceBus.AcceptanceTests
     using System.Threading;
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
-    using AcceptanceTesting.Support;
     using NUnit.Framework;
     using NUnit.Framework.Interfaces;
     using NUnit.Framework.Internal;

--- a/src/NServiceBus.AcceptanceTests/NServiceBusAcceptanceTest.cs
+++ b/src/NServiceBus.AcceptanceTests/NServiceBusAcceptanceTest.cs
@@ -2,8 +2,12 @@ namespace NServiceBus.AcceptanceTests
 {
     using System.Linq;
     using System.Threading;
+    using AcceptanceTesting;
     using AcceptanceTesting.Customization;
+    using AcceptanceTesting.Support;
     using NUnit.Framework;
+    using NUnit.Framework.Interfaces;
+    using NUnit.Framework.Internal;
 
     /// <summary>
     /// Base class for all the NSB test that sets up our conventions
@@ -35,6 +39,24 @@ namespace NServiceBus.AcceptanceTests
 
                 return testName + "." + endpointBuilder;
             };
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if ((TestExecutionContext.CurrentContext.CurrentResult.ResultState == ResultState.Failure || TestExecutionContext.CurrentContext.CurrentResult.ResultState == ResultState.Error) && TestExecutionContext.CurrentContext.CurrentTest.Properties.ContainsKey("NServiceBus.ScenarioContext"))
+            {
+                var scenarioContext = TestExecutionContext.CurrentContext.CurrentTest.Properties
+                    .Get("NServiceBus.ScenarioContext") as ScenarioContext;
+
+                TestContext.WriteLine($"Log entries (log level: {scenarioContext.LogLevel}):");
+                TestContext.WriteLine("--- Start log entries ---------------------------------------------------");
+                foreach (var logEntry in scenarioContext.Logs)
+                {
+                    TestContext.WriteLine($"{logEntry.Timestamp:T} {logEntry.Level} {logEntry.Endpoint ?? TestContext.CurrentContext.Test.Name}: {logEntry.Message}");
+                }
+                TestContext.WriteLine("--- End log entries ---------------------------------------------------");
+            }
         }
     }
 }


### PR DESCRIPTION
An attempt to further reduce log output for passing tests.

Currently, the acceptance testing `Scenario` writes additional log output when the scenario fails. However, we have quite a few tests that use `Assert.Throws` since they test cases where exceptions are expected. However, the scenario isn't aware of the assertions and logs regardless. This causes a lot (~2-6k lines) of additional log output for each execution of the acceptance tests that aren't really necessary and might be quite confusing when looking through log files.

I think the best approach is to move the logging responsibility away from the `Scenario` classes into the tests instead. Since all acceptance tests already have a shared base class, this isn't too hard (however it adds some coupling as data need to be shared between the acceptance testing framework and the acceptance tests setup classes ).

Some other ideas I've been thinking about:
* Throwing a custom `ScenarioException` that wraps the original exception and captures additional test context. However, due to the way test runners render the exception output, this doesn't work well as the only way would be to overwrite the `Message` property which leads to messy exception messages when we try to dump the whole log. Nunit also doesn't seem to expose the actual exception type of a failed test in their extension APIs.
* Move the assertions into the testing framework so that the test failure happens within the context of the `Scenario`. This would be a lot more effort and would require adjusting all tests too.
