### PR TITLE
Fix ReplacementTypeOrMember for DateTimeExtensions

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -220,8 +220,8 @@ namespace NServiceBus
         public void SetValue(object valueToSet) { }
     }
     [System.Obsolete("Public APIs no longer use DateTime but DateTimeOffset. See the upgrade guide for " +
-        "more details. Use `NServiceBus.DateTimeOffsetExtensions` instead. Will be remove" +
-        "d in version 9.0.0.", true)]
+        "more details. Use `NServiceBus.DateTimeOffsetHelper` instead. Will be removed in" +
+        " version 9.0.0.", true)]
     public static class DateTimeExtensions
     {
         [System.Obsolete("Public APIs no longer use DateTime but DateTimeOffset. See the upgrade guide for " +

--- a/src/NServiceBus.Core/obsoletes-v8.cs
+++ b/src/NServiceBus.Core/obsoletes-v8.cs
@@ -683,7 +683,7 @@ namespace NServiceBus
 
     [ObsoleteEx(
         Message = "Public APIs no longer use DateTime but DateTimeOffset. See the upgrade guide for more details.",
-        ReplacementTypeOrMember = "NServiceBus.DateTimeOffsetExtensions",
+        ReplacementTypeOrMember = "NServiceBus.DateTimeOffsetHelper",
         TreatAsErrorFromVersion = "8",
         RemoveInVersion = "9")]
     public static class DateTimeExtensions


### PR DESCRIPTION
The obsolete message on the class type referred to `DateTimeOffsetExtensions`, which is an internal class. Instead, it should be `DateTimeOffsetHelper`, as it correctly is on all class members.

- [x] Approved API