### PR TITLE
Set AnalysisLevel to 8.0-minimum

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <AnalyzerTargetFramework>netstandard2.0</AnalyzerTargetFramework>
+    <AnalysisLevel>8.0-minimum</AnalysisLevel>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/Outbox/AcceptanceTestingOutboxStorage.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/Outbox/AcceptanceTestingOutboxStorage.cs
@@ -83,7 +83,7 @@
             public void MarkAsDispatched()
             {
                 Dispatched = true;
-                TransportOperations = new TransportOperation[0];
+                TransportOperations = [];
             }
 
             protected bool Equals(StoredMessage other)

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/SagaPersister/AcceptanceTestingSagaPersister.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/SagaPersister/AcceptanceTestingSagaPersister.cs
@@ -120,7 +120,7 @@ namespace NServiceBus.AcceptanceTesting
             entries[sagaId] = value;
         }
 
-        static Entry GetEntry(IReadOnlyContextBag context, Guid sagaDataId)
+        static Entry GetEntry(ContextBag context, Guid sagaDataId)
         {
             if (context.TryGet(ContextKey, out Dictionary<Guid, Entry> entries))
             {

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransportInfrastructure.cs
@@ -19,7 +19,7 @@
             storagePath = transportSettings.StorageLocation ?? Path.Combine(FindSolutionRoot(), ".attransport");
         }
 
-        string FindSolutionRoot()
+        static string FindSolutionRoot()
         {
             var directory = AppDomain.CurrentDomain.BaseDirectory;
 

--- a/src/NServiceBus.AcceptanceTesting/Scenario.cs
+++ b/src/NServiceBus.AcceptanceTesting/Scenario.cs
@@ -6,7 +6,7 @@
 
     public class Scenario
     {
-        public static Func<ScenarioContext, ILoggerFactory> GetLoggerFactory = _ => new ContextAppenderFactory();
+        public static Func<ScenarioContext, ILoggerFactory> GetLoggerFactory { get; } = _ => new ContextAppenderFactory();
 
         public static IScenarioWithEndpointBehavior<T> Define<T>() where T : ScenarioContext, new()
         {

--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointBehaviorBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointBehaviorBuilder.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.AcceptanceTesting.Support
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
 

--- a/src/NServiceBus.AcceptanceTests/ConfigureEndpointAcceptanceTestingPersistence.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureEndpointAcceptanceTestingPersistence.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿namespace NServiceBus.AcceptanceTests;
+
+using System.Threading.Tasks;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
 

--- a/src/NServiceBus.AcceptanceTests/ConfigureEndpointAcceptanceTestingTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureEndpointAcceptanceTestingTransport.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿namespace NServiceBus.AcceptanceTests;
+
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using NServiceBus;

--- a/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.AcceptanceTests.Core.AutomaticSubscriptions
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
@@ -20,7 +19,7 @@ namespace NServiceBus.AcceptanceTests.Core.AutomaticSubscriptions
                 .Done(c => c.EndpointsStarted)
                 .Run();
 
-            Assert.False(context.EventsSubscribedTo.Any(), "Events only handled by sagas should not be auto subscribed");
+            Assert.False(context.EventsSubscribedTo.Count != 0, "Events only handled by sagas should not be auto subscribed");
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Conventions/When_receiving_unobtrusive_message_without_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Conventions/When_receiving_unobtrusive_message_without_handler.cs
@@ -16,7 +16,7 @@ namespace NServiceBus.AcceptanceTests.Core.Conventions
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<Sender>(c => c.When(s => s.Send(new MyCommand())))
                 .WithEndpoint<Receiver>(c => c.DoNotFailOnErrorMessages())
-                .Done(c => c.FailedMessages.Any())
+                .Done(c => !c.FailedMessages.IsEmpty)
                 .Run();
 
             Assert.True(context.Logs.Any(l => l.Level == LogLevel.Error && l.Message.Contains($"No handlers could be found for message type: {typeof(MyCommand).FullName}")), "No handlers could be found was not logged.");

--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_endpoint_is_warmed_up.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_endpoint_is_warmed_up.cs
@@ -110,7 +110,7 @@
         {
             public Dictionary<Type, RegisteredService> RegisteredServices { get; } = [];
 
-            IServiceProvider ServiceProvider { get; }
+            ServiceProvider ServiceProvider { get; }
 
             public SpyContainer(IServiceCollection serviceCollection)
             {

--- a/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_overriding_input_queue_name.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_overriding_input_queue_name.cs
@@ -3,7 +3,6 @@ namespace NServiceBus.AcceptanceTests.Core.Diagnostics
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using Features;
     using NUnit.Framework;
 
     public class When_overriding_input_queue_name : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Core/Installers/InstallationOnlyComponent.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Installers/InstallationOnlyComponent.cs
@@ -25,7 +25,7 @@ public class InstallationOnlyComponent<TConfigurationFactory> : IComponentBehavi
         return new InstallationRunner(endpointConfiguration);
     }
 
-    void RegisterScenarioContext(EndpointConfiguration endpointConfiguration, ScenarioContext scenarioContext)
+    static void RegisterScenarioContext(EndpointConfiguration endpointConfiguration, ScenarioContext scenarioContext)
     {
         var type = scenarioContext.GetType();
         while (type != typeof(object))

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/TestingActivityListener.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/TestingActivityListener.cs
@@ -37,7 +37,11 @@
             };
         }
 
-        public void Dispose() => activityListener?.Dispose();
+        public void Dispose()
+        {
+            activityListener?.Dispose();
+            GC.SuppressFinalize(this);
+        }
 
         public ConcurrentQueue<Activity> StartedActivities { get; } = new ConcurrentQueue<Activity>();
         public ConcurrentQueue<Activity> CompletedActivities { get; } = new ConcurrentQueue<Activity>();

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_processing_incoming_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_processing_incoming_message.cs
@@ -6,7 +6,6 @@
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
     public class When_processing_incoming_message : OpenTelemetryAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_sending_replies.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_sending_replies.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.AcceptanceTests.Core.OpenTelemetry
 {
     using System.Threading.Tasks;
     using NServiceBus.AcceptanceTesting;
-    using NServiceBus.AcceptanceTests.EndpointTemplates;
     using NUnit.Framework;
 
     public class When_sending_replies : OpenTelemetryAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_configuring_unrecoverable_exception.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_configuring_unrecoverable_exception.cs
@@ -26,7 +26,7 @@ namespace NServiceBus.AcceptanceTests.Core.Recoverability
                             Id = ctx.TestRunId
                         }))
                     )
-                    .Done(c => c.FailedMessages.Any())
+                    .Done(c => !c.FailedMessages.IsEmpty)
                     .Run();
             });
 

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_custom_policy_executed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_custom_policy_executed.cs
@@ -6,7 +6,6 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using Features;
     using NUnit.Framework;
     using Transport;
 
@@ -21,7 +20,7 @@
                 .WithEndpoint<Endpoint>(b =>
                     b.When(bus => bus.SendLocal(new MessageToBeRetried()))
                      .DoNotFailOnErrorMessages())
-                .Done(c => c.FailedMessages.Any())
+                .Done(c => !c.FailedMessages.IsEmpty)
                 .Run();
 
             Assert.That(context.ErrorContexts.Count, Is.EqualTo(2), "because the custom policy should have been invoked twice");

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_custom_policy_provided.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_custom_policy_provided.cs
@@ -18,7 +18,7 @@ namespace NServiceBus.AcceptanceTests.Core.Recoverability
                 .WithEndpoint<Endpoint>(b =>
                     b.When(bus => bus.SendLocal(new MessageToBeRetried()))
                         .DoNotFailOnErrorMessages())
-                .Done(c => c.FailedMessages.Any())
+                .Done(c => !c.FailedMessages.IsEmpty)
                 .Run();
 
             Assert.That(context.Configuration.Immediate.MaxNumberOfRetries, Is.EqualTo(MaxImmediateRetries));

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_delayed_retries_with_regular_exception.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_delayed_retries_with_regular_exception.cs
@@ -19,7 +19,7 @@ namespace NServiceBus.AcceptanceTests.Core.Recoverability
                 .WithEndpoint<RetryEndpoint>(b => b
                     .When(session => session.SendLocal(new MessageToBeRetried()))
                     .DoNotFailOnErrorMessages())
-                .Done(c => c.FailedMessages.Any())
+                .Done(c => !c.FailedMessages.IsEmpty)
                 .Run(TimeSpan.FromSeconds(120));
 
             var delayedRetryBody = context.FailedMessages.Single().Value.Single().Body;

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_failing_mutated_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_failing_mutated_message.cs
@@ -19,7 +19,7 @@
                 .WithEndpoint<RetryEndpoint>(b => b
                     .When(session => session.SendLocal(new MessageToBeRetried()))
                     .DoNotFailOnErrorMessages())
-                .Done(c => c.FailedMessages.Any())
+                .Done(c => !c.FailedMessages.IsEmpty)
                 .Run();
 
             var errorBody = context.FailedMessages.Single().Value.Single().Body;

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_message_is_moved_to_error_queue_with_header_customizations.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_message_is_moved_to_error_queue_with_header_customizations.cs
@@ -34,7 +34,7 @@ namespace NServiceBus.AcceptanceTests.Core.Recoverability
         class Context : ScenarioContext
         {
             public bool MessageMovedToErrorQueue { get; set; }
-            public IReadOnlyDictionary<string, string> Headers { get; set; }
+            public Dictionary<string, string> Headers { get; set; }
         }
 
         class EndpointWithFailingHandler : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_messages_never_succeed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_messages_never_succeed.cs
@@ -9,8 +9,8 @@ namespace NServiceBus.AcceptanceTests.Core.Recoverability
 
     public class When_messages_never_succeed : NServiceBusAcceptanceTest
     {
-        public static int NumberOfConsecutiveFailuresBeforeThrottling = 1;
-        public static TimeSpan TimeToWaitBetweenThrottledAttempts = TimeSpan.FromSeconds(0);
+        static int NumberOfConsecutiveFailuresBeforeThrottling = 1;
+        static TimeSpan TimeToWaitBetweenThrottledAttempts = TimeSpan.FromSeconds(0);
 
         [Test]
         public async Task Should_throttle_pipeline_after_configured_number_of_consecutive_failures()
@@ -31,7 +31,7 @@ namespace NServiceBus.AcceptanceTests.Core.Recoverability
                         }
                     })
                 )
-                .Done(c => c.ThrottleModeEntered && c.FailuresBeforeThrottling >= NumberOfConsecutiveFailuresBeforeThrottling)
+                .Done(c => c.ThrottleModeEntered && Context.FailuresBeforeThrottling >= NumberOfConsecutiveFailuresBeforeThrottling)
                 .Run();
         }
 
@@ -54,7 +54,7 @@ namespace NServiceBus.AcceptanceTests.Core.Recoverability
                         }
                     })
                 )
-                .Done(c => c.FailuresBeforeThrottling == 10 && !c.ThrottleModeEntered)
+                .Done(c => Context.FailuresBeforeThrottling == 10 && !c.ThrottleModeEntered)
                 .Run();
         }
 
@@ -65,7 +65,7 @@ namespace NServiceBus.AcceptanceTests.Core.Recoverability
             public DateTime LastProcessedTimeStamp { get; set; }
             public TimeSpan TimeBetweenProcessingAttempts { get; set; }
 
-            public int FailuresBeforeThrottling => failuresBeforeThrottling;
+            public static int FailuresBeforeThrottling => failuresBeforeThrottling;
         }
 
         class EndpointWithFailingHandler : EndpointConfigurationBuilder
@@ -95,9 +95,9 @@ namespace NServiceBus.AcceptanceTests.Core.Recoverability
 
             class InitiatingHandler : IHandleMessages<InitiatingMessage>
             {
-                public InitiatingHandler(Context contect)
+                public InitiatingHandler(Context context)
                 {
-                    testContext = contect;
+                    testContext = context;
                 }
                 public Task Handle(InitiatingMessage initiatingMessage, IMessageHandlerContext context)
                 {

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_transport_transaction_provided.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_transport_transaction_provided.cs
@@ -23,7 +23,7 @@
                         config.Recoverability().AddUnrecoverableException<SimulatedException>();
                     })
                     .When((session, _) => session.SendLocal(new SomeMessage())))
-                .Done(c => c.FailedMessages.Any())
+                .Done(c => !c.FailedMessages.IsEmpty)
                 .Run();
 
             Assert.AreSame(context.IncomingPipelineTransportTransaction, context.DispatchPipelineTransportTransaction, "Transport Transaction was not the same");

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_a_saga_is_completed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_a_saga_is_completed.cs
@@ -4,7 +4,6 @@
     using System.Threading.Tasks;
     using AcceptanceTesting;
     using EndpointTemplates;
-    using Features;
     using NUnit.Framework;
 
     public class When_a_saga_is_completed : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_overriding_saga_id_creation.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_overriding_saga_id_creation.cs
@@ -7,7 +7,6 @@
     using AcceptanceTesting;
     using Configuration.AdvancedExtensibility;
     using EndpointTemplates;
-    using Features;
     using NServiceBus.Sagas;
     using NUnit.Framework;
 
@@ -54,12 +53,10 @@
                 static Guid ToGuid(string src)
                 {
                     var stringbytes = Encoding.UTF8.GetBytes(src);
-                    using (var provider = SHA1.Create())
-                    {
-                        var hashedBytes = provider.ComputeHash(stringbytes);
-                        Array.Resize(ref hashedBytes, 16);
-                        return new Guid(hashedBytes);
-                    }
+
+                    var hashedBytes = SHA1.HashData(stringbytes);
+                    Array.Resize(ref hashedBytes, 16);
+                    return new Guid(hashedBytes);
                 }
             }
 

--- a/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/AcceptanceTestingTransportServer.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/AcceptanceTestingTransportServer.cs
@@ -4,8 +4,6 @@
     using System.Threading.Tasks;
     using AcceptanceTesting.Customization;
     using AcceptanceTesting.Support;
-    using EndpointTemplates;
-    using NServiceBus.Hosting.Helpers;
 
     class AcceptanceTestingTransportServer : IEndpointSetupTemplate
     {

--- a/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_used_with_default_transaction_mode.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_used_with_default_transaction_mode.cs
@@ -2,7 +2,6 @@
 {
     using System.Threading.Tasks;
     using AcceptanceTesting;
-    using Configuration.AdvancedExtensibility;
     using EndpointTemplates;
     using FakeTransport;
     using NUnit.Framework;

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_to_non_local.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_to_non_local.cs
@@ -5,7 +5,6 @@
     using AcceptanceTesting;
     using AcceptanceTesting.Customization;
     using EndpointTemplates;
-    using Features;
     using NUnit.Framework;
 
     public class When_deferring_to_non_local : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/DeterministicGuid.cs
+++ b/src/NServiceBus.AcceptanceTests/DeterministicGuid.cs
@@ -8,14 +8,10 @@
     {
         public static Guid Create(params object[] data)
         {
-            // use MD5 hash to get a 16-byte hash of the string
-            using (var provider = MD5.Create())
-            {
-                var inputBytes = Encoding.Default.GetBytes(string.Concat(data));
-                var hashBytes = provider.ComputeHash(inputBytes);
-                // generate a guid from the hash:
-                return new Guid(hashBytes);
-            }
+            var inputBytes = Encoding.Default.GetBytes(string.Concat(data));
+            var hashBytes = MD5.HashData(inputBytes);
+            // generate a guid from the hash:
+            return new Guid(hashBytes);
         }
     }
 }

--- a/src/NServiceBus.AcceptanceTests/EndpointTemplates/TestSuiteConstraints.cs
+++ b/src/NServiceBus.AcceptanceTests/EndpointTemplates/TestSuiteConstraints.cs
@@ -23,6 +23,6 @@
 
     public partial class TestSuiteConstraints : ITestSuiteConstraints
     {
-        public static TestSuiteConstraints Current = new TestSuiteConstraints();
+        public static TestSuiteConstraints Current { get; } = new TestSuiteConstraints();
     }
 }

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Cross_q_tx_msg_moved_to_error_q.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Cross_q_tx_msg_moved_to_error_q.cs
@@ -28,7 +28,7 @@
                 .Run();
 
             Assert.IsFalse(context.OutgoingMessageSent, "Outgoing messages should not be sent");
-            Assert.IsTrue(context.FailedMessages.Any());
+            Assert.IsTrue(!context.FailedMessages.IsEmpty);
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Recoverability/CustomPolicyDoes1DelayedRetryThenSendsToError.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/CustomPolicyDoes1DelayedRetryThenSendsToError.cs
@@ -26,7 +26,7 @@ namespace NServiceBus.AcceptanceTests.Recoverability
                         return bus.Send(new MessageToBeRetried(), sendOptions);
                     })
                     .DoNotFailOnErrorMessages())
