### PR TITLE
Prevent Type property on DataBusProperty<T> from being serialized

### DIFF
--- a/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties_with_systemjsonserializer.cs
+++ b/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties_with_systemjsonserializer.cs
@@ -1,0 +1,85 @@
+﻿namespace NServiceBus.AcceptanceTests.DataBus
+{
+    using System.IO;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using NUnit.Framework;
+
+    public class When_sending_databus_properties_with_systemjsonserializer : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_receive_messages_with_largepayload_correctly()
+        {
+            var payloadToSend = new byte[PayloadSize];
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(b => b.When(session => session.Send(new MyMessageWithLargePayload
+                {
+                    Payload = new DataBusProperty<byte[]>(payloadToSend)
+                })))
+                .WithEndpoint<Receiver>()
+                .Done(c => c.ReceivedPayload != null)
+                .Run();
+
+            Assert.AreEqual(payloadToSend, context.ReceivedPayload, "The large payload should be marshalled correctly using the databus");
+        }
+
+        const int PayloadSize = 500;
+
+        public class Context : ScenarioContext
+        {
+            public byte[] ReceivedPayload { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(builder =>
+                {
+                    var basePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "databus", "sender");
+                    builder.UseDataBus<FileShareDataBus, SystemJsonDataBusSerializer>().BasePath(basePath);
+                    builder.UseSerialization<SystemJsonSerializer>();
+                    builder.ConfigureRouting().RouteToEndpoint(typeof(MyMessageWithLargePayload), typeof(Receiver));
+                });
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(builder =>
+                {
+                    var basePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "databus", "sender");
+                    builder.UseDataBus<FileShareDataBus, SystemJsonDataBusSerializer>().BasePath(basePath);
+                    builder.UseSerialization<SystemJsonSerializer>();
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessageWithLargePayload>
+            {
+                public MyMessageHandler(Context context)
+                {
+                    testContext = context;
+                }
+
+                public Task Handle(MyMessageWithLargePayload messageWithLargePayload, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedPayload = messageWithLargePayload.Payload.Value;
+
+                    return Task.CompletedTask;
+                }
+
+                Context testContext;
+            }
+        }
+
+        public class MyMessageWithLargePayload : ICommand
+        {
+            public DataBusProperty<byte[]> Payload { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -167,6 +167,7 @@ namespace NServiceBus
         protected DataBusProperty(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public bool HasValue { get; set; }
         public string Key { get; set; }
+        [System.Text.Json.Serialization.JsonIgnore]
         public System.Type Type { get; }
         public T Value { get; }
         public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }

--- a/src/NServiceBus.Core/DataBus/DataBusProperty.cs
+++ b/src/NServiceBus.Core/DataBus/DataBusProperty.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Runtime.Serialization;
     using System.Security;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Default implementation for <see cref="IDataBusProperty" />.
@@ -55,6 +56,7 @@
         /// <summary>
         /// The property <see cref="Type" />.
         /// </summary>
+        [JsonIgnore]
         public Type Type { get; }
 
         /// <summary>


### PR DESCRIPTION
Fixes: https://github.com/Particular/NServiceBus/issues/6804