### PR TITLE
You do not need to reference System.* nuget packages

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -11,9 +11,6 @@
   <ItemGroup Label="Public dependencies">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-rc.2.23479.6" />
     <PackageReference Include="NServiceBus.MessageInterfaces" Version="1.0.0-alpha.1" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0-rc.2.23479.6" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.0-rc.2.23479.6" />
-    <PackageReference Include="System.Text.Json" Version="8.0.0-rc.2.23479.6" />
   </ItemGroup>
 
   <ItemGroup Label="Private dependencies">


### PR DESCRIPTION
Explicitly depending on [System.Security.Cryptography.Xml](https://www.nuget.org/packages/System.Security.Cryptography.Xml/) has twice led you to having security vulnerabilities in recent times including the ongoing denial of service vulnerability that impacts your current release.

When you target net8.0, net7.0, or net6.0 just let the framework provide the transitive dependencies you only need them for old .NET framework or .NET standard target framework monikers.

Existing ongoing DoS vulnerability: https://github.com/advisories/GHSA-555c-2p6r-68mm
Previous disclosure vulnerability: https://github.com/advisories/GHSA-2m65-m22p-9wjw
