### PR TITLE
Remove default IAsyncDisposable implementation from ICompletableSynchronizedStorageSession

### DIFF
--- a/src/NServiceBus.Core/Reliability/SynchronizedStorage/ICompletableSynchronizedStorageSession.cs
+++ b/src/NServiceBus.Core/Reliability/SynchronizedStorage/ICompletableSynchronizedStorageSession.cs
@@ -41,13 +41,4 @@ public interface ICompletableSynchronizedStorageSession : ISynchronizedStorageSe
     /// Completes the session by saving the changes.
     /// </summary>
     Task CompleteAsync(CancellationToken cancellationToken = default);
-
-    ValueTask IAsyncDisposable.DisposeAsync()
-    {
-        Dispose();
-
-        GC.SuppressFinalize(this);
-
-        return default;
-    }
 }


### PR DESCRIPTION
Now that we're working a new major, we can remove the default `IAsyncDisposable` implementation on `ICompletableSynchronizedStorageSession`.

This aligns the interface to match the changes in #7407 so that we don't have one interface with a default implementation and one without.