### PR TITLE
Consistently use PublisherMetadata to facilitate endpoint setup in Azure Service Bus

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Customization/EndpointConfigurationExtensions.cs
+++ b/src/NServiceBus.AcceptanceTesting/Customization/EndpointConfigurationExtensions.cs
@@ -76,4 +76,12 @@ public static class EndpointConfigurationExtensions
         var destinationEndpointAddress = Conventions.EndpointNamingConvention(destinationEndpointType);
         routingSettings.RouteToEndpoint(messageType, destinationEndpointAddress);
     }
+
+    public static void EnforcePublisherMetadataRegistration(this EndpointConfiguration config, string endpointName, PublisherMetadata publisherMetadata)
+    {
+        config.Pipeline.Register(new EnforcePublisherMetadataBehavior(endpointName, publisherMetadata),
+            "Enforces all published events have corresponding mappings in the PublisherMetadata");
+        config.Pipeline.Register(new EnforceSubscriptionPublisherMetadataBehavior(endpointName, publisherMetadata),
+            "Enforces all subscribed events have corresponding mappings in the PublisherMetadata");
+    }
 }

--- a/src/NServiceBus.AcceptanceTesting/Support/EnforcePublisherMetadataBehavior.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EnforcePublisherMetadataBehavior.cs
@@ -1,0 +1,18 @@
+namespace NServiceBus.AcceptanceTesting.Support;
+
+using System;
+using System.Threading.Tasks;
+using Pipeline;
+
+public class EnforcePublisherMetadataBehavior(string endpointName, PublisherMetadata publisherMetadata) : IBehavior<IOutgoingPublishContext, IOutgoingPublishContext>
+{
+    public Task Invoke(IOutgoingPublishContext context, Func<IOutgoingPublishContext, Task> next)
+    {
+        var publisherDetails = publisherMetadata[endpointName];
+        if (!publisherDetails.Events.Contains(context.Message.MessageType))
+        {
+            throw new Exception($"The event '{context.Message.MessageType}' being published by '{endpointName}' does not have a corresponding mapping in the PublisherMetadata. Add the following code to the endpoint configuration builder: metadata.RegisterSelfAsPublisherFor<{context.Message.MessageType}>(this);");
+        }
+        return next(context);
+    }
+}

--- a/src/NServiceBus.AcceptanceTesting/Support/EnforceSubscriptionPublisherMetadataBehavior.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EnforceSubscriptionPublisherMetadataBehavior.cs
@@ -1,0 +1,30 @@
+namespace NServiceBus.AcceptanceTesting.Support;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Pipeline;
+
+public class EnforceSubscriptionPublisherMetadataBehavior(string endpointName, PublisherMetadata publisherMetadata) : IBehavior<ISubscribeContext, ISubscribeContext>
+{
+    readonly HashSet<Type> eventTypeMap = publisherMetadata.Publishers.SelectMany(publisher => publisher.Events).ToHashSet();
+
+    public Task Invoke(ISubscribeContext context, Func<ISubscribeContext, Task> next)
+    {
+        var unmappedEventTypes = new List<Type>(context.EventTypes.Where(eventType => !eventTypeMap.Contains(eventType)));
+        if (unmappedEventTypes.Count == 0)
+        {
+            return next(context);
+        }
+
+        var builder = new StringBuilder();
+        _ = builder.AppendLine($"The following event(s) are being subscribed to by '{endpointName}' but do not have a corresponding mapping in the PublisherMetadata:");
+        foreach (var eventType in unmappedEventTypes)
+        {
+            _ = builder.AppendLine($"- metadata.RegisterPublisherFor<{eventType}>(\"typeof(PublisherEndpointToBeDetermined)\");");
+        }
+        throw new Exception(builder.ToString());
+    }
+}

--- a/src/NServiceBus.AcceptanceTesting/Support/PublisherMetadata.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/PublisherMetadata.cs
@@ -23,33 +23,31 @@ public class PublisherMetadata
         publisher.RegisterOwnedEvent<T>();
     }
 
-    public void RegisterPublisherFor<T>(Type endpointType)
+    public void RegisterSelfAsPublisherFor<TEventType>(EndpointConfigurationBuilder self) =>
+        RegisterPublisherFor<TEventType>(Conventions.EndpointNamingConvention(self.GetType()));
+
+    public void RegisterPublisherFor<TEventType, TPublisher>() where TPublisher : EndpointConfigurationBuilder =>
+        RegisterPublisherFor<TEventType>(Conventions.EndpointNamingConvention(typeof(TPublisher)));
+
+    public void RegisterPublisherFor<TEventType>(Type endpointType) =>
+        RegisterPublisherFor<TEventType>(Conventions.EndpointNamingConvention(endpointType));
+
+    public PublisherDetails this[string publisherName] =>
+        publisherDetails.TryGetValue(publisherName, out var publisherDetail)
+            ? publisherDetail
+            : new PublisherDetails(publisherName);
+
+    readonly Dictionary<string, PublisherDetails> publisherDetails = [];
+
+    public class PublisherDetails(string publisherName)
     {
-        RegisterPublisherFor<T>(Conventions.EndpointNamingConvention(endpointType));
-    }
+        public HashSet<Type> Events { get; } = [];
 
-    Dictionary<string, PublisherDetails> publisherDetails = [];
-
-    public class PublisherDetails
-    {
-        public PublisherDetails(string publisherName)
-        {
-            PublisherName = publisherName;
-        }
-
-        public List<Type> Events { get; } = [];
-
-        public string PublisherName { get; }
+        public string PublisherName { get; } = publisherName;
 
         public void RegisterOwnedEvent<T>()
         {
             var eventType = typeof(T);
-
-            if (Events.Contains(eventType))
-            {
-                return;
-            }
-
             Events.Add(eventType);
         }
     }

--- a/src/NServiceBus.AcceptanceTests/ConfigureEndpointAcceptanceTestingTransport.cs
+++ b/src/NServiceBus.AcceptanceTests/ConfigureEndpointAcceptanceTestingTransport.cs
@@ -3,19 +3,18 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
+using AcceptanceTesting.Customization;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
 using NUnit.Framework;
 
-public class ConfigureEndpointAcceptanceTestingTransport : IConfigureEndpointTestExecution
+public class ConfigureEndpointAcceptanceTestingTransport(
+    bool useNativePubSub,
+    bool useNativeDelayedDelivery,
+    TransportTransactionMode? transactionMode = null,
+    bool? enforcePublisherMetadata = null)
+    : IConfigureEndpointTestExecution
 {
-    public ConfigureEndpointAcceptanceTestingTransport(bool useNativePubSub, bool useNativeDelayedDelivery, TransportTransactionMode? transactionMode = null)
-    {
-        this.useNativePubSub = useNativePubSub;
-        this.useNativeDelayedDelivery = useNativeDelayedDelivery;
-        this.transactionMode = transactionMode;
-    }
-
     public Task Cleanup()
     {
         try
@@ -25,26 +24,22 @@ public class ConfigureEndpointAcceptanceTestingTransport : IConfigureEndpointTes
                 Directory.Delete(storageDir, true);
             }
         }
-        catch { }
+        catch
+        {
+            // ignored
+        }
 
         return Task.CompletedTask;
     }
 
