### PR TITLE
`ICompletableSynchronizedStorageSession` now inherits from `IAsyncDisposable`

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/AcceptanceTestingSynchronizedStorageSession.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/AcceptanceTestingSynchronizedStorageSession.cs
@@ -13,6 +13,11 @@ class AcceptanceTestingSynchronizedStorageSession : ICompletableSynchronizedStor
 {
     public AcceptanceTestingTransaction Transaction { get; private set; }
 
+    public void Dispose()
+    {
+        Transaction = null;
+    }
+
     public ValueTask DisposeAsync()
     {
         Transaction = null;

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/AcceptanceTestingSynchronizedStorageSession.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/AcceptanceTestingSynchronizedStorageSession.cs
@@ -13,7 +13,11 @@ class AcceptanceTestingSynchronizedStorageSession : ICompletableSynchronizedStor
 {
     public AcceptanceTestingTransaction Transaction { get; private set; }
 
-    public void Dispose() => Transaction = null;
+    public ValueTask DisposeAsync()
+    {
+        Transaction = null;
+        return ValueTask.CompletedTask;
+    }
 
     public ValueTask<bool> TryOpen(IOutboxTransaction transaction, ContextBag context,
         CancellationToken cancellationToken = default)

--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/AcceptanceTestingSynchronizedStorageSession.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingPersistence/AcceptanceTestingSynchronizedStorageSession.cs
@@ -13,15 +13,12 @@ class AcceptanceTestingSynchronizedStorageSession : ICompletableSynchronizedStor
 {
     public AcceptanceTestingTransaction Transaction { get; private set; }
 
-    public void Dispose()
-    {
-        Transaction = null;
-    }
+    public void Dispose() => Transaction = null;
 
     public ValueTask DisposeAsync()
     {
         Transaction = null;
-        return ValueTask.CompletedTask;
+        return default;
     }
 
     public ValueTask<bool> TryOpen(IOutboxTransaction transaction, ContextBag context,

--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_endpoint_is_warmed_up.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_endpoint_is_warmed_up.cs
@@ -139,16 +139,16 @@ public class When_endpoint_is_warmed_up : NServiceBusAcceptanceTest
 
         public IServiceScope CreateScope()
         {
-            var scope = ServiceProvider.CreateScope();
+            AsyncServiceScope scope = ServiceProvider.CreateAsyncScope();
             return new SpyScope(scope, RegisteredServices);
         }
 
-        class SpyScope : IServiceScope, IServiceProvider
+        class SpyScope : IServiceScope, IServiceProvider, IAsyncDisposable
         {
-            readonly IServiceScope decorated;
+            readonly AsyncServiceScope decorated;
             readonly Dictionary<Type, RegisteredService> registeredServices;
 
-            public SpyScope(IServiceScope decorated, Dictionary<Type, RegisteredService> registeredServices)
+            public SpyScope(AsyncServiceScope decorated, Dictionary<Type, RegisteredService> registeredServices)
             {
                 this.registeredServices = registeredServices;
                 this.decorated = decorated;
@@ -166,6 +166,8 @@ public class When_endpoint_is_warmed_up : NServiceBusAcceptanceTest
             }
 
             public void Dispose() => decorated.Dispose();
+
+            public async ValueTask DisposeAsync() => await decorated.DisposeAsync();
         }
 
         public class RegisteredService

--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_endpoint_is_warmed_up.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_endpoint_is_warmed_up.cs
@@ -139,7 +139,7 @@ public class When_endpoint_is_warmed_up : NServiceBusAcceptanceTest
 
         public IServiceScope CreateScope()
         {
-            AsyncServiceScope scope = ServiceProvider.CreateAsyncScope();
+            var scope = ServiceProvider.CreateAsyncScope();
             return new SpyScope(scope, RegisteredServices);
         }
 

--- a/src/NServiceBus.AcceptanceTests/Core/Reliability/SynchronizedStorage/When_opening_storage_session_outside_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Reliability/SynchronizedStorage/When_opening_storage_session_outside_pipeline.cs
@@ -85,7 +85,7 @@ public class When_opening_storage_session_outside_pipeline : NServiceBusAcceptan
                 protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                 {
                     using (var scope = provider.CreateScope())
-                    using (var completableSynchronizedStorageSession =
+                    await using (var completableSynchronizedStorageSession =
                            scope.ServiceProvider.GetRequiredService<ICompletableSynchronizedStorageSession>())
                     {
                         await completableSynchronizedStorageSession.Open(new ContextBag(), cancellationToken);

--- a/src/NServiceBus.AcceptanceTests/Core/Reliability/SynchronizedStorage/When_opening_storage_session_outside_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Reliability/SynchronizedStorage/When_opening_storage_session_outside_pipeline.cs
@@ -84,7 +84,7 @@ public class When_opening_storage_session_outside_pipeline : NServiceBusAcceptan
 
                 protected override async Task OnStart(IMessageSession session, CancellationToken cancellationToken = default)
                 {
-                    using (var scope = provider.CreateScope())
+                    await using (var scope = provider.CreateAsyncScope())
                     await using (var completableSynchronizedStorageSession =
                            scope.ServiceProvider.GetRequiredService<ICompletableSynchronizedStorageSession>())
                     {

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1669,7 +1669,7 @@ namespace NServiceBus.Persistence
         public static System.Threading.Tasks.ValueTask Open(this NServiceBus.Persistence.ICompletableSynchronizedStorageSession session, NServiceBus.Pipeline.IIncomingLogicalMessageContext context) { }
         public static System.Threading.Tasks.ValueTask Open(this NServiceBus.Persistence.ICompletableSynchronizedStorageSession session, NServiceBus.Outbox.IOutboxTransaction outboxTransaction, NServiceBus.Transport.TransportTransaction transportTransaction, NServiceBus.Extensibility.ContextBag contextBag, System.Threading.CancellationToken cancellationToken = default) { }
     }
-    public interface ICompletableSynchronizedStorageSession : NServiceBus.Persistence.ISynchronizedStorageSession, System.IDisposable
+    public interface ICompletableSynchronizedStorageSession : NServiceBus.Persistence.ISynchronizedStorageSession, System.IAsyncDisposable
     {
         System.Threading.Tasks.Task CompleteAsync(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task Open(NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1669,7 +1669,7 @@ namespace NServiceBus.Persistence
         public static System.Threading.Tasks.ValueTask Open(this NServiceBus.Persistence.ICompletableSynchronizedStorageSession session, NServiceBus.Pipeline.IIncomingLogicalMessageContext context) { }
         public static System.Threading.Tasks.ValueTask Open(this NServiceBus.Persistence.ICompletableSynchronizedStorageSession session, NServiceBus.Outbox.IOutboxTransaction outboxTransaction, NServiceBus.Transport.TransportTransaction transportTransaction, NServiceBus.Extensibility.ContextBag contextBag, System.Threading.CancellationToken cancellationToken = default) { }
     }
-    public interface ICompletableSynchronizedStorageSession : NServiceBus.Persistence.ISynchronizedStorageSession, System.IAsyncDisposable
+    public interface ICompletableSynchronizedStorageSession : NServiceBus.Persistence.ISynchronizedStorageSession, System.IAsyncDisposable, System.IDisposable
     {
         System.Threading.Tasks.Task CompleteAsync(System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task Open(NServiceBus.Extensibility.ContextBag context, System.Threading.CancellationToken cancellationToken = default);

--- a/src/NServiceBus.Core.Tests/Fakes/FakeSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/FakeSynchronizedStorageSession.cs
@@ -58,6 +58,11 @@ public sealed class FakeSynchronizedStorageSession : ICompletableSynchronizedSto
         return Task.CompletedTask;
     }
 
+    public void Dispose()
+    {
+        Transaction = null;
+    }
+
     public ValueTask DisposeAsync()
     {
         Transaction = null;

--- a/src/NServiceBus.Core.Tests/Fakes/FakeSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/FakeSynchronizedStorageSession.cs
@@ -66,7 +66,7 @@ public sealed class FakeSynchronizedStorageSession : ICompletableSynchronizedSto
     public ValueTask DisposeAsync()
     {
         Transaction = null;
-        return ValueTask.CompletedTask;
+        return default;
     }
 
     public Task CompleteAsync(CancellationToken cancellationToken = default)

--- a/src/NServiceBus.Core.Tests/Fakes/FakeSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/FakeSynchronizedStorageSession.cs
@@ -9,7 +9,7 @@ using NServiceBus.Persistence;
 using Outbox;
 using Transport;
 
-public class FakeSynchronizedStorageSession : ICompletableSynchronizedStorageSession
+public sealed class FakeSynchronizedStorageSession : ICompletableSynchronizedStorageSession
 {
     public FakeSynchronizedStorageSession(FakeTransaction transaction)
     {
@@ -58,10 +58,10 @@ public class FakeSynchronizedStorageSession : ICompletableSynchronizedStorageSes
         return Task.CompletedTask;
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
         Transaction = null;
-        GC.SuppressFinalize(this);
+        return ValueTask.CompletedTask;
     }
 
     public Task CompleteAsync(CancellationToken cancellationToken = default)

--- a/src/NServiceBus.Core/Persistence/Learning/LearningSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/LearningSynchronizedStorageSession.cs
@@ -13,6 +13,16 @@ using Transport;
 [SkipWeaving]
 class LearningSynchronizedStorageSession : ICompletableSynchronizedStorageSession
 {
+    public void Dispose()
+    {
+        foreach (var sagaFile in sagaFiles.Values)
+        {
+            sagaFile.Dispose();
+        }
+
+        sagaFiles.Clear();
+    }
+
     public async ValueTask DisposeAsync()
     {
         foreach (var sagaFile in sagaFiles.Values)

--- a/src/NServiceBus.Core/Persistence/Learning/LearningSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/LearningSynchronizedStorageSession.cs
@@ -13,11 +13,11 @@ using Transport;
 [SkipWeaving]
 class LearningSynchronizedStorageSession : ICompletableSynchronizedStorageSession
 {
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         foreach (var sagaFile in sagaFiles.Values)
         {
-            sagaFile.Dispose();
+            await sagaFile.DisposeAsync().ConfigureAwait(false);
         }
 
         sagaFiles.Clear();

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaStorageFile.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaStorageFile.cs
@@ -9,11 +9,24 @@ using System.Threading.Tasks;
 using Janitor;
 
 [SkipWeaving]
-class SagaStorageFile : IAsyncDisposable
+class SagaStorageFile : IDisposable, IAsyncDisposable
 {
     SagaStorageFile(FileStream fileStream)
     {
         this.fileStream = fileStream;
+    }
+
+    public void Dispose()
+    {
+        fileStream.Close();
+
+        if (isCompleted)
+        {
+            File.Delete(fileStream.Name);
+        }
+
+        fileStream.Dispose(); // Already closed, but for completeness
+        fileStream = null;
     }
 
     public async ValueTask DisposeAsync()

--- a/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaStorageFile.cs
+++ b/src/NServiceBus.Core/Persistence/Learning/SagaPersister/SagaStorageFile.cs
@@ -9,14 +9,14 @@ using System.Threading.Tasks;
 using Janitor;
 
 [SkipWeaving]
-class SagaStorageFile : IDisposable
+class SagaStorageFile : IAsyncDisposable
 {
     SagaStorageFile(FileStream fileStream)
     {
         this.fileStream = fileStream;
     }
 
-    public void Dispose()
+    public async ValueTask DisposeAsync()
     {
         fileStream.Close();
 
@@ -25,6 +25,7 @@ class SagaStorageFile : IDisposable
             File.Delete(fileStream.Name);
         }
 
+        await fileStream.DisposeAsync().ConfigureAwait(false); // Already closed, but for completeness
         fileStream = null;
     }
 

--- a/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
@@ -20,7 +20,10 @@ class LoadHandlersConnector(MessageHandlerRegistry messageHandlerRegistry, IActi
     {
         ValidateTransactionMode(context);
 
-        using var storageSession = context.Builder.GetService<ICompletableSynchronizedStorageSession>() ?? NoOpCompletableSynchronizedStorageSession.Instance;
+#pragma warning disable CA2007
+        await using var storageSession = context.Builder.GetService<ICompletableSynchronizedStorageSession>()
+                                         ?? NoOpCompletableSynchronizedStorageSession.Instance;
+#pragma warning restore CA2007
         await storageSession.Open(context).ConfigureAwait(false);
 
         var handlersToInvoke = messageHandlerRegistry.GetHandlersFor(context.Message.MessageType);
@@ -113,6 +116,7 @@ class LoadHandlersConnector(MessageHandlerRegistry messageHandlerRegistry, IActi
 
     static readonly ILog logger = LogManager.GetLogger<LoadHandlersConnector>();
     static readonly bool isDebugIsEnabled = logger.IsDebugEnabled;
+
     static readonly string scopeInconsistencyMessage =
         "This can result in inconsistent data because other enlisting operations won't be committed atomically with the receive transaction. " +
         $"The transport transaction mode must be changed to something other than '{nameof(TransportTransactionMode.TransactionScope)}' before attempting to manually control the TransactionScope in the pipeline.";

--- a/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs
@@ -116,7 +116,6 @@ class LoadHandlersConnector(MessageHandlerRegistry messageHandlerRegistry, IActi
 
     static readonly ILog logger = LogManager.GetLogger<LoadHandlersConnector>();
     static readonly bool isDebugIsEnabled = logger.IsDebugEnabled;
-
     static readonly string scopeInconsistencyMessage =
         "This can result in inconsistent data because other enlisting operations won't be committed atomically with the receive transaction. " +
         $"The transport transaction mode must be changed to something other than '{nameof(TransportTransactionMode.TransactionScope)}' before attempting to manually control the TransactionScope in the pipeline.";

--- a/src/NServiceBus.Core/Reliability/SynchronizedStorage/ICompletableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Reliability/SynchronizedStorage/ICompletableSynchronizedStorageSession.cs
@@ -47,6 +47,6 @@ public interface ICompletableSynchronizedStorageSession : ISynchronizedStorageSe
 #pragma warning restore CA1816
     {
         Dispose();
-        return ValueTask.CompletedTask;
+        return default;
     }
 }

--- a/src/NServiceBus.Core/Reliability/SynchronizedStorage/ICompletableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Reliability/SynchronizedStorage/ICompletableSynchronizedStorageSession.cs
@@ -10,7 +10,7 @@ using Transport;
 /// <summary>
 /// Represents a storage session from point of view of the infrastructure.
 /// </summary>
-public interface ICompletableSynchronizedStorageSession : ISynchronizedStorageSession, IDisposable
+public interface ICompletableSynchronizedStorageSession : ISynchronizedStorageSession, IAsyncDisposable
 {
     /// <summary>
     /// Tries to open the storage session with the provided outbox transaction.

--- a/src/NServiceBus.Core/Reliability/SynchronizedStorage/ICompletableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Reliability/SynchronizedStorage/ICompletableSynchronizedStorageSession.cs
@@ -10,7 +10,7 @@ using Transport;
 /// <summary>
 /// Represents a storage session from point of view of the infrastructure.
 /// </summary>
-public interface ICompletableSynchronizedStorageSession : ISynchronizedStorageSession, IAsyncDisposable
+public interface ICompletableSynchronizedStorageSession : ISynchronizedStorageSession, IDisposable, IAsyncDisposable
 {
     /// <summary>
     /// Tries to open the storage session with the provided outbox transaction.
@@ -41,4 +41,12 @@ public interface ICompletableSynchronizedStorageSession : ISynchronizedStorageSe
     /// Completes the session by saving the changes.
     /// </summary>
     Task CompleteAsync(CancellationToken cancellationToken = default);
+
+#pragma warning disable CA1816
+    ValueTask IAsyncDisposable.DisposeAsync()
+#pragma warning restore CA1816
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
 }

--- a/src/NServiceBus.Core/Reliability/SynchronizedStorage/NoOpCompletableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Reliability/SynchronizedStorage/NoOpCompletableSynchronizedStorageSession.cs
@@ -26,9 +26,7 @@ sealed class NoOpCompletableSynchronizedStorageSession : ICompletableSynchronize
 
     public Task CompleteAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
-    public void Dispose()
-    {
-    }
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     public static readonly ICompletableSynchronizedStorageSession Instance = new NoOpCompletableSynchronizedStorageSession();
 }

--- a/src/NServiceBus.Core/Reliability/SynchronizedStorage/NoOpCompletableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Reliability/SynchronizedStorage/NoOpCompletableSynchronizedStorageSession.cs
@@ -26,6 +26,10 @@ sealed class NoOpCompletableSynchronizedStorageSession : ICompletableSynchronize
 
     public Task CompleteAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
+    public void Dispose()
+    {
+    }
+
     public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
     public static readonly ICompletableSynchronizedStorageSession Instance = new NoOpCompletableSynchronizedStorageSession();

--- a/src/NServiceBus.Core/Reliability/SynchronizedStorage/NoOpCompletableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Reliability/SynchronizedStorage/NoOpCompletableSynchronizedStorageSession.cs
@@ -30,7 +30,7 @@ sealed class NoOpCompletableSynchronizedStorageSession : ICompletableSynchronize
     {
     }
 
-    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => default;
 
     public static readonly ICompletableSynchronizedStorageSession Instance = new NoOpCompletableSynchronizedStorageSession();
 }

--- a/src/NServiceBus.PersistenceTests/Sagas/SagaPersisterTests.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/SagaPersisterTests.cs
@@ -27,7 +27,7 @@ public class SagaPersisterTests(TestVariant param)
     protected async Task SaveSaga<TSagaData>(TSagaData saga, CancellationToken cancellationToken = default) where TSagaData : class, IContainSagaData, new()
     {
         var insertContextBag = configuration.GetContextBagForSagaStorage();
-        using var insertSession = configuration.CreateStorageSession();
+        await using var insertSession = configuration.CreateStorageSession();
         await insertSession.Open(insertContextBag, cancellationToken);
 
         await SaveSagaWithSession(saga, insertSession, insertContextBag, cancellationToken);
@@ -47,7 +47,7 @@ public class SagaPersisterTests(TestVariant param)
         var context = configuration.GetContextBagForSagaStorage();
         var persister = configuration.SagaStorage;
 
-        using var completeSession = configuration.CreateStorageSession();
+        await using var completeSession = configuration.CreateStorageSession();
         await completeSession.Open(context, cancellationToken);
 
         var sagaData = await persister.Get<TSagaData>(correlatedPropertyName, correlationPropertyData, completeSession, context, cancellationToken);
@@ -60,7 +60,7 @@ public class SagaPersisterTests(TestVariant param)
     protected async Task<TSagaData> GetById<TSagaData>(Guid sagaId, CancellationToken cancellationToken = default) where TSagaData : class, IContainSagaData, new()
     {
         var readContextBag = configuration.GetContextBagForSagaStorage();
-        using var readSession = configuration.CreateStorageSession();
+        await using var readSession = configuration.CreateStorageSession();
         await readSession.Open(readContextBag, cancellationToken);
 
         var sagaData = await configuration.SagaStorage.Get<TSagaData>(sagaId, readSession, readContextBag, cancellationToken);

--- a/src/NServiceBus.PersistenceTests/Sagas/When_completing_a_saga_loaded_by_id.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_completing_a_saga_loaded_by_id.cs
@@ -13,7 +13,7 @@ public class When_completing_a_saga_loaded_by_id : SagaPersisterTests
         await SaveSaga(saga);
 
         var context = configuration.GetContextBagForSagaStorage();
-        using (var completeSession = configuration.CreateStorageSession())
+        await using (var completeSession = configuration.CreateStorageSession())
         {
             await completeSession.Open(context);
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_completing_a_saga_with_correlation_property.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_completing_a_saga_with_correlation_property.cs
@@ -15,7 +15,7 @@ public class When_completing_a_saga_with_correlation_property : SagaPersisterTes
 
         const string correlatedPropertyName = nameof(SagaWithCorrelationPropertyData.CorrelatedProperty);
         var context = configuration.GetContextBagForSagaStorage();
-        using (var completeSession = configuration.CreateStorageSession())
+        await using (var completeSession = configuration.CreateStorageSession())
         {
             await completeSession.Open(context);
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_completing_saga_with_no_mapping_loaded_by_id.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_completing_saga_with_no_mapping_loaded_by_id.cs
@@ -24,7 +24,7 @@ public class When_completing_saga_with_no_mapping_loaded_by_id : SagaPersisterTe
         await SaveSaga(saga);
 
         var context = configuration.GetContextBagForSagaStorage();
-        using (var completeSession = configuration.CreateStorageSession())
+        await using (var completeSession = configuration.CreateStorageSession())
         {
             await completeSession.Open(context);
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_concurrent_update_exceed_lock_request_timeout_pessimistic.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_concurrent_update_exceed_lock_request_timeout_pessimistic.cs
@@ -32,7 +32,7 @@ public class When_concurrent_update_exceed_lock_request_timeout_pessimistic : Sa
         async Task FirstSession()
         {
             var firstSessionContext = configuration.GetContextBagForSagaStorage();
-            using var firstSaveSession = configuration.CreateStorageSession();
+            await using var firstSaveSession = configuration.CreateStorageSession();
             await firstSaveSession.Open(firstSessionContext);
 
             var record = await persister.Get<TestSagaData>(saga.Id, firstSaveSession, firstSessionContext);
@@ -50,7 +50,7 @@ public class When_concurrent_update_exceed_lock_request_timeout_pessimistic : Sa
         async Task SecondSession()
         {
             var secondContext = configuration.GetContextBagForSagaStorage();
-            using var secondSession = configuration.CreateStorageSession();
+            await using var secondSession = configuration.CreateStorageSession();
             await secondSession.Open(secondContext);
 
             await firstSessionGetDone.Task.ConfigureAwait(false);

--- a/src/NServiceBus.PersistenceTests/Sagas/When_concurrently_persisting_sagas_with_same_correlation_prop.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_concurrently_persisting_sagas_with_same_correlation_prop.cs
@@ -22,7 +22,7 @@ public class When_concurrently_persisting_sagas_with_same_correlation_prop : Sag
         };
 
         var winningContextBag = configuration.GetContextBagForSagaStorage();
-        using (var winningSession = configuration.CreateStorageSession())
+        await using (var winningSession = configuration.CreateStorageSession())
         {
             await winningSession.Open(winningContextBag);
 
@@ -31,7 +31,7 @@ public class When_concurrently_persisting_sagas_with_same_correlation_prop : Sag
         }
 
         var losingContextBag = configuration.GetContextBagForSagaStorage();
-        using (var losingSession = configuration.CreateStorageSession())
+        await using (var losingSession = configuration.CreateStorageSession())
         {
             await losingSession.Open(losingContextBag);
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_multiple_sagas_in_outbox_transaction.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_multiple_sagas_in_outbox_transaction.cs
@@ -19,7 +19,7 @@ public class When_multiple_sagas_in_outbox_transaction : SagaPersisterTests
         Assert.That(outboxMessage, Is.Null);
         using (var outboxTransaction = await configuration.OutboxStorage.BeginTransaction(context))
         {
-            using (var saga1Session = configuration.CreateStorageSession())
+            await using (var saga1Session = configuration.CreateStorageSession())
             {
                 await saga1Session.TryOpen(outboxTransaction, context);
                 var saga1Data = await configuration.SagaStorage.Get<Saga1Data>(nameof(Saga1Data.CorrelationId),
@@ -31,7 +31,7 @@ public class When_multiple_sagas_in_outbox_transaction : SagaPersisterTests
                 await saga1Session.CompleteAsync();
             }
 
-            using (var saga2Session = configuration.CreateStorageSession())
+            await using (var saga2Session = configuration.CreateStorageSession())
             {
                 await saga2Session.TryOpen(outboxTransaction, context);
                 var saga2Data = await configuration.SagaStorage.Get<Saga2Data>(nameof(Saga2Data.CorrelationId),
@@ -67,7 +67,7 @@ public class When_multiple_sagas_in_outbox_transaction : SagaPersisterTests
         Assert.That(outboxMessage, Is.Null);
         using (var outboxTransaction = await configuration.OutboxStorage.BeginTransaction(context))
         {
-            using (var saga1Session = configuration.CreateStorageSession())
+            await using (var saga1Session = configuration.CreateStorageSession())
             {
                 await saga1Session.TryOpen(outboxTransaction, context);
                 var saga1Data = await configuration.SagaStorage.Get<Saga1Data>(nameof(Saga1Data.CorrelationId),
@@ -79,7 +79,7 @@ public class When_multiple_sagas_in_outbox_transaction : SagaPersisterTests
                 await saga1Session.CompleteAsync();
             }
 
-            using (var saga2Session = configuration.CreateStorageSession())
+            await using (var saga2Session = configuration.CreateStorageSession())
             {
                 await saga2Session.TryOpen(outboxTransaction, context);
                 var saga2Data = await configuration.SagaStorage.Get<Saga2Data>(nameof(Saga2Data.CorrelationId),
@@ -115,7 +115,7 @@ public class When_multiple_sagas_in_outbox_transaction : SagaPersisterTests
         Assert.That(outboxMessage, Is.Null);
         using (var outboxTransaction = await configuration.OutboxStorage.BeginTransaction(context))
         {
-            using (var saga1Session = configuration.CreateStorageSession())
+            await using (var saga1Session = configuration.CreateStorageSession())
             {
                 await saga1Session.TryOpen(outboxTransaction, context);
 
@@ -127,7 +127,7 @@ public class When_multiple_sagas_in_outbox_transaction : SagaPersisterTests
                 await saga1Session.CompleteAsync();
             }
 
-            using (var saga2Session = configuration.CreateStorageSession())
+            await using (var saga2Session = configuration.CreateStorageSession())
             {
                 await saga2Session.TryOpen(outboxTransaction, context);
 
@@ -165,7 +165,7 @@ public class When_multiple_sagas_in_outbox_transaction : SagaPersisterTests
         Assert.That(outboxMessage, Is.Null);
         using (var outboxTransaction = await configuration.OutboxStorage.BeginTransaction(context))
         {
-            using (var saga1Session = configuration.CreateStorageSession())
+            await using (var saga1Session = configuration.CreateStorageSession())
             {
                 await saga1Session.TryOpen(outboxTransaction, context);
 
@@ -177,7 +177,7 @@ public class When_multiple_sagas_in_outbox_transaction : SagaPersisterTests
                 await saga1Session.CompleteAsync();
             }
 
-            using (var saga2Session = configuration.CreateStorageSession())
+            await using (var saga2Session = configuration.CreateStorageSession())
             {
                 await saga2Session.TryOpen(outboxTransaction, context);
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
@@ -28,7 +28,7 @@ public class When_persisting_a_saga_with_an_escalated_DTC_transaction : SagaPers
             var transportTransaction = new TransportTransaction();
             transportTransaction.Set(Transaction.Current);
 
-            using var session = configuration.CreateStorageSession();
+            await using var session = configuration.CreateStorageSession();
             var contextBag = configuration.GetContextBagForSagaStorage();
 
             await session.TryOpen(transportTransaction, contextBag);
@@ -66,7 +66,7 @@ public class When_persisting_a_saga_with_an_escalated_DTC_transaction : SagaPers
             var transportTransaction = new TransportTransaction();
             transportTransaction.Set(Transaction.Current);
 
-            using var session = configuration.CreateStorageSession();
+            await using var session = configuration.CreateStorageSession();
             var contextBag = configuration.GetContextBagForSagaStorage();
 
             await session.TryOpen(transportTransaction, contextBag);

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_the_same_unique_prop_as_another_saga.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_the_same_unique_prop_as_another_saga.cs
@@ -22,7 +22,7 @@ public class When_persisting_a_saga_with_the_same_unique_prop_as_another_saga : 
 
         var persister = configuration.SagaStorage;
         var savingContextBag = configuration.GetContextBagForSagaStorage();
-        using (var session = configuration.CreateStorageSession())
+        await using (var session = configuration.CreateStorageSession())
         {
             await session.Open(savingContextBag);
 
@@ -33,7 +33,7 @@ public class When_persisting_a_saga_with_the_same_unique_prop_as_another_saga : 
         }
 
         var readContextBag = configuration.GetContextBagForSagaStorage();
-        using (var readSession = configuration.CreateStorageSession())
+        await using (var readSession = configuration.CreateStorageSession())
         {
             await readSession.Open(readContextBag);
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_different_sagas_without_mapping.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_different_sagas_without_mapping.cs
@@ -27,7 +27,7 @@ public class When_persisting_different_sagas_without_mapping : SagaPersisterTest
         };
 
         var savingContextBag = configuration.GetContextBagForSagaStorage();
-        using (var session = configuration.CreateStorageSession())
+        await using (var session = configuration.CreateStorageSession())
         {
             await session.Open(savingContextBag);
 
@@ -37,7 +37,7 @@ public class When_persisting_different_sagas_without_mapping : SagaPersisterTest
         }
 
         var readContextBag = configuration.GetContextBagForSagaStorage();
-        using (var readSession = configuration.CreateStorageSession())
+        await using (var readSession = configuration.CreateStorageSession())
         {
             await readSession.Open(readContextBag);
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_saga_with_same_unique_prop_as_completed_saga.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_saga_with_same_unique_prop_as_completed_saga.cs
@@ -17,7 +17,7 @@ public class When_persisting_saga_with_same_unique_prop_as_completed_saga : Saga
 
         await SaveSaga(saga1);
         var context1 = configuration.GetContextBagForSagaStorage();
-        using (var completeSession = configuration.CreateStorageSession())
+        await using (var completeSession = configuration.CreateStorageSession())
         {
             await completeSession.Open(context1);
 
@@ -32,7 +32,7 @@ public class When_persisting_saga_with_same_unique_prop_as_completed_saga : Saga
 
         await SaveSaga(saga2);
         var context2 = configuration.GetContextBagForSagaStorage();
-        using (var completeSession = configuration.CreateStorageSession())
+        await using (var completeSession = configuration.CreateStorageSession())
         {
             await completeSession.Open(context2);
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_rolling_back_storage_session.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_rolling_back_storage_session.cs
@@ -17,7 +17,7 @@ public class When_rolling_back_storage_session : SagaPersisterTests
         await SaveSaga(sagaData);
 
         var contextBag = configuration.GetContextBagForSagaStorage();
-        using (var session = configuration.CreateStorageSession())
+        await using (var session = configuration.CreateStorageSession())
         {
             await session.Open(contextBag);
 
@@ -45,7 +45,7 @@ public class When_rolling_back_storage_session : SagaPersisterTests
         };
 
         var contextBag = configuration.GetContextBagForSagaStorage();
-        using (var session = configuration.CreateStorageSession())
+        await using (var session = configuration.CreateStorageSession())
         {
             await session.Open(contextBag);
 
@@ -70,7 +70,7 @@ public class When_rolling_back_storage_session : SagaPersisterTests
         await SaveSaga(sagaData);
 
         var contextBag = configuration.GetContextBagForSagaStorage();
-        using (var session = configuration.CreateStorageSession())
+        await using (var session = configuration.CreateStorageSession())
         {
             await session.Open(contextBag);
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_on_different_threads.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_on_different_threads.cs
@@ -23,7 +23,7 @@ public class When_updating_saga_concurrently_on_different_threads : SagaPersiste
         var firstTask = Task.Run(async () =>
         {
             var winningContext = configuration.GetContextBagForSagaStorage();
-            using var winningSaveSession = configuration.CreateStorageSession();
+            await using var winningSaveSession = configuration.CreateStorageSession();
             await winningSaveSession.Open(winningContext);
 
             var record = await persister.Get<TestSagaData>(generatedSagaId, winningSaveSession, winningContext);
@@ -41,7 +41,7 @@ public class When_updating_saga_concurrently_on_different_threads : SagaPersiste
             await startSecondTaskSync.Task;
 
             var losingSaveContext = configuration.GetContextBagForSagaStorage();
-            using var losingSaveSession = configuration.CreateStorageSession();
+            await using var losingSaveSession = configuration.CreateStorageSession();
             await losingSaveSession.Open(losingSaveContext);
 
             var staleRecord = await persister.Get<TestSagaData>("SomeId", correlationPropertyData, losingSaveSession, losingSaveContext);

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_on_same_thread.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_on_same_thread.cs
@@ -24,7 +24,7 @@ public class When_updating_saga_concurrently_on_same_thread : SagaPersisterTests
         var persister = configuration.SagaStorage;
 
         var winningContext = configuration.GetContextBagForSagaStorage();
-        using (var winningSaveSession = configuration.CreateStorageSession())
+        await using (var winningSaveSession = configuration.CreateStorageSession())
         {
             await winningSaveSession.Open(winningContext);
 
@@ -51,7 +51,7 @@ public class When_updating_saga_concurrently_on_same_thread : SagaPersisterTests
         }
         finally
         {
-            losingSaveSession.Dispose();
+            await losingSaveSession.DisposeAsync();
         }
     }
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_twice_on_the_same_thread.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_concurrently_twice_on_the_same_thread.cs
@@ -42,7 +42,7 @@ public class When_updating_saga_concurrently_twice_on_the_same_thread : SagaPers
         }
         finally
         {
-            winningSaveSession1.Dispose();
+            await winningSaveSession1.DisposeAsync();
         }
 
         try
@@ -56,7 +56,7 @@ public class When_updating_saga_concurrently_twice_on_the_same_thread : SagaPers
         }
         finally
         {
-            losingSaveSession1.Dispose();
+            await losingSaveSession1.DisposeAsync();
         }
 
         ContextBag losingContext2;
@@ -82,7 +82,7 @@ public class When_updating_saga_concurrently_twice_on_the_same_thread : SagaPers
         }
         finally
         {
-            winningSaveSession2.Dispose();
+            await winningSaveSession2.DisposeAsync();
         }
 
         try
@@ -96,7 +96,7 @@ public class When_updating_saga_concurrently_twice_on_the_same_thread : SagaPers
         }
         finally
         {
-            losingSaveSession2.Dispose();
+            await losingSaveSession2.DisposeAsync();
         }
     }
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_found_by_correlation_property.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_found_by_correlation_property.cs
@@ -22,7 +22,7 @@ public class When_updating_saga_found_by_correlation_property : SagaPersisterTes
         var context = configuration.GetContextBagForSagaStorage();
         var correlatedPropertyName = nameof(SagaWithCorrelationPropertyData.CorrelatedProperty);
         var persister = configuration.SagaStorage;
-        using (var completeSession = configuration.CreateStorageSession())
+        await using (var completeSession = configuration.CreateStorageSession())
         {
             await completeSession.Open(context);
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_found_by_id.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_found_by_id.cs
@@ -21,7 +21,7 @@ public class When_updating_saga_found_by_id : SagaPersisterTests
         var updatedValue = "bar";
         var context = configuration.GetContextBagForSagaStorage();
         var persister = configuration.SagaStorage;
-        using (var completeSession = configuration.CreateStorageSession())
+        await using (var completeSession = configuration.CreateStorageSession())
         {
             await completeSession.Open(context);
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_in_outbox_transaction.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_in_outbox_transaction.cs
@@ -17,7 +17,7 @@ public class When_updating_saga_in_outbox_transaction : SagaPersisterTests
         var sagaData = new TestSagaData { SomeId = Guid.NewGuid().ToString() };
         using (var outboxTransaction = await configuration.OutboxStorage.BeginTransaction(contextBag))
         {
-            using (var synchronizedStorageSession = configuration.CreateStorageSession())
+            await using (var synchronizedStorageSession = configuration.CreateStorageSession())
             {
                 var sessionCreated = await synchronizedStorageSession.TryOpen(outboxTransaction, contextBag);
                 Assert.That(sessionCreated, Is.True);

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_with_no_mapping_found_by_finder.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_with_no_mapping_found_by_finder.cs
@@ -23,7 +23,7 @@ public class When_updating_saga_with_no_mapping_found_by_finder : SagaPersisterT
 
         var updateValue = Guid.NewGuid().ToString();
         var context = configuration.GetContextBagForSagaStorage();
-        using (var completeSession = configuration.CreateStorageSession())
+        await using (var completeSession = configuration.CreateStorageSession())
         {
             await completeSession.Open(context);
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_with_no_mapping_found_by_id.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_updating_saga_with_no_mapping_found_by_id.cs
@@ -24,7 +24,7 @@ public class When_updating_saga_with_no_mapping_found_by_id : SagaPersisterTests
 
         var updateValue = Guid.NewGuid().ToString();
         var context = configuration.GetContextBagForSagaStorage();
-        using (var completeSession = configuration.CreateStorageSession())
+        await using (var completeSession = configuration.CreateStorageSession())
         {
             await completeSession.Open(context);
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_worker_tries_to_complete_saga_update_by_another_optimistic.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_worker_tries_to_complete_saga_update_by_another_optimistic.cs
@@ -42,7 +42,7 @@ public class When_worker_tries_to_complete_saga_update_by_another_optimistic : S
         }
         finally
         {
-            winningSaveSession.Dispose();
+            await winningSaveSession.DisposeAsync();
         }
 
         try
@@ -55,7 +55,7 @@ public class When_worker_tries_to_complete_saga_update_by_another_optimistic : S
         }
         finally
         {
-            losingSaveSession.Dispose();
+            await losingSaveSession.DisposeAsync();
         }
     }
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_worker_tries_to_complete_saga_update_by_another_pessimistic.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_worker_tries_to_complete_saga_update_by_another_pessimistic.cs
@@ -25,7 +25,7 @@ public class When_worker_tries_to_complete_saga_update_by_another_pessimistic : 
         async Task FirstSession()
         {
             var firstContent = configuration.GetContextBagForSagaStorage();
-            using var firstSaveSession = configuration.CreateStorageSession();
+            await using var firstSaveSession = configuration.CreateStorageSession();
             await firstSaveSession.Open(firstContent);
 
             var record = await persister.Get<TestSagaData>(saga.Id, firstSaveSession, firstContent);
@@ -40,7 +40,7 @@ public class When_worker_tries_to_complete_saga_update_by_another_pessimistic : 
         async Task SecondSession()
         {
             var secondContext = configuration.GetContextBagForSagaStorage();
-            using var secondSession = configuration.CreateStorageSession();
+            await using var secondSession = configuration.CreateStorageSession();
             await secondSession.Open(secondContext);
 
             await firstSessionGetDone.Task.ConfigureAwait(false);


### PR DESCRIPTION
`ICompletableSynchronizedStorageSession` now inherits from `IAsyncDisposable` instead of `IDisposable`

Alternatively `ICompletableSynchronizedStorageSession` should not inherit either from `IDisposable` or `IAsyncDisposable` as this usually is deferred to the implementation.

However, that causes issue with this specific interfaces as Dispose is used for transaction rollback.