### PR TITLE
Transport concurrency test

### DIFF
--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -73,7 +73,10 @@
             testCancellationTokenSource.Dispose();
         }
 
-        protected async Task StartPump(OnMessage onMessage, OnError onError, TransportTransactionMode transactionMode, Action<string, Exception, CancellationToken> onCriticalError = null, CancellationToken cancellationToken = default)
+        protected async Task StartPump(OnMessage onMessage, OnError onError, TransportTransactionMode transactionMode,
+            Action<string, Exception, CancellationToken> onCriticalError = null,
+            PushRuntimeSettings pushRuntimeSettings = null,
+            CancellationToken cancellationToken = default)
         {
             onMessage = onMessage ?? throw new ArgumentNullException(nameof(onMessage));
             onError = onError ?? throw new ArgumentNullException(nameof(onError));
@@ -115,7 +118,7 @@
             receiver = transportInfrastructure.Receivers.Single().Value;
 
             await receiver.Initialize(
-                new PushRuntimeSettings(8),
+                pushRuntimeSettings ?? new PushRuntimeSettings(8),
                 (context, token) =>
                     context.Headers.Contains(TestIdHeaderName, testId) ? onMessage(context, token) : Task.CompletedTask,
                 (context, token) =>
@@ -230,6 +233,8 @@
 
             return testName;
         }
+
+        public CancellationToken TestTimeoutCancellationToken => testCancellationTokenSource.Token;
 
         protected string InputQueueName;
         protected string ErrorQueueName;

--- a/src/NServiceBus.TransportTests/When_multiple_messages_are_available.cs
+++ b/src/NServiceBus.TransportTests/When_multiple_messages_are_available.cs
@@ -34,9 +34,6 @@ public class When_multiple_messages_are_available : NServiceBusTransportTest
             await SendMessage(InputQueueName);
         }
 
