### PR TITLE
Fix learning competing consumers bug

### DIFF
--- a/src/NServiceBus.Core/Transports/Learning/AsyncFile.cs
+++ b/src/NServiceBus.Core/Transports/Learning/AsyncFile.cs
@@ -121,7 +121,7 @@ static class AsyncFile
 
             if (!IsFileLocked(targetPath))
             {
-                break;
+                return true;
             }
 
             await Task.Delay(100, cancellationToken).ConfigureAwait(false);
@@ -129,7 +129,7 @@ static class AsyncFile
             count++;
         }
 
-        return true;
+        return false;
     }
 
     static bool IsFileLocked(string filePath)

--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -32,7 +32,6 @@ class DirectoryBasedTransaction : ILearningTransportTransaction
 
         Directory.Delete(transactionDir, true);
         return false;
-
     }
 
     public async Task Commit(CancellationToken cancellationToken = default)

--- a/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
+++ b/src/NServiceBus.Core/Transports/Learning/DirectoryBasedTransaction.cs
@@ -19,12 +19,20 @@ class DirectoryBasedTransaction : ILearningTransportTransaction
 
     public string FileToProcess { get; private set; }
 
-    public Task<bool> BeginTransaction(string incomingFilePath, CancellationToken cancellationToken = default)
+    public async Task<bool> BeginTransaction(string incomingFilePath, CancellationToken cancellationToken = default)
     {
         Directory.CreateDirectory(transactionDir);
         FileToProcess = Path.Combine(transactionDir, Path.GetFileName(incomingFilePath));
 
-        return AsyncFile.Move(incomingFilePath, FileToProcess, cancellationToken);
+        var succeeded = await AsyncFile.Move(incomingFilePath, FileToProcess, cancellationToken).ConfigureAwait(false);
+        if (succeeded)
+        {
+            return true;
+        }
+
+        Directory.Delete(transactionDir, true);
+        return false;
+
     }
 
     public async Task Commit(CancellationToken cancellationToken = default)


### PR DESCRIPTION
- Moving the file to the `.pending` transaction folder only returns `true` if file exists and is not locked (and not just when all attempts have been used)
- `BeginTransaction` removes the `.pending` folder if fails to begin the transaction