### PR TITLE
Centralizable code analysis workflow

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,4 +1,4 @@
-name: Integrity
+name: Code Analysis
 on:
   push:
     branches:
@@ -13,8 +13,8 @@ defaults:
   run:
     shell: pwsh
 jobs:
-  repo-integrity:
-    name: Repo integrity
+  code-analysis:
+    name: Code Analysis
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/integrity.yml
+++ b/.github/workflows/integrity.yml
@@ -2,8 +2,7 @@ name: Integrity
 on:
   push:
     branches:
-      - master
-      - main
+      - ${{ github.event.repository.default_branch }}
       - release-*
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/integrity.yml
+++ b/.github/workflows/integrity.yml
@@ -2,7 +2,8 @@ name: Integrity
 on:
   push:
     branches:
-      - ${{ github.event.repository.default_branch }}
+      - main
+      - master
       - release-*
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/integrity.yml
+++ b/.github/workflows/integrity.yml
@@ -1,0 +1,23 @@
+name: Integrity
+on:
+  push:
+    branches:
+      - master
+      - main
+      - release-*
+  pull_request:
+  workflow_dispatch:
+env:
+  DOTNET_NOLOGO: true
+defaults:
+  run:
+    shell: pwsh
+jobs:
+  repo-integrity:
+    name: Repo integrity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Repo integrity tests
+        uses: Particular/repo-integrity-action@main


### PR DESCRIPTION
Replaces https://github.com/Particular/NServiceBus/pull/6951, however that PR shows the fixes necessary to pass the repo integrity tests. Note, however, changes due to .NET 9 preparations will require some of the repo integrity tests to change before a global rollout.