### PR TITLE
Support slnx solution files

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransportInfrastructure.cs
+++ b/src/NServiceBus.AcceptanceTesting/AcceptanceTestingTransport/AcceptanceTestingTransportInfrastructure.cs
@@ -25,7 +25,7 @@ class AcceptanceTestingTransportInfrastructure : TransportInfrastructure
 
         while (true)
         {
-            if (Directory.EnumerateFiles(directory).Any(file => file.EndsWith(".sln")))
+            if (Directory.EnumerateFiles(directory).Any(file => Path.GetExtension(file) is ".sln" or ".slnx"))
             {
                 return directory;
             }

--- a/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
+++ b/src/NServiceBus.Core/Transports/Learning/LearningTransportInfrastructure.cs
@@ -35,7 +35,7 @@ class LearningTransportInfrastructure : TransportInfrastructure
         while (true)
         {
             // Finding a solution file takes precedence
-            if (Directory.EnumerateFiles(directory).Any(file => file.EndsWith(".sln")))
+            if (Directory.EnumerateFiles(directory).Any(file => Path.GetExtension(file) is ".sln" or ".slnx"))
             {
                 return Path.Combine(directory, DefaultLearningTransportDirectory);
             }


### PR DESCRIPTION
Microsoft is adding support for [a new solution file format](https://devblogs.microsoft.com/visualstudio/new-simpler-solution-file-format/).

The learning and acceptance test transports both look for a solution file to determine the default location of the transport folder. As the file extension has changed for the new format, it breaks these transports.

This PR adds support for the new format by checking for `.sln` _and_ `.slnx` files.