### PR TITLE
Overriding the host name does not work consistently

### DIFF
--- a/src/NServiceBus.Core.Tests/Hosting/HostInfoSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Hosting/HostInfoSettingsTests.cs
@@ -37,7 +37,10 @@ public class HostInfoSettingsTests
 
         busConfig.UniquelyIdentifyRunningInstance().UsingHostName("overridenhostname");
 
-        var hostName = RuntimeEnvironment.MachineName;
-        Assert.That(hostName, Is.EqualTo("overridenhostname"));
+        var runtimeMachineName = RuntimeEnvironment.MachineName;
+        Assert.That(runtimeMachineName, Is.EqualTo("overridenhostname"));
+
+        var settingsMachineName = busConfig.Settings.Get<HostingComponent.Settings>().Properties["Machine"];
+        Assert.That(settingsMachineName, Is.EqualTo("overridenhostname"));
     }
 }

--- a/src/NServiceBus.Core/Hosting/HostInfoSettings.cs
+++ b/src/NServiceBus.Core/Hosting/HostInfoSettings.cs
@@ -2,7 +2,6 @@ namespace NServiceBus;
 
 using System;
 using Hosting;
-using NServiceBus.Support;
 
 /// <summary>
 /// Configuration class for <see cref="HostInformation" /> settings.
@@ -74,7 +73,9 @@ public class HostInfoSettings
     public HostInfoSettings UsingHostName(string hostName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(hostName);
-        RuntimeEnvironment.SetMachineName(hostName);
+
+        config.Settings.Get<HostingComponent.Settings>().UpdateHost(hostName);
+
         return this;
     }
 

--- a/src/NServiceBus.Core/Hosting/HostingComponent.Settings.cs
+++ b/src/NServiceBus.Core/Hosting/HostingComponent.Settings.cs
@@ -104,6 +104,14 @@ partial class HostingComponent
             settings.Set(HostIdSettingsKey, DeterministicGuid.Create(fullPathToStartingExe, RuntimeEnvironment.MachineName));
         }
 
+        internal void UpdateHost(string hostName)
+        {
+            RuntimeEnvironment.SetMachineName(hostName);
+            settings.Set(HostIdSettingsKey, DeterministicGuid.Create(fullPathToStartingExe, hostName));
+            Properties["Machine"] = hostName;
+            settings.SetDefault(DisplayNameSettingsKey, hostName);
+        }
+
         readonly SettingsHolder settings;
         readonly string fullPathToStartingExe;
 


### PR DESCRIPTION
Backport of #7282 which fixes #7026 for the release-9.2 branch