### PR TITLE
Fix DTC persistence test

### DIFF
--- a/src/NServiceBus.PersistenceTests/IPersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.PersistenceTests/IPersistenceTestsConfiguration.cs
@@ -48,13 +48,13 @@
     {
         public PersistenceTestsConfiguration(TestVariant variant)
         {
+            SessionTimeout = variant.SessionTimeout;
+            Variant = variant;
+
             if (OperatingSystem.IsWindows() && SupportsDtc)
             {
                 TransactionManager.ImplicitDistributedTransactions = true;
             }
-
-            SessionTimeout = variant.SessionTimeout;
-            Variant = variant;
         }
 
         public Func<ContextBag> GetContextBagForSagaStorage { get; private set; } = () => new ContextBag();

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
@@ -18,7 +18,6 @@
             await SaveSaga(sagaData);
             var generatedSagaId = sagaData.Id;
             var enlistmentNotifier = new EnlistmentWhichEnforcesDtcEscalation();
-            var exceptionCaught = false;
 
             Assert.That(async () =>
             {
@@ -50,9 +49,8 @@
                         tx.Complete();
                     }
                 }
-            }, Throws.Exception.AssignableFrom<Exception>());
+            }, Throws.Exception);
 
-            Assert.IsTrue(exceptionCaught);
             Assert.IsTrue(enlistmentNotifier.RollbackWasCalled);
             Assert.IsFalse(enlistmentNotifier.CommitWasCalled);
         }

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
@@ -18,6 +18,7 @@
             await SaveSaga(sagaData);
             var generatedSagaId = sagaData.Id;
             var enlistmentNotifier = new EnlistmentWhichEnforcesDtcEscalation();
+            var exceptionCaught = false;
 
             try
             {
@@ -37,9 +38,7 @@
                             await unenlistedSession.Open(unenlistedContextBag);
                             await enlistedSession.TryOpen(transportTransaction, enlistedContextBag);
 
-                            var unenlistedRecord = await persister.Get<TestSagaData>(generatedSagaId, unenlistedSession,
-                                unenlistedContextBag);
-
+                            var unenlistedRecord = await persister.Get<TestSagaData>(generatedSagaId, unenlistedSession, unenlistedContextBag);
                             var enlistedRecord = await persister.Get<TestSagaData>(generatedSagaId, enlistedSession, enlistedContextBag);
 
                             await persister.Update(unenlistedRecord, unenlistedSession, unenlistedContextBag);
@@ -54,9 +53,10 @@
             }
             catch (Exception)
             {
-                // Ignore
+                exceptionCaught = true;
             }
 
+            Assert.IsTrue(exceptionCaught);
             Assert.IsTrue(enlistmentNotifier.RollbackWasCalled);
             Assert.IsFalse(enlistmentNotifier.CommitWasCalled);
         }

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
@@ -20,7 +20,7 @@
             var enlistmentNotifier = new EnlistmentWhichEnforcesDtcEscalation();
             var exceptionCaught = false;
 
-            try
+            Assert.That(async () =>
             {
                 using (var tx = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
                 {
@@ -50,11 +50,7 @@
                         tx.Complete();
                     }
                 }
-            }
-            catch (Exception)
-            {
-                exceptionCaught = true;
-            }
+            }, Throws.Exception.AssignableFrom<Exception>());
 
             Assert.IsTrue(exceptionCaught);
             Assert.IsTrue(enlistmentNotifier.RollbackWasCalled);


### PR DESCRIPTION
Change the logic in the DTC persistence test to confirm participating transactions are rolled back when the persistence fails to update instead of expecting a specific exception type.

Prior to these changes, this test was written to expect the same implementation as the NonDurable persistence, where the [update logic](https://github.com/Particular/NServiceBus.Persistence.NonDurable/blob/master/src/NServiceBus.Persistence.NonDurable/SagaPersister/NonDurableSagaPersister.cs#L99) is enlisted and committed as part of a [DTC enlistment notification implementation](https://github.com/Particular/NServiceBus.Persistence.NonDurable/blob/master/src/NServiceBus.Persistence.NonDurable/SynchronizedStorage/NonDurableSynchronizedStorageSession.cs#L67).

In other persistences, such as SQL Persistence, the update logic is not [implemented the same way](https://github.com/Particular/NServiceBus.Persistence.Sql/blob/master/src/SqlPersistence/Saga/SagaPersister_Update.cs#L15) and throws an exception earlier in the process than the NonDurable persistence, outside of any enlistment notification implementations.  

