### PR TITLE
Remove wrongly added RemoveSourceFileFromPackage elements from ATT project

### DIFF
--- a/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
+++ b/src/NServiceBus.AcceptanceTests/NServiceBus.AcceptanceTests.csproj
@@ -26,8 +26,6 @@
 
   <ItemGroup>
     <RemoveSourceFileFromPackage Include="Core\**\*.cs" />
-    <RemoveSourceFileFromPackage Remove="Core\DependencyInjection\When_resolving_address_translator.cs" />
-    <RemoveSourceFileFromPackage Remove="Core\OpenTelemetry\Metrics\When_retrying_messages.cs" />
     <RemoveSourceFileFromPackage Include="AssemblyInfo.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
Two unneeded `RemoveSourceFileFromPackage` sneaked into the NServiceBus.AcceptanceTests project, causing the linked test sources to be included in the source package and ultimately causing downstream packages to fail when updating to Core 9.1.

This pull request removes the unwanted MSBuild elements, removing the two test files from the source package