### PR TITLE
Log debug when using generic message types

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Hosting/When_disabling_assembly_scanning.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Hosting/When_disabling_assembly_scanning.cs
@@ -15,7 +15,7 @@ public class When_disabling_assembly_scanning : NServiceBusAcceptanceTest
             .Done(c => c.EndpointsStarted)
             .Run());
 
-        StringAssert.Contains($"Assembly scanning has been disabled. This prevents messages, message handlers, features and other functionality to not load correctly. Enable {nameof(AssemblyScannerConfiguration.ScanAppDomainAssemblies)} or {nameof(AssemblyScannerConfiguration.ScanFileSystemAssemblies)}", exception.Message);
+        StringAssert.Contains($"Assembly scanning has been disabled. This prevents messages, message handlers, features and other functionality from loading correctly. Enable {nameof(AssemblyScannerConfiguration.ScanAppDomainAssemblies)} or {nameof(AssemblyScannerConfiguration.ScanFileSystemAssemblies)}", exception.Message);
     }
 
     public class EndpointWithDisabledAssemblyScanning : EndpointConfigurationBuilder

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
@@ -41,7 +41,7 @@ class AssemblyScanningComponent
 
         if (!assemblyScanner.ScanAppDomainAssemblies && !assemblyScanner.ScanFileSystemAssemblies)
         {
-            throw new Exception($"Assembly scanning has been disabled. This prevents messages, message handlers, features and other functionality to not load correctly. Enable {nameof(AssemblyScannerConfiguration.ScanAppDomainAssemblies)} or {nameof(AssemblyScannerConfiguration.ScanFileSystemAssemblies)} to resolve this error.");
+            throw new Exception($"Assembly scanning has been disabled. This prevents messages, message handlers, features and other functionality from loading correctly. Enable {nameof(AssemblyScannerConfiguration.ScanAppDomainAssemblies)} or {nameof(AssemblyScannerConfiguration.ScanFileSystemAssemblies)} to resolve this error.");
         }
 
         var scannableAssemblies = assemblyScanner.GetScannableAssemblies();

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -175,10 +175,7 @@ public class MessageMetadataRegistry
             .Where(t => isMessageType(t))
             .OrderByDescending(PlaceInMessageHierarchy);
 
-        var metadata = new MessageMetadata(messageType, new[]
-        {
-                messageType
-            }.Concat(parentMessages).ToArray());
+        var metadata = new MessageMetadata(messageType, [messageType, .. parentMessages]);
 
         messages[messageType.TypeHandle] = metadata;
         cachedTypes.TryAdd(messageType.AssemblyQualifiedName, messageType);

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -167,7 +167,7 @@ public class MessageMetadataRegistry
         if (messageType.IsGenericType)
         {
             // This is not an error because in most cases it will work, but it's still not supported should issues arise
-            Logger.Warn($"Generic messages types are not supported. Consider converting {messageType.AssemblyQualifiedName} to a dedicated, simple type");
+            Logger.Debug($"Generic messages types are not supported. Consider converting '{messageType.AssemblyQualifiedName}' to a dedicated, simple type");
         }
 
         //get the parent types

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -65,10 +65,9 @@ public class MessageMetadataRegistry
 
             if (messageType == null)
             {
+                var messageTypeFullName = AssemblyQualifiedNameParser.GetMessageTypeNameWithoutAssembly(messageTypeIdentifier);
                 foreach (var item in messages.Values)
                 {
-                    var messageTypeFullName = AssemblyQualifiedNameParser.GetMessageTypeNameWithoutAssembly(messageTypeIdentifier);
-
                     if (item.MessageType.FullName == messageTypeIdentifier ||
                         item.MessageType.FullName == messageTypeFullName)
                     {

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -165,6 +165,12 @@ public class MessageMetadataRegistry
 
     MessageMetadata RegisterMessageType(Type messageType)
     {
+        if (messageType.IsGenericType)
+        {
+            // This is not an error because in most cases it will work, but it's still not supported should issues arise
+            Logger.Warn($"Generic messages types are not supported. Consider converting {messageType.AssemblyQualifiedName} to a dedicated, simple type");
+        }
+
         //get the parent types
         var parentMessages = GetParentTypes(messageType)
             .Where(t => isMessageType(t))


### PR DESCRIPTION
as per [the documentation](https://docs.particular.net/nservicebus/messaging/messages-events-commands#designing-messages), generic message types are not supported. This change adds a debug log to that effect