### PR TITLE
Update version parsing

### DIFF
--- a/src/NServiceBus.Core.Tests/Unicast/MessageTypeTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/MessageTypeTests.cs
@@ -59,7 +59,6 @@ public class MessageTypeTests
         });
     }
 
-
     class TestMessage
     {
 

--- a/src/NServiceBus.Core.Tests/Unicast/MessageTypeTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/MessageTypeTests.cs
@@ -42,6 +42,23 @@ public class MessageTypeTests
         });
     }
 
+    [Test]
+    public void Should_parse_partial_assembly_strings()
+    {
+        var expectedTypeName = typeof(TestMessage).FullName;
+        var expectedVersion = typeof(TestMessage).Assembly.GetName().Version;
+
+        var input = $"{expectedTypeName},Version={expectedVersion}";
+
+        var messageType = new Subscriptions.MessageType(input);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(expectedTypeName, Is.EqualTo(messageType.TypeName));
+            Assert.That(expectedVersion, Is.EqualTo(messageType.Version));
+        });
+    }
+
 
     class TestMessage
     {

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageType.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageType.cs
@@ -78,8 +78,12 @@ public class MessageType
         if (versionPrefixIndex >= 0)
         {
             input = input[(versionPrefixIndex + versionPrefix.Length)..];
+
             var firstComma = input.IndexOf(',');
-            input = input[..firstComma];
+            if (firstComma > 0)
+            {
+                input = input[..firstComma];
+            }
         }
 
         return Version.Parse(input);

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageType.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageType.cs
@@ -78,9 +78,9 @@ public class MessageType
         if (versionPrefixIndex >= 0)
         {
             input = input[(versionPrefixIndex + versionPrefix.Length)..];
-
             var firstComma = input.IndexOf(',');
-            if (firstComma > 0)
+
+            if (firstComma >= 0)
             {
                 input = input[..firstComma];
             }


### PR DESCRIPTION
Fix `ArgumentOutOfRangeException` when parsing `MessageType` with no trailing comma after `Version=...`

This PR fixes a bug introduced by #7349 in `MessageType.ParseVersion` where it assumed that a comma always follows the `Version=` segment in the message type string. If no comma is present (e.g. `"TypeName, Version=1.0.0.0"`), the method would still attempt to slice the span using `[..-1]` resulting in an `ArgumentOutOfRangeException`.

This PR includes a test to validate the behavior, and modifies the `ParseVersion` method logic to only attempt to slice the span when a comma is found after the `Version=` part of the string. 