### PR TITLE
AssemblyNames containing a dot without file extensions cannot be excluded in the assembly scanner

### DIFF
--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_exclusion_predicate_is_used.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_exclusion_predicate_is_used.cs
@@ -29,5 +29,22 @@
             Assert.That(explicitlySkippedDll, Is.Not.Null);
             Assert.That(explicitlySkippedDll.SkipReason, Contains.Substring("File was explicitly excluded from scanning"));
         }
+
+        [Test]
+        public void Assemblies_that_have_no_extension_can_be_excluded()
+        {
+            var results = new AssemblyScanner(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestDlls"))
+            {
+                AssembliesToSkip = new List<string> { "some.random" },
+                ScanAppDomainAssemblies = false
+            }
+            .GetScannableAssemblies();
+
+            var skippedFiles = results.SkippedFiles;
+            var explicitlySkippedDll = skippedFiles.FirstOrDefault(s => s.FilePath.Contains("some.random.dll"));
+
+            Assert.That(explicitlySkippedDll, Is.Not.Null);
+            Assert.That(explicitlySkippedDll.SkipReason, Contains.Substring("File was explicitly excluded from scanning"));
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/TestDlls/some.random.dll
+++ b/src/NServiceBus.Core.Tests/TestDlls/some.random.dll
@@ -1,0 +1,1 @@
+this is not a DLL

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -57,8 +57,13 @@ namespace NServiceBus.Hosting.Helpers
 
         internal IReadOnlyCollection<string> AssembliesToSkip
         {
-            set => assembliesToSkip = new HashSet<string>(value.Select(Path.GetFileNameWithoutExtension), StringComparer.OrdinalIgnoreCase);
+            set => assembliesToSkip = new HashSet<string>(value.Select(RemoveExtension), StringComparer.OrdinalIgnoreCase);
         }
+
+        static string RemoveExtension(string assemblyName) =>
+            assemblyName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) || assemblyName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)
+                ? Path.GetFileNameWithoutExtension(assemblyName)
+                : assemblyName;
 
         internal IReadOnlyCollection<Type> TypesToSkip
         {
@@ -349,9 +354,7 @@ namespace NServiceBus.Hosting.Helpers
             return fileInfo;
         }
 
-        bool IsExcluded(string assemblyNameOrFileNameWithoutExtension) =>
-            assembliesToSkip.Contains(assemblyNameOrFileNameWithoutExtension) ||
-            DefaultAssemblyExclusions.Contains(assemblyNameOrFileNameWithoutExtension);
+        bool IsExcluded(string assemblyName) => assembliesToSkip.Contains(assemblyName) || DefaultAssemblyExclusions.Contains(assemblyName);
 
         // The parameter and return types of this method are deliberately using the most concrete types
         // to avoid unnecessary allocations


### PR DESCRIPTION
- Backport of https://github.com/Particular/NServiceBus/pull/6834 to `release-8.0`