### PR TITLE
Robust and faster handling of AssemblyQualifiedNames in MessageMetadataRegistry

### DIFF
--- a/src/NServiceBus.Core.Tests/Unicast/Messages/AssemblyQualifiedNameParserTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/Messages/AssemblyQualifiedNameParserTests.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using NUnit.Framework;
 
 [TestFixture]
-public class AssemblyQuallifiedNameParserTests
+public class AssemblyQualifiedNameParserTests
 {
     [Theory]
     [TestCaseSource(nameof(AssemblyQualifiedNames))]

--- a/src/NServiceBus.Core.Tests/Unicast/Messages/AssemblyQualifiedNameParserTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/Messages/AssemblyQualifiedNameParserTests.cs
@@ -22,10 +22,18 @@ public class AssemblyQualifiedNameParserTests
     [
         [typeof(ICommand).AssemblyQualifiedName, typeof(ICommand).FullName],
         [typeof(MyEvent).AssemblyQualifiedName, typeof(MyEvent).FullName],
+        // Array types
+        [typeof(ICommand[]).AssemblyQualifiedName, typeof(ICommand[]).FullName],
+        [typeof(MyEvent[]).AssemblyQualifiedName, typeof(MyEvent[]).FullName],
         // Yes generic are not officially supported but we should still make sure the type parsing logic doesn't break
         [typeof(MyEventGeneric<>).AssemblyQualifiedName, typeof(MyEventGeneric<>).FullName],
         [typeof(MyEventGeneric<MyEvent>).AssemblyQualifiedName, typeof(MyEventGeneric<MyEvent>).FullName],
         [typeof(MyEventGeneric<MyEventGeneric<MyEvent>>).AssemblyQualifiedName, typeof(MyEventGeneric<MyEventGeneric<MyEvent>>).FullName],
+        // Generic array types
+        [typeof(MyEventGeneric<MyEvent>[]).AssemblyQualifiedName, typeof(MyEventGeneric<MyEvent>[]).FullName],
+        [typeof(MyEventGeneric<MyEventGeneric<MyEvent>>[]).AssemblyQualifiedName, typeof(MyEventGeneric<MyEventGeneric<MyEvent>>[]).FullName],
+        // Generic Nested array types
+        [typeof(MyEventGeneric<MyEventGeneric<MyEvent>[]>[]).AssemblyQualifiedName, typeof(MyEventGeneric<MyEventGeneric<MyEvent>[]>[]).FullName],
         // Special case according to https://learn.microsoft.com/de-de/dotnet/api/system.type.assemblyqualifiedname
         ["TopNamespace.Sub\\+Namespace.ContainingClass+NestedClass, MyAssembly, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089", "TopNamespace.Sub\\+Namespace.ContainingClass+NestedClass"]
     ];
@@ -45,10 +53,18 @@ public class AssemblyQualifiedNameParserTests
     [
         [typeof(ICommand).FullName, typeof(ICommand).FullName],
         [typeof(MyEvent).FullName, typeof(MyEvent).FullName],
+        // Array types
+        [typeof(ICommand[]).FullName, typeof(ICommand[]).FullName],
+        [typeof(MyEvent[]).FullName, typeof(MyEvent[]).FullName],
         // Yes generic are not officially supported but we should still make sure the type parsing logic doesn't break
         [typeof(MyEventGeneric<>).FullName, typeof(MyEventGeneric<>).FullName],
         [typeof(MyEventGeneric<MyEvent>).FullName, typeof(MyEventGeneric<MyEvent>).FullName],
         [typeof(MyEventGeneric<MyEventGeneric<MyEvent>>).FullName, typeof(MyEventGeneric<MyEventGeneric<MyEvent>>).FullName],
+        // Generic array types
+        [typeof(MyEventGeneric<MyEvent>[]).FullName, typeof(MyEventGeneric<MyEvent>[]).FullName],
+        [typeof(MyEventGeneric<MyEventGeneric<MyEvent>>[]).FullName, typeof(MyEventGeneric<MyEventGeneric<MyEvent>>[]).FullName],
+        // Generic Nested array types
+        [typeof(MyEventGeneric<MyEventGeneric<MyEvent>[]>[]).FullName, typeof(MyEventGeneric<MyEventGeneric<MyEvent>[]>[]).FullName],
         // Special case according to https://learn.microsoft.com/de-de/dotnet/api/system.type.assemblyqualifiedname
         ["TopNamespace.Sub\\+Namespace.ContainingClass+NestedClass", "TopNamespace.Sub\\+Namespace.ContainingClass+NestedClass"]
     ];

--- a/src/NServiceBus.Core.Tests/Unicast/Messages/AssemblyQuallifiedNameParserTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/Messages/AssemblyQuallifiedNameParserTests.cs
@@ -1,0 +1,70 @@
+namespace NServiceBus.Unicast.Tests;
+
+using System;
+using System.Collections.Generic;
+using NServiceBus.Unicast.Messages;
+using NUnit.Framework;
+
+[TestFixture]
+public class AssemblyQuallifiedNameParserTests
+{
+    [Theory]
+    [TestCaseSource(nameof(AssemblyQualifiedNames))]
+    public void Should_extract_fullname_from_qualified_assembly_name(string assemblyQualifiedName, string expectedFullName)
+    {
+        Console.WriteLine(assemblyQualifiedName);
+
+        var typeNameWithoutAssembly = AssemblyQualifiedNameParser.GetMessageTypeNameWithoutAssemblyOld(assemblyQualifiedName);
+
+        Assert.AreEqual(expectedFullName, typeNameWithoutAssembly);
+    }
+
+    static IEnumerable<object[]> AssemblyQualifiedNames =>
+    [
+        [typeof(ICommand).AssemblyQualifiedName, typeof(ICommand).FullName],
+        [typeof(MyEvent).AssemblyQualifiedName, typeof(MyEvent).FullName],
+        // Yes generic are not officially supported but we should still make sure the type parsing logic doesn't break
+        [typeof(MyEventGeneric<>).AssemblyQualifiedName, typeof(MyEventGeneric<>).FullName],
+        [typeof(MyEventGeneric<MyEvent>).AssemblyQualifiedName, typeof(MyEventGeneric<MyEvent>).FullName],
+        [typeof(MyEventGeneric<MyEventGeneric<MyEvent>>).AssemblyQualifiedName, typeof(MyEventGeneric<MyEventGeneric<MyEvent>>).FullName],
+        // Special case according to https://learn.microsoft.com/de-de/dotnet/api/system.type.assemblyqualifiedname
+        ["TopNamespace.Sub\\+Namespace.ContainingClass+NestedClass, MyAssembly, Version=1.3.0.0, Culture=neutral, PublicKeyToken=b17a5c561934e089", "TopNamespace.Sub\\+Namespace.ContainingClass+NestedClass"]
+    ];
+
+    [Theory]
+    [TestCaseSource(nameof(FullNames))]
+    public void Should_extract_fullname_from_fullname(string assemblyQualifiedName, string expectedFullName)
+    {
+        Console.WriteLine(assemblyQualifiedName);
+
+        var messageType = AssemblyQualifiedNameParser.GetMessageTypeNameWithoutAssemblyOld(assemblyQualifiedName);
+
+        Assert.AreEqual(expectedFullName, messageType);
+    }
+
+    static IEnumerable<object[]> FullNames =>
+    [
+        [typeof(ICommand).FullName, typeof(ICommand).FullName],
+        [typeof(MyEvent).FullName, typeof(MyEvent).FullName],
+        // Yes generic are not officially supported but we should still make sure the type parsing logic doesn't break
+        [typeof(MyEventGeneric<>).FullName, typeof(MyEventGeneric<>).FullName],
+        [typeof(MyEventGeneric<MyEvent>).FullName, typeof(MyEventGeneric<MyEvent>).FullName],
+        [typeof(MyEventGeneric<MyEventGeneric<MyEvent>>).FullName, typeof(MyEventGeneric<MyEventGeneric<MyEvent>>).FullName],
+        // Special case according to https://learn.microsoft.com/de-de/dotnet/api/system.type.assemblyqualifiedname
+        ["TopNamespace.Sub\\+Namespace.ContainingClass+NestedClass", "TopNamespace.Sub\\+Namespace.ContainingClass+NestedClass"]
+    ];
+
+    class MyEvent : ConcreteParent1, IInterfaceParent1;
+
+    class ConcreteParent1 : ConcreteParentBase;
+    class ConcreteParentBase : IMessage;
+
+    interface IInterfaceParent1 : IInterfaceParent1Base;
+
+    interface IInterfaceParent1Base : IMessage;
+
+    class MyEventGeneric<T>
+    {
+        public T Payload { get; set; }
+    }
+}

--- a/src/NServiceBus.Core.Tests/Unicast/Messages/AssemblyQuallifiedNameParserTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/Messages/AssemblyQuallifiedNameParserTests.cs
@@ -2,7 +2,6 @@ namespace NServiceBus.Unicast.Tests;
 
 using System;
 using System.Collections.Generic;
-using NServiceBus.Unicast.Messages;
 using NUnit.Framework;
 
 [TestFixture]

--- a/src/NServiceBus.Core.Tests/Unicast/Messages/AssemblyQuallifiedNameParserTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/Messages/AssemblyQuallifiedNameParserTests.cs
@@ -53,17 +53,7 @@ public class AssemblyQuallifiedNameParserTests
         ["TopNamespace.Sub\\+Namespace.ContainingClass+NestedClass", "TopNamespace.Sub\\+Namespace.ContainingClass+NestedClass"]
     ];
 
