### PR TITLE
Stop using IWantToRunBeforeConfigurationIsFinalized for persistence config

### DIFF
--- a/src/NServiceBus.Core.Tests/Persistence/PersistenceStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/PersistenceStartupTests.cs
@@ -14,7 +14,7 @@ public class When_no_persistence_has_been_configured
     {
         var settings = new SettingsHolder();
 
-        var supported = PersistenceStartup.HasSupportFor<StorageType.Subscriptions>(settings);
+        var supported = PersistenceComponent.HasSupportFor<StorageType.Subscriptions>(settings);
 
         Assert.That(supported, Is.False);
     }
@@ -33,11 +33,11 @@ public class When_persistence_has_been_configured
         config.EnableFeature<Outbox>();
         config.EnableFeature<Sagas>();
 
-        var startup = new PersistenceStartup();
+        var startup = new PersistenceComponent();
 
         Assert.Throws<Exception>(() =>
         {
-            startup.Run(config.Settings);
+            PersistenceComponent.Configure(config.Settings);
         }, "Sagas and Outbox need to use the same type of persistence. Saga is configured to use FakeSagaPersistence. Outbox is configured to use FakeOutboxPersistence");
     }
 
@@ -59,9 +59,9 @@ public class When_persistence_has_been_configured
             config.EnableFeature<Outbox>();
         }
 
-        var startup = new PersistenceStartup();
+        var startup = new PersistenceComponent();
 
-        Assert.DoesNotThrow(() => startup.Run(config.Settings), "Should not throw for a single single feature enabled out of the two.");
+        Assert.DoesNotThrow(() => PersistenceComponent.Configure(config.Settings), "Should not throw for a single single feature enabled out of the two.");
     }
 
     class FakeSagaPersistence : PersistenceDefinition

--- a/src/NServiceBus.Core.Tests/Persistence/PersistenceStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/PersistenceStartupTests.cs
@@ -14,7 +14,7 @@ public class When_no_persistence_has_been_configured
     {
         var settings = new SettingsHolder();
 
-        var supported = PersistenceComponent.HasSupportFor<StorageType.Subscriptions>(settings);
+        var supported = settings.HasSupportFor<StorageType.Subscriptions>();
 
         Assert.That(supported, Is.False);
     }

--- a/src/NServiceBus.Core.Tests/Persistence/PersistenceStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/PersistenceStartupTests.cs
@@ -33,8 +33,6 @@ public class When_persistence_has_been_configured
         config.EnableFeature<Outbox>();
         config.EnableFeature<Sagas>();
 
-        var startup = new PersistenceComponent();
-
         Assert.Throws<Exception>(() =>
         {
             PersistenceComponent.Configure(config.Settings);
@@ -59,24 +57,16 @@ public class When_persistence_has_been_configured
             config.EnableFeature<Outbox>();
         }
 
-        var startup = new PersistenceComponent();
-
         Assert.DoesNotThrow(() => PersistenceComponent.Configure(config.Settings), "Should not throw for a single single feature enabled out of the two.");
     }
 
     class FakeSagaPersistence : PersistenceDefinition
     {
-        public FakeSagaPersistence()
-        {
-            Supports<StorageType.Sagas>(settings => { });
-        }
+        public FakeSagaPersistence() => Supports<StorageType.Sagas>(_ => { });
     }
 
     class FakeOutboxPersistence : PersistenceDefinition
     {
-        public FakeOutboxPersistence()
-        {
-            Supports<StorageType.Outbox>(settings => { });
-        }
+        public FakeOutboxPersistence() => Supports<StorageType.Outbox>(_ => { });
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/PersistenceStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/PersistenceStartupTests.cs
@@ -35,7 +35,7 @@ public class When_persistence_has_been_configured
 
         Assert.Throws<Exception>(() =>
         {
-            PersistenceComponent.Configure(config.Settings);
+            config.Settings.ConfigurePersistence();
         }, "Sagas and Outbox need to use the same type of persistence. Saga is configured to use FakeSagaPersistence. Outbox is configured to use FakeOutboxPersistence");
     }
 
