### PR TITLE
Enable nullable type annotations on the ContextBag

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1149,17 +1149,17 @@ namespace NServiceBus.Extensibility
 {
     public class ContextBag : NServiceBus.Extensibility.IReadOnlyContextBag
     {
-        public ContextBag(NServiceBus.Extensibility.ContextBag parentBag = null) { }
-        public T Get<T>() { }
-        public T Get<T>(string key) { }
-        public T GetOrCreate<T>()
+        public ContextBag(NServiceBus.Extensibility.ContextBag? parentBag = null) { }
+        public T? Get<T>() { }
+        public T? Get<T>(string key) { }
+        public T? GetOrCreate<T>()
             where T :  class, new () { }
         public void Remove(string key) { }
         public void Remove<T>() { }
         public void Set<T>(T t) { }
         public void Set<T>(string key, T t) { }
-        public bool TryGet<T>(out T result) { }
-        public bool TryGet<T>(string key, out T result) { }
+        public bool TryGet<T>(out T? result) { }
+        public bool TryGet<T>(string key, out T? result) { }
     }
     public abstract class ExtendableOptions
     {

--- a/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/NullableAnnotations.ApproveNullableTypes.approved.txt
@@ -27,7 +27,6 @@ NServiceBus.EndpointConfigurationExtensions
 NServiceBus.EndpointInstanceExtensions
 NServiceBus.EndpointWithExternallyManagedContainer
 NServiceBus.ErrorQueueSettings
-NServiceBus.Extensibility.ContextBag
 NServiceBus.Extensibility.ExtendableOptionsExtensions
 NServiceBus.Extensibility.IExtendable
 NServiceBus.Extensibility.IReadOnlyContextBag
@@ -218,7 +217,6 @@ NServiceBus.Transport.TransportDefinition
 NServiceBus.Transport.TransportInfrastructure
 NServiceBus.Transport.TransportOperation
 NServiceBus.Transport.TransportOperations
-NServiceBus.Transport.TransportTransaction
 NServiceBus.Transport.UnicastTransportOperation
 NServiceBus.TransportExtensions`1
 NServiceBus.Unicast.MessageEventArgs

--- a/src/NServiceBus.Core.Tests/ContextBagTests.cs
+++ b/src/NServiceBus.Core.Tests/ContextBagTests.cs
@@ -7,6 +7,21 @@ using NUnit.Framework;
 public class ContextBagTests
 {
     [Test]
+    public void Should_allow_storing_null_values()
+    {
+        var contextBag = new ContextBag();
+
+        contextBag.Set<string>("NullValue", null);
+
+        var result = ((IReadOnlyContextBag)contextBag).TryGet("NullValue", out object theValue);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.True, "Should be able to retrieve a null value");
+            Assert.That(theValue, Is.Null);
+        });
+    }
+
+    [Test]
     public void ShouldAllowMonkeyPatching()
     {
         var contextBag = new ContextBag();

--- a/src/NServiceBus.Core/DelayedDelivery/ThrowIfCannotDeferMessageBehavior.cs
+++ b/src/NServiceBus.Core/DelayedDelivery/ThrowIfCannotDeferMessageBehavior.cs
@@ -11,7 +11,7 @@ sealed class ThrowIfCannotDeferMessageBehavior : IBehavior<IRoutingContext, IRou
 {
     public Task Invoke(IRoutingContext context, Func<IRoutingContext, Task> next)
     {
-        if (context.Extensions.TryGet<DispatchProperties>(out var properties) && (properties.DelayDeliveryWith != null || properties.DoNotDeliverBefore != null))
+        if (context.Extensions.TryGet<DispatchProperties>(out var properties) && (properties?.DelayDeliveryWith != null || properties?.DoNotDeliverBefore != null))
         {
             throw new InvalidOperationException("Cannot delay delivery of messages when there is no infrastructure support for delayed messages.");
         }

--- a/src/NServiceBus.Core/Extensibility/ContextBag.cs
+++ b/src/NServiceBus.Core/Extensibility/ContextBag.cs
@@ -35,10 +35,7 @@ public class ContextBag : IReadOnlyContextBag
     /// <typeparam name="T">The type to retrieve.</typeparam>
     /// <param name="result">The type instance.</param>
     /// <returns><code>true</code> if found, otherwise <code>false</code>.</returns>
-    public bool TryGet<T>(out T? result)
-    {
-        return TryGet(typeof(T).FullName!, out result);
-    }
+    public bool TryGet<T>(out T? result) => TryGet(typeof(T).FullName!, out result);
 
     /// <summary>
     /// Tries to retrieve the specified type from the context.

--- a/src/NServiceBus.Core/Extensibility/ContextBag.cs
+++ b/src/NServiceBus.Core/Extensibility/ContextBag.cs
@@ -1,7 +1,10 @@
+#nullable enable
+
 namespace NServiceBus.Extensibility;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Pipeline;
 
 /// <summary>
@@ -12,11 +15,11 @@ public class ContextBag : IReadOnlyContextBag
     /// <summary>
     /// Initialized a new instance of <see cref="ContextBag" />.
     /// </summary>
-    public ContextBag(ContextBag parentBag = null)
+    public ContextBag(ContextBag? parentBag = null)
     {
         this.parentBag = parentBag;
         root = parentBag?.root ?? this;
-        Behaviors = parentBag?.Behaviors;
+        Behaviors = parentBag?.Behaviors ?? [];
     }
 
     /// <summary>
@@ -24,10 +27,7 @@ public class ContextBag : IReadOnlyContextBag
     /// </summary>
     /// <typeparam name="T">The type to retrieve.</typeparam>
     /// <returns>The type instance.</returns>
-    public T Get<T>()
-    {
-        return Get<T>(typeof(T).FullName);
-    }
+    public T? Get<T>() => Get<T>(typeof(T).FullName!);
 
     /// <summary>
     /// Tries to retrieve the specified type from the context.
@@ -35,9 +35,9 @@ public class ContextBag : IReadOnlyContextBag
     /// <typeparam name="T">The type to retrieve.</typeparam>
     /// <param name="result">The type instance.</param>
     /// <returns><code>true</code> if found, otherwise <code>false</code>.</returns>
-    public bool TryGet<T>(out T result)
+    public bool TryGet<T>(out T? result)
     {
-        return TryGet(typeof(T).FullName, out result);
+        return TryGet(typeof(T).FullName!, out result);
     }
 
     /// <summary>
@@ -47,12 +47,12 @@ public class ContextBag : IReadOnlyContextBag
     /// <param name="key">The key of the value being looked up.</param>
     /// <param name="result">The type instance.</param>
     /// <returns><code>true</code> if found, otherwise <code>false</code>.</returns>
-    public bool TryGet<T>(string key, out T result)
+    public bool TryGet<T>(string key, out T? result)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
         if (stash?.TryGetValue(key, out var value) == true)
         {
-            result = (T)value;
+            result = (T?)value;
             return true;
         }
 
@@ -66,24 +66,27 @@ public class ContextBag : IReadOnlyContextBag
     }
 
     /// <inheritdoc />
-    public T Get<T>(string key)
+    public T? Get<T>(string key)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(key);
 
-        if (!TryGet(key, out T result))
+        if (!TryGet(key, out T? value))
         {
-            throw new KeyNotFoundException("No item found in behavior context with key: " + key);
+            ThrowKeyNotFoundException(key);
         }
 
-        return result;
+        return value;
+
+        [DoesNotReturn]
+        static void ThrowKeyNotFoundException(string key) => throw new KeyNotFoundException($"No item found in behavior context with key: {key}");
     }
 
     /// <summary>
     /// Gets the requested extension, a new one will be created if needed.
     /// </summary>
-    public T GetOrCreate<T>() where T : class, new()
+    public T? GetOrCreate<T>() where T : class, new()
     {
-        if (TryGet(out T value))
+        if (TryGet(out T? value))
         {
             return value;
         }
@@ -101,20 +104,14 @@ public class ContextBag : IReadOnlyContextBag
     /// </summary>
     /// <typeparam name="T">The type to store.</typeparam>
     /// <param name="t">The instance type to store.</param>
-    public void Set<T>(T t)
-    {
-        Set(typeof(T).FullName, t);
-    }
+    public void Set<T>(T t) => Set(typeof(T).FullName!, t);
 
 
     /// <summary>
     /// Removes the instance type from the context.
     /// </summary>
     /// <typeparam name="T">The type to remove.</typeparam>
-    public void Remove<T>()
-    {
-        Remove(typeof(T).FullName);
-    }
+    public void Remove<T>() => Remove(typeof(T).FullName!);
 
     /// <summary>
     /// Removes the instance type from the context.
@@ -142,10 +139,7 @@ public class ContextBag : IReadOnlyContextBag
     /// Be careful, values set on the root are available to all pipeline forks that are created off the root context! Therefore there there's a risk of conflicting keys or overriding existing keys from other forks. The same pipeline behaviors can be executed multiple times on nested chains (e.g. nested sends).
     /// 
     /// </summary>
-    internal void SetOnRoot<T>(string key, T t)
-    {
-        root.Set(key, t);
-    }
+    internal void SetOnRoot<T>(string key, T t) => root.Set(key, t);
 
     /// <summary>
     /// Merges the passed context into this one.
@@ -165,7 +159,7 @@ public class ContextBag : IReadOnlyContextBag
         }
     }
 
-    Dictionary<string, object> GetOrCreateStash()
+    Dictionary<string, object?> GetOrCreateStash()
     {
         stash ??= [];
 
@@ -179,9 +173,9 @@ public class ContextBag : IReadOnlyContextBag
     /// </summary>
     internal IBehavior[] Behaviors { get; set; }
 
-    internal ContextBag parentBag;
+    internal ContextBag? parentBag;
 
     private protected ContextBag root;
 
-    Dictionary<string, object> stash; // might be null!
+    Dictionary<string, object?>? stash;
 }

--- a/src/NServiceBus.Core/Pipeline/Incoming/DeserializeMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/DeserializeMessageConnector.cs
@@ -32,7 +32,7 @@ class DeserializeMessageConnector(
             if (first) // ignore the legacy case in which a single message payload contained multiple messages
             {
                 var availableMetricTags = context.Extensions.Get<IncomingPipelineMetricTags>();
-                availableMetricTags.Add(MeterTags.MessageType, message.MessageType.FullName!);
+                availableMetricTags?.Add(MeterTags.MessageType, message.MessageType.FullName!);
                 first = false;
             }
             await stage(this.CreateIncomingLogicalMessageContext(message, context)).ConfigureAwait(false);

--- a/src/NServiceBus.Core/Transports/TransportTransaction.cs
+++ b/src/NServiceBus.Core/Transports/TransportTransaction.cs
@@ -10,7 +10,7 @@ public sealed class TransportTransaction : ContextBag
     /// <summary>
     /// Create an instance of <see cref="TransportTransaction" />.
     /// </summary>
-    public TransportTransaction() : base(null)
+    public TransportTransaction()
     {
     }
 }


### PR DESCRIPTION
This PR enables Nullable annotations on the context bag. It seems there are valid use cases to store a key with a null value when the key itself and a null value are used as an indicator. For example, NServiceBus uses that as part of the ConversationRoutingExtensions

https://github.com/Particular/NServiceBus/blob/master/src/NServiceBus.Core/Causation/ConversationRoutingExtensions.cs#L15-L16

Therefore the nullable annotations have been changed to clearly indicate that the T values can be null in some cases.