### PR TITLE
Backport transport test changes from sql transport

### DIFF
--- a/src/NServiceBus.TransportTests/IConfigureTransportInfrastructure.cs
+++ b/src/NServiceBus.TransportTests/IConfigureTransportInfrastructure.cs
@@ -11,6 +11,16 @@ using Transport;
 public interface IConfigureTransportInfrastructure
 {
     /// <summary>
+    /// Gets the transport specific queue name to use as the input queue for the test. 
+    /// </summary>
+    string GetInputQueueName(string testName, TransportTransactionMode transactionMode) => $"{testName}{transactionMode}";
+
+    /// <summary>
+    /// Gets the transport specific error queue name to use as the input queue for the test. 
+    /// </summary>
+    string GetErrorQueueName(string testName, TransportTransactionMode transactionMode) => $"{testName}{transactionMode}.error";
+
+    /// <summary>
     /// Creates a <see cref="TransportDefinition"/> instance used for running a test case.
     /// </summary>
     TransportDefinition CreateTransportDefinition();

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -4,8 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
@@ -255,30 +253,6 @@ public abstract class NServiceBusTransportTest
         testName = testName.Replace("_", "");
 
         return testName;
-    }
-
-    static void GetQueueNames(TransportTransactionMode transactionMode, out string inputQueueName, out string errorQueueName)
-    {
-        var testName = GetTestName();
-        var fullTestName = $"{testName}{transactionMode}";
-        var fullTestNameHash = CreateDeterministicHash(fullTestName);
-
-        // Max length for table name is 63. We need to reserve space for the ".delayed" suffix (8), the hashcode (8), and "_seq_seq" sequence suffix: 63-8-8-8=39
-        var charactersToConsider = int.Min(fullTestName.Length, 39);
-
-        inputQueueName = $"{fullTestName.Substring(0, charactersToConsider)}{fullTestNameHash:X8}";
-
-        // Max length for table name is 63. We need to reserve space for the ".error" suffix (6) the hashcode (8), and "_seq_seq" sequence suffix: 63-8-6-8=41
-        var charactersToConsiderForTheErrorQueue = int.Min(fullTestName.Length, 41);
-        errorQueueName = $"{fullTestName.Substring(0, charactersToConsiderForTheErrorQueue)}_error{fullTestNameHash:X8}";
-    }
-
-    public static uint CreateDeterministicHash(string input)
-    {
-        var inputBytes = Encoding.Default.GetBytes(input);
-        var hashBytes = MD5.HashData(inputBytes);
-        // generate a guid from the hash:
-        return BitConverter.ToUInt32(hashBytes, 0) % 1000000;
     }
 
     public CancellationToken TestTimeoutCancellationToken => testCancellationTokenSource.Token;

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -300,8 +300,8 @@ public abstract class NServiceBusTransportTest
 
     protected string InputQueueName;
     protected string ErrorQueueName;
-    protected static TransportTestLoggerFactory LogFactory;
-    protected static TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
+    protected static readonly TransportTestLoggerFactory LogFactory;
+    protected static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(30);
     protected Action<TransportDefinition> CustomizeTransportDefinition;
     protected IMessageReceiver receiver;
 

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -97,9 +97,12 @@ public abstract class NServiceBusTransportTest
         onMessage = onMessage ?? throw new ArgumentNullException(nameof(onMessage));
         onError = onError ?? throw new ArgumentNullException(nameof(onError));
 
-        GetQueueNames(transactionMode, out InputQueueName, out ErrorQueueName);
-
         configurer = CreateConfigurer();
+
+        var testName = GetTestName();
+
+        InputQueueName = configurer.GetInputQueueName(testName, transactionMode);
+        ErrorQueueName = configurer.GetErrorQueueName(testName, transactionMode);
 
         var hostSettings = new HostSettings(
             InputQueueName,

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -154,7 +154,7 @@ public abstract class NServiceBusTransportTest
         receiver = null;
     }
 
-    void IgnoreUnsupportedTransactionModes(TransportDefinition transportDefinition, TransportTransactionMode requestedTransactionMode)
+    static void IgnoreUnsupportedTransactionModes(TransportDefinition transportDefinition, TransportTransactionMode requestedTransactionMode)
     {
         if (!transportDefinition.GetSupportedTransactionModes().Contains(requestedTransactionMode))
         {

--- a/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
+++ b/src/NServiceBus.TransportTests/NServiceBusTransportTest.cs
@@ -323,12 +323,7 @@ public abstract class NServiceBusTransportTest
         {
             var candidate = Environment.GetEnvironmentVariable(variable, EnvironmentVariableTarget.User);
 
-            if (string.IsNullOrWhiteSpace(candidate))
-            {
-                return Environment.GetEnvironmentVariable(variable);
-            }
-
-            return candidate;
+            return string.IsNullOrWhiteSpace(candidate) ? Environment.GetEnvironmentVariable(variable) : candidate;
         }
     }
 }


### PR DESCRIPTION
This updates the base transport test to allow SqlTransport to remove its own local copy.

See https://github.com/Particular/NServiceBus.SqlServer/pull/1435 for more context