### PR TITLE
Throw exception on premature ITransportAddressResolver access

### DIFF
--- a/src/NServiceBus.Core/Transports/TransportSeam.cs
+++ b/src/NServiceBus.Core/Transports/TransportSeam.cs
@@ -62,7 +62,7 @@ class TransportSeam
         hostingConfiguration.Services.AddSingleton(_ => transportSeam.TransportInfrastructure.Dispatcher);
 
         hostingConfiguration.Services.AddSingleton<ITransportAddressResolver>(_ =>
-            new TransportAddressResolver(transportSeam.TransportInfrastructure));
+            new TransportAddressResolver(transportSeam.TransportInfrastructure ?? throw new Exception($"{nameof(TransportInfrastructure)} is accessed before the endpoint has been started.")));
 
         return transportSeam;
     }


### PR DESCRIPTION
Potential quick fix for https://github.com/Particular/NServiceBus/issues/6961 which prevents the singelton instance to be created in an invalid state.