### PR TITLE
Add GC.SuppressFinalize to ICompletableSynchronizedStorageSession

### DIFF
--- a/src/NServiceBus.Core/Reliability/SynchronizedStorage/ICompletableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Reliability/SynchronizedStorage/ICompletableSynchronizedStorageSession.cs
@@ -45,9 +45,9 @@ public interface ICompletableSynchronizedStorageSession : ISynchronizedStorageSe
     ValueTask IAsyncDisposable.DisposeAsync()
     {
         Dispose();
-        
+
         GC.SuppressFinalize(this);
-        
+
         return default;
     }
 }

--- a/src/NServiceBus.Core/Reliability/SynchronizedStorage/ICompletableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Reliability/SynchronizedStorage/ICompletableSynchronizedStorageSession.cs
@@ -42,11 +42,12 @@ public interface ICompletableSynchronizedStorageSession : ISynchronizedStorageSe
     /// </summary>
     Task CompleteAsync(CancellationToken cancellationToken = default);
 
-#pragma warning disable CA1816
     ValueTask IAsyncDisposable.DisposeAsync()
-#pragma warning restore CA1816
     {
         Dispose();
+        
+        GC.SuppressFinalize(this);
+        
         return default;
     }
 }


### PR DESCRIPTION
Add GC.SuppressFinalize to ICompletableSynchronizedStorageSession

so that if any future classes inherit from it, they won't have to worry about calling GC.SuppressFinalize