### PR TITLE
Add top-level reference to System.Security.Cryptography.Pkcs

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
@@ -23,6 +23,10 @@
     <PackageReference Include="System.Text.Json" Version="7.0.3" />
   </ItemGroup>
 
+  <ItemGroup Label="System.Security.Cryptography.Xml 7.0.1 references Pkcs 7.0.0, which has a vulnerability. This should be removed when Xml updates to reference a non-vulernable version">
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.3" />
+  </ItemGroup>
+
   <ItemGroup Label="Private dependencies">
     <PackageReference Include="Fody" Version="6.7.0" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.9.0" PrivateAssets="All" />
@@ -31,10 +35,7 @@
     <PackageReference Include="Particular.Packaging" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="SimpleJson" Version="0.38.0" PrivateAssets="All" />
     <PackageReference Include="FastExpressionCompiler.Internal.src" Version="3.3.4" PrivateAssets="All" />
-    <PackageReference Include="PolySharp" Version="1.13.2">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="PolySharp" Version="1.13.2" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
System.Security.Cryptography.Xml 7.0.1 references System.Security.Cryptography.Pkcs 7.0.0, which is affected by [CVE-2023-29331](https://github.com/dotnet/announcements/issues/257).

System.Security.Cryptography.Pkcs has been elevated to a top-level dependency and updated to a non-vulnerable version to ensure that systems using NServiceBus are not relying on a vulnerable version of System.Security.Cryptography.Pkcs. 