### PR TITLE
Revert 7.x system dependencies to 6.x; fixes InProcess Azure Functions runtime

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -17,17 +17,17 @@
   </ItemGroup>
 
   <ItemGroup Label="Public dependencies">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="7.0.1" />
-    <PackageReference Include="System.Text.Json" Version="7.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
+    <PackageReference Include="System.Text.Json" Version="6.0.8" />
   </ItemGroup>
 
   <ItemGroup Label="Private dependencies">
-    <PackageReference Include="Fody" Version="6.7.0" PrivateAssets="All" />
+    <PackageReference Include="Fody" Version="6.8.0" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.9.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
-    <PackageReference Include="Particular.Licensing.Sources" Version="5.1.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Licensing.Sources" Version="5.0.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="SimpleJson" Version="0.38.0" PrivateAssets="All" />
     <PackageReference Include="FastExpressionCompiler.Internal.src" Version="3.3.4" PrivateAssets="All" />


### PR DESCRIPTION
Since the latest version of NServiceBus the System.x and Microsoft.Extensions.x packages are upgraded to 7.x. Using 7.x System and Extension dependencies is not supported in .NET6 InProcess Azure Functions. As far as I understand, the Azure Functions runtime should provide the host process with these assemblies and they are therefore stripped from the deployment.

This produces the following error at runtime (package name obscured for privacy reasons since we use an internal package for sharing NServiceBus configuration).
![image](https://github.com/Particular/NServiceBus/assets/4289336/fe8cbaac-b867-4d3b-ab3b-ba7ccb3df746)

This PR reverts these packages to version 6.x. Since `Particular.Licensing.Sources` also depends on 7.x packages and is not publicly accessible, this package is reverted as well.
