### PR TITLE
FileShareDataBusImplementation throws a FileNotFoundException when sending databus messages from Windows to Linux

### DIFF
--- a/src/NServiceBus.Core/DataBus/FileShareDataBusImplementation.cs
+++ b/src/NServiceBus.Core/DataBus/FileShareDataBusImplementation.cs
@@ -9,6 +9,32 @@ namespace NServiceBus
 
     class FileShareDataBusImplementation : IDataBus
     {
+        // to account for mixed platforms ie windows -> linux or linux -> windows
+        internal class PathNormalizer
+        {
+            //    Example keys
+            //    string key1 = "foldername/filename";
+            //    string key2 = "foldername\\filename";
+
+            //    Normalize the keys
+            //    string normalizedKey1 = NormalizePath(key1);
+            //    string normalizedKey2 = NormalizePath(key2);
+
+            //    Output the normalized keys
+            //    Console.WriteLine(normalizedKey1); // Output will be "foldername\filename" on Windows, "foldername/filename" on Unix-based systems
+            //    Console.WriteLine(normalizedKey2); // Output will be "foldername\filename" on Windows, "foldername/filename" on Unix-based systems 
+            internal static string NormalizePath(string key)
+            {
+                // Determine the directory separator for the current platform
+                char separator = Path.DirectorySeparatorChar;
+                // Replace any forward slashes (common in URIs) and backward slashes with the platform-specific separator
+                string normalizedPath = key.Replace('/', separator).Replace('\\', separator);
+
+                return normalizedPath;
+            }
+        }
+
+
         public FileShareDataBusImplementation(string basePath)
         {
             this.basePath = basePath;
@@ -18,7 +44,7 @@ namespace NServiceBus
 
         public Task<Stream> Get(string key, CancellationToken cancellationToken = default)
         {
-            var filePath = Path.Combine(basePath, key);
+            var filePath = Path.Combine(basePath, PathNormalizer.NormalizePath(key));
 
             logger.DebugFormat("Opening stream from '{0}'.", filePath);
 


### PR DESCRIPTION
Backport of #7042 which fixes #7043 for the 8.1 branch