### PR TITLE
Use shared workflow for code analysis

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -7,17 +7,6 @@ on:
       - release-*
   pull_request:
   workflow_dispatch:
-env:
-  DOTNET_NOLOGO: true
-defaults:
-  run:
-    shell: pwsh
 jobs:
   code-analysis:
-    name: Code Analysis
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Repo integrity tests
-        uses: Particular/repo-integrity-action@main
+    uses: particular/shared-workflows/.github/workflows/code-analysis.yml@main


### PR DESCRIPTION
The new code analysis was not working because the NServiceBus repo is using a global.json file stipulating .NET 9 while the code analysis action itself is built in .NET 8.

This now uses a shared workflow so that the workflow synced to each repo is minimal. The workfow and action itself has been updated so that it changes paths to avoid the target repo's global.json getting in the way.