-    class MyEvent : ConcreteParent1, IInterfaceParent1;
+    class MyEvent;
 
-    class ConcreteParent1 : ConcreteParentBase;
-    class ConcreteParentBase : IMessage;
-
-    interface IInterfaceParent1 : IInterfaceParent1Base;
-
-    interface IInterfaceParent1Base : IMessage;
-
-    class MyEventGeneric<T>
-    {
-        public T Payload { get; set; }
-    }
+    class MyEventGeneric<T>;
 }

--- a/src/NServiceBus.Core.Tests/Unicast/Messages/AssemblyQuallifiedNameParserTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/Messages/AssemblyQuallifiedNameParserTests.cs
@@ -14,7 +14,7 @@ public class AssemblyQuallifiedNameParserTests
     {
         Console.WriteLine(assemblyQualifiedName);
 
-        var typeNameWithoutAssembly = AssemblyQualifiedNameParser.GetMessageTypeNameWithoutAssemblyOld(assemblyQualifiedName);
+        var typeNameWithoutAssembly = AssemblyQualifiedNameParser.GetMessageTypeNameWithoutAssembly(assemblyQualifiedName);
 
         Assert.AreEqual(expectedFullName, typeNameWithoutAssembly);
     }
@@ -37,7 +37,7 @@ public class AssemblyQuallifiedNameParserTests
     {
         Console.WriteLine(assemblyQualifiedName);
 
-        var messageType = AssemblyQualifiedNameParser.GetMessageTypeNameWithoutAssemblyOld(assemblyQualifiedName);
+        var messageType = AssemblyQualifiedNameParser.GetMessageTypeNameWithoutAssembly(assemblyQualifiedName);
 
         Assert.AreEqual(expectedFullName, messageType);
     }