-    public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings, PublisherMetadata publisherMetadata)
+    public Task Configure(string endpointName, EndpointConfiguration configuration, RunSettings settings,
+        PublisherMetadata publisherMetadata)
     {
         var testRunId = TestContext.CurrentContext.Test.ID;
 
-        string tempDir;
-
-        if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-        {
+        string tempDir =
             //can't use bin dir since that will be too long on the build agents
-            tempDir = @"c:\temp";
-        }
-        else
-        {
-            tempDir = Path.GetTempPath();
-        }
+            Environment.OSVersion.Platform == PlatformID.Win32NT ? @"c:\temp" : Path.GetTempPath();
 
         storageDir = Path.Combine(tempDir, "acc", testRunId);
 
@@ -58,6 +53,11 @@ public class ConfigureEndpointAcceptanceTestingTransport : IConfigureEndpointTes
         if (transactionMode.HasValue)
         {
             acceptanceTestingTransport.TransportTransactionMode = transactionMode.Value;
+        }
+
+        if (enforcePublisherMetadata.GetValueOrDefault(false))
+        {
+            configuration.EnforcePublisherMetadataRegistration(endpointName, publisherMetadata);
         }
 
         var routing = configuration.UseTransport(acceptanceTestingTransport);
@@ -76,10 +76,6 @@ public class ConfigureEndpointAcceptanceTestingTransport : IConfigureEndpointTes
 
         return Task.CompletedTask;
     }
-
-    readonly bool useNativePubSub;
-    readonly bool useNativeDelayedDelivery;
-    readonly TransportTransactionMode? transactionMode;
 
     string storageDir;
 }

--- a/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_excluding_event_type_from_autosubscribe.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_excluding_event_type_from_autosubscribe.cs
@@ -50,8 +50,8 @@ public class When_excluding_event_type_from_autosubscribe : NServiceBusAcceptanc
                 },
                 metadata =>
                 {
-                    metadata.RegisterPublisherFor<EventToSubscribeTo>(typeof(Subscriber));
-                    metadata.RegisterPublisherFor<EventToExclude>(typeof(Subscriber));
+                    metadata.RegisterPublisherFor<EventToSubscribeTo, Subscriber>();
+                    metadata.RegisterPublisherFor<EventToExclude, Subscriber>();
                 });
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga.cs
@@ -40,8 +40,8 @@ public class When_starting_an_endpoint_with_a_saga : NServiceBusAcceptanceTest
             EndpointSetup<DefaultServer>((c, r) => c.Pipeline.Register("SubscriptionSpy", new SubscriptionSpy((Context)r.ScenarioContext), "Spies on subscriptions made"),
                 metadata =>
                 {
-                    metadata.RegisterPublisherFor<MyEventBase>(typeof(Subscriber));
-                    metadata.RegisterPublisherFor<MyEvent>(typeof(Subscriber));
+                    metadata.RegisterPublisherFor<MyEventBase, Subscriber>();
+                    metadata.RegisterPublisherFor<MyEvent, Subscriber>();
                 });
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_starting_an_endpoint_with_a_saga_autosubscribe_disabled.cs
@@ -43,8 +43,8 @@ public class When_starting_an_endpoint_with_a_saga_autosubscribe_disabled : NSer
                 },
                 metadata =>
                 {
-                    metadata.RegisterPublisherFor<MyEventWithParent>(typeof(Subscriber));
-                    metadata.RegisterPublisherFor<MyEvent>(typeof(Subscriber));
+                    metadata.RegisterPublisherFor<MyEventWithParent, Subscriber>();
+                    metadata.RegisterPublisherFor<MyEvent, Subscriber>();
                 });
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_starting_an_endpoint_with_autosubscribe.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_starting_an_endpoint_with_autosubscribe.cs
@@ -56,8 +56,8 @@ public class When_starting_an_endpoint_with_autosubscribe : NServiceBusAcceptanc
                 },
                 metadata =>
                 {
-                    metadata.RegisterPublisherFor<MyEvent>(typeof(Subscriber));
-                    metadata.RegisterPublisherFor<MyEventWithNoHandler>(typeof(Subscriber));
+                    metadata.RegisterPublisherFor<MyEvent, Subscriber>();
+                    metadata.RegisterPublisherFor<MyEventWithNoHandler, Subscriber>();
                 });
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_incoming_event_has_trace.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_incoming_event_has_trace.cs
@@ -88,7 +88,7 @@ public class When_incoming_event_has_trace : OpenTelemetryAcceptanceTest
                 },
                 metadata =>
                 {
-                    metadata.RegisterPublisherFor<SomeEvent>(typeof(Publisher));
+                    metadata.RegisterPublisherFor<SomeEvent, Publisher>();
                 });
 
         public class ThisHandlesSomethingHandler : IHandleMessages<SomeEvent>

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_publishing_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_publishing_messages.cs
@@ -165,7 +165,7 @@ public class When_publishing_messages : OpenTelemetryAcceptanceTest
             },
                 metadata =>
                 {
-                    metadata.RegisterPublisherFor<ThisIsAnEvent>(typeof(Publisher));
+                    metadata.RegisterPublisherFor<ThisIsAnEvent, Publisher>();
                 });
 
         public class ThisHandlesSomethingHandler : IHandleMessages<ThisIsAnEvent>

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_subscribing.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_subscribing.cs
@@ -73,7 +73,7 @@ public class When_subscribing : OpenTelemetryAcceptanceTest
     {
         public SubscribingEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>(
             c => c.DisableFeature<AutoSubscribe>(),
-            p => p.RegisterPublisherFor<DemoEvent>(typeof(PublishingEndpoint)));
+            p => p.RegisterPublisherFor<DemoEvent, PublishingEndpoint>());
     }
 
     class PublishingEndpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_unsubscribing.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_unsubscribing.cs
@@ -72,7 +72,7 @@ public class When_unsubscribing : OpenTelemetryAcceptanceTest
     {
         public SubscriberEndpoint() => EndpointSetup<OpenTelemetryEnabledEndpoint>(
             c => c.DisableFeature<AutoSubscribe>(),
-            p => p.RegisterPublisherFor<DemoEvent>(typeof(PublishingEndpoint)));
+            p => p.RegisterPublisherFor<DemoEvent, PublishingEndpoint>());
     }
 
     class PublishingEndpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_extending_the_publish_api.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_extending_the_publish_api.cs
@@ -88,7 +88,7 @@ public class When_extending_the_publish_api : NServiceBusAcceptanceTest
     {
         public Subscriber1()
         {
-            EndpointSetup<DefaultServer>(builder => builder.DisableFeature<AutoSubscribe>(), metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
+            EndpointSetup<DefaultServer>(builder => builder.DisableFeature<AutoSubscribe>(), metadata => metadata.RegisterPublisherFor<MyEvent, Publisher>());
         }
 
         public class MyHandler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_configuring_subscription_authorizer.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_configuring_subscription_authorizer.cs
@@ -58,8 +58,8 @@ public class When_configuring_subscription_authorizer : NServiceBusAcceptanceTes
                 routingSettings.DisablePublishing();
             }, p =>
             {
-                p.RegisterPublisherFor<ForbiddenEvent>(typeof(PublisherWithAuthorizer));
-                p.RegisterPublisherFor<AllowedEvent>(typeof(PublisherWithAuthorizer));
+                p.RegisterPublisherFor<ForbiddenEvent, PublisherWithAuthorizer>();
+                p.RegisterPublisherFor<AllowedEvent, PublisherWithAuthorizer>();
             });
         }
     }

