### PR TITLE
Saga unit test coverage using a C# 13.0 partial property as correlation id

### DIFF
--- a/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
+++ b/src/NServiceBus.Core.Tests/NServiceBus.Core.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
+    <LangVersion>13.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.Core.Tests/Sagas/SagaModelPartialProperty1Tests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaModelPartialProperty1Tests.cs
@@ -1,14 +1,10 @@
-namespace NServiceBus.Core.Tests.Sagas.TypeBasedSagas;
+namespace NServiceBus.Core.Tests.Sagas;
 
 public partial class MyPartialEntity : ContainSagaData
-{
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0032:Use auto property", Justification = "Manual getter/setter provides control over property behavior.")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Field is part of a partial property implementation.")]
-
-    int _uniqueProperty;
-
+{        
+#pragma warning disable IDE0055
     public partial int UniqueProperty { get; set; }
-
+#pragma warning restore IDE0055
 }
 
 

--- a/src/NServiceBus.Core.Tests/Sagas/SagaModelPartialProperty1Tests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaModelPartialProperty1Tests.cs
@@ -1,0 +1,14 @@
+namespace NServiceBus.Core.Tests.Sagas.TypeBasedSagas;
+
+public partial class MyPartialEntity : ContainSagaData
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0032:Use auto property", Justification = "Manual getter/setter provides control over property behavior.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0051:Remove unused private members", Justification = "Field is part of a partial property implementation.")]
+
+    int _uniqueProperty;
+
+    public partial int UniqueProperty { get; set; }
+
+}
+
+

--- a/src/NServiceBus.Core.Tests/Sagas/SagaModelPartialProperty2Tests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaModelPartialProperty2Tests.cs
@@ -1,7 +1,9 @@
-namespace NServiceBus.Core.Tests.Sagas.TypeBasedSagas;
+namespace NServiceBus.Core.Tests.Sagas;
 
 public partial class MyPartialEntity : ContainSagaData
 {
+#pragma warning disable IDE0032
+    int _uniqueProperty;
 
     public partial int UniqueProperty
     {
@@ -14,6 +16,7 @@ public partial class MyPartialEntity : ContainSagaData
             _uniqueProperty = value;
         }
     }
+#pragma warning restore IDE0032
 }
 
 

--- a/src/NServiceBus.Core.Tests/Sagas/SagaModelPartialProperty2Tests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaModelPartialProperty2Tests.cs
@@ -1,0 +1,19 @@
+namespace NServiceBus.Core.Tests.Sagas.TypeBasedSagas;
+
+public partial class MyPartialEntity : ContainSagaData
+{
+
+    public partial int UniqueProperty
+    {
+        get
+        {
+            return _uniqueProperty;
+        }
+        set
+        {
+            _uniqueProperty = value;
+        }
+    }
+}
+
+

--- a/src/NServiceBus.Core.Tests/Sagas/SagaModelTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaModelTests.cs
@@ -40,6 +40,17 @@ public class SagaModelTests
     }
 
     [Test]
+    public void FindSagasByPartialEntityName()
+    {
+        var model = GetModel(typeof(MySaga3));
+
+        var metadata = model.FindByEntity(typeof(MyPartialEntity));
+
+
+        Assert.That(metadata, Is.Not.Null);
+    }
+
+    [Test]
     public void ValidateAssumptionsAboutSagaMappings()
     {
         var model = GetModel(typeof(MySaga));
@@ -150,6 +161,26 @@ public class SagaModelTests
         public int UniqueProperty { get; set; }
     }
 
+    public partial class MyPartialEntity : ContainSagaData
+    {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0032:Use auto property", Justification = "<Pending>")]
+        int _uniqueProperty;
+
+        public partial int UniqueProperty { get; set; }
+
+        public partial int UniqueProperty
+        {
+            get
+            {
+                return _uniqueProperty;
+            }
+            set
+            {
+                _uniqueProperty = value;
+            }
+        }
+    }
+
     public class MyEntity2 : MyEntity
     {
 
@@ -174,6 +205,26 @@ public class SagaModelTests
         }
     }
 
+
+    class MySaga3 : Saga<MyPartialEntity>, IAmStartedByMessages<Message1>, IHandleMessages<Message2>
+    {
+        public Task Handle(Message1 message, IMessageHandlerContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Handle(Message2 message, IMessageHandlerContext context)
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MyPartialEntity> mapper)
+        {
+            mapper.ConfigureMapping<Message1>(m => m.UniqueProperty).ToSaga(s => s.UniqueProperty);
+            mapper.ConfigureMapping<Message2>(m => m.UniqueProperty).ToSaga(s => s.UniqueProperty);
+        }
+    }
+
     abstract class AbstractSaga : Saga<MyEntity>, IAmStartedByMessages<Message1>
     {
         public abstract Task Handle(Message1 message, IMessageHandlerContext context);
@@ -192,4 +243,5 @@ public class SagaModelTests
     {
         public int UniqueProperty { get; set; }
     }
+
 }

--- a/src/NServiceBus.Core.Tests/Sagas/SagaModelTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaModelTests.cs
@@ -161,25 +161,7 @@ public class SagaModelTests
         public int UniqueProperty { get; set; }
     }
 
-    public partial class MyPartialEntity : ContainSagaData
-    {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0032:Use auto property", Justification = "<Pending>")]
-        int _uniqueProperty;
 
-        public partial int UniqueProperty { get; set; }
-
-        public partial int UniqueProperty
-        {
-            get
-            {
-                return _uniqueProperty;
-            }
-            set
-            {
-                _uniqueProperty = value;
-            }
-        }
-    }
 
     public class MyEntity2 : MyEntity
     {

--- a/src/NServiceBus.Core.Tests/Sagas/When_saga_is_correlated_on_a_unsupported_datetime_property_type.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/When_saga_is_correlated_on_a_unsupported_datetime_property_type.cs
@@ -1,7 +1,6 @@
 namespace NServiceBus.Core.Tests.Sagas.TypeBasedSagas;
 
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using NServiceBus.Sagas;
 using NUnit.Framework;


### PR DESCRIPTION
Adds saga unit test coverage using a C# 13.0 partial property as correlation id