### PR TITLE
Add props file to buildTransitive also

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -35,7 +35,7 @@
 
   <Target Name="AddPropsFileToPackage">
     <ItemGroup>
-      <TfmSpecificPackageFile Include="NServiceBus.props" PackagePath="build/$(TargetFramework)" />
+      <TfmSpecificPackageFile Include="NServiceBus.props" PackagePath="build/$(TargetFramework);buildTransitive/$(TargetFramework)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
The NServiceBus.props file adds the `NServiceBus` namespace to the list of implicltly referenced namespaces when `<ImplicitUsings>enable</ImplicitUsings>` is set in a project file. However, when the NServiceBus package is referenced transitively (for example, like we do in a lot of our samples), the namespace isn't added properly.

Adding the props file to the `buildTransitive` folder in the package fixes that.