### PR TITLE
Remove explicit DisposeAsync method NoOpCompletableSynchronizedStorag…

### DIFF
--- a/src/NServiceBus.Core/Reliability/SynchronizedStorage/NoOpCompletableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Reliability/SynchronizedStorage/NoOpCompletableSynchronizedStorageSession.cs
@@ -30,7 +30,5 @@ sealed class NoOpCompletableSynchronizedStorageSession : ICompletableSynchronize
     {
     }
 
-    public ValueTask DisposeAsync() => default;
-
     public static readonly ICompletableSynchronizedStorageSession Instance = new NoOpCompletableSynchronizedStorageSession();
 }


### PR DESCRIPTION
…eSession.cs

DisposeAsync default implementation is added in ICompletableSynchronizedStorageSession, so no need to add the same implementation nhere.