### PR TITLE
Add nuget.config to src to see if that fixes Dependabot

### DIFF
--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="particular packages" value="https://f.feedz.io/particular-software/packages/nuget/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="particular packages">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="local packages">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>


### PR DESCRIPTION
Dependabot isn't opening PRs for packages that we only push to Feedz. I have a hunch it's because it's no longer finding our `nuget.config` in the repo root.

For now, let's copy it into the `src` folder, and we'll see if that fixes Dependabot.