### PR TITLE
New API include assembly in scan

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -21,6 +21,7 @@ namespace NServiceBus
         public bool ThrowExceptions { get; set; }
         public void ExcludeAssemblies(params string[] assemblies) { }
         public void ExcludeTypes(params System.Type[] types) { }
+        public void IncludeAssembly(System.Reflection.Assembly assembly) { }
     }
     public static class AssemblyScannerConfigurationExtensions
     {

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanner.cs
@@ -72,6 +72,8 @@ public class AssemblyScanner
 
     internal string AdditionalAssemblyScanningPath { get; set; }
 
+    internal List<Assembly> AdditionalAssemblies { get; set; }
+
     /// <summary>
     /// Traverses the specified base directory including all sub-directories, generating a list of assemblies that should be
     /// scanned for handlers, a list of skipped files, and a list of errors that occurred while scanning.
@@ -143,6 +145,14 @@ public class AssemblyScanner
                 {
                     AddTypesToResult(assembly, results);
                 }
+            }
+        }
+
+        if (AdditionalAssemblies is not null)
+        {
+            foreach (var assembly in AdditionalAssemblies)
+            {
+                AddTypesToResult(assembly, results);
             }
         }
 

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScannerConfiguration.cs
@@ -55,6 +55,17 @@ public class AssemblyScannerConfiguration
     }
 
     /// <summary>
+    /// Additional <see cref="Assembly"/> to include in assembly scanning.
+    /// Allows scanning assemblies that do not reference NServiceBus assemblies.
+    /// </summary>
+    public void IncludeAssembly(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+
+        AdditionalAssemblies.Add(assembly);
+    }
+
+    /// <summary>
     /// A list of <see cref="Type" />s to ignore in the assembly scanning.
     /// </summary>
     public void ExcludeTypes(params Type[] types)
@@ -70,4 +81,5 @@ public class AssemblyScannerConfiguration
 
     internal List<string> ExcludedAssemblies { get; } = [];
     internal List<Type> ExcludedTypes { get; } = [];
+    internal List<Assembly> AdditionalAssemblies { get; } = [];
 }

--- a/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
+++ b/src/NServiceBus.Core/Hosting/Helpers/AssemblyScanningComponent.cs
@@ -38,6 +38,7 @@ class AssemblyScanningComponent
         assemblyScanner.ScanFileSystemAssemblies = assemblyScannerSettings.ScanFileSystemAssemblies;
         assemblyScanner.ScanAppDomainAssemblies = assemblyScannerSettings.ScanAppDomainAssemblies;
         assemblyScanner.AdditionalAssemblyScanningPath = assemblyScannerSettings.AdditionalAssemblyScanningPath;
+        assemblyScanner.AdditionalAssemblies = assemblyScannerSettings.AdditionalAssemblies;
 
         if (!assemblyScanner.ScanAppDomainAssemblies && !assemblyScanner.ScanFileSystemAssemblies)
         {

--- a/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
+++ b/src/NServiceBus.Core/Unicast/Messages/MessageMetadataRegistry.cs
@@ -114,11 +114,12 @@ public class MessageMetadataRegistry
         {
             try
             {
+                Logger.Warn($"Message type identifier '{messageTypeIdentifier}' was dynamically loaded. Consider including the assembly containing this type to the assembly scanner to prevent problems when the assembly version changes.");
                 return Type.GetType(messageTypeIdentifier);
             }
             catch (Exception ex)
             {
-                Logger.Warn($"Message type identifier '{messageTypeIdentifier}' could not be loaded", ex);
+                Logger.Warn($"Message type identifier '{messageTypeIdentifier}' could not be loaded. Consider including the assembly containing this type to the assembly scanner.", ex);
             }
         }
         else


### PR DESCRIPTION
Adds an API to include an assembly in scanning, even if it does not reference an NServiceBus assembly.

```csharp
endpointConfiguration.AssemblyScanner()
  .IncludeAssembly(
    typeof(MyMessage).Assembly
  );
```

This is useful when using unobtrusive message definitions as these assemblies do not need to reference NServiceBus assemblies.

As part of this change, the system notifies the user (WARN level log) when a message type is dynamically loaded (or could not be dynamically loaded) to use this API. Note that the results are cached so this message is only shown once per message type per endpoint run.