### PR TITLE
Add manual trigger to push packages to testing feed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_dispatch:
 env:
   DOTNET_NOLOGO: true
 jobs:
@@ -34,7 +35,13 @@ jobs:
           name: nugets
           path: nugets/*
           retention-days: 1
+      - name: Push packages to testing feed
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: dotnet nuget push nugets\*.nupkg --api-key ${{ secrets.FEEDZIO_PUBLISH_API_KEY }} --source "${{ vars.PARTICULAR_TESTING_FEED_URL }}"
+        shell: pwsh
       - name: Deploy
+        if: ${{ github.event_name == 'push' && github.ref_type == 'tag' }}
         uses: Particular/push-octopus-package-action@v1.1.0
         with:
           octopus-deploy-api-key: ${{ secrets.OCTOPUS_DEPLOY_API_KEY }}
+


### PR DESCRIPTION
This PR lets the release workflow be manually triggered on any branch or tag in the repo.

When it is is manually triggered, the release workflow pushes the packages to a new testing feed instead of deploying to Octopus.

This testing feed can then be used on downstream PRs to test the changes easily without causing any of the problems that would occur if Octopus/the main feed was used.