@@ -57,7 +57,7 @@ public class When_persistence_has_been_configured
             config.EnableFeature<Outbox>();
         }
 
-        Assert.DoesNotThrow(() => PersistenceComponent.Configure(config.Settings), "Should not throw for a single single feature enabled out of the two.");
+        Assert.DoesNotThrow(() => config.Settings.ConfigurePersistence(), "Should not throw for a single single feature enabled out of the two.");
     }
 
     class FakeSagaPersistence : PersistenceDefinition

--- a/src/NServiceBus.Core.Tests/Persistence/PersistenceStorageMergerTests.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/PersistenceStorageMergerTests.cs
@@ -15,7 +15,7 @@ public class When_no_storage_persistence_overrides_are_enabled
         config.UsePersistence<FakePersistence>();
         var persistences = config.Settings.Get<List<EnabledPersistence>>(PersistenceComponent.PersistenceDefinitionsSettingsKey);
 
-        var resultedEnabledPersistences = PersistenceStorageMerger.Merge(persistences, config.Settings);
+        var resultedEnabledPersistences = config.Settings.MergePersistences(persistences);
 
         Assert.That(resultedEnabledPersistences[0].SelectedStorages, Is.EquivalentTo(StorageType.GetAvailableStorageTypes()));
     }
@@ -24,9 +24,9 @@ public class When_no_storage_persistence_overrides_are_enabled
     {
         public FakePersistence()
         {
-            Supports<StorageType.Sagas>(settings => { });
-            Supports<StorageType.Outbox>(settings => { });
-            Supports<StorageType.Subscriptions>(settings => { });
+            Supports<StorageType.Sagas>(_ => { });
+            Supports<StorageType.Outbox>(_ => { });
+            Supports<StorageType.Subscriptions>(_ => { });
         }
     }
 }
@@ -43,7 +43,7 @@ public class When_storage_overrides_are_provided
         config.UsePersistence<FakePersistence2, StorageType.Subscriptions>();
         var persistences = config.Settings.Get<List<EnabledPersistence>>(PersistenceComponent.PersistenceDefinitionsSettingsKey);
 
-        var resultedEnabledPersistences = PersistenceStorageMerger.Merge(persistences, config.Settings);
+        var resultedEnabledPersistences = config.Settings.MergePersistences(persistences);
 
         Assert.Multiple(() =>
         {
@@ -56,8 +56,8 @@ public class When_storage_overrides_are_provided
     {
         public FakePersistence2()
         {
-            Supports<StorageType.Sagas>(settings => { });
-            Supports<StorageType.Subscriptions>(settings => { });
+            Supports<StorageType.Sagas>(_ => { });
+            Supports<StorageType.Subscriptions>(_ => { });
         }
     }
 
@@ -65,9 +65,9 @@ public class When_storage_overrides_are_provided
     {
         public FakePersistence()
         {
-            Supports<StorageType.Sagas>(settings => { });
-            Supports<StorageType.Outbox>(settings => { });
-            Supports<StorageType.Subscriptions>(settings => { });
+            Supports<StorageType.Sagas>(_ => { });
+            Supports<StorageType.Outbox>(_ => { });
+            Supports<StorageType.Subscriptions>(_ => { });
         }
     }
 }
@@ -82,7 +82,7 @@ public class When_explicitly_enabling_selected_storage
         config.UsePersistence<FakePersistence, StorageType.Sagas>();
         var persistences = config.Settings.Get<List<EnabledPersistence>>(PersistenceComponent.PersistenceDefinitionsSettingsKey);
 
-        var resultedEnabledPersistences = PersistenceStorageMerger.Merge(persistences, config.Settings);
+        var resultedEnabledPersistences = config.Settings.MergePersistences(persistences);
 
         Assert.That(resultedEnabledPersistences.Any(p => p.SelectedStorages.Contains(typeof(StorageType.Subscriptions))), Is.False);
     }
