### PR TITLE
Remove unnecessary packages

### DIFF
--- a/src/NServiceBus.Core.Tests/DocumentationTests.cs
+++ b/src/NServiceBus.Core.Tests/DocumentationTests.cs
@@ -128,7 +128,7 @@
                     return;
                 }
                 var declaringType = currentMember.DeclaringType;
-                if (declaringType != null && (declaringType.FullName.Contains("JetBrains") || declaringType.FullName.Contains("FastExpressionCompiler") || declaringType.FullName.Contains("SimpleJson")))
+                if (declaringType != null && declaringType.FullName.Contains("FastExpressionCompiler"))
                 {
                     return;
                 }

--- a/src/NServiceBus.Core.Tests/StandardsTests.cs
+++ b/src/NServiceBus.Core.Tests/StandardsTests.cs
@@ -40,9 +40,6 @@
                     !x.IsNested &&
                     !IsCompilerGenerated(x) &&
                     !x.FullName.Contains("System") &&
-                    !x.FullName.Contains("JetBrains") &&
-                    !x.FullName.StartsWith("Newtonsoft.Json") &&
-                    !x.FullName.StartsWith("SimpleJson") &&
                     !x.FullName.StartsWith("FastExpressionCompiler") &&
                     x.Namespace != "Particular.Licensing" &&
                     x.Namespace != "NServiceBus.Features" &&

--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -11,19 +11,16 @@
   <ItemGroup Label="Public dependencies">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-rc.2.23479.6" />
     <PackageReference Include="NServiceBus.MessageInterfaces" Version="1.0.0-alpha.1" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0-rc.2.23479.6" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.0-rc.2.23479.6" />
-    <PackageReference Include="System.Text.Json" Version="8.0.0-rc.2.23479.6" />
   </ItemGroup>
 
   <ItemGroup Label="Private dependencies">
+    <PackageReference Include="FastExpressionCompiler.Internal.src" Version="3.3.4" PrivateAssets="All" />
     <PackageReference Include="Fody" Version="6.8.0" PrivateAssets="All" />
     <PackageReference Include="Janitor.Fody" Version="1.9.0" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Licensing.Sources" Version="6.0.0-alpha.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="3.0.0" PrivateAssets="All" />
-    <PackageReference Include="SimpleJson" Version="0.38.0" PrivateAssets="All" />
-    <PackageReference Include="FastExpressionCompiler.Internal.src" Version="3.3.4" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
We don't need to reference System.Diagnostics.DiagnosticSource or System.Text.Json because they ship as part of .NET.

SimpleJson had already been removed from the repo, but the package was still being referenced.

There were also some leftover references to things that have been removed in some tests, so I cleaned those up as well.