### PR TITLE
Optimize PathUtilities.Sanitize() and DeterministicGuid.Create()

### DIFF
--- a/src/NServiceBus.Core/Utils/DeterministicGuid.cs
+++ b/src/NServiceBus.Core/Utils/DeterministicGuid.cs
@@ -6,16 +6,19 @@
 
     static class DeterministicGuid
     {
-        public static Guid Create(params object[] data)
+        public static Guid Create(string data1, string data2) => Create($"{data1}{data2}");
+
+        public static Guid Create(string data)
         {
             // use MD5 hash to get a 16-byte hash of the string
-            using (var provider = MD5.Create())
-            {
-                var inputBytes = Encoding.Default.GetBytes(string.Concat(data));
-                var hashBytes = provider.ComputeHash(inputBytes);
-                // generate a guid from the hash:
-                return new Guid(hashBytes);
-            }
+            var inputBytes = Encoding.Default.GetBytes(data);
+
+            Span<byte> hashBytes = stackalloc byte[16];
+
+            _ = MD5.HashData(inputBytes, hashBytes);
+
+            // generate a guid from the hash:
+            return new Guid(hashBytes);
         }
     }
 }

--- a/src/NServiceBus.Core/Utils/PathUtilities.cs
+++ b/src/NServiceBus.Core/Utils/PathUtilities.cs
@@ -1,19 +1,29 @@
 ﻿namespace NServiceBus
 {
-    using System.Linq;
-    using System.Text.RegularExpressions;
+    using System;
 
     static class PathUtilities
     {
         public static string SanitizedPath(string commandLine)
         {
-            if (commandLine.StartsWith("\""))
+            if (commandLine.StartsWith('"'))
             {
-                return (from Match match in Regex.Matches(commandLine, "\"([^\"]*)\"")
-                        select match.ToString()).First().Trim('"');
+                var nextIndex = commandLine.IndexOf('"', 1);
+                if (nextIndex == -1)
+                {
+                    throw new FormatException("The provided path is in an invalid format");
+                }
+
+                return commandLine[1..nextIndex];
             }
 
-            return commandLine.Split(' ').First();
+            var firstSpace = commandLine.IndexOf(' ');
+            if (firstSpace == -1)
+            {
+                return commandLine;
+            }
+
+            return commandLine[..firstSpace];
         }
     }
 }


### PR DESCRIPTION
I found two low-hanging fruit for optimization within the Utils namespace. I've put these up as one PR but please let me know if you'd prefer separate. I've also relied mostly on preexisting unit tests for these but I'm happy to add more to support the changes if you like. PathUtilities has some dedicated unit test coverage in place already which could be expanded, however it looks like DeterministicGuid's existing coverage is mostly through other means.

## DeterministicGuid.Create()
The changes here are mostly around using the new one-shot hash function and using a `Span<byte>` rather than having an additional returned array to deal with.

**Benchmarks**
```
| Method   | Mean     | Error   | StdDev  | Ratio | Gen0   | Allocated | Alloc Ratio |
|--------- |---------:|--------:|--------:|------:|-------:|----------:|------------:|
| Original | 352.5 ns | 2.35 ns | 2.08 ns |  1.00 | 0.0596 |     376 B |        1.00 |
| V2       | 200.0 ns | 0.51 ns | 0.43 ns |  0.57 | 0.0138 |      88 B |        0.23 |
```

<details>
  <summary>Benchmark Code</summary>

  ```csharp
 [MemoryDiagnoser]
public class DeterministicGuidBenchmarks
{
    [Benchmark(Baseline = true)]
    public Guid Original() => DeterministicGuid_Original.Create("Instance", "Host");

    [Benchmark]
    public Guid V2() => DeterministicGuidV2.Create("Instance", "Host");

    static class DeterministicGuid_Original
    {
        public static Guid Create(params object[] data)
        {
            // use MD5 hash to get a 16-byte hash of the string
            using (var provider = MD5.Create())
            {
                var inputBytes = Encoding.Default.GetBytes(string.Concat(data));
                var hashBytes = provider.ComputeHash(inputBytes);
                // generate a guid from the hash:
                return new Guid(hashBytes);
            }
        }
    }
    
    static class DeterministicGuidV2
    {
        public static Guid Create(string data1, string data2) => Create($"{data1}{data2}");

        public static Guid Create(string data)
        {
            // use MD5 hash to get a 16-byte hash of the string
            var inputBytes = Encoding.Default.GetBytes(data);

            Span<byte> hashBytes = stackalloc byte[16];

            _ = MD5.HashData(inputBytes, hashBytes);

            // generate a guid from the hash:
            return new Guid(hashBytes);
        }
    }
}
  ```
</details>

## PathUtilities.Sanitize()
The function seemed to mostly handle two scenarios:
- Extract out a quote-encapsulated part of a string if the string began with a double quote
- Else, return everything before the first space is encountered (or the whole string if none exists)

Some LINQ and a regex were removed here to convert the above rules to plain-old C#. I tried a source generator regex approach as well (including the start-of-line anchor) but it was an order of magnitude slower than the hand-rolled solution.

**Benchmarks**
```
| Method   | Mean       | Error     | StdDev    | Ratio | Gen0   | Gen1   | Allocated | Alloc Ratio |
|--------- |-----------:|----------:|----------:|------:|-------:|-------:|----------:|------------:|
| Original | 231.144 ns | 1.6449 ns | 1.4581 ns |  1.00 | 0.1349 | 0.0002 |     848 B |        1.00 |
| V2       |   6.969 ns | 0.0458 ns | 0.0406 ns |  0.03 | 0.0115 |      - |      72 B |        0.08 |
```

<details>
  <summary>Benchmark Code</summary>

  ```csharp
 [MemoryDiagnoser]
public class PathUtilitiesBenchmarks
{
    private const string Input = "\"pathto\\mysuper duper.exe\" \"somevar with spaces\"";

    [Benchmark(Baseline = true)]
    public string Original() => PathUtilities_Original.SanitizedPath(Input);

    [Benchmark]
    public string V2() => PathUtilities_V2.SanitizedPath(Input);

    static class PathUtilities_V2
    {
        public static string SanitizedPath(string commandLine)
        {
            if (commandLine.StartsWith('"'))
            {
                var nextIndex = commandLine.IndexOf('"', 1);
                if (nextIndex == -1)
                {
                    throw new FormatException("The provided path is in an invalid format");
                }

                return commandLine[1..nextIndex];
            }

            var firstSpace = commandLine.IndexOf(' ');
            if (firstSpace == -1)
            {
                return commandLine;
            }

            return commandLine[..firstSpace];
        }
    }


    static class PathUtilities_Original
    {
        public static string SanitizedPath(string commandLine)
        {
            if (commandLine.StartsWith("\""))
            {
                return (from Match match in Regex.Matches(commandLine, "\"([^\"]*)\"")
                        select match.ToString()).First().Trim('"');
            }

            return commandLine.Split(' ').First();
        }
    }
}
  ```
</details>