### PR TITLE
Introduce processing time metric.

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Metrics/When_message_is_processed_successfully.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Metrics/When_message_is_processed_successfully.cs
@@ -30,12 +30,16 @@ public class When_message_is_processed_successfully : OpenTelemetryAcceptanceTes
         metricsListener.AssertMetric("nservicebus.messaging.successes", 5);
         metricsListener.AssertMetric("nservicebus.messaging.fetches", 5);
         metricsListener.AssertMetric("nservicebus.messaging.failures", 0);
+        metricsListener.AssertMetric("nservicebus.messaging.critical_time", 5);
+        metricsListener.AssertMetric("nservicebus.messaging.processing_time", 5);
+        metricsListener.AssertMetric("nservicebus.messaging.handler_time", 5);
 
         metricsListener.AssertTags("nservicebus.messaging.fetches",
             new Dictionary<string, object>
             {
                 ["nservicebus.queue"] = Conventions.EndpointNamingConvention(typeof(EndpointWithMetrics)),
                 ["nservicebus.discriminator"] = "disc",
+                ["nservicebus.message_type"] = typeof(OutgoingMessage).FullName
             });
 
         metricsListener.AssertTags("nservicebus.messaging.successes",
@@ -43,7 +47,33 @@ public class When_message_is_processed_successfully : OpenTelemetryAcceptanceTes
             {
                 ["nservicebus.queue"] = Conventions.EndpointNamingConvention(typeof(EndpointWithMetrics)),
                 ["nservicebus.discriminator"] = "disc",
+                ["nservicebus.message_type"] = typeof(OutgoingMessage).FullName
+            });
+
+        metricsListener.AssertTags("nservicebus.messaging.critical_time",
+            new Dictionary<string, object>
+            {
+                ["nservicebus.queue"] = Conventions.EndpointNamingConvention(typeof(EndpointWithMetrics)),
+                ["nservicebus.discriminator"] = "disc",
+                ["nservicebus.message_type"] = typeof(OutgoingMessage).FullName
+            });
+
+        metricsListener.AssertTags("nservicebus.messaging.processing_time",
+            new Dictionary<string, object>
+            {
+                ["nservicebus.queue"] = Conventions.EndpointNamingConvention(typeof(EndpointWithMetrics)),
+                ["nservicebus.discriminator"] = "disc",
+                ["nservicebus.message_type"] = typeof(OutgoingMessage).FullName
+            });
+
+        metricsListener.AssertTags("nservicebus.messaging.handler_time",
+            new Dictionary<string, object>
+            {
+                ["nservicebus.queue"] = Conventions.EndpointNamingConvention(typeof(EndpointWithMetrics)),
+                ["nservicebus.discriminator"] = "disc",
                 ["nservicebus.message_type"] = typeof(OutgoingMessage).FullName,
+                ["nservicebus.message_handler_type"] = typeof(EndpointWithMetrics.MessageHandler).FullName,
+                ["execution.result"] = "success"
             });
     }
 
@@ -68,9 +98,12 @@ public class When_message_is_processed_successfully : OpenTelemetryAcceptanceTes
         metricsListener.AssertMetric("nservicebus.messaging.fetches", 5);
         metricsListener.AssertMetric("nservicebus.messaging.failures", 0);
 
-        var successEndpoint = metricsListener.AssertTagKeyExists("nservicebus.messaging.successes", "nservicebus.queue");
-        var successType = metricsListener.AssertTagKeyExists("nservicebus.messaging.successes", "nservicebus.message_type");
-        var successHandlerType = metricsListener.AssertTagKeyExists("nservicebus.messaging.successes", "nservicebus.message_handler_types");
+        var successEndpoint =
+            metricsListener.AssertTagKeyExists("nservicebus.messaging.successes", "nservicebus.queue");
+        var successType =
+            metricsListener.AssertTagKeyExists("nservicebus.messaging.successes", "nservicebus.message_type");
+        var successHandlerType =
+            metricsListener.AssertTagKeyExists("nservicebus.messaging.successes", "nservicebus.message_handler_types");
 
         var fetchedEndpoint = metricsListener.AssertTagKeyExists("nservicebus.messaging.fetches", "nservicebus.queue");
 
