### PR TITLE
AssemblyScanner improvements

### DIFF
--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_exclusion_predicate_is_used.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_exclusion_predicate_is_used.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.Core.Tests.AssemblyScanner
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
@@ -15,13 +16,13 @@
         {
             var results = new AssemblyScanner(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestDlls"))
             {
-                AssembliesToSkip = new List<string>
+                AssembliesToSkip = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
                     {
-                        "dotNet.dll"
+                        "dotNet"
                     },
                 ScanAppDomainAssemblies = false
             }
-                .GetScannableAssemblies();
+            .GetScannableAssemblies();
 
             var skippedFiles = results.SkippedFiles;
             var explicitlySkippedDll = skippedFiles.FirstOrDefault(s => s.FilePath.Contains("dotNet.dll"));

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_exclusion_predicate_is_used.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_exclusion_predicate_is_used.cs
@@ -16,9 +16,9 @@
         {
             var results = new AssemblyScanner(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestDlls"))
             {
-                AssembliesToSkip = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                AssembliesToSkip = new List<string>
                     {
-                        "dotNet"
+                        "dotNet.dll"
                     },
                 ScanAppDomainAssemblies = false
             }

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_exclusion_predicate_is_used.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_exclusion_predicate_is_used.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Core.Tests.AssemblyScanner
 {
-    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
@@ -10,7 +9,6 @@
     [TestFixture]
     public class When_exclusion_predicate_is_used
     {
-
         [Test]
         public void No_files_explicitly_excluded_are_returned()
         {

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_validating_assemblies.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_validating_assemblies.cs
@@ -10,12 +10,11 @@
         [Test]
         public void Should_not_validate_system_assemblies()
         {
-            var validator = new AssemblyValidator();
             var systemAssemblies = AppDomain.CurrentDomain.GetAssemblies().Where(a => a.FullName.Contains("System"));
 
             foreach (var assembly in systemAssemblies)
             {
-                validator.ValidateAssemblyFile(assembly.Location, out var shouldLoad, out var reason);
+                AssemblyValidator.ValidateAssemblyFile(assembly.Location, out var shouldLoad, out var reason);
 
                 Assert.IsFalse(shouldLoad, $"Should not validate {assembly.FullName}");
                 Assert.That(reason == "File is a .NET runtime assembly.");
@@ -25,9 +24,7 @@
         [Test]
         public void Should_validate_NServiceBus_Core_assembly()
         {
-            var validator = new AssemblyValidator();
-
-            validator.ValidateAssemblyFile(typeof(EndpointConfiguration).Assembly.Location, out var shouldLoad, out var reason);
+            AssemblyValidator.ValidateAssemblyFile(typeof(EndpointConfiguration).Assembly.Location, out var shouldLoad, out var reason);
 
             Assert.IsTrue(shouldLoad);
             Assert.That(reason == "File is a .NET assembly.");
@@ -36,9 +33,7 @@
         [Test]
         public void Should_validate_non_system_assemblies()
         {
-            var validator = new AssemblyValidator();
-
-            validator.ValidateAssemblyFile(GetType().Assembly.Location, out var shouldLoad, out var reason);
+            AssemblyValidator.ValidateAssemblyFile(GetType().Assembly.Location, out var shouldLoad, out var reason);
 
             Assert.IsTrue(shouldLoad);
             Assert.That(reason == "File is a .NET assembly.");

--- a/src/NServiceBus.Core.Tests/Config/When_scanning_assemblies.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_scanning_assemblies.cs
@@ -50,7 +50,7 @@ namespace NServiceBus.Core.Tests.Config
 
             if (assembliesToSkip != null)
             {
-                assemblyScanner.AssembliesToSkip = new HashSet<string>(assembliesToSkip.ToList(), StringComparer.OrdinalIgnoreCase);
+                assemblyScanner.AssembliesToSkip = assembliesToSkip;
             }
             return assemblyScanner
                 .GetScannableAssemblies()

--- a/src/NServiceBus.Core.Tests/Config/When_scanning_assemblies.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_scanning_assemblies.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Core.Tests.Config
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
@@ -49,7 +50,7 @@ namespace NServiceBus.Core.Tests.Config
 
             if (assembliesToSkip != null)
             {
-                assemblyScanner.AssembliesToSkip = assembliesToSkip.ToList();
+                assemblyScanner.AssembliesToSkip = new HashSet<string>(assembliesToSkip.ToList(), StringComparer.OrdinalIgnoreCase);
             }
             return assemblyScanner
                 .GetScannableAssemblies()

--- a/src/NServiceBus.Core.Tests/Config/When_scanning_assemblies.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_scanning_assemblies.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus.Core.Tests.Config
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -53,6 +53,16 @@ namespace NServiceBus.Hosting.Helpers
 
         internal string CoreAssemblyName { get; set; } = NServicebusCoreAssemblyName;
 
+        internal IReadOnlyCollection<string> AssembliesToSkip
+        {
+            set => asssembliesToSkip = new HashSet<string>(value.Select(Path.GetFileNameWithoutExtension), StringComparer.OrdinalIgnoreCase);
+        }
+
+        internal IReadOnlyCollection<Type> TypesToSkip
+        {
+            set => typesToSkip = new HashSet<Type>(value);
+        }
+
         internal string AdditionalAssemblyScanningPath { get; set; }
 
         /// <summary>
@@ -322,7 +332,7 @@ namespace NServiceBus.Hosting.Helpers
         bool IsAllowedType(Type type) =>
             type is { IsValueType: false } &&
             Attribute.GetCustomAttribute(type, typeof(CompilerGeneratedAttribute), false) == null &&
-            !TypesToSkip.Contains(type);
+            !typesToSkip.Contains(type);
 
         void AddTypesToResult(Assembly assembly, AssemblyScannerResults results)
         {
@@ -372,11 +382,11 @@ namespace NServiceBus.Hosting.Helpers
             return !IsExcluded(assemblyName.Name);
         }
 
-        internal HashSet<string> AssembliesToSkip = new(StringComparer.OrdinalIgnoreCase);
         internal bool ScanNestedDirectories;
-        internal HashSet<Type> TypesToSkip = new();
         readonly Assembly assemblyToScan;
         readonly string baseDirectoryToScan;
+        HashSet<Type> typesToSkip = new();
+        HashSet<string> asssembliesToSkip = new(StringComparer.OrdinalIgnoreCase);
         const string NServicebusCoreAssemblyName = "NServiceBus.Core";
 
         static readonly string[] FileSearchPatternsToUse =

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -51,11 +51,11 @@ namespace NServiceBus.Hosting.Helpers
         /// </summary>
         public bool ScanFileSystemAssemblies { get; set; } = true;
 
-        internal string CoreAssemblyName { get; set; } = NServicebusCoreAssemblyName;
+        internal string CoreAssemblyName { get; set; } = NServiceBusCoreAssemblyName;
 
         internal IReadOnlyCollection<string> AssembliesToSkip
         {
-            set => asssembliesToSkip = new HashSet<string>(value.Select(Path.GetFileNameWithoutExtension), StringComparer.OrdinalIgnoreCase);
+            set => assembliesToSkip = new HashSet<string>(value.Select(Path.GetFileNameWithoutExtension), StringComparer.OrdinalIgnoreCase);
         }
 
         internal IReadOnlyCollection<Type> TypesToSkip
@@ -313,7 +313,7 @@ namespace NServiceBus.Hosting.Helpers
         }
 
         bool IsExcluded(string assemblyNameOrFileNameWithoutExtension) =>
-            asssembliesToSkip.Contains(assemblyNameOrFileNameWithoutExtension) ||
+            assembliesToSkip.Contains(assemblyNameOrFileNameWithoutExtension) ||
             DefaultAssemblyExclusions.Contains(assemblyNameOrFileNameWithoutExtension);
 
         // The input and output signature of this method is deliberate
@@ -387,8 +387,8 @@ namespace NServiceBus.Hosting.Helpers
         readonly Assembly assemblyToScan;
         readonly string baseDirectoryToScan;
         HashSet<Type> typesToSkip = new();
-        HashSet<string> asssembliesToSkip = new(StringComparer.OrdinalIgnoreCase);
-        const string NServicebusCoreAssemblyName = "NServiceBus.Core";
+        HashSet<string> assembliesToSkip = new(StringComparer.OrdinalIgnoreCase);
+        const string NServiceBusCoreAssemblyName = "NServiceBus.Core";
 
         static readonly string[] FileSearchPatternsToUse =
         {

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -397,7 +397,6 @@ namespace NServiceBus.Hosting.Helpers
             "*.exe"
         };
 
-        //TODO: delete when we make message scanning lazy #1617
         static readonly HashSet<string> DefaultAssemblyExclusions = new(StringComparer.OrdinalIgnoreCase)
         {
             // NSB Build-Dependencies

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -312,10 +312,12 @@ namespace NServiceBus.Hosting.Helpers
             return fileInfo;
         }
 
-        bool IsExcluded(string assemblyNameOrFileName) => AssembliesToSkip.Contains(assemblyNameOrFileName) || DefaultAssemblyExclusions.Contains(assemblyNameOrFileName);
+        bool IsExcluded(string assemblyNameOrFileNameWithoutExtension) =>
+            asssembliesToSkip.Contains(assemblyNameOrFileNameWithoutExtension) ||
+            DefaultAssemblyExclusions.Contains(assemblyNameOrFileNameWithoutExtension);
 
         // The input and output signature of this method is deliberate
-        List<Type> AllowedTypes(Type[] types)
+        List<Type> FilterAllowedTypes(Type[] types)
         {
             // assume the majority of types will be allowed to preallocate the list
             var allowedTypes = new List<Type>(types.Length);
@@ -340,7 +342,7 @@ namespace NServiceBus.Hosting.Helpers
             {
                 //will throw if assembly cannot be loaded
                 var types = assembly.GetTypes();
-                results.Types.AddRange(AllowedTypes(types));
+                results.Types.AddRange(FilterAllowedTypes(types));
             }
             catch (ReflectionTypeLoadException e)
             {
@@ -353,7 +355,7 @@ namespace NServiceBus.Hosting.Helpers
                 }
 
                 LogManager.GetLogger<AssemblyScanner>().Warn(errorMessage);
-                results.Types.AddRange(AllowedTypes(e.Types));
+                results.Types.AddRange(FilterAllowedTypes(e.Types));
             }
             results.Assemblies.Add(assembly);
         }

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -297,10 +297,7 @@ namespace NServiceBus.Hosting.Helpers
             var searchOption = scanNestedDirectories ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
             foreach (var searchPattern in FileSearchPatternsToUse)
             {
-                foreach (var info in baseDir.GetFiles(searchPattern, searchOption))
-                {
-                    fileInfo.Add(info);
-                }
+                fileInfo.AddRange(baseDir.GetFiles(searchPattern, searchOption));
             }
             return fileInfo;
         }

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -320,21 +320,20 @@ namespace NServiceBus.Hosting.Helpers
         }
 
         static bool IsMatch(string expression1, string expression2)
-            => DistillLowerAssemblyName(expression1) == DistillLowerAssemblyName(expression2);
+            => string.Equals(RemoveFileExtensionIfNecessary(expression1), RemoveFileExtensionIfNecessary(expression2), StringComparison.OrdinalIgnoreCase);
 
         bool IsAllowedType(Type type) =>
             type is { IsValueType: false } &&
             Attribute.GetCustomAttribute(type, typeof(CompilerGeneratedAttribute), false) == null &&
             !TypesToSkip.Contains(type);
 
-        static string DistillLowerAssemblyName(string assemblyOrFileName)
+        static string RemoveFileExtensionIfNecessary(string assemblyOrFileName)
         {
-            var lowerAssemblyName = assemblyOrFileName.ToLowerInvariant();
-            if (lowerAssemblyName.EndsWith(".dll") || lowerAssemblyName.EndsWith(".exe"))
+            if (assemblyOrFileName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || assemblyOrFileName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
             {
-                lowerAssemblyName = lowerAssemblyName.Substring(0, lowerAssemblyName.Length - 4);
+                return assemblyOrFileName[..^4];
             }
-            return lowerAssemblyName;
+            return assemblyOrFileName;
         }
 
         void AddTypesToResult(Assembly assembly, AssemblyScannerResults results)

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -374,8 +374,7 @@ namespace NServiceBus.Hosting.Helpers
                 return false;
             }
 
-            var tokenString = Convert.ToHexString(assemblyName.GetPublicKeyToken() ?? Array.Empty<byte>());
-            if (AssemblyValidator.IsRuntimeAssembly(tokenString))
+            if (AssemblyValidator.IsRuntimeAssembly(assemblyName))
             {
                 return false;
             }

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -156,7 +156,7 @@ namespace NServiceBus.Hosting.Helpers
                 return false;
             }
 
-            assemblyValidator.ValidateAssemblyFile(assemblyPath, out var shouldLoad, out var reason);
+            AssemblyValidator.ValidateAssemblyFile(assemblyPath, out var shouldLoad, out var reason);
 
             if (!shouldLoad)
             {
@@ -400,7 +400,6 @@ namespace NServiceBus.Hosting.Helpers
             return true;
         }
 
-        readonly AssemblyValidator assemblyValidator = new();
         internal List<string> AssembliesToSkip = new();
         internal bool ScanNestedDirectories;
         internal List<Type> TypesToSkip = new();

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -248,7 +248,7 @@ namespace NServiceBus.Hosting.Helpers
         {
             var sb = new StringBuilder($"Could not enumerate all types for '{fileName}'.");
 
-            if (!e.LoaderExceptions.Any())
+            if (e.LoaderExceptions.Length == 0)
             {
                 sb.NewLine($"Exception message: {e}");
                 return sb.ToString();

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -320,9 +320,7 @@ namespace NServiceBus.Hosting.Helpers
         }
 
         static bool IsMatch(string expression1, string expression2)
-        {
-            return DistillLowerAssemblyName(expression1) == DistillLowerAssemblyName(expression2);
-        }
+            => DistillLowerAssemblyName(expression1) == DistillLowerAssemblyName(expression2);
 
         bool IsAllowedType(Type type)
         {

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -322,18 +322,10 @@ namespace NServiceBus.Hosting.Helpers
         static bool IsMatch(string expression1, string expression2)
             => DistillLowerAssemblyName(expression1) == DistillLowerAssemblyName(expression2);
 
-        bool IsAllowedType(Type type)
-        {
-            return type != null &&
-                   !type.IsValueType &&
-                   !IsCompilerGenerated(type) &&
-                   !TypesToSkip.Contains(type);
-        }
-
-        static bool IsCompilerGenerated(Type type)
-        {
-            return type.GetCustomAttribute<CompilerGeneratedAttribute>(false) != null;
-        }
+        bool IsAllowedType(Type type) =>
+            type is { IsValueType: false } &&
+            Attribute.GetCustomAttribute(type, typeof(CompilerGeneratedAttribute), false) == null &&
+            !TypesToSkip.Contains(type);
 
         static string DistillLowerAssemblyName(string assemblyOrFileName)
         {

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -304,16 +304,20 @@ namespace NServiceBus.Hosting.Helpers
 
         bool IsExcluded(string assemblyNameOrFileName)
         {
-            var isExplicitlyExcluded = AssembliesToSkip.Any(excluded => IsMatch(excluded, assemblyNameOrFileName));
-            if (isExplicitlyExcluded)
+            foreach (var explicitlyExcludedAssembly in AssembliesToSkip)
             {
-                return true;
+                if (IsMatch(explicitlyExcludedAssembly, assemblyNameOrFileName))
+                {
+                    return true;
+                }
             }
-
-            var isExcludedByDefault = DefaultAssemblyExclusions.Any(exclusion => IsMatch(exclusion, assemblyNameOrFileName));
-            if (isExcludedByDefault)
+            
+            foreach (var excludedByDefaultAssembly in DefaultAssemblyExclusions)
             {
-                return true;
+                if (IsMatch(excludedByDefaultAssembly, assemblyNameOrFileName))
+                {
+                    return true;
+                }
             }
 
             return false;

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -260,7 +260,7 @@ namespace NServiceBus.Hosting.Helpers
 
             foreach (var ex in e.LoaderExceptions)
             {
-                if (ex is FileLoadException loadException && loadException.FileName != null)
+                if (ex is FileLoadException { FileName: not null } loadException)
                 {
                     if (!files.Contains(loadException.FileName))
                     {

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -392,7 +392,8 @@ namespace NServiceBus.Hosting.Helpers
                 return false;
             }
 
-            if (AssemblyValidator.IsRuntimeAssembly(assemblyName.GetPublicKeyToken()))
+            var tokenString = Convert.ToHexString(assemblyName.GetPublicKeyToken() ?? Array.Empty<byte>());
+            if (AssemblyValidator.IsRuntimeAssembly(tokenString))
             {
                 return false;
             }

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -389,7 +389,7 @@ namespace NServiceBus.Hosting.Helpers
 
         internal List<string> AssembliesToSkip = new();
         internal bool ScanNestedDirectories;
-        internal List<Type> TypesToSkip = new();
+        internal HashSet<Type> TypesToSkip = new();
         readonly Assembly assemblyToScan;
         readonly string baseDirectoryToScan;
         const string NServicebusCoreAssemblyName = "NServiceBus.Core";

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -316,7 +316,8 @@ namespace NServiceBus.Hosting.Helpers
             assembliesToSkip.Contains(assemblyNameOrFileNameWithoutExtension) ||
             DefaultAssemblyExclusions.Contains(assemblyNameOrFileNameWithoutExtension);
 
-        // The input and output signature of this method is deliberate
+        // The parameter and return types of this method are deliberately using the most concrete types
+        // to avoid unnecessary allocations
         List<Type> FilterAllowedTypes(Type[] types)
         {
             // assume the majority of types will be allowed to preallocate the list

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
@@ -68,7 +68,7 @@ namespace NServiceBus
             ExcludedTypes.AddRange(types);
         }
 
-        internal List<string> ExcludedAssemblies { get; } = new List<string>(0);
-        internal List<Type> ExcludedTypes { get; } = new List<Type>(0);
+        internal List<string> ExcludedAssemblies { get; } = new(0);
+        internal List<Type> ExcludedTypes { get; } = new(0);
     }
 }

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
@@ -3,9 +3,9 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using Settings;
-    using Hosting.Helpers;
     using System.Reflection;
+    using Hosting.Helpers;
+    using Settings;
 
     class AssemblyScanningComponent
     {

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
     using Settings;
     using Hosting.Helpers;
@@ -32,8 +31,8 @@
 
             var assemblyScannerSettings = configuration.AssemblyScannerConfiguration;
 
-            assemblyScanner.AssembliesToSkip = new HashSet<string>(assemblyScannerSettings.ExcludedAssemblies.Select(Path.GetFileNameWithoutExtension).ToArray(), StringComparer.OrdinalIgnoreCase);
-            assemblyScanner.TypesToSkip = new HashSet<Type>(assemblyScannerSettings.ExcludedTypes);
+            assemblyScanner.AssembliesToSkip = assemblyScannerSettings.ExcludedAssemblies;
+            assemblyScanner.TypesToSkip = assemblyScannerSettings.ExcludedTypes;
             assemblyScanner.ScanNestedDirectories = assemblyScannerSettings.ScanAssembliesInNestedDirectories;
             assemblyScanner.ThrowExceptions = assemblyScannerSettings.ThrowExceptions;
             assemblyScanner.ScanFileSystemAssemblies = assemblyScannerSettings.ScanFileSystemAssemblies;

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
@@ -67,19 +67,13 @@
             return new AssemblyScanningComponent(availableTypes);
         }
 
-        AssemblyScanningComponent(List<Type> availableTypes)
-        {
-            AvailableTypes = availableTypes;
-        }
+        AssemblyScanningComponent(List<Type> availableTypes) => AvailableTypes = availableTypes;
 
         public List<Type> AvailableTypes { get; }
 
         public class Configuration
         {
-            public Configuration(SettingsHolder settings)
-            {
-                this.settings = settings;
-            }
+            public Configuration(SettingsHolder settings) => this.settings = settings;
 
             public List<Type> UserProvidedTypes { get; set; }
 
@@ -87,10 +81,7 @@
 
             public IList<Type> AvailableTypes => settings.Get<IList<Type>>(TypesToScanSettingsKey);
 
-            public void SetDefaultAvailableTypes(IList<Type> scannedTypes)
-            {
-                settings.SetDefault(TypesToScanSettingsKey, scannedTypes);
-            }
+            public void SetDefaultAvailableTypes(IList<Type> scannedTypes) => settings.SetDefault(TypesToScanSettingsKey, scannedTypes);
 
             readonly SettingsHolder settings;
 

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
     using System.Linq;
     using Settings;
     using Hosting.Helpers;
@@ -31,7 +32,7 @@
 
             var assemblyScannerSettings = configuration.AssemblyScannerConfiguration;
 
-            assemblyScanner.AssembliesToSkip = assemblyScannerSettings.ExcludedAssemblies;
+            assemblyScanner.AssembliesToSkip = new HashSet<string>(assemblyScannerSettings.ExcludedAssemblies.Select(Path.GetFileNameWithoutExtension).ToArray(), StringComparer.OrdinalIgnoreCase);
             assemblyScanner.TypesToSkip = new HashSet<Type>(assemblyScannerSettings.ExcludedTypes);
             assemblyScanner.ScanNestedDirectories = assemblyScannerSettings.ScanAssembliesInNestedDirectories;
             assemblyScanner.ThrowExceptions = assemblyScannerSettings.ThrowExceptions;

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
@@ -32,7 +32,7 @@
             var assemblyScannerSettings = configuration.AssemblyScannerConfiguration;
 
             assemblyScanner.AssembliesToSkip = assemblyScannerSettings.ExcludedAssemblies;
-            assemblyScanner.TypesToSkip = assemblyScannerSettings.ExcludedTypes;
+            assemblyScanner.TypesToSkip = new HashSet<Type>(assemblyScannerSettings.ExcludedTypes);
             assemblyScanner.ScanNestedDirectories = assemblyScannerSettings.ScanAssembliesInNestedDirectories;
             assemblyScanner.ThrowExceptions = assemblyScannerSettings.ThrowExceptions;
             assemblyScanner.ScanFileSystemAssemblies = assemblyScannerSettings.ScanFileSystemAssemblies;

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
@@ -47,30 +47,23 @@
             reason = "File is a .NET assembly.";
         }
 
-        static byte[] GetPublicKeyToken(byte[] publicKey)
+        static string GetPublicKeyToken(byte[] publicKey)
         {
             using var sha1 = SHA1.Create();
-            var hash = sha1.ComputeHash(publicKey);
-            var publicKeyToken = new byte[8];
-
-            for (var i = 0; i < 8; i++)
-            {
-                publicKeyToken[i] = hash[^(i + 1)];
-            }
-
-            return publicKeyToken;
+            Span<byte> publicKeyToken = stackalloc byte[20];
+            // returns false when the destination doesn't have enough space
+            _ = sha1.TryComputeHash(publicKey, publicKeyToken, out _);
+            Span<byte> lastEightBytes = publicKeyToken.Slice(publicKeyToken.Length - 8, 8);
+            lastEightBytes.Reverse();
+            return Convert.ToHexString(lastEightBytes);
         }
 
-        public static bool IsRuntimeAssembly(byte[] publicKeyToken)
-        {
-            var tokenString = BitConverter.ToString(publicKeyToken).Replace("-", string.Empty).ToLowerInvariant();
-
-            return tokenString switch
+        public static bool IsRuntimeAssembly(string tokenString) =>
+            tokenString switch
             {
                 // Microsoft tokens
-                "b77a5c561934e089" or "7cec85d7bea7798e" or "b03f5f7f11d50a3a" or "31bf3856ad364e35" or "cc7b13ffcd2ddd51" or "adb9793829ddae60" or "7e34167dcc6d6d8c" or "23ec7fc2d6eaa4a5" => true,
+                "B77A5C561934E089" or "7CEC85D7BEA7798E" or "B03F5F7F11D50A3A" or "31BF3856AD364E35" or "CC7B13FFCD2DDD51" or "ADB9793829DDAE60" or "7E34167DCC6D6D8C" or "23EC7FC2D6EAA4A5" => true,
                 _ => false,
             };
-        }
     }
 }

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.IO;
+    using System.Reflection;
     using System.Reflection.Metadata;
     using System.Reflection.PortableExecutable;
     using System.Security.Cryptography;
@@ -47,6 +48,12 @@
             reason = "File is a .NET assembly.";
         }
 
+        public static bool IsRuntimeAssembly(AssemblyName assemblyName)
+        {
+            var tokenString = Convert.ToHexString(assemblyName.GetPublicKeyToken() ?? Array.Empty<byte>());
+            return IsRuntimeAssembly(tokenString);
+        }
+
         static string GetPublicKeyToken(byte[] publicKey)
         {
             using var sha1 = SHA1.Create();
@@ -58,7 +65,7 @@
             return Convert.ToHexString(lastEightBytes);
         }
 
-        public static bool IsRuntimeAssembly(string tokenString) =>
+        static bool IsRuntimeAssembly(string tokenString) =>
             tokenString switch
             {
                 // Microsoft tokens


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus/issues/6820

Improves the assembly scanner performance in "regular cases" slightly and in cases when the exclusion list is larger, up to 4 times.

I was doing some investigations for a customer that mentioned they are seeing slow startup times in their rather large solution. Once I was able to get my hands on the profiler data it was apparent that the `IsExcluded` check is the culprit. 

## Scenarios

I have created a [solution generator](https://github.com/danielmarbach/NServiceBusAssemblyScanning) that allows simulating arbitrary solution sizes. As a reference point, I created a solution with roughly 960 projects and more than 140K types. 

### Without Exclusions

#### Before

![image](https://github.com/Particular/NServiceBus/assets/174258/79515641-5f74-4e17-aec7-a0061eb7f4ac)


#### After

![image](https://github.com/Particular/NServiceBus/assets/174258/8c75e2f2-d50f-4447-9b3f-7ad8c17d4b64)


### With a larger number of exclusions

#### Before

![image](https://github.com/Particular/NServiceBus/assets/174258/d832902b-0279-4d58-8d40-22a1deabca20)

Here is the excerpt from the customer callstack

![image](https://github.com/Particular/NServiceBus/assets/174258/00c142f5-afba-4d49-b19f-276e2799c635)


#### After

![image](https://github.com/Particular/NServiceBus/assets/174258/c3ff4de9-3b23-4e58-9e53-7ac51e463365)

## Benchmarks

### Attribute.GetCustomAttribute

|         Method |       Mean |     Error |    StdDev |     Median | Ratio | RatioSD |
|--------------- |-----------:|----------:|----------:|-----------:|------:|--------:|
|           Type | 1,148.2 ns | 135.51 ns | 386.63 ns | 1,010.9 ns |  1.00 |    0.00 |
| AttributeBased |   804.7 ns |  12.05 ns |  11.27 ns |   801.7 ns |  0.99 |    0.20 |

### Matching Strings

|                Method |            Input |      Mean |    Error |   StdDev | Ratio |  Gen 0 | Allocated |
|---------------------- |----------------- |----------:|---------:|---------:|------:|-------:|----------:|
|         **MatchOriginal** |     **SomeAssembly** | **146.94 ns** | **0.815 ns** | **0.680 ns** |  **1.00** | **0.0010** |      **96 B** |
|        MatchOptimized |     SomeAssembly |  28.90 ns | 0.441 ns | 0.368 ns |  0.20 |      - |         - |
| MatchOptimizedHashSet |     SomeAssembly |  17.72 ns | 0.057 ns | 0.047 ns |  0.12 |      - |         - |
|                       |                  |           |          |          |       |        |           |
|         **MatchOriginal** | **SomeAssembly.Dll** | **149.63 ns** | **2.527 ns** | **2.363 ns** |  **1.00** | **0.0024** |     **208 B** |
|        MatchOptimized | SomeAssembly.Dll |  59.56 ns | 0.504 ns | 0.447 ns |  0.40 | 0.0011 |      96 B |
| MatchOptimizedHashSet | SomeAssembly.Dll |  11.01 ns | 0.106 ns | 0.089 ns |  0.07 |      - |         - |
|                       |                  |           |          |          |       |        |           |
|         **MatchOriginal** | **SomeAssembly.Exe** | **184.95 ns** | **1.662 ns** | **1.473 ns** |  **1.00** | **0.0024** |     **208 B** |
|        MatchOptimized | SomeAssembly.Exe |  72.69 ns | 0.963 ns | 0.901 ns |  0.39 | 0.0011 |      96 B |
| MatchOptimizedHashSet | SomeAssembly.Exe |  10.87 ns | 0.038 ns | 0.036 ns |  0.06 |      - |         - |


### PublicKeyValidation

| Method |       Mean |    Error |   StdDev | Ratio |  Gen 0 | Allocated |
|------- |-----------:|---------:|---------:|------:|-------:|----------:|
| Before | 1,157.2 ns | 13.39 ns | 12.53 ns |  1.00 | 0.0687 |     432 B |
|  After |   842.8 ns |  7.07 ns |  5.90 ns |  0.73 | 0.0277 |     176 B |