### PR TITLE
Startup diagnostic serialization fails when diagnostic entries include System.Type properties

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/DiagnosticsWriterTests.ShouldWriteEntriesWithTypesUsingTheFullName.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/DiagnosticsWriterTests.ShouldWriteEntriesWithTypesUsingTheFullName.approved.txt
@@ -1,0 +1,1 @@
+{"TypeIndicator":{"SomeType":"NServiceBus.Core.Tests.OpenTelemetry.DiagnosticsWriterTests"}}

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/DiagnosticsWriterTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/DiagnosticsWriterTests.cs
@@ -29,5 +29,24 @@ namespace NServiceBus.Core.Tests.OpenTelemetry
 
             Approver.Verify(output);
         }
+
+        [Test]
+        public async Task ShouldWriteEntriesWithTypesUsingTheFullName()
+        {
+            var output = string.Empty;
+            var testWriter = new Func<string, CancellationToken, Task>((diagnosticOutput, _) =>
+            {
+                output = diagnosticOutput;
+                return Task.CompletedTask;
+            });
+            var diagnostics = new StartupDiagnosticEntries();
+            diagnostics.Add("TypeIndicator", new { SomeType = typeof(DiagnosticsWriterTests) });
+
+            var writer = new HostStartupDiagnosticsWriter(testWriter, true);
+
+            await writer.Write(diagnostics.entries);
+
+            Approver.Verify(output);
+        }
     }
 }


### PR DESCRIPTION
- Fixes https://github.com/Particular/NServiceBus/issues/6813