@@ -90,7 +123,7 @@ public class When_message_is_processed_successfully : OpenTelemetryAcceptanceTes
     {
         public EndpointWithMetrics() => EndpointSetup<OpenTelemetryEnabledEndpoint>();
 
-        class MessageHandler : IHandleMessages<OutgoingMessage>
+        public class MessageHandler : IHandleMessages<OutgoingMessage>
         {
             readonly Context testContext;
 

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Metrics/When_message_processing_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Metrics/When_message_processing_fails.cs
@@ -23,12 +23,34 @@ public class When_message_processing_fails : OpenTelemetryAcceptanceTest
         metricsListener.AssertMetric("nservicebus.messaging.fetches", 1);
         metricsListener.AssertMetric("nservicebus.messaging.failures", 1);
         metricsListener.AssertMetric("nservicebus.messaging.successes", 0);
+        metricsListener.AssertMetric("nservicebus.messaging.critical_time", 0);
+        metricsListener.AssertMetric("nservicebus.messaging.processing_time", 0);
+        metricsListener.AssertMetric("nservicebus.messaging.handler_time", 1);
+
+        metricsListener.AssertTags("nservicebus.messaging.fetches",
+            new Dictionary<string, object>
+            {
+                ["nservicebus.queue"] = Conventions.EndpointNamingConvention(typeof(FailingEndpoint)),
+                ["nservicebus.discriminator"] = "disc",
+                ["nservicebus.message_type"] = typeof(FailingMessage).FullName
+            });
 
         metricsListener.AssertTags("nservicebus.messaging.failures",
             new Dictionary<string, object>
             {
                 ["nservicebus.queue"] = Conventions.EndpointNamingConvention(typeof(FailingEndpoint)),
                 ["nservicebus.discriminator"] = "disc",
+                ["nservicebus.message_type"] = typeof(FailingMessage).FullName,
+                ["error.type"] = typeof(SimulatedException).FullName,
+            });
+
+        metricsListener.AssertTags("nservicebus.messaging.handler_time",
+            new Dictionary<string, object>
+            {
+                ["nservicebus.queue"] = Conventions.EndpointNamingConvention(typeof(FailingEndpoint)),
+                ["nservicebus.discriminator"] = "disc",
+                ["nservicebus.message_type"] = typeof(FailingMessage).FullName,
+                ["execution.result"] = "failure",
                 ["error.type"] = typeof(SimulatedException).FullName,
             });
     }
@@ -55,7 +77,6 @@ public class When_message_processing_fails : OpenTelemetryAcceptanceTest
             }
 
             const string ErrorMessage = "oh no!";
-
         }
     }
 

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/MeterTests.Verify_MeterAPI.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/MeterTests.Verify_MeterAPI.approved.txt
@@ -1,6 +1,7 @@
 {
   "Note": "Changes to metrics API should result in an update to NServiceBusMeter version.",
-  "ActivitySourceVersion": "0.2.0",
+  "MetricsSourceName": "NServiceBus.Core.Pipeline.Incoming",
+  "MetricsSourceVersion": "0.2.0",
   "Tags": [
     "error.type",
     "execution.result",
@@ -15,6 +16,7 @@
     "nservicebus.messaging.failures => Counter",
     "nservicebus.messaging.fetches => Counter",
     "nservicebus.messaging.handler_time => Histogram, Unit: s",
+    "nservicebus.messaging.processing_time => Histogram, Unit: s",
     "nservicebus.messaging.successes => Counter",
     "nservicebus.recoverability.delayed => Counter",
     "nservicebus.recoverability.error => Counter",

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/Helpers/TestingMetricListener.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/Helpers/TestingMetricListener.cs
@@ -12,6 +12,7 @@ class TestingMetricListener : IDisposable
     readonly MeterListener meterListener;
     public List<Instrument> metrics = [];
     public string version = "";
+    public string metricsSourceName = "";
 
     public TestingMetricListener(string sourceName)
     {
@@ -25,6 +26,7 @@ class TestingMetricListener : IDisposable
                     listener.EnableMeasurementEvents(instrument);
                     metrics.Add(instrument);
                     version = instrument.Meter.Version;
+                    metricsSourceName = instrument.Meter.Name;
                 }
             }
         };

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/MeterTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/MeterTests.cs
@@ -30,7 +30,8 @@ public class MeterTests
         Approver.Verify(new
         {
             Note = "Changes to metrics API should result in an update to NServiceBusMeter version.",
-            ActivitySourceVersion = metricsListener.version,
+            MetricsSourceName = metricsListener.metricsSourceName,
+            MetricsSourceVersion = metricsListener.version,
             Tags = meterTags,
             Metrics = metrics
         });

