### PR TITLE
Add top-level reference to System.Security.Cryptography.Pkcs

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -23,6 +23,10 @@
     <PackageReference Include="System.Security.Cryptography.Xml" Version="7.0.1" />
   </ItemGroup>
 
+  <ItemGroup Label="System.Security.Cryptography.Xml 7.0.1 references Pkcs 7.0.0, which has a vulnerability. This should be removed when Xml updates to reference a non-vulernable version">
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.3" />
+  </ItemGroup>
+
   <ItemGroup Label="Private dependencies">
     <PackageReference Include="Fody" Version="6.6.3" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.9.0" PrivateAssets="All" />

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -20,7 +20,7 @@
   <ItemGroup Label="Public dependencies">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="7.0.1" />
   </ItemGroup>
 
   <ItemGroup Label="Private dependencies">


### PR DESCRIPTION
System.Security.Cryptography.Xml 7.0.1 references System.Security.Cryptography.Pkcs 7.0.0, which is affected by [CVE-2023-29331](https://github.com/dotnet/announcements/issues/257).

System.Security.Cryptography.Pkcs has been elevated to a top-level dependency and updated to a non-vulnerable version to ensure that systems using NServiceBus are not relying on a vulnerable version of System.Security.Cryptography.Pkcs. 