### PR TITLE
Spike exposing the endpoint specific service provider to acceptance tests

### DIFF
--- a/src/NServiceBus.AcceptanceTesting/Support/EndpointBehaviorBuilder.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/EndpointBehaviorBuilder.cs
@@ -8,10 +8,12 @@ public class EndpointBehaviorBuilder<TContext> where TContext : ScenarioContext
 {
     public EndpointBehaviorBuilder(IEndpointConfigurationFactory endpointConfigurationFactory)
     {
-        behavior = new EndpointBehavior(endpointConfigurationFactory)
-        {
-            Whens = []
-        };
+        behavior = new EndpointBehavior(endpointConfigurationFactory) { Whens = [] };
+    }
+
+    public EndpointBehaviorBuilder<TContext> When(Func<IServiceProvider, IMessageSession, TContext, Task> action)
+    {
+        return When(c => true, action);
     }
 
     public EndpointBehaviorBuilder<TContext> When(Func<IMessageSession, TContext, Task> action)
@@ -41,6 +43,13 @@ public class EndpointBehaviorBuilder<TContext> where TContext : ScenarioContext
     public EndpointBehaviorBuilder<TContext> When(Func<TContext, Task<bool>> condition, Func<IMessageSession, TContext, Task> action)
     {
         behavior.Whens.Add(new WhenDefinition<TContext>(condition, action));
+
+        return this;
+    }
+
+    public EndpointBehaviorBuilder<TContext> When(Predicate<TContext> condition, Func<IServiceProvider, IMessageSession, TContext, Task> action)
+    {
+        behavior.Whens.Add(new WhenDefinition<TContext>(ctx => Task.FromResult(condition(ctx)), action));
 
         return this;
     }

--- a/src/NServiceBus.AcceptanceTesting/Support/IWhenDefinition.cs
+++ b/src/NServiceBus.AcceptanceTesting/Support/IWhenDefinition.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 public interface IWhenDefinition
 {
-    Task<bool> ExecuteAction(ScenarioContext context, IMessageSession session);
+    Task<bool> ExecuteAction(ScenarioContext context, IMessageSession session, IServiceProvider serviceProvider);
 
     Guid Id { get; }
 }


### PR DESCRIPTION
Spike to see if there is a better way to handle scenarios like https://github.com/Particular/NServiceBus.TransactionalSession/blob/main/src/NServiceBus.TransactionalSession.AcceptanceTests/When_using_outbox.cs#L20 where acceptance tests need access to the endpoints service provider.