--- a/src/NServiceBus.Core/OpenTelemetry/Metrics/MetricsExtensions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Metrics/MetricsExtensions.cs
@@ -2,6 +2,7 @@ namespace NServiceBus;
 
 using System;
 using System.Collections.Generic;
+using Extensibility;
 
 static class MetricsExtensions
 {
@@ -26,4 +27,10 @@ static class MetricsExtensions
         deliverAt = DateTimeOffset.MinValue;
         return false;
     }
+
+    public static void SetPipelineStartedAt(this ContextBag contextBag, DateTimeOffset pipelineStartedAt) =>
+        contextBag.Set("PipelineStartedAt", pipelineStartedAt);
+
+    public static bool TryGetPipelineStartedAt(this ContextBag contextBag, out DateTimeOffset pipelineStartedAt) =>
+        contextBag.TryGet("PipelineStartedAt", out pipelineStartedAt);
 }

--- a/src/NServiceBus.Core/OpenTelemetry/Metrics/MetricsExtensions.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Metrics/MetricsExtensions.cs
@@ -2,7 +2,6 @@ namespace NServiceBus;
 
 using System;
 using System.Collections.Generic;
-using Extensibility;
 
 static class MetricsExtensions
 {
@@ -27,10 +26,4 @@ static class MetricsExtensions
         deliverAt = DateTimeOffset.MinValue;
         return false;
     }
-
-    public static void SetPipelineStartedAt(this ContextBag contextBag, DateTimeOffset pipelineStartedAt) =>
-        contextBag.Set("PipelineStartedAt", pipelineStartedAt);
-
-    public static bool TryGetPipelineStartedAt(this ContextBag contextBag, out DateTimeOffset pipelineStartedAt) =>
-        contextBag.TryGet("PipelineStartedAt", out pipelineStartedAt);
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
@@ -20,7 +20,6 @@ class TransportReceiveToPhysicalMessageConnector : IStageForkConnector<ITranspor
 
     public async Task Invoke(ITransportReceiveContext context, Func<IIncomingPhysicalMessageContext, Task> next)
     {
-        //startedAt
         var messageId = context.Message.MessageId;
         var physicalMessageContext = this.CreateIncomingPhysicalMessageContext(context.Message, context);
 

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -63,8 +63,10 @@ class MainPipelineExecutor(
 
                 ex.Data["Pipeline canceled"] = transportReceiveContext.CancellationToken.IsCancellationRequested;
 
-                incomingPipelineMetrics.RecordMessageProcessingFailure(incomingPipelineMetricsTags, ex);
-
+                if (!ex.IsCausedBy(transportReceiveContext.CancellationToken))
+                {
+                    incomingPipelineMetrics.RecordMessageProcessingFailure(incomingPipelineMetricsTags, ex);
+                }
                 throw;
             }
             finally

--- a/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
+++ b/src/NServiceBus.Core/Pipeline/MainPipelineExecutor.cs
@@ -20,7 +20,6 @@ class MainPipelineExecutor(
     public async Task Invoke(MessageContext messageContext, CancellationToken cancellationToken = default)
     {
         var pipelineStartedAt = DateTimeOffset.UtcNow;
-        messageContext.Extensions.SetPipelineStartedAt(pipelineStartedAt);
         using var activity = activityFactory.StartIncomingPipelineActivity(messageContext);
 
         var incomingPipelineMetricsTags = messageContext.Extensions.Get<IncomingPipelineMetricTags>();


### PR DESCRIPTION
- Adds a new metric for the processing time (time to invoke all handlers and persist the sagas and the outbox data)
- Adjusts the critical time metric to include the time it takes to successfully dispatch the outgoing messages

Documentation PR https://github.com/Particular/docs.particular.net/pull/6724