--- a/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/PublishSubscribe/When_disabling_publishing.cs
@@ -62,7 +62,7 @@ public class When_disabling_publishing : NServiceBusAcceptanceTest
                     var routingSettings = new RoutingSettings<AcceptanceTestingTransport>(c.GetSettings());
                     routingSettings.DisablePublishing();
                 },
-                pm => pm.RegisterPublisherFor<TestEvent>(typeof(MessageDrivenPublisher)));
+                pm => pm.RegisterPublisherFor<TestEvent, MessageDrivenPublisher>());
         }
 
         class EventHandler : IHandleMessages<TestEvent>

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/AutomaticSubscriptions/When_handling_local_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/AutomaticSubscriptions/When_handling_local_event.cs
@@ -50,7 +50,7 @@ public class When_handling_local_event : NServiceBusAcceptanceTest
                         context.EventSubscribed = true;
                     }
                 });
-            }, metadata => metadata.RegisterPublisherFor<Event>(typeof(PublisherAndSubscriber)));
+            }, metadata => metadata.RegisterPublisherFor<Event, PublisherAndSubscriber>());
         }
 
         public class Handler : IHandleMessages<Event>

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/MessageDrivenSubscriptions/Extend_event_routing.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/MessageDrivenSubscriptions/Extend_event_routing.cs
@@ -1,11 +1,11 @@
-﻿namespace NServiceBus.AcceptanceTests.Routing.MessageDrivenSubscriptions;
+﻿namespace NServiceBus.AcceptanceTests.Core.Routing.MessageDrivenSubscriptions;
 
 using System.Threading.Tasks;
-using AcceptanceTesting;
-using AcceptanceTesting.Customization;
-using Configuration.AdvancedExtensibility;
-using EndpointTemplates;
-using Features;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.AcceptanceTesting.Customization;
+using NServiceBus.AcceptanceTests.EndpointTemplates;
+using NServiceBus.Configuration.AdvancedExtensibility;
+using NServiceBus.Features;
 using NServiceBus.Routing.MessageDrivenSubscriptions;
 using NUnit.Framework;
 

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/MessageDrivenSubscriptions/Missing_pub_info.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/MessageDrivenSubscriptions/Missing_pub_info.cs
@@ -1,11 +1,11 @@
-﻿namespace NServiceBus.AcceptanceTests.Routing.MessageDrivenSubscriptions;
+﻿namespace NServiceBus.AcceptanceTests.Core.Routing.MessageDrivenSubscriptions;
 
 using System.Linq;
 using System.Threading.Tasks;
-using AcceptanceTesting;
-using EndpointTemplates;
-using Features;
-using Logging;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.AcceptanceTests.EndpointTemplates;
+using NServiceBus.Features;
+using NServiceBus.Logging;
 using NUnit.Framework;
 
 public class Missing_pub_info : NServiceBusAcceptanceTest

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/MessageDrivenSubscriptions/Pub_from_sendonly.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/MessageDrivenSubscriptions/Pub_from_sendonly.cs
@@ -1,19 +1,19 @@
-﻿namespace NServiceBus.AcceptanceTests.Routing.MessageDrivenSubscriptions;
+﻿namespace NServiceBus.AcceptanceTests.Core.Routing.MessageDrivenSubscriptions;
 
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using AcceptanceTesting;
-using EndpointTemplates;
-using Extensibility;
-using Features;
 using Microsoft.Extensions.DependencyInjection;
 using NServiceBus;
+using NServiceBus.AcceptanceTesting;
+using NServiceBus.AcceptanceTests.EndpointTemplates;
+using NServiceBus.Extensibility;
+using NServiceBus.Features;
+using NServiceBus.Persistence;
+using NServiceBus.Unicast.Subscriptions;
+using NServiceBus.Unicast.Subscriptions.MessageDrivenSubscriptions;
 using NUnit.Framework;
-using Persistence;
-using Unicast.Subscriptions;
-using Unicast.Subscriptions.MessageDrivenSubscriptions;
 using Conventions = AcceptanceTesting.Customization.Conventions;
 
 public class Pub_from_sendonly : NServiceBusAcceptanceTest
@@ -46,7 +46,7 @@ public class Pub_from_sendonly : NServiceBusAcceptanceTest
                 b.SendOnly();
                 b.UsePersistence(typeof(HardCodedPersistence));
                 b.DisableFeature<AutoSubscribe>();
-            });
+            }, metadata => metadata.RegisterSelfAsPublisherFor<MyEvent>(this));
         }
     }
 

--- a/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/When_publisher_has_subscription_migration_mode_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/When_publisher_has_subscription_migration_mode_enabled.cs
@@ -48,7 +48,7 @@ public class When_publisher_has_subscription_migration_mode_enabled : NServiceBu
     {
         public MessageDrivenSubscriber()
         {
-            EndpointSetup<EndpointWithMessageDrivenPubSub>(_ => { }, p => p.RegisterPublisherFor<SomeEvent>(typeof(MigratedPublisher)));
+            EndpointSetup<EndpointWithMessageDrivenPubSub>(_ => { }, p => p.RegisterPublisherFor<SomeEvent, MigratedPublisher>());
         }
 
         class SomeEventHandler : IHandleMessages<SomeEvent>

--- a/src/NServiceBus.AcceptanceTests/Core/TestSuiteConstraints.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/TestSuiteConstraints.cs
@@ -1,6 +1,7 @@
 ﻿namespace NServiceBus.AcceptanceTests;
 
 using AcceptanceTesting.Support;
+using NUnit.Framework;
 
 public partial class TestSuiteConstraints
 {
@@ -19,7 +20,14 @@ public partial class TestSuiteConstraints
 
     public bool SupportsPurgeOnStartup => true;
 
-    public IConfigureEndpointTestExecution CreateTransportConfiguration() => new ConfigureEndpointAcceptanceTestingTransport(SupportsNativePubSub, SupportsDelayedDelivery);
+    public IConfigureEndpointTestExecution CreateTransportConfiguration()
+        => new ConfigureEndpointAcceptanceTestingTransport(SupportsNativePubSub, SupportsDelayedDelivery, enforcePublisherMetadata: EnforcePublisherMetadata);
+
+    // Making sure all tests shipped to down streams have the necessary publisher metadata available but exclude
+    // the ones in the Core folder since they are not shipped to down streams.
+    static bool EnforcePublisherMetadata =>
+        TestContext.CurrentContext.Test.Namespace != null &&
+        !TestContext.CurrentContext.Test.Namespace.StartsWith("NServiceBus.AcceptanceTests.Core.");
 
     public IConfigureEndpointTestExecution CreatePersistenceConfiguration() => new ConfigureEndpointAcceptanceTestingPersistence();
 }

--- a/src/NServiceBus.AcceptanceTests/Feature/When_subscribing_in_FST.cs
+++ b/src/NServiceBus.AcceptanceTests/Feature/When_subscribing_in_FST.cs
@@ -62,7 +62,7 @@ public class When_subscribing_in_FST : NServiceBusAcceptanceTest
                         }
                     });
                 },
-                p => p.RegisterPublisherFor<LocalEvent>(typeof(EndpointWithStartupTask)));
+                p => p.RegisterPublisherFor<LocalEvent, EndpointWithStartupTask>());
         }
 
         class MessageHandler : IHandleMessages<LocalEvent>

