### PR TITLE
Utils improvements

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>NServiceBus</RootNamespace>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBus.snk</AssemblyOriginatorKeyFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup Label="Public dependencies">

--- a/src/NServiceBus.Core/Utils/DeterministicGuid.cs
+++ b/src/NServiceBus.Core/Utils/DeterministicGuid.cs
@@ -6,16 +6,19 @@
 
     static class DeterministicGuid
     {
-        public static Guid Create(params object[] data)
+        public static Guid Create(string data1, string data2) => Create($"{data1}{data2}");
+
+        public static Guid Create(string data)
         {
             // use MD5 hash to get a 16-byte hash of the string
-            using (var provider = MD5.Create())
-            {
-                var inputBytes = Encoding.Default.GetBytes(string.Concat(data));
-                var hashBytes = provider.ComputeHash(inputBytes);
-                // generate a guid from the hash:
-                return new Guid(hashBytes);
-            }
+            var inputBytes = Encoding.Default.GetBytes(data);
+
+            Span<byte> hashBytes = stackalloc byte[16];
+
+            _ = MD5.HashData(inputBytes, hashBytes);
+
+            // generate a guid from the hash:
+            return new Guid(hashBytes);
         }
     }
 }

--- a/src/NServiceBus.Core/Utils/PathUtilities.cs
+++ b/src/NServiceBus.Core/Utils/PathUtilities.cs
@@ -1,19 +1,29 @@
 ﻿namespace NServiceBus
 {
-    using System.Linq;
-    using System.Text.RegularExpressions;
+    using System;
 
     static class PathUtilities
     {
         public static string SanitizedPath(string commandLine)
         {
-            if (commandLine.StartsWith("\""))
+            if (commandLine.StartsWith('"'))
             {
-                return (from Match match in Regex.Matches(commandLine, "\"([^\"]*)\"")
-                        select match.ToString()).First().Trim('"');
+                var nextIndex = commandLine.IndexOf('"', 1);
+                if (nextIndex == -1)
+                {
+                    throw new FormatException("The provided path is in an invalid format");
+                }
+
+                return commandLine[1..nextIndex];
             }
 
-            return commandLine.Split(' ').First();
+            var firstSpace = commandLine.IndexOf(' ');
+            if (firstSpace == -1)
+            {
+                return commandLine;
+            }
+
+            return commandLine[..firstSpace];
         }
     }
 }


### PR DESCRIPTION
Incorporates https://github.com/Particular/NServiceBus/pull/6843

|   Method |              input1 |              input2 |       Mean |    Error |   StdDev | Ratio |  Gen 0 | Allocated |
|--------- |-------------------- |-------------------- |-----------:|---------:|---------:|------:|-------:|----------:|
| Original |            Instance |                Host | 1,237.7 ns | 23.49 ns | 23.07 ns |  1.00 | 0.0038 |     368 B |
|       V2 |            Instance |                Host |   542.0 ns |  6.28 ns |  5.57 ns |  0.44 | 0.0010 |      88 B |
|       V3 |            Instance |                Host |   501.0 ns |  3.96 ns |  3.51 ns |  0.41 |      - |      48 B |
|          |                     |                     |            |          |          |       |        |           |
| Original | Inst(...)ance [160] | Inst(...)ance [160] | 1,772.1 ns | 29.17 ns | 27.29 ns |  1.00 | 0.0153 |   1,288 B |
|       V2 | Inst(...)ance [160] | Inst(...)ance [160] | 1,032.9 ns |  6.24 ns |  5.21 ns |  0.58 | 0.0114 |   1,008 B |
|       V3 | Inst(...)ance [160] | Inst(...)ance [160] | 1,033.4 ns | 10.05 ns |  8.91 ns |  0.58 | 0.0076 |     664 B |

<details>
  <summary>Benchmark Code</summary>

```csharp
using System;
using System.Buffers;
using System.Collections.Generic;
using System.Runtime.CompilerServices;
using System.Security.Cryptography;
using System.Text;
using BenchmarkDotNet.Attributes;

namespace MicroBenchmarks.NServiceBus;

[MemoryDiagnoser]
public class DeterministicGuidBenchmarks
{
    public IEnumerable<object> Inputs()
    {
        yield return new object[] { "Instance", "Host" };
        yield return new object[] { "InstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstance", "InstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstanceInstance" };
    }
    
    [Benchmark(Baseline = true)]
    [ArgumentsSource(nameof(Inputs))]
    public Guid Original(string input1, string input2) => DeterministicGuid_Original.Create(input1, input2);

    [Benchmark]
    [ArgumentsSource(nameof(Inputs))]
    public Guid V2(string input1, string input2) => DeterministicGuidV2.Create(input1, input2);

    [Benchmark]
    [ArgumentsSource(nameof(Inputs))]
    public Guid V3(string input1, string input2) => DeterministicGuidV3.Create(input1, input2);
    static class DeterministicGuid_Original
    {
        public static Guid Create(params object[] data)
        {
            // use MD5 hash to get a 16-byte hash of the string
            using (var provider = MD5.Create())
            {
                var inputBytes = Encoding.Default.GetBytes(string.Concat(data));
                var hashBytes = provider.ComputeHash(inputBytes);
                // generate a guid from the hash:
                return new Guid(hashBytes);
            }
        }
    }
  
    static class DeterministicGuidV2
    {
        public static Guid Create(string data1, string data2) => Create($"{data1}{data2}");

        public static Guid Create(string data)
        {
            // use MD5 hash to get a 16-byte hash of the string
            var inputBytes = Encoding.Default.GetBytes(data);

            Span<byte> hashBytes = stackalloc byte[16];

            _ = MD5.HashData(inputBytes, hashBytes);

            // generate a guid from the hash:
            return new Guid(hashBytes);
        }
    }
    
    static class DeterministicGuidV3
    {
        public static Guid Create(string data1, string data2) => Create($"{data1}{data2}");

        [SkipLocalsInit]
        public static Guid Create(string data)
        {
            const int MaxStackLimit = 256;
            var encoding = Encoding.UTF8;
            var maxByteCount = encoding.GetMaxByteCount(data.Length);

            byte[]? sharedBuffer = null;
            var stringBufferSpan = maxByteCount <= MaxStackLimit ?
                stackalloc byte[MaxStackLimit] :
                sharedBuffer = ArrayPool<byte>.Shared.Rent(maxByteCount);

            try
            {
                var numberOfBytesWritten = encoding.GetBytes(data, stringBufferSpan);
                Span<byte> hashBytes = stackalloc byte[16];

                _ = MD5.HashData(stringBufferSpan[..numberOfBytesWritten], hashBytes);
                
                // generate a guid from the hash:
                return new Guid(hashBytes);
            }
            finally
            {
                if (sharedBuffer != null)
                {
                    ArrayPool<byte>.Shared.Return(sharedBuffer, clearArray: true);
                }
            }
        }
    }
}
```

</details>