-        TestContext.WriteLine("before assertion");
-
-        TestContext.WriteLine($"before await {DateTime.UtcNow:F}");
         // we need to wait because it might take a bit till the pump has invoked all pipelines?
         while (onMessageCalls.Count < concurrencyLevel)
         {

--- a/src/NServiceBus.TransportTests/When_multiple_messages_are_available.cs
+++ b/src/NServiceBus.TransportTests/When_multiple_messages_are_available.cs
@@ -1,0 +1,62 @@
+﻿namespace NServiceBus.TransportTests;
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Transport;
+
+public class When_multiple_messages_are_available : NServiceBusTransportTest
+{
+    [TestCase(TransportTransactionMode.None)]
+    [TestCase(TransportTransactionMode.ReceiveOnly)]
+    [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
+    [TestCase(TransportTransactionMode.TransactionScope)]
+    public async Task Should_invoke_on_message_in_parallel(TransportTransactionMode transactionMode)
+    {
+        const int concurrencyLevel = 10;
+        var onMessageCalls = new ConcurrentQueue<TaskCompletionSource>();
+
+        await StartPump(async (context, _) =>
+            {
+                var tcs = CreateTaskCompletionSource();
+                onMessageCalls.Enqueue(tcs);
+                // "block" current pipeline invocation
+                await tcs.Task;
+            },
+            (errorContext, __) => throw new Exception("unexpected error", errorContext.Exception),
+            transactionMode,
+            pushRuntimeSettings: new PushRuntimeSettings(concurrencyLevel));
+
+        for (int i = 0; i < concurrencyLevel * 2; i++)
+        {
+            await SendMessage(InputQueueName);
+        }
+
+        TestContext.WriteLine("before assertion");
+
+        TestContext.WriteLine($"before await {DateTime.UtcNow:F}");
+        // we need to wait because it might take a bit till the pump has invoked all pipelines?
+        while (onMessageCalls.Count < concurrencyLevel)
+        {
+            await Task.Delay(50, TestTimeoutCancellationToken);
+        }
+
+        Assert.AreEqual(concurrencyLevel, onMessageCalls.Count, "should not process more messages than configured at once");
+
+        // unblock pumps
+        int messagesProcessed = 0;
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        while (messagesProcessed < concurrencyLevel * 2)
+        {
+            if (onMessageCalls.TryDequeue(out var messagePipelineTcs))
+            {
+                messagePipelineTcs.SetResult();
+                messagesProcessed++;
+            }
+            TestTimeoutCancellationToken.ThrowIfCancellationRequested();
+        }
+        Assert.AreEqual(concurrencyLevel * 2, messagesProcessed, "should process all enqueued messages");
+    }
+}

--- a/src/NServiceBus.TransportTests/When_multiple_messages_are_available.cs
+++ b/src/NServiceBus.TransportTests/When_multiple_messages_are_available.cs
@@ -13,7 +13,7 @@ public class When_multiple_messages_are_available : NServiceBusTransportTest
     [TestCase(TransportTransactionMode.ReceiveOnly)]
     [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
     [TestCase(TransportTransactionMode.TransactionScope)]
-    public async Task Should_invoke_on_message_in_parallel(TransportTransactionMode transactionMode)
+    public async Task Should_handle_messages_concurrently(TransportTransactionMode transactionMode)
     {
         const int concurrencyLevel = 10;
         var onMessageCalls = new ConcurrentQueue<TaskCompletionSource>();

--- a/src/NServiceBus.TransportTests/When_multiple_messages_are_available.cs
+++ b/src/NServiceBus.TransportTests/When_multiple_messages_are_available.cs
@@ -1,59 +1,62 @@
-﻿namespace NServiceBus.TransportTests;
-
-using System;
-using System.Collections.Concurrent;
-using System.Threading;
-using System.Threading.Tasks;
-using NUnit.Framework;
-using Transport;
-
-public class When_multiple_messages_are_available : NServiceBusTransportTest
+﻿namespace NServiceBus.TransportTests
 {
-    [TestCase(TransportTransactionMode.None)]
-    [TestCase(TransportTransactionMode.ReceiveOnly)]
-    [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
-    [TestCase(TransportTransactionMode.TransactionScope)]
-    public async Task Should_handle_messages_concurrently(TransportTransactionMode transactionMode)
+    using System;
+    using System.Collections.Concurrent;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+    using Transport;
+
+    public class When_multiple_messages_are_available : NServiceBusTransportTest
     {
-        const int concurrencyLevel = 10;
-        var onMessageCalls = new ConcurrentQueue<TaskCompletionSource>();
+        [TestCase(TransportTransactionMode.None)]
+        [TestCase(TransportTransactionMode.ReceiveOnly)]
+        [TestCase(TransportTransactionMode.SendsAtomicWithReceive)]
+        [TestCase(TransportTransactionMode.TransactionScope)]
+        public async Task Should_handle_messages_concurrently(TransportTransactionMode transactionMode)
+        {
+            const int concurrencyLevel = 10;
+            var onMessageCalls = new ConcurrentQueue<TaskCompletionSource>();
 
-        await StartPump(async (context, _) =>
+            await StartPump(async (context, _) =>
+                {
+                    var tcs = CreateTaskCompletionSource();
+                    onMessageCalls.Enqueue(tcs);
+                    // "block" current pipeline invocation
+                    await tcs.Task;
+                },
+                (errorContext, __) => throw new Exception("unexpected error", errorContext.Exception),
+                transactionMode,
+                pushRuntimeSettings: new PushRuntimeSettings(concurrencyLevel));
+
+            for (int i = 0; i < concurrencyLevel * 2; i++)
             {
-                var tcs = CreateTaskCompletionSource();
-                onMessageCalls.Enqueue(tcs);
-                // "block" current pipeline invocation
-                await tcs.Task;
-            },
-            (errorContext, __) => throw new Exception("unexpected error", errorContext.Exception),
-            transactionMode,
-            pushRuntimeSettings: new PushRuntimeSettings(concurrencyLevel));
-
-        for (int i = 0; i < concurrencyLevel * 2; i++)
-        {
-            await SendMessage(InputQueueName);
-        }
-
-        // we need to wait because it might take a bit till the pump has invoked all pipelines?
-        while (onMessageCalls.Count < concurrencyLevel)
-        {
-            await Task.Delay(50, TestTimeoutCancellationToken);
-        }
-
-        Assert.AreEqual(concurrencyLevel, onMessageCalls.Count, "should not process more messages than configured at once");
-
-        // unblock pumps
-        int messagesProcessed = 0;
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-        while (messagesProcessed < concurrencyLevel * 2)
-        {
-            if (onMessageCalls.TryDequeue(out var messagePipelineTcs))
-            {
-                messagePipelineTcs.SetResult();
-                messagesProcessed++;
+                await SendMessage(InputQueueName);
             }
-            TestTimeoutCancellationToken.ThrowIfCancellationRequested();
+
+            // we need to wait because it might take a bit till the pump has invoked all pipelines?
+            while (onMessageCalls.Count < concurrencyLevel)
+            {
+                await Task.Delay(50, TestTimeoutCancellationToken);
+            }
+
+            int maximumConcurrentMessages = onMessageCalls.Count;
+
+            // unblock pumps
+            int messagesProcessed = 0;
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            while (messagesProcessed < concurrencyLevel * 2)
+            {
+                if (onMessageCalls.TryDequeue(out var messagePipelineTcs))
+                {
+                    messagePipelineTcs.SetResult();
+                    messagesProcessed++;
+                }
+                TestTimeoutCancellationToken.ThrowIfCancellationRequested();
+            }
+
+            Assert.AreEqual(concurrencyLevel, maximumConcurrentMessages, "should not process more messages than configured at once");
+            Assert.AreEqual(concurrencyLevel * 2, messagesProcessed, "should process all enqueued messages");
         }
-        Assert.AreEqual(concurrencyLevel * 2, messagesProcessed, "should process all enqueued messages");
     }
 }

--- a/src/NServiceBus.TransportTests/When_multiple_messages_are_available.cs
+++ b/src/NServiceBus.TransportTests/When_multiple_messages_are_available.cs
@@ -23,7 +23,7 @@
                     var tcs = CreateTaskCompletionSource();
                     onMessageCalls.Enqueue(tcs);
                     // "block" current pipeline invocation
-                    await tcs.Task;
+                    await tcs.Task.WaitAsync(TestTimeoutCancellationToken);
                 },
                 (errorContext, __) => throw new Exception("unexpected error", errorContext.Exception),
                 transactionMode,
@@ -34,7 +34,7 @@
                 await SendMessage(InputQueueName);
             }
 
-            // we need to wait because it might take a bit till the pump has invoked all pipelines?
+            // we need to wait because it might take a bit till the pump has invoked all pipelines
             while (onMessageCalls.Count < concurrencyLevel)
             {
                 await Task.Delay(50, TestTimeoutCancellationToken);


### PR DESCRIPTION
A new transport test that verifies the concurrent message processing behavior by testing whether message processing pipelines are guaranteed to execute in parallel and independently from each other.

Todo:
* [x] Verify on downstream before merging
  * MSMQ - not going to be updated to core v9
  * [x] RabbitMQ https://github.com/Particular/NServiceBus.RabbitMQ/pull/1308
  * [x] SQS https://github.com/Particular/NServiceBus.AmazonSQS/pull/2292
  * [x] ASB https://github.com/Particular/NServiceBus.Transport.AzureServiceBus/pull/882
  * [x] ASQ https://github.com/Particular/NServiceBus.AzureStorageQueues/pull/1080
  * [x] SQLT -  not on core v9 yet but [manually verified ](https://github.com/Particular/NServiceBus/pull/6851#issuecomment-1729680218)