### PR TITLE
use collection expression spread operator

### DIFF
--- a/src/NServiceBus.Core/Features/FeatureActivator.cs
+++ b/src/NServiceBus.Core/Features/FeatureActivator.cs
@@ -150,10 +150,7 @@ class FeatureActivator
                 return true;
             }
 
-            var newVisitedNodes = visitedNodes.Union(new[]
-            {
-                node
-            }).ToArray();
+            Node[] newVisitedNodes = [.. visitedNodes, node];
 
             foreach (var subNode in node.previous)
             {


### PR DESCRIPTION
- avoid additional array allocation and conversion
- avoid implicit checking of duplicates using `Union` method