### PR TITLE
Remove unnecessary WaitAsync

### DIFF
--- a/src/NServiceBus.TransportTests/When_multiple_messages_are_available.cs
+++ b/src/NServiceBus.TransportTests/When_multiple_messages_are_available.cs
@@ -23,7 +23,7 @@
                     var tcs = CreateTaskCompletionSource();
                     onMessageCalls.Enqueue(tcs);
                     // "block" current pipeline invocation
-                    await tcs.Task.WaitAsync(TestTimeoutCancellationToken);
+                    await tcs.Task;
                 },
                 (errorContext, __) => throw new Exception("unexpected error", errorContext.Exception),
                 transactionMode,


### PR DESCRIPTION
I realized that this `WaitAsync` is not necessary as the `TaskCompletionSource` created via `CreateTaskCompletionSource()` is already hooked up to the test timeout cancellation token, therefore this is redundant.