@@ -91,8 +91,8 @@ public class When_explicitly_enabling_selected_storage
     {
         public FakePersistence()
         {
-            Supports<StorageType.Sagas>(settings => { });
-            Supports<StorageType.Subscriptions>(settings => { });
+            Supports<StorageType.Sagas>(_ => { });
+            Supports<StorageType.Subscriptions>(_ => { });
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Persistence/PersistenceStorageMergerTests.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/PersistenceStorageMergerTests.cs
@@ -13,7 +13,7 @@ public class When_no_storage_persistence_overrides_are_enabled
     {
         var config = new EndpointConfiguration("MyEndpoint");
         config.UsePersistence<FakePersistence>();
-        var persistences = config.Settings.Get<List<EnabledPersistence>>("PersistenceDefinitions");
+        var persistences = config.Settings.Get<List<EnabledPersistence>>(PersistenceComponent.PersistenceDefinitionsSettingsKey);
 
         var resultedEnabledPersistences = PersistenceStorageMerger.Merge(persistences, config.Settings);
 
@@ -41,7 +41,7 @@ public class When_storage_overrides_are_provided
         config.UsePersistence<FakePersistence>();
         config.UsePersistence<FakePersistence2, StorageType.Sagas>();
         config.UsePersistence<FakePersistence2, StorageType.Subscriptions>();
-        var persistences = config.Settings.Get<List<EnabledPersistence>>("PersistenceDefinitions");
+        var persistences = config.Settings.Get<List<EnabledPersistence>>(PersistenceComponent.PersistenceDefinitionsSettingsKey);
 
         var resultedEnabledPersistences = PersistenceStorageMerger.Merge(persistences, config.Settings);
 
@@ -80,7 +80,7 @@ public class When_explicitly_enabling_selected_storage
     {
         var config = new EndpointConfiguration("MyEndpoint");
         config.UsePersistence<FakePersistence, StorageType.Sagas>();
-        var persistences = config.Settings.Get<List<EnabledPersistence>>("PersistenceDefinitions");
+        var persistences = config.Settings.Get<List<EnabledPersistence>>(PersistenceComponent.PersistenceDefinitionsSettingsKey);
 
         var resultedEnabledPersistences = PersistenceStorageMerger.Merge(persistences, config.Settings);
 

--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -82,6 +82,7 @@ public partial class EndpointConfiguration : ExposeSettings
         Settings.Get<TransportSeam.Settings>().TransportDefinition = transportDefinition;
         return new RoutingSettings<TTransport>(Settings);
     }
+
     //This needs to be here since we have downstreams that use reflection to access this property
     internal void TypesToScanInternal(IEnumerable<Type> typesToScan)
     {
@@ -94,6 +95,8 @@ public partial class EndpointConfiguration : ExposeSettings
 
         ActivateAndInvoke<INeedInitialization>(availableTypes, t => t.Customize(this));
         ActivateAndInvoke<IWantToRunBeforeConfigurationIsFinalized>(availableTypes, t => t.Run(Settings));
+
+        PersistenceComponent.Configure(Settings);
     }
 
     internal ConventionsBuilder ConventionsBuilder;

--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -95,8 +95,6 @@ public partial class EndpointConfiguration : ExposeSettings
 
         ActivateAndInvoke<INeedInitialization>(availableTypes, t => t.Customize(this));
         ActivateAndInvoke<IWantToRunBeforeConfigurationIsFinalized>(availableTypes, t => t.Run(Settings));
-
-        PersistenceComponent.Configure(Settings);
     }
 
     internal ConventionsBuilder ConventionsBuilder;

--- a/src/NServiceBus.Core/EndpointCreator.cs
+++ b/src/NServiceBus.Core/EndpointCreator.cs
@@ -28,6 +28,8 @@ class EndpointCreator
 
         endpointConfiguration.FinalizeConfiguration(assemblyScanningComponent.AvailableTypes);
 
+        endpointConfiguration.Settings.ConfigurePersistence();
+
         var hostingConfiguration = HostingComponent.PrepareConfiguration(settings.Get<HostingComponent.Settings>(), assemblyScanningComponent, serviceCollection);
 
         var endpointCreator = new EndpointCreator(settings, hostingConfiguration, settings.Get<Conventions>());

--- a/src/NServiceBus.Core/Persistence/PersistenceComponent.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceComponent.cs
@@ -8,11 +8,11 @@ using Logging;
 using Persistence;
 using Settings;
 
-class PersistenceStartup : IWantToRunBeforeConfigurationIsFinalized
+class PersistenceComponent
 {
-    public void Run(SettingsHolder settings)
+    public static void Configure(SettingsHolder settings)
     {
-        if (!settings.TryGet("PersistenceDefinitions", out List<EnabledPersistence> definitions))
+        if (!settings.TryGet(PersistenceDefinitionsSettingsKey, out List<EnabledPersistence> definitions))
         {
             return;
         }
@@ -44,7 +44,7 @@ class PersistenceStartup : IWantToRunBeforeConfigurationIsFinalized
             }
         }
 
-        settings.Set("ResultingSupportedStorages", resultingSupportedStorages);
+        settings.Set(ResultingSupportedStoragesSettingsKey, resultingSupportedStorages);
 
         settings.AddStartupDiagnosticsSection("Persistence", diagnostics);
     }
@@ -66,10 +66,14 @@ class PersistenceStartup : IWantToRunBeforeConfigurationIsFinalized
 
     internal static bool HasSupportFor<T>(IReadOnlySettings settings) where T : StorageType
     {
-        settings.TryGet("ResultingSupportedStorages", out List<Type> supportedStorages);
+        settings.TryGet(ResultingSupportedStoragesSettingsKey, out List<Type> supportedStorages);
 
         return supportedStorages?.Contains(typeof(T)) ?? false;
     }
 
-    static readonly ILog Logger = LogManager.GetLogger(typeof(PersistenceStartup));
+    internal const string PersistenceDefinitionsSettingsKey = "PersistenceDefinitions";
+
+    const string ResultingSupportedStoragesSettingsKey = "ResultingSupportedStorages";
+
+    static readonly ILog Logger = LogManager.GetLogger(typeof(PersistenceComponent));
 }