--- a/src/NServiceBus.Core/Unicast/Messages/AssemblyQualifiedNameParser.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/AssemblyQualifiedNameParser.cs
@@ -1,4 +1,4 @@
-namespace NServiceBus.Unicast.Messages;
+namespace NServiceBus;
 
 using System;
 

--- a/src/NServiceBus.Core/Unicast/Messages/AssemblyQualifiedNameParser.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/AssemblyQualifiedNameParser.cs
@@ -1,0 +1,15 @@
+namespace NServiceBus.Unicast.Messages;
+
+static class AssemblyQualifiedNameParser
+{
+    public static string GetMessageTypeNameWithoutAssemblyOld(string messageTypeIdentifier)
+    {
+        var typeParts = messageTypeIdentifier.Split(',');
+        if (typeParts.Length > 1)
+        {
+            return typeParts[0]; //Take the type part only
+        }
+
+        return messageTypeIdentifier;
+    }
+}

--- a/src/NServiceBus.Core/Unicast/Messages/AssemblyQualifiedNameParser.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/AssemblyQualifiedNameParser.cs
@@ -1,13 +1,23 @@
 namespace NServiceBus.Unicast.Messages;
 
+using System;
+
 static class AssemblyQualifiedNameParser
 {
-    public static string GetMessageTypeNameWithoutAssemblyOld(string messageTypeIdentifier)
+    public static string GetMessageTypeNameWithoutAssembly(string messageTypeIdentifier)
     {
-        var typeParts = messageTypeIdentifier.Split(',');
-        if (typeParts.Length > 1)
+        int lastIndexOf = messageTypeIdentifier.LastIndexOf(']');
+        if (lastIndexOf > 0)
         {
-            return typeParts[0]; //Take the type part only
+            var messageType = messageTypeIdentifier.AsSpan()[..++lastIndexOf].ToString();
+            return messageType;
+        }
+
+        int firstIndexOfComma = messageTypeIdentifier.IndexOf(',');
+        if (firstIndexOfComma > 0)
+        {
+            var messageType = messageTypeIdentifier.AsSpan()[..firstIndexOfComma].ToString();
+            return messageType;
         }
 
         return messageTypeIdentifier;

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -67,7 +67,7 @@ public class MessageMetadataRegistry
             {
                 foreach (var item in messages.Values)
                 {
-                    var messageTypeFullName = GetMessageTypeNameWithoutAssembly(messageTypeIdentifier);
+                    var messageTypeFullName = AssemblyQualifiedNameParser.GetMessageTypeNameWithoutAssembly(messageTypeIdentifier);
 
                     if (item.MessageType.FullName == messageTypeIdentifier ||
                         item.MessageType.FullName == messageTypeFullName)
@@ -108,17 +108,6 @@ public class MessageMetadataRegistry
     /// </summary>
     /// <returns>An array of <see cref="MessageMetadata" /> for all known message.</returns>
     public MessageMetadata[] GetAllMessages() => messages.Values.ToArray();
-
-    static string GetMessageTypeNameWithoutAssembly(string messageTypeIdentifier)
-    {
-        var typeParts = messageTypeIdentifier.Split(',');
-        if (typeParts.Length > 1)
-        {
-            return typeParts[0]; //Take the type part only
-        }
-
-        return messageTypeIdentifier;
-    }
 
     Type GetType(string messageTypeIdentifier)
     {


### PR DESCRIPTION
The current fallback logic to extract the fullname bluntly assumes it is OK to split by `,` and then take the first part. While this works in some cases it fails with more advanced types like generics. We are aware [that generic are not officially supported](https://docs.particular.net/nservicebus/messaging/messages-events-commands#designing-messages), but regardless of that, the parsing logic should treat the assembly qualified names properly and not lead to invalid data types.

Instead of string splitting or trying to do a fancy regular expression match and replace (with all the consequences of those potentially timing out etc.), I came up with a straightforward approach that should be robust and reliable (see test cases) and even in the cases when we get a full name already even faster since we are not attempting to split that also involves an unnecessary array allocation.

## Benchmark

![image](https://github.com/Particular/NServiceBus/assets/174258/4e61ff9a-38c3-49ee-8997-242a2d14207e)

<details>

```csharp
using System;
using System.Collections.Generic;
using BenchmarkDotNet.Attributes;

namespace MicroBenchmarks.NServiceBus;

[SimpleJob]
[MemoryDiagnoser]
public class AssemblyQualifiedNameParser
{
    [Benchmark(Baseline = true)]
    [ArgumentsSource(nameof(Arguments))]
    public string Before(string messageIdentifier) => GetMessageTypeNameWithoutAssemblyOld(messageIdentifier);
    
    [Benchmark]
    [ArgumentsSource(nameof(Arguments))]
    public string After(string messageIdentifier) => GetMessageTypeNameWithoutAssembly(messageIdentifier);
    
    public IEnumerable<object[]> Arguments()
    {
        yield return [typeof(ICommand).FullName];
        yield return [typeof(ICommand).AssemblyQualifiedName];
        yield return [typeof(MyEvent).FullName];
        yield return [typeof(MyEvent).AssemblyQualifiedName];
        yield return [typeof(MyEventGeneric<>).AssemblyQualifiedName];
        yield return [typeof(MyEventGeneric<MyEvent>).AssemblyQualifiedName];
        yield return [typeof(MyEventGeneric<MyEventGeneric<MyEvent>>).AssemblyQualifiedName];
    }
    public static string GetMessageTypeNameWithoutAssembly(string messageTypeIdentifier)
    {
        int lastIndexOf = messageTypeIdentifier.LastIndexOf(']');
        if (lastIndexOf > 0)
        {
            var messageType = messageTypeIdentifier.AsSpan()[..++lastIndexOf].ToString();
            return messageType;
        }

        int firstIndexOfComma = messageTypeIdentifier.IndexOf(',');
        if (firstIndexOfComma > 0)
        {
            var messageType = messageTypeIdentifier.AsSpan()[..firstIndexOfComma].ToString();
            return messageType;
        }

        return messageTypeIdentifier;
    }
    
    public static string GetMessageTypeNameWithoutAssemblyOld(string messageTypeIdentifier)
    {
        var typeParts = messageTypeIdentifier.Split(',');
        if (typeParts.Length > 1)
        {
            return typeParts[0]; //Take the type part only
        }

        return messageTypeIdentifier;
    }
    
    class MyEvent
    {
    }

    class MyEventGeneric<T>
    {
        public T Payload { get; set; }
    }
}
```

</details>