### PR TITLE
Improve processing time metric

### DIFF
--- a/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/TransportReceiveToPhysicalMessageConnector.cs
@@ -20,7 +20,7 @@ class TransportReceiveToPhysicalMessageConnector : IStageForkConnector<ITranspor
 
     public async Task Invoke(ITransportReceiveContext context, Func<IIncomingPhysicalMessageContext, Task> next)
     {
-        var processingStartedAt = DateTimeOffset.UtcNow;
+        var processingStartedAt = Stopwatch.GetTimestamp();
         var messageId = context.Message.MessageId;
         var physicalMessageContext = this.CreateIncomingPhysicalMessageContext(context.Message, context);
 
@@ -45,8 +45,8 @@ class TransportReceiveToPhysicalMessageConnector : IStageForkConnector<ITranspor
             // We are measuring outside the transaction scope instead of right after the transaction is committed.
             // Under some specific configurations the heavy lifting is not done as part of the commit but
             // as part of the transaction scope dispose (e.g., when using SQL with transaction scope and DTC)
-            var processingCompletedAt = DateTimeOffset.UtcNow;
-            incomingPipelineMetrics.RecordProcessingTime(context, processingCompletedAt - processingStartedAt);
+            var elapsedTime = Stopwatch.GetElapsedTime(processingStartedAt);
+            incomingPipelineMetrics.RecordProcessingTime(context, elapsedTime);
 
             physicalMessageContext.Extensions.Remove<PendingTransportOperations>();
         }


### PR DESCRIPTION
This is an outcome of a revelation from some work around metrics in the transactional session.

This pull request updates how message processing time is measured in `TransportReceiveToPhysicalMessageConnector`. Instead of using `DateTimeOffset.UtcNow`, it now uses `Stopwatch` for more accurate timing and moves the measurement outside the transaction scope to better reflect the actual processing duration, especially for configurations where work is done during transaction scope disposal.

Improvements to message processing time measurement:

* Changed the start time measurement from `DateTimeOffset.UtcNow` to `Stopwatch.GetTimestamp()` for higher precision.
* Moved the processing time calculation and recording to after the transaction scope is disposed, using `Stopwatch.GetElapsedTime`, to account for scenarios where significant work occurs during scope disposal (e.g., SQL with DTC).