--- a/src/NServiceBus.AcceptanceTests/Outbox/When_publishing_with_outbox.cs
+++ b/src/NServiceBus.AcceptanceTests/Outbox/When_publishing_with_outbox.cs
@@ -96,7 +96,7 @@ public class When_publishing_with_outbox : NServiceBusAcceptanceTest
                     }
                 });
                 b.DisableFeature<AutoSubscribe>();
-            });
+            }, metadata => metadata.RegisterSelfAsPublisherFor<MyEvent>(this));
 
         public class TriggerHandler : IHandleMessages<TriggerMessage>
         {
@@ -124,7 +124,7 @@ public class When_publishing_with_outbox : NServiceBusAcceptanceTest
     {
         public Subscriber1() =>
             EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(),
-                metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
+                metadata => metadata.RegisterPublisherFor<MyEvent, Publisher>());
 
         public class MyHandler(Context testContext) : IHandleMessages<MyEvent>
         {
@@ -140,7 +140,7 @@ public class When_publishing_with_outbox : NServiceBusAcceptanceTest
     {
         public Subscriber2() =>
             EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(),
-                metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
+                metadata => metadata.RegisterPublisherFor<MyEvent, Publisher>());
 
         public class MyHandler(Context testContext) : IHandleMessages<MyEvent>
         {

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Multi_sub_to_poly_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Multi_sub_to_poly_event.cs
@@ -65,7 +65,7 @@ public class MultiSubscribeToPolymorphicEvent : NServiceBusAcceptanceTest
                         context.Publisher1HasASubscriberForIMyEvent = true;
                     }
                 });
-            });
+            }, metadata => metadata.RegisterSelfAsPublisherFor<MyEvent1>(this));
         }
     }
 
@@ -87,7 +87,7 @@ public class MultiSubscribeToPolymorphicEvent : NServiceBusAcceptanceTest
                         context.Publisher2HasDetectedASubscriberForEvent2 = true;
                     }
                 });
-            });
+            }, metadata => metadata.RegisterSelfAsPublisherFor<MyEvent2>(this));
         }
     }
 
@@ -98,8 +98,8 @@ public class MultiSubscribeToPolymorphicEvent : NServiceBusAcceptanceTest
             EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(),
                     metadata =>
                     {
-                        metadata.RegisterPublisherFor<IMyEvent>(typeof(Publisher1));
-                        metadata.RegisterPublisherFor<MyEvent2>(typeof(Publisher2));
+                        metadata.RegisterPublisherFor<IMyEvent, Publisher1>();
+                        metadata.RegisterPublisherFor<MyEvent2, Publisher2>();
                     });
         }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Pub_to_scaled_out_subs.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Pub_to_scaled_out_subs.cs
@@ -62,7 +62,10 @@ public class Pub_to_scaled_out_subs : NServiceBusAcceptanceTest
     {
         public Publisher()
         {
-            EndpointSetup<DefaultServer>(c => { c.OnEndpointSubscribed<Context>((s, context) => { context.IncrementSubscribersCounter(); }); });
+            EndpointSetup<DefaultServer>(c =>
+            {
+                c.OnEndpointSubscribed<Context>((s, context) => { context.IncrementSubscribersCounter(); });
+            }, metadata => metadata.RegisterSelfAsPublisherFor<MyEvent>(this));
         }
     }
 
@@ -70,7 +73,7 @@ public class Pub_to_scaled_out_subs : NServiceBusAcceptanceTest
     {
         public SubscriberA()
         {
-            EndpointSetup<DefaultServer>(publisherMetadata: metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
+            EndpointSetup<DefaultServer>(publisherMetadata: metadata => metadata.RegisterPublisherFor<MyEvent, Publisher>());
         }
 
         public class MyHandler : IHandleMessages<MyEvent>
@@ -94,7 +97,7 @@ public class Pub_to_scaled_out_subs : NServiceBusAcceptanceTest
     {
         public SubscriberB()
         {
-            EndpointSetup<DefaultServer>(publisherMetadata: metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
+            EndpointSetup<DefaultServer>(publisherMetadata: metadata => metadata.RegisterPublisherFor<MyEvent, Publisher>());
         }
 
         public class MyHandler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Sub_to_base_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Sub_to_base_event.cs
@@ -41,7 +41,13 @@ public class Sub_to_base_event : NServiceBusAcceptanceTest
     {
         public Publisher()
         {
-            EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((args, context) => { context.SubscriberSubscribed = true; }));
+            EndpointSetup<DefaultPublisher>(b =>
+                b.OnEndpointSubscribed<Context>((args, context) => { context.SubscriberSubscribed = true; }),
+                metadata =>
+                {
+                    metadata.RegisterSelfAsPublisherFor<SpecificEvent>(this);
+                    metadata.RegisterSelfAsPublisherFor<IBaseEvent>(this);
+                });
         }
     }
 
@@ -49,8 +55,8 @@ public class Sub_to_base_event : NServiceBusAcceptanceTest
     {
         public GeneralSubscriber()
         {
-            EndpointSetup<DefaultServer>(c => { c.DisableFeature<AutoSubscribe>(); },
-                metadata => metadata.RegisterPublisherFor<IBaseEvent>(typeof(Publisher)));
+            EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(),
+                metadata => metadata.RegisterPublisherFor<IBaseEvent, Publisher>());
         }
 
         public class MyHandler : IHandleMessages<IBaseEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Sub_to_derived_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Sub_to_derived_event.cs
@@ -47,7 +47,7 @@ public class Sub_to_derived_event : NServiceBusAcceptanceTest
                     context.SubscriberSubscribed = true;
                 });
                 b.ConfigureRouting().RouteToEndpoint(typeof(Done), typeof(Subscriber));
-            });
+            }, metadata => metadata.RegisterSelfAsPublisherFor<IBaseEvent>(this));
         }
     }
 
@@ -60,7 +60,7 @@ public class Sub_to_derived_event : NServiceBusAcceptanceTest
                 c.DisableFeature<AutoSubscribe>();
                 c.LimitMessageProcessingConcurrencyTo(1); //To ensure Done is processed after the event.
             },
-            metadata => metadata.RegisterPublisherFor<SpecificEvent>(typeof(Publisher)));
+            metadata => metadata.RegisterPublisherFor<SpecificEvent, Publisher>());
         }
 
         public class MyHandler : IHandleMessages<SpecificEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Sub_to_scaled_out_pubs.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Sub_to_scaled_out_pubs.cs
@@ -59,7 +59,7 @@ public class Sub_to_scaled_out_pubs : NServiceBusAcceptanceTest
                         new EndpointInstance(publisherName, "2")
                     ]);
                 },
-                metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(ScaledOutPublisher)));
+                metadata => metadata.RegisterPublisherFor<MyEvent, ScaledOutPublisher>());
         }
     }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Unsub_from_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Unsub_from_event.cs
@@ -80,7 +80,7 @@ public class Unsub_from_event : NServiceBusAcceptanceTest
                         ctx.Subscriber2Unsubscribed = true;
                     }
                 });
-            });
+            }, metadata => metadata.RegisterSelfAsPublisherFor<Event>(this));
         }
     }
 
@@ -93,7 +93,7 @@ public class Unsub_from_event : NServiceBusAcceptanceTest
                    c.DisableFeature<AutoSubscribe>();
                    c.LimitMessageProcessingConcurrencyTo(1);
                },
