### PR TITLE
Fixes for Particular.Analyzers 2.1.2 - master

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <AnalyzerTargetFramework>netstandard2.0</AnalyzerTargetFramework>
     <AnalysisLevel>8.0-minimum</AnalysisLevel>
-    <ParticularAnalyzersVersion>2.0.0</ParticularAnalyzersVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/NServiceBus.Core.Analyzer/SemanticModelCache.cs
+++ b/src/NServiceBus.Core.Analyzer/SemanticModelCache.cs
@@ -6,7 +6,9 @@
     class SemanticModelCache
     {
         Compilation compilation;
+#pragma warning disable PS0025 // Dictionary keys should implement IEquatable<T> - A SemanticModelCache is not long-lived and is meant to use reference equality
         Dictionary<SyntaxTree, SemanticModel> dict;
+#pragma warning restore PS0025 // Dictionary keys should implement IEquatable<T>
 
         public SemanticModelCache(Compilation compilation, SyntaxTree originalSyntaxTree, SemanticModel originalSemanticModel)
         {

--- a/src/NServiceBus.Core.Tests/Serializers/XML/SerializerTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/SerializerTests.cs
@@ -1358,7 +1358,9 @@ namespace NServiceBus.Serializers.XML.Test
 
     public class MessageWithDictionaryWithAnObjectAsKey
     {
+#pragma warning disable PS0025 // Dictionary keys should implement IEquatable<T>
         public Dictionary<object, string> Content { get; set; }
+#pragma warning restore PS0025 // Dictionary keys should implement IEquatable<T>
     }
 
     public class MessageWithDictionaryWithAnObjectAsValue

--- a/src/NServiceBus.Core/DeepCopy.cs
+++ b/src/NServiceBus.Core/DeepCopy.cs
@@ -14,6 +14,8 @@ namespace System
     using System.Collections.Generic;
     using System.Reflection;
 
+    [Diagnostics.CodeAnalysis.SuppressMessage("Code", "PS0025:Dictionary keys should implement IEquatable<T>",
+        Justification = "A DeepCopy algorithm requires reference counting necessitating dictionaries keyed on objects by reference")]
     static class ObjectExtensions
     {
         static readonly MethodInfo CloneMethod = typeof(object).GetMethod("MemberwiseClone", BindingFlags.NonPublic | BindingFlags.Instance);

--- a/src/NServiceBus.Core/MessageMutators/MutateInstanceMessage/MutateIncomingMessageBehavior.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateInstanceMessage/MutateIncomingMessageBehavior.cs
@@ -7,6 +7,7 @@ using MessageMutator;
 using Microsoft.Extensions.DependencyInjection;
 using Pipeline;
 
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Code", "PS0025:Dictionary keys should implement GetHashCode", Justification = "Mutators are registered based on reference equality")]
 class MutateIncomingMessageBehavior : IBehavior<IIncomingLogicalMessageContext, IIncomingLogicalMessageContext>
 {
     public MutateIncomingMessageBehavior(HashSet<IMutateIncomingMessages> mutators)

--- a/src/NServiceBus.Core/MessageMutators/MutateInstanceMessage/MutateOutgoingMessageBehavior.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateInstanceMessage/MutateOutgoingMessageBehavior.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Pipeline;
 using Transport;
 
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Code", "PS0025:Dictionary keys should implement GetHashCode", Justification = "Mutators are registered based on reference equality")]
 class MutateOutgoingMessageBehavior : IBehavior<IOutgoingLogicalMessageContext, IOutgoingLogicalMessageContext>
 {
     public MutateOutgoingMessageBehavior(HashSet<IMutateOutgoingMessages> mutators)

--- a/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehavior.cs
@@ -7,6 +7,7 @@ using MessageMutator;
 using Microsoft.Extensions.DependencyInjection;
 using Pipeline;
 
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Code", "PS0025:Dictionary keys should implement GetHashCode", Justification = "Mutators are registered based on reference equality")]
 class MutateIncomingTransportMessageBehavior : IBehavior<IIncomingPhysicalMessageContext, IIncomingPhysicalMessageContext>
 {
     public MutateIncomingTransportMessageBehavior(HashSet<IMutateIncomingTransportMessages> mutators)

--- a/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateOutgoingTransportMessageBehavior.cs
+++ b/src/NServiceBus.Core/MessageMutators/MutateTransportMessage/MutateOutgoingTransportMessageBehavior.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Pipeline;
 using Transport;
 
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Code", "PS0025:Dictionary keys should implement GetHashCode", Justification = "Mutators are registered based on reference equality")]
 class MutateOutgoingTransportMessageBehavior : IBehavior<IOutgoingPhysicalMessageContext, IOutgoingPhysicalMessageContext>
 {
     public MutateOutgoingTransportMessageBehavior(HashSet<IMutateOutgoingTransportMessages> mutators)

--- a/src/NServiceBus.Core/MessageMutators/Mutators.cs
+++ b/src/NServiceBus.Core/MessageMutators/Mutators.cs
@@ -1,7 +1,7 @@
 ﻿namespace NServiceBus.Features;
 
-using MessageMutator;
 using System.Collections.Generic;
+using MessageMutator;
 
 class Mutators : Feature
 {
@@ -20,6 +20,7 @@ class Mutators : Feature
         context.Pipeline.Register("MutateOutgoingTransportMessage", new MutateOutgoingTransportMessageBehavior(registry.OutgoingTransportMessage), "Executes IMutateOutgoingTransportMessages");
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Code", "PS0025:Dictionary keys should implement GetHashCode", Justification = "Mutators are registered based on reference equality")]
     public class RegisteredMutators
     {
         public readonly HashSet<IMutateIncomingMessages> IncomingMessage = [];

--- a/src/NServiceBus.Core/Routing/EndpointInstances.cs
+++ b/src/NServiceBus.Core/Routing/EndpointInstances.cs
@@ -55,6 +55,6 @@ public class EndpointInstances
     }
 
     Dictionary<string, HashSet<EndpointInstance>> allInstances = [];
-    readonly Dictionary<object, IList<EndpointInstance>> registrations = [];
+    readonly Dictionary<string, IList<EndpointInstance>> registrations = [];
     readonly object updateLock = new object();
 }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/Publishers.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/Publishers.cs
@@ -45,6 +45,6 @@ public class Publishers
     }
 
     Dictionary<Type, HashSet<PublisherAddress>> publishers = [];
-    readonly Dictionary<object, IList<PublisherTableEntry>> publisherRegistrations = [];
+    readonly Dictionary<string, IList<PublisherTableEntry>> publisherRegistrations = [];
     readonly object updateLock = new object();
 }

--- a/src/NServiceBus.Core/Routing/UnicastRoutingTable.cs
+++ b/src/NServiceBus.Core/Routing/UnicastRoutingTable.cs
@@ -44,6 +44,6 @@ public class UnicastRoutingTable
     }
 
     Dictionary<Type, UnicastRoute> routeTable = [];
-    readonly Dictionary<object, IList<RouteTableEntry>> routeGroups = [];
+    readonly Dictionary<string, IList<RouteTableEntry>> routeGroups = [];
     readonly object updateLock = new object();
 }


### PR DESCRIPTION
Particular.Analyzers 2.1.0 will introduce `PS0025:Dictionary keys should implement IEquatable<T>`. This PR prepares the repo by fixing the issues that analyzer will find, based on an alpha version of the analyzer.

Contains 1 change to public API, making `NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions.Subscriber` a record class, automatically creating the `IEquatable<Subscriber>` implementation necessary to be used as a HashSet key in [AcceptanceTestingSubscriptionStorage](https://github.com/Particular/NServiceBus/blob/9.0.0/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/SubscriptionStorage/AcceptanceTestingSubscriptionStorage.cs#L31-L42).