### PR TITLE
Particular.Packaging update follow-up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: 8.0.x
-          dotnet-quality: 'preview'
       - name: Build
         run: dotnet build src --configuration Release
       - name: Upload packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/setup-dotnet@v3.2.0
         with:
           dotnet-version: 8.0.x
-          dotnet-quality: 'preview'
       - name: Build
         run: dotnet build src --configuration Release
       - name: Sign NuGet packages

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -1,0 +1,42 @@
+License notice for net-object-deep-copy
+---------------------------------------
+
+https://github.com/Burtsev-Alexey/net-object-deep-copy/blob/master/README
+
+Source code is released under the MIT license.
+
+The MIT License (MIT)
+Copyright (c) 2014 Burtsev Alexey
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+License notice for FastExpressionCompiler
+-----------------------------------------
+
+https://github.com/dadhi/FastExpressionCompiler/blob/master/LICENSE
+
+The MIT License (MIT)
+
+Copyright (c) 2016-2023 Maksim Volkau
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -29,10 +29,4 @@
     <RemoveSourceFileFromPackage Include="AssemblyInfo.cs" />
   </ItemGroup>
 
-  <Target Name="WorkaroundForTesthostBeingAddedAsContent" BeforeTargets="_GetPackageFiles">
-    <ItemGroup>
-      <Content Update="**\testhost.*" Pack="false" />
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/src/NServiceBus.PersistenceTests/NServiceBus.PersistenceTests.csproj
+++ b/src/NServiceBus.PersistenceTests/NServiceBus.PersistenceTests.csproj
@@ -32,10 +32,4 @@
     <RemoveSourceFileFromPackage Include="PersistenceTestsConfiguration.cs" />
   </ItemGroup>
 
-  <Target Name="WorkaroundForTesthostBeingAddedAsContent" BeforeTargets="_GetPackageFiles">
-    <ItemGroup>
-      <Content Update="**\testhost.*" Pack="false" />
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
+++ b/src/NServiceBus.TransportTests/NServiceBus.TransportTests.csproj
@@ -28,10 +28,4 @@
     <RemoveSourceFileFromPackage Include="TransportTestPolicy.cs" />
   </ItemGroup>
 
-  <Target Name="WorkaroundForTesthostBeingAddedAsContent" BeforeTargets="_GetPackageFiles">
-    <ItemGroup>
-      <Content Update="**\testhost.*" Pack="false" />
-    </ItemGroup>
-  </Target>
-
 </Project>


### PR DESCRIPTION
Follow-up to #6924 to adjust the repo to the new Particular.Packaging version.

I also went ahead and removed the `preview` quality from the workflow files because I noticed that despite the RTM version of the SDK being available, the RC was still being used.

