### PR TITLE
Make handler span surround the entire handler pipeline stage

### DIFF
--- a/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityFactoryTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityFactoryTests.cs
@@ -249,7 +249,7 @@ public class ActivityFactoryTests
         public void Should_not_start_activity_when_no_parent_activity_exists()
         {
             Type handlerType = typeof(StartHandlerActivity);
-            var activity = activityFactory.StartHandlerActivity(new MessageHandler((_, _, _) => Task.CompletedTask, handlerType), null);
+            var activity = activityFactory.StartHandlerActivity(new MessageHandler((_, _, _) => Task.CompletedTask, handlerType));
 
             Assert.That(activity, Is.Null, "should not start handler activity when no parent activity exists");
         }
@@ -262,7 +262,7 @@ public class ActivityFactoryTests
             using var ambientActivity = new Activity("ambient activity");
             ambientActivity.Start();
 
-            var activity = activityFactory.StartHandlerActivity(new MessageHandler((_, _, _) => Task.CompletedTask, handlerType), null);
+            var activity = activityFactory.StartHandlerActivity(new MessageHandler((_, _, _) => Task.CompletedTask, handlerType));
 
             Assert.That(activity, Is.Not.Null);
             var tags = activity.Tags.ToImmutableDictionary();
@@ -277,12 +277,9 @@ public class ActivityFactoryTests
             using var ambientActivity = new Activity("ambient activity");
             ambientActivity.Start();
 
-            var activity = activityFactory.StartHandlerActivity(new MessageHandler((_, _, _) => Task.CompletedTask, typeof(StartHandlerActivity)), sagaInstance);
+            var activity = activityFactory.StartHandlerActivity(new MessageHandler((_, _, _) => Task.CompletedTask, typeof(StartHandlerActivity)));
 
             Assert.That(activity, Is.Not.Null);