--- a/src/NServiceBus.Core/Persistence/PersistenceComponent.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceComponent.cs
@@ -8,7 +8,7 @@ using Logging;
 using Persistence;
 using Settings;
 
-class PersistenceComponent
+static class PersistenceComponent
 {
     public static void Configure(SettingsHolder settings)
     {

--- a/src/NServiceBus.Core/Persistence/PersistenceComponent.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceComponent.cs
@@ -64,6 +64,18 @@ static class PersistenceComponent
         }
     }
 
+    internal static List<EnabledPersistence> GetOrSetEnabledPersistences(this SettingsHolder settings)
+    {
+        if (settings.TryGet(PersistenceDefinitionsSettingsKey, out List<EnabledPersistence> definitions))
+        {
+            return definitions;
+        }
+
+        definitions = [];
+        settings.Set(PersistenceDefinitionsSettingsKey, definitions);
+        return definitions;
+    }
+
     internal static bool HasSupportFor<T>(this IReadOnlySettings settings) where T : StorageType
     {
         settings.TryGet(ResultingSupportedStoragesSettingsKey, out List<Type> supportedStorages);
@@ -71,7 +83,7 @@ static class PersistenceComponent
         return supportedStorages?.Contains(typeof(T)) ?? false;
     }
 
-    internal const string PersistenceDefinitionsSettingsKey = "PersistenceDefinitions";
+    const string PersistenceDefinitionsSettingsKey = "PersistenceDefinitions";
 
     const string ResultingSupportedStoragesSettingsKey = "ResultingSupportedStorages";
 

