### PR TITLE
Fix for FileNotFoundException in FileShareDataBusImplementation in cross-platform scenarios

### DIFF
--- a/src/NServiceBus.Core/DataBus/FileShareDataBusImplementation.cs
+++ b/src/NServiceBus.Core/DataBus/FileShareDataBusImplementation.cs
@@ -8,30 +8,30 @@ using DataBus;
 using Logging;
 
 class FileShareDataBusImplementation : IDataBus
-{ 
+{
     // to account for mixed platforms ie windows -> linux or linux -> windows
     internal class PathNormalizer
-    {  
+    {
         //    Example keys
         //    string key1 = "foldername/filename";
         //    string key2 = "foldername\\filename";
-            
+
         //    Normalize the keys
         //    string normalizedKey1 = NormalizePath(key1);
         //    string normalizedKey2 = NormalizePath(key2);
-            
+
         //    Output the normalized keys
         //    Console.WriteLine(normalizedKey1); // Output will be "foldername\filename" on Windows, "foldername/filename" on Unix-based systems
         //    Console.WriteLine(normalizedKey2); // Output will be "foldername\filename" on Windows, "foldername/filename" on Unix-based systems 
         internal static string NormalizePath(string key)
         {
             // Determine the directory separator for the current platform
-            char separator = Path.DirectorySeparatorChar;            
+            char separator = Path.DirectorySeparatorChar;
             // Replace any forward slashes (common in URIs) and backward slashes with the platform-specific separator
             string normalizedPath = key.Replace('/', separator).Replace('\\', separator);
-            
+
             return normalizedPath;
-        }       
+        }
     }
 
 

--- a/src/NServiceBus.Core/DataBus/FileShareDataBusImplementation.cs
+++ b/src/NServiceBus.Core/DataBus/FileShareDataBusImplementation.cs
@@ -8,7 +8,33 @@ using DataBus;
 using Logging;
 
 class FileShareDataBusImplementation : IDataBus
-{
+{ 
+    // to account for mixed platforms ie windows -> linux or linux -> windows
+    internal class PathNormalizer
+    {  
+        //    Example keys
+        //    string key1 = "foldername/filename";
+        //    string key2 = "foldername\\filename";
+            
+        //    Normalize the keys
+        //    string normalizedKey1 = NormalizePath(key1);
+        //    string normalizedKey2 = NormalizePath(key2);
+            
+        //    Output the normalized keys
+        //    Console.WriteLine(normalizedKey1); // Output will be "foldername\filename" on Windows, "foldername/filename" on Unix-based systems
+        //    Console.WriteLine(normalizedKey2); // Output will be "foldername\filename" on Windows, "foldername/filename" on Unix-based systems 
+        internal static string NormalizePath(string key)
+        {
+            // Determine the directory separator for the current platform
+            char separator = Path.DirectorySeparatorChar;            
+            // Replace any forward slashes (common in URIs) and backward slashes with the platform-specific separator
+            string normalizedPath = key.Replace('/', separator).Replace('\\', separator);
+            
+            return normalizedPath;
+        }       
+    }
+
+
     public FileShareDataBusImplementation(string basePath)
     {
         this.basePath = basePath;
@@ -18,7 +44,7 @@ class FileShareDataBusImplementation : IDataBus
 
     public Task<Stream> Get(string key, CancellationToken cancellationToken = default)
     {
-        var filePath = Path.Combine(basePath, key);
+        var filePath = Path.Combine(basePath, PathNormalizer.NormalizePath(key));
 
         logger.DebugFormat("Opening stream from '{0}'.", filePath);
 


### PR DESCRIPTION
Fixes FileNotFoundException in cross-platform scenarios (Windows to Linux or Linux to Windows). The bug was due to incompatible path separators causing exceptions.