### PR TITLE
Update DataBusProperty serialization

### DIFF
--- a/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties_with_systemjson_message_serializer.cs
+++ b/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties_with_systemjson_message_serializer.cs
@@ -1,0 +1,100 @@
+﻿namespace NServiceBus.AcceptanceTests.DataBus
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+    using AcceptanceTesting;
+    using AcceptanceTesting.Customization;
+    using EndpointTemplates;
+    using MessageMutator;
+    using NUnit.Framework;
+
+    public class When_sending_databus_properties_with_systemjson_message_serializer : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_receive_messages_with_largepayload_correctly()
+        {
+            var payloadToSend = new byte[PayloadSize];
+
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<Sender>(b => b.When(session => session.Send(new MyMessageWithLargePayload
+                {
+                    Payload = new DataBusProperty<byte[]>(payloadToSend)
+                })))
+                .WithEndpoint<Receiver>()
+                .Done(c => c.ReceivedPayload != null)
+                .Run();
+
+            Assert.AreEqual(payloadToSend, context.ReceivedPayload, "The large payload should be marshalled correctly using the databus");
+        }
+
+        const int PayloadSize = 500;
+
+        public class Context : ScenarioContext
+        {
+            public byte[] ReceivedPayload { get; set; }
+        }
+
+        public class Sender : EndpointConfigurationBuilder
+        {
+            public Sender()
+            {
+                EndpointSetup<DefaultServer>(builder =>
+                {
+                    var basePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "databus", "sender");
+                    builder.UseDataBus<FileShareDataBus, SystemJsonDataBusSerializer>().BasePath(basePath);
+                    builder.UseSerialization<SystemJsonSerializer>();
+                    builder.ConfigureRouting().RouteToEndpoint(typeof(MyMessageWithLargePayload), typeof(Receiver));
+                });
+            }
+        }
+
+        public class Receiver : EndpointConfigurationBuilder
+        {
+            public Receiver()
+            {
+                EndpointSetup<DefaultServer>(builder =>
+                {
+                    var basePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "databus", "sender");
+                    builder.UseDataBus<FileShareDataBus, SystemJsonDataBusSerializer>().BasePath(basePath);
+                    builder.UseSerialization<SystemJsonSerializer>();
+                    builder.RegisterMessageMutator(new Mutator());
+                });
+            }
+
+            public class MyMessageHandler : IHandleMessages<MyMessageWithLargePayload>
+            {
+                public MyMessageHandler(Context context)
+                {
+                    testContext = context;
+                }
+
+                public Task Handle(MyMessageWithLargePayload messageWithLargePayload, IMessageHandlerContext context)
+                {
+                    testContext.ReceivedPayload = messageWithLargePayload.Payload.Value;
+
+                    return Task.CompletedTask;
+                }
+
+                Context testContext;
+            }
+
+            public class Mutator : IMutateIncomingTransportMessages
+            {
+                public Task MutateIncoming(MutateIncomingTransportMessageContext context)
+                {
+                    if (context.Body.Length > PayloadSize)
+                    {
+                        throw new Exception("The message body is too large, which means the DataBus was not used to transfer the payload.");
+                    }
+                    return Task.CompletedTask;
+                }
+            }
+        }
+
+        public class MyMessageWithLargePayload : ICommand
+        {
+            public DataBusProperty<byte[]> Payload { get; set; }
+        }
+    }
+}

--- a/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties_with_xml_message_serializer.cs
+++ b/src/NServiceBus.AcceptanceTests/DataBus/When_sending_databus_properties_with_xml_message_serializer.cs
@@ -6,10 +6,10 @@
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using EndpointTemplates;
-    using NServiceBus.MessageMutator;
+    using MessageMutator;
     using NUnit.Framework;
 
-    public class When_sending_databus_properties_with_systemjsonserializer : NServiceBusAcceptanceTest
+    public class When_sending_databus_properties_with_xml_message_serializer : NServiceBusAcceptanceTest
     {
         [Test]
         public async Task Should_receive_messages_with_largepayload_correctly()
@@ -43,7 +43,7 @@
                 {
                     var basePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "databus", "sender");
                     builder.UseDataBus<FileShareDataBus, SystemJsonDataBusSerializer>().BasePath(basePath);
-                    builder.UseSerialization<SystemJsonSerializer>();
+                    builder.UseSerialization<XmlSerializer>();
                     builder.ConfigureRouting().RouteToEndpoint(typeof(MyMessageWithLargePayload), typeof(Receiver));
                 });
             }
