### PR TITLE
Update RPL1.5 license URL

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -3,7 +3,7 @@ If you do not agree to these terms, do not access Particular Software code.
 
 Your license to Particular Software source code and/or binaries is governed by the Reciprocal Public License 1.5 (RPL1.5) license as described here: 
 
-https://www.opensource.org/licenses/rpl1.5.txt
+https://opensource.org/license/rpl-1-5
 
 If you do not wish to release the source of software you build using Particular Software source code and/or binaries under the terms above, you may use Particular Software source code and/or binaries under the License Agreement described here:
 


### PR DESCRIPTION
While looking at LICENSE.md I noticed that the link to opensource.org was invalid. 
So I've updated it with the up-to-date one.