--- a/src/NServiceBus.Core/Persistence/PersistenceComponent.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceComponent.cs
@@ -10,16 +10,16 @@ using Settings;
 
 static class PersistenceComponent
 {
-    public static void Configure(SettingsHolder settings)
+    public static void ConfigurePersistence(this SettingsHolder settings)
     {
         if (!settings.TryGet(PersistenceDefinitionsSettingsKey, out List<EnabledPersistence> definitions))
         {
             return;
         }
 
-        var enabledPersistences = PersistenceStorageMerger.Merge(definitions, settings);
+        var enabledPersistences = settings.MergePersistences(definitions);
 
-        ValidateSagaAndOutboxUseSamePersistence(enabledPersistences, settings);
+        settings.ValidateSagaAndOutboxUseSamePersistence(enabledPersistences);
 
         var resultingSupportedStorages = new List<Type>();
         var diagnostics = new Dictionary<string, object>();
@@ -49,7 +49,7 @@ static class PersistenceComponent
         settings.AddStartupDiagnosticsSection("Persistence", diagnostics);
     }
 
-    static void ValidateSagaAndOutboxUseSamePersistence(List<EnabledPersistence> enabledPersistences, SettingsHolder settings)
+    static void ValidateSagaAndOutboxUseSamePersistence(this SettingsHolder settings, List<EnabledPersistence> enabledPersistences)
     {
         var sagaPersisterType = enabledPersistences.FirstOrDefault(p => p.SelectedStorages.Contains(typeof(StorageType.Sagas)));
         var outboxPersisterType = enabledPersistences.FirstOrDefault(p => p.SelectedStorages.Contains(typeof(StorageType.Outbox)));
@@ -64,7 +64,7 @@ static class PersistenceComponent
         }
     }
 
-    internal static bool HasSupportFor<T>(IReadOnlySettings settings) where T : StorageType
+    internal static bool HasSupportFor<T>(this IReadOnlySettings settings) where T : StorageType
     {
         settings.TryGet(ResultingSupportedStoragesSettingsKey, out List<Type> supportedStorages);
 

--- a/src/NServiceBus.Core/Persistence/PersistenceComponent.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceComponent.cs
@@ -83,7 +83,7 @@ static class PersistenceComponent
         return supportedStorages?.Contains(typeof(T)) ?? false;
     }
 
-    const string PersistenceDefinitionsSettingsKey = "PersistenceDefinitions";
+    internal const string PersistenceDefinitionsSettingsKey = "PersistenceDefinitions";
 
     const string ResultingSupportedStoragesSettingsKey = "ResultingSupportedStorages";
 