@@ -57,7 +57,7 @@
                 {
                     var basePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "databus", "sender");
                     builder.UseDataBus<FileShareDataBus, SystemJsonDataBusSerializer>().BasePath(basePath);
-                    builder.UseSerialization<SystemJsonSerializer>();
+                    builder.UseSerialization<XmlSerializer>();
                     builder.RegisterMessageMutator(new Mutator());
                 });
             }
@@ -78,17 +78,17 @@
 
                 Context testContext;
             }
-        }
 
-        public class Mutator : IMutateIncomingTransportMessages
-        {
-            public Task MutateIncoming(MutateIncomingTransportMessageContext context)
+            public class Mutator : IMutateIncomingTransportMessages
             {
-                if (context.Body.Length > PayloadSize)
+                public Task MutateIncoming(MutateIncomingTransportMessageContext context)
                 {
-                    throw new Exception("The message body is too large, which means the DataBus was not used to transfer the payload.");
+                    if (context.Body.Length > PayloadSize)
+                    {
+                        throw new Exception("The message body is too large, which means the DataBus was not used to transfer the payload.");
+                    }
+                    return Task.CompletedTask;
                 }
-                return Task.CompletedTask;
             }
         }
 

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -164,14 +164,13 @@ namespace NServiceBus
     {
         public DataBusProperty() { }
         public DataBusProperty(T value) { }
-        protected DataBusProperty(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public bool HasValue { get; set; }
         public string Key { get; set; }
         [System.Text.Json.Serialization.JsonIgnore]
         public System.Type Type { get; }
         [System.Text.Json.Serialization.JsonIgnore]
+        [System.Xml.Serialization.XmlIgnore]
         public T Value { get; }
-        public void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public object GetValue() { }
         public void SetValue(object valueToSet) { }
     }

--- a/src/NServiceBus.Core/DataBus/DataBusProperty.cs
+++ b/src/NServiceBus.Core/DataBus/DataBusProperty.cs
@@ -11,12 +11,12 @@
     public class DataBusProperty<T> : IDataBusProperty where T : class
     {
         /// <summary>
-        /// initializes a <see cref="DataBusProperty{T}" /> with no value set.
+        /// Initializes a <see cref="DataBusProperty{T}" /> with no value set.
         /// </summary>
         public DataBusProperty() { }
 
         /// <summary>
-        /// initializes a <see cref="DataBusProperty{T}" /> with the <paramref name="value" />.
+        /// Initializes a <see cref="DataBusProperty{T}" /> with the <paramref name="value" />.
         /// </summary>
         /// <param name="value">The value to initialize with.</param>
         public DataBusProperty(T value) => SetValue(value);

--- a/src/NServiceBus.Core/DataBus/DataBusProperty.cs
+++ b/src/NServiceBus.Core/DataBus/DataBusProperty.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Text.Json.Serialization;
+    using System.Xml.Serialization;
 
     /// <summary>
     /// Default implementation for <see cref="IDataBusProperty" />.
@@ -23,10 +24,9 @@
         /// <summary>
         /// The value.
         /// </summary>
-#pragma warning disable IDE0032 // Use auto property - Value will be serialized into the message body if it is an auto property
         [JsonIgnore]
-        public T Value => value;
-#pragma warning restore IDE0032 // Use auto property
+        [XmlIgnore]
+        public T Value { get; private set; }
 
         /// <summary>
         /// The property <see cref="Type" />.
@@ -50,21 +50,14 @@
         /// <param name="valueToSet">The value to set.</param>
         public void SetValue(object valueToSet)
         {
-            value = valueToSet as T;
-            HasValue = value != null;
+            Value = valueToSet as T;
+            HasValue = Value != null;
         }
 
         /// <summary>
         /// Gets the value of the <see cref="IDataBusProperty" />.
         /// </summary>
         /// <returns>The value.</returns>
-        public object GetValue()
-        {
-            return Value;
-        }
-
-#pragma warning disable IDE0032 // Use auto property - value will be serialized into the message body if it is an auto property
-        T value;
-#pragma warning restore IDE0032 // Use auto property
+        public object GetValue() => Value;
     }
 }

