### PR TITLE
Enable distributed transactions in persistence tests

### DIFF
--- a/src/NServiceBus.PersistenceTests/IPersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.PersistenceTests/IPersistenceTestsConfiguration.cs
@@ -5,6 +5,7 @@
     using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
+    using System.Transactions;
     using Extensibility;
     using NServiceBus.Outbox;
     using NServiceBus.Sagas;
@@ -47,6 +48,11 @@
     {
         public PersistenceTestsConfiguration(TestVariant variant)
         {
+            if (OperatingSystem.IsWindows() && SupportsDtc)
+            {
+                TransactionManager.ImplicitDistributedTransactions = true;
+            }
+
             SessionTimeout = variant.SessionTimeout;
             Variant = variant;
         }


### PR DESCRIPTION
This PR enables `ImplicitDistributedTransactions` in the persistence tests package.

Follow-up to #6850