-               metadata => metadata.RegisterPublisherFor<Event>(typeof(Publisher)));
+               metadata => metadata.RegisterPublisherFor<Event, Publisher>());
         }
 
         public class Handler : IHandleMessages<Event>
@@ -122,7 +122,7 @@ public class Unsub_from_event : NServiceBusAcceptanceTest
                     c.DisableFeature<AutoSubscribe>();
                     c.LimitMessageProcessingConcurrencyTo(1);
                 },
-                metadata => metadata.RegisterPublisherFor<Event>(typeof(Publisher)));
+                metadata => metadata.RegisterPublisherFor<Event, Publisher>());
         }
 
         public class Handler : IHandleMessages<Event>

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Unsub_from_scaled_out_pubs.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Unsub_from_scaled_out_pubs.cs
@@ -61,7 +61,7 @@ public class Unsub_from_scaled_out_pubs : NServiceBusAcceptanceTest
                         new EndpointInstance(publisherName, "2")
                     ]);
                 },
-                metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(ScaledOutPublisher)));
+                metadata => metadata.RegisterPublisherFor<MyEvent, ScaledOutPublisher>());
         }
     }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/MultiSubscribeToPolymorphicEvent.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/MultiSubscribeToPolymorphicEvent.cs
@@ -44,7 +44,7 @@ public class MultiSubscribeToPolymorphicEvent : NServiceBusAcceptanceTest
     {
         public Publisher1()
         {
-            EndpointSetup<DefaultPublisher>();
+            EndpointSetup<DefaultPublisher>(_ => { }, metadata => metadata.RegisterSelfAsPublisherFor<MyEvent1>(this));
         }
     }
 
@@ -52,7 +52,7 @@ public class MultiSubscribeToPolymorphicEvent : NServiceBusAcceptanceTest
     {
         public Publisher2()
         {
-            EndpointSetup<DefaultPublisher>();
+            EndpointSetup<DefaultPublisher>(_ => { }, metadata => metadata.RegisterSelfAsPublisherFor<MyEvent2>(this));
         }
     }
 
@@ -60,7 +60,11 @@ public class MultiSubscribeToPolymorphicEvent : NServiceBusAcceptanceTest
     {
         public Subscriber()
         {
-            EndpointSetup<DefaultServer>();
+            EndpointSetup<DefaultServer>(_ => { }, metadata =>
+            {
+                metadata.RegisterPublisherFor<IMyEvent, Publisher1>();
+                metadata.RegisterPublisherFor<IMyEvent, Publisher2>();
+            });
         }
 
         public class MyHandler : IHandleMessages<IMyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_publishing_from_sendonly.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_publishing_from_sendonly.cs
@@ -34,7 +34,7 @@ public class When_publishing_from_sendonly : NServiceBusAcceptanceTest
             EndpointSetup<DefaultPublisher>(b =>
             {
                 b.SendOnly();
-            });
+            }, metadata => metadata.RegisterSelfAsPublisherFor<MyEvent>(this));
         }
     }
 
@@ -42,7 +42,7 @@ public class When_publishing_from_sendonly : NServiceBusAcceptanceTest
     {
         public Subscriber()
         {
-            EndpointSetup<DefaultServer>();
+            EndpointSetup<DefaultServer>(_ => { }, metadata => metadata.RegisterPublisherFor<MyEvent, SendOnlyPublisher>());
         }
 
         public class MyHandler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_publishing_to_scaled_out_subscribers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_publishing_to_scaled_out_subscribers.cs
@@ -54,7 +54,7 @@ public class When_publishing_to_scaled_out_subscribers : NServiceBusAcceptanceTe
     {
         public Publisher()
         {
-            EndpointSetup<DefaultServer>();
+            EndpointSetup<DefaultServer>(_ => { }, metadata => metadata.RegisterSelfAsPublisherFor<MyEvent>(this));
         }
     }
 
@@ -62,7 +62,7 @@ public class When_publishing_to_scaled_out_subscribers : NServiceBusAcceptanceTe
     {
         public SubscriberA()
         {
-            EndpointSetup<DefaultServer>();
+            EndpointSetup<DefaultServer>(_ => { }, metadata => metadata.RegisterPublisherFor<MyEvent, Publisher>());
         }
 
         public class MyHandler : IHandleMessages<MyEvent>
@@ -86,7 +86,7 @@ public class When_publishing_to_scaled_out_subscribers : NServiceBusAcceptanceTe
     {
         public SubscriberB()
         {
-            EndpointSetup<DefaultServer>();
+            EndpointSetup<DefaultServer>(_ => { }, metadata => metadata.RegisterPublisherFor<MyEvent, Publisher>());
         }
 
         public class MyHandler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_subscribing_to_a_base_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_subscribing_to_a_base_event.cs
@@ -45,7 +45,11 @@ public class When_subscribing_to_a_base_event : NServiceBusAcceptanceTest
     {
         public Publisher()
         {
-            EndpointSetup<DefaultPublisher>();
+            EndpointSetup<DefaultPublisher>(_ => { }, metadata =>
+            {
+                metadata.RegisterSelfAsPublisherFor<SpecificEvent>(this);
+                metadata.RegisterSelfAsPublisherFor<IBaseEvent>(this);
+            });
         }
     }
 
@@ -53,7 +57,8 @@ public class When_subscribing_to_a_base_event : NServiceBusAcceptanceTest
     {
         public GeneralSubscriber()
         {
-            EndpointSetup<DefaultServer>(c => { c.DisableFeature<AutoSubscribe>(); });
+            EndpointSetup<DefaultServer>(c => { c.DisableFeature<AutoSubscribe>(); },
+                metadata => metadata.RegisterPublisherFor<IBaseEvent, Publisher>());
         }
 
         public class MyHandler : IHandleMessages<IBaseEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_subscribing_to_a_derived_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_subscribing_to_a_derived_event.cs
@@ -45,7 +45,8 @@ public class When_subscribing_to_a_derived_event : NServiceBusAcceptanceTest
         public Publisher()
         {
             EndpointSetup<DefaultPublisher>(b =>
-                b.ConfigureRouting().RouteToEndpoint(typeof(Done), typeof(Subscriber)));
+                b.ConfigureRouting().RouteToEndpoint(typeof(Done), typeof(Subscriber)),
+                metadata => metadata.RegisterSelfAsPublisherFor<IBaseEvent>(this));
         }
     }
 
@@ -57,7 +58,7 @@ public class When_subscribing_to_a_derived_event : NServiceBusAcceptanceTest
             {
                 c.DisableFeature<AutoSubscribe>();
                 c.LimitMessageProcessingConcurrencyTo(1); //To ensure Done is processed after the event.
-            });
+            }, metadata => metadata.RegisterPublisherFor<SpecificEvent, Publisher>());
         }
 
         public class MyHandler : IHandleMessages<SpecificEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_unsubscribing_from_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_unsubscribing_from_event.cs
@@ -70,7 +70,7 @@ public class When_unsubscribing_from_event : NServiceBusAcceptanceTest
     {
         public Publisher()
         {
-            EndpointSetup<DefaultServer>();
+            EndpointSetup<DefaultServer>(_ => { }, metadata => metadata.RegisterSelfAsPublisherFor<Event>(this));
         }
     }
 
@@ -78,7 +78,8 @@ public class When_unsubscribing_from_event : NServiceBusAcceptanceTest
     {
         public Subscriber1()
         {
-            EndpointSetup<DefaultServer>(c => { c.DisableFeature<AutoSubscribe>(); });
+            EndpointSetup<DefaultServer>(c => { c.DisableFeature<AutoSubscribe>(); },
+                metadata => metadata.RegisterPublisherFor<Event, Publisher>());
         }
 
         public class Handler : IHandleMessages<Event>
@@ -103,7 +104,7 @@ public class When_unsubscribing_from_event : NServiceBusAcceptanceTest
     {
         public Subscriber2()
         {
-            EndpointSetup<DefaultServer>(c => { c.DisableFeature<AutoSubscribe>(); });
+            EndpointSetup<DefaultServer>(c => { c.DisableFeature<AutoSubscribe>(); }, metadata => metadata.RegisterPublisherFor<Event, Publisher>());
         }
 
         public class Handler : IHandleMessages<Event>

--- a/src/NServiceBus.AcceptanceTests/Routing/When_base_event_from_2_publishers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_base_event_from_2_publishers.cs
@@ -50,8 +50,7 @@ public class When_base_event_from_2_publishers : NServiceBusAcceptanceTest
 
     public class Publisher1 : EndpointConfigurationBuilder
     {
-        public Publisher1()
-        {
+        public Publisher1() =>
             EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
             {
                 context.AddTrace($"{Conventions.EndpointNamingConvention(typeof(Publisher1))} SubscriberEndpoint={s.SubscriberEndpoint}");
@@ -59,14 +58,12 @@ public class When_base_event_from_2_publishers : NServiceBusAcceptanceTest
                 {
                     context.SubscribedToPublisher1 = true;
                 }
-            }));
-        }
+            }), metadata => metadata.RegisterSelfAsPublisherFor<DerivedEvent1>(this));
     }
 
     public class Publisher2 : EndpointConfigurationBuilder
     {
-        public Publisher2()
-        {
+        public Publisher2() =>
             EndpointSetup<DefaultPublisher>(b => b.OnEndpointSubscribed<Context>((s, context) =>
             {
                 context.AddTrace($"{Conventions.EndpointNamingConvention(typeof(Publisher2))} SubscriberEndpoint={s.SubscriberEndpoint}");
@@ -75,29 +72,21 @@ public class When_base_event_from_2_publishers : NServiceBusAcceptanceTest
                 {
                     context.SubscribedToPublisher2 = true;
                 }
-            }));
-        }
+            }), metadata => metadata.RegisterSelfAsPublisherFor<DerivedEvent2>(this));
     }
 
     public class Subscriber1 : EndpointConfigurationBuilder
     {
-        public Subscriber1()
-        {
+        public Subscriber1() =>
             EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(),
                 metadata =>
                 {
-                    metadata.RegisterPublisherFor<DerivedEvent1>(typeof(Publisher1));
-                    metadata.RegisterPublisherFor<DerivedEvent2>(typeof(Publisher2));
+                    metadata.RegisterPublisherFor<DerivedEvent1, Publisher1>();
+                    metadata.RegisterPublisherFor<DerivedEvent2, Publisher2>();
                 });
-        }
 
-        public class Handler : IHandleMessages<BaseEvent>
+        public class Handler(Context testContext) : IHandleMessages<BaseEvent>
         {
-            public Handler(Context context)
-            {
-                testContext = context;
-            }
-
             public Task Handle(BaseEvent message, IMessageHandlerContext context)
             {
                 if (message.GetType().FullName.Contains(nameof(DerivedEvent1)))
@@ -111,23 +100,12 @@ public class When_base_event_from_2_publishers : NServiceBusAcceptanceTest
 
                 return Task.CompletedTask;
             }
-
-            Context testContext;
         }
     }
 
+    public class BaseEvent : IEvent;
 
-    public class BaseEvent : IEvent
-    {
-    }
+    public class DerivedEvent1 : BaseEvent;
 
-
-    public class DerivedEvent1 : BaseEvent
-    {
-    }
-
-
-    public class DerivedEvent2 : BaseEvent
-    {
-    }
+    public class DerivedEvent2 : BaseEvent;
 }

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing.cs
@@ -119,7 +119,7 @@ public class When_publishing : NServiceBusAcceptanceTest
                     }
                 });
                 b.DisableFeature<AutoSubscribe>();
-            });
+            }, metadata => metadata.RegisterSelfAsPublisherFor<MyEvent>(this));
         }
     }
 
@@ -135,7 +135,7 @@ public class When_publishing : NServiceBusAcceptanceTest
                     context.AddTrace($"{subscriber3} is now subscribed");
                     context.Subscriber3Subscribed = true;
                 }
-            }));
+            }), metadata => metadata.RegisterSelfAsPublisherFor<IFoo>(this));
         }
     }
 
@@ -144,7 +144,7 @@ public class When_publishing : NServiceBusAcceptanceTest
         public Subscriber3()
         {
             EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(),
-                metadata => metadata.RegisterPublisherFor<IFoo>(typeof(Publisher3)));
+                metadata => metadata.RegisterPublisherFor<IFoo, Publisher3>());
         }
 
         public class MyHandler : IHandleMessages<IFoo>
@@ -169,7 +169,7 @@ public class When_publishing : NServiceBusAcceptanceTest
         public Subscriber1()
         {
             EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(),
-                 metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
+                 metadata => metadata.RegisterPublisherFor<MyEvent, Publisher>());
         }
 
         public class MyHandler : IHandleMessages<MyEvent>
@@ -195,7 +195,7 @@ public class When_publishing : NServiceBusAcceptanceTest
         public Subscriber2()
         {
             EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(),
-                metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
+                metadata => metadata.RegisterPublisherFor<MyEvent, Publisher>());
         }
 
         public class MyHandler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
@@ -73,7 +73,7 @@ public class When_publishing_an_event_implementing_two_unrelated_interfaces : NS
                         }
                     }
                 });
-            });
+            }, metadata => metadata.RegisterSelfAsPublisherFor<CompositeEvent>(this));
         }
     }
 
@@ -87,8 +87,8 @@ public class When_publishing_an_event_implementing_two_unrelated_interfaces : NS
                 },
                 metadata =>
                 {
-                    metadata.RegisterPublisherFor<IEventA>(typeof(Publisher));
-                    metadata.RegisterPublisherFor<IEventB>(typeof(Publisher));
+                    metadata.RegisterPublisherFor<IEventA, Publisher>();
+                    metadata.RegisterPublisherFor<IEventB, Publisher>();
                 });
         }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface.cs
@@ -56,7 +56,7 @@ public class When_publishing_an_interface : NServiceBusAcceptanceTest
                         context.Subscribed = true;
                     }
                 });
-            });
+            }, metadata => metadata.RegisterSelfAsPublisherFor<IMyEvent>(this));
         }
 
         class EventTypeSpy : IBehavior<IOutgoingLogicalMessageContext, IOutgoingLogicalMessageContext>
@@ -84,7 +84,7 @@ public class When_publishing_an_interface : NServiceBusAcceptanceTest
                 {
                     c.DisableFeature<AutoSubscribe>();
                 },
-                metadata => metadata.RegisterPublisherFor<IMyEvent>(typeof(Publisher)));
+                metadata => metadata.RegisterPublisherFor<IMyEvent, Publisher>());
         }
 
         public class MyHandler : IHandleMessages<IMyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface_with_unobtrusive.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface_with_unobtrusive.cs
@@ -57,7 +57,7 @@ public class When_publishing_an_interface_with_unobtrusive : NServiceBusAcceptan
                         context.Subscribed = true;
                     }
                 });
-            }).ExcludeType<IMyEvent>(); // remove that type from assembly scanning to simulate what would happen with true unobtrusive mode
+            }, metadata => metadata.RegisterSelfAsPublisherFor<IMyEvent>(this)).ExcludeType<IMyEvent>(); // remove that type from assembly scanning to simulate what would happen with true unobtrusive mode
         }
 
         class EventTypeSpy : IBehavior<IOutgoingLogicalMessageContext, IOutgoingLogicalMessageContext>
@@ -86,7 +86,7 @@ public class When_publishing_an_interface_with_unobtrusive : NServiceBusAcceptan
                 c.Conventions().DefiningEventsAs(t => t.Namespace != null && t.Name.EndsWith("Event"));
                 c.DisableFeature<AutoSubscribe>();
             },
-            metadata => metadata.RegisterPublisherFor<IMyEvent>(typeof(Publisher)));
+            metadata => metadata.RegisterPublisherFor<IMyEvent, Publisher>());
         }
 
         public class MyHandler : IHandleMessages<IMyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_pre_created_interface.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_pre_created_interface.cs
@@ -56,7 +56,7 @@ public class When_publishing_pre_created_interface : NServiceBusAcceptanceTest
                         context.Subscribed = true;
                     }
                 });
-            });
+            }, metadata => metadata.RegisterSelfAsPublisherFor<IMyEvent>(this));
         }
 
         public class StartMessageHandler : IHandleMessages<StartMessage>
@@ -99,7 +99,7 @@ public class When_publishing_pre_created_interface : NServiceBusAcceptanceTest
                 {
                     c.DisableFeature<AutoSubscribe>();
                 },
-                metadata => metadata.RegisterPublisherFor<IMyEvent>(typeof(Publisher)));
+                metadata => metadata.RegisterPublisherFor<IMyEvent, Publisher>());
         }
 
         public class MyHandler : IHandleMessages<IMyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_using_base_type.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_using_base_type.cs
@@ -52,7 +52,7 @@ public class When_publishing_using_base_type : NServiceBusAcceptanceTest
                 {
                     context.Subscriber1Subscribed = true;
                 }
-            }));
+            }), metadata => metadata.RegisterSelfAsPublisherFor<EventMessage>(this));
         }
     }
 
@@ -60,7 +60,7 @@ public class When_publishing_using_base_type : NServiceBusAcceptanceTest
     {
         public Subscriber1()
         {
-            EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(), p => p.RegisterPublisherFor<EventMessage>(typeof(Publisher)));
+            EndpointSetup<DefaultServer>(c => c.DisableFeature<AutoSubscribe>(), p => p.RegisterPublisherFor<EventMessage, Publisher>());
         }
 
         public class MyHandler : IHandleMessages<EventMessage>

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_with_overridden_local_address.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_with_overridden_local_address.cs
@@ -46,7 +46,7 @@ public class When_publishing_with_overridden_local_address : NServiceBusAcceptan
                 {
                     context.Subscriber1Subscribed = true;
                 }
-            }));
+            }), metadata => metadata.RegisterSelfAsPublisherFor<MyEvent>(this));
         }
     }
 
@@ -59,7 +59,7 @@ public class When_publishing_with_overridden_local_address : NServiceBusAcceptan
                 builder.DisableFeature<AutoSubscribe>();
                 builder.OverrideLocalAddress("myinputqueue");
             },
-            metadata => metadata.RegisterPublisherFor<MyEvent>(typeof(Publisher)));
+            metadata => metadata.RegisterPublisherFor<MyEvent, Publisher>());
         }
 
         public class MyHandler : IHandleMessages<MyEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/When_registering_publishers_unobtrusive_messages_code.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_registering_publishers_unobtrusive_messages_code.cs
@@ -40,7 +40,7 @@ public class When_registering_publishers_unobtrusive_messages_code : NServiceBus
             {
                 c.OnEndpointSubscribed<Context>((e, ctx) => ctx.Subscribed = true);
                 c.Conventions().DefiningEventsAs(t => t == typeof(SomeEvent));
-            }).ExcludeType<SomeEvent>();
+            }, metadata => metadata.RegisterSelfAsPublisherFor<SomeEvent>(this)).ExcludeType<SomeEvent>();
         }
     }
 
@@ -50,7 +50,7 @@ public class When_registering_publishers_unobtrusive_messages_code : NServiceBus
         {
             EndpointSetup<DefaultServer>(
                 c => c.Conventions().DefiningEventsAs(t => t == typeof(SomeEvent)),
-                metadata => metadata.RegisterPublisherFor<SomeEvent>(typeof(Publisher)));
+                metadata => metadata.RegisterPublisherFor<SomeEvent, Publisher>());
         }
 
         public class Handler : IHandleMessages<SomeEvent>

--- a/src/NServiceBus.AcceptanceTests/Routing/When_registering_publishers_unobtrusive_messages_config.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_registering_publishers_unobtrusive_messages_config.cs
@@ -40,7 +40,7 @@ public class When_registering_publishers_unobtrusive_messages_config : NServiceB
             {
                 c.OnEndpointSubscribed<Context>((e, ctx) => ctx.Subscribed = true);
                 c.Conventions().DefiningEventsAs(t => t == typeof(SomeEvent));
-            }).ExcludeType<SomeEvent>();
+            }, metadata => metadata.RegisterSelfAsPublisherFor<SomeEvent>(this)).ExcludeType<SomeEvent>();
         }
     }
 
@@ -49,7 +49,7 @@ public class When_registering_publishers_unobtrusive_messages_config : NServiceB
         public Subscriber()
         {
             EndpointSetup<DefaultServer>(c => c.Conventions().DefiningEventsAs(t => t == typeof(SomeEvent)),
-            metadata => metadata.RegisterPublisherFor<SomeEvent>(typeof(Publisher)));
+            metadata => metadata.RegisterPublisherFor<SomeEvent, Publisher>());
         }
 
         public class Handler : IHandleMessages<SomeEvent>

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_replying_to_saga_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_replying_to_saga_event.cs
@@ -44,7 +44,7 @@ public class When_replying_to_saga_event : NServiceBusAcceptanceTest
     {
         public ReplyEndpoint()
         {
-            EndpointSetup<DefaultServer>(b => b.DisableFeature<AutoSubscribe>(), metadata => metadata.RegisterPublisherFor<DidSomething>(typeof(SagaEndpoint)));
+            EndpointSetup<DefaultServer>(b => b.DisableFeature<AutoSubscribe>(), metadata => metadata.RegisterPublisherFor<DidSomething, SagaEndpoint>());
         }
 
         class DidSomethingHandler : IHandleMessages<DidSomething>
@@ -66,7 +66,7 @@ public class When_replying_to_saga_event : NServiceBusAcceptanceTest
             EndpointSetup<DefaultPublisher>(b =>
             {
                 b.OnEndpointSubscribed<Context>((s, context) => { context.Subscribed = true; });
-            });
+            }, metadata => metadata.RegisterSelfAsPublisherFor<DidSomething>(this));
         }
 
         public class ReplyToPubMsgSaga : Saga<ReplyToPubMsgSaga.ReplyToPubMsgSagaData>, IAmStartedByMessages<StartSaga>, IHandleMessages<DidSomethingResponse>

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_base_event_from_other_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_base_event_from_other_saga.cs
@@ -48,7 +48,7 @@ public class When_started_by_base_event_from_other_saga : NServiceBusAcceptanceT
             {
                 context.AddTrace($"Subscription received for {s.SubscriberEndpoint}");
                 context.IsEventSubscriptionReceived = true;
-            }));
+            }), metadata => metadata.RegisterSelfAsPublisherFor<ISomethingHappenedEvent>(this));
         }
     }
 
@@ -60,7 +60,7 @@ public class When_started_by_base_event_from_other_saga : NServiceBusAcceptanceT
             {
                 c.DisableFeature<AutoSubscribe>();
             },
-            metadata => metadata.RegisterPublisherFor<IBaseEvent>(typeof(Publisher)));
+            metadata => metadata.RegisterPublisherFor<IBaseEvent, Publisher>());
         }
 
         public class SagaStartedByBaseEvent : Saga<SagaStartedByBaseEvent.SagaStartedByBaseEventSagaData>, IAmStartedByMessages<IBaseEvent>

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_event_from_another_saga.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_started_by_event_from_another_saga.cs
@@ -53,7 +53,7 @@ public class When_started_by_event_from_another_saga : NServiceBusAcceptanceTest
             EndpointSetup<DefaultPublisher>(b =>
             {
                 b.OnEndpointSubscribed<Context>((s, context) => { context.IsEventSubscriptionReceived = true; });
-            });
+            }, metadata => metadata.RegisterSelfAsPublisherFor<ISomethingHappenedEvent>(this));
         }
 
         public class EventFromOtherSaga1 : Saga<EventFromOtherSaga1.EventFromOtherSaga1Data>,
@@ -109,7 +109,7 @@ public class When_started_by_event_from_another_saga : NServiceBusAcceptanceTest
             {
                 c.DisableFeature<AutoSubscribe>();
             },
-            metadata => metadata.RegisterPublisherFor<ISomethingHappenedEvent>(typeof(SagaThatPublishesAnEvent)));
+            metadata => metadata.RegisterPublisherFor<ISomethingHappenedEvent, SagaThatPublishesAnEvent>());
         }
 
         public class EventFromOtherSaga2 : Saga<EventFromOtherSaga2.EventFromOtherSaga2Data>,

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_two_sagas_subscribe_to_the_same_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_two_sagas_subscribe_to_the_same_event.cs
@@ -44,7 +44,7 @@ public class When_two_sagas_subscribe_to_the_same_event : NServiceBusAcceptanceT
             EndpointSetup<DefaultPublisher>(b =>
             {
                 b.OnEndpointSubscribed<Context>((s, context) => { context.Subscribed = true; });
-            });
+            }, metadata => metadata.RegisterSelfAsPublisherFor<GroupPendingEvent>(this));
         }
 
         class OpenGroupCommandHandler : IHandleMessages<OpenGroupCommand>
@@ -67,7 +67,7 @@ public class When_two_sagas_subscribe_to_the_same_event : NServiceBusAcceptanceT
                 {
                     c.ConfigureRouting().RouteToEndpoint(typeof(OpenGroupCommand), typeof(Publisher));
                 },
-                metadata => metadata.RegisterPublisherFor<GroupPendingEvent>(typeof(Publisher)));
+                metadata => metadata.RegisterPublisherFor<GroupPendingEvent, Publisher>());
         }
 
         public class Saga1 : Saga<Saga1.MySaga1Data>,

--- a/src/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
+++ b/src/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
@@ -74,7 +74,7 @@ public class When_multiple_versions_of_a_message_is_published : NServiceBusAccep
                 {
                     context.V2Subscribed = true;
                 }
-            }));
+            }), metadata => metadata.RegisterSelfAsPublisherFor<V2Event>(this));
         }
     }
 
@@ -83,7 +83,7 @@ public class When_multiple_versions_of_a_message_is_published : NServiceBusAccep
         public V1Subscriber()
         {
             EndpointSetup<DefaultServer>(b => b.DisableFeature<AutoSubscribe>(),
-                metadata => metadata.RegisterPublisherFor<V1Event>(typeof(V2Publisher)))
+                metadata => metadata.RegisterPublisherFor<V1Event, V2Publisher>())
                 .ExcludeType<V2Event>();
         }
 
@@ -109,7 +109,7 @@ public class When_multiple_versions_of_a_message_is_published : NServiceBusAccep
         public V2Subscriber()
         {
             EndpointSetup<DefaultServer>(b => b.DisableFeature<AutoSubscribe>(),
-                 metadata => metadata.RegisterPublisherFor<V2Event>(typeof(V2Publisher)));
+                 metadata => metadata.RegisterPublisherFor<V2Event, V2Publisher>());
         }
 
         class V2Handler : IHandleMessages<V2Event>

--- a/src/NServiceBus.Core/Extensibility/ContextBag.cs
+++ b/src/NServiceBus.Core/Extensibility/ContextBag.cs
@@ -30,7 +30,7 @@ public class ContextBag : IReadOnlyContextBag
     }
 
     /// <summary>
-    /// Tries to retrieves the specified type from the context.
+    /// Tries to retrieve the specified type from the context.
     /// </summary>
     /// <typeparam name="T">The type to retrieve.</typeparam>
     /// <param name="result">The type instance.</param>
@@ -41,7 +41,7 @@ public class ContextBag : IReadOnlyContextBag
     }
 
     /// <summary>
-    /// Tries to retrieves the specified type from the context.
+    /// Tries to retrieve the specified type from the context.
     /// </summary>
     /// <typeparam name="T">The type to retrieve.</typeparam>
     /// <param name="key">The key of the value being looked up.</param>

--- a/src/NServiceBus.Learning.AcceptanceTests/ConfigureEndpointLearningTransport.cs
+++ b/src/NServiceBus.Learning.AcceptanceTests/ConfigureEndpointLearningTransport.cs
@@ -2,12 +2,13 @@ namespace NServiceBus.AcceptanceTests;
 
 using System.IO;
 using System.Threading.Tasks;
+using AcceptanceTesting.Customization;
 using NServiceBus;
 using NServiceBus.AcceptanceTesting.Support;
 using NServiceBus.Transport;
 using NUnit.Framework;
 
-public class ConfigureEndpointLearningTransport : IConfigureEndpointTestExecution
+public class ConfigureEndpointLearningTransport(bool enforcePublisherMetadata = true) : IConfigureEndpointTestExecution
 {
     public Task Cleanup()
     {
@@ -28,6 +29,11 @@ public class ConfigureEndpointLearningTransport : IConfigureEndpointTestExecutio
         var testRunId = TestContext.CurrentContext.Test.ID;
 
         storageDir = Path.Combine(Path.GetTempPath(), "learn", testRunId);
+
+        if (enforcePublisherMetadata)
+        {
+            configuration.EnforcePublisherMetadataRegistration(endpointName, publisherMetadata);
+        }
 
         //we want the tests to be exposed to concurrency
         configuration.LimitMessageProcessingConcurrencyTo(PushRuntimeSettings.Default.MaxConcurrency);


### PR DESCRIPTION
Brings back https://github.com/Particular/NServiceBus/pull/7257 to release-9.2

Contains a cherry pick of the typo changes in #7247