### PR TITLE
Learning Transport: Stop pumps on shutdown

### DIFF
--- a/src/NServiceBus.Core.Tests/StandardsTests.cs
+++ b/src/NServiceBus.Core.Tests/StandardsTests.cs
@@ -44,7 +44,7 @@ public class StandardsTests
                 !x.FullName.StartsWith("FastExpressionCompiler") &&
                 // TODO: This can be removed once this bug is fixed in Roslyn: https://github.com/dotnet/roslyn/issues/72539
                 // so that we can use inline arrays in public code without breaking this test
-                !x.FullName.Contains("__InlineArray") &&
+                !x.FullName.Contains("__InlineArray") && !x.FullName.Contains("__ReadOnlyArray") &&
                 x.Namespace != "Particular.Licensing" &&
                 x.Namespace != "NServiceBus.Features" &&
                 x.Name != "NServiceBusCore_ProcessedByFody" &&

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransport.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransport.cs
@@ -28,10 +28,7 @@ public class LearningTransport : TransportDefinition
     public override Task<TransportInfrastructure> Initialize(HostSettings hostSettings, ReceiveSettings[] receivers, string[] sendingAddresses, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(hostSettings);
-        var learningTransportInfrastructure = new LearningTransportInfrastructure(hostSettings, this, receivers);
-        learningTransportInfrastructure.Initialize();
-
-        return Task.FromResult<TransportInfrastructure>(learningTransportInfrastructure);
+        return Task.FromResult<TransportInfrastructure>(new LearningTransportInfrastructure(hostSettings, this, receivers));
     }
 
     /// <inheritdoc />

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransport.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransport.cs
@@ -37,15 +37,12 @@ public class LearningTransport : TransportDefinition
     }
 
     /// <inheritdoc />
-    public override IReadOnlyCollection<TransportTransactionMode> GetSupportedTransactionModes()
-    {
-        return new[]
-        {
-            TransportTransactionMode.None,
-            TransportTransactionMode.ReceiveOnly,
-            TransportTransactionMode.SendsAtomicWithReceive
-        };
-    }
+    public override IReadOnlyCollection<TransportTransactionMode> GetSupportedTransactionModes() =>
+    [
+        TransportTransactionMode.None,
+        TransportTransactionMode.ReceiveOnly,
+        TransportTransactionMode.SendsAtomicWithReceive
+    ];
 
     /// <summary>
     /// Configures the storage directory to store files created by the transport.

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransport.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransport.cs
@@ -29,9 +29,7 @@ public class LearningTransport : TransportDefinition
     {
         ArgumentNullException.ThrowIfNull(hostSettings);
         var learningTransportInfrastructure = new LearningTransportInfrastructure(hostSettings, this, receivers);
-        learningTransportInfrastructure.ConfigureSendInfrastructure();
-
-        learningTransportInfrastructure.ConfigureReceiveInfrastructure();
+        learningTransportInfrastructure.Initialize();
 
         return Task.FromResult<TransportInfrastructure>(learningTransportInfrastructure);
     }

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
@@ -95,10 +95,9 @@ class LearningTransportInfrastructure : TransportInfrastructure
     public const string StorageLocationKey = "LearningTransport.StoragePath";
     public const string NoPayloadSizeRestrictionKey = "LearningTransport.NoPayloadSizeRestrictionKey";
 
-    public override Task Shutdown(CancellationToken cancellationToken = default)
-    {
-        return Task.CompletedTask;
-    }
+    public override async Task Shutdown(CancellationToken cancellationToken = default) =>
+        await Task.WhenAll(Receivers.Values.Select(r => r.StopReceive(cancellationToken)))
+            .ConfigureAwait(false);
 
     public override string ToTransportAddress(QueueAddress queueAddress)
     {

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus;
+﻿#nullable enable
+
+namespace NServiceBus;
 
 using System;
 using System.IO;
@@ -60,7 +62,7 @@ class LearningTransportInfrastructure : TransportInfrastructure
 
         var queueAddress = ToTransportAddress(receiveSettings.ReceiveAddress);
 
-        ISubscriptionManager subscriptionManager = null;
+        ISubscriptionManager? subscriptionManager = null;
         if (receiveSettings.UsePublishSubscribe)
         {
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -88,7 +88,7 @@ class LearningTransportMessagePump : IMessageReceiver
             return;
         }
 
-        messagePumpCancellationTokenSource?.Cancel();
+        await messagePumpCancellationTokenSource.CancelAsync().ConfigureAwait(false);
 
         delayedMessagePoller.Stop();
 

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportMessagePump.cs
@@ -82,6 +82,12 @@ class LearningTransportMessagePump : IMessageReceiver
 
     public async Task StopReceive(CancellationToken cancellationToken = default)
     {
+        if (messagePumpCancellationTokenSource is null)
+        {
+            // Receiver hasn't been started or is already stopped
+            return;
+        }
+
         messagePumpCancellationTokenSource?.Cancel();
 
         delayedMessagePoller.Stop();
@@ -111,6 +117,7 @@ class LearningTransportMessagePump : IMessageReceiver
 
         concurrencyLimiter?.Dispose();
         messagePumpCancellationTokenSource?.Dispose();
+        messagePumpCancellationTokenSource = null;
         messageProcessingCancellationTokenSource.Dispose();
     }
 


### PR DESCRIPTION
This aligns the learning transport to stop the pumps on transport shutdown and at the same time makes sure the pumps stop method can be called multiple times. 

This is part of addressing some low-hanging fruit to align all transports for the transport seam usage scenarios to make sure pumps are stopped when the transport shuts down. 

I have tried to write a transport test for it to enforce it eventually for all transport but couldn't find a way to do that without introducing flags on the transport interface and using fancy techniques like default members which seams overkill