### PR TITLE
Port fix learning competing consumers bug (#7324)

### DIFF
--- a/src/NServiceBus.Core/Transports/Learning/AsyncFile.cs
+++ b/src/NServiceBus.Core/Transports/Learning/AsyncFile.cs
@@ -121,7 +121,7 @@ static class AsyncFile
 
             if (!IsFileLocked(targetPath))
             {
-                break;
+                return true;
             }
 
             await Task.Delay(100, cancellationToken).ConfigureAwait(false);
@@ -129,7 +129,7 @@ static class AsyncFile
             count++;
         }
 
-        return true;
+        return false;
     }
 
     static bool IsFileLocked(string filePath)


### PR DESCRIPTION
* AsyncFile.Move returns true only if the file was read (i.e. exists and not locked)
* Clean up the .pending directory if unable to move and unlock the file