-            var tags = activity.Tags.ToImmutableDictionary();
-
-            Assert.That(tags[ActivityTags.HandlerSagaId], Is.EqualTo(sagaInstance.SagaId));
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
@@ -11,7 +11,7 @@ using Testing;
 [TestFixture]
 public class InvokeHandlerTerminatorTest
 {
-    InvokeHandlerTerminator terminator = new(new NoOpActivityFactory(), new IncomingPipelineMetrics(new TestMeterFactory(), "queue", "disc"));
+    InvokeHandlerTerminator terminator = new(new IncomingPipelineMetrics(new TestMeterFactory(), "queue", "disc"));
 
     [Test]
     public async Task When_saga_found_and_handler_is_saga_should_invoke_handler()

--- a/src/NServiceBus.Core.Tests/Unicast/LoadHandlersConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/LoadHandlersConnectorTests.cs
@@ -16,7 +16,7 @@ public class LoadHandlersConnectorTests
     [Test]
     public void Should_throw_when_there_are_no_registered_message_handlers()
     {
-        var behavior = new LoadHandlersConnector(new MessageHandlerRegistry());
+        var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(), new NoOpActivityFactory());
 
         var context = new TestableIncomingLogicalMessageContext();
 
@@ -29,7 +29,7 @@ public class LoadHandlersConnectorTests
     [Test]
     public void Should_throw_if_ambient_transaction_is_different_from_scope_used_by_transport()
     {
-        var behavior = new LoadHandlersConnector(new MessageHandlerRegistry());
+        var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(), new NoOpActivityFactory());
 
         var context = new TestableIncomingLogicalMessageContext();
 
@@ -49,7 +49,7 @@ public class LoadHandlersConnectorTests
     [Test]
     public void Should_throw_if_ambient_transaction_suppressed_when_transport_uses_a_scope()
     {
-        var behavior = new LoadHandlersConnector(new MessageHandlerRegistry());
+        var behavior = new LoadHandlersConnector(new MessageHandlerRegistry(), new NoOpActivityFactory());
 
         var context = new TestableIncomingLogicalMessageContext();
 
@@ -77,7 +77,7 @@ public class LoadHandlersConnectorTests
         context.Services.AddSingleton<FakeHandler>();
         context.Extensions.Set<IOutboxTransaction>(new NoOpOutboxTransaction());
 
-        var behavior = new LoadHandlersConnector(messageHandlerRegistry);
+        var behavior = new LoadHandlersConnector(messageHandlerRegistry, new NoOpActivityFactory());
 
         using (new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
         {

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/ActivityFactory.cs
@@ -2,7 +2,6 @@
 
 using System.Diagnostics;
 using Pipeline;
-using Sagas;
 using Transport;
 
 class ActivityFactory : IActivityFactory
@@ -84,7 +83,7 @@ class ActivityFactory : IActivityFactory
         return activity;
     }
 
-    public Activity StartHandlerActivity(MessageHandler messageHandler, ActiveSagaInstance saga)
+    public Activity StartHandlerActivity(MessageHandler messageHandler)
     {
         if (Activity.Current == null)
         {
@@ -98,11 +97,6 @@ class ActivityFactory : IActivityFactory
         {
             activity.DisplayName = messageHandler.HandlerType.Name;
             activity.AddTag(ActivityTags.HandlerType, messageHandler.HandlerType.FullName);
-
-            if (saga != null)
-            {
-                activity.AddTag(ActivityTags.HandlerSagaId, saga.SagaId);
-            }
         }
 
         return activity;

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/IActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/IActivityFactory.cs
@@ -2,12 +2,11 @@
 
 using System.Diagnostics;
 using Pipeline;
-using Sagas;
 using Transport;
 
 interface IActivityFactory
 {
     Activity StartIncomingPipelineActivity(MessageContext context);
     Activity StartOutgoingPipelineActivity(string activityName, string displayName, IBehaviorContext outgoingContext);
-    Activity StartHandlerActivity(MessageHandler messageHandler, ActiveSagaInstance saga);
+    Activity StartHandlerActivity(MessageHandler messageHandler);
 }

--- a/src/NServiceBus.Core/OpenTelemetry/Tracing/NoOpActivityFactory.cs
+++ b/src/NServiceBus.Core/OpenTelemetry/Tracing/NoOpActivityFactory.cs
@@ -2,7 +2,6 @@
 
 using System.Diagnostics;
 using Pipeline;
-using Sagas;
 using Transport;
 
 class NoOpActivityFactory : IActivityFactory
@@ -11,5 +10,5 @@ class NoOpActivityFactory : IActivityFactory
 
     public Activity StartOutgoingPipelineActivity(string activityName, string displayName, IBehaviorContext outgoingContext) => null;
 
-    public Activity StartHandlerActivity(MessageHandler messageHandler, ActiveSagaInstance saga) => null;
+    public Activity StartHandlerActivity(MessageHandler messageHandler) => null;
 }

--- a/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
+++ b/src/NServiceBus.Core/Receiving/ReceiveComponent.cs
@@ -66,9 +66,9 @@ partial class ReceiveComponent
             return new TransportReceiveToPhysicalMessageConnector(storage, b.GetRequiredService<IncomingPipelineMetrics>());
         }, "Allows to abort processing the message");
 
-        pipelineSettings.Register("LoadHandlersConnector", b => new LoadHandlersConnector(b.GetRequiredService<MessageHandlerRegistry>()), "Gets all the handlers to invoke from the MessageHandler registry based on the message type.");
+        pipelineSettings.Register("LoadHandlersConnector", b => new LoadHandlersConnector(b.GetRequiredService<MessageHandlerRegistry>(), hostingConfiguration.ActivityFactory), "Gets all the handlers to invoke from the MessageHandler registry based on the message type.");
 
-        pipelineSettings.Register("InvokeHandlers", sp => new InvokeHandlerTerminator(hostingConfiguration.ActivityFactory, sp.GetService<IncomingPipelineMetrics>()), "Calls the IHandleMessages<T>.Handle(T)");
+        pipelineSettings.Register("InvokeHandlers", sp => new InvokeHandlerTerminator(sp.GetService<IncomingPipelineMetrics>()), "Calls the IHandleMessages<T>.Handle(T)");
 
         var handlerDiagnostics = new Dictionary<string, List<string>>();
 

--- a/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
+++ b/src/NServiceBus.Core/Sagas/SagaPersistenceBehavior.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Logging;
@@ -110,6 +111,8 @@ class SagaPersistenceBehavior : IBehavior<IInvokeHandlerContext, IInvokeHandlerC
             context.Extensions.Get<SagaInvocationResult>().SagaFound();
             sagaInstanceState.AttachExistingEntity(loadedEntity);
         }
+
+        Activity.Current?.AddTag(ActivityTags.HandlerSagaId, sagaInstanceState.SagaId);
 
         await next(context).ConfigureAwait(false);
 
@@ -265,6 +268,7 @@ class SagaPersistenceBehavior : IBehavior<IInvokeHandlerContext, IInvokeHandlerC
                 return finderDefinition;
             }
         }
+
         return null;
     }
 


### PR DESCRIPTION
Going down this route enables the user to use pipeline behaviors to enrich the span if needed.

No tests had to be changed, but this is arguably a behavior change since the span now includes a larger chunk of the pipeline. I think that is ok, though.

Potential solution for https://github.com/Particular/NServiceBus/issues/7315

Docs changes to consider:

- [x] Show access to the handler span in https://docs.particular.net/samples/open-telemetry/customizing/
   - Will be done once we figure out when this will be released 
- [x] Not mentioned today either but perhaps mention the handler span in https://docs.particular.net/nservicebus/operations/opentelemetry#traces-emitted-span-structure
    - Went with a retitle instead https://github.com/Particular/docs.particular.net/pull/7077 