-                .Done(c => c.FailedMessages.Any())
+                .Done(c => !c.FailedMessages.IsEmpty)
                 .Run();
 
             Assert.AreEqual(2, context.Count);

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_custom_policy_always_moves_to_error.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_custom_policy_always_moves_to_error.cs
@@ -24,7 +24,7 @@ namespace NServiceBus.AcceptanceTests.Recoverability
                         return bus.Send(new MessageToBeRetried(), sendOptions);
                     })
                     .DoNotFailOnErrorMessages())
-                .Done(c => c.FailedMessages.Any())
+                .Done(c => !c.FailedMessages.IsEmpty)
                 .Run();
 
             Assert.AreEqual(1, context.Count);

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_delayed_retries_with_immediate_retries_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_delayed_retries_with_immediate_retries_disabled.cs
@@ -18,7 +18,7 @@
                 .WithEndpoint<RetryEndpoint>(b => b
                     .When((session, ctx) => session.SendLocal(new MessageToBeRetried { Id = ctx.Id }))
                     .DoNotFailOnErrorMessages())
-                .Done(c => c.FailedMessages.Any())
+                .Done(c => !c.FailedMessages.IsEmpty)
                 .Run();
 
             Assert.AreEqual(ConfiguredNumberOfDelayedRetries + 1, context.ReceiveCount, "Message should be delivered 4 times. Once initially and retried 3 times by Delayed Retries");

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_fail.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_fail.cs
@@ -21,7 +21,7 @@
                         Id = ctx.Id
                     }))
                     .DoNotFailOnErrorMessages())
-                .Done(c => c.FailedMessages.Any())
+                .Done(c => !c.FailedMessages.IsEmpty)
                 .Run();
 
             Assert.GreaterOrEqual(context.NumberOfRetriesAttempted, 1, "Should retry one or more times");

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_message_fails_retries.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_message_fails_retries.cs
@@ -15,7 +15,7 @@
             var exception = Assert.ThrowsAsync<MessageFailedException>(async () => await Scenario.Define<Context>()
                     .WithEndpoint<RetryEndpoint>(b => b
                         .When((session, c) => session.SendLocal(new MessageWhichFailsRetries())))
-                    .Done(c => c.FailedMessages.Any())
+                    .Done(c => !c.FailedMessages.IsEmpty)
                     .Run());
 
             Assert.AreEqual(1, exception.ScenarioContext.FailedMessages.Count);

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_message_is_deferred_by_delayed_retries_using_dtc.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_message_is_deferred_by_delayed_retries_using_dtc.cs
@@ -24,7 +24,7 @@
                         Id = c.Id
                     }))
                  )
-                .Done(c => c.FailedMessages.Any())
+                .Done(c => !c.FailedMessages.IsEmpty)
                 .Run();
 
             Assert.GreaterOrEqual(context.NumberOfRetriesAttempted, 3, "Should retry at least three times");

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_non_transactional_message_is_moved_to_error_queue.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_non_transactional_message_is_moved_to_error_queue.cs
@@ -27,7 +27,7 @@
                 .Done(c => c.MessageMovedToErrorQueue && c.OutgoingMessageSent)
                 .Run();
 
-            Assert.IsTrue(context.FailedMessages.Any(), "Messages should have failed");
+            Assert.IsTrue(!context.FailedMessages.IsEmpty, "Messages should have failed");
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_receiveonly_message_is_moved_to_error_queue.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_receiveonly_message_is_moved_to_error_queue.cs
@@ -27,7 +27,7 @@
                 .Done(c => c.MessageMovedToErrorQueue && c.OutgoingMessageSent)
                 .Run();
 
-            Assert.IsTrue(context.FailedMessages.Any(), "Messages should have failed");
+            Assert.IsTrue(!context.FailedMessages.IsEmpty, "Messages should have failed");
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_transactionscope_message_is_moved_to_error_queue.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_transactionscope_message_is_moved_to_error_queue.cs
@@ -28,7 +28,7 @@
                 .Run();
 
             Assert.IsFalse(context.OutgoingMessageSent, "Outgoing messages should not be sent");
-            Assert.IsTrue(context.FailedMessages.Any(), "There should be failed messages registered in this scenario");
+            Assert.IsTrue(!context.FailedMessages.IsEmpty, "There should be failed messages registered in this scenario");
         }
 
         class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_correlation_property_is_null.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_correlation_property_is_null.cs
@@ -18,7 +18,7 @@
                         {
                             CorrelationProperty = null
                         })))
-                .Done(c => c.FailedMessages.Count > 0)
+                .Done(c => !c.FailedMessages.IsEmpty)
                 .Run());
 
             var errorMessage = $"Message {typeof(MessageWithNullCorrelationProperty).FullName} mapped to saga {typeof(SagaWithCorrelationPropertyEndpoint.SagaWithCorrelatedProperty).FullName} has attempted to assign null to the correlation property {nameof(SagaWithCorrelationPropertyEndpoint.SagaDataWithCorrelatedProperty.CorrelatedProperty)}. Correlation properties cannot be assigned null.";

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_handles_unmapped_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_handles_unmapped_message.cs
@@ -24,7 +24,7 @@
                         SomeId = id
                     }));
                 })
-                .Done(c => c.MappedEchoReceived && (c.EchoReceived || c.FailedMessages.Any()))
+                .Done(c => c.MappedEchoReceived && (c.EchoReceived || !c.FailedMessages.IsEmpty))
                 .Run();
 
             Assert.AreEqual(true, context.StartReceived);

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
@@ -21,7 +21,7 @@
                         {
                             DataId = Guid.NewGuid()
                         })))
-                    .Done(c => c.FailedMessages.Any())
+                    .Done(c => !c.FailedMessages.IsEmpty)
                     .Run());
 
             Assert.That(exception.ScenarioContext.FailedMessages, Has.Count.EqualTo(1));

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
@@ -19,7 +19,7 @@
                     {
                         SomeId = Guid.NewGuid()
                     })))
-                    .Done(c => c.FailedMessages.Any())
+                    .Done(c => !c.FailedMessages.IsEmpty)
                     .Run());
 
             Assert.IsTrue(((Context)exception.ScenarioContext).ModifiedCorrelationProperty);

--- a/src/NServiceBus.AcceptanceTests/Tx/FakePromotableResourceManager.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/FakePromotableResourceManager.cs
@@ -21,7 +21,7 @@
 
         public byte[] Promote() => TransactionInterop.GetTransmitterPropagationToken(new CommittableTransaction());
 
-        public static Guid ResourceManagerId = Guid.Parse("6f057e24-a0d8-4c95-b091-b8dc9a916fa4");
+        public static Guid ResourceManagerId { get; } = Guid.Parse("6f057e24-a0d8-4c95-b091-b8dc9a916fa4");
 
         public static void ForceDtc() => Transaction.Current.EnlistDurable(ResourceManagerId, new FakePromotableResourceManager(), EnlistmentOptions.None);
     }

--- a/src/NServiceBus.ContainerTests/When_building_components.cs
+++ b/src/NServiceBus.ContainerTests/When_building_components.cs
@@ -98,7 +98,7 @@ namespace NServiceBus.ContainerTests
             }
         }
 
-        void InitializeServices(IServiceCollection serviceCollection)
+        static void InitializeServices(IServiceCollection serviceCollection)
         {
             serviceCollection.AddSingleton(typeof(SingletonComponent));
             serviceCollection.AddTransient(typeof(TransientComponent));
@@ -151,7 +151,9 @@ namespace NServiceBus.ContainerTests
 
     public class StaticFactory
     {
+#pragma warning disable CA1822 // Mark members as static
         public ComponentCreatedByFactory Create()
+#pragma warning restore CA1822 // Mark members as static
         {
             return new ComponentCreatedByFactory();
         }

--- a/src/NServiceBus.ContainerTests/When_disposing_the_builder.cs
+++ b/src/NServiceBus.ContainerTests/When_disposing_the_builder.cs
@@ -28,21 +28,23 @@ namespace NServiceBus.ContainerTests
 
         public class DisposableComponent : IDisposable
         {
-            public static bool DisposeCalled;
+            public static bool DisposeCalled { get; set; }
 
             public void Dispose()
             {
                 DisposeCalled = true;
+                GC.SuppressFinalize(this);
             }
         }
 
         public class AnotherSingletonComponent : IDisposable
         {
-            public static bool DisposeCalled;
+            public static bool DisposeCalled { get; set; }
 
             public void Dispose()
             {
                 DisposeCalled = true;
+                GC.SuppressFinalize(this);
             }
         }
     }

--- a/src/NServiceBus.ContainerTests/When_querying_for_registered_components.cs
+++ b/src/NServiceBus.ContainerTests/When_querying_for_registered_components.cs
@@ -34,7 +34,7 @@ namespace NServiceBus.ContainerTests
             Assert.True(serviceCollection.Any(sd => sd.ServiceType == typeof(ExistingComponentWithUnsatisfiedDependency)));
         }
 
-        void InitializeBuilder(IServiceCollection c)
+        static void InitializeBuilder(IServiceCollection c)
         {
             c.AddTransient(typeof(ExistingComponent));
             c.AddTransient(typeof(ExistingComponentWithUnsatisfiedDependency));

--- a/src/NServiceBus.ContainerTests/When_registering_components.cs
+++ b/src/NServiceBus.ContainerTests/When_registering_components.cs
@@ -141,7 +141,7 @@ namespace NServiceBus.ContainerTests
 
         public void Dispose()
         {
-            throw new NotImplementedException();
+            GC.SuppressFinalize(this);
         }
     }
 

--- a/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
+++ b/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
@@ -178,6 +178,7 @@ namespace NServiceBus.ContainerTests
     {
         public void Dispose()
         {
+            GC.SuppressFinalize(this);
         }
     }
 
@@ -186,9 +187,10 @@ namespace NServiceBus.ContainerTests
         public void Dispose()
         {
             DisposeCalled = true;
+            GC.SuppressFinalize(this);
         }
 
-        public static bool DisposeCalled;
+        public static bool DisposeCalled { get; private set; }
     }
 
     public class SingletonComponent : ISingletonComponent
