### PR TITLE
Add more restrictive where clause to type forwarding test

### DIFF
--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_using_type_forwarding.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_using_type_forwarding.cs
@@ -29,6 +29,7 @@ public class When_using_type_forwarding
             .Select(exportedType => (AssemblyReferenceHandle)exportedType.Implementation)
             .Select(assemblyReferenceHandle => metadataReader.GetAssemblyReference(assemblyReferenceHandle))
             .Select(assemblyReference => metadataReader.GetString(assemblyReference.Name))
+            .Where(assemblyName => assemblyName.StartsWith("NServiceBus") || assemblyName.StartsWith("Particular"))
             .Distinct()
             .ToList();
 


### PR DESCRIPTION
While back port #7081 the System.Runtime assembly had exported types which caused me to realize there should be a where clause there. I did already bring the change here to the back ported PRs otherwise it wouldn't have passed on the release-8.2 branch