--- a/src/NServiceBus.Core/DataBus/DataBusProperty.cs
+++ b/src/NServiceBus.Core/DataBus/DataBusProperty.cs
@@ -12,24 +12,13 @@
         /// <summary>
         /// initializes a <see cref="DataBusProperty{T}" /> with no value set.
         /// </summary>
-        public DataBusProperty()
-        {
-            Type = typeof(T);
-        }
+        public DataBusProperty() { }
 
         /// <summary>
         /// initializes a <see cref="DataBusProperty{T}" /> with the <paramref name="value" />.
         /// </summary>
         /// <param name="value">The value to initialize with.</param>
-        public DataBusProperty(T value)
-        {
-            if (value != null)
-            {
-                Type = typeof(T);
-            }
-
-            SetValue(value);
-        }
+        public DataBusProperty(T value) => SetValue(value);
 
         /// <summary>
         /// The value.
@@ -43,7 +32,7 @@
         /// The property <see cref="Type" />.
         /// </summary>
         [JsonIgnore]
-        public Type Type { get; }
+        public Type Type { get; } = typeof(T);
 
         /// <summary>
         /// The <see cref="IDataBusProperty" /> key.

--- a/src/NServiceBus.Core/DataBus/DataBusProperty.cs
+++ b/src/NServiceBus.Core/DataBus/DataBusProperty.cs
@@ -1,8 +1,6 @@
 ﻿namespace NServiceBus
 {
     using System;
-    using System.Runtime.Serialization;
-    using System.Security;
     using System.Text.Json.Serialization;
 
     /// <summary>
@@ -34,22 +32,9 @@
         }
 
         /// <summary>
-        /// For serialization purposes.
-        /// </summary>
-        /// <param name="info">The <see cref="SerializationInfo" /> to populate with data. </param>
-        /// <param name="context">The destination (see <see cref="StreamingContext" />) for this serialization. </param>
-        /// <exception cref="SecurityException">The caller does not have the required permission. </exception>
-        protected DataBusProperty(SerializationInfo info, StreamingContext context)
-        {
-            ArgumentNullException.ThrowIfNull(info);
-            Key = info.GetString("Key");
-            HasValue = info.GetBoolean("HasValue");
-        }
-
-        /// <summary>
         /// The value.
         /// </summary>
-#pragma warning disable IDE0032 // Use auto property - Value will be serialized into the message body if it is an auto property        
+#pragma warning disable IDE0032 // Use auto property - Value will be serialized into the message body if it is an auto property
         [JsonIgnore]
         public T Value => value;
 #pragma warning restore IDE0032 // Use auto property
@@ -89,23 +74,8 @@
             return Value;
         }
 
-
-        /// <summary>
-        /// Populates a <see cref="SerializationInfo" /> with the data needed to serialize the target object.
-        /// </summary>
-        /// <param name="info">The <see cref="SerializationInfo" /> to populate with data. </param>
-        /// <param name="context">The destination (see <see cref="StreamingContext" />) for this serialization. </param>
-        /// <exception cref="T:System.Security.SecurityException">The caller does not have the required permission. </exception>
-        public void GetObjectData(SerializationInfo info, StreamingContext context)
-        {
-            ArgumentNullException.ThrowIfNull(info);
-            info.AddValue("Key", Key);
-            info.AddValue("HasValue", HasValue);
-        }
-
 #pragma warning disable IDE0032 // Use auto property - value will be serialized into the message body if it is an auto property
         T value;
 #pragma warning restore IDE0032 // Use auto property
     }
-
 }


### PR DESCRIPTION
This PR finishes up the changes made to `DataBusProperty<T>` in #6810 and #6889. It cleans up leftover stuff from the `ISerializable` removal and ensures that it will still be able to serialize properly with the in-box serializers.

I also expanded the test coverage a bit to ensure that both message serializers are tested for both `DataBusProperty<T>` and unobtrusive DataBus options. 