@@ -205,21 +207,23 @@ namespace NServiceBus.ContainerTests
 
     public class DisposableComponent : IDisposable
     {
-        public static bool DisposeCalled;
+        public static bool DisposeCalled { get; set; }
 
         public void Dispose()
         {
             DisposeCalled = true;
+            GC.SuppressFinalize(this);
         }
     }
 
     public class AnotherDisposableComponent : IDisposable
     {
-        public static bool DisposeCalled;
+        public static bool DisposeCalled { get; set; }
 
         public void Dispose()
         {
             DisposeCalled = true;
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/AnalyzerTestFixture.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/AnalyzerTestFixture.cs
@@ -177,7 +177,7 @@
 
                 while (remainingCode.Length > 0)
                 {
-                    var beforeAndAfterOpening = remainingCode.Split(new[] { "[|" }, 2, StringSplitOptions.None);
+                    var beforeAndAfterOpening = remainingCode.Split(openingSeparator, 2, StringSplitOptions.None);
 
                     if (beforeAndAfterOpening.Length == 1)
                     {
@@ -185,7 +185,7 @@
                         break;
                     }
 
-                    var midAndAfterClosing = beforeAndAfterOpening[1].Split(new[] { "|]" }, 2, StringSplitOptions.None);
+                    var midAndAfterClosing = beforeAndAfterOpening[1].Split(closingSeparator, 2, StringSplitOptions.None);
 
                     if (midAndAfterClosing.Length == 1)
                     {
@@ -209,5 +209,8 @@
 
         protected static readonly bool VerboseLogging = Environment.GetEnvironmentVariable("CI") != "true"
             || Environment.GetEnvironmentVariable("VERBOSE_TEST_LOGGING")?.ToLower() == "true";
+
+        static readonly string[] openingSeparator = ["[|"];
+        static readonly string[] closingSeparator = ["|]"];
     }
 }

--- a/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/CodeFixTestFixture.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/CodeFixTestFixture.cs
@@ -56,14 +56,14 @@
             var analyzerDiagnostics = (await compilation.GetAnalyzerDiagnostics(new TAnalyzer(), cancellationToken)).ToList();
             WriteAnalyzerDiagnostics(analyzerDiagnostics);
 
-            if (!analyzerDiagnostics.Any())
+            if (analyzerDiagnostics.Count == 0)
             {
                 return codeFiles;
             }
 
             var actions = await project.GetCodeActions(new TCodeFix(), analyzerDiagnostics.First(), cancellationToken);
 
-            if (!actions.Any())
+            if (actions.Length == 0)
             {
                 return codeFiles;
             }

--- a/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/CompilationExtensions.cs
+++ b/src/NServiceBus.Core.Analyzer.Tests.Common/Helpers/CompilationExtensions.cs
@@ -47,7 +47,7 @@
                 .WithAnalyzers(ImmutableArray.Create(analyzer), analysisOptions)
                 .GetAnalyzerDiagnosticsAsync(cancellationToken);
 
-            if (exceptions.Any())
+            if (exceptions.Count != 0)
             {
                 throw new AggregateException(exceptions);
             }

--- a/src/NServiceBus.Core.Tests/API/APIApprovals.cs
+++ b/src/NServiceBus.Core.Tests/API/APIApprovals.cs
@@ -12,8 +12,9 @@
         {
             var publicApi = typeof(Endpoint).Assembly.GeneratePublicApi(new ApiGeneratorOptions
             {
-                ExcludeAttributes = new[] { "System.Runtime.Versioning.TargetFrameworkAttribute", "System.Reflection.AssemblyMetadataAttribute" }
+                ExcludeAttributes = ["System.Runtime.Versioning.TargetFrameworkAttribute", "System.Reflection.AssemblyMetadataAttribute"]
             });
+
             Approver.Verify(publicApi);
         }
     }

--- a/src/NServiceBus.Core.Tests/API/NullableAnnotations.cs
+++ b/src/NServiceBus.Core.Tests/API/NullableAnnotations.cs
@@ -41,7 +41,7 @@
         {
             var allInfo = AllMemberNullabilityInfoFor(type).ToArray();
             var noNullInfoFor = allInfo.Where(info => info.Info.WriteState is NullabilityState.Unknown || info.Info.ReadState == NullabilityState.Unknown).ToArray();
-            return noNullInfoFor.Any();
+            return noNullInfoFor.Length != 0;
         }
 
         IEnumerable<(object Item, NullabilityInfo Info)> AllMemberNullabilityInfoFor(Type type)

--- a/src/NServiceBus.Core.Tests/API/NullableApiUsages.cs
+++ b/src/NServiceBus.Core.Tests/API/NullableApiUsages.cs
@@ -22,7 +22,7 @@ namespace NServiceBus.Core.Tests.API.NullableApiUsages
 
     public class TopLevelApis
     {
-        public async Task SetupEndpoint(CancellationToken cancellationToken = default)
+        public static async Task SetupEndpoint(CancellationToken cancellationToken = default)
         {
             var cfg = new EndpointConfiguration("EndpointName");
 

--- a/src/NServiceBus.Core.Tests/API/Types.cs
+++ b/src/NServiceBus.Core.Tests/API/Types.cs
@@ -13,7 +13,7 @@
             var violators = NServiceBusAssembly.Types
                 .Where(type => type.IsStatic())
                 .Where(type => type.Name.Length > 1)
-                .Where(type => type.Name.StartsWith("I", StringComparison.Ordinal) && !type.FullName.StartsWith("FastExpressionCompiler"))
+                .Where(type => type.Name.StartsWith('I') && !type.FullName.StartsWith("FastExpressionCompiler"))
                 .Where(type => char.IsUpper(type.Name.ElementAt(1)))
                 .Prettify()
                 .ToList();

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/ErrorLoggingTest.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/ErrorLoggingTest.cs
@@ -13,7 +13,7 @@
         [Test]
         public void ApproveErrorLog_FileLoadException_NServiceBus()
         {
-            var exception = new ReflectionTypeLoadException(new Type[0], new[]
+            var exception = new ReflectionTypeLoadException(Array.Empty<Type>(), new[]
             {
                 new Exception("Generic exception 1"),
                 new FileLoadException("File load exception", typeof(AssemblyScanner).Assembly.FullName),
@@ -27,7 +27,7 @@
         [Test]
         public void ApproveErrorLog_FileLoadException_NServiceBus_Only()
         {
-            var exception = new ReflectionTypeLoadException(new Type[0], new Exception[]
+            var exception = new ReflectionTypeLoadException(Array.Empty<Type>(), new Exception[]
             {
                 new FileLoadException("File load exception", typeof(AssemblyScanner).Assembly.FullName),
             });
@@ -39,7 +39,7 @@
         [Test]
         public void ApproveErrorLog_FileLoadException()
         {
-            var exception = new ReflectionTypeLoadException(new Type[0], new[]
+            var exception = new ReflectionTypeLoadException(Array.Empty<Type>(), new[]
             {
                 new Exception("Generic exception 1"),
                 new FileLoadException("File load exception", typeof(ErrorLoggingTest).Assembly.FullName),
@@ -53,7 +53,7 @@
         [Test]
         public void ApproveErrorLog_FileLoadException_Only()
         {
-            var exception = new ReflectionTypeLoadException(new Type[0], new Exception[]
+            var exception = new ReflectionTypeLoadException(Array.Empty<Type>(), new Exception[]
             {
                 new FileLoadException("File load exception", typeof(ErrorLoggingTest).Assembly.FullName),
             });
@@ -65,7 +65,7 @@
         [Test]
         public void ApproveErrorLog_FileLoadException_NServiceBus_Other()
         {
-            var exception = new ReflectionTypeLoadException(new Type[0], new Exception[]
+            var exception = new ReflectionTypeLoadException(Array.Empty<Type>(), new Exception[]
             {
                 new FileLoadException("File load exception", typeof(ErrorLoggingTest).Assembly.FullName),
                 new FileLoadException("File load exception", typeof(AssemblyScanner).Assembly.FullName),
@@ -78,7 +78,7 @@
         [Test]
         public void ApproveErrorLog_GenericExceptions()
         {
-            var exception = new ReflectionTypeLoadException(new Type[0], new[]
+            var exception = new ReflectionTypeLoadException(Array.Empty<Type>(), new[]
             {
                 new Exception("Generic exception 1"),
                 new Exception("Generic exception 2"),
@@ -91,7 +91,7 @@
         [Test]
         public void ApproveErrorLog_NoExceptions()
         {
-            var exception = new ReflectionTypeLoadException(new Type[0], new Exception[0]);
+            var exception = new ReflectionTypeLoadException(Array.Empty<Type>(), Array.Empty<Exception>());
 
             var formattedException = AssemblyScanner.FormatReflectionTypeLoadException("MyFile", exception);
             Approver.Verify(formattedException);

--- a/src/NServiceBus.Core.Tests/Causation/AttachCausationHeadersBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Causation/AttachCausationHeadersBehaviorTests.cs
@@ -34,7 +34,7 @@
             var transportMessage = new IncomingMessage("xyz", new Dictionary<string, string>
             {
                 {Headers.ConversationId, incomingConversationId}
-            }, new byte[0]);
+            }, Array.Empty<byte>());
             context.Extensions.Set(transportMessage);
 
             await behavior.Invoke(context, ctx => Task.CompletedTask);
@@ -78,7 +78,7 @@
             var transportMessage = new IncomingMessage("xyz", new Dictionary<string, string>
             {
                 {Headers.ConversationId, incomingConversationId}
-            }, new byte[0]);
+            }, Array.Empty<byte>());
             context.Extensions.Set(transportMessage);
 
             var exception = Assert.ThrowsAsync<Exception>(() => behavior.Invoke(context, ctx => Task.CompletedTask));
@@ -92,7 +92,7 @@
             var behavior = new AttachCausationHeadersBehavior(ReturnDefaultConversationId);
             var context = new TestableOutgoingLogicalMessageContext();
 
-            context.Extensions.Set(new IncomingMessage("the message id", [], new byte[0]));
+            context.Extensions.Set(new IncomingMessage("the message id", [], Array.Empty<byte>()));
 
             await behavior.Invoke(context, ctx => Task.CompletedTask);
 

--- a/src/NServiceBus.Core.Tests/Causation/CustomConversationIdStrategyTests.cs
+++ b/src/NServiceBus.Core.Tests/Causation/CustomConversationIdStrategyTests.cs
@@ -35,7 +35,7 @@
             Assert.True(Guid.TryParse(Invoke(_ => ConversationId.Default), out var _));
         }
 
-        string Invoke(Func<ConversationIdStrategyContext, ConversationId> strategy)
+        static string Invoke(Func<ConversationIdStrategyContext, ConversationId> strategy)
         {
             return MessageCausation.WrapUserDefinedInvocation(strategy)(new TestableOutgoingLogicalMessageContext());
         }

--- a/src/NServiceBus.Core.Tests/Config/When_scanning_assemblies.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_scanning_assemblies.cs
@@ -22,25 +22,25 @@ namespace NServiceBus.Core.Tests.Config
         [Ignore("Does not work")]
         public void Should_for_our_code_exclude_everything_but_NServiceBus_by_default()
         {
-            CollectionAssert.AreEquivalent(new string[0],
+            CollectionAssert.AreEquivalent(System.Array.Empty<string>(),
                 foundAssemblies.Where(a => !a.FullName.StartsWith("NServiceBus") && !a.FullName.StartsWith("Obsolete")));
         }
 
         [Test]
         public void Should_exclude_system_assemblies()
         {
-            CollectionAssert.AreEquivalent(new string[0],
+            CollectionAssert.AreEquivalent(System.Array.Empty<string>(),
                 foundAssemblies.Where(a => a.FullName.StartsWith("System")).ToArray());
         }
 
         [Test]
         public void Should_exclude_nhibernate_assemblies()
         {
-            CollectionAssert.AreEquivalent(new string[0],
-                foundAssemblies.Where(a => a.FullName.ToLower().StartsWith("nhibernate")).ToArray());
+            CollectionAssert.AreEquivalent(System.Array.Empty<string>(),
+                foundAssemblies.Where(a => a.FullName.StartsWith("nhibernate", System.StringComparison.OrdinalIgnoreCase)).ToArray());
         }
 
-        IEnumerable<Assembly> GetAssembliesInDirectory(string path, params string[] assembliesToSkip)
+        static List<Assembly> GetAssembliesInDirectory(string path, params string[] assembliesToSkip)
         {
             var assemblyScanner = new AssemblyScanner(path)
             {

--- a/src/NServiceBus.Core.Tests/DocumentationTests.cs
+++ b/src/NServiceBus.Core.Tests/DocumentationTests.cs
@@ -24,7 +24,7 @@
 
             var list = GetListOfMissingDocs(assemblyMembers).ToList();
 
-            if (list.Any())
+            if (list.Count != 0)
             {
                 var errors = string.Join(Environment.NewLine, list);
                 throw new Exception($"Some members have empty documentation or have a sentence that does not end with a period:{Environment.NewLine}{errors}");
@@ -109,7 +109,7 @@
                 }
                 if (!string.IsNullOrWhiteSpace(text))
                 {
-                    if (text.Trim().EndsWith("."))
+                    if (text.Trim().EndsWith('.'))
                     {
                         return;
                     }

--- a/src/NServiceBus.Core.Tests/Fakes/FakeOutboxTransaction.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/FakeOutboxTransaction.cs
@@ -17,6 +17,7 @@
         public void Dispose()
         {
             Transaction = null;
+            GC.SuppressFinalize(this);
         }
 
         public Task Commit(CancellationToken cancellationToken = default)

--- a/src/NServiceBus.Core.Tests/Fakes/FakeSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/FakeSynchronizedStorageSession.cs
@@ -58,7 +58,11 @@
             return Task.CompletedTask;
         }
 
-        public void Dispose() => Transaction = null;
+        public void Dispose()
+        {
+            Transaction = null;
+            GC.SuppressFinalize(this);
+        }
 
         public Task CompleteAsync(CancellationToken cancellationToken = default)
         {

--- a/src/NServiceBus.Core.Tests/Fakes/TestableContextChecker.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/TestableContextChecker.cs
@@ -28,7 +28,7 @@
 
             foreach (var behaviorContextInterface in behaviorContextInterfaces)
             {
-                var testableImplementationName = "Testable" + behaviorContextInterface.Name.Substring(1);
+                var testableImplementationName = string.Concat("Testable", behaviorContextInterface.Name.AsSpan(1));
 
                 if (!testingAssembly.DefinedTypes.Any(t => t.Name == testableImplementationName && behaviorContextInterface.IsAssignableFrom(t)))
                 {

--- a/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
@@ -283,6 +283,7 @@
                 public void Dispose()
                 {
                     parentFeature.TaskDisposed = true;
+                    GC.SuppressFinalize(this);
                 }
 
                 protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
@@ -341,6 +342,7 @@
                 public void Dispose()
                 {
                     parentFeature.TaskDisposed = true;
+                    GC.SuppressFinalize(this);
                 }
 
                 protected override Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)

--- a/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
+++ b/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
@@ -13,9 +13,8 @@
         public void ShouldLogNoStatusMessageWhenLicenseIsValid()
         {
             var logger = new TestableLogger();
-            var licenseManager = new LicenseManager();
 
-            licenseManager.LogLicenseStatus(LicenseStatus.Valid, logger, new License(), "fake-url");
+            LicenseManager.LogLicenseStatus(LicenseStatus.Valid, logger, new License(), "fake-url");
 
             Assert.AreEqual(0, logger.Logs.Count);
         }
@@ -24,9 +23,8 @@
         public void WhenSubscriptionLicenseExpired()
         {
             var logger = new TestableLogger();
-            var licenseManager = new LicenseManager();
 
-            licenseManager.LogLicenseStatus(LicenseStatus.InvalidDueToExpiredSubscription, logger, new License(), "fake-url");
+            LicenseManager.LogLicenseStatus(LicenseStatus.InvalidDueToExpiredSubscription, logger, new License(), "fake-url");
 
             Assert.AreEqual(1, logger.Logs.Count);
             Assert.AreEqual(LogLevel.Error, logger.Logs[0].level);
@@ -37,9 +35,8 @@
         public void WhenUpgradeProtectionExpiredForThisRelease()
         {
             var logger = new TestableLogger();
-            var licenseManager = new LicenseManager();
 
-            licenseManager.LogLicenseStatus(LicenseStatus.InvalidDueToExpiredUpgradeProtection, logger, new License(), "fake-url");
+            LicenseManager.LogLicenseStatus(LicenseStatus.InvalidDueToExpiredUpgradeProtection, logger, new License(), "fake-url");
 
             Assert.AreEqual(1, logger.Logs.Count);
             Assert.AreEqual(LogLevel.Error, logger.Logs[0].level);
@@ -51,10 +48,9 @@
         public void WhenTrialLicenseExpired(bool isDevLicenseRenewal, string expectedMessage)
         {
             var logger = new TestableLogger();
-            var licenseManager = new LicenseManager();
             var license = new License { IsExtendedTrial = isDevLicenseRenewal };
 
-            licenseManager.LogLicenseStatus(LicenseStatus.InvalidDueToExpiredTrial, logger, license, "fake-url");
+            LicenseManager.LogLicenseStatus(LicenseStatus.InvalidDueToExpiredTrial, logger, license, "fake-url");
 
             Assert.AreEqual(1, logger.Logs.Count);
             Assert.AreEqual(LogLevel.Error, logger.Logs[0].level);
@@ -79,7 +75,7 @@
                 IsExtendedTrial = isDevLicenseRenewal
             };
 
-            licenseManager.LogLicenseStatus(LicenseStatus.ValidWithExpiringTrial, logger, license, "fake-url");
+            LicenseManager.LogLicenseStatus(LicenseStatus.ValidWithExpiringTrial, logger, license, "fake-url");
 
             Assert.AreEqual(1, logger.Logs.Count);
             Assert.AreEqual(LogLevel.Warn, logger.Logs[0].level);
@@ -100,7 +96,7 @@
                 ExpirationDate = today.AddDays(daysRemaining)
             };
 
-            licenseManager.LogLicenseStatus(LicenseStatus.ValidWithExpiringSubscription, logger, license, "fake-url");
+            LicenseManager.LogLicenseStatus(LicenseStatus.ValidWithExpiringSubscription, logger, license, "fake-url");
 
             Assert.AreEqual(1, logger.Logs.Count);
             Assert.AreEqual(LogLevel.Warn, logger.Logs[0].level);
@@ -121,7 +117,7 @@
                 UpgradeProtectionExpiration = today.AddDays(daysRemaining)
             };
 
-            licenseManager.LogLicenseStatus(LicenseStatus.ValidWithExpiringUpgradeProtection, logger, license, "fake-url");
+            LicenseManager.LogLicenseStatus(LicenseStatus.ValidWithExpiringUpgradeProtection, logger, license, "fake-url");
 
             Assert.AreEqual(1, logger.Logs.Count);
             Assert.AreEqual(LogLevel.Warn, logger.Logs[0].level);
@@ -141,7 +137,7 @@
                 UpgradeProtectionExpiration = today.AddDays(-10)
             };
 
-            licenseManager.LogLicenseStatus(LicenseStatus.ValidWithExpiredUpgradeProtection, logger, license, "fake-url");
+            LicenseManager.LogLicenseStatus(LicenseStatus.ValidWithExpiredUpgradeProtection, logger, license, "fake-url");
 
             Assert.AreEqual(1, logger.Logs.Count);
             Assert.AreEqual(LogLevel.Warn, logger.Logs[0].level);

--- a/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
@@ -71,7 +71,7 @@
             }
         }
 
-        static IDisposable LockFile(string single)
+        static FileStream LockFile(string single)
         {
             return new FileStream(single, FileMode.Open, FileAccess.Read, FileShare.None);
         }

--- a/src/NServiceBus.Core.Tests/MessageMapper/When_mapping_interfaces.cs
+++ b/src/NServiceBus.Core.Tests/MessageMapper/When_mapping_interfaces.cs
@@ -72,6 +72,7 @@ namespace MessageMapperTests
             string SomeOtherProperty { get; set; }
         }
 
+        [AttributeUsage(AttributeTargets.All)]
         public class SomeAttribute : Attribute
         {
         }
@@ -94,6 +95,7 @@ namespace MessageMapperTests
             string SomeProperty { get; set; }
         }
 
+        [AttributeUsage(AttributeTargets.All)]
         public class NoDefaultConstructorAttribute : Attribute
         {
             public string Name { get; set; }
@@ -123,6 +125,7 @@ namespace MessageMapperTests
         /// <summary>
         /// Break the heuristics of finding the properties from constructor parameter names
         /// </summary>
+        [AttributeUsage(AttributeTargets.All)]
         public class NoDefaultConstructorAndNoMatchingParametersAttribute : Attribute
         {
             public string Name { get; set; }
@@ -168,6 +171,7 @@ namespace MessageMapperTests
             Guid EventId { get; set; }
         }
 
+        [AttributeUsage(AttributeTargets.All)]
         public class ValuePropertiesAttribute : Attribute
         {
             public ValuePropertiesAttribute() { }
@@ -186,7 +190,7 @@ namespace MessageMapperTests
             public int MyAge { get; set; }
         }
 
-        bool PropertyContainsAttribute(string propertyName, Type attributeType, object obj)
+        static bool PropertyContainsAttribute(string propertyName, Type attributeType, object obj)
         {
             return obj.GetType().GetProperty(propertyName).GetCustomAttributes(attributeType, true).Length > 0;
         }

--- a/src/NServiceBus.Core.Tests/MessageMutators/MutateInstanceMessage/MutateIncomingMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageMutators/MutateInstanceMessage/MutateIncomingMessageBehaviorTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Core.Tests.MessageMutators.MutateInstanceMessage
 {
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using MessageMutator;
     using Microsoft.Extensions.DependencyInjection;
@@ -100,7 +99,7 @@
 
             var context = new InterceptUpdateMessageIncomingLogicalMessageContext();
 
-            context.Services.AddTransient(sp => new IMutateIncomingMessages[] { });
+            context.Services.AddTransient(sp => System.Array.Empty<IMutateIncomingMessages>());
 
             await behavior.Invoke(context, ctx => Task.CompletedTask);
 

--- a/src/NServiceBus.Core.Tests/MessageMutators/MutateInstanceMessage/MutateOutgoingMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageMutators/MutateInstanceMessage/MutateOutgoingMessageBehaviorTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Core.Tests.MessageMutators.MutateInstanceMessage
 {
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using MessageMutator;
     using Microsoft.Extensions.DependencyInjection;
@@ -68,7 +67,7 @@
             var behavior = new MutateOutgoingMessageBehavior([]);
 
             var context = new TestableOutgoingLogicalMessageContext();
-            context.Extensions.Set(new IncomingMessage("messageId", [], new byte[0]));
+            context.Extensions.Set(new IncomingMessage("messageId", [], System.Array.Empty<byte>()));
             context.Extensions.Set(new LogicalMessage(null, null));
             context.Services.AddTransient<IMutateOutgoingMessages>(sp => new MutateOutgoingMessagesReturnsNull());
 
@@ -96,7 +95,7 @@
 
             var context = new InterceptUpdateMessageOutgoingLogicalMessageContext();
 
-            context.Services.AddTransient(sp => new IMutateOutgoingMessages[] { });
+            context.Services.AddTransient(sp => System.Array.Empty<IMutateOutgoingMessages>());
 
             await behavior.Invoke(context, ctx => Task.CompletedTask);
 

--- a/src/NServiceBus.Core.Tests/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehaviorTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Core.Tests.MessageMutators.MutateTransportMessage
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using MessageMutator;
     using Microsoft.Extensions.DependencyInjection;
@@ -94,7 +93,7 @@
 
             var context = new InterceptUpdateMessageIncomingPhysicalMessageContext();
 
-            context.Services.AddTransient(sp => new IMutateIncomingTransportMessages[] { });
+            context.Services.AddTransient(sp => Array.Empty<IMutateIncomingTransportMessages>());
 
             await behavior.Invoke(context, ctx => Task.CompletedTask);
 
@@ -159,7 +158,7 @@
         {
             public Task MutateIncoming(MutateIncomingTransportMessageContext context)
             {
-                context.Body = new byte[0];
+                context.Body = Array.Empty<byte>();
 
                 return Task.CompletedTask;
             }

--- a/src/NServiceBus.Core.Tests/MessageMutators/MutateTransportMessage/MutateOutgoingTransportMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageMutators/MutateTransportMessage/MutateOutgoingTransportMessageBehaviorTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Core.Tests.MessageMutators.MutateTransportMessage
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using MessageMutator;
     using Microsoft.Extensions.DependencyInjection;
@@ -100,7 +99,7 @@
             var context = new InterceptUpdateMessageOutgoingPhysicalMessageContext();
             context.Extensions.Set(new OutgoingLogicalMessage(typeof(FakeMessage), new FakeMessage()));
 
-            context.Services.AddTransient(sp => new IMutateOutgoingTransportMessages[] { });
+            context.Services.AddTransient(sp => Array.Empty<IMutateOutgoingTransportMessages>());
 
             await behavior.Invoke(context, ctx => Task.CompletedTask);
 
@@ -166,7 +165,7 @@
         {
             public Task MutateOutgoing(MutateOutgoingTransportMessageContext context)
             {
-                context.OutgoingBody = new byte[0];
+                context.OutgoingBody = Array.Empty<byte>();
 
                 return Task.CompletedTask;
             }

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/ContextPropagationTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/ContextPropagationTests.cs
@@ -169,7 +169,7 @@
         public class ContextPropagationTestCase
         {
             string caseName;
-            IDictionary<string, string> baggageItems = new Dictionary<string, string>();
+            Dictionary<string, string> baggageItems = [];
 
             public ContextPropagationTestCase(string caseName)
             {
@@ -193,7 +193,7 @@
 
             public override string ToString() => caseName;
 
-            public bool HasBaggage => baggageItems.Any();
+            public bool HasBaggage => baggageItems.Count != 0;
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Performance/TimeToBeReceived/TimeToBeReceivedAttributeTests.cs
+++ b/src/NServiceBus.Core.Tests/Performance/TimeToBeReceived/TimeToBeReceivedAttributeTests.cs
@@ -41,9 +41,7 @@
         [Test]
         public void Should_use_TimeToBeReceived_from_bottom_of_tree_when_tryget()
         {
-            var mappings = new TimeToBeReceivedMappings(new Type[]
-            {
-            }, TimeToBeReceivedMappings.DefaultConvention, true);
+            var mappings = new TimeToBeReceivedMappings(Array.Empty<Type>(), TimeToBeReceivedMappings.DefaultConvention, true);
 
             Assert.True(mappings.TryGetTimeToBeReceived(typeof(InheritedClassWithAttribute), out var timeToBeReceived));
             Assert.AreEqual(TimeSpan.FromSeconds(2), timeToBeReceived);
@@ -52,9 +50,7 @@
         [Test]
         public void Should_use_inherited_TimeToBeReceived_when_tryget()
         {
-            var mappings = new TimeToBeReceivedMappings(new Type[]
-            {
-            }, TimeToBeReceivedMappings.DefaultConvention, true);
+            var mappings = new TimeToBeReceivedMappings(Array.Empty<Type>(), TimeToBeReceivedMappings.DefaultConvention, true);
 
             Assert.True(mappings.TryGetTimeToBeReceived(typeof(InheritedClassWithNoAttribute), out var timeToBeReceived));
             Assert.AreEqual(TimeSpan.FromSeconds(1), timeToBeReceived);
@@ -63,9 +59,7 @@
         [Test]
         public void Should_throw_when_discard_before_received_not_supported_when_tryget()
         {
-            var mappings = new TimeToBeReceivedMappings(new Type[]
-            {
-            }, TimeToBeReceivedMappings.DefaultConvention, doesTransportSupportDiscardIfNotReceivedBefore: false);
+            var mappings = new TimeToBeReceivedMappings(Array.Empty<Type>(), TimeToBeReceivedMappings.DefaultConvention, doesTransportSupportDiscardIfNotReceivedBefore: false);
 
             Assert.That(() =>
             {

--- a/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
@@ -142,7 +142,7 @@
             return messageHandler;
         }
 
-        static IInvokeHandlerContext CreateBehaviorContext(MessageHandler messageHandler)
+        static TestableInvokeHandlerContext CreateBehaviorContext(MessageHandler messageHandler)
         {
             var behaviorContext = new TestableInvokeHandlerContext
             {

--- a/src/NServiceBus.Core.Tests/Pipeline/MainPipelineExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MainPipelineExecutorTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Core.Tests.Pipeline
 {
     using System;
-    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Threading.Tasks;
     using Extensibility;

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingLogicalMessageContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingLogicalMessageContextTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Core.Tests.Pipeline.Outgoing
 {
     using System;
-    using System.Collections.Generic;
     using System.Reflection;
     using MessageInterfaces.MessageMapper.Reflection;
     using NServiceBus.Pipeline;

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingPublishContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingPublishContextTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Core.Tests.Pipeline.Outgoing
 {
-    using System.Collections.Generic;
     using Extensibility;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
@@ -36,7 +35,7 @@
 
             var parentContext = new FakeRootContext();
 
-            new OutgoingPublishContext(message, "message-id", options.OutgoingHeaders, options.Context, parentContext);
+            _ = new OutgoingPublishContext(message, "message-id", options.OutgoingHeaders, options.Context, parentContext);
 
             var valueFound = parentContext.TryGet("someKey", out string _);
 

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingReplyContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingReplyContextTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Core.Tests.Pipeline.Outgoing
 {
-    using System.Collections.Generic;
     using Extensibility;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
@@ -37,7 +36,7 @@
 
             var parentContext = new FakeRootContext();
 
-            new OutgoingReplyContext(message, "message-id", options.OutgoingHeaders, options.Context, parentContext);
+            _ = new OutgoingReplyContext(message, "message-id", options.OutgoingHeaders, options.Context, parentContext);
 
             var valueFound = parentContext.TryGet("someKey", out string _);
 

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingSendContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingSendContextTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Core.Tests.Pipeline.Outgoing
 {
-    using System.Collections.Generic;
     using Extensibility;
     using NServiceBus.Pipeline;
     using NUnit.Framework;
@@ -36,7 +35,7 @@
 
             var parentContext = new FakeRootContext();
 
-            new OutgoingSendContext(message, "message-id", options.OutgoingHeaders, options.Context, parentContext);
+            _ = new OutgoingSendContext(message, "message-id", options.OutgoingHeaders, options.Context, parentContext);
 
             var valueFound = parentContext.TryGet("someKey", out string _);
 

--- a/src/NServiceBus.Core.Tests/Recoverability/DefaultRecoverabilityPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/DefaultRecoverabilityPolicyTests.cs
@@ -167,7 +167,7 @@
                     ? new Dictionary<string, string> { { Headers.DelayedRetries, retryNumber.ToString() } }
                     : headers ?? [],
                 "message-id",
-                new byte[0],
+                Array.Empty<byte>(),
                 new TransportTransaction(),
                 numberOfDeliveryAttempts,
                 "my-queue",

--- a/src/NServiceBus.Core.Tests/Recoverability/ErrorContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/ErrorContextTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Core.Tests.Recoverability
 {
     using System;
-    using System.Collections.Generic;
     using Extensibility;
     using NUnit.Framework;
     using Transport;
@@ -14,7 +13,7 @@
         {
             var contextBag = new ContextBag();
             contextBag.Set("MyKey", "MyValue");
-            var context = new ErrorContext(new Exception(), [], "ID", new byte[0], new TransportTransaction(), 0, "my-queue", contextBag);
+            var context = new ErrorContext(new Exception(), [], "ID", Array.Empty<byte>(), new TransportTransaction(), 0, "my-queue", contextBag);
 
             Assert.AreEqual("MyValue", context.Extensions.Get<string>("MyKey"));
         }

--- a/src/NServiceBus.Core.Tests/Recoverability/FaultMetadataExtractorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/FaultMetadataExtractorTests.cs
@@ -66,10 +66,10 @@ namespace NServiceBus.Core.Tests.Recoverability
 
         ErrorContext CreateErrorContext(Exception exception = null)
         {
-            return new ErrorContext(exception ?? GetAnException(), [], "some-id", new byte[0], new TransportTransaction(), 0, "my-address", new ContextBag());
+            return new ErrorContext(exception ?? GetAnException(), [], "some-id", Array.Empty<byte>(), new TransportTransaction(), 0, "my-address", new ContextBag());
         }
 
-        Exception GetAnException()
+        static Exception GetAnException()
         {
             try
             {
@@ -83,7 +83,7 @@ namespace NServiceBus.Core.Tests.Recoverability
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        public void MethodThatThrows1()
+        public static void MethodThatThrows1()
         {
             try
             {
@@ -96,7 +96,7 @@ namespace NServiceBus.Core.Tests.Recoverability
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        void MethodThatThrows2()
+        static void MethodThatThrows2()
         {
             throw new Exception("My Inner Exception");
         }

--- a/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageConnectorTests.cs
@@ -33,7 +33,7 @@
 
             fakeOutbox.ExistingMessage = new OutboxMessage(messageId, new[]
             {
-                new NServiceBus.Outbox.TransportOperation("x", options, new byte[0], [])
+                new NServiceBus.Outbox.TransportOperation("x", options, Array.Empty<byte>(), [])
             });
 
             var context = CreateContext(fakeBatchPipeline, messageId);
@@ -65,7 +65,7 @@
 
             fakeOutbox.ExistingMessage = new OutboxMessage(messageId, new[]
             {
-                new NServiceBus.Outbox.TransportOperation("x", properties, new byte[0], [])
+                new NServiceBus.Outbox.TransportOperation("x", properties, Array.Empty<byte>(), [])
             });
 
             var context = CreateContext(fakeBatchPipeline, messageId);
@@ -91,7 +91,7 @@
 
             fakeOutbox.ExistingMessage = new OutboxMessage(messageId, new[]
             {
-                new NServiceBus.Outbox.TransportOperation("x", properties, new byte[0], [])
+                new NServiceBus.Outbox.TransportOperation("x", properties, Array.Empty<byte>(), [])
             });
 
             var context = CreateContext(fakeBatchPipeline, messageId);
@@ -142,7 +142,7 @@
             });
 
             var startDispatchErActivityEventsvent = pipelineActivity.Events.Where(e => e.Name == "Start dispatching").ToArray();
-            Assert.AreEqual(1, startDispatchErActivityEventsvent.Count());
+            Assert.AreEqual(1, startDispatchErActivityEventsvent.Length);
             Assert.AreEqual(3, startDispatchErActivityEventsvent.Single().Tags.ToImmutableDictionary()["message-count"]);
             Assert.AreEqual(1, pipelineActivity.Events.Count(e => e.Name == "Finished dispatching"));
         }
@@ -162,11 +162,11 @@
             Assert.AreEqual(0, pipelineActivity.Events.Count(e => e.Name == "Finished dispatching"));
         }
 
-        static ITransportReceiveContext CreateContext(FakeBatchPipeline pipeline, string messageId)
+        static TestableTransportReceiveContext CreateContext(FakeBatchPipeline pipeline, string messageId)
         {
             var context = new TestableTransportReceiveContext
             {
-                Message = new IncomingMessage(messageId, [], new byte[0])
+                Message = new IncomingMessage(messageId, [], Array.Empty<byte>())
             };
 
             context.Extensions.Set<IPipelineCache>(new FakePipelineCache(pipeline));

--- a/src/NServiceBus.Core.Tests/Routing/ApplyReplyToAddressBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/ApplyReplyToAddressBehaviorTests.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Threading.Tasks;
     using Extensibility;
-    using NServiceBus.Pipeline;
     using NUnit.Framework;
     using Testing;
 
@@ -22,7 +21,7 @@
             Assert.AreEqual("PublicAddress", context.Headers[Headers.ReplyToAddress]);
         }
 
-        static IOutgoingLogicalMessageContext CreateContext(ExtendableOptions options)
+        static TestableOutgoingLogicalMessageContext CreateContext(ExtendableOptions options)
         {
             var context = new TestableOutgoingLogicalMessageContext
             {

--- a/src/NServiceBus.Core.Tests/Routing/DetermineRouteForPublishBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DetermineRouteForPublishBehaviorTests.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Core.Tests.Routing
 {
-    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using NServiceBus.Pipeline;

--- a/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/DetermineRouteForReplyBehaviorTests.cs
@@ -26,7 +26,7 @@
                 {
                     {Headers.ReplyToAddress, "ReplyAddressOfIncomingMessage"}
                 },
-                new byte[0]));
+                Array.Empty<byte>()));
 
             UnicastAddressTag addressTag = null;
             await behavior.Invoke(context, c =>
@@ -48,7 +48,7 @@
             context.Extensions.Set(new IncomingMessage(
                 "id",
                 [],
-                new byte[0]));
+                Array.Empty<byte>()));
 
             Assert.That(async () => await behavior.Invoke(context, _ => Task.CompletedTask), Throws.InstanceOf<Exception>().And.Message.Contains(typeof(MyReply).FullName));
         }
@@ -74,7 +74,7 @@
             Assert.AreEqual("CustomReplyToAddress", addressTag.Destination);
         }
 
-        TestableOutgoingReplyContext CreateContext(OutgoingLogicalMessage message)
+        static TestableOutgoingReplyContext CreateContext(OutgoingLogicalMessage message)
         {
             return new TestableOutgoingReplyContext
             {

--- a/src/NServiceBus.Core.Tests/Routing/Routers/SendConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/SendConnectorTests.cs
@@ -47,7 +47,7 @@
             Assert.AreEqual("LogicalAddress", addressTag.Destination);
         }
 
-        static IOutgoingSendContext CreateContext(SendOptions options = null, object message = null)
+        static TestableOutgoingSendContext CreateContext(SendOptions options = null, object message = null)
         {
             message ??= new MyMessage();
 

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterTests.cs
@@ -416,7 +416,7 @@ namespace NServiceBus.Core.Tests.Routing
         {
         }
 
-        static IOutgoingSendContext CreateContext(SendOptions options, object message = null)
+        static TestableOutgoingSendContext CreateContext(SendOptions options, object message = null)
         {
             message ??= new MyMessage();
 

--- a/src/NServiceBus.Core.Tests/Routing/RoutingToDispatchConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingToDispatchConnectorTests.cs
@@ -36,7 +36,7 @@
 
             var dispatched = false;
             var behavior = new RoutingToDispatchConnector();
-            var message = new OutgoingMessage("ID", [], new byte[0]);
+            var message = new OutgoingMessage("ID", [], Array.Empty<byte>());
 
             await behavior.Invoke(new RoutingContext(message,
                 new UnicastRoutingStrategy("Destination"), CreateContext(options, true)), c =>
@@ -53,7 +53,7 @@
         {
             var dispatched = false;
             var behavior = new RoutingToDispatchConnector();
-            var message = new OutgoingMessage("ID", [], new byte[0]);
+            var message = new OutgoingMessage("ID", [], Array.Empty<byte>());
 
             await behavior.Invoke(new RoutingContext(message,
                 new UnicastRoutingStrategy("Destination"), CreateContext(new SendOptions(), false)), c =>
@@ -70,7 +70,7 @@
         {
             var dispatched = false;
             var behavior = new RoutingToDispatchConnector();
-            var message = new OutgoingMessage("ID", [], new byte[0]);
+            var message = new OutgoingMessage("ID", [], Array.Empty<byte>());
 
             await behavior.Invoke(new RoutingContext(message,
                 new UnicastRoutingStrategy("Destination"), CreateContext(new SendOptions(), true)), c =>
@@ -102,7 +102,7 @@
             Assert.IsNull(ambientActivity.GetTagItem(ActivityTags.ContentType), "should not set tags on Activity.Current");
         }
 
-        static IOutgoingSendContext CreateContext(SendOptions options, bool fromHandler)
+        static OutgoingSendContext CreateContext(SendOptions options, bool fromHandler)
         {
             var message = new MyMessage();
             var context = new OutgoingSendContext(new OutgoingLogicalMessage(message.GetType(), message), options.UserDefinedMessageId ?? Guid.NewGuid().ToString(), options.OutgoingHeaders, options.Context, new FakeRootContext());

--- a/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SingleInstanceRoundRobinDistributionStrategyTests.cs
@@ -75,7 +75,7 @@
                 strategy.SelectDestination(distributionContext),
                 strategy.SelectDestination(distributionContext)
             };
-            instances = instances.Concat(new[] { "3" }).ToArray(); // add new instance
+            instances = [.. instances, "3"]; // add new instance
             distributionContext = new DistributionContext(instances, null, null, null, null, null);
             result.Add(strategy.SelectDestination(distributionContext));
 

--- a/src/NServiceBus.Core.Tests/Routing/SubscribeContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SubscribeContextTests.cs
@@ -33,7 +33,7 @@
 
             var parentContext = new FakeRootContext();
 
-            new SubscribeContext(parentContext, Type.EmptyTypes, context);
+            _ = new SubscribeContext(parentContext, Type.EmptyTypes, context);
 
             var valueFound = parentContext.TryGet("someKey", out string _);
 

--- a/src/NServiceBus.Core.Tests/Routing/UnsubscribeContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnsubscribeContextTests.cs
@@ -32,7 +32,7 @@
 
             var parentContext = new FakeRootContext();
 
-            new UnsubscribeContext(parentContext, typeof(object), context);
+            _ = new UnsubscribeContext(parentContext, typeof(object), context);
 
             var valueFound = parentContext.TryGet("someKey", out string _);
 

--- a/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
@@ -231,7 +231,7 @@
             Assert.AreEqual(typeof(SagaWithInheritanceChain.SagaData), metadata.SagaEntityType);
         }
 
-        SagaFinderDefinition GetFinder(SagaMetadata metadata, string messageType)
+        static SagaFinderDefinition GetFinder(SagaMetadata metadata, string messageType)
         {
             if (!metadata.TryGetFinder(messageType, out var finder))
             {

--- a/src/NServiceBus.Core.Tests/Sagas/SagaModelTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaModelTests.cs
@@ -10,7 +10,7 @@ namespace NServiceBus.Core.Tests.Sagas.TypeBasedSagas
     [TestFixture]
     public class SagaModelTests
     {
-        SagaMetadataCollection GetModel(params Type[] types)
+        static SagaMetadataCollection GetModel(params Type[] types)
         {
             var sagaMetaModel = new SagaMetadataCollection();
             sagaMetaModel.Initialize(types.ToList(), new Conventions());

--- a/src/NServiceBus.Core.Tests/Serializers/XML/SerializerTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/SerializerTests.cs
@@ -16,10 +16,8 @@ namespace NServiceBus.Serializers.XML.Test
     using A;
     using AlternateNamespace;
     using B;
-    using MessageInterfaces;
     using MessageInterfaces.MessageMapper.Reflection;
     using NUnit.Framework;
-    using Serialization;
 
     [TestFixture]
     public class SerializerTests
@@ -27,7 +25,7 @@ namespace NServiceBus.Serializers.XML.Test
         [Test]
         public void SerializeInvalidCharacters()
         {
-            IMessageMapper mapper = new MessageMapper();
+            var mapper = new MessageMapper();
             var serializer = SerializerFactory.Create<MessageWithInvalidCharacter>();
             var msg = mapper.CreateInstance<MessageWithInvalidCharacter>();
 
@@ -416,7 +414,7 @@ namespace NServiceBus.Serializers.XML.Test
             AssertSerializedEquals(serializer, msg, expected);
         }
 
-        static void AssertSerializedEquals(IMessageSerializer serializer, IMessage msg, string expected)
+        static void AssertSerializedEquals(XmlMessageSerializer serializer, IMessage msg, string expected)
         {
             using (var stream = new MemoryStream())
             {
@@ -637,8 +635,8 @@ namespace NServiceBus.Serializers.XML.Test
                 }
             })
             };
-            o.Data = new byte[]
-            {
+            o.Data =
+            [
                 1,
                 2,
                 3,
@@ -648,7 +646,7 @@ namespace NServiceBus.Serializers.XML.Test
                 3,
                 2,
                 1
-            };
+            ];
             o.SomeStrings = new List<string>
             {
                 "a",
@@ -656,8 +654,8 @@ namespace NServiceBus.Serializers.XML.Test
                 "c"
             };
 
-            o.ArrayFoos = new[]
-            {
+            o.ArrayFoos =
+            [
                 new Foo
                 {
                     Name = "FooArray1",
@@ -668,9 +666,9 @@ namespace NServiceBus.Serializers.XML.Test
                     Name = "FooAray2",
                     Title = "Mrs"
                 }
-            };
-            o.Bars = new[]
-            {
+            ];
+            o.Bars =
+            [
                 new Bar
                 {
                     Name = "Bar1",
@@ -681,27 +679,16 @@ namespace NServiceBus.Serializers.XML.Test
                     Name = "BAr2",
                     Length = 5
                 }
-            };
-            o.NaturalNumbers = new HashSet<int>(new[]
-            {
-                0,
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7,
-                8,
-                9
-            });
-            o.Developers = new HashSet<string>(new[]
-            {
+            ];
+            o.NaturalNumbers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+            o.Developers =
+            [
                 "Udi Dahan",
                 "Andreas Ohlund",
                 "Matt Burton",
                 "Jonathan Oliver et al"
-            });
+            ];
 
             o.Parent = mapper.CreateInstance<IFirstSerializableMessage>();
             o.Parent.Name = "udi";
@@ -818,7 +805,7 @@ namespace NServiceBus.Serializers.XML.Test
         [Test]
         public void SerializeLists()
         {
-            IMessageMapper mapper = new MessageMapper();
+            var mapper = new MessageMapper();
             var serializer = SerializerFactory.Create<MessageWithList>();
             var msg = mapper.CreateInstance<MessageWithList>();
 
@@ -844,7 +831,7 @@ namespace NServiceBus.Serializers.XML.Test
         [Test]
         public void SerializeClosedGenericListsInAlternateNamespace()
         {
-            IMessageMapper mapper = new MessageMapper();
+            var mapper = new MessageMapper();
             var serializer = SerializerFactory.Create<MessageWithClosedListInAlternateNamespace>();
             var msg = mapper.CreateInstance<MessageWithClosedListInAlternateNamespace>();
 
@@ -870,7 +857,7 @@ namespace NServiceBus.Serializers.XML.Test
         [Test]
         public void SerializeClosedGenericListsInAlternateNamespaceMultipleIEnumerableImplementations()
         {
-            IMessageMapper mapper = new MessageMapper();
+            var mapper = new MessageMapper();
             var serializer = SerializerFactory.Create<MessageWithClosedListInAlternateNamespaceMultipleIEnumerableImplementations>();
             var msg = mapper.CreateInstance<MessageWithClosedListInAlternateNamespaceMultipleIEnumerableImplementations>();
 
@@ -896,7 +883,7 @@ namespace NServiceBus.Serializers.XML.Test
         [Test]
         public void SerializeClosedGenericListsInAlternateNamespaceMultipleIListImplementations()
         {
-            IMessageMapper mapper = new MessageMapper();
+            var mapper = new MessageMapper();
             var serializer = SerializerFactory.Create<MessageWithClosedListInAlternateNamespaceMultipleIListImplementations>();
             var msg = mapper.CreateInstance<MessageWithClosedListInAlternateNamespaceMultipleIListImplementations>();
 
@@ -922,7 +909,7 @@ namespace NServiceBus.Serializers.XML.Test
         [Test]
         public void SerializeClosedGenericListsInSameNamespace()
         {
-            IMessageMapper mapper = new MessageMapper();
+            var mapper = new MessageMapper();
             var serializer = SerializerFactory.Create<MessageWithClosedList>();
             var msg = mapper.CreateInstance<MessageWithClosedList>();
 
@@ -948,7 +935,7 @@ namespace NServiceBus.Serializers.XML.Test
         [Test]
         public void SerializeEmptyLists()
         {
-            IMessageMapper mapper = new MessageMapper();
+            var mapper = new MessageMapper();
             var serializer = SerializerFactory.Create<MessageWithList>();
             var msg = mapper.CreateInstance<MessageWithList>();
 
@@ -965,8 +952,7 @@ namespace NServiceBus.Serializers.XML.Test
             }
         }
 
-
-        void DataContractSerialize(XmlWriterSettings xmlWriterSettings, DataContractSerializer dataContractSerializer, IMessage[] messages, Stream stream)
+        static void DataContractSerialize(XmlWriterSettings xmlWriterSettings, DataContractSerializer dataContractSerializer, IMessage[] messages, Stream stream)
         {
             var o = new ArrayList(messages);
             using (var xmlWriter = XmlWriter.Create(stream, xmlWriterSettings))
@@ -1033,7 +1019,7 @@ namespace NServiceBus.Serializers.XML.Test
             return secondMessage;
         }
 
-        void Time(object message, IMessageSerializer serializer)
+        void Time(object message, XmlMessageSerializer serializer)
         {
             var watch = new Stopwatch();
             watch.Start();
@@ -1234,7 +1220,7 @@ namespace NServiceBus.Serializers.XML.Test
             var nServiceBusPublicTypeName = nameof(ReplyOptions);
 
             var xml = $@"<?xml version=""1.0""?>
-                        <{nServiceBusPublicTypeName} xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" 
+                        <{nServiceBusPublicTypeName} xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance""
                                 xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" xmlns=""http://tempuri.net/NServiceBus"">
                         </{nServiceBusPublicTypeName}>";
 
@@ -1246,8 +1232,8 @@ namespace NServiceBus.Serializers.XML.Test
         public void Should_throw_exception_when_deserializing_payloads_with_system_types()
         {
             var xml = @"<?xml version=""1.0""?>
-                        <ArrayList xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" 
-                        xmlns:xsd=""http://www.w3.org/2001/XMLSchema"" 
+                        <ArrayList xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance""
+                        xmlns:xsd=""http://www.w3.org/2001/XMLSchema""
                         xmlns=""http://tempuri.net/System.Collections"">
                     </ArrayList>";
 

--- a/src/NServiceBus.Core.Tests/Serializers/XML/SerializingArrayTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/SerializingArrayTests.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.Serializers.XML.Test
 {
     using System;
     using System.IO;
-    using System.Linq;
     using System.Text;
     using System.Xml.Linq;
     using NUnit.Framework;
@@ -70,7 +69,7 @@ namespace NServiceBus.Serializers.XML.Test
         [Test]
         public void CanSerializeAndBack()
         {
-            var message = new MessageWithArray(Guid.NewGuid(), new[] { 1234, 5323 });
+            var message = new MessageWithArray(Guid.NewGuid(), [1234, 5323]);
 
             var result = ExecuteSerializer.ForMessage<MessageWithArray>(message);
 
@@ -98,12 +97,12 @@ namespace NServiceBus.Serializers.XML.Test
         {
             var message = new MessageWithArrayAndNoDefaultCtor
             {
-                SomeWords = new string[0]
+                SomeWords = Array.Empty<string>()
             };
 
             var result = ExecuteSerializer.ForMessage<MessageWithArrayAndNoDefaultCtor>(message);
 
-            Assert.AreEqual(result.SomeWords, new string[0]);
+            Assert.AreEqual(result.SomeWords, Array.Empty<string>());
         }
 
         [Test]
@@ -189,7 +188,7 @@ namespace NServiceBus.Serializers.XML.Test
             var msgArray = SerializerFactory.Create<MessageWithNullableArray>().Deserialize(data, new[] { typeof(MessageWithNullableArray) });
             var result = (MessageWithNullableArray)msgArray[0];
 
-            Assert.IsFalse(result.SomeInts.Any());
+            Assert.IsFalse(result.SomeInts.Length != 0);
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/StandardsTests.cs
+++ b/src/NServiceBus.Core.Tests/StandardsTests.cs
@@ -21,9 +21,7 @@
                 Assert.IsFalse(featureType.Name.EndsWith("Feature"), "Features should not be suffixed with 'Feature'. " + featureType.FullName);
                 if (featureType.IsPublic)
                 {
-                    var constructorInfo = featureType.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, null, new Type[]
-                    {
-                    }, null);
+                    var constructorInfo = featureType.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, null, Array.Empty<Type>(), null);
                     Assert.IsFalse(constructorInfo.IsPublic, "Features should have an internal constructor. " + featureType.FullName);
                 }
             }

--- a/src/NServiceBus.Core.Tests/Transports/IncomingMessageTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/IncomingMessageTests.cs
@@ -11,7 +11,7 @@
         public void Should_assign_transport_message_id_when_NServiceBus_message_id_header_is_missing()
         {
             var headers = new Dictionary<string, string>();
-            var message = new IncomingMessage("nativeId", headers, new byte[] { });
+            var message = new IncomingMessage("nativeId", headers, System.Array.Empty<byte>());
 
             Assert.AreEqual("nativeId", message.NativeMessageId);
             Assert.AreEqual("nativeId", message.MessageId);
@@ -25,7 +25,7 @@
             {
                 { Headers.MessageId, "coreId" }
             };
-            var message = new IncomingMessage("nativeId", headers, new byte[] { });
+            var message = new IncomingMessage("nativeId", headers, System.Array.Empty<byte>());
 
             Assert.AreEqual("nativeId", message.NativeMessageId);
             Assert.AreEqual("coreId", message.MessageId);
@@ -38,7 +38,7 @@
             {
                 { Headers.MessageId, "" }
             };
-            var message = new IncomingMessage("nativeId", headers, new byte[] { });
+            var message = new IncomingMessage("nativeId", headers, System.Array.Empty<byte>());
 
             Assert.AreEqual("nativeId", message.NativeMessageId);
             Assert.AreEqual("nativeId", message.MessageId);

--- a/src/NServiceBus.Core.Tests/Transports/MulticastTransportOperationTest.cs
+++ b/src/NServiceBus.Core.Tests/Transports/MulticastTransportOperationTest.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Core.Tests.Transports
 {
     using System;
-    using System.Collections.Generic;
     using NServiceBus.Performance.TimeToBeReceived;
     using NUnit.Framework;
     using Transport;
@@ -12,8 +11,8 @@ namespace NServiceBus.Core.Tests.Transports
         [Test]
         public void Should_not_share_constraints_when_not_provided()
         {
-            var transportOperation = new MulticastTransportOperation(new OutgoingMessage(Guid.NewGuid().ToString(), [], new byte[0]), typeof(Guid), []);
-            var secondTransportOperation = new MulticastTransportOperation(new OutgoingMessage(Guid.NewGuid().ToString(), [], new byte[0]), typeof(Guid), []);
+            var transportOperation = new MulticastTransportOperation(new OutgoingMessage(Guid.NewGuid().ToString(), [], Array.Empty<byte>()), typeof(Guid), []);
+            var secondTransportOperation = new MulticastTransportOperation(new OutgoingMessage(Guid.NewGuid().ToString(), [], Array.Empty<byte>()), typeof(Guid), []);
 
             transportOperation.Properties.DiscardIfNotReceivedBefore = new DiscardIfNotReceivedBefore(TimeSpan.FromDays(1));
 

--- a/src/NServiceBus.Core.Tests/Transports/TransportOperationTest.cs
+++ b/src/NServiceBus.Core.Tests/Transports/TransportOperationTest.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Core.Tests.Transports
 {
     using System;
-    using System.Collections.Generic;
     using NServiceBus.Routing;
     using NUnit.Framework;
     using Transport;
@@ -12,8 +11,8 @@ namespace NServiceBus.Core.Tests.Transports
         [Test]
         public void Should_not_share_constraints_when_not_provided()
         {
-            var transportOperation = new TransportOperation(new OutgoingMessage(Guid.NewGuid().ToString(), [], new byte[0]), new UnicastAddressTag("destination"));
-            var secondTransportOperation = new TransportOperation(new OutgoingMessage(Guid.NewGuid().ToString(), [], new byte[0]), new UnicastAddressTag("destination2"));
+            var transportOperation = new TransportOperation(new OutgoingMessage(Guid.NewGuid().ToString(), [], Array.Empty<byte>()), new UnicastAddressTag("destination"));
+            var secondTransportOperation = new TransportOperation(new OutgoingMessage(Guid.NewGuid().ToString(), [], Array.Empty<byte>()), new UnicastAddressTag("destination2"));
 
             Assert.AreNotSame(transportOperation.Properties, secondTransportOperation.Properties);
             Assert.IsEmpty(transportOperation.Properties);

--- a/src/NServiceBus.Core.Tests/Transports/TransportOperationsTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/TransportOperationsTests.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Core.Tests.Transports
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using NServiceBus.Routing;
     using Transport;
@@ -23,14 +22,14 @@
 
             var result = new TransportOperations(operations);
 
-            Assert.AreEqual(1, result.MulticastTransportOperations.Count());
+            Assert.AreEqual(1, result.MulticastTransportOperations.Count);
             var multicastOp = result.MulticastTransportOperations.Single();
             Assert.AreEqual(multicastOperation.Message, multicastOp.Message);
             Assert.AreEqual((multicastOperation.AddressTag as MulticastAddressTag)?.MessageType, multicastOp.MessageType);
             Assert.AreEqual(multicastOperation.Properties, multicastOp.Properties);
             Assert.AreEqual(multicastOperation.RequiredDispatchConsistency, multicastOp.RequiredDispatchConsistency);
 
-            Assert.AreEqual(1, result.UnicastTransportOperations.Count());
+            Assert.AreEqual(1, result.UnicastTransportOperations.Count);
             var unicastOp = result.UnicastTransportOperations.Single();
             Assert.AreEqual(unicastOperation.Message, unicastOp.Message);
             Assert.AreEqual((unicastOperation.AddressTag as UnicastAddressTag)?.Destination, unicastOp.Destination);
@@ -43,8 +42,8 @@
         {
             var result = new TransportOperations();
 
-            Assert.AreEqual(0, result.MulticastTransportOperations.Count());
-            Assert.AreEqual(0, result.UnicastTransportOperations.Count());
+            Assert.AreEqual(0, result.MulticastTransportOperations.Count);
+            Assert.AreEqual(0, result.UnicastTransportOperations.Count);
         }
 
         [Test]
@@ -61,7 +60,7 @@
 
         static OutgoingMessage CreateUniqueMessage()
         {
-            return new OutgoingMessage(Guid.NewGuid().ToString(), [], new byte[0]);
+            return new OutgoingMessage(Guid.NewGuid().ToString(), [], Array.Empty<byte>());
         }
 
         class CustomAddressTag : AddressTag

--- a/src/NServiceBus.Core.Tests/Transports/UnicastTransportOperationTest.cs
+++ b/src/NServiceBus.Core.Tests/Transports/UnicastTransportOperationTest.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Core.Tests.Transports
 {
     using System;
-    using System.Collections.Generic;
     using NServiceBus.Performance.TimeToBeReceived;
     using NUnit.Framework;
     using Transport;
@@ -12,8 +11,8 @@ namespace NServiceBus.Core.Tests.Transports
         [Test]
         public void Should_not_share_constraints_when_not_provided()
         {
-            var transportOperation = new UnicastTransportOperation(new OutgoingMessage(Guid.NewGuid().ToString(), [], new byte[0]), "destination", []);
-            var secondTransportOperation = new UnicastTransportOperation(new OutgoingMessage(Guid.NewGuid().ToString(), [], new byte[0]), "destination2", []);
+            var transportOperation = new UnicastTransportOperation(new OutgoingMessage(Guid.NewGuid().ToString(), [], Array.Empty<byte>()), "destination", []);
+            var secondTransportOperation = new UnicastTransportOperation(new OutgoingMessage(Guid.NewGuid().ToString(), [], Array.Empty<byte>()), "destination2", []);
 
             transportOperation.Properties.DiscardIfNotReceivedBefore = new DiscardIfNotReceivedBefore(TimeSpan.FromDays(1));
 

--- a/src/NServiceBus.Core.Tests/Unicast/LoadHandlersConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/LoadHandlersConnectorTests.cs
@@ -90,7 +90,7 @@
             }
         }
 
-        TransportTransaction CreateTransactionScopeModeTransportTransaction()
+        static TransportTransaction CreateTransactionScopeModeTransportTransaction()
         {
             var transportTransaction = new TransportTransaction();
 

--- a/src/NServiceBus.Core.Tests/Unicast/Messages/DefaultMessageRegistryTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/Messages/DefaultMessageRegistryTests.cs
@@ -35,7 +35,7 @@
             var messageMetadata = defaultMessageRegistry.GetMessageMetadata(typeof(int));
 
             Assert.AreEqual(typeof(int), messageMetadata.MessageType);
-            Assert.AreEqual(1, messageMetadata.MessageHierarchy.Count());
+            Assert.AreEqual(1, messageMetadata.MessageHierarchy.Length);
         }
 
 
@@ -47,7 +47,7 @@
             defaultMessageRegistry.RegisterMessageTypesFoundIn(new List<Type> { typeof(MyEvent) });
             var messageMetadata = defaultMessageRegistry.GetMessageMetadata(typeof(MyEvent));
 
-            Assert.AreEqual(5, messageMetadata.MessageHierarchy.Count());
+            Assert.AreEqual(5, messageMetadata.MessageHierarchy.Length);
 
             Assert.AreEqual(typeof(MyEvent), messageMetadata.MessageHierarchy.ToList()[0]);
             Assert.AreEqual(typeof(IInterfaceParent1), messageMetadata.MessageHierarchy.ToList()[1]);

--- a/src/NServiceBus.Core/Conventions/Conventions.cs
+++ b/src/NServiceBus.Core/Conventions/Conventions.cs
@@ -1,11 +1,11 @@
 ﻿namespace NServiceBus
 {
-    using Logging;
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using Logging;
 
     /// <summary>
     /// Message convention definitions.
@@ -250,7 +250,7 @@
         readonly List<Func<Type, bool>> IsSystemMessageActions = [];
         readonly ConventionCache MessagesConventionCache = new ConventionCache();
 
-        readonly IList<IMessageConvention> conventions = new List<IMessageConvention>();
+        readonly List<IMessageConvention> conventions = [];
         readonly OverridableMessageConvention defaultMessageConvention;
 
         static readonly ILog logger = LogManager.GetLogger<Conventions>();

--- a/src/NServiceBus.Core/DataBus/DataBusDeserializer.cs
+++ b/src/NServiceBus.Core/DataBus/DataBusDeserializer.cs
@@ -53,7 +53,7 @@
             return deserializer.Deserialize(propertyType, stream);
         }
 
-        readonly IDictionary<string, IDataBusSerializer> deserializers;
+        readonly Dictionary<string, IDataBusSerializer> deserializers;
 
         static readonly ILog logger = LogManager.GetLogger<DataBusDeserializer>();
     }

--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -1,6 +1,5 @@
 namespace NServiceBus
 {
-    using Transport;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -9,6 +8,7 @@ namespace NServiceBus
     using Microsoft.Extensions.DependencyInjection;
     using Pipeline;
     using Settings;
+    using Transport;
 
     /// <summary>
     /// Configuration used to create an endpoint instance.
@@ -105,7 +105,7 @@ namespace NServiceBus
                 throw new ArgumentException("Endpoint name must not be empty", nameof(endpointName));
             }
 
-            if (endpointName.Contains("@"))
+            if (endpointName.Contains('@'))
             {
                 throw new ArgumentException("Endpoint name must not contain an '@' character.", nameof(endpointName));
             }

--- a/src/NServiceBus.Core/Extensibility/ExtendableOptionsExtensions.cs
+++ b/src/NServiceBus.Core/Extensibility/ExtendableOptionsExtensions.cs
@@ -1,8 +1,8 @@
 namespace NServiceBus.Extensibility
 {
     using System;
-    using Transport;
     using Pipeline;
+    using Transport;
 
     /// <summary>
     /// Provides hidden access to the extension context.
@@ -11,7 +11,7 @@ namespace NServiceBus.Extensibility
     {
         /// <summary>
         /// Gets access to a "bucket" that allows the developer to pass information from extension methods down to behaviors.
-        /// </summary>        
+        /// </summary>
         public static ContextBag GetExtensions(this ExtendableOptions options)
         {
             ArgumentNullException.ThrowIfNull(options);
@@ -47,7 +47,7 @@ namespace NServiceBus.Extensibility
         /// </summary>
         public static IReadOnlyContextBag GetOperationProperties(this IRoutingContext behaviorContext) => GetOperationPropertiesInternal(behaviorContext);
 
-        static IReadOnlyContextBag GetOperationPropertiesInternal(this IBehaviorContext behaviorContext)
+        static ContextBag GetOperationPropertiesInternal(this IBehaviorContext behaviorContext)
         {
             ArgumentNullException.ThrowIfNull(behaviorContext);
             if (!behaviorContext.Extensions.TryGet(ExtendableOptions.OperationPropertiesKey, out ContextBag context))

--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -132,9 +132,7 @@ namespace NServiceBus.Features
             // Step 4: DFS to check if we have an directed acyclic graph
             foreach (var node in allNodes)
             {
-                if (DirectedCycleExistsFrom(node, new Node[]
-                {
-                }))
+                if (DirectedCycleExistsFrom(node, []))
                 {
                     throw new ArgumentException("Cycle in dependency graph detected");
                 }
@@ -145,7 +143,7 @@ namespace NServiceBus.Features
 
         static bool DirectedCycleExistsFrom(Node node, Node[] visitedNodes)
         {
-            if (node.previous.Any())
+            if (node.previous.Count != 0)
             {
                 if (visitedNodes.Any(n => n == node))
                 {

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -241,7 +241,7 @@ namespace NServiceBus.Hosting.Helpers
             return processed[assembly.FullName];
         }
 
-        Assembly GetReferencedAssembly(AssemblyName assemblyName)
+        static Assembly GetReferencedAssembly(AssemblyName assemblyName)
         {
             Assembly referencedAssembly = null;
 

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyValidator.cs
@@ -56,11 +56,9 @@
 
         static string GetPublicKeyToken(byte[] publicKey)
         {
-            using var sha1 = SHA1.Create();
             Span<byte> publicKeyToken = stackalloc byte[20];
-            // returns false when the destination doesn't have enough space
-            _ = sha1.TryComputeHash(publicKey, publicKeyToken, out _);
-            Span<byte> lastEightBytes = publicKeyToken.Slice(publicKeyToken.Length - 8, 8);
+            _ = SHA1.HashData(publicKey, publicKeyToken);
+            var lastEightBytes = publicKeyToken.Slice(publicKeyToken.Length - 8, 8);
             lastEightBytes.Reverse();
             return Convert.ToHexString(lastEightBytes);
         }

--- a/src/NServiceBus.Core/Hosting/HostInformation.cs
+++ b/src/NServiceBus.Core/Hosting/HostInformation.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.Hosting
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using Support;
 
     /// <summary>
@@ -19,7 +18,7 @@ namespace NServiceBus.Hosting
             : this(hostId, displayName, new Dictionary<string, string>
             {
                 {"Machine", RuntimeEnvironment.MachineName},
-                {"ProcessID", Process.GetCurrentProcess().Id.ToString()},
+                {"ProcessID", Environment.ProcessId.ToString()},
                 {"UserName", Environment.UserName}
             })
         {

--- a/src/NServiceBus.Core/Hosting/HostingComponent.Settings.cs
+++ b/src/NServiceBus.Core/Hosting/HostingComponent.Settings.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.DependencyInjection;
@@ -23,7 +22,7 @@
                 settings.SetDefault(PropertiesSettingsKey, new Dictionary<string, string>
                 {
                     {"Machine", RuntimeEnvironment.MachineName},
-                    {"ProcessID", Process.GetCurrentProcess().Id.ToString()},
+                    {"ProcessID", Environment.ProcessId.ToString()},
                     {"UserName", Environment.UserName},
                     {"PathToExecutable", fullPathToStartingExe}
                 });

--- a/src/NServiceBus.Core/Hosting/StartupDiagnostics/Host.cs
+++ b/src/NServiceBus.Core/Hosting/StartupDiagnostics/Host.cs
@@ -43,13 +43,15 @@
             throw new Exception(GetMapPathError($"Failed since path returned ({appDataPath}) does not exist. Ensure this directory is created and restart the endpoint."));
         }
 
+        internal static readonly string[] parameters = ["~/App_Data/"];
+
         static string TryMapPath(Assembly systemWebAssembly)
         {
             try
             {
                 var hostingEnvironment = systemWebAssembly?.GetType("System.Web.Hosting.HostingEnvironment");
                 var mapPath = hostingEnvironment?.GetMethod("MapPath", BindingFlags.Static | BindingFlags.Public);
-                var result = mapPath?.Invoke(null, new[] { "~/App_Data/" }) as string;
+                var result = mapPath?.Invoke(null, parameters) as string;
 
                 return result;
             }

--- a/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnosticsWriter.cs
+++ b/src/NServiceBus.Core/Hosting/StartupDiagnostics/HostStartupDiagnosticsWriter.cs
@@ -51,15 +51,14 @@
             }
         }
 
-        IEnumerable<StartupDiagnosticEntries.StartupDiagnosticEntry> DeduplicateEntries(List<StartupDiagnosticEntries.StartupDiagnosticEntry> entries)
+        static IEnumerable<StartupDiagnosticEntries.StartupDiagnosticEntry> DeduplicateEntries(List<StartupDiagnosticEntries.StartupDiagnosticEntry> entries)
         {
             var countMap = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var entry in entries)
             {
-                if (!countMap.ContainsKey(entry.Name))
+                if (countMap.TryAdd(entry.Name, 1))
                 {
-                    countMap.Add(entry.Name, 1);
                     yield return entry;
                 }
                 else
@@ -90,7 +89,7 @@
         /// By default System.Text.Json would throw with "Serialization and deserialization of 'System.Type' instances are not supported" which normally
         /// would make sense because it can be considered unsafe to serialize and deserialize types. We add a custom converter here to make
         /// sure when diagnostics entries accidentally use types it will just print the full name as a string. We never intent to read these things
-        /// back so this is a safe approach. 
+        /// back so this is a safe approach.
         /// </summary>
         sealed class TypeConverter : JsonConverter<Type>
         {

--- a/src/NServiceBus.Core/Hosting/StartupDiagnostics/JsonPrettyPrinter.cs
+++ b/src/NServiceBus.Core/Hosting/StartupDiagnostics/JsonPrettyPrinter.cs
@@ -56,7 +56,7 @@ namespace NServiceBus
                         builder.Append(ch);
                         if (!quoted)
                         {
-                            builder.Append(" ");
+                            builder.Append(' ');
                         }
 
                         break;

--- a/src/NServiceBus.Core/Licensing/LicenseManager.cs
+++ b/src/NServiceBus.Core/Licensing/LicenseManager.cs
@@ -32,7 +32,7 @@ namespace NServiceBus
             }
         }
 
-        public void LogLicenseStatus(LicenseStatus licenseStatus, ILog logger, License license, string developerLicenseUrl)
+        public static void LogLicenseStatus(LicenseStatus licenseStatus, ILog logger, License license, string developerLicenseUrl)
         {
             var whenLicenseExpiresPhrase = GetRemainingDaysString(license.GetDaysUntilLicenseExpires());
             var whenUpgradeProtectedExpiresPhrase = GetRemainingDaysString(license.GetDaysUntilUpgradeProtectionExpires());
@@ -106,7 +106,7 @@ namespace NServiceBus
             Logger.Info(string.Join(Environment.NewLine, result.SelectedLicenseReport));
         }
 
-        void OpenDeveloperLicensePage(string developerLicenseUrl)
+        static void OpenDeveloperLicensePage(string developerLicenseUrl)
         {
             if (!(Debugger.IsAttached && Environment.UserInteractive))
             {
@@ -153,7 +153,7 @@ namespace NServiceBus
             return $"https://particular.net/license/nservicebus?v={version}&t={isRenewal}&p={platform}&f={frameworkVersion}";
         }
 
-        string GetPlatformCode()
+        static string GetPlatformCode()
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -173,7 +173,7 @@ namespace NServiceBus
             return "unknown";
         }
 
-        string GetFrameworkVersion()
+        static string GetFrameworkVersion()
         {
             var match = Regex.Match(RuntimeInformation.FrameworkDescription, @"\d+");
             return match.Success ? match.Value : "0";

--- a/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/ConcreteProxyCreator.cs
+++ b/src/NServiceBus.Core/MessageInterfaces/MessageMapper/Reflection/ConcreteProxyCreator.cs
@@ -136,7 +136,7 @@ namespace NServiceBus
         /// <summary>
         /// Returns all properties on the given type, going up the inheritance hierarchy.
         /// </summary>
-        static IEnumerable<PropertyInfo> GetAllProperties(Type type)
+        static List<PropertyInfo> GetAllProperties(Type type)
         {
             var props = new List<PropertyInfo>(type.GetProperties());
             foreach (var interfaceType in type.GetInterfaces())

--- a/src/NServiceBus.Core/Persistence/PersistenceStorageMerger.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceStorageMerger.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus
 {
     using System.Collections.Generic;
-    using System.Linq;
     using Persistence;
     using Settings;
 
@@ -35,7 +34,7 @@
                     }
                 }
 
-                if (currentDefinition.SelectedStorages.Any())
+                if (currentDefinition.SelectedStorages.Count != 0)
                 {
                     mergedEnabledPersistences.Add(currentDefinition);
                 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
@@ -53,7 +53,7 @@
             await storageSession.CompleteAsync(context.CancellationToken).ConfigureAwait(false);
         }
 
-        void ValidateTransactionMode(IIncomingLogicalMessageContext context)
+        static void ValidateTransactionMode(IIncomingLogicalMessageContext context)
         {
             var transportTransaction = context.Extensions.Get<TransportTransaction>();
 

--- a/src/NServiceBus.Core/Pipeline/RegisterStep.cs
+++ b/src/NServiceBus.Core/Pipeline/RegisterStep.cs
@@ -21,7 +21,7 @@ namespace NServiceBus.Pipeline
         protected RegisterStep(string stepId, Type behavior, string description, Func<IServiceProvider, IBehavior> factoryMethod = null)
         {
             this.factoryMethod = factoryMethod;
-            BehaviorTypeChecker.ThrowIfInvalid(behavior, "behavior");
+            BehaviorTypeChecker.ThrowIfInvalid(behavior, nameof(behavior));
             ArgumentException.ThrowIfNullOrWhiteSpace(stepId);
             ArgumentException.ThrowIfNullOrWhiteSpace(description);
 

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -28,7 +28,7 @@ namespace NServiceBus
         {
             if (configuration.IsSendOnlyEndpoint)
             {
-                configuration.transportSeam.Configure(new ReceiveSettings[0]);
+                configuration.transportSeam.Configure([]);
                 return new ReceiveComponent(configuration, hostingConfiguration.ActivityFactory);
             }
 
@@ -278,7 +278,7 @@ namespace NServiceBus
                 .Any(genericTypeDef => genericTypeDef == IHandleMessagesType);
         }
 
-        IMessageReceiver CreateReceiver(ConsecutiveFailuresConfiguration consecutiveFailuresConfiguration, IMessageReceiver receiver)
+        static IMessageReceiver CreateReceiver(ConsecutiveFailuresConfiguration consecutiveFailuresConfiguration, IMessageReceiver receiver)
         {
             if (consecutiveFailuresConfiguration.RateLimitSettings != null)
             {

--- a/src/NServiceBus.Core/Recoverability/RecoverabilityComponent.cs
+++ b/src/NServiceBus.Core/Recoverability/RecoverabilityComponent.cs
@@ -191,7 +191,7 @@
         RecoverabilityConfig recoverabilityConfig;
         FaultMetadataExtractor faultMetadataExtractor;
         HostInformation hostInformation;
-        readonly IReadOnlySettings settings;
+        readonly SettingsHolder settings;
         bool transactionsOn;
         bool delayedRetriesAvailable;
         bool immediateRetriesAvailable;

--- a/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
@@ -27,11 +27,11 @@
             DependsOn<SynchronizedStorage>();
         }
 
-        bool ReceivingEnabled(IReadOnlySettings settings) => !settings.GetOrDefault<bool>("Endpoint.SendOnly");
+        static bool ReceivingEnabled(IReadOnlySettings settings) => !settings.GetOrDefault<bool>("Endpoint.SendOnly");
 
-        bool TransactionsEnabled(IReadOnlySettings settings) => settings.GetRequiredTransactionModeForReceives() != TransportTransactionMode.None;
+        static bool TransactionsEnabled(IReadOnlySettings settings) => settings.GetRequiredTransactionModeForReceives() != TransportTransactionMode.None;
 
-        bool AllowUseWithoutReceiving(IReadOnlySettings settings) => settings.GetOrDefault<bool>("Outbox.AllowUseWithoutReceiving");
+        static bool AllowUseWithoutReceiving(IReadOnlySettings settings) => settings.GetOrDefault<bool>("Outbox.AllowUseWithoutReceiving");
 
         /// <summary>
         /// See <see cref="Feature.Setup" />.

--- a/src/NServiceBus.Core/Routing/AssemblyRouteSource.cs
+++ b/src/NServiceBus.Core/Routing/AssemblyRouteSource.cs
@@ -24,7 +24,7 @@ namespace NServiceBus
                 .Select(t => new RouteTableEntry(t, route))
                 .ToArray();
 
-            if (!routes.Any())
+            if (routes.Length == 0)
             {
                 throw new Exception($"Cannot configure routing for assembly {messageAssembly.GetName().Name} because it contains no types considered as messages. Message types have to either implement NServiceBus.IMessage interface or match a defined message convention.");
             }

--- a/src/NServiceBus.Core/Routing/EndpointInstance.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstance.cs
@@ -116,7 +116,7 @@
             {
                 return true;
             }
-            return obj is EndpointInstance && Equals((EndpointInstance)obj);
+            return obj is EndpointInstance instance && Equals(instance);
         }
 
         /// <summary>
@@ -151,7 +151,7 @@
             return !Equals(left, right);
         }
 
-        static readonly IEqualityComparer<KeyValuePair<string, string>> propertyComparer = new PropertyComparer();
+        static readonly PropertyComparer propertyComparer = new();
 
         class PropertyComparer : IEqualityComparer<KeyValuePair<string, string>>
         {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/AssemblyPublisherSource.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/AssemblyPublisherSource.cs
@@ -24,7 +24,7 @@ namespace NServiceBus
                 .Select(t => new PublisherTableEntry(t, address))
                 .ToArray();
 
-            if (!entries.Any())
+            if (entries.Length == 0)
             {
                 throw new Exception($"Cannot configure publisher for assembly {messageAssembly.GetName().Name} because it contains no types considered as events. Event types have to either implement NServiceBus.IEvent interface or match a defined event convention.");
             }
@@ -39,7 +39,7 @@ namespace NServiceBus
                 .Select(t => new PublisherTableEntry(t, address))
                 .ToArray();
 
-            if (!entries.Any())
+            if (entries.Length == 0)
             {
                 throw new Exception($"Cannot configure publisher for assembly {messageAssembly.GetName().Name} because it contains no types considered as messages. Message types have to either implement NServiceBus.IMessage interface or match a defined convention.");
             }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensions.cs
@@ -94,7 +94,7 @@ namespace NServiceBus
 
         static void ThrowOnAddress(string publisherEndpoint)
         {
-            if (publisherEndpoint.Contains("@"))
+            if (publisherEndpoint.Contains('@'))
             {
                 throw new ArgumentException($"A logical endpoint name should not contain '@', but received '{publisherEndpoint}'. To specify an endpoint's address, use the instance mapping file for the MSMQ transport, or refer to the routing documentation.");
             }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageType.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageType.cs
@@ -62,7 +62,7 @@ namespace NServiceBus.Unicast.Subscriptions
         /// </summary>
         public Version Version { get; }
 
-        Version ParseVersion(string versionString)
+        static Version ParseVersion(string versionString)
         {
             const string version = "Version=";
             var index = versionString.IndexOf(version);

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/NamespacePublisherSource.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/NamespacePublisherSource.cs
@@ -26,7 +26,7 @@ namespace NServiceBus
                 .Select(t => new PublisherTableEntry(t, address))
                 .ToArray();
 
-            if (!entries.Any())
+            if (entries.Length == 0)
             {
                 throw new Exception($"Cannot configure publisher for namespace {messageNamespace} because it contains no types considered as events. Event types have to either implement NServiceBus.IEvent interface or match a defined event convention.");
             }
@@ -41,7 +41,7 @@ namespace NServiceBus
                 .Select(t => new PublisherTableEntry(t, address))
                 .ToArray();
 
-            if (!entries.Any())
+            if (entries.Length == 0)
             {
                 throw new Exception($"Cannot configure publisher for namespace {messageNamespace} because it contains no types considered as messages. Message types have to either implement NServiceBus.IMessage interface or match a defined convention.");
             }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/PublisherAddress.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/PublisherAddress.cs
@@ -84,7 +84,7 @@ namespace NServiceBus.Routing.MessageDrivenSubscriptions
                 && CollectionEquals(instances, other.instances);
         }
 
-        bool CollectionEquals<T>(IEnumerable<T> left, IEnumerable<T> right)
+        static bool CollectionEquals<T>(IEnumerable<T> left, IEnumerable<T> right)
         {
             if (left is null && right is null)
             {

--- a/src/NServiceBus.Core/Routing/NamespaceRouteSource.cs
+++ b/src/NServiceBus.Core/Routing/NamespaceRouteSource.cs
@@ -25,7 +25,7 @@ namespace NServiceBus
                 .Where(t => conventions.IsMessageType(t) && string.Equals(t.Namespace, messageNamespace, StringComparison.OrdinalIgnoreCase))
                 .Select(t => new RouteTableEntry(t, route))
                 .ToArray();
-            if (!routes.Any())
+            if (routes.Length == 0)
             {
                 throw new Exception($"Cannot configure routing for namespace {messageNamespace} because it contains no types considered as messages. Message types have to either implement NServiceBus.IMessage interface or match a defined message convention.");
             }

--- a/src/NServiceBus.Core/Routing/RoutingComponent.cs
+++ b/src/NServiceBus.Core/Routing/RoutingComponent.cs
@@ -13,8 +13,10 @@ namespace NServiceBus
 
         public bool EnforceBestPractices { get; }
 
+#pragma warning disable CA1822 // Mark members as static
         public UnicastSendRouter UnicastSendRouterBuilder(IServiceProvider serviceProvider) =>
             serviceProvider.GetRequiredService<UnicastSendRouter>();
+#pragma warning restore CA1822 // Mark members as static
 
         public static RoutingComponent Initialize(Configuration configuration,
             ReceiveComponent.Configuration receiveConfiguration,

--- a/src/NServiceBus.Core/Routing/RoutingSettings.cs
+++ b/src/NServiceBus.Core/Routing/RoutingSettings.cs
@@ -78,7 +78,7 @@
 
         static void ThrowOnAddress(string destination)
         {
-            if (destination.Contains("@"))
+            if (destination.Contains('@'))
             {
                 throw new ArgumentException($"A logical endpoint name should not contain '@', but received '{destination}'. To specify an endpoint's address, use the instance mapping file for the MSMQ transport, or refer to the routing documentation.");
             }

--- a/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/SubscriptionMigrationModeSettings.cs
+++ b/src/NServiceBus.Core/Routing/SubscriptionMigrationMode/SubscriptionMigrationModeSettings.cs
@@ -80,7 +80,7 @@
 
         static void ThrowOnAddress(string publisherEndpoint)
         {
-            if (publisherEndpoint.Contains("@"))
+            if (publisherEndpoint.Contains('@'))
             {
                 throw new ArgumentException($"A logical endpoint name should not contain '@', but received '{publisherEndpoint}'. To specify an endpoint's address, use the instance mapping file for the MSMQ transport, or refer to the routing documentation.");
             }

--- a/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
+++ b/src/NServiceBus.Core/Routing/UnicastPublishRouter.cs
@@ -36,7 +36,7 @@ namespace NServiceBus
             return destinations;
         }
 
-        void WarnIfNoSubscribersFound(Type messageType, int subscribersFound)
+        static void WarnIfNoSubscribersFound(Type messageType, int subscribersFound)
         {
             if (subscribersFound == 0)
             {

--- a/src/NServiceBus.Core/Sagas/HeaderPropertySagaFinder.cs
+++ b/src/NServiceBus.Core/Sagas/HeaderPropertySagaFinder.cs
@@ -61,7 +61,7 @@
                 throw new Exception($"Message {messageName} mapped to saga {sagaEntityName} has attempted to assign null to the correlation property {correlationPropertyName}. Correlation properties cannot be assigned null.");
             }
 
-            if (correlationPropertyName.ToLower() == "id")
+            if (correlationPropertyName.Equals("id", StringComparison.OrdinalIgnoreCase))
             {
                 return await persister.Get<TSagaData>((Guid)convertedHeaderValue, storageSession, context, cancellationToken).ConfigureAwait(false);
             }

--- a/src/NServiceBus.Core/Sagas/PropertySagaFinder.cs
+++ b/src/NServiceBus.Core/Sagas/PropertySagaFinder.cs
@@ -34,7 +34,7 @@ namespace NServiceBus
                 throw new Exception($"Message {messageName} mapped to saga {sagaEntityName} has attempted to assign null to the correlation property {sagaPropertyName}. Correlation properties cannot be assigned null.");
             }
 
-            if (sagaPropertyName.ToLower() == "id")
+            if (sagaPropertyName.Equals("id", StringComparison.OrdinalIgnoreCase))
             {
                 return await sagaPersister.Get<TSagaData>((Guid)propertyValue, storageSession, context, cancellationToken).ConfigureAwait(false);
             }

--- a/src/NServiceBus.Core/Sagas/SagaMetadata.cs
+++ b/src/NServiceBus.Core/Sagas/SagaMetadata.cs
@@ -189,7 +189,7 @@ Sagas must have at least one message that is allowed to start the saga. Add at l
 
             CorrelationPropertyMetadata correlationProperty = null;
 
-            if (propertyMappings.Any())
+            if (propertyMappings.Count != 0)
             {
                 var mapping = propertyMappings.Single().First();
                 correlationProperty = new CorrelationPropertyMetadata(mapping.SagaPropName, mapping.SagaPropType);
@@ -261,7 +261,7 @@ Sagas must have at least one message that is allowed to start the saga. Add at l
             }
         }
 
-        static IEnumerable<SagaMessage> GetAssociatedMessages(Type sagaType)
+        static List<SagaMessage> GetAssociatedMessages(Type sagaType)
         {
             var result = GetMessagesCorrespondingToFilterOnSaga(sagaType, typeof(IAmStartedByMessages<>))
                 .Select(t => new SagaMessage(t, true)).ToList();
@@ -409,7 +409,7 @@ Sagas must have at least one message that is allowed to start the saga. Add at l
                 });
             }
 
-            void ThrowIfNotPropertyLambdaExpression<TSagaEntity>(Expression<Func<TSagaEntity, object>> expression, PropertyInfo propertyInfo)
+            static void ThrowIfNotPropertyLambdaExpression<TSagaEntity>(Expression<Func<TSagaEntity, object>> expression, PropertyInfo propertyInfo)
             {
                 if (propertyInfo == null)
                 {

--- a/src/NServiceBus.Core/Sagas/SagaMetadataCollection.cs
+++ b/src/NServiceBus.Core/Sagas/SagaMetadataCollection.cs
@@ -105,7 +105,7 @@ namespace NServiceBus.Sagas
                 }
             }
 
-            if (violations.Any())
+            if (violations.Count != 0)
             {
                 throw new Exception("Best practice violation: Multiple saga types are sharing the same saga state which can result in persisters to physically share the same storage structure.\n\n- " + string.Join("\n- ", violations));
             }

--- a/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
@@ -256,7 +256,7 @@
             return finder.Find(context.Builder, finderDefinition, context.SynchronizedStorageSession, context.Extensions, context.MessageBeingHandled, context.MessageHeaders, context.CancellationToken);
         }
 
-        SagaFinderDefinition GetSagaFinder(SagaMetadata metadata, IInvokeHandlerContext context)
+        static SagaFinderDefinition GetSagaFinder(SagaMetadata metadata, IInvokeHandlerContext context)
         {
             foreach (var messageType in context.MessageMetadata.MessageHierarchy)
             {

--- a/src/NServiceBus.Core/Serializers/XML/XmlMessageSerializer.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlMessageSerializer.cs
@@ -100,7 +100,7 @@ namespace NServiceBus
             }
         }
 
-        string TrimPotentialTrailingForwardSlashes(string value)
+        static string TrimPotentialTrailingForwardSlashes(string value)
         {
             return value?.TrimEnd('/');
         }

--- a/src/NServiceBus.Core/Serializers/XML/XmlSanitizingStream.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlSanitizingStream.cs
@@ -107,7 +107,7 @@ namespace NServiceBus
 
             if (buffer.Length - index < count)
             {
-                throw new ArgumentException();
+                throw new ArgumentException("Offset and length were out of bounds for the array or count is greater than the number of elements from index to the end of the source collection.");
             }
             var number = 0;
             do

--- a/src/NServiceBus.Core/Serializers/XML/XmlSerialization.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlSerialization.cs
@@ -279,7 +279,7 @@
             return propertyInfo?.GetIndexParameters().Length > 0;
         }
 
-        void WriteElementNamespaces(XElement elem, IReadOnlyList<string> baseTypes)
+        static void WriteElementNamespaces(XElement elem, IReadOnlyList<string> baseTypes)
         {
             elem.Add(new XAttribute(XNamespace.Xmlns + "xsi", xsiNamespace),
                 new XAttribute(XNamespace.Xmlns + "xsd", xsdNamespace));
@@ -303,7 +303,7 @@
         readonly Type messageType;
         readonly string @namespace;
         readonly bool skipWrappingRawXml;
-        readonly XmlWriter writer;
+        readonly RawXmlTextWriter writer;
         const string BaseType = "baseType";
 
         const string DefaultNamespace = "http://tempuri.net";

--- a/src/NServiceBus.Core/Serializers/XML/XmlSerializerCache.cs
+++ b/src/NServiceBus.Core/Serializers/XML/XmlSerializerCache.cs
@@ -108,11 +108,11 @@ namespace NServiceBus
 
             if (args.Length == 1 && args[0].IsValueType)
             {
-                if (args[0].GetGenericArguments().Any() || typeof(Nullable<>).MakeGenericType(args[0]) == t)
+                if (args[0].GetGenericArguments().Length != 0 || typeof(Nullable<>).MakeGenericType(args[0]) == t)
                 {
                     InitTypeInternal(args[0]);
 
-                    if (!args[0].GetGenericArguments().Any())
+                    if (args[0].GetGenericArguments().Length == 0)
                     {
                         return;
                     }
@@ -140,7 +140,7 @@ namespace NServiceBus
             typeMembers[t] = new Tuple<FieldInfo[], PropertyInfo[]>(fields, props);
         }
 
-        PropertyInfo[] GetAllPropertiesForType(Type t, bool isKeyValuePair)
+        static PropertyInfo[] GetAllPropertiesForType(Type t, bool isKeyValuePair)
         {
             var result = new List<PropertyInfo>();
 
@@ -202,7 +202,7 @@ namespace NServiceBus
             return result.Distinct().ToArray();
         }
 
-        FieldInfo[] GetAllFieldsForType(Type t)
+        static FieldInfo[] GetAllFieldsForType(Type t)
         {
             return t.GetFields(BindingFlags.FlattenHierarchy | BindingFlags.Instance | BindingFlags.Public);
         }

--- a/src/NServiceBus.Core/ServicePlatform/Retries/RetryAcknowledgementBehavior.cs
+++ b/src/NServiceBus.Core/ServicePlatform/Retries/RetryAcknowledgementBehavior.cs
@@ -39,7 +39,7 @@
                         { RetryUniqueMessageIdHeaderKey, id },
                         { Headers.ControlMessageHeader, bool.TrueString }
                     },
-                    new byte[0]);
+                    Array.Empty<byte>());
                 var routingContext = new RoutingContext(messageToDispatch, new UnicastRoutingStrategy(acknowledgementQueue), context);
                 await this.Fork(routingContext).ConfigureAwait(false);
             }

--- a/src/NServiceBus.Core/Transports/Learning/AsyncFile.cs
+++ b/src/NServiceBus.Core/Transports/Learning/AsyncFile.cs
@@ -29,7 +29,7 @@ namespace NServiceBus
             {
                 using (var stream = CreateWriteStream(tempFile, FileMode.Open))
                 {
-                    await stream.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
+                    await stream.WriteAsync(bytes, cancellationToken).ConfigureAwait(false);
                 }
             }
             catch (Exception ex) when (ex.IsCausedBy(cancellationToken))
@@ -91,7 +91,7 @@ namespace NServiceBus
             {
                 var length = (int)stream.Length;
                 var body = new byte[length];
-                await stream.ReadAsync(body, 0, length, cancellationToken).ConfigureAwait(false);
+                await stream.ReadAsync(body.AsMemory(0, length), cancellationToken).ConfigureAwait(false);
 
                 return body;
             }

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportDispatcher.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportDispatcher.cs
@@ -160,7 +160,7 @@ namespace NServiceBus
             return subscribers;
         }
 
-        static IEnumerable<Type> GetPotentialEventTypes(Type messageType)
+        static HashSet<Type> GetPotentialEventTypes(Type messageType)
         {
             var allEventTypes = new HashSet<Type>();
 

--- a/src/NServiceBus.Core/Transports/TransportSeam.cs
+++ b/src/NServiceBus.Core/Transports/TransportSeam.cs
@@ -30,7 +30,9 @@
         // The dependency in IServiceProvider ensures that the TransportInfrastructure can't be resolved too early.
         public TransportInfrastructure GetTransportInfrastructure(IServiceProvider _) => TransportInfrastructure;
 
+#pragma warning disable CA1822 // Mark members as static
         public ITransportAddressResolver TransportAddressResolverBuilder(IServiceProvider sp) => sp.GetRequiredService<ITransportAddressResolver>();
+#pragma warning restore CA1822 // Mark members as static
 
         public async Task<TransportInfrastructure> CreateTransportInfrastructure(CancellationToken cancellationToken = default)
         {

--- a/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs
@@ -5,9 +5,9 @@
     using System.Linq;
     using System.Linq.Expressions;
     using System.Threading.Tasks;
+    using FastExpressionCompiler;
     using Logging;
     using Pipeline;
-    using FastExpressionCompiler;
 
     /// <summary>
     /// Maintains the message handlers for this endpoint.
@@ -150,7 +150,7 @@
                 .ToArray();
         }
 
-        void ValidateHandlerType(Type handlerType)
+        static void ValidateHandlerType(Type handlerType)
         {
             var propertyTypes = handlerType.GetProperties().Select(p => p.PropertyType).ToList();
             var ctorArguments = handlerType.GetConstructors()

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -109,7 +109,7 @@
         /// <returns>An array of <see cref="MessageMetadata" /> for all known message.</returns>
         public MessageMetadata[] GetAllMessages() => messages.Values.ToArray();
 
-        string GetMessageTypeNameWithoutAssembly(string messageTypeIdentifier)
+        static string GetMessageTypeNameWithoutAssembly(string messageTypeIdentifier)
         {
             var typeParts = messageTypeIdentifier.Split(',');
             if (typeParts.Length > 1)
@@ -158,7 +158,7 @@
             }
         }
 
-        IEnumerable<Type> GetHandledMessageTypes(Type messageHandlerType)
+        static IEnumerable<Type> GetHandledMessageTypes(Type messageHandlerType)
         {
             if (messageHandlerType.IsAbstract || messageHandlerType.IsGenericTypeDefinition)
             {

--- a/src/NServiceBus.Core/Unicast/Transport/ControlMessageFactory.cs
+++ b/src/NServiceBus.Core/Unicast/Transport/ControlMessageFactory.cs
@@ -1,5 +1,6 @@
 namespace NServiceBus.Unicast.Transport
 {
+    using System;
     using NServiceBus.Transport;
 
     /// <summary>
@@ -13,7 +14,7 @@ namespace NServiceBus.Unicast.Transport
         /// <returns>Transport Message.</returns>
         public static OutgoingMessage Create(MessageIntent intent)
         {
-            var message = new OutgoingMessage(CombGuid.Generate().ToString(), [], new byte[0]);
+            var message = new OutgoingMessage(CombGuid.Generate().ToString(), [], Array.Empty<byte>());
             message.Headers[Headers.ControlMessageHeader] = bool.TrueString;
             message.Headers[Headers.MessageIntent] = intent.ToString();
             return message;

--- a/src/NServiceBus.Core/Utils/Reflection/ExtensionMethods.cs
+++ b/src/NServiceBus.Core/Utils/Reflection/ExtensionMethods.cs
@@ -11,9 +11,7 @@ namespace NServiceBus
     {
         public static T Construct<T>(this Type type)
         {
-            var defaultConstructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, null, new Type[]
-            {
-            }, null);
+            var defaultConstructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic, null, Array.Empty<Type>(), null);
             if (defaultConstructor != null)
             {
                 return (T)defaultConstructor.Invoke(null);
@@ -58,7 +56,7 @@ namespace NServiceBus
                 var index = t.Name.IndexOf('`');
                 if (index >= 0)
                 {
-                    var result = t.Name.Substring(0, index) + "Of";
+                    var result = string.Concat(t.Name.AsSpan(0, index), "Of");
                     var args = t.GetGenericArguments();
                     for (var i = 0; i < args.Length; i++)
                     {

--- a/src/NServiceBus.Core/Utils/Reflection/Reflect.cs
+++ b/src/NServiceBus.Core/Utils/Reflection/Reflect.cs
@@ -23,10 +23,7 @@ namespace NServiceBus
 
         public static MemberInfo GetMemberInfo(Expression member, bool checkForSingleDot)
         {
-            if (member == null)
-            {
-                throw new ArgumentNullException(nameof(member));
-            }
+            ArgumentNullException.ThrowIfNull(member);
 
             if (member is not LambdaExpression lambda)
             {
@@ -35,11 +32,11 @@ namespace NServiceBus
 
             MemberExpression memberExpr = null;
 
-            // The Func<TTarget, object> we use returns an object, so first statement can be either 
+            // The Func<TTarget, object> we use returns an object, so first statement can be either
             // a cast (if the field/property does not return an object) or the direct member access.
             if (lambda.Body.NodeType == ExpressionType.Convert)
             {
-                // The cast is an unary expression, where the operand is the 
+                // The cast is an unary expression, where the operand is the
                 // actual member access expression.
                 memberExpr = ((UnaryExpression)lambda.Body).Operand as MemberExpression;
             }

--- a/src/NServiceBus.Learning.AcceptanceTests/ConfigureEndpointLearningPersistence.cs
+++ b/src/NServiceBus.Learning.AcceptanceTests/ConfigureEndpointLearningPersistence.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿namespace NServiceBus.AcceptanceTests;
+
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using NServiceBus;

--- a/src/NServiceBus.Learning.AcceptanceTests/ConfigureEndpointLearningTransport.cs
+++ b/src/NServiceBus.Learning.AcceptanceTests/ConfigureEndpointLearningTransport.cs
@@ -1,3 +1,5 @@
+namespace NServiceBus.AcceptanceTests;
+
 using System.IO;
 using System.Threading.Tasks;
 using NServiceBus;

--- a/src/NServiceBus.PersistenceTests/Outbox/OutboxStorageTests.cs
+++ b/src/NServiceBus.PersistenceTests/Outbox/OutboxStorageTests.cs
@@ -155,7 +155,7 @@
             Assert.NotNull(message);
         }
 
-        IPersistenceTestsConfiguration configuration;
+        PersistenceTestsConfiguration configuration;
         TestVariant param;
     }
 }

--- a/src/NServiceBus.Testing.Fakes/TestableAuditContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableAuditContext.cs
@@ -24,7 +24,7 @@
         /// <summary>
         /// The message to be audited.
         /// </summary>
-        public OutgoingMessage Message { get; set; } = new OutgoingMessage(Guid.NewGuid().ToString(), [], new byte[0]);
+        public OutgoingMessage Message { get; set; } = new OutgoingMessage(Guid.NewGuid().ToString(), [], Array.Empty<byte>());
 
         /// <summary>
         /// Metadata of the audited message.

--- a/src/NServiceBus.Testing.Fakes/TestableBehaviorContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableBehaviorContext.cs
@@ -5,7 +5,6 @@
     using System.Threading;
     using Extensibility;
     using Microsoft.Extensions.DependencyInjection;
-    using ObjectBuilder;
     using Pipeline;
 
     /// <summary>

--- a/src/NServiceBus.Testing.Fakes/TestableIncomingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableIncomingPhysicalMessageContext.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Testing
 {
     using System;
-    using System.Collections.Generic;
     using Pipeline;
     using Transport;
 
@@ -15,7 +14,7 @@
         /// </summary>
         public TestableIncomingPhysicalMessageContext()
         {
-            Message = new IncomingMessage(Guid.NewGuid().ToString(), [], new byte[] { });
+            Message = new IncomingMessage(Guid.NewGuid().ToString(), [], Array.Empty<byte>());
         }
 
         /// <summary>

--- a/src/NServiceBus.Testing.Fakes/TestableOutgoingContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableOutgoingContext.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections.Generic;
     using Microsoft.Extensions.DependencyInjection;
-    using ObjectBuilder;
     using Pipeline;
 
     /// <summary>

--- a/src/NServiceBus.Testing.Fakes/TestableOutgoingLogicalMessageContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableOutgoingLogicalMessageContext.cs
@@ -25,6 +25,6 @@
         /// <summary>
         /// The routing strategies for this message.
         /// </summary>
-        public IReadOnlyCollection<RoutingStrategy> RoutingStrategies { get; set; } = new RoutingStrategy[0];
+        public IReadOnlyCollection<RoutingStrategy> RoutingStrategies { get; set; } = System.Array.Empty<RoutingStrategy>();
     }
 }

--- a/src/NServiceBus.Testing.Fakes/TestableOutgoingPhysicalMessageContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableOutgoingPhysicalMessageContext.cs
@@ -29,6 +29,6 @@
         /// <summary>
         /// The routing strategies for this message.
         /// </summary>
-        public IReadOnlyCollection<RoutingStrategy> RoutingStrategies { get; set; } = new RoutingStrategy[0];
+        public IReadOnlyCollection<RoutingStrategy> RoutingStrategies { get; set; } = Array.Empty<RoutingStrategy>();
     }
 }

--- a/src/NServiceBus.Testing.Fakes/TestableRoutingContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableRoutingContext.cs
@@ -14,11 +14,11 @@
         /// <summary>
         /// The message to dispatch the the transport.
         /// </summary>
-        public OutgoingMessage Message { get; set; } = new OutgoingMessage(Guid.NewGuid().ToString(), [], new byte[0]);
+        public OutgoingMessage Message { get; set; } = new OutgoingMessage(Guid.NewGuid().ToString(), [], Array.Empty<byte>());
 
         /// <summary>
         /// The routing strategies for the operation to be dispatched.
         /// </summary>
-        public IReadOnlyCollection<RoutingStrategy> RoutingStrategies { get; set; } = new RoutingStrategy[0];
+        public IReadOnlyCollection<RoutingStrategy> RoutingStrategies { get; set; } = Array.Empty<RoutingStrategy>();
     }
 }

--- a/src/NServiceBus.Testing.Fakes/TestableTransportReceiveContext.cs
+++ b/src/NServiceBus.Testing.Fakes/TestableTransportReceiveContext.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Testing
 {
     using System;
-    using System.Collections.Generic;
     using Pipeline;
     using Transport;
 
@@ -13,6 +12,6 @@
         /// <summary>
         /// The physical message being processed.
         /// </summary>
-        public IncomingMessage Message { get; set; } = new IncomingMessage(Guid.NewGuid().ToString(), [], new byte[0]);
+        public IncomingMessage Message { get; set; } = new IncomingMessage(Guid.NewGuid().ToString(), [], Array.Empty<byte>());
     }
 }

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -140,7 +140,7 @@
             receiver = null;
         }
 
-        void IgnoreUnsupportedTransactionModes(TransportDefinition transportDefinition, TransportTransactionMode requestedTransactionMode)
+        static void IgnoreUnsupportedTransactionModes(TransportDefinition transportDefinition, TransportTransactionMode requestedTransactionMode)
         {
             if (!transportDefinition.GetSupportedTransactionModes().Contains(requestedTransactionMode))
             {
@@ -238,8 +238,8 @@
 
         protected string InputQueueName;
         protected string ErrorQueueName;
-        protected static TransportTestLoggerFactory LogFactory;
-        protected static TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+        protected static readonly TransportTestLoggerFactory LogFactory;
+        protected static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
 
         string testId;
 


### PR DESCRIPTION
This bumps up the `AnalysisLevel` to `8.0-minimum` and fixes everything that was flagged from it.

There were a few places where I've added pragmas to suppress a warning, only where it seemed potentially incorrect to make the suggested change.

The primary example of this is in `TransportSeam` and `RoutingComponent`, where it wanted to convert some methods to static. However, doing this leads to a ripple effect of removing some dependencies between components, so I suppressed it instead for now.