### PR TITLE
Verify that users are not tampering with the transaction scope opened by the transport

### DIFF
--- a/src/NServiceBus.Core.Tests/Unicast/LoadHandlersConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/LoadHandlersConnectorTests.cs
@@ -1,14 +1,14 @@
 ﻿namespace NServiceBus.Unicast.Tests
 {
+    using System;
     using System.Threading.Tasks;
-    using Outbox;
+    using System.Transactions;
+    using Core.Tests.Fakes;
+    using Microsoft.Extensions.DependencyInjection;
     using NServiceBus.Transport;
     using NUnit.Framework;
+    using Outbox;
     using Testing;
-    using Core.Tests.Fakes;
-    using System.Transactions;
-    using System;
-    using Microsoft.Extensions.DependencyInjection;
 
     [TestFixture]
     public class LoadHandlersConnectorTests
@@ -41,7 +41,7 @@
                 {
                     var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await behavior.Invoke(context, c => Task.CompletedTask));
 
-                    StringAssert.Contains("A TransactionScope has been opened in the current context overriding the one created by the transport", ex.Message);
+                    StringAssert.Contains("A TransactionScope has been created that is overriding the one created by the transport", ex.Message);
                 }
             }
         }

--- a/src/NServiceBus.Core.Tests/Unicast/LoadHandlersConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/LoadHandlersConnectorTests.cs
@@ -6,6 +6,9 @@
     using NUnit.Framework;
     using Testing;
     using Core.Tests.Fakes;
+    using System.Transactions;
+    using System;
+    using Microsoft.Extensions.DependencyInjection;
 
     [TestFixture]
     public class LoadHandlersConnectorTests
@@ -21,6 +24,65 @@
             context.Extensions.Set(new TransportTransaction());
 
             Assert.That(async () => await behavior.Invoke(context, c => Task.CompletedTask), Throws.InvalidOperationException);
+        }
+
+        [Test]
+        public void Should_throw_if_scope_in_transport_transaction_differs_from_the_ambient()
+        {
+            var behavior = new LoadHandlersConnector(new MessageHandlerRegistry());
+
+            var context = new TestableIncomingLogicalMessageContext();
+
+            context.Extensions.Set<IOutboxTransaction>(new NoOpOutboxTransaction());
+
+            using (new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                var transportTransaction = new TransportTransaction();
+
+                transportTransaction.Set(Transaction.Current);
+
+                context.Extensions.Set(transportTransaction);
+
+                using (new TransactionScope(TransactionScopeOption.RequiresNew, TransactionScopeAsyncFlowOption.Enabled))
+                {
+                    var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await behavior.Invoke(context, c => Task.CompletedTask));
+
+                    StringAssert.Contains("A TransactionScope has been opened in the current context overriding the one created by the transport", ex.Message);
+                }
+            }
+        }
+
+        [Test]
+        public void Should_not_throw_if_scope_in_transport_transaction_are_the_same_as_the_ambient()
+        {
+            var messageHandlerRegistry = new MessageHandlerRegistry();
+            messageHandlerRegistry.RegisterHandler(typeof(FakeHandler));
+
+            var context = new TestableIncomingLogicalMessageContext();
+
+            context.Services.AddSingleton<FakeHandler>();
+            context.Extensions.Set<IOutboxTransaction>(new NoOpOutboxTransaction());
+
+            var behavior = new LoadHandlersConnector(messageHandlerRegistry);
+
+            using (new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                var transportTransaction = new TransportTransaction();
+
+                transportTransaction.Set(Transaction.Current);
+
+                context.Extensions.Set(transportTransaction);
+
+                using (new TransactionScope(TransactionScopeOption.Required, TransactionScopeAsyncFlowOption.Enabled))
+                {
+                    Assert.DoesNotThrowAsync(async () => await behavior.Invoke(context, c => Task.CompletedTask));
+                }
+            }
+        }
+
+        class FakeHandler : IHandleMessages<object>
+        {
+            public Task Handle(object message, IMessageHandlerContext context) => Task.CompletedTask;
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Unicast/LoadHandlersConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/LoadHandlersConnectorTests.cs
@@ -61,7 +61,7 @@
                 {
                     var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await behavior.Invoke(context, c => Task.CompletedTask));
 
-                    StringAssert.Contains("The TransactionScope created by the transport has been supressed", ex.Message);
+                    StringAssert.Contains("The TransactionScope created by the transport has been suppressed", ex.Message);
                 }
             }
         }

--- a/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
@@ -66,7 +66,7 @@
 
             if (currentScope == null)
             {
-                throw new InvalidOperationException("The TransactionScope created by the transport has been supressed. " + ScopeInconsistencyMessage);
+                throw new InvalidOperationException("The TransactionScope created by the transport has been suppressed. " + ScopeInconsistencyMessage);
 
             }
 

--- a/src/NServiceBus.Core/Reliability/SynchronizedStorage/CompletableSynchronizedStorageSessionExtensions.cs
+++ b/src/NServiceBus.Core/Reliability/SynchronizedStorage/CompletableSynchronizedStorageSessionExtensions.cs
@@ -1,7 +1,9 @@
 namespace NServiceBus.Persistence
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using System.Transactions;
     using Extensibility;
     using Outbox;
     using Pipeline;
@@ -36,6 +38,19 @@ namespace NServiceBus.Persistence
             IOutboxTransaction outboxTransaction, TransportTransaction transportTransaction,
             ContextBag contextBag, CancellationToken cancellationToken = default)
         {
+            // Transport supports DTC and uses TxScope owned by the transport
+            var scopeTx = Transaction.Current;
+
+            if (transportTransaction.TryGet(out Transaction transportTx) &&
+                scopeTx != null &&
+                transportTx != scopeTx)
+            {
+                throw new InvalidOperationException("A TransactionScope has been opened in the current context overriding the one created by the transport. "
+                                    + "This setup can result in inconsistent data because operations done via resource managers enlisted in the context scope won't be committed "
+                                    + "atomically with the receive transaction. To manually control the TransactionScope in the pipeline switch the transport transaction mode "
+                                    + $"to values lower than '{nameof(TransportTransactionMode.TransactionScope)}'.");
+            }
+
             if (await session.TryOpen(outboxTransaction, contextBag, cancellationToken).ConfigureAwait(false))
             {
                 return;

--- a/src/NServiceBus.Testing.Fakes/TestableIncomingContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableIncomingContext.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using Microsoft.Extensions.DependencyInjection;
-    using ObjectBuilder;
     using Pipeline;
 
     /// <summary>


### PR DESCRIPTION
Once merged:

- Remove validation code in SqlP like https://github.com/Particular/NServiceBus.Persistence.Sql/blob/master/src/SqlPersistence/SynchronizedStorage/SqlDialect_MsSqlServer.cs#L36