### PR TITLE
Test record messages

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Pipeline/When_sending_record_class_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Pipeline/When_sending_record_class_messages.cs
@@ -1,0 +1,75 @@
+﻿namespace NServiceBus.AcceptanceTests.Pipeline
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_sending_record_class_messages : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_process_record_message()
+        {
+            string expectedText = Guid.NewGuid().ToString();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<RecordHandlingEndpoint>(e =>
+                    e.When(s => s.SendLocal(new RecordClassMessage() { SomeText = expectedText })))
+                .Done(c => c.ReceivedText != null)
+                .Run();
+
+            Assert.AreEqual(expectedText, context.ReceivedText);
+        }
+
+        [Test]
+        public async Task Should_process_positional_record_message()
+        {
+            string expectedText = Guid.NewGuid().ToString();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<RecordHandlingEndpoint>(e =>
+                    e.When(s => s.SendLocal(new ReadonlyRecordClassMessage(expectedText))))
+                .Done(c => c.ReceivedText != null)
+                .Run();
+
+            Assert.AreEqual(expectedText, context.ReceivedText);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public string ReceivedText { get; set; }
+        }
+
+        public class RecordHandlingEndpoint : EndpointConfigurationBuilder
+        {
+            public RecordHandlingEndpoint() => EndpointSetup<DefaultServer>();
+
+            public class RecordMessageHandler(Context testContext) :
+                IHandleMessages<RecordClassMessage>,
+                IHandleMessages<ReadonlyRecordClassMessage>
+            {
+                public Task Handle(RecordClassMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedText = message.SomeText;
+                    return Task.CompletedTask;
+                }
+
+                public Task Handle(ReadonlyRecordClassMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedText = message.SomeText;
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        public record class RecordClassMessage : IMessage
+        {
+            public string SomeText { get; set; }
+        }
+
+        public record class ReadonlyRecordClassMessage(string SomeText) : IMessage
+        {
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/Pipeline/When_sending_record_struct_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Pipeline/When_sending_record_struct_messages.cs
@@ -1,0 +1,75 @@
+﻿namespace NServiceBus.AcceptanceTests.Pipeline
+{
+    using System;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_sending_record_struct_messages : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_process_record_message()
+        {
+            string expectedText = Guid.NewGuid().ToString();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<RecordHandlingEndpoint>(e =>
+                    e.When(s => s.SendLocal(new RecordStructMessage { SomeText = expectedText })))
+                .Done(c => c.ReceivedText != null)
+                .Run();
+
+            Assert.AreEqual(expectedText, context.ReceivedText);
+        }
+
+        [Test]
+        public async Task Should_process_readonly_record_message()
+        {
+            string expectedText = Guid.NewGuid().ToString();
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<RecordHandlingEndpoint>(e =>
+                    e.When(s => s.SendLocal(new ReadonlyRecordStructMessage(expectedText))))
+                .Done(c => c.ReceivedText != null)
+                .Run();
+
+            Assert.AreEqual(expectedText, context.ReceivedText);
+        }
+
+        public class Context : ScenarioContext
+        {
+            public string ReceivedText { get; set; }
+        }
+
+        public class RecordHandlingEndpoint : EndpointConfigurationBuilder
+        {
+            public RecordHandlingEndpoint() => EndpointSetup<DefaultServer>();
+
+            public class RecordMessageHandler(Context testContext) :
+                IHandleMessages<RecordStructMessage>,
+                IHandleMessages<ReadonlyRecordStructMessage>
+            {
+                public Task Handle(RecordStructMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedText = message.SomeText;
+                    return Task.CompletedTask;
+                }
+
+                public Task Handle(ReadonlyRecordStructMessage message, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedText = message.SomeText;
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        public record struct RecordStructMessage : IMessage
+        {
+            public string SomeText { get; set; }
+        }
+
+        public readonly record struct ReadonlyRecordStructMessage(string SomeText) : IMessage
+        {
+        }
+    }
+}


### PR DESCRIPTION
Tests different types of record messages (record classes/structs) for compatibility with the pipeline.

Note that this should probably also be added explicitly to the serializer compatibility tests