### PR TITLE
Checking endpoint started within When is no longer necessary

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_extending_command_routing_with_thisinstance.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_extending_command_routing_with_thisinstance.cs
@@ -20,7 +20,7 @@ public class When_extending_command_routing_with_thisinstance : NServiceBusAccep
     public async Task Should_route_according_to_distribution_strategy()
     {
         var ctx = await Scenario.Define<Context>()
-            .WithEndpoint<Endpoint>(b => b.When(c => c.EndpointsStarted, session =>
+            .WithEndpoint<Endpoint>(b => b.When(session =>
             {
                 var sendOptions = new SendOptions();
                 sendOptions.RouteToThisEndpoint();

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/MultiSubscribeToPolymorphicEvent.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/MultiSubscribeToPolymorphicEvent.cs
@@ -13,12 +13,12 @@ public class MultiSubscribeToPolymorphicEvent : NServiceBusAcceptanceTest
         Requires.NativePubSubSupport();
 
         var context = await Scenario.Define<Context>()
-            .WithEndpoint<Publisher1>(b => b.When(c => c.EndpointsStarted, (session, c) =>
+            .WithEndpoint<Publisher1>(b => b.When((session, c) =>
             {
                 c.AddTrace("Publishing MyEvent1");
                 return session.Publish(new MyEvent1());
             }))
-            .WithEndpoint<Publisher2>(b => b.When(c => c.EndpointsStarted, (session, c) =>
+            .WithEndpoint<Publisher2>(b => b.When((session, c) =>
             {
                 c.AddTrace("Publishing MyEvent2");
                 return session.Publish(new MyEvent2());

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_publishing_to_scaled_out_subscribers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_publishing_to_scaled_out_subscribers.cs
@@ -15,7 +15,7 @@ public class When_publishing_to_scaled_out_subscribers : NServiceBusAcceptanceTe
 
         var context = await Scenario.Define<Context>()
             .WithEndpoint<Publisher>(b => b
-                .When(c => c.EndpointsStarted, (session, c) => session.Publish(new MyEvent())))
+                .When(session => session.Publish(new MyEvent())))
             .WithEndpoint<SubscriberA>(b => b.CustomConfig(c => c.MakeInstanceUniquelyAddressable("1")))
             .WithEndpoint<SubscriberA>(b => b.CustomConfig(c => c.MakeInstanceUniquelyAddressable("2")))
             .WithEndpoint<SubscriberB>(b => b.CustomConfig(c => c.MakeInstanceUniquelyAddressable("1")))

--- a/src/NServiceBus.AcceptanceTests/Routing/When_base_event_from_2_publishers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_base_event_from_2_publishers.cs
@@ -19,7 +19,7 @@ public class When_base_event_from_2_publishers : NServiceBusAcceptanceTest
             .WithEndpoint<Publisher2>(b =>
                 b.When(c => c.SubscribedToPublisher2, session => session.Publish(new DerivedEvent2()))
             )
-            .WithEndpoint<Subscriber1>(b => b.When(c => c.EndpointsStarted, async (session, c) =>
+            .WithEndpoint<Subscriber1>(b => b.When(async (session, c) =>
             {
                 await session.Subscribe<DerivedEvent1>();
                 await session.Subscribe<DerivedEvent2>();

--- a/src/NServiceBus.AcceptanceTests/Routing/When_extending_command_routing.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_extending_command_routing.cs
@@ -20,7 +20,7 @@ public class When_extending_command_routing : NServiceBusAcceptanceTest
     {
         var ctx = await Scenario.Define<Context>()
             .WithEndpoint<Sender>(b =>
-                b.When(c => c.EndpointsStarted, async session =>
+                b.When(async session =>
                 {
                     await session.Send(new MyCommand());
                     await session.Send(new MyCommand());

--- a/src/NServiceBus.AcceptanceTests/Routing/When_using_custom_routing_strategy.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_using_custom_routing_strategy.cs
@@ -20,7 +20,7 @@ public class When_using_custom_routing_strategy : NServiceBusAcceptanceTest
     {
         var ctx = await Scenario.Define<Context>()
             .WithEndpoint<Sender>(b =>
-                b.When(c => c.EndpointsStarted, async session =>
+                b.When(async session =>
                 {
                     await session.Send(new MyCommand { Instance = Discriminator1 });
                     await session.Send(new MyCommand { Instance = Discriminator2 });


### PR DESCRIPTION
The scenario runner firsts starts all endpoints concurrently and then executes the whens concurrently