--- a/src/NServiceBus.Core/Persistence/PersistenceExtensions.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceExtensions.cs
@@ -58,11 +58,7 @@ public class PersistenceExtensions : ExposeSettings
     public PersistenceExtensions(Type definitionType, SettingsHolder settings, Type storageType)
         : base(settings)
     {
-        if (!Settings.TryGet(PersistenceComponent.PersistenceDefinitionsSettingsKey, out List<EnabledPersistence> definitions))
-        {
-            definitions = [];
-            Settings.Set(PersistenceComponent.PersistenceDefinitionsSettingsKey, definitions);
-        }
+        List<EnabledPersistence> definitions = settings.GetOrSetEnabledPersistences();
 
         var enabledPersistence = new EnabledPersistence
         {

--- a/src/NServiceBus.Core/Persistence/PersistenceExtensions.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceExtensions.cs
@@ -58,10 +58,10 @@ public class PersistenceExtensions : ExposeSettings
     public PersistenceExtensions(Type definitionType, SettingsHolder settings, Type storageType)
         : base(settings)
     {
-        if (!Settings.TryGet("PersistenceDefinitions", out List<EnabledPersistence> definitions))
+        if (!Settings.TryGet(PersistenceComponent.PersistenceDefinitionsSettingsKey, out List<EnabledPersistence> definitions))
         {
             definitions = [];
-            Settings.Set("PersistenceDefinitions", definitions);
+            Settings.Set(PersistenceComponent.PersistenceDefinitionsSettingsKey, definitions);
         }
 
         var enabledPersistence = new EnabledPersistence

--- a/src/NServiceBus.Core/Persistence/PersistenceStorageMerger.cs
+++ b/src/NServiceBus.Core/Persistence/PersistenceStorageMerger.cs
@@ -4,9 +4,9 @@ using System.Collections.Generic;
 using Persistence;
 using Settings;
 
-class PersistenceStorageMerger
+static class PersistenceStorageMerger
 {
-    public static List<EnabledPersistence> Merge(List<EnabledPersistence> definitions, SettingsHolder settings)
+    public static List<EnabledPersistence> MergePersistences(this SettingsHolder settings, List<EnabledPersistence> definitions)
     {
         definitions.Reverse();
 

--- a/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
@@ -38,7 +38,7 @@ public class Outbox : Feature
     /// </summary>
     protected internal override void Setup(FeatureConfigurationContext context)
     {
-        if (!PersistenceStartup.HasSupportFor<StorageType.Outbox>(context.Settings))
+        if (!PersistenceComponent.HasSupportFor<StorageType.Outbox>(context.Settings))
         {
             throw new Exception("The selected persistence doesn't have support for outbox storage. Select another persistence or disable the outbox feature using endpointConfiguration.DisableFeature<Outbox>()");
         }

--- a/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/Outbox.cs
@@ -38,7 +38,7 @@ public class Outbox : Feature
     /// </summary>
     protected internal override void Setup(FeatureConfigurationContext context)
     {
-        if (!PersistenceComponent.HasSupportFor<StorageType.Outbox>(context.Settings))
+        if (!context.Settings.HasSupportFor<StorageType.Outbox>())
         {
             throw new Exception("The selected persistence doesn't have support for outbox storage. Select another persistence or disable the outbox feature using endpointConfiguration.DisableFeature<Outbox>()");
         }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -59,7 +59,7 @@ class MessageDrivenSubscriptions : Feature
         var publishingEnabled = context.Settings.Get<bool>(EnablePublishingSettingsKey);
         if (publishingEnabled)
         {
-            if (!PersistenceStartup.HasSupportFor<StorageType.Subscriptions>(context.Settings))
+            if (!PersistenceComponent.HasSupportFor<StorageType.Subscriptions>(context.Settings))
             {
                 throw new Exception("The selected persistence doesn't have support for subscription storage. Select another persistence or disable the publish functionality using transportConfiguration.DisablePublishing()");
             }

--- a/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
+++ b/src/NServiceBus.Core/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptions.cs
@@ -59,7 +59,7 @@ class MessageDrivenSubscriptions : Feature
         var publishingEnabled = context.Settings.Get<bool>(EnablePublishingSettingsKey);
         if (publishingEnabled)
         {
-            if (!PersistenceComponent.HasSupportFor<StorageType.Subscriptions>(context.Settings))
+            if (!context.Settings.HasSupportFor<StorageType.Subscriptions>())
             {
                 throw new Exception("The selected persistence doesn't have support for subscription storage. Select another persistence or disable the publish functionality using transportConfiguration.DisablePublishing()");
             }

--- a/src/NServiceBus.Core/Sagas/Sagas.cs
+++ b/src/NServiceBus.Core/Sagas/Sagas.cs
@@ -41,7 +41,7 @@ public class Sagas : Feature
     /// </summary>
     protected internal override void Setup(FeatureConfigurationContext context)
     {
-        if (!PersistenceComponent.HasSupportFor<StorageType.Sagas>(context.Settings))
+        if (!context.Settings.HasSupportFor<StorageType.Sagas>())
         {
             throw new Exception("The selected persistence doesn't have support for saga storage. Select another persistence or disable the sagas feature using endpointConfiguration.DisableFeature<Sagas>()");
         }

--- a/src/NServiceBus.Core/Sagas/Sagas.cs
+++ b/src/NServiceBus.Core/Sagas/Sagas.cs
@@ -41,7 +41,7 @@ public class Sagas : Feature
     /// </summary>
     protected internal override void Setup(FeatureConfigurationContext context)
     {
-        if (!PersistenceStartup.HasSupportFor<StorageType.Sagas>(context.Settings))
+        if (!PersistenceComponent.HasSupportFor<StorageType.Sagas>(context.Settings))
         {
             throw new Exception("The selected persistence doesn't have support for saga storage. Select another persistence or disable the sagas feature using endpointConfiguration.DisableFeature<Sagas>()");
         }


### PR DESCRIPTION
Minimal changes to avoid assembly scanning for persistence startup to happen