### PR TITLE
Use `Path.GetTempPath` to ensure IO happens Windows/Linux temp folder

### DIFF
--- a/src/NServiceBus.PersistenceTests/PersistenceTestsConfiguration.cs
+++ b/src/NServiceBus.PersistenceTests/PersistenceTestsConfiguration.cs
@@ -32,7 +32,7 @@ public partial class PersistenceTestsConfiguration
         SagaIdGenerator = new LearningSagaIdGenerator();
 
         var sagaManifests = new SagaManifestCollection(SagaMetadataCollection,
-            Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ".sagas"),
+            Path.Combine(Path.GetTempPath(), AppDomain.CurrentDomain.FriendlyName, ".sagas"),
             name => DeterministicGuid.Create(name).ToString());
 
         SagaStorage = new LearningSagaPersister(sagaManifests);

--- a/src/NServiceBus.TransportTests/ConfigureLearningTransportInfrastructure.cs
+++ b/src/NServiceBus.TransportTests/ConfigureLearningTransportInfrastructure.cs
@@ -10,7 +10,7 @@ class ConfigureLearningTransportInfrastructure : IConfigureTransportInfrastructu
 {
     public TransportDefinition CreateTransportDefinition()
     {
-        storageDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ".transporttests");
+        storageDir = Path.Combine(Path.GetTempPath(), AppDomain.CurrentDomain.FriendlyName, ".transporttests");
         return new LearningTransport
         {
             StorageDirectory = storageDir,


### PR DESCRIPTION
Use `Path.GetTempPath` to ensure IO happens Windows/Linux temp folders (`TEMPDIR,`TEMP,`TMP`). On Linux this almost always is a `tmpfs` RAM drive and much faster.