### PR TITLE
Limit metric tag to concrete message type

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_messages_processed_successfully.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/When_messages_processed_successfully.cs
@@ -37,8 +37,40 @@ public class When_messages_processed_successfully : OpenTelemetryAcceptanceTest
 
         Assert.AreEqual(Conventions.EndpointNamingConvention(typeof(EndpointWithMetrics)), successEndpoint);
         Assert.AreEqual(Conventions.EndpointNamingConvention(typeof(EndpointWithMetrics)), fetchedEndpoint);
-        Assert.AreEqual(successType, typeof(OutgoingMessage).AssemblyQualifiedName);
-        Assert.AreEqual(fetchedType, typeof(OutgoingMessage).AssemblyQualifiedName);
+        Assert.AreEqual(typeof(OutgoingMessage).FullName, successType);
+        Assert.AreEqual(typeof(OutgoingMessage).FullName, fetchedType);
+    }
+
+    [Test]
+    public async Task Should_only_tag_most_concrete_type_on_metric()
+    {
+        using var metricsListener = TestingMetricListener.SetupNServiceBusMetricsListener();
+
+        _ = await Scenario.Define<Context>()
+            .WithEndpoint<EndpointWithMetrics>(b => b
+                .When(async (session, ctx) =>
+                {
+                    for (var x = 0; x < 5; x++)
+                    {
+                        await session.SendLocal(new OutgoingWithComplexHierarchyMessage());
+                    }
+                }))
+            .Done(c => c.OutgoingMessagesReceived == 5)
+            .Run();
+
+        metricsListener.AssertMetric("nservicebus.messaging.successes", 5);
+        metricsListener.AssertMetric("nservicebus.messaging.fetches", 5);
+        metricsListener.AssertMetric("nservicebus.messaging.failures", 0);
+
+        var successEndpoint = metricsListener.AssertTagKeyExists("nservicebus.messaging.successes", "nservicebus.queue");
+        var successType = metricsListener.AssertTagKeyExists("nservicebus.messaging.successes", "nservicebus.message_type");
+        var fetchedEndpoint = metricsListener.AssertTagKeyExists("nservicebus.messaging.fetches", "nservicebus.queue");
+        var fetchedType = metricsListener.AssertTagKeyExists("nservicebus.messaging.fetches", "nservicebus.message_type").ToString();
+
+        Assert.AreEqual(Conventions.EndpointNamingConvention(typeof(EndpointWithMetrics)), successEndpoint);
+        Assert.AreEqual(Conventions.EndpointNamingConvention(typeof(EndpointWithMetrics)), fetchedEndpoint);
+        Assert.AreEqual(typeof(OutgoingWithComplexHierarchyMessage).FullName, successType);
+        Assert.AreEqual(typeof(OutgoingWithComplexHierarchyMessage).FullName, fetchedType);
     }
 
     class Context : ScenarioContext
@@ -50,13 +82,23 @@ public class When_messages_processed_successfully : OpenTelemetryAcceptanceTest
     {
         public EndpointWithMetrics() => EndpointSetup<OpenTelemetryEnabledEndpoint>();
 
-        class MessageHandler : IHandleMessages<OutgoingMessage>
+        class MessageHandler : IHandleMessages<OutgoingMessage>, IHandleMessages<OutgoingWithComplexHierarchyMessage>
         {
             readonly Context testContext;
 
             public MessageHandler(Context testContext) => this.testContext = testContext;
 
             public Task Handle(OutgoingMessage message, IMessageHandlerContext context)
+            {
+                return Handle();
+            }
+
+            public Task Handle(OutgoingWithComplexHierarchyMessage message, IMessageHandlerContext context)
+            {
+                return Handle();
+            }
+
+            Task Handle()
             {
                 Interlocked.Increment(ref testContext.OutgoingMessagesReceived);
                 return Task.CompletedTask;
@@ -65,6 +107,10 @@ public class When_messages_processed_successfully : OpenTelemetryAcceptanceTest
     }
 
     public class OutgoingMessage : IMessage
+    {
+    }
+
+    public class OutgoingWithComplexHierarchyMessage : OutgoingMessage
     {
     }
 }

--- a/src/NServiceBus.Core/OpenTelemetry/Metrics/ReceiveDiagnosticsBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Metrics/ReceiveDiagnosticsBehavior.cs
@@ -19,13 +19,14 @@ class ReceiveDiagnosticsBehavior : IBehavior<IIncomingPhysicalMessageContext, II
     public async Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
     {
         context.MessageHeaders.TryGetValue(Headers.EnclosedMessageTypes, out var messageTypes);
-        string handlerType = !string.IsNullOrEmpty(messageTypes) ? messageTypes.Split(';').LastOrDefault() : default;
+        string fullHandlerType = !string.IsNullOrEmpty(messageTypes) ? messageTypes.Split(';').FirstOrDefault() : default;
+        string handlerTypeName = !string.IsNullOrEmpty(fullHandlerType) ? fullHandlerType.Split(',').FirstOrDefault() : default;
 
         var tags = new TagList(new KeyValuePair<string, object>[]
         {
             new(MeterTags.EndpointDiscriminator, discriminator ?? ""),
             new(MeterTags.QueueName, queueNameBase ?? ""),
-            new(MeterTags.MessageType, handlerType ?? ""),
+            new(MeterTags.MessageType, handlerTypeName ?? ""),
         }.AsSpan());
 
         Meters.TotalFetched.Add(1, tags);

--- a/src/NServiceBus.Core/OpenTelemetry/Metrics/ReceiveDiagnosticsBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Metrics/ReceiveDiagnosticsBehavior.cs
@@ -19,14 +19,14 @@ class ReceiveDiagnosticsBehavior : IBehavior<IIncomingPhysicalMessageContext, II
     public async Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
     {
         context.MessageHeaders.TryGetValue(Headers.EnclosedMessageTypes, out var messageTypes);
-        string fullHandlerType = !string.IsNullOrEmpty(messageTypes) ? messageTypes.Split(';').FirstOrDefault() : default;
-        string handlerTypeName = !string.IsNullOrEmpty(fullHandlerType) ? fullHandlerType.Split(',').FirstOrDefault() : default;
+        string messageTypeHeader = !string.IsNullOrEmpty(messageTypes) ? messageTypes.Split(';').FirstOrDefault() : default;
+        string messageTypeName = !string.IsNullOrEmpty(messageTypeHeader) ? messageTypeHeader.Split(',').FirstOrDefault() : default;
 
         var tags = new TagList(new KeyValuePair<string, object>[]
         {
             new(MeterTags.EndpointDiscriminator, discriminator ?? ""),
             new(MeterTags.QueueName, queueNameBase ?? ""),
-            new(MeterTags.MessageType, handlerTypeName ?? ""),
+            new(MeterTags.MessageType, messageTypeName ?? ""),
         }.AsSpan());
 
         Meters.TotalFetched.Add(1, tags);

--- a/src/NServiceBus.Core/OpenTelemetry/Metrics/ReceiveDiagnosticsBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Metrics/ReceiveDiagnosticsBehavior.cs
@@ -3,6 +3,7 @@ namespace NServiceBus;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Pipeline;
 
@@ -18,12 +19,13 @@ class ReceiveDiagnosticsBehavior : IBehavior<IIncomingPhysicalMessageContext, II
     public async Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
     {
         context.MessageHeaders.TryGetValue(Headers.EnclosedMessageTypes, out var messageTypes);
+        string handlerType = !string.IsNullOrEmpty(messageTypes) ? messageTypes.Split(';').LastOrDefault() : default;
 
         var tags = new TagList(new KeyValuePair<string, object>[]
         {
             new(MeterTags.EndpointDiscriminator, discriminator ?? ""),
             new(MeterTags.QueueName, queueNameBase ?? ""),
-            new(MeterTags.MessageType, messageTypes ?? ""),
+            new(MeterTags.MessageType, handlerType ?? ""),
         }.AsSpan());
 
         Meters.TotalFetched.Add(1, tags);

--- a/src/NServiceBus.Core/OpenTelemetry/Metrics/ReceiveDiagnosticsBehavior.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Metrics/ReceiveDiagnosticsBehavior.cs
@@ -19,8 +19,8 @@ class ReceiveDiagnosticsBehavior : IBehavior<IIncomingPhysicalMessageContext, II
     public async Task Invoke(IIncomingPhysicalMessageContext context, Func<IIncomingPhysicalMessageContext, Task> next)
     {
         context.MessageHeaders.TryGetValue(Headers.EnclosedMessageTypes, out var messageTypes);
-        string messageTypeHeader = !string.IsNullOrEmpty(messageTypes) ? messageTypes.Split(';').FirstOrDefault() : default;
-        string messageTypeName = !string.IsNullOrEmpty(messageTypeHeader) ? messageTypeHeader.Split(',').FirstOrDefault() : default;
+        var messageTypeHeader = !string.IsNullOrEmpty(messageTypes) ? messageTypes.Split(';').FirstOrDefault() : default;
+        var messageTypeName = !string.IsNullOrEmpty(messageTypeHeader) ? messageTypeHeader.Split(',').FirstOrDefault() : default;
 
         var tags = new TagList(new KeyValuePair<string, object>[]
         {


### PR DESCRIPTION
_related to https://github.com/Particular/NServiceBus/issues/7022_

Currently, a metric tag containing the content of the EnclosedMessageTypes header is added to the Fetches, Failures, and Success metrics emitted through System.Diagnostics in Core.

However, the value of this header can be quite large, and doesn't provide as much value, as filtering makes most sense on the message type, not its entire hierarchy tree.
This PR changes that value to be limited to the most concrete message type, and only includes the message type full name, and excludes assembly info.

The full contents of the header are still emitted as trace tags.