### PR TITLE
Always scan message assemblies

### DIFF
--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -24,6 +24,8 @@ class EndpointCreator
         var settings = endpointConfiguration.Settings;
         CheckIfSettingsWhereUsedToCreateAnotherEndpoint(settings);
 
+        IncludeMessageAssembliesInScan(settings);
+
         var assemblyScanningComponent = AssemblyScanningComponent.Initialize(settings.Get<AssemblyScanningComponent.Configuration>(), settings);
 
         endpointConfiguration.FinalizeConfiguration(assemblyScanningComponent.AvailableTypes);
@@ -43,6 +45,17 @@ class EndpointCreator
             }
 
             settings.Set("UsedToCreateEndpoint", true);
+        }
+    }
+
+    static void IncludeMessageAssembliesInScan(SettingsHolder settings)
+    {
+        var routingComponentSettings = settings.Get<RoutingComponent.Settings>();
+        var scanningComponentSettings = settings.Get<AssemblyScanningComponent.Configuration>();
+
+        foreach (var messageAssembly in routingComponentSettings.MessageAssemblies.GetAll())
+        {
+            scanningComponentSettings.AssemblyScannerConfiguration.AdditionalAssemblies.Add(messageAssembly);
         }
     }
 

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -72,6 +72,9 @@ public class AssemblyScanner
 
     internal string AdditionalAssemblyScanningPath { get; set; }
 
+    internal void ScanAdditionalAssembly(Assembly assembly)
+        => additionalAssemblies.Add(assembly);
+
     /// <summary>
     /// Traverses the specified base directory including all sub-directories, generating a list of assemblies that should be
     /// scanned for handlers, a list of skipped files, and a list of errors that occurred while scanning.
@@ -143,6 +146,14 @@ public class AssemblyScanner
                 {
                     AddTypesToResult(assembly, results);
                 }
+            }
+        }
+
+        foreach (var additionalAssembly in additionalAssemblies)
+        {
+            if (ScanAssembly(additionalAssembly, processed))
+            {
+                AddTypesToResult(additionalAssembly, results);
             }
         }
 
@@ -404,6 +415,7 @@ public class AssemblyScanner
     readonly string baseDirectoryToScan;
     HashSet<Type> typesToSkip = [];
     HashSet<string> assembliesToSkip = new(StringComparer.OrdinalIgnoreCase);
+    HashSet<Assembly> additionalAssemblies = [];
     const string NServiceBusCoreAssemblyName = "NServiceBus.Core";
     const string NServiceBusMessageInterfacesAssemblyName = "NServiceBus.MessageInterfaces";
 

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
@@ -70,4 +70,5 @@ public class AssemblyScannerConfiguration
 
     internal List<string> ExcludedAssemblies { get; } = [];
     internal List<Type> ExcludedTypes { get; } = [];
+    internal HashSet<Assembly> AdditionalAssemblies = [];
 }

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
@@ -38,6 +38,10 @@ class AssemblyScanningComponent
         assemblyScanner.ScanFileSystemAssemblies = assemblyScannerSettings.ScanFileSystemAssemblies;
         assemblyScanner.ScanAppDomainAssemblies = assemblyScannerSettings.ScanAppDomainAssemblies;
         assemblyScanner.AdditionalAssemblyScanningPath = assemblyScannerSettings.AdditionalAssemblyScanningPath;
+        foreach (var additionalAssembly in assemblyScannerSettings.AdditionalAssemblies)
+        {
+            assemblyScanner.ScanAdditionalAssembly(additionalAssembly);
+        }
 
         if (!assemblyScanner.ScanAppDomainAssemblies && !assemblyScanner.ScanFileSystemAssemblies)
         {

--- a/src/NServiceBus.Core/Routing/MessageAssemblies.cs
+++ b/src/NServiceBus.Core/Routing/MessageAssemblies.cs
@@ -1,0 +1,17 @@
+﻿namespace NServiceBus;
+
+using System.Collections.Generic;
+using System.Reflection;
+
+partial class RoutingComponent
+{
+    internal class MessageAssemblies
+    {
+        readonly HashSet<Assembly> assemblies = [];
+
+        public void Add(Assembly assembly)
+            => assemblies.Add(assembly);
+
+        public Assembly[] GetAll() => [.. assemblies];
+    }
+}

--- a/src/NServiceBus.Core/Routing/RoutingComponent.Settings.cs
+++ b/src/NServiceBus.Core/Routing/RoutingComponent.Settings.cs
@@ -29,6 +29,8 @@ partial class RoutingComponent
 
         public Publishers Publishers => settings.GetOrCreate<Publishers>();
 
+        internal MessageAssemblies MessageAssemblies => settings.GetOrCreate<MessageAssemblies>();
+
         public bool EnforceBestPractices
         {
             get => settings.Get<bool>("NServiceBus.Routing.EnforceBestPractices");

--- a/src/NServiceBus.Core/Routing/RoutingSettings.cs
+++ b/src/NServiceBus.Core/Routing/RoutingSettings.cs
@@ -32,6 +32,7 @@ public class RoutingSettings : ExposeSettings
         ThrowOnAddress(destination);
 
         Settings.Get<RoutingComponent.Settings>().ConfiguredUnicastRoutes.Add(new TypeRouteSource(messageType, UnicastRoute.CreateFromEndpointName(destination)));
+        Settings.Get<RoutingComponent.Settings>().MessageAssemblies.Add(messageType.Assembly);
     }
 
     /// <summary>
@@ -47,6 +48,7 @@ public class RoutingSettings : ExposeSettings
         ThrowOnAddress(destination);
 
         Settings.Get<RoutingComponent.Settings>().ConfiguredUnicastRoutes.Add(new AssemblyRouteSource(assembly, UnicastRoute.CreateFromEndpointName(destination)));
+        Settings.Get<RoutingComponent.Settings>().MessageAssemblies.Add(assembly);
     }
 
     /// <summary>
@@ -66,6 +68,7 @@ public class RoutingSettings : ExposeSettings
         @namespace = @namespace == string.Empty ? null : @namespace;
 
         Settings.Get<RoutingComponent.Settings>().ConfiguredUnicastRoutes.Add(new NamespaceRouteSource(assembly, @namespace, UnicastRoute.CreateFromEndpointName(destination)));
+        Settings.Get<RoutingComponent.Settings>().MessageAssemblies.Add(assembly);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #6967

This change means that any assembly referenced by routing is included in assembly scanning, even if it does not reference an NServiceBus library. 

NOTE: This does not help in cases where a message assembly only contains messages that the endpoint handles. i.e. If you have message handlers for messages found in an assembly but do not send or publish a message in the assembly, the assembly will not be scanned.

- [ ] Write tests