### PR TITLE
Convert tests use to Assert.EnterMultipleScope

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Audit/When_a_replymessage_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Audit/When_a_replymessage_is_audited.cs
@@ -21,12 +21,12 @@ public class When_a_replymessage_is_audited : NServiceBusAcceptanceTest
             .Done(c => c.MessageAudited)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.MessageProcessed, Is.True);
             Assert.That(context.MessageAudited, Is.True);
             Assert.That(context.HeaderValue, Is.EqualTo("SomeValue"));
-        });
+        }
     }
 
     public static byte Checksum(byte[] data)

--- a/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_starting_an_endpoint_with_autosubscribe.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/AutomaticSubscriptions/When_starting_an_endpoint_with_autosubscribe.cs
@@ -22,13 +22,13 @@ public class When_starting_an_endpoint_with_autosubscribe : NServiceBusAcceptanc
 
         Assert.That(context.EventsSubscribedTo, Has.Count.EqualTo(1));
         Assert.That(context.EventsSubscribedTo, Does.Contain(typeof(MyEvent).AssemblyQualifiedName), "Events should be auto subscribed");
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.EventsSubscribedTo.Contains(typeof(MyEventWithNoRouting).AssemblyQualifiedName), Is.False, "Events without routing should not be auto subscribed");
             Assert.That(context.EventsSubscribedTo.Contains(typeof(MyEventWithNoHandler).AssemblyQualifiedName), Is.False, "Events without handlers should not be auto subscribed");
             Assert.That(context.EventsSubscribedTo.Contains(typeof(MyCommand).AssemblyQualifiedName), Is.False, "Commands should not be auto subscribed");
             Assert.That(context.EventsSubscribedTo.Contains(typeof(MyMessage).AssemblyQualifiedName), Is.False, "Plain messages should not be auto subscribed by default");
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Causation/When_a_message_is_sent.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Causation/When_a_message_is_sent.cs
@@ -15,11 +15,11 @@ public class When_a_message_is_sent : NServiceBusAcceptanceTest
             .Done(c => c.Done)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.ConversationIdReceived, Is.EqualTo(context.FirstConversationId), "Conversation id should flow to outgoing messages");
             Assert.That(context.RelatedToReceived, Is.EqualTo(context.MessageIdOfFirstMessage), "RelatedToId on outgoing messages should be set to the message id of the message causing it to be sent");
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Causation/When_overriding_conversation_id_generation.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Causation/When_overriding_conversation_id_generation.cs
@@ -34,11 +34,11 @@ public class When_overriding_conversation_id_generation : NServiceBusAcceptanceT
             .Done(c => c.MatchingMessageReceived && c.NonMatchingMessageReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.MatchingConversationIdReceived, Is.EqualTo($"{tennantId}-{myBusinessMessage.MyBusinessId}"));
             Assert.That(Guid.TryParse(context.NonMatchingConversationIdReceived, out var _), Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Causation/When_starting_new_conversation_inside_message_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Causation/When_starting_new_conversation_inside_message_handler.cs
@@ -23,11 +23,11 @@ public class When_starting_new_conversation_inside_message_handler : NServiceBus
             .Done(ctx => ctx.MessageHandled)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.NewConversationId, Is.EqualTo(UserDefinedConverstionId), "ConversationId should be set to the user defined value.");
             Assert.That(context.PreviousConversationId, Is.EqualTo(context.OriginalConversationId), "PreviousConversationId header should be set to the original conversation id.");
-        });
+        }
     }
 
     [Test]
@@ -43,11 +43,11 @@ public class When_starting_new_conversation_inside_message_handler : NServiceBus
             .Run();
 
         Assert.That(context.NewConversationId, Is.EqualTo(GeneratedConversationId), "ConversationId should be generated.");
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.NewConversationId, Is.Not.EqualTo(context.OriginalConversationId), "ConversationId should not be equal to the original conversation id.");
             Assert.That(context.PreviousConversationId, Is.EqualTo(context.OriginalConversationId), "PreviousConversationId header should be set to the original conversation id.");
-        });
+        }
     }
 
     class NewConversationScenario : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Causation/When_starting_new_conversation_outside_message_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Causation/When_starting_new_conversation_outside_message_handler.cs
@@ -26,11 +26,11 @@ public class When_starting_new_conversation_outside_message_handler : NServiceBu
             .Done(ctx => ctx.MessageHandled)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.ConversationId, Is.EqualTo(NewConversionId), "ConversationId should be set to configured user defined value.");
             Assert.That(context.PreviousConversationId, Is.Null, "Previous ConversationId should not be set when handling a message outside of a message handler.");
-        });
+        }
     }
 
     [Test]
@@ -49,11 +49,11 @@ public class When_starting_new_conversation_outside_message_handler : NServiceBu
             .Run();
 
         Assert.That(context.ConversationId, Is.EqualTo(GeneratedConversationId), "ConversationId should be generated.");
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.ConversationId, Is.Not.EqualTo(context.PreviousConversationId), "ConversationId should not match the previous conversationId.");
             Assert.That(context.PreviousConversationId, Is.Null, "Previous ConversationId should not be set when handling a message outside of a message handler.");
-        });
+        }
     }
 
     [Test]
@@ -83,11 +83,11 @@ public class When_starting_new_conversation_outside_message_handler : NServiceBu
             .Run();
 
         var expectedExceptionMessage = $"Cannot set the NServiceBus.ConversationId header to '{overrideConversationId}' as StartNewConversation() was called.";
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.ExceptionThrown, Is.True, "Exception should be thrown when trying to directly set conversationId");
             Assert.That(context.ExceptionMessage, Is.EqualTo(expectedExceptionMessage));
-        });
+        }
     }
 
     public class AnyMessage : IMessage

--- a/src/NServiceBus.AcceptanceTests/Core/Conventions/When_receiving_unobtrusive_message_without_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Conventions/When_receiving_unobtrusive_message_without_handler.cs
@@ -19,12 +19,12 @@ public class When_receiving_unobtrusive_message_without_handler : NServiceBusAcc
             .Done(c => !c.FailedMessages.IsEmpty)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Logs.Any(l => l.Level == LogLevel.Error && l.Message.Contains($"No handlers could be found for message type: {typeof(MyCommand).FullName}")), Is.True, "No handlers could be found was not logged.");
             Assert.That(context.Logs.Any(l => l.Level == LogLevel.Warn && l.Message.Contains($"Message header '{typeof(MyCommand).FullName}' was mapped to type '{typeof(MyCommand).FullName}' but that type was not found in the message registry, ensure the same message registration conventions are used in all endpoints, especially if using unobtrusive mode.")), Is.False, "Message type could not be mapped.");
             Assert.That(context.Logs.Any(l => l.Level == LogLevel.Warn && l.Message.Contains($"Could not determine message type from message header '{typeof(MyCommand).FullName}'")), Is.False, "Message type could not be mapped.");
-        });
+        }
     }
 
     public class Context : ScenarioContext { }

--- a/src/NServiceBus.AcceptanceTests/Core/Conventions/When_sending_with_conventions.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Conventions/When_sending_with_conventions.cs
@@ -20,11 +20,11 @@ public class When_sending_with_conventions : NServiceBusAcceptanceTest
             .Done(c => c.MessageClassReceived && c.MessageInterfaceReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.MessageClassReceived, Is.True);
             Assert.That(context.MessageInterfaceReceived, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_at_startup.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/CriticalError/When_raising_critical_error_at_startup.cs
@@ -29,11 +29,11 @@ public class When_raising_critical_error_at_startup : NServiceBusAcceptanceTest
             .Done(c => c.CriticalErrorsRaised >= 2 && exceptions.Count >= 2)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.CriticalErrorsRaised, Is.EqualTo(2));
             Assert.That(exceptions, Has.Count.EqualTo(context.CriticalErrorsRaised));
-        });
+        }
     }
 
     public class TestContext : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/When_delayed_delivery_is_not_supported.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DelayedDelivery/When_delayed_delivery_is_not_supported.cs
@@ -28,11 +28,11 @@ public class When_delayed_delivery_is_not_supported : NServiceBusAcceptanceTest
             .Done(c => c.ExceptionThrown || c.SecondMessageReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.ExceptionThrown, Is.EqualTo(true));
             Assert.That(context.SecondMessageReceived, Is.EqualTo(false));
-        });
+        }
 
     }
 

--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_overriding_services_in_registercomponents.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_overriding_services_in_registercomponents.cs
@@ -31,14 +31,14 @@ public class When_overriding_services_in_registercomponents : NServiceBusAccepta
             .Done(c => c.EndpointsStarted)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.DependencyFromFeature, Is.InstanceOf<OverridenDependency>());
             Assert.That(context.DependencyBeforeEndpointConfiguration, Is.InstanceOf<OverridenDependency>());
 
             // Registrations after the startable endpoint has been created can't be overriden by the RegisterComponents API
             Assert.That(context.DependencyBeforeEndpointStart, Is.InstanceOf<OriginallyDefinedDependency>());
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_registering_async_disposables_externally_managed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_registering_async_disposables_externally_managed.cs
@@ -35,11 +35,11 @@ public class When_registering_async_disposables_externally_managed : NServiceBus
 
         await serviceProvider.DisposeAsync();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.ScopedAsyncDisposableDisposed, Is.True, "Scoped AsyncDisposable wasn't disposed as it should have been.");
             Assert.That(context.SingletonAsyncDisposableDisposed, Is.True, "Singleton AsyncDisposable wasn't disposed as it should have been.");
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_registering_async_disposables_internally_managed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_registering_async_disposables_internally_managed.cs
@@ -21,11 +21,11 @@ public class When_registering_async_disposables_internally_managed : NServiceBus
             .Done(c => c.ScopedAsyncDisposableDisposed)
             .Run(TimeSpan.FromSeconds(10));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.ScopedAsyncDisposableDisposed, Is.True, "Scoped AsyncDisposable wasn't disposed as it should have been.");
             Assert.That(context.SingletonAsyncDisposableDisposed, Is.True, "Singleton AsyncDisposable wasn't disposed as it should have been.");
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_using_externally_managed_container.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/DependencyInjection/When_using_externally_managed_container.cs
@@ -29,11 +29,11 @@ public class When_using_externally_managed_container : NServiceBusAcceptanceTest
         .Done(c => c.MessageReceived)
         .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result.ServiceProvider, Is.Not.Null, "IServiceProvider should be injectable");
             Assert.That(result.CustomService, Is.SameAs(myComponent), "Should inject custom services");
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_a_message_is_audited.cs
@@ -17,13 +17,13 @@ public class When_a_message_is_audited : NServiceBusAcceptanceTest
             .Done(c => c.Done)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.HostId, Is.Not.Null);
             Assert.That(context.HostName, Is.Not.Null);
             Assert.That(context.Endpoint, Is.Not.Null);
             Assert.That(context.Machine, Is.Not.Null);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_a_message_is_faulted.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_a_message_is_faulted.cs
@@ -17,13 +17,13 @@ public class When_a_message_is_faulted : NServiceBusAcceptanceTest
             .Done(c => c.Done)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.HostId, Is.Not.Null, "Host Id should be included in fault message headers");
             Assert.That(context.HostName, Is.Not.Null, "Host Name should be included in fault message headers");
             Assert.That(context.Endpoint, Is.Not.Null, "Endpoint name should be included in fault message headers.");
             Assert.That(context.Machine, Is.Not.Null, "Machine should be included in fault message headers.");
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_message_is_audited.cs
@@ -26,12 +26,12 @@ public class When_message_is_audited : NServiceBusAcceptanceTest
         var processingEnded = DateTimeOffsetHelper.ToDateTimeOffset(context.Headers[Headers.ProcessingEnded]);
         var timeSent = DateTimeOffsetHelper.ToDateTimeOffset(context.Headers[Headers.TimeSent]);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(processingStarted, Is.EqualTo(now).Within(TimeSpan.FromSeconds(30)), nameof(processingStarted));
             Assert.That(processingEnded, Is.EqualTo(now).Within(TimeSpan.FromSeconds(30)), nameof(processingEnded));
             Assert.That(timeSent, Is.EqualTo(now).Within(TimeSpan.FromSeconds(30)), nameof(timeSent));
-        });
+        }
         Assert.That(processingStarted, Is.LessThanOrEqualTo(processingEnded), nameof(processingStarted));
         Assert.That(timeSent, Is.LessThanOrEqualTo(processingEnded), nameof(timeSent));
         Assert.That(context.IsMessageHandledByTheAuditEndpoint, Is.True, nameof(context.IsMessageHandledByTheAuditEndpoint));

--- a/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_message_is_faulted.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_message_is_faulted.cs
@@ -28,22 +28,22 @@ public class When_message_is_faulted : NServiceBusAcceptanceTest
         var timeSent = DateTimeOffsetHelper.ToDateTimeOffset(context.Headers[Headers.TimeSent]);
         var timeSentWhenFailedMessageWasSentToTheErrorQueue = DateTimeOffsetHelper.ToDateTimeOffset(context.FaultHeaders[Headers.TimeSent]);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(processingStarted, Is.EqualTo(now).Within(TimeSpan.FromSeconds(30)), nameof(processingStarted));
             Assert.That(processingEnded, Is.EqualTo(now).Within(TimeSpan.FromSeconds(30)), nameof(processingEnded));
             Assert.That(timeSent, Is.EqualTo(now).Within(TimeSpan.FromSeconds(30)), nameof(timeSent));
             Assert.That(timeSentWhenFailedMessageWasSentToTheErrorQueue, Is.EqualTo(now).Within(TimeSpan.FromSeconds(30)), nameof(timeSentWhenFailedMessageWasSentToTheErrorQueue));
-        });
+        }
         Assert.That(timeSent, Is.LessThanOrEqualTo(processingEnded), nameof(processingEnded));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(timeSent, Is.LessThanOrEqualTo(timeSentWhenFailedMessageWasSentToTheErrorQueue), nameof(timeSentWhenFailedMessageWasSentToTheErrorQueue));
 
             Assert.That(timeSentWhenFailedMessageWasSentToTheErrorQueue, Is.EqualTo(context.TimeSentOnTheFailingMessageWhenItWasHandled), nameof(timeSentWhenFailedMessageWasSentToTheErrorQueue));
             Assert.That(processingStarted, Is.LessThanOrEqualTo(processingEnded), nameof(processingStarted));
             Assert.That(context.IsMessageHandledByTheFaultEndpoint, Is.True, nameof(context.IsMessageHandledByTheFaultEndpoint));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_overriding_input_queue_name.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_overriding_input_queue_name.cs
@@ -15,11 +15,11 @@ public class When_overriding_input_queue_name : NServiceBusAcceptanceTest
             .Done(c => c.Done)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Done, Is.True);
             Assert.That(context.InputQueue, Does.StartWith("OverriddenInputQueue"));
-        });
+        }
     }
 
     public class MyEndpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_sending_ensure_proper_headers.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Diagnostics/When_sending_ensure_proper_headers.cs
@@ -20,13 +20,13 @@ public class When_sending_ensure_proper_headers : NServiceBusAcceptanceTest
             .Done(c => c.WasCalled)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.WasCalled, Is.True, "The message handler should be called");
             Assert.That(context.ReceivedHeaders[Headers.OriginatingEndpoint], Is.EqualTo("SenderForEnsureProperHeadersTest"), "Message should contain the Originating endpoint");
             Assert.That(context.ReceivedHeaders[Headers.OriginatingHostId], Is.Not.Null.Or.Empty, "OriginatingHostId cannot be null or empty");
             Assert.That(context.ReceivedHeaders[Headers.OriginatingMachine], Is.Not.Null.Or.Empty, "Endpoint machine name cannot be null or empty");
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/FakeTransport/CriticalError/When_registering_custom_critical_error_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/FakeTransport/CriticalError/When_registering_custom_critical_error_handler.cs
@@ -19,11 +19,11 @@ public class When_registering_custom_critical_error_handler : NServiceBusAccepta
             .Done(c => c.ExceptionReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Message, Does.StartWith("Startup task failed to complete."));
             Assert.That(context.Exception.Message, Is.EqualTo("ExceptionInBusStarts"));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_feature.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Feature/When_depending_on_feature.cs
@@ -23,11 +23,11 @@ public class When_depending_on_feature : NServiceBusAcceptanceTest
             .Done(c => c.EndpointsStarted)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.StartCalled, Is.True);
             Assert.That(context.StopCalled, Is.True);
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Hosting/When_custom_host_id_is_configured.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Hosting/When_custom_host_id_is_configured.cs
@@ -22,11 +22,11 @@ public class When_custom_host_id_is_configured : NServiceBusAcceptanceTest
             .Done(c => c.EndpointsStarted)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.HostIdDefaultApplied, Is.False);
             Assert.That(context.HostIdObserved, Is.EqualTo(context.CustomHostId));
-        });
+        }
     }
 
     public class MyEndpoint : EndpointConfigurationBuilder

--- a/src/NServiceBus.AcceptanceTests/Core/Installers/When_installing_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Installers/When_installing_endpoint.cs
@@ -20,12 +20,12 @@ public class When_installing_endpoint : NServiceBusAcceptanceTest
             .WithComponent(new InstallationOnlyComponent<EndpointWithInstaller>())
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.InstallerCalled, Is.True, "Should run installers");
             Assert.That(context.FeatureSetupCalled, Is.True, "Should initialize Features");
             Assert.That(context.FeatureStartupTaskCalled, Is.False, "Should not start FeatureStartupTasks");
-        });
+        }
         Assert.That(new string[]
         {
             $"{nameof(TransportDefinition)}.{nameof(TransportDefinition.Initialize)}",

--- a/src/NServiceBus.AcceptanceTests/Core/Mutators/When_defining_outgoing_message_mutators.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Mutators/When_defining_outgoing_message_mutators.cs
@@ -16,12 +16,12 @@ public class When_defining_outgoing_message_mutators : NServiceBusAcceptanceTest
             .Done(c => c.MessageProcessed)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.TransportMutatorCalled, Is.True);
             Assert.That(context.OtherTransportMutatorCalled, Is.True);
             Assert.That(context.MessageMutatorCalled, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Mutators/When_incoming_mutator_changes_message_type.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Mutators/When_incoming_mutator_changes_message_type.cs
@@ -17,13 +17,13 @@ public class When_incoming_mutator_changes_message_type : NServiceBusAcceptanceT
             .Done(c => c.NewMessageHandlerCalled || c.OriginalMessageHandlerCalled)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.NewMessageHandlerCalled, Is.True);
             Assert.That(context.NewMessageSagaHandlerCalled, Is.True);
             Assert.That(context.OriginalMessageHandlerCalled, Is.False);
             Assert.That(context.OriginalMessageSagaHandlerCalled, Is.False);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Mutators/When_mutating.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Mutators/When_mutating.cs
@@ -77,55 +77,55 @@ public class When_mutating : NServiceBusAcceptanceTest
         {
             public Task MutateIncoming(MutateIncomingMessageContext context)
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(context.Headers, Is.Not.Empty);
                     Assert.That(context.Message, Is.Not.Null);
-                });
+                }
                 return Task.CompletedTask;
             }
 
             public Task MutateIncoming(MutateIncomingTransportMessageContext context)
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(context.Headers, Is.Not.Empty);
                     Assert.That(context.Body, Is.Not.EqualTo(default(ReadOnlyMemory<byte>)));
-                });
+                }
                 return Task.CompletedTask;
             }
 
             public Task MutateOutgoing(MutateOutgoingMessageContext context)
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(context.OutgoingHeaders, Is.Not.Empty);
                     Assert.That(context.OutgoingMessage, Is.Not.Null);
-                });
+                }
                 context.TryGetIncomingHeaders(out var incomingHeaders);
                 context.TryGetIncomingMessage(out var incomingMessage);
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(incomingHeaders, Is.Not.Empty);
                     Assert.That(incomingMessage, Is.Not.Null);
-                });
+                }
                 return Task.CompletedTask;
             }
 
             public Task MutateOutgoing(MutateOutgoingTransportMessageContext context)
             {
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(context.OutgoingHeaders, Is.Not.Empty);
                     Assert.That(context.OutgoingBody, Is.Not.EqualTo(default(ReadOnlyMemory<byte>)));
-                });
+                }
                 context.TryGetIncomingHeaders(out var incomingHeaders);
                 context.TryGetIncomingMessage(out var incomingMessage);
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(incomingHeaders, Is.Not.Empty);
                     Assert.That(incomingMessage, Is.Not.Null);
-                });
+                }
                 return Task.CompletedTask;
             }
         }

--- a/src/NServiceBus.AcceptanceTests/Core/Mutators/When_outgoing_mutator_replaces_instance.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Mutators/When_outgoing_mutator_replaces_instance.cs
@@ -16,11 +16,11 @@ public class When_outgoing_mutator_replaces_instance : NServiceBusAcceptanceTest
             .Done(c => c.V2MessageReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.V2MessageReceived, Is.True);
             Assert.That(context.V1MessageReceived, Is.False);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Mutators/When_using_outgoing_tm_mutator.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Mutators/When_using_outgoing_tm_mutator.cs
@@ -17,11 +17,11 @@ public class When_using_outgoing_tm_mutator : NServiceBusAcceptanceTest
             .Done(c => c.MessageProcessed)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.CanAddHeaders, Is.True);
             Assert.That(context.MutatedPropertyValue, Is.EqualTo("SomeValue"), "Mutator should be able to mutate body.");
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/ActivityTestingExtensions.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/ActivityTestingExtensions.cs
@@ -9,11 +9,11 @@ public static class ActivityTestingExtensions
 {
     public static void VerifyTag(this ImmutableDictionary<string, string> tags, string tagName, string expectedValue)
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(tags.TryGetValue(tagName, out var tagValue), Is.True, $"Tags should contain key '{tagName}'");
             Assert.That(tagValue, Is.EqualTo(expectedValue), $"Tag value with key '{tagName}' is incorrect");
-        });
+        }
     }
 
     /// <summary>

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Metrics/TestingMetricListener.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Metrics/TestingMetricListener.cs
@@ -71,11 +71,11 @@ class TestingMetricListener : IDisposable
         }
         else
         {
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(ReportedMeters.ContainsKey(metricName), Is.True, $"'{metricName}' metric was not reported.");
                 Assert.That(ReportedMeters[metricName], Is.EqualTo(expected));
-            });
+            }
         }
     }
 

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Metrics/When_message_is_processed_successfully.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Metrics/When_message_is_processed_successfully.cs
@@ -107,13 +107,13 @@ public class When_message_is_processed_successfully : OpenTelemetryAcceptanceTes
 
         var fetchedEndpoint = metricsListener.AssertTagKeyExists("nservicebus.messaging.fetches", "nservicebus.queue");
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(successEndpoint, Is.EqualTo(Conventions.EndpointNamingConvention(typeof(EndpointWithMetrics))));
             Assert.That(fetchedEndpoint, Is.EqualTo(Conventions.EndpointNamingConvention(typeof(EndpointWithMetrics))));
             Assert.That(successType, Is.EqualTo(typeof(OutgoingWithComplexHierarchyMessage).FullName));
             Assert.That(successHandlerType, Is.EqualTo(typeof(EndpointWithMetrics.ComplexMessageHandler).FullName));
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_ambient_trace_in_message_session.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_ambient_trace_in_message_session.cs
@@ -37,7 +37,7 @@ public class When_ambient_trace_in_message_session : OpenTelemetryAcceptanceTest
         var outgoingMessageActivity = NServiceBusActivityListener.CompletedActivities.GetSendMessageActivities().Single();
         var incomingMessageActivity = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities().Single();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(outgoingMessageActivity.ParentId, Is.EqualTo(context.WrapperActivityId), "outgoing message should be connected to the ambient span");
             Assert.That(outgoingMessageActivity.RootId, Is.EqualTo(context.WrapperActivityRootId), "outgoing message should be connected to the ambient trace");
@@ -45,7 +45,7 @@ public class When_ambient_trace_in_message_session : OpenTelemetryAcceptanceTest
             Assert.That(incomingMessageActivity.ParentId, Is.EqualTo(outgoingMessageActivity.Id), "received message should be connected to send operation span");
             Assert.That(incomingMessageActivity.RootId, Is.EqualTo(context.WrapperActivityRootId), "received message should be connected to the ambient trace");
             Assert.That(incomingMessageActivity.TraceStateString, Is.EqualTo(wrapperActivityTraceState), "ambient trace state should be floated to incoming message span");
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_ambient_trace_in_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_ambient_trace_in_pipeline.cs
@@ -24,14 +24,14 @@ public class When_ambient_trace_in_pipeline : OpenTelemetryAcceptanceTest
 
         var handlerActivity = NServiceBusActivityListener.CompletedActivities.GetInvokedHandlerActivities().First();
         var sendFromHandlerActivity = NServiceBusActivityListener.CompletedActivities.GetSendMessageActivities().Last();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(sendFromHandlerActivity.ParentId, Is.EqualTo(context.AmbientActivityId), "the outgoing message should be connected to the ambient span");
             Assert.That(sendFromHandlerActivity.RootId, Is.EqualTo(context.AmbientActivityRootId), "outgoing and ambient activity should belong to same trace");
             Assert.That(sendFromHandlerActivity.TraceStateString, Is.EqualTo(ExpectedTraceState), "outgoing activity should capture ambient trace state");
             Assert.That(context.AmbientActivityParentId, Is.EqualTo(handlerActivity.Id), "the ambient activity should be connected to the handler span");
             Assert.That(context.AmbientActivityRootId, Is.EqualTo(handlerActivity.RootId), "handler and ambient activity should belong to same trace");
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_incoming_event_has_trace.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_incoming_event_has_trace.cs
@@ -30,7 +30,7 @@ public class When_incoming_event_has_trace : OpenTelemetryAcceptanceTest
         var incomingActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
         var outgoingActivities = NServiceBusActivityListener.CompletedActivities.GetSendMessageActivities();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(incomingActivities, Has.Count.EqualTo(2), "2 messages are received as part of this test (event + reply)");
             Assert.That(outgoingActivities, Has.Count.EqualTo(1), "1 message is sent as part of this test (reply)");
@@ -38,7 +38,7 @@ public class When_incoming_event_has_trace : OpenTelemetryAcceptanceTest
 
             Assert.That(incomingActivities.Concat(outgoingActivities)
                 .All(a => a.RootId == incomingActivities[0].RootId), Is.True, "all activities should belong to the same trace");
-        });
+        }
     }
     public class Context : ScenarioContext
     {

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_incoming_message_has_trace.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_incoming_message_has_trace.cs
@@ -22,18 +22,18 @@ public class When_incoming_message_has_trace : OpenTelemetryAcceptanceTest // as
 
         var incomingMessageActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
         var outgoingMessageActivities = NServiceBusActivityListener.CompletedActivities.GetSendMessageActivities();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(incomingMessageActivities, Has.Count.EqualTo(2), "2 messages are received as part of this test");
             Assert.That(outgoingMessageActivities, Has.Count.EqualTo(2), "2 messages are sent as part of this test");
-        });
+        }
 
         var sendRequest = outgoingMessageActivities[0];
         var receiveRequest = incomingMessageActivities[0];
         var sendReply = outgoingMessageActivities[1];
         var receiveReply = incomingMessageActivities[1];
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(receiveRequest.RootId, Is.EqualTo(sendRequest.RootId), "first send operation is the root activity");
             Assert.That(receiveRequest.ParentId, Is.EqualTo(sendRequest.Id), "first incoming message is correlated to the first send operation");
@@ -45,7 +45,7 @@ public class When_incoming_message_has_trace : OpenTelemetryAcceptanceTest // as
             Assert.That(receiveRequest.Tags.ToImmutableDictionary()["nservicebus.message_id"], Is.EqualTo(context.IncomingMessageId));
             Assert.That(sendReply.Tags.ToImmutableDictionary()["nservicebus.message_id"], Is.EqualTo(context.ReplyMessageId));
             Assert.That(receiveReply.Tags.ToImmutableDictionary()["nservicebus.message_id"], Is.EqualTo(context.ReplyMessageId));
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_incoming_message_moved_to_error_queue.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_incoming_message_moved_to_error_queue.cs
@@ -19,11 +19,11 @@ public class When_incoming_message_moved_to_error_queue : OpenTelemetryAcceptanc
             .Run();
 
         var failedMessage = context.FailedMessages.First().Value.First();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(failedMessage.Headers.ContainsKey(Headers.StartNewTrace), Is.True);
             Assert.That(failedMessage.Headers[Headers.StartNewTrace], Is.EqualTo(bool.TrueString));
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_processing_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_processing_fails.cs
@@ -22,22 +22,22 @@ public class When_processing_fails : OpenTelemetryAcceptanceTest
         Assert.That(context.FailedMessages, Has.Count.EqualTo(1), "the message should have failed");
 
         Activity failedPipelineActivity = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities().Single();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(failedPipelineActivity.Status, Is.EqualTo(ActivityStatusCode.Error));
             Assert.That(failedPipelineActivity.StatusDescription, Is.EqualTo(ErrorMessage));
-        });
+        }
 
         var pipelineActivityTags = failedPipelineActivity.Tags.ToImmutableDictionary();
         pipelineActivityTags.VerifyTag("otel.status_code", "ERROR");
         pipelineActivityTags.VerifyTag("otel.status_description", ErrorMessage);
 
         Activity failedHandlerActivity = NServiceBusActivityListener.CompletedActivities.GetInvokedHandlerActivities().Single();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(failedHandlerActivity.Status, Is.EqualTo(ActivityStatusCode.Error));
             Assert.That(failedHandlerActivity.StatusDescription, Is.EqualTo(ErrorMessage));
-        });
+        }
 
         var handlerActivityTags = failedHandlerActivity.Tags.ToImmutableDictionary();
         handlerActivityTags.VerifyTag("otel.status_code", "ERROR");

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_processing_incoming_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_processing_incoming_message.cs
@@ -23,12 +23,12 @@ public class When_processing_incoming_message : OpenTelemetryAcceptanceTest
         Assert.That(incomingMessageActivities, Has.Count.EqualTo(1), "1 message is being processed");
 
         var incomingActivity = incomingMessageActivities.Single();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(incomingActivity.Kind, Is.EqualTo(ActivityKind.Consumer), "asynchronous receivers should use 'Consumer'");
 
             Assert.That(incomingActivity.Status, Is.EqualTo(ActivityStatusCode.Ok));
-        });
+        }
         var destination = AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(ReceivingEndpoint));
         Assert.That(incomingActivity.DisplayName, Is.EqualTo("process message"));
 

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_processing_message_with_multiple_handlers.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_processing_message_with_multiple_handlers.cs
@@ -23,11 +23,11 @@ public class When_processing_message_with_multiple_handlers : OpenTelemetryAccep
         var invokedHandlerActivities = NServiceBusActivityListener.CompletedActivities.GetInvokedHandlerActivities();
         var receivePipelineActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(invokedHandlerActivities, Has.Count.EqualTo(2), "a dedicated span for each handler should be created");
             Assert.That(receivePipelineActivities, Has.Count.EqualTo(1), "the receive pipeline should be invoked once");
-        });
+        }
 
         var recordedHandlerTypes = new HashSet<string>();
 
@@ -36,11 +36,11 @@ public class When_processing_message_with_multiple_handlers : OpenTelemetryAccep
             var handlerTypeTag = invokedHandlerActivity.GetTagItem("nservicebus.handler.handler_type") as string;
             Assert.That(handlerTypeTag, Is.Not.Null, "Handler type tag should be set");
             recordedHandlerTypes.Add(handlerTypeTag);
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(invokedHandlerActivity.ParentId, Is.EqualTo(receivePipelineActivities[0].Id));
                 Assert.That(invokedHandlerActivity.Status, Is.EqualTo(ActivityStatusCode.Ok));
-            });
+            }
 
             Assert.That(invokedHandlerActivity.GetTagItem("custom_handler_tag"), Is.Not.Null, "Custom tag should be set");
         }

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_publishing_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_publishing_messages.cs
@@ -33,11 +33,11 @@ public class When_publishing_messages : OpenTelemetryAcceptanceTest
 
         var publishedMessage = outgoingEventActivities.Single();
         publishedMessage.VerifyUniqueTags();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(publishedMessage.DisplayName, Is.EqualTo("publish event"));
             Assert.That(publishedMessage.ParentId, Is.Null, "publishes without ambient span should start a new trace");
-        });
+        }
 
         var sentMessageTags = publishedMessage.Tags.ToImmutableDictionary();
         sentMessageTags.VerifyTag("nservicebus.message_id", context.PublishedMessageId);
@@ -70,20 +70,20 @@ public class When_publishing_messages : OpenTelemetryAcceptanceTest
 
         var publishMessageActivities = NServiceBusActivityListener.CompletedActivities.GetPublishEventActivities();
         var receiveMessageActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(publishMessageActivities, Has.Count.EqualTo(1), "1 message is published as part of this test");
             Assert.That(receiveMessageActivities, Has.Count.EqualTo(1), "1 message is received as part of this test");
-        });
+        }
 
         var publishRequest = publishMessageActivities[0];
         var receiveRequest = receiveMessageActivities[0];
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(receiveRequest.RootId, Is.EqualTo(publishRequest.RootId), "publish and receive operations are part the same root activity");
             Assert.That(receiveRequest.ParentId, Is.Not.Null, "incoming message does have a parent");
-        });
+        }
 
         Assert.That(receiveRequest.Links, Is.Empty, "receive does not have links");
     }
@@ -111,20 +111,20 @@ public class When_publishing_messages : OpenTelemetryAcceptanceTest
 
         var publishMessageActivities = NServiceBusActivityListener.CompletedActivities.GetPublishEventActivities();
         var receiveMessageActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(publishMessageActivities, Has.Count.EqualTo(1), "1 message is published as part of this test");
             Assert.That(receiveMessageActivities, Has.Count.EqualTo(1), "1 message is received as part of this test");
-        });
+        }
 
         var publishRequest = publishMessageActivities[0];
         var receiveRequest = receiveMessageActivities[0];
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(receiveRequest.RootId, Is.Not.EqualTo(publishRequest.RootId), "publish and receive operations are part of different root activities");
             Assert.That(receiveRequest.ParentId, Is.Null, "incoming message does not have a parent, it's a root");
-        });
+        }
 
         ActivityLink link = receiveRequest.Links.FirstOrDefault();
         Assert.That(link, Is.Not.EqualTo(default(ActivityLink)), "Receive has a link");

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_retrying_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_retrying_messages.cs
@@ -22,18 +22,18 @@ public class When_retrying_messages : OpenTelemetryAcceptanceTest
         var receiveActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
         var sendActivities = NServiceBusActivityListener.CompletedActivities.GetSendMessageActivities();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(sendActivities, Has.Count.EqualTo(1));
             Assert.That(receiveActivities, Has.Count.EqualTo(2), "the message should be processed twice due to one immediate retry");
-        });
-        Assert.Multiple(() =>
+        }
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(receiveActivities[0].ParentId, Is.EqualTo(sendActivities[0].Id), "should not change parent span");
             Assert.That(receiveActivities[1].ParentId, Is.EqualTo(sendActivities[0].Id), "should not change parent span");
 
             Assert.That(sendActivities.Concat(receiveActivities).All(a => a.TraceId == sendActivities[0].TraceId), Is.True, "all activities should be part of the same trace");
-        });
+        }
     }
 
     [Test]
@@ -52,18 +52,18 @@ public class When_retrying_messages : OpenTelemetryAcceptanceTest
         var receiveActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
         var sendActivities = NServiceBusActivityListener.CompletedActivities.GetSendMessageActivities();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(sendActivities, Has.Count.EqualTo(1));
             Assert.That(receiveActivities, Has.Count.EqualTo(2), "the message should be processed twice due to one immediate retry");
-        });
-        Assert.Multiple(() =>
+        }
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(receiveActivities[0].ParentId, Is.EqualTo(sendActivities[0].Id), "should not change parent span");
             Assert.That(receiveActivities[1].ParentId, Is.EqualTo(sendActivities[0].Id), "should not change parent span");
 
             Assert.That(sendActivities.Concat(receiveActivities).All(a => a.TraceId == sendActivities[0].TraceId), Is.True, "all activities should be part of the same trace");
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_sending_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_sending_messages.cs
@@ -23,11 +23,11 @@ public class When_sending_messages : OpenTelemetryAcceptanceTest
         Assert.That(outgoingMessageActivities, Has.Count.EqualTo(1), "1 message is being sent");
         var sentMessage = outgoingMessageActivities.Single();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(sentMessage.ParentId, Is.Null, "sends without ambient span should start a new trace");
             Assert.That(sentMessage.DisplayName, Is.EqualTo("send message"));
-        });
+        }
 
         var sentMessageTags = sentMessage.Tags.ToImmutableDictionary();
         sentMessageTags.VerifyTag("nservicebus.message_id", context.SentMessageId);
@@ -56,20 +56,20 @@ public class When_sending_messages : OpenTelemetryAcceptanceTest
 
         var sendMessageActivities = NServiceBusActivityListener.CompletedActivities.GetSendMessageActivities();
         var receiveMessageActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(sendMessageActivities, Has.Count.EqualTo(1), "1 message is sent as part of this test");
             Assert.That(receiveMessageActivities, Has.Count.EqualTo(1), "1 message is received as part of this test");
-        });
+        }
 
         var sendRequest = sendMessageActivities[0];
         var receiveRequest = receiveMessageActivities[0];
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(receiveRequest.RootId, Is.EqualTo(sendRequest.RootId), "send and receive operations are part of the same root activity");
             Assert.That(receiveRequest.ParentId, Is.Not.Null, "incoming message does have a parent");
-        });
+        }
 
         Assert.That(receiveRequest.Links, Is.Empty, "receive does not have links");
     }
@@ -91,20 +91,20 @@ public class When_sending_messages : OpenTelemetryAcceptanceTest
 
         var sendMessageActivities = NServiceBusActivityListener.CompletedActivities.GetSendMessageActivities();
         var receiveMessageActivities = NServiceBusActivityListener.CompletedActivities.GetReceiveMessageActivities();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(sendMessageActivities, Has.Count.EqualTo(1), "1 message is sent as part of this test");
             Assert.That(receiveMessageActivities, Has.Count.EqualTo(1), "1 message is received as part of this test");
-        });
+        }
 
         var sendRequest = sendMessageActivities[0];
         var receiveRequest = receiveMessageActivities[0];
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(receiveRequest.RootId, Is.Not.EqualTo(sendRequest.RootId), "send and receive operations are part of different root activities");
             Assert.That(receiveRequest.ParentId, Is.Null, "incoming message does not have a parent, it's a root");
-        });
+        }
 
         ActivityLink link = receiveRequest.Links.FirstOrDefault();
         Assert.That(link, Is.Not.EqualTo(default(ActivityLink)), "Receive has a link");

--- a/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_sending_replies.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/OpenTelemetry/Traces/When_sending_replies.cs
@@ -19,12 +19,12 @@ public class When_sending_replies : OpenTelemetryAcceptanceTest
         Assert.That(outgoingMessageActivities, Has.Count.EqualTo(2), "2 messages are being sent");
         var replyMessage = outgoingMessageActivities[1];
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(replyMessage.DisplayName, Is.EqualTo("reply"));
             Assert.That(replyMessage.RootId, Is.EqualTo(outgoingMessageActivities[0].RootId), "reply should belong to same trace as the triggering message");
             Assert.That(replyMessage.ParentId, Is.Not.Null, "reply should have ambient span");
-        });
+        }
 
         replyMessage.VerifyUniqueTags();
     }

--- a/src/NServiceBus.AcceptanceTests/Core/Outbox/When_outbox_enabled_with_transactions_off.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Outbox/When_outbox_enabled_with_transactions_off.cs
@@ -27,11 +27,11 @@ public class When_outbox_enabled_with_transactions_off : NServiceBusAcceptanceTe
         var satisfied = outboxFeature["PrerequisiteStatus"]["IsSatisfied"].GetValue<bool>();
         var reason = (outboxFeature["PrerequisiteStatus"]["Reasons"] as JsonArray).Single().GetValue<string>();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(satisfied, Is.False);
             Assert.That(reason, Is.EqualTo("Outbox isn't needed since the receive transactions have been turned off"));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Persistence/When_a_persistence_provides_synchronized_session.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Persistence/When_a_persistence_provides_synchronized_session.cs
@@ -16,11 +16,11 @@ public class When_a_persistence_provides_synchronized_session : NServiceBusAccep
             .Done(c => c.MessageReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result.SynchronizedStorageSessionInstanceInContainer, Is.Not.Null);
             Assert.That(result.SynchronizedStorageSessionInstanceInHandlingContext, Is.Not.Null);
-        });
+        }
         Assert.That(result.SynchronizedStorageSessionInstanceInHandlingContext, Is.SameAs(result.SynchronizedStorageSessionInstanceInContainer));
     }
 

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_aborting_the_behavior_chain.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_aborting_the_behavior_chain.cs
@@ -15,11 +15,11 @@ public class When_aborting_the_behavior_chain : NServiceBusAcceptanceTest
             .Done(c => c.FirstHandlerInvoked)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.FirstHandlerInvoked, Is.True);
             Assert.That(context.SecondHandlerInvoked, Is.False);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_discontinuing_message_dispatch.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_discontinuing_message_dispatch.cs
@@ -19,11 +19,11 @@ public class When_discontinuing_message_dispatch : NServiceBusAcceptanceTest
             .Done(c => c.InterceptingHandlerCalled)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.InterceptingHandlerCalled, Is.True, "The intercepting handler should be called");
             Assert.That(context.SagaStarted, Is.False, "The saga should not have been started since the intercepting handler stops the pipeline");
-        });
+        }
     }
 
     public class SagaEndpointContext : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_extending_behavior_context.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_extending_behavior_context.cs
@@ -20,11 +20,11 @@ public class When_extending_behavior_context : NServiceBusAcceptanceTest
             .Done(c => c.HandlerAExtensionValue != null && c.HandlerBExtensionValue != null)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.HandlerAExtensionValue, Is.EqualTo(ExtensionValue));
             Assert.That(context.HandlerBExtensionValue, Is.EqualTo(ExtensionValue));
-        });
+        }
     }
 
     static string ExtensionValue;

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_handling_message_with_several_messagehandlers.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_handling_message_with_several_messagehandlers.cs
@@ -20,11 +20,11 @@ public class When_handling_message_with_several_messagehandlers : NServiceBusAcc
             .Done(c => c.FirstHandlerWasCalled)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.FirstHandlerWasCalled, Is.True);
             Assert.That(context.SecondHandlerWasCalled, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_providing_custom_handler_registry.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_providing_custom_handler_registry.cs
@@ -26,13 +26,13 @@ public class When_providing_custom_handler_registry : NServiceBusAcceptanceTest
                        && c.ManuallyRegisteredEventHandlerInvoked)
             .Run(TimeSpan.FromSeconds(10));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.RegularCommandHandlerInvoked, Is.True);
             Assert.That(context.ManuallyRegisteredCommandHandlerInvoked, Is.True);
             Assert.That(context.RegularEventHandlerInvoked, Is.True);
             Assert.That(context.ManuallyRegisteredEventHandlerInvoked, Is.True);
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_receiving_with_catch_all_handlers_registered.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_receiving_with_catch_all_handlers_registered.cs
@@ -19,12 +19,12 @@ public class When_receiving_with_catch_all_handlers_registered : NServiceBusAcce
             .Done(c => c.ObjectHandlerWasCalled && c.DynamicHandlerWasCalled && c.IMessageHandlerWasCalled)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.ObjectHandlerWasCalled, Is.True);
             Assert.That(context.DynamicHandlerWasCalled, Is.True);
             Assert.That(context.IMessageHandlerWasCalled, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_replacing_behavior.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_replacing_behavior.cs
@@ -18,11 +18,11 @@ public class When_replacing_behavior : NServiceBusAcceptanceTest
             .Done(c => c.MessageHandled)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.OriginalBehaviorInvoked, Is.False);
             Assert.That(context.ReplacementBehaviorInvoked, Is.True);
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_setting_ttbr_in_outer_publish.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_setting_ttbr_in_outer_publish.cs
@@ -23,11 +23,11 @@ public class When_setting_ttbr_in_outer_publish : NServiceBusAcceptanceTest
             .Done(c => c.OuterEventReceived && c.InnerEventReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.OuterEventTtbr, Is.Not.Null, "Outer event should have TTBR settings applied");
             Assert.That(context.InnerEventTtbr, Is.Null, "Inner event should not have TTBR settings applied");
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_skipping_serialization_with_nested_send.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_skipping_serialization_with_nested_send.cs
@@ -20,12 +20,12 @@ public class When_skipping_serialization_with_nested_send : NServiceBusAcceptanc
             .Done(c => c.NestedMessageReceived)
             .Run(TimeSpan.FromSeconds(15));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.NestedMessageReceived, Is.True, "the serialization should the nested message should not be skipped");
             Assert.That(context.NestedMessagePropertyValue, Is.EqualTo("Some property value for NestedMessage"), "the message sould be correctly serialized");
             Assert.That(context.MessageWithSkippedSerializationReceived, Is.False, "NServiceBus should discard messages without a body");
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_subscribed_to_ReceivePipelineCompleted.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_subscribed_to_ReceivePipelineCompleted.cs
@@ -17,13 +17,13 @@ class When_subscribed_to_ReceivePipelineCompleted : NServiceBusAcceptanceTest
             .Done(c => c.NotificationEventFired)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.NotificationEventFired, Is.True, "ReceivePipelineCompleted was not raised");
             Assert.That(context.ReceivePipelineCompletedMessage.ProcessedMessage.MessageId, Is.EqualTo(context.MessageId), "MessageId mismatch");
             Assert.That(context.ReceivePipelineCompletedMessage.StartedAt, Is.Not.EqualTo(DateTimeOffset.MinValue), "StartedAt was not set");
             Assert.That(context.ReceivePipelineCompletedMessage.CompletedAt, Is.Not.EqualTo(DateTimeOffset.MinValue), "CompletedAt was not set");
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_using_per_uow_component_in_the_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_using_per_uow_component_in_the_pipeline.cs
@@ -24,11 +24,11 @@ public class When_using_per_uow_component_in_the_pipeline : NServiceBusAcceptanc
             .Done(c => c.MessagesProcessed >= 2)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.ValueEmpty, Is.False, "Empty value in the UoW component meaning the UoW component has been registered as per-call");
             Assert.That(context.ValueAlreadyInitialized, Is.False, "Value in the UoW has already been initialized when it was resolved for the first time in a given pipeline meaning the UoW component has been registered as a singleton.");
-        });
+        }
     }
 
     static Task SendMessage(IMessageSession s)

--- a/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_using_polymorphic_message_handlers.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Pipeline/When_using_polymorphic_message_handlers.cs
@@ -18,11 +18,11 @@ public class When_using_polymorphic_message_handlers : NServiceBusAcceptanceTest
             .Done(c => c.SpecificHandlerInvoked && c.CatchAllHandlerInvoked)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.SpecificHandlerInvoked, Is.True);
             Assert.That(context.CatchAllHandlerInvoked, Is.True);
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_applying_message_recoverability.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_applying_message_recoverability.cs
@@ -33,11 +33,11 @@ public class When_applying_message_recoverability : NServiceBusAcceptanceTest
             .Done(c => c.MessageMovedToErrorQueue)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.MessageBodyWasEmpty, Is.True);
             Assert.That(onMessageSentToErrorQueueTriggered, Is.True);
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_configuring_unrecoverable_exception.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_configuring_unrecoverable_exception.cs
@@ -30,12 +30,12 @@ public class When_configuring_unrecoverable_exception : NServiceBusAcceptanceTes
                 .Run();
         });
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(exception.FailedMessage.Exception, Is.TypeOf<CustomException>());
             Assert.That(exception.ScenarioContext.FailedMessages, Has.Count.EqualTo(1));
             Assert.That(context.HandlerInvoked, Is.EqualTo(1));
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_custom_policy_executed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_custom_policy_executed.cs
@@ -24,7 +24,7 @@ public class When_custom_policy_executed : NServiceBusAcceptanceTest
             .Run();
 
         Assert.That(context.ErrorContexts, Has.Count.EqualTo(2), "because the custom policy should have been invoked twice");
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.ErrorContexts[0].Message, Is.Not.Null);
             Assert.That(context.ErrorContexts[0].Exception, Is.TypeOf<SimulatedException>());
@@ -32,7 +32,7 @@ public class When_custom_policy_executed : NServiceBusAcceptanceTest
             Assert.That(context.ErrorContexts[1].Message, Is.Not.Null);
             Assert.That(context.ErrorContexts[1].Exception, Is.TypeOf<SimulatedException>());
             Assert.That(context.ErrorContexts[1].DelayedDeliveriesPerformed, Is.EqualTo(1));
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_custom_policy_provided.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_custom_policy_provided.cs
@@ -21,12 +21,12 @@ public class When_custom_policy_provided : NServiceBusAcceptanceTest
             .Done(c => !c.FailedMessages.IsEmpty)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Configuration.Immediate.MaxNumberOfRetries, Is.EqualTo(MaxImmediateRetries));
             Assert.That(context.Configuration.Delayed.MaxNumberOfRetries, Is.EqualTo(MaxDelayedRetries));
             Assert.That(context.Configuration.Delayed.TimeIncrease, Is.EqualTo(DelayedRetryDelayIncrease));
-        });
+        }
     }
 
     static TimeSpan DelayedRetryDelayIncrease = TimeSpan.FromMinutes(1);

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_message_is_moved_to_error_queue_with_header_customizations.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_message_is_moved_to_error_queue_with_header_customizations.cs
@@ -26,12 +26,12 @@ public class When_message_is_moved_to_error_queue_with_header_customizations : N
             .Done(c => c.MessageMovedToErrorQueue)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Headers.ContainsKey("NServiceBus.ExceptionInfo.ExceptionType"), Is.False);
             Assert.That(context.Headers["NServiceBus.ExceptionInfo.Message"], Is.EqualTo("this is a large message"));
             Assert.That(context.Headers["NServiceBus.ExceptionInfo.NotInventedHere"], Is.EqualTo("NotInventedHere"));
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_delayed_retries_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_delayed_retries_notifications.cs
@@ -26,14 +26,14 @@ public class When_subscribing_to_delayed_retries_notifications : NServiceBusAcce
             .Done(c => c.MessageSentToError)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.LastDelayedRetryInfo?.Exception, Is.InstanceOf<SimulatedException>());
             // Immediate Retries max retries = 3 means we will be processing 4 times. Delayed Retries max retries = 2 means we will do 3 * Immediate Retries
             Assert.That(context.TotalNumberOfHandlerInvocations, Is.EqualTo(4 * 3));
             Assert.That(context.NumberOfDelayedRetriesPerformed, Is.EqualTo(2));
             Assert.That(context.LastDelayedRetryInfo.RetryAttempt, Is.EqualTo(2));
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_error_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_error_notifications.cs
@@ -27,7 +27,7 @@ public class When_subscribing_to_error_notifications : NServiceBusAcceptanceTest
             .Done(c => c.MessageSentToError)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.MessageSentToErrorException, Is.InstanceOf<SimulatedException>());
             Assert.That(context.Logs.Any(l => l.Level == LogLevel.Error && l.Message.Contains("Simulated exception message")), Is.True, "The last exception should be logged as `error` before sending it to the error queue");
@@ -36,7 +36,7 @@ public class When_subscribing_to_error_notifications : NServiceBusAcceptanceTest
             Assert.That(context.TotalNumberOfHandlerInvocations, Is.EqualTo(4 * 3));
             Assert.That(context.TotalNumberOfImmediateRetriesEventInvocations, Is.EqualTo(3 * 3));
             Assert.That(context.NumberOfDelayedRetriesPerformed, Is.EqualTo(2));
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_immediate_retries_notifications.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_subscribing_to_immediate_retries_notifications.cs
@@ -21,14 +21,14 @@ public class When_subscribing_to_immediate_retries_notifications : NServiceBusAc
             .Done(c => c.MessageSentToError)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.LastImmediateRetryInfo.Exception, Is.InstanceOf<SimulatedException>());
             // Immediate Retries max retries = 3 means we will be processing 4 times. Delayed Retries max retries = 2 means we will do 3 * Immediate Retries
             Assert.That(context.TotalNumberOfHandlerInvocations, Is.EqualTo(4));
             Assert.That(context.TotalNumberOfImmediateRetriesEventInvocations, Is.EqualTo(3));
             Assert.That(context.LastImmediateRetryInfo.RetryAttempt, Is.EqualTo(2));
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Reliability/SynchronizedStorage/When_opening_storage_session_outside_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Reliability/SynchronizedStorage/When_opening_storage_session_outside_pipeline.cs
@@ -35,11 +35,11 @@ public class When_opening_storage_session_outside_pipeline : NServiceBusAcceptan
             .Done(c => c.Done)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.SessionNotNullAfterOpening, Is.True, "The adapted session was null after opening the session.");
             Assert.That(context.StorageSessionEqual, Is.True, "The scoped storage session should be equal.");
-        });
+        }
 
         if (useOutbox)
         {

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/MessageDrivenSubscriptions/Missing_pub_info.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/MessageDrivenSubscriptions/Missing_pub_info.cs
@@ -23,11 +23,11 @@ public class Missing_pub_info : NServiceBusAcceptanceTest
         Assert.That(context.EndpointsStarted, Is.True, "because it should not prevent endpoint startup");
 
         var log = context.Logs.Single(l => l.Message.Contains($"AutoSubscribe was unable to subscribe to an event:"));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(log.Level, Is.EqualTo(LogLevel.Error));
             Assert.That(log.LoggerName, Is.EqualTo(typeof(AutoSubscribe).FullName));
-        });
+        }
         Assert.That(log.Message, Does.Contain($"No publisher address could be found for message type '{typeof(MyEvent).FullName}'."));
     }
 

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_callbacks_are_used_to_reply_with_int_or_enum.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_callbacks_are_used_to_reply_with_int_or_enum.cs
@@ -17,14 +17,14 @@ public class When_callbacks_are_used_to_reply_with_int_or_enum : NServiceBusAcce
             .Done(c => c.GotTheRequest)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.GotExceptionFromReply, Is.True);
 
             //this verifies a callbacks assumption that core won't throw until after the `IOutgoingLogicalMessageContext` stage
             // See https://github.com/Particular/NServiceBus.Callbacks/blob/develop/src/NServiceBus.Callbacks/Reply/SetCallbackResponseReturnCodeBehavior.cs#L7
             Assert.That(context.WasAbleToInterceptBeforeCoreThrows, Is.True, "Callbacks needs to be able to intercept the pipeline before core throws");
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_extending_command_routing_with_thisinstance.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_extending_command_routing_with_thisinstance.cs
@@ -30,11 +30,11 @@ public class When_extending_command_routing_with_thisinstance : NServiceBusAccep
             .Done(c => c.MessageDelivered >= 1)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ctx.MessageDelivered, Is.EqualTo(1));
             Assert.That(ctx.StrategyCalled, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_inner_send_with_outer_immediate_dispatch.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_inner_send_with_outer_immediate_dispatch.cs
@@ -22,11 +22,11 @@ public class When_inner_send_with_outer_immediate_dispatch : NServiceBusAcceptan
             .Done(c => c.MessageBReceived)
             .Run(TimeSpan.FromSeconds(15));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.MessageBReceived, Is.True);
             Assert.That(context.MessageCReceived, Is.False);
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_nested_send_with_outer_replyTo_routing.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_nested_send_with_outer_replyTo_routing.cs
@@ -28,11 +28,11 @@ public class When_nested_send_with_outer_replyTo_routing : NServiceBusAcceptance
             .Done(c => c.OuterMessageReceived && c.InnerMessageReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.OuterMessageReplyAddress, Is.EqualTo(customReplyAddress));
             Assert.That(context.InnerMessageReplyAddress, Is.EqualTo(Conventions.EndpointNamingConvention(typeof(SenderEndpoint))));
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_replying_with_pre_created_interface.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_replying_with_pre_created_interface.cs
@@ -17,11 +17,11 @@ public class When_replying_with_pre_created_interface : NServiceBusAcceptanceTes
             .Done(c => c.GotTheReply)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.GotTheReply, Is.True);
             Assert.That(context.MessageTypeInPipeline, Is.EqualTo(typeof(IMyReply)));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Routing/When_sending_from_outgoing_pipeline.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Routing/When_sending_from_outgoing_pipeline.cs
@@ -25,11 +25,11 @@ public class When_sending_from_outgoing_pipeline : NServiceBusAcceptanceTest
             .Done(c => c.LocalMessageReceived && c.BehaviorMessageReceived)
             .Run(TimeSpan.FromSeconds(15));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.LocalMessageReceived, Is.True);
             Assert.That(context.BehaviorMessageReceived, Is.True);
-        });
+        }
     }
 
     [Test]
@@ -46,11 +46,11 @@ public class When_sending_from_outgoing_pipeline : NServiceBusAcceptanceTest
             .Done(c => c.LocalMessageReceived && c.BehaviorMessageReceived)
             .Run(TimeSpan.FromSeconds(15));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.LocalMessageReceived, Is.True);
             Assert.That(context.BehaviorMessageReceived, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_a_saga_is_completed.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_a_saga_is_completed.cs
@@ -30,11 +30,11 @@ public class When_a_saga_is_completed : NServiceBusAcceptanceTest
             .Done(c => c.AnotherMessageReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.AnotherMessageReceived, Is.True, "AnotherMessage should have been delivered to the handler outside the saga");
             Assert.That(context.SagaReceivedAnotherMessage, Is.False, "AnotherMessage should not be delivered to the saga after completion");
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_adding_state_to_context.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_adding_state_to_context.cs
@@ -24,11 +24,11 @@ public class When_adding_state_to_context : NServiceBusAcceptanceTest
             .Done(c => c.FinderUsed)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.FinderUsed, Is.True);
             Assert.That(context.ContextBag.Get<SagaEndpoint.BehaviorWhichAddsThingsToTheContext.State>().SomeData, Is.EqualTo("SomeData"));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_finder_cant_find_saga_instance.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_finder_cant_find_saga_instance.cs
@@ -21,11 +21,11 @@ public class When_finder_cant_find_saga_instance : NServiceBusAcceptanceTest
             .Done(c => c.SagaStarted)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.FinderUsed, Is.True);
             Assert.That(context.SagaStarted, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_handling_message_with_handler_and_timeout_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_handling_message_with_handler_and_timeout_handler.cs
@@ -19,11 +19,11 @@ public class When_handling_message_with_handler_and_timeout_handler : NServiceBu
             .Done(c => c.HandlerInvoked || c.TimeoutHandlerInvoked)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.HandlerInvoked, Is.True, "Regular handler should be invoked");
             Assert.That(context.TimeoutHandlerInvoked, Is.False, "Timeout handler should not be invoked");
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_using_ReplyToOriginator.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_using_ReplyToOriginator.cs
@@ -30,11 +30,11 @@ public class When_using_ReplyToOriginator : NServiceBusAcceptanceTest
             .Done(c => c.CorrelationIdOnReply != null)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Intent, Is.EqualTo(MessageIntent.Reply));
             Assert.That(context.CorrelationIdOnReply, Is.EqualTo(context.OriginalCorrelationId), "Correlation id should be preserved so that things like callbacks work properly");
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/Sagas/When_using_ReplyToOriginator_and_outgoing_behavior.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Sagas/When_using_ReplyToOriginator_and_outgoing_behavior.cs
@@ -30,12 +30,12 @@ public class When_using_ReplyToOriginator_and_outgoing_behavior : NServiceBusAcc
             .Done(c => c.SagaContinued && c.ReplyToOriginatorReceived && c.BehaviorMessageReceived && c.BehaviorEventReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.ReplyToOriginatorReceivedCorrId, Is.EqualTo(context.StartingSagaCorrId), "When using ReplyToOriginator, the correlationId should be the same of the message that originally started the saga");
             Assert.That(context.HandlingBehaviorMessageCorrId, Is.EqualTo(context.ContinueSagaMessageCorrId), "When ReplyToOriginator is used, it shouldn't leak the CorrId to new messages sent from a behavior");
             Assert.That(context.HandlingBehaviorEventCorrId, Is.EqualTo(context.ContinueSagaMessageCorrId), "When ReplyToOriginator is used, it shouldn't leak the CorrId to new events published from a behavior");
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/SelfVerification/When_using_custom_components.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/SelfVerification/When_using_custom_components.cs
@@ -17,12 +17,12 @@ public class When_using_custom_components : NServiceBusAcceptanceTest
             .Done(c => c.Starting)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ctx.Starting, Is.True);
             Assert.That(ctx.ComponentsStarted, Is.True);
             Assert.That(ctx.Stopped, Is.True);
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/When_publisher_has_subscription_migration_mode_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/When_publisher_has_subscription_migration_mode_enabled.cs
@@ -18,11 +18,11 @@ public class When_publisher_has_subscription_migration_mode_enabled : NServiceBu
             .Done(c => c.EventReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.EventReceived, Is.True);
             Assert.That(context.Subscriber, Is.EqualTo(Conventions.EndpointNamingConvention(typeof(MessageDrivenSubscriber))));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/When_subscriber_has_subscription_migration_mode_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/SubscriptionMigration/When_subscriber_has_subscription_migration_mode_enabled.cs
@@ -19,11 +19,11 @@ public class When_subscriber_has_subscription_migration_mode_enabled : NServiceB
             .Done(c => c.EventReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.EventReceived, Is.True);
             Assert.That(context.Subscriber, Is.EqualTo(Conventions.EndpointNamingConvention(typeof(MigratedSubscriber))));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_transport_is_started.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/TransportSeam/When_transport_is_started.cs
@@ -21,7 +21,7 @@ public class When_transport_is_started : NServiceBusAcceptanceTest
 
         var endpointName = AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(Endpoint));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.ResolvedAddress, Is.EqualTo("SomeAddress"));
             Assert.That(context.ReceiveAddresses.MainReceiveAddress, Is.EqualTo(endpointName));
@@ -29,7 +29,7 @@ public class When_transport_is_started : NServiceBusAcceptanceTest
             Assert.That(context.ReceiveAddresses.SatelliteReceiveAddresses.Single(), Is.EqualTo("MySatellite"));
             Assert.That(context.LocalQueueAddress.ToString(), Is.EqualTo(endpointName));
             Assert.That(context.InstanceSpecificQueueAddress.ToString(), Is.EqualTo(endpointName + "-MyInstance"));
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_transactionscope_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/UnitOfWork/TransactionScope/When_transactionscope_enabled.cs
@@ -16,11 +16,11 @@ public class When_transactionscope_enabled : NServiceBusAcceptanceTest
             .Done(c => c.Done)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.AmbientTransactionPresent, Is.True, "There should be a ambient transaction present");
             Assert.That(context.IsolationLevel, Is.EqualTo(IsolationLevel.RepeatableRead), "There should be a ambient transaction present");
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_outer_send.cs
+++ b/src/NServiceBus.AcceptanceTests/DelayedDelivery/When_deferring_outer_send.cs
@@ -27,11 +27,11 @@ public class When_deferring_outer_send : NServiceBusAcceptanceTest
             .Done(c => c.ReceivedNonDelayedMessage && c.ReceivedDelayedMessage)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.DelayedMessageDelayed, Is.True, "should delay the message sent with 'DelayDeliveryWith'");
             Assert.That(context.NonDelayedMessageDelayed, Is.False, "should not delay the message sent with default options");
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_empty_id_header.cs
+++ b/src/NServiceBus.AcceptanceTests/MessageId/When_message_has_empty_id_header.cs
@@ -19,11 +19,11 @@ public class When_message_has_empty_id_header : NServiceBusAcceptanceTest
             .Done(c => c.MessageReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(string.IsNullOrWhiteSpace(context.MessageId), Is.False);
             Assert.That(context.Headers[Headers.MessageId], Is.EqualTo(context.MessageId), "Should populate the NServiceBus.MessageId header with the new value");
-        });
+        }
     }
 
     class CorruptionBehavior : IBehavior<IDispatchContext, IDispatchContext>

--- a/src/NServiceBus.AcceptanceTests/Outbox/When_a_duplicate_message_arrives.cs
+++ b/src/NServiceBus.AcceptanceTests/Outbox/When_a_duplicate_message_arrives.cs
@@ -35,11 +35,11 @@ public class When_a_duplicate_message_arrives : NServiceBusAcceptanceTest
             .Done(c => c.Done && c.MessagesReceivedByDownstreamEndpoint >= 2 && c.MessagesReceivedByOutboxEndpoint >= 2)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.MessagesReceivedByDownstreamEndpoint, Is.EqualTo(2));
             Assert.That(context.MessagesReceivedByOutboxEndpoint, Is.EqualTo(2));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Outbox/When_publishing_with_outbox.cs
+++ b/src/NServiceBus.AcceptanceTests/Outbox/When_publishing_with_outbox.cs
@@ -55,11 +55,11 @@ public class When_publishing_with_outbox : NServiceBusAcceptanceTest
             .Done(c => c.Subscriber1GotTheEvent && c.Subscriber2GotTheEvent)
             .Run(TimeSpan.FromSeconds(10));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Subscriber1GotTheEvent, Is.True);
             Assert.That(context.Subscriber2GotTheEvent, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Outbox/When_subscribers_handles_the_same_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Outbox/When_subscribers_handles_the_same_event.cs
@@ -49,11 +49,11 @@ public class When_subscribers_handles_the_same_event : NServiceBusAcceptanceTest
             .Done(c => c.Subscriber1GotTheEvent && c.Subscriber2GotTheEvent)
             .Run(TimeSpan.FromSeconds(10));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Subscriber1GotTheEvent, Is.True);
             Assert.That(context.Subscriber2GotTheEvent, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Pipeline/When_a_message_is_audited.cs
+++ b/src/NServiceBus.AcceptanceTests/Pipeline/When_a_message_is_audited.cs
@@ -17,11 +17,11 @@ public class When_a_message_is_audited : NServiceBusAcceptanceTest
             .Done(c => c.Done)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.RelatedTo, Is.EqualTo(context.OriginRelatedTo), "The RelatedTo header in audit message should be be equal to RelatedTo header in origin.");
             Assert.That(context.ConversationId, Is.EqualTo(context.OriginConversationId), "The ConversationId header in audit message should be be equal to ConversationId header in origin.");
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Pipeline/When_a_message_is_faulted.cs
+++ b/src/NServiceBus.AcceptanceTests/Pipeline/When_a_message_is_faulted.cs
@@ -17,11 +17,11 @@ public class When_a_message_is_faulted : NServiceBusAcceptanceTest
             .Done(c => c.Done)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.RelatedTo, Is.EqualTo(context.OriginRelatedTo), "The RelatedTo header in fault message should be be equal to RelatedTo header in origin.");
             Assert.That(context.ConversationId, Is.EqualTo(context.OriginConversationId), "The ConversationId header in fault message should be be equal to ConversationId header in origin.");
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Pipeline/When_message_processing_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Pipeline/When_message_processing_fails.cs
@@ -18,14 +18,14 @@ public class When_message_processing_fails : NServiceBusAcceptanceTest
             .Done(c => c.MessageFailed)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Exception.Data.Contains("Message type"), Is.True);
             Assert.That(context.Exception.Data.Contains("Handler type"), Is.True);
             Assert.That(context.Exception.Data.Contains("Handler start time"), Is.True);
             Assert.That(context.Exception.Data.Contains("Handler failure time"), Is.True);
             Assert.That(context.Exception.Data.Contains("Message ID"), Is.True);
-        });
+        }
         // we can't assert for the native message ID as not every transport has uses a different ID internally
     }
 

--- a/src/NServiceBus.AcceptanceTests/Pipeline/When_sending_to_another_endpoint.cs
+++ b/src/NServiceBus.AcceptanceTests/Pipeline/When_sending_to_another_endpoint.cs
@@ -31,14 +31,14 @@ public class When_sending_to_another_endpoint : NServiceBusAcceptanceTest
             .Done(c => c.WasCalled)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.WasCalled, Is.True, "The message handler should be called");
             Assert.That(context.TimesCalled, Is.EqualTo(1), "The message handler should only be invoked once");
             Assert.That(context.ReceivedHeaders["MyStaticHeader"], Is.EqualTo("StaticHeaderValue"), "Static headers should be attached to outgoing messages");
             Assert.That(context.MyHeader, Is.EqualTo("MyHeaderValue"), "Static headers should be attached to outgoing messages");
             Assert.That(context.MyMessageId, Is.EqualTo("MyMessageId"), "MessageId should be applied to outgoing messages");
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Recoverability/Cross_q_tx_msg_moved_to_error_q.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/Cross_q_tx_msg_moved_to_error_q.cs
@@ -27,11 +27,11 @@ public class Cross_q_tx_msg_moved_to_error_q : NServiceBusAcceptanceTest
             .Done(c => c.MessageMovedToErrorQueue)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.OutgoingMessageSent, Is.False, "Outgoing messages should not be sent");
             Assert.That(!context.FailedMessages.IsEmpty, Is.True);
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_custom_policy_discards_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_custom_policy_discards_message.cs
@@ -16,11 +16,11 @@ public class When_custom_policy_discards_failed_message : NServiceBusAcceptanceT
             .Done(c => c.HandlerInvoked >= 1)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.FailedMessages, Is.Empty, "the message should not be moved to the error queue");
             Assert.That(context.HandlerInvoked, Is.EqualTo(1), "the discarded message should not be retried");
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_are_enabled.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_immediate_retries_are_enabled.cs
@@ -19,13 +19,13 @@ public class When_immediate_retries_are_enabled : NServiceBusAcceptanceTest
             .Done(c => c.ForwardedToErrorQueue)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.ForwardedToErrorQueue, Is.True);
             Assert.That(context.NumberOfTimesInvoked, Is.EqualTo(numberOfRetries + 1), "Message should be retried 5 times immediately");
             Assert.That(context.Logs.Count(l => l.Message
                 .StartsWith($"Immediate Retry is going to retry message '{context.MessageId}' because of an exception:")), Is.EqualTo(numberOfRetries));
-        });
+        }
     }
 
     const int numberOfRetries = 5;

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_message_fails_retries.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_message_fails_retries.cs
@@ -21,12 +21,12 @@ public class When_message_fails_retries : NServiceBusAcceptanceTest
         Assert.That(exception.ScenarioContext.FailedMessages, Has.Count.EqualTo(1));
 
         var testContext = (Context)exception.ScenarioContext;
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(exception.FailedMessage.Headers[Headers.EnclosedMessageTypes], Is.EqualTo(typeof(MessageWhichFailsRetries).AssemblyQualifiedName));
             Assert.That(exception.FailedMessage.MessageId, Is.EqualTo(testContext.PhysicalMessageId));
             Assert.That(exception.FailedMessage.Exception, Is.AssignableFrom<SimulatedException>());
-        });
+        }
 
         Assert.That(testContext.Logs.Count(l => l.Message
             .StartsWith($"Moving message '{testContext.PhysicalMessageId}' to the error queue 'error' because processing failed due to an exception:")), Is.EqualTo(1));

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_message_is_deferred_by_delayed_retries_using_dtc.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_message_is_deferred_by_delayed_retries_using_dtc.cs
@@ -27,11 +27,11 @@ public class When_message_is_deferred_by_delayed_retries_using_dtc : NServiceBus
             .Done(c => !c.FailedMessages.IsEmpty)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.NumberOfRetriesAttempted, Is.GreaterThanOrEqualTo(3), "Should retry at least three times");
             Assert.That(context.TransactionStatuses, Is.All.Not.EqualTo(TransactionStatus.Committed));
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_message_with_TimeToBeReceived_fails.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_message_with_TimeToBeReceived_fails.cs
@@ -26,11 +26,11 @@ public class When_message_with_TimeToBeReceived_fails : NServiceBusAcceptanceTes
             .Done(c => c.MessageFailed && c.TTBRHasExpiredAndMessageIsStillInErrorQueue)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.MessageFailed, Is.True);
             Assert.That(context.TTBRHasExpiredAndMessageIsStillInErrorQueue, Is.True);
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_retrying_message_from_error_queue.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_retrying_message_from_error_queue.cs
@@ -30,17 +30,17 @@ public class When_retrying_message_from_error_queue : NServiceBusAcceptanceTest
             .Done(c => c.ConfirmedRetryId != null && c.AuditHeaders != null)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.MessageProcessed, Is.True);
             Assert.That(context.ConfirmedRetryId, Is.EqualTo(context.RetryId));
-        });
+        }
         var processingTime = DateTimeOffsetHelper.ToDateTimeOffset(context.RetryProcessingTimestamp);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(processingTime, Is.EqualTo(DateTimeOffset.UtcNow).Within(TimeSpan.FromMinutes(1)));
             Assert.That(context.AuditHeaders.ContainsKey("ServiceControl.Retry.AcknowledgementSent"), Is.True);
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Recoverability/When_transactionscope_message_is_moved_to_error_queue.cs
+++ b/src/NServiceBus.AcceptanceTests/Recoverability/When_transactionscope_message_is_moved_to_error_queue.cs
@@ -27,11 +27,11 @@ public class When_transactionscope_message_is_moved_to_error_queue : NServiceBus
             .Done(c => c.MessageMovedToErrorQueue)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.OutgoingMessageSent, Is.False, "Outgoing messages should not be sent");
             Assert.That(!context.FailedMessages.IsEmpty, Is.True, "There should be failed messages registered in this scenario");
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Multi_sub_to_poly_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Multi_sub_to_poly_event.cs
@@ -33,11 +33,11 @@ public class MultiSubscribeToPolymorphicEvent : NServiceBusAcceptanceTest
             .Done(c => c.SubscriberGotIMyEvent && c.SubscriberGotMyEvent2)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.SubscriberGotIMyEvent, Is.True);
             Assert.That(context.SubscriberGotMyEvent2, Is.True);
-        });
+        }
 
     }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Pub_to_scaled_out_subs.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Pub_to_scaled_out_subs.cs
@@ -22,11 +22,11 @@ public class Pub_to_scaled_out_subs : NServiceBusAcceptanceTest
             .Done(c => c.ProcessedByA > 0 && c.ProcessedByB > 0)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.ProcessedByA, Is.EqualTo(1));
             Assert.That(context.ProcessedByB, Is.EqualTo(1));
-        });
+        }
 
     }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Sub_to_base_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Sub_to_base_event.cs
@@ -23,11 +23,11 @@ public class Sub_to_base_event : NServiceBusAcceptanceTest
             .Done(c => c.SubscriberGotBaseEvent && c.SubscriberGotSpecificEvent)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.SubscriberGotBaseEvent, Is.True);
             Assert.That(context.SubscriberGotSpecificEvent, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Sub_to_multiple_pubs.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Sub_to_multiple_pubs.cs
@@ -31,11 +31,11 @@ public class Sub_to_multiple_pubs : NServiceBusAcceptanceTest
             .Done(c => c.SubscribedToPublisher1 && c.SubscribedToPublisher2)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.SubscribedToPublisher1, Is.True);
             Assert.That(context.SubscribedToPublisher2, Is.True);
-        });
+        }
 
     }
 

--- a/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Unsub_from_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/MessageDrivenSubscriptions/Unsub_from_event.cs
@@ -38,12 +38,12 @@ public class Unsub_from_event : NServiceBusAcceptanceTest
             .Done(c => c.Subscriber1ReceivedMessages >= 4)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Subscriber1ReceivedMessages, Is.EqualTo(4));
             Assert.That(context.Subscriber2ReceivedMessages, Is.EqualTo(1));
             Assert.That(context.Subscriber2Unsubscribed, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/MultiSubscribeToPolymorphicEvent.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/MultiSubscribeToPolymorphicEvent.cs
@@ -27,11 +27,11 @@ public class MultiSubscribeToPolymorphicEvent : NServiceBusAcceptanceTest
             .Done(c => c.SubscriberGotIMyEvent && c.SubscriberGotMyEvent2)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.SubscriberGotIMyEvent, Is.True);
             Assert.That(context.SubscriberGotMyEvent2, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_publishing_to_scaled_out_subscribers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_publishing_to_scaled_out_subscribers.cs
@@ -23,11 +23,11 @@ public class When_publishing_to_scaled_out_subscribers : NServiceBusAcceptanceTe
             .Done(c => c.SubscriberACounter > 0 && c.SubscriberBCounter > 0)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.SubscriberACounter, Is.EqualTo(1));
             Assert.That(context.SubscriberBCounter, Is.EqualTo(1));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_subscribing_to_a_base_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_subscribing_to_a_base_event.cs
@@ -27,11 +27,11 @@ public class When_subscribing_to_a_base_event : NServiceBusAcceptanceTest
             .Done(c => c.SubscriberGotBaseEvent && c.SubscriberGotSpecificEvent)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.SubscriberGotBaseEvent, Is.True);
             Assert.That(context.SubscriberGotSpecificEvent, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_unsubscribing_from_event.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/NativePublishSubscribe/When_unsubscribing_from_event.cs
@@ -49,12 +49,12 @@ public class When_unsubscribing_from_event : NServiceBusAcceptanceTest
             .Done(c => c.Subscriber1ReceivedMessages >= 4)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Subscriber1ReceivedMessages, Is.EqualTo(4));
             Assert.That(context.Subscriber2ReceivedMessages, Is.EqualTo(1));
             Assert.That(context.Subscriber2Unsubscribed, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/When_base_event_from_2_publishers.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_base_event_from_2_publishers.cs
@@ -33,11 +33,11 @@ public class When_base_event_from_2_publishers : NServiceBusAcceptanceTest
             .Done(c => c.GotTheEventFromPublisher1 && c.GotTheEventFromPublisher2)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.GotTheEventFromPublisher1, Is.True);
             Assert.That(context.GotTheEventFromPublisher2, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/When_multiple_mappings_exists.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_multiple_mappings_exists.cs
@@ -18,11 +18,11 @@ public class When_multiple_mappings_exists : NServiceBusAcceptanceTest
             .Done(c => c.WasCalled1 || c.WasCalled2)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.WasCalled1, Is.True);
             Assert.That(context.WasCalled2, Is.False);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing.cs
@@ -77,12 +77,12 @@ public class When_publishing : NServiceBusAcceptanceTest
             .Done(c => c.Subscriber1GotTheEvent && c.Subscriber2GotTheEvent)
             .Run(TimeSpan.FromSeconds(10));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Subscriber1GotTheEvent, Is.True);
             Assert.That(context.Subscriber2GotTheEvent, Is.True);
             Assert.That(context.HeaderValue, Is.EqualTo("SomeValue"));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_event_implementing_two_unrelated_interfaces.cs
@@ -37,11 +37,11 @@ public class When_publishing_an_event_implementing_two_unrelated_interfaces : NS
             .Done(c => c.GotEventA && c.GotEventB)
             .Run(TimeSpan.FromSeconds(20));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.GotEventA, Is.True);
             Assert.That(context.GotEventB, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface.cs
@@ -28,11 +28,11 @@ public class When_publishing_an_interface : NServiceBusAcceptanceTest
             .Done(c => c.GotTheEvent)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.GotTheEvent, Is.True);
             Assert.That(context.EventTypePassedToRouting, Is.EqualTo(typeof(IMyEvent)));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface_with_unobtrusive.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_an_interface_with_unobtrusive.cs
@@ -28,11 +28,11 @@ public class When_publishing_an_interface_with_unobtrusive : NServiceBusAcceptan
             .Done(c => c.GotTheEvent)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.GotTheEvent, Is.True);
             Assert.That(context.EventTypePassedToRouting, Is.EqualTo(typeof(IMyEvent)));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/When_publishing_pre_created_interface.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_publishing_pre_created_interface.cs
@@ -28,11 +28,11 @@ public class When_publishing_pre_created_interface : NServiceBusAcceptanceTest
             .Done(c => c.GotTheEvent)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.GotTheEvent, Is.True);
             Assert.That(context.EventTypePassedToRouting, Is.EqualTo(typeof(IMyEvent)));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/When_registering_publishers_unobtrusive_messages_code.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_registering_publishers_unobtrusive_messages_code.cs
@@ -19,11 +19,11 @@ public class When_registering_publishers_unobtrusive_messages_code : NServiceBus
             .Done(c => c.ReceivedMessage)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Subscribed, Is.True);
             Assert.That(context.ReceivedMessage, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/When_registering_publishers_unobtrusive_messages_config.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_registering_publishers_unobtrusive_messages_config.cs
@@ -19,11 +19,11 @@ public class When_registering_publishers_unobtrusive_messages_config : NServiceB
             .Done(c => c.ReceivedMessage)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Subscribed, Is.True);
             Assert.That(context.ReceivedMessage, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/When_replying_to_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_replying_to_message.cs
@@ -20,11 +20,11 @@ public class When_replying_to_message : NServiceBusAcceptanceTest
             .Done(c => c.SendingEndpointGotResponse)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ctx.SendingEndpointGotResponse, Is.True);
             Assert.That(ctx.OtherEndpointGotResponse, Is.False);
-        });
+        }
     }
 
     [Test]
@@ -56,11 +56,11 @@ public class When_replying_to_message : NServiceBusAcceptanceTest
             .Done(c => c.OtherEndpointGotResponse)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ctx.OtherEndpointGotResponse, Is.True);
             Assert.That(ctx.SendingEndpointGotResponse, Is.False);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/When_replying_to_message_with_interface_and_unobtrusive.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_replying_to_message_with_interface_and_unobtrusive.cs
@@ -19,11 +19,11 @@ public class When_replying_to_message_with_interface_and_unobtrusive : NServiceB
             .Done(c => c.SendingEndpointGotResponse)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ctx.SendingEndpointGotResponse, Is.True);
             Assert.That(ctx.OtherEndpointGotResponse, Is.False);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Routing/When_using_custom_routing_strategy.cs
+++ b/src/NServiceBus.AcceptanceTests/Routing/When_using_custom_routing_strategy.cs
@@ -33,11 +33,11 @@ public class When_using_custom_routing_strategy : NServiceBusAcceptanceTest
             .Done(c => c.MessageDeliveredReceiver1 >= 3 && c.MessageDeliveredReceiver2 >= 1)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ctx.MessageDeliveredReceiver1, Is.EqualTo(3));
             Assert.That(ctx.MessageDeliveredReceiver2, Is.EqualTo(1));
-        });
+        }
     }
 
     static string Discriminator1 = "553E9649";

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_correlation_property_is_guid.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_correlation_property_is_guid.cs
@@ -22,11 +22,11 @@ class When_correlation_property_is_guid : NServiceBusAcceptanceTest
             .Done(c => c.MessageCorrelated)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.MessageCorrelated, Is.True);
             Assert.That(context.CorrelatedId, Is.EqualTo(default(Guid)));
-        });
+        }
     }
 
     public class MessageWithGuidCorrelationProperty : IMessage

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_correlation_property_is_int.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_correlation_property_is_int.cs
@@ -21,11 +21,11 @@ class When_correlation_property_is_int : NServiceBusAcceptanceTest
             .Done(c => c.MessageCorrelated)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.MessageCorrelated, Is.True);
             Assert.That(context.CorrelatedId, Is.EqualTo(default(int)));
-        });
+        }
     }
 
     public class MessageWithIntCorrelationProperty : IMessage

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_message_has_a_saga_id.cs
@@ -29,12 +29,12 @@ public class When_message_has_a_saga_id : NServiceBusAcceptanceTest
             .Done(c => c.Done)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.NotFoundHandlerCalled, Is.True);
             Assert.That(context.MessageHandlerCalled, Is.False);
             Assert.That(context.TimeoutHandlerCalled, Is.False);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_multiple_timeouts.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_receiving_multiple_timeouts.cs
@@ -23,12 +23,12 @@ public class When_receiving_multiple_timeouts : NServiceBusAcceptanceTest
             .Done(c => (c.Saga1TimeoutFired && c.Saga2TimeoutFired) || c.SagaNotFound)
             .Run(TimeSpan.FromSeconds(60));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.SagaNotFound, Is.False);
             Assert.That(context.Saga1TimeoutFired, Is.True);
             Assert.That(context.Saga2TimeoutFired, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_reply_from_saga_not_found_handler.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_reply_from_saga_not_found_handler.cs
@@ -21,13 +21,13 @@ public class When_reply_from_saga_not_found_handler : NServiceBusAcceptanceTest
             .Done(c => c.ReplyReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Logs.Any(m => m.Message.Equals("Could not find a started saga of 'NServiceBus.AcceptanceTests.Sagas.When_reply_from_saga_not_found_handler+ReceiverWithSaga+NotFoundHandlerSaga1' for message type 'NServiceBus.AcceptanceTests.Sagas.When_reply_from_saga_not_found_handler+MessageToSaga'.")), Is.True);
             Assert.That(context.Logs.Any(m => m.Message.Equals("Could not find a started saga of 'NServiceBus.AcceptanceTests.Sagas.When_reply_from_saga_not_found_handler+ReceiverWithSaga+NotFoundHandlerSaga2' for message type 'NServiceBus.AcceptanceTests.Sagas.When_reply_from_saga_not_found_handler+MessageToSaga'.")), Is.True);
             Assert.That(context.Logs.Count(m => m.Message.Equals("Could not find any started sagas for message type 'NServiceBus.AcceptanceTests.Sagas.When_reply_from_saga_not_found_handler+MessageToSaga'. Going to invoke SagaNotFoundHandlers.")), Is.EqualTo(1));
             Assert.That(context.ReplyReceived, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_handles_unmapped_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_handles_unmapped_message.cs
@@ -27,14 +27,14 @@ public class When_saga_handles_unmapped_message : NServiceBusAcceptanceTest
             .Done(c => c.MappedEchoReceived && (c.EchoReceived || !c.FailedMessages.IsEmpty))
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.StartReceived, Is.EqualTo(true));
             Assert.That(context.OutboundReceived, Is.EqualTo(true));
             Assert.That(context.MappedEchoReceived, Is.EqualTo(true));
             Assert.That(context.EchoReceived, Is.EqualTo(false));
             Assert.That(context.FailedMessages, Has.Count.EqualTo(1));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_id_changed.cs
@@ -24,12 +24,12 @@ public class When_saga_id_changed : NServiceBusAcceptanceTest
                 .Done(c => !c.FailedMessages.IsEmpty)
                 .Run());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(exception.ScenarioContext.FailedMessages, Has.Count.EqualTo(1));
             Assert.That(((Context)exception.ScenarioContext).MessageId, Is.EqualTo(exception.FailedMessage.MessageId), "Message should be moved to errorqueue");
             Assert.That(exception.FailedMessage.Exception.Message, Contains.Substring("A modification of IContainSagaData.Id has been detected. This property is for infrastructure purposes only and should not be modified. SagaType:"));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_is_mapped_to_complex_expression.cs
@@ -25,11 +25,11 @@ public class When_saga_is_mapped_to_complex_expression : NServiceBusAcceptanceTe
             .Done(c => c.SecondMessageReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.SecondMessageReceived, Is.True);
             Assert.That(context.SagaIdWhenOtherMessageReceived, Is.EqualTo(context.SagaIdWhenStartSagaMessageReceived));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_saga_started_concurrently.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_saga_started_concurrently.cs
@@ -30,11 +30,11 @@ public class When_saga_started_concurrently : NServiceBusAcceptanceTest
             .Done(c => c.PlacedSagaId != Guid.Empty && c.BilledSagaId != Guid.Empty)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.PlacedSagaId, Is.Not.EqualTo(Guid.Empty));
             Assert.That(context.BilledSagaId, Is.Not.EqualTo(Guid.Empty));
-        });
+        }
         Assert.That(context.BilledSagaId, Is.EqualTo(context.PlacedSagaId), "Both messages should have been handled by the same saga, but SagaIds don't match.");
     }
 

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_cant_be_found.cs
@@ -35,14 +35,14 @@ public class When_sagas_cant_be_found : NServiceBusAcceptanceTest
             .Done(c => c.Done)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Logs.Any(m => m.Message.Equals("Could not find a started saga of 'NServiceBus.AcceptanceTests.Sagas.When_sagas_cant_be_found+ReceiverWithOrderedSagas+ReceiverWithOrderedSagasSaga1' for message type 'NServiceBus.AcceptanceTests.Sagas.When_sagas_cant_be_found+MessageToSaga'.")), Is.True);
             Assert.That(context.Logs.Any(m => m.Message.Equals("Could not find a started saga of 'NServiceBus.AcceptanceTests.Sagas.When_sagas_cant_be_found+ReceiverWithOrderedSagas+ReceiverWithOrderedSagasSaga2' for message type 'NServiceBus.AcceptanceTests.Sagas.When_sagas_cant_be_found+MessageToSaga'.")), Is.False);
             Assert.That(context.Logs.Any(m => m.Message.Contains("Going to invoke SagaNotFoundHandlers.")), Is.False);
 
             Assert.That(context.TimesFired, Is.EqualTo(0));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_share_timeout_messages.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_sagas_share_timeout_messages.cs
@@ -21,11 +21,11 @@ public class When_sagas_share_timeout_messages : NServiceBusAcceptanceTest
             .Done(c => c.Saga1ReceivedTimeout || c.Saga2ReceivedTimeout)
             .Run(TimeSpan.FromSeconds(30));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Saga2ReceivedTimeout, Is.True);
             Assert.That(context.Saga1ReceivedTimeout, Is.False);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_updating_existing_correlation_property.cs
@@ -22,11 +22,11 @@ public class When_updating_existing_correlation_property : NServiceBusAcceptance
                 .Done(c => !c.FailedMessages.IsEmpty)
                 .Run());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(((Context)exception.ScenarioContext).ModifiedCorrelationProperty, Is.True);
             Assert.That(exception.ScenarioContext.FailedMessages, Has.Count.EqualTo(1));
-        });
+        }
         Assert.That(
             exception.FailedMessage.Exception.Message,
             Does.Contain("Changing the value of correlated properties at runtime is currently not supported"));

--- a/src/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
+++ b/src/NServiceBus.AcceptanceTests/Sagas/When_using_a_received_message_for_timeout.cs
@@ -21,11 +21,11 @@ public class When_using_a_received_message_for_timeout : NServiceBusAcceptanceTe
             .Done(c => c.TimeoutReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.TimeoutReceived, Is.True);
             Assert.That(context.HandlerCalled, Is.EqualTo(1));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
+++ b/src/NServiceBus.AcceptanceTests/Satellites/When_a_message_is_available.cs
@@ -20,7 +20,7 @@ public class When_a_message_is_available : NServiceBusAcceptanceTest
             .Done(c => c.MessageReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.MessageReceived, Is.True);
             // In the future we want the transport transaction to be an explicit
@@ -28,7 +28,7 @@ public class When_a_message_is_available : NServiceBusAcceptanceTest
             // to the context will not be necessary at that point.
             // See GitHub issue #4047 for more background information.
             Assert.That(context.TransportTransactionAddedToContext, Is.True);
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_disabling_serializer_type_inference.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_disabling_serializer_type_inference.cs
@@ -25,11 +25,11 @@ class When_disabling_serializer_type_inference : NServiceBusAcceptanceTest
             .Done(c => c.IncomingMessageReceived)
             .Run(TimeSpan.FromSeconds(35));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.HandlerInvoked, Is.False);
             Assert.That(context.FailedMessages.Single().Value, Has.Count.EqualTo(1));
-        });
+        }
         Exception exception = context.FailedMessages.Single().Value.Single().Exception;
         Assert.That(exception, Is.InstanceOf<MessageDeserializationException>());
         Assert.That(exception.InnerException.Message, Does.Contain($"Could not determine the message type from the '{Headers.EnclosedMessageTypes}' header"));
@@ -45,11 +45,11 @@ class When_disabling_serializer_type_inference : NServiceBusAcceptanceTest
             .Done(c => c.IncomingMessageReceived)
             .Run(TimeSpan.FromSeconds(35));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.HandlerInvoked, Is.False);
             Assert.That(context.FailedMessages.Single().Value, Has.Count.EqualTo(1));
-        });
+        }
         Exception exception = context.FailedMessages.Single().Value.Single().Exception;
         Assert.That(exception, Is.InstanceOf<MessageDeserializationException>());
         Assert.That(exception.InnerException.Message, Does.Contain($"Could not determine the message type from the '{Headers.EnclosedMessageTypes}' header"));

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_message_type_header_is_whitespaces.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_message_type_header_is_whitespaces.cs
@@ -20,11 +20,11 @@ public class When_message_type_header_is_whitespaces : NServiceBusAcceptanceTest
             .Done(c => c.IncomingMessageReceived)
             .Run(TimeSpan.FromSeconds(20));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.HandlerInvoked, Is.False);
             Assert.That(context.FailedMessages.Single().Value, Has.Count.EqualTo(1));
-        });
+        }
         Exception exception = context.FailedMessages.Single().Value.Single().Exception;
         Assert.That(exception, Is.InstanceOf<MessageDeserializationException>());
     }

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_registering_additional_deserializers.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_registering_additional_deserializers.cs
@@ -30,13 +30,13 @@ public class When_registering_additional_deserializers : NServiceBusAcceptanceTe
             .Done(c => c.HandlerGotTheRequest)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.HandlerGotTheRequest, Is.True);
             Assert.That(context.SerializeCalled, Is.True);
             Assert.That(context.DeserializeCalled, Is.True);
             Assert.That(context.ValueFromSettings, Is.EqualTo("SomeFancySettings"));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_registering_custom_serializer.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_registering_custom_serializer.cs
@@ -24,11 +24,11 @@ public class When_registering_custom_serializer : NServiceBusAcceptanceTest
             .Done(c => c.HandlerGotTheRequest)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.SerializeCalled, Is.True);
             Assert.That(context.DeserializeCalled, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_registering_deserializers_with_settings.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_registering_deserializers_with_settings.cs
@@ -32,14 +32,14 @@ public class When_registering_deserializers_with_settings : NServiceBusAcceptanc
             .Done(c => c.DeserializeCalled)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.HandlerGotTheRequest, Is.True);
             Assert.That(context.SerializeCalled, Is.True);
             Assert.That(context.DeserializeCalled, Is.True);
             Assert.That(context.ValueFromSettingsForMainSerializer, Is.EqualTo(Value1));
             Assert.That(context.ValueFromSettingsForDeserializer, Is.EqualTo(Value2));
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_serializing_a_message.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_serializing_a_message.cs
@@ -35,7 +35,7 @@ public class When_serializing_a_message : NServiceBusAcceptanceTest
             .Done(c => c.ReceivedMessage != null)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.ReceivedMessage.DateTime, Is.EqualTo(expectedDateTime));
             Assert.That(context.ReceivedMessage.DateTimeLocal, Is.EqualTo(expectedDateTimeLocal));
@@ -43,13 +43,13 @@ public class When_serializing_a_message : NServiceBusAcceptanceTest
             Assert.That(context.ReceivedMessage.DateTimeOffset, Is.EqualTo(expectedDateTimeOffset));
             Assert.That(context.ReceivedMessage.DateTimeOffsetLocal, Is.EqualTo(expectedDateTimeOffsetLocal));
             Assert.That(context.ReceivedMessage.DateTimeOffsetUtc, Is.EqualTo(expectedDateTimeOffsetUtc));
-        });
+        }
         Assert.That(context.ReceivedMessage.DateTimeOffsetLocal, Is.EqualTo(expectedDateTimeOffsetLocal));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.ReceivedMessage.DateTimeOffsetLocal.Offset, Is.EqualTo(expectedDateTimeOffsetLocal.Offset));
             Assert.That(context.ReceivedMessage.DateTimeOffsetUtc, Is.EqualTo(expectedDateTimeOffsetUtc));
-        });
+        }
         Assert.That(context.ReceivedMessage.DateTimeOffsetUtc.Offset, Is.EqualTo(expectedDateTimeOffsetUtc.Offset));
     }
 

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_skip_wrapping_xml.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_skip_wrapping_xml.cs
@@ -23,12 +23,12 @@ public class When_skip_wrapping_xml : NServiceBusAcceptanceTest
             .Done(c => c.MessageReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.XmlPropertyValue.ToString(), Is.EqualTo(xmlContent.ToString()));
             Assert.That(context.XmlMessage.Root.Name.LocalName, Is.EqualTo(nameof(MessageWithRawXml)));
             Assert.That(context.XmlMessage.Root.Elements().Single().ToString(), Is.EqualTo(xmlContent.ToString()));
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Serialization/When_wrapping_is_not_skipped.cs
+++ b/src/NServiceBus.AcceptanceTests/Serialization/When_wrapping_is_not_skipped.cs
@@ -23,14 +23,14 @@ public class When_wrapping_is_not_skipped : NServiceBusAcceptanceTest
             .Done(c => c.MessageReceived)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.XmlPropertyValue.ToString(), Is.EqualTo(xmlContent.ToString()));
             Assert.That(context.XmlMessage.Root.Name.LocalName, Is.EqualTo(nameof(MessageWithRawXml)));
             Assert.That(context.XmlMessage.Root.Elements().Single().Name.LocalName, Is.EqualTo("Document"));
             Assert.That(context.XmlMessage.Root.Elements().Single().Elements().Single().Name.LocalName, Is.EqualTo("Document"));
             Assert.That(context.XmlMessage.Root.Elements().Single().Elements().Single().ToString(), Is.EqualTo(xmlContent.ToString()));
-        });
+        }
     }
 
     class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_not_expired.cs
+++ b/src/NServiceBus.AcceptanceTests/TimeToBeReceived/When_TimeToBeReceived_has_not_expired.cs
@@ -16,11 +16,11 @@ public class When_TimeToBeReceived_has_not_expired : NServiceBusAcceptanceTest
             .Done(c => c.WasCalled)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.WasCalled, Is.True);
             Assert.That(context.TTBROnIncomingMessage, Is.EqualTo(TimeSpan.FromSeconds(10)), "TTBR should be available as a header so receiving endpoints can know what value was used when the message was originally sent");
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_native_multi_queue_transaction.cs
+++ b/src/NServiceBus.AcceptanceTests/Tx/When_receiving_with_native_multi_queue_transaction.cs
@@ -17,11 +17,11 @@ public class When_receiving_with_native_multi_queue_transaction : NServiceBusAcc
             .Done(c => c.MessageHandled)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.HasFailed, Is.False);
             Assert.That(context.MessageHandled, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
+++ b/src/NServiceBus.AcceptanceTests/Versioning/When_multiple_versions_of_a_message_is_published.cs
@@ -41,11 +41,11 @@ public class When_multiple_versions_of_a_message_is_published : NServiceBusAccep
             .Done(c => c.V1SubscriberGotTheMessage && c.V2SubscriberGotTheMessage)
             .Run();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.V1SubscriberGotTheMessage, Is.True);
             Assert.That(context.V2SubscriberGotTheMessage, Is.True);
-        });
+        }
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.ContainerTests/When_disposing_the_builder.cs
+++ b/src/NServiceBus.ContainerTests/When_disposing_the_builder.cs
@@ -22,11 +22,11 @@ public class When_disposing_the_builder
         serviceProvider.GetService(typeof(AnotherSingletonComponent));
         (serviceProvider as IDisposable)?.Dispose();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(DisposableComponent.DisposeCalled, Is.True, "Dispose should be called on DisposableComponent");
             Assert.That(AnotherSingletonComponent.DisposeCalled, Is.False, "Dispose should not be called on AnotherSingletonComponent");
-        });
+        }
     }
 
     public class DisposableComponent : IDisposable

--- a/src/NServiceBus.ContainerTests/When_registering_components.cs
+++ b/src/NServiceBus.ContainerTests/When_registering_components.cs
@@ -68,13 +68,13 @@ public class When_registering_components
         using var serviceProvider = serviceCollection.BuildServiceProvider();
         var dependency = (ComponentThatDependsOnMultiSingletons)serviceProvider.GetService(typeof(ComponentThatDependsOnMultiSingletons));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(dependency.Singleton1, Is.Not.Null);
             Assert.That(dependency.Singleton2, Is.Not.Null);
 
             Assert.That(singleton, Is.EqualTo(serviceProvider.GetService(typeof(ISingleton1))));
-        });
+        }
         Assert.That(singleton, Is.EqualTo(serviceProvider.GetService(typeof(ISingleton2))));
     }
 

--- a/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
+++ b/src/NServiceBus.ContainerTests/When_using_nested_containers.cs
@@ -156,11 +156,11 @@ public class When_using_nested_containers
             scope.ServiceProvider.GetService(typeof(DisposableComponent));
         }
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(AnotherDisposableComponent.DisposeCalled, Is.False, "Dispose should not be called on AnotherSingletonComponent because it belongs to main container");
             Assert.That(DisposableComponent.DisposeCalled, Is.True, "Dispose should be called on DisposableComponent");
-        });
+        }
     }
 
     public interface IInstanceToReplaceInNested

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_assemblies_with_circular_dependencies.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_assemblies_with_circular_dependencies.cs
@@ -18,10 +18,10 @@ public class When_scanning_assemblies_with_circular_dependencies
 
         var result = scanner.GetScannableAssemblies();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result.Assemblies.Any(a => a.FullName.Contains("ClassLibraryA")), Is.False);
             Assert.That(result.Assemblies.Any(a => a.FullName.Contains("ClassLibraryB")), Is.False);
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_directory_with_nested_directories.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_scanning_directory_with_nested_directories.cs
@@ -21,11 +21,11 @@ public class When_scanning_directory_with_nested_directories
         var foundTypeFromNestedAssembly = result.Types.Any(x => x.Name == "NestedClass");
         var foundTypeFromDerivedAssembly = result.Types.Any(x => x.Name == "DerivedClass");
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(foundTypeFromNestedAssembly, Is.False, "Was expected not to scan nested assemblies, but 'nested.dll' was scanned.");
             Assert.That(foundTypeFromDerivedAssembly, Is.False, "Was expected not to scan nested assemblies, but 'Derived.dll' was scanned.");
-        });
+        }
     }
 
     [Test]
@@ -42,10 +42,10 @@ public class When_scanning_directory_with_nested_directories
         var foundTypeFromNestedAssembly = result.Types.Any(x => x.Name == "NestedClass");
         var foundTypeFromDerivedAssembly = result.Types.Any(x => x.Name == "DerivedClass");
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(foundTypeFromNestedAssembly, Is.True, "Was expected to scan nested assemblies, but 'nested.dll' was not scanned.");
             Assert.That(foundTypeFromDerivedAssembly, Is.True, "Was expected to scan nested assemblies, but 'Derived.dll' was not scanned.");
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/AssemblyScanner/When_validating_assemblies.cs
+++ b/src/NServiceBus.Core.Tests/AssemblyScanner/When_validating_assemblies.cs
@@ -16,11 +16,11 @@ public class When_validating_assemblies
         {
             AssemblyValidator.ValidateAssemblyFile(assembly.Location, out var shouldLoad, out var reason);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(shouldLoad, Is.False, $"Should not validate {assembly.FullName}");
                 Assert.That(reason, Is.EqualTo("File is a .NET runtime assembly."));
-            });
+            }
         }
     }
 
@@ -29,11 +29,11 @@ public class When_validating_assemblies
     {
         AssemblyValidator.ValidateAssemblyFile(typeof(EndpointConfiguration).Assembly.Location, out var shouldLoad, out var reason);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(shouldLoad, Is.True);
             Assert.That(reason, Is.EqualTo("File is a .NET assembly."));
-        });
+        }
     }
 
     [Test]
@@ -41,10 +41,10 @@ public class When_validating_assemblies
     {
         AssemblyValidator.ValidateAssemblyFile(GetType().Assembly.Location, out var shouldLoad, out var reason);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(shouldLoad, Is.True);
             Assert.That(reason, Is.EqualTo("File is a .NET assembly."));
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Audit/AuditConfigReaderTests.cs
+++ b/src/NServiceBus.Core.Tests/Audit/AuditConfigReaderTests.cs
@@ -14,11 +14,11 @@ public class AuditConfigReaderTests
 
         settingsHolder.Set(new AuditConfigReader.Result(configuredAddress, null));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(settingsHolder.TryGetAuditQueueAddress(out var address), Is.True);
             Assert.That(address, Is.EqualTo(configuredAddress));
-        });
+        }
     }
 
     [Test]
@@ -29,11 +29,11 @@ public class AuditConfigReaderTests
 
         settingsHolder.Set(new AuditConfigReader.Result("someAddress", configuredExpiration));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(settingsHolder.TryGetAuditMessageExpiration(out var expiration), Is.True);
             Assert.That(expiration, Is.EqualTo(configuredExpiration));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Config/When_configuring_transport_twice.cs
+++ b/src/NServiceBus.Core.Tests/Config/When_configuring_transport_twice.cs
@@ -25,11 +25,11 @@ public class When_configuring_transport_twice
 
         await endpoint.Stop();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(transport1.Initialized, Is.False, "First transport should not be initialized");
             Assert.That(transport2.Initialized, Is.True, "Second transport should be initialized");
-        });
+        }
     }
 
     class FakeTransportDefinition : TransportDefinition, IMessageDrivenSubscriptionTransport

--- a/src/NServiceBus.Core.Tests/ContextBagTests.cs
+++ b/src/NServiceBus.Core.Tests/ContextBagTests.cs
@@ -13,11 +13,11 @@ public class ContextBagTests
     {
         var contextBag = new ContextBag();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(() => contextBag.Set<string>("NullValue", null!), Throws.ArgumentNullException);
             Assert.That(() => contextBag.SetOnRoot<string>("NullValue", null!), Throws.ArgumentNullException);
-        });
+        }
     }
 
     [Test]
@@ -25,11 +25,11 @@ public class ContextBagTests
     {
         var contextBag = new ContextBag();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(() => contextBag.Set<string?>("NullValue", null), Throws.ArgumentNullException);
             Assert.That(() => contextBag.SetOnRoot<string?>("NullValue", null), Throws.ArgumentNullException);
-        });
+        }
     }
 
     [Test]
@@ -55,11 +55,11 @@ public class ContextBagTests
 
         context.SetOnRoot(key, 42);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(root.Get<int>(key), Is.EqualTo(42), "should store value on root context");
             Assert.That(context.Get<int>(key), Is.EqualTo(42), "stored value should be readable in the writing context");
             Assert.That(fork.Get<int>(key), Is.EqualTo(42), "stored value should be visible to a forked context");
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/DateTimeExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/DateTimeExtensionsTests.cs
@@ -24,7 +24,7 @@ class DateTimeExtensionsTests
         var dateString = DateTimeOffsetHelper.ToWireFormattedString(date);
         var result = DateTimeOffsetHelper.ToDateTimeOffset(dateString);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result.Year, Is.EqualTo(date.Year));
             Assert.That(result.Month, Is.EqualTo(date.Month));
@@ -35,7 +35,7 @@ class DateTimeExtensionsTests
             Assert.That(result.Millisecond, Is.EqualTo(date.Millisecond));
             Assert.That(result.Microseconds(), Is.EqualTo(date.Microseconds()));
             Assert.That(result.Offset, Is.EqualTo(date.Offset));
-        });
+        }
     }
 
     [Test]
@@ -45,7 +45,7 @@ class DateTimeExtensionsTests
         var date = DateTimeOffset.ParseExact(dateString, "yyyy-MM-dd HH:mm:ss:ffffff Z", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
         var result = DateTimeOffsetHelper.ToDateTimeOffset(dateString);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result.Year, Is.EqualTo(date.Year));
             Assert.That(result.Month, Is.EqualTo(date.Month));
@@ -56,7 +56,7 @@ class DateTimeExtensionsTests
             Assert.That(result.Millisecond, Is.EqualTo(date.Millisecond));
             Assert.That(result.Microseconds(), Is.EqualTo(date.Microseconds()));
             Assert.That(result.Offset, Is.EqualTo(date.Offset));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Fakes/TestableMessageHandlerContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/TestableMessageHandlerContextTests.cs
@@ -18,11 +18,11 @@ public class TestableMessageHandlerContextTests
         await context.Send(messageInstance, sendOptions);
 
         Assert.That(context.SentMessages, Has.Length.EqualTo(1));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.SentMessages[0].Message, Is.SameAs(messageInstance));
             Assert.That(context.SentMessages[0].Options, Is.SameAs(sendOptions));
-        });
+        }
     }
 
     [Test]
@@ -45,11 +45,11 @@ public class TestableMessageHandlerContextTests
         await context.Publish(messageInstance, publishOptions);
 
         Assert.That(context.PublishedMessages, Has.Length.EqualTo(1));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.PublishedMessages[0].Message, Is.SameAs(messageInstance));
             Assert.That(context.PublishedMessages[0].Options, Is.SameAs(publishOptions));
-        });
+        }
     }
 
     [Test]
@@ -72,11 +72,11 @@ public class TestableMessageHandlerContextTests
         await context.Reply(messageInstance, publishOptions);
 
         Assert.That(context.RepliedMessages, Has.Length.EqualTo(1));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.RepliedMessages[0].Message, Is.SameAs(messageInstance));
             Assert.That(context.RepliedMessages[0].Options, Is.SameAs(publishOptions));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Fakes/TestableMessageSessionTests.cs
+++ b/src/NServiceBus.Core.Tests/Fakes/TestableMessageSessionTests.cs
@@ -15,11 +15,11 @@ public class TestableMessageSessionTests
         await session.Subscribe(typeof(MyEvent), options);
 
         Assert.That(session.Subscriptions, Has.Length.EqualTo(1));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(session.Subscriptions[0].Options, Is.SameAs(options));
             Assert.That(session.Subscriptions[0].Message, Is.EqualTo(typeof(MyEvent)));
-        });
+        }
     }
 
     [Test]
@@ -31,11 +31,11 @@ public class TestableMessageSessionTests
         await session.Unsubscribe(typeof(MyEvent), options);
 
         Assert.That(session.Unsubscription, Has.Length.EqualTo(1));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(session.Unsubscription[0].Options, Is.SameAs(options));
             Assert.That(session.Unsubscription[0].Message, Is.EqualTo(typeof(MyEvent)));
-        });
+        }
     }
 
     class MyEvent

--- a/src/NServiceBus.Core.Tests/Features/FeatureDefaultsTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDefaultsTests.cs
@@ -88,7 +88,7 @@ public class FeatureDefaultsTests
 
         featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(level1.IsActive, Is.True, "Activate1 wasn't activated");
             Assert.That(level2.IsActive, Is.True, "Activate2 wasn't activated");
@@ -97,7 +97,7 @@ public class FeatureDefaultsTests
             Assert.That(defaultsOrder[0], Is.InstanceOf<Activate1>(), "Upstream dependencies should be activated first");
             Assert.That(defaultsOrder[1], Is.InstanceOf<Activate2>(), "Upstream dependencies should be activated first");
             Assert.That(defaultsOrder[2], Is.InstanceOf<Activate3>(), "Upstream dependencies should be activated first");
-        });
+        }
 
         Assert.That(activatedOrder, Is.EqualTo(defaultsOrder).AsCollection);
     }
@@ -123,12 +123,12 @@ public class FeatureDefaultsTests
 
         featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(dependingFeature.IsActive, Is.True);
 
             Assert.That(defaultsOrder.First(), Is.InstanceOf<MyFeature1>(), "Upstream dependencies should be activated first");
-        });
+        }
     }
 
     [Test]
@@ -164,14 +164,14 @@ public class FeatureDefaultsTests
 
         featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(dependingFeature.IsActive, Is.True);
 
             Assert.That(defaultsOrder[0], Is.InstanceOf<MyFeature1>(), "Upstream dependencies should be activated first");
             Assert.That(defaultsOrder[1], Is.InstanceOf<MyFeature2>(), "Upstream dependencies should be activated first");
             Assert.That(defaultsOrder[2], Is.InstanceOf<MyFeature3>(), "Upstream dependencies should be activated first");
-        });
+        }
     }
 
     [Test]
@@ -199,7 +199,7 @@ public class FeatureDefaultsTests
 
         featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(level1.IsActive, Is.True, "Level1 wasn't activated");
             Assert.That(level2.IsActive, Is.True, "Level2 wasn't activated");
@@ -208,7 +208,7 @@ public class FeatureDefaultsTests
             Assert.That(defaultsOrder[0], Is.InstanceOf<Level1>(), "Upstream dependencies should be activated first");
             Assert.That(defaultsOrder[1], Is.InstanceOf<Level2>(), "Upstream dependencies should be activated first");
             Assert.That(defaultsOrder[2], Is.InstanceOf<Level3>(), "Upstream dependencies should be activated first");
-        });
+        }
     }
 
     public class Level1 : TestFeature

--- a/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDependencyTests.cs
@@ -88,12 +88,12 @@ public class FeatureDependencyTests
 
         featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(dependingFeature.IsActive, Is.True);
 
             Assert.That(order.First(), Is.InstanceOf<MyFeature1>(), "Upstream dependencies should be activated first");
-        });
+        }
     }
 
     [Test]
@@ -120,11 +120,11 @@ public class FeatureDependencyTests
 
         featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(dependingFeature.IsActive, Is.True);
             Assert.That(order.First(), Is.InstanceOf<MyFeature2>(), "Upstream dependencies should be activated first");
-        });
+        }
     }
 
     [Test]
@@ -149,11 +149,11 @@ public class FeatureDependencyTests
 
         featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(dependingFeature.IsActive, Is.False);
             Assert.That(order, Is.Empty);
-        });
+        }
     }
 
     [Test]
@@ -192,14 +192,14 @@ public class FeatureDependencyTests
 
         featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(dependingFeature.IsActive, Is.True);
 
             Assert.That(order[0], Is.InstanceOf<MyFeature1>(), "Upstream dependencies should be activated first");
             Assert.That(order[1], Is.InstanceOf<MyFeature2>(), "Upstream dependencies should be activated first");
             Assert.That(order[2], Is.InstanceOf<MyFeature3>(), "Upstream dependencies should be activated first");
-        });
+        }
     }
 
     [Test]
@@ -231,7 +231,7 @@ public class FeatureDependencyTests
 
         featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(level1.IsActive, Is.True, "Level1 wasn't activated");
             Assert.That(level2.IsActive, Is.True, "Level2 wasn't activated");
@@ -240,7 +240,7 @@ public class FeatureDependencyTests
             Assert.That(order[0], Is.InstanceOf<Level1>(), "Upstream dependencies should be activated first");
             Assert.That(order[1], Is.InstanceOf<Level2>(), "Upstream dependencies should be activated first");
             Assert.That(order[2], Is.InstanceOf<Level3>(), "Upstream dependencies should be activated first");
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Features/FeatureDifferingOnlyByNamespaceTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureDifferingOnlyByNamespaceTests.cs
@@ -33,12 +33,12 @@
 
             featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(dependingFeature.IsActive, Is.True);
 
                 Assert.That(order.First(), Is.InstanceOf<NamespaceA.MyFeature>(), "Upstream dependencies should be activated first");
-            });
+            }
         }
     }
 }

--- a/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureSettingsTests.cs
@@ -30,13 +30,13 @@ public class FeatureSettingsTests
 
         featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(featureWithTrueCondition.IsActive, Is.True);
             Assert.That(featureWithFalseCondition.IsActive, Is.False);
             Assert.That(featureSettings.Status.Single(s => s.Name == featureWithFalseCondition.Name).PrerequisiteStatus.Reasons.First(),
                 Is.EqualTo("The description"));
-        });
+        }
     }
 
     [Test]
@@ -58,11 +58,11 @@ public class FeatureSettingsTests
 
         featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(settings.HasSetting("Test1"), Is.False);
             Assert.That(settings.HasSetting("Test2"), Is.False);
-        });
+        }
     }
 
 

--- a/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
+++ b/src/NServiceBus.Core.Tests/Features/FeatureStartupTests.cs
@@ -30,11 +30,11 @@ public class FeatureStartupTests
         await featureSettings.StartFeatures(null, null);
         await featureSettings.StopFeatures(null);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(feature.TaskStarted, Is.True);
             Assert.That(feature.TaskStopped, Is.True);
-        });
+        }
     }
 
     [Test]
@@ -88,7 +88,7 @@ public class FeatureStartupTests
         featureSettings.SetupFeatures(new FakeFeatureConfigurationContext());
 
         var exception = Assert.ThrowsAsync<InvalidOperationException>(async () => await featureSettings.StartFeatures(null, null));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(exception.Message, Is.EqualTo("feature2"));
 
@@ -97,7 +97,7 @@ public class FeatureStartupTests
             Assert.That(feature1.TaskStopCalled, Is.True, "An attempt should have been made to stop feature 1.");
             Assert.That(feature2.TaskStopCalled, Is.False, "No attempt should have been made to stop feature 2.");
             Assert.That(feature3.TaskStartCalled, Is.False, "No attempt should have been made to start feature 3.");
-        });
+        }
     }
 
     [Test]
@@ -115,11 +115,11 @@ public class FeatureStartupTests
 
         Assert.DoesNotThrowAsync(async () => await featureSettings.StopFeatures(null));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(feature1.TaskStarted && feature1.TaskStopped, Is.True);
             Assert.That(feature2.TaskStarted && !feature2.TaskStopped, Is.True);
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Handlers/MessageHandlerRegistryTests.cs
+++ b/src/NServiceBus.Core.Tests/Handlers/MessageHandlerRegistryTests.cs
@@ -43,11 +43,11 @@ public class MessageHandlerRegistryTests
         timeoutHandler.Instance = timeoutInstance;
         await timeoutHandler.Invoke(new MyMessage(), new TestableInvokeHandlerContext());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(timeoutInstance.TimeoutCalled, Is.True);
             Assert.That(timeoutInstance.HandlerCalled, Is.False);
-        });
+        }
 
         var regularHandler = handlers.SingleOrDefault(h => !h.IsTimeoutHandler);
 
@@ -58,11 +58,11 @@ public class MessageHandlerRegistryTests
         regularHandler.Instance = regularInstance;
         await regularHandler.Invoke(new MyMessage(), new TestableInvokeHandlerContext());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(regularInstance.TimeoutCalled, Is.False);
             Assert.That(regularInstance.HandlerCalled, Is.True);
-        });
+        }
     }
 
     class HandlerWithIMessageSessionProperty : IHandleMessages<MyMessage>

--- a/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
+++ b/src/NServiceBus.Core.Tests/Licensing/LicenseManagerTests.cs
@@ -27,11 +27,11 @@ class LicenseManagerTests
         LicenseManager.LogLicenseStatus(LicenseStatus.InvalidDueToExpiredSubscription, logger, new License(), "fake-url");
 
         Assert.That(logger.Logs, Has.Count.EqualTo(1));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(logger.Logs[0].level, Is.EqualTo(LogLevel.Error));
             Assert.That(logger.Logs[0].message, Is.EqualTo("License expired. Contact us to renew your license: contact@particular.net"));
-        });
+        }
     }
 
     [Test]
@@ -42,11 +42,11 @@ class LicenseManagerTests
         LicenseManager.LogLicenseStatus(LicenseStatus.InvalidDueToExpiredUpgradeProtection, logger, new License(), "fake-url");
 
         Assert.That(logger.Logs, Has.Count.EqualTo(1));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(logger.Logs[0].level, Is.EqualTo(LogLevel.Error));
             Assert.That(logger.Logs[0].message, Is.EqualTo("Upgrade protection expired. In order for us to continue to provide you with support and new versions of the Particular Service Platform, contact us to renew your license: contact@particular.net"));
-        });
+        }
     }
 
     [TestCase(false, "Trial license expired. Get your free development license at fake-url")]
@@ -59,11 +59,11 @@ class LicenseManagerTests
         LicenseManager.LogLicenseStatus(LicenseStatus.InvalidDueToExpiredTrial, logger, license, "fake-url");
 
         Assert.That(logger.Logs, Has.Count.EqualTo(1));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(logger.Logs[0].level, Is.EqualTo(LogLevel.Error));
             Assert.That(logger.Logs[0].message, Is.EqualTo(expectedMessage));
-        });
+        }
     }
 
     [TestCase(3, false, "Trial license expiring in 3 days. Get your free development license at fake-url")]
@@ -86,11 +86,11 @@ class LicenseManagerTests
         LicenseManager.LogLicenseStatus(LicenseStatus.ValidWithExpiringTrial, logger, license, "fake-url");
 
         Assert.That(logger.Logs, Has.Count.EqualTo(1));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(logger.Logs[0].level, Is.EqualTo(LogLevel.Warn));
             Assert.That(logger.Logs[0].message, Is.EqualTo(expectedMessage));
-        });
+        }
     }
 
     [TestCase(3, "License expiring in 3 days. Contact us to renew your license: contact@particular.net")]
@@ -109,11 +109,11 @@ class LicenseManagerTests
         LicenseManager.LogLicenseStatus(LicenseStatus.ValidWithExpiringSubscription, logger, license, "fake-url");
 
         Assert.That(logger.Logs, Has.Count.EqualTo(1));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(logger.Logs[0].level, Is.EqualTo(LogLevel.Warn));
             Assert.That(logger.Logs[0].message, Is.EqualTo(expectedMessage));
-        });
+        }
     }
 
     [TestCase(3, "Upgrade protection expiring in 3 days. Contact us to renew your license: contact@particular.net")]
@@ -132,11 +132,11 @@ class LicenseManagerTests
         LicenseManager.LogLicenseStatus(LicenseStatus.ValidWithExpiringUpgradeProtection, logger, license, "fake-url");
 
         Assert.That(logger.Logs, Has.Count.EqualTo(1));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(logger.Logs[0].level, Is.EqualTo(LogLevel.Warn));
             Assert.That(logger.Logs[0].message, Is.EqualTo(expectedMessage));
-        });
+        }
     }
 
     [Test]
@@ -154,11 +154,11 @@ class LicenseManagerTests
         LicenseManager.LogLicenseStatus(LicenseStatus.ValidWithExpiredUpgradeProtection, logger, license, "fake-url");
 
         Assert.That(logger.Logs, Has.Count.EqualTo(1));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(logger.Logs[0].level, Is.EqualTo(LogLevel.Warn));
             Assert.That(logger.Logs[0].message, Is.EqualTo("Upgrade protection expired. In order for us to continue to provide you with support and new versions of the Particular Service Platform, contact us to renew your license: contact@particular.net"));
-        });
+        }
     }
 
     class TestableLogger : ILog

--- a/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
+++ b/src/NServiceBus.Core.Tests/Logging/RollingLoggerTests.cs
@@ -20,22 +20,22 @@ public class RollingLoggerTests
         };
         logger1.WriteLine("Foo");
         var files1 = tempPath.GetFiles();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(files1, Has.Count.EqualTo(1));
             Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(files1.First()), Is.EqualTo($"Foo{Environment.NewLine}"));
-        });
+        }
         var logger2 = new RollingLogger(tempPath.TempDirectory)
         {
             GetDate = () => dateTime
         };
         logger2.WriteLine("Bar");
         var files2 = tempPath.GetFiles();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(files2, Has.Count.EqualTo(1));
             Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(files2.First()), Is.EqualTo($"Foo{Environment.NewLine}Bar{Environment.NewLine}"));
-        });
+        }
     }
 
     [Test]
@@ -118,18 +118,18 @@ public class RollingLoggerTests
         Assert.That(files, Has.Count.EqualTo(2));
 
         var first = files[0];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(Path.GetFileName(first), Is.EqualTo("nsb_log_2010-10-01_0.txt"));
             Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(files.First()), Is.EqualTo($"Some long text{Environment.NewLine}"));
-        });
+        }
 
         var second = files[1];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(Path.GetFileName(second), Is.EqualTo("nsb_log_2010-10-01_1.txt"));
             Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(second), Is.EqualTo($"Bar{Environment.NewLine}"));
-        });
+        }
     }
 
     [Test]
@@ -151,18 +151,18 @@ public class RollingLoggerTests
         Assert.That(files, Has.Count.EqualTo(2));
 
         var first = files[0];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(Path.GetFileName(first), Is.EqualTo("nsb_log_2010-10-01_0.txt"));
             Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(files.First()), Is.EqualTo($"Foo{Environment.NewLine}"));
-        });
+        }
 
         var second = files[1];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(Path.GetFileName(second), Is.EqualTo("nsb_log_2010-10-02_0.txt"));
             Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(second), Is.EqualTo($"Bar{Environment.NewLine}"));
-        });
+        }
     }
 
     [Test]
@@ -201,18 +201,18 @@ public class RollingLoggerTests
         Assert.That(files, Has.Count.EqualTo(2));
 
         var first = files[0];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(Path.GetFileName(first), Is.EqualTo("nsb_log_2010-10-01_0.txt"));
             Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(first), Is.EqualTo($"Some long text{Environment.NewLine}"));
-        });
+        }
 
         var second = files[1];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(Path.GetFileName(second), Is.EqualTo("nsb_log_2010-10-01_1.txt"));
             Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(second), Is.EqualTo($"Bar{Environment.NewLine}"));
-        });
+        }
     }
 
     [Test]
@@ -256,18 +256,18 @@ public class RollingLoggerTests
         Assert.That(files, Has.Count.EqualTo(2));
 
         var first = files[0];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(Path.GetFileName(first), Is.EqualTo("nsb_log_2010-10-01_0.txt"));
             Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(first), Is.EqualTo($"Foo{Environment.NewLine}"));
-        });
+        }
 
         var second = files[1];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(Path.GetFileName(second), Is.EqualTo("nsb_log_2010-10-02_0.txt"));
             Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(second), Is.EqualTo($"Bar{Environment.NewLine}"));
-        });
+        }
     }
 
     [Test]
@@ -321,25 +321,25 @@ public class RollingLoggerTests
         Assert.That(files, Has.Count.EqualTo(3), "Should be numberOfArchiveFilesToKeep + 1 (the current file) ");
 
         var first = files[0];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(Path.GetFileName(first), Is.EqualTo("nsb_log_2010-10-01_2.txt"));
             Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(first), Is.EqualTo($"Long text2{Environment.NewLine}"));
-        });
+        }
 
         var second = files[1];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(Path.GetFileName(second), Is.EqualTo("nsb_log_2010-10-01_3.txt"));
             Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(second), Is.EqualTo($"Long text3{Environment.NewLine}"));
-        });
+        }
 
         var third = files[2];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(Path.GetFileName(third), Is.EqualTo("nsb_log_2010-10-01_4.txt"));
             Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(third), Is.EqualTo($"Long text4{Environment.NewLine}"));
-        });
+        }
     }
 
     [Test]
@@ -363,25 +363,25 @@ public class RollingLoggerTests
         Assert.That(files, Has.Count.EqualTo(3), "Should be numberOfArchiveFilesToKeep + 1 (the current file) ");
 
         var first = files[0];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(Path.GetFileName(first), Is.EqualTo("nsb_log_2010-10-03_0.txt"));
             Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(first), Is.EqualTo($"Foo3{Environment.NewLine}"));
-        });
+        }
 
         var second = files[1];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(Path.GetFileName(second), Is.EqualTo("nsb_log_2010-10-04_0.txt"));
             Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(second), Is.EqualTo($"Foo4{Environment.NewLine}"));
-        });
+        }
 
         var third = files[2];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(Path.GetFileName(third), Is.EqualTo("nsb_log_2010-10-05_0.txt"));
             Assert.That(NonLockingFileReader.ReadAllTextWithoutLocking(third), Is.EqualTo($"Foo5{Environment.NewLine}"));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/MessageMapper/MessageMapperTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageMapper/MessageMapperTests.cs
@@ -140,11 +140,11 @@ public class MessageMapperTests
         var messageInstance = mapper.CreateInstance<SampleMessageClass>();
 
         Assert.That(messageInstance, Is.Not.Null);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(messageInstance.GetType(), Is.EqualTo(typeof(SampleMessageClass)));
             Assert.That(messageInstance.CtorInvoked, Is.True);
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/MessageMapper/When_mapping_interfaces.cs
+++ b/src/NServiceBus.Core.Tests/MessageMapper/When_mapping_interfaces.cs
@@ -58,13 +58,13 @@ public class When_mapping_interfaces
     {
         var mapper = new MessageMapper();
         mapper.Initialize([typeof(IInterfaceWithPropertiesAndAttributes)]);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(PropertyContainsAttribute("SomeProperty", typeof(SomeAttribute), mapper.CreateInstance(typeof(IInterfaceWithPropertiesAndAttributes))), Is.True);
 
             // Doesn't affect properties without attributes
             Assert.That(PropertyContainsAttribute("SomeOtherProperty", typeof(SomeAttribute), mapper.CreateInstance(typeof(IInterfaceWithPropertiesAndAttributes))), Is.False);
-        });
+        }
     }
 
     public interface IInterfaceWithPropertiesAndAttributes

--- a/src/NServiceBus.Core.Tests/MessageMutators/MutateInstanceMessage/MutateIncomingMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageMutators/MutateInstanceMessage/MutateIncomingMessageBehaviorTests.cs
@@ -23,11 +23,11 @@ class MutateIncomingMessageBehaviorTests
 
         await behavior.Invoke(context, ctx => Task.CompletedTask);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(mutator.MutateIncomingCalled, Is.True);
             Assert.That(otherMutator.MutateIncomingCalled, Is.True);
-        });
+        }
     }
 
     [Test]
@@ -43,11 +43,11 @@ class MutateIncomingMessageBehaviorTests
 
         await behavior.Invoke(context, ctx => Task.CompletedTask);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(explicitMutator.MutateIncomingCalled, Is.True);
             Assert.That(containerMutator.MutateIncomingCalled, Is.True);
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/MessageMutators/MutateInstanceMessage/MutateOutgoingMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageMutators/MutateInstanceMessage/MutateOutgoingMessageBehaviorTests.cs
@@ -23,11 +23,11 @@ class MutateOutgoingMessageBehaviorTests
 
         await behavior.Invoke(context, ctx => Task.CompletedTask);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(mutator.MutateOutgoingCalled, Is.True);
             Assert.That(otherMutator.MutateOutgoingCalled, Is.True);
-        });
+        }
     }
 
     [Test]
@@ -43,11 +43,11 @@ class MutateOutgoingMessageBehaviorTests
 
         await behavior.Invoke(context, ctx => Task.CompletedTask);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(explicitMutator.MutateOutgoingCalled, Is.True);
             Assert.That(containerMutator.MutateOutgoingCalled, Is.True);
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageMutators/MutateTransportMessage/MutateIncomingTransportMessageBehaviorTests.cs
@@ -22,11 +22,11 @@ public class MutateIncomingTransportMessageBehaviorTests
 
         await behavior.Invoke(context, ctx => Task.CompletedTask);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(mutator.MutateIncomingCalled, Is.True);
             Assert.That(otherMutator.MutateIncomingCalled, Is.True);
-        });
+        }
     }
 
     [Test]
@@ -42,11 +42,11 @@ public class MutateIncomingTransportMessageBehaviorTests
 
         await behavior.Invoke(context, ctx => Task.CompletedTask);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(explicitMutator.MutateIncomingCalled, Is.True);
             Assert.That(containerMutator.MutateIncomingCalled, Is.True);
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/MessageMutators/MutateTransportMessage/MutateOutgoingTransportMessageBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/MessageMutators/MutateTransportMessage/MutateOutgoingTransportMessageBehaviorTests.cs
@@ -24,11 +24,11 @@ class MutateOutgoingTransportMessageBehaviorTests
 
         await behavior.Invoke(physicalContext, ctx => Task.CompletedTask);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(mutator.MutateOutgoingCalled, Is.True);
             Assert.That(otherMutator.MutateOutgoingCalled, Is.True);
-        });
+        }
     }
 
     [Test]
@@ -45,11 +45,11 @@ class MutateOutgoingTransportMessageBehaviorTests
 
         await behavior.Invoke(physicalContext, ctx => Task.CompletedTask);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(explicitMutator.MutateOutgoingCalled, Is.True);
             Assert.That(containerMutator.MutateOutgoingCalled, Is.True);
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityDecoratorTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityDecoratorTests.cs
@@ -53,10 +53,10 @@ public class ActivityDecoratorTests
         var tags = activity.Tags.ToImmutableDictionary();
 
         Assert.That(tags.Count, Is.EqualTo(2), "should only contain approved NServiceBus headers");
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(tags["nservicebus.message_id"], Is.EqualTo(headers[Headers.MessageId]));
             Assert.That(tags["nservicebus.control_message"], Is.EqualTo(headers[Headers.ControlMessageHeader]));
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityExtensionsTests.cs
@@ -14,11 +14,11 @@ public class ActivityExtensionsTests
         ambientActivity.Start();
 
         var contextBag = new ContextBag();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(contextBag.TryGetRecordingOutgoingPipelineActivity(out var activity), Is.False);
             Assert.That(activity, Is.Null);
-        });
+        }
     }
 
     [Test]
@@ -29,11 +29,11 @@ public class ActivityExtensionsTests
 
         var contextBag = new ContextBag();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(contextBag.TryGetRecordingOutgoingPipelineActivity(out var activity), Is.False);
             Assert.That(activity, Is.Null);
-        });
+        }
     }
 
     [Test]
@@ -48,10 +48,10 @@ public class ActivityExtensionsTests
         var contextBag = new ContextBag();
         contextBag.SetOutgoingPipelineActitvity(recordingActivity);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(contextBag.TryGetRecordingOutgoingPipelineActivity(out var activity), Is.True);
             Assert.That(activity, Is.EqualTo(recordingActivity));
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityFactoryTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/ActivityFactoryTests.cs
@@ -41,11 +41,11 @@ public class ActivityFactoryTests
             var activity = activityFactory.StartIncomingPipelineActivity(CreateMessageContext(contextBag: contextBag));
 
             Assert.That(activity, Is.Not.Null, "should create activity for receive pipeline");
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(activity.ParentId, Is.EqualTo(contextActivity.Id), "should use context activity as parent");
                 Assert.That(activity.Links.Count(), Is.EqualTo(0), "should not link to logical send span");
-            });
+            }
         }
 
         [Test]
@@ -62,13 +62,13 @@ public class ActivityFactoryTests
             var activity = activityFactory.StartIncomingPipelineActivity(CreateMessageContext(messageHeaders, contextBag));
 
             Assert.That(activity, Is.Not.Null, "should create activity for receive pipeline");
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(activity.ParentId, Is.EqualTo(contextActivity.Id), "should use context activity as parent");
                 Assert.That(activity.Links.Count(), Is.EqualTo(1), "should link to logical send span");
                 Assert.That(activity.Links.Single().Context.TraceId, Is.EqualTo(sendActivity.TraceId));
                 Assert.That(activity.Links.Single().Context.SpanId, Is.EqualTo(sendActivity.SpanId));
-            });
+            }
         }
 
         [Test]
@@ -99,11 +99,11 @@ public class ActivityFactoryTests
             var activity = activityFactory.StartIncomingPipelineActivity(CreateMessageContext(contextBag: contextBag));
 
             Assert.That(activity, Is.Not.Null, "should create activity for receive pipeline");
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(activity.ParentId, Is.Null, "should create a new trace");
                 Assert.That(activity.IdFormat, Is.EqualTo(ActivityIdFormat.W3C));
-            });
+            }
         }
 
         [Test]
@@ -116,11 +116,11 @@ public class ActivityFactoryTests
             var activity = activityFactory.StartIncomingPipelineActivity(CreateMessageContext(messageHeaders));
 
             Assert.That(activity, Is.Not.Null, "should create activity for receive pipeline");
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(activity.ParentId, Is.EqualTo(sendActivity.Id));
                 Assert.That(activity.Links.Count(), Is.EqualTo(0), "should not link to logical send span");
-            });
+            }
         }
 
         [TestCase(ActivityIdFormat.W3C)]
@@ -134,11 +134,11 @@ public class ActivityFactoryTests
             var activity = activityFactory.StartIncomingPipelineActivity(CreateMessageContext());
 
             Assert.That(activity, Is.Not.Null, "should create activity for receive pipeline");
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(activity.ParentId, Is.EqualTo(ambientActivity.Id), "should attach to ambient activity");
                 Assert.That(activity.IdFormat, Is.EqualTo(ActivityIdFormat.W3C));
-            });
+            }
         }
 
         [Test]
@@ -147,11 +147,11 @@ public class ActivityFactoryTests
             var activity = activityFactory.StartIncomingPipelineActivity(CreateMessageContext());
 
             Assert.That(activity, Is.Not.Null, "should create activity for receive pipeline");
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(activity.ParentId, Is.Null, "should start a new trace");
                 Assert.That(activity.IdFormat, Is.EqualTo(ActivityIdFormat.W3C));
-            });
+            }
         }
 
         [Test]
@@ -162,11 +162,11 @@ public class ActivityFactoryTests
             var activity = activityFactory.StartIncomingPipelineActivity(CreateMessageContext(messageHeaders));
 
             Assert.That(activity, Is.Not.Null, "should create activity for receive pipeline");
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(activity.ParentId, Is.Null, "should start new trace");
                 Assert.That(activity.Links.Count(), Is.EqualTo(0), "should not link to logical send span");
-            });
+            }
         }
 
         [Test]
@@ -220,11 +220,11 @@ public class ActivityFactoryTests
 
             var activity = activityFactory.StartOutgoingPipelineActivity("activityName", "activityDisplayName", new FakeRootContext());
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(activity?.ParentId, Is.EqualTo(ambientActivity.Id));
                 Assert.That(activity?.IdFormat, Is.EqualTo(ActivityIdFormat.W3C));
-            });
+            }
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/ContextPropagationTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/ContextPropagationTests.cs
@@ -47,11 +47,11 @@ public class ContextPropagationTests
         contextBag.Set(Headers.StartNewTrace, bool.TrueString);
         ContextPropagation.PropagateContextToHeaders(activity, headers, contextBag);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(headers.ContainsKey(Headers.StartNewTrace), Is.True, bool.TrueString);
             Assert.That(bool.TrueString, Is.EqualTo(headers[Headers.StartNewTrace]));
-        });
+        }
     }
 
     [Test]
@@ -127,12 +127,12 @@ public class ContextPropagationTests
 
         if (testCase.HasBaggage)
         {
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(baggageHeaderSet, Is.True, "Should have a baggage header if there is baggage");
 
                 Assert.That(baggageValue, Is.EqualTo(testCase.BaggageHeaderValueWithoutOptionalWhitespace), "baggage header is set but is not correct");
-            });
+            }
         }
         else
         {

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/Helpers/TestingMetricListener.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/Helpers/TestingMetricListener.cs
@@ -67,11 +67,11 @@ class TestingMetricListener : IDisposable
         }
         else
         {
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(ReportedMeters.ContainsKey(metricName), Is.True, $"'{metricName}' metric was not reported.");
                 Assert.That(ReportedMeters[metricName], Is.EqualTo(expected));
-            });
+            }
         }
     }
 

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/MessageOperationsTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/MessageOperationsTests.cs
@@ -38,7 +38,7 @@ public class MessageOperationsTests
         await operations.Send(new FakeRootContext(), new object(), new SendOptions());
 
         Assert.That(activity, Is.Not.Null);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(activity.IdFormat, Is.EqualTo(ActivityIdFormat.W3C));
             Assert.That(activity.Status, Is.EqualTo(ActivityStatusCode.Ok));
@@ -48,7 +48,7 @@ public class MessageOperationsTests
             Assert.That(activity.DisplayName, Is.EqualTo("send message"));
 
             Assert.That(operations.SendPipeline.LastContext.Extensions.Get<Activity>(ActivityExtensions.OutgoingActivityKey), Is.EqualTo(activity));
-        });
+        }
     }
 
     [Test]
@@ -64,7 +64,7 @@ public class MessageOperationsTests
         await operations.Publish(new FakeRootContext(), new object(), new PublishOptions());
 
         Assert.That(activity, Is.Not.Null);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(activity.IdFormat, Is.EqualTo(ActivityIdFormat.W3C));
             Assert.That(activity.Status, Is.EqualTo(ActivityStatusCode.Ok));
@@ -74,7 +74,7 @@ public class MessageOperationsTests
             Assert.That(activity.DisplayName, Is.EqualTo("publish event"));
 
             Assert.That(operations.PublishPipeline.LastContext.Extensions.Get<Activity>(ActivityExtensions.OutgoingActivityKey), Is.EqualTo(activity));
-        });
+        }
     }
 
     [Test]
@@ -90,7 +90,7 @@ public class MessageOperationsTests
         await operations.Reply(new FakeRootContext(), new object(), new ReplyOptions());
 
         Assert.That(activity, Is.Not.Null);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(activity.IdFormat, Is.EqualTo(ActivityIdFormat.W3C));
             Assert.That(activity.Status, Is.EqualTo(ActivityStatusCode.Ok));
@@ -100,7 +100,7 @@ public class MessageOperationsTests
             Assert.That(activity.DisplayName, Is.EqualTo("reply"));
 
             Assert.That(operations.ReplyPipeline.LastContext.Extensions.Get<Activity>(ActivityExtensions.OutgoingActivityKey), Is.EqualTo(activity));
-        });
+        }
     }
 
     [Test]
@@ -116,7 +116,7 @@ public class MessageOperationsTests
         await operations.Subscribe(new FakeRootContext(), typeof(object), new SubscribeOptions());
 
         Assert.That(activity, Is.Not.Null);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(activity.IdFormat, Is.EqualTo(ActivityIdFormat.W3C));
             Assert.That(activity.Status, Is.EqualTo(ActivityStatusCode.Ok));
@@ -126,7 +126,7 @@ public class MessageOperationsTests
             Assert.That(activity.DisplayName, Is.EqualTo("subscribe event"));
 
             Assert.That(operations.SubscribePipeline.LastContext.Extensions.Get<Activity>(ActivityExtensions.OutgoingActivityKey), Is.EqualTo(activity));
-        });
+        }
     }
 
     [Test]
@@ -142,7 +142,7 @@ public class MessageOperationsTests
         await operations.Unsubscribe(new FakeRootContext(), typeof(object), new UnsubscribeOptions());
 
         Assert.That(activity, Is.Not.Null);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(activity.IdFormat, Is.EqualTo(ActivityIdFormat.W3C));
             Assert.That(activity.Status, Is.EqualTo(ActivityStatusCode.Ok));
@@ -152,7 +152,7 @@ public class MessageOperationsTests
             Assert.That(activity.DisplayName, Is.EqualTo("unsubscribe event"));
 
             Assert.That(operations.UnsubscribePipeline.LastContext.Extensions.Get<Activity>(ActivityExtensions.OutgoingActivityKey), Is.EqualTo(activity));
-        });
+        }
     }
 
     [Test]
@@ -170,11 +170,11 @@ public class MessageOperationsTests
 
         Assert.That(activity.Status, Is.EqualTo(ActivityStatusCode.Error));
         var tags = activity.Tags.ToImmutableDictionary();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(tags["otel.status_code"], Is.EqualTo("ERROR"));
             Assert.That(tags["otel.status_description"], Is.EqualTo(ex.Message));
-        });
+        }
     }
 
     [Test]
@@ -195,11 +195,11 @@ public class MessageOperationsTests
         await operations.Send(new FakeRootContext(), new object(), new SendOptions());
 
         Assert.That(activity, Is.Not.Null);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(activity.IdFormat, Is.EqualTo(ActivityIdFormat.W3C));
             Assert.That(activity.ParentId, Is.EqualTo(ambientActivity.Id));
             Assert.That(activity.TraceId, Is.Not.EqualTo(ambientActivity.TraceId));
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/OpenTelemetry/TracingExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/OpenTelemetry/TracingExtensionsTests.cs
@@ -51,11 +51,11 @@ public class TracingExtensionsTests
         Assert.That(activity.Status, Is.EqualTo(ActivityStatusCode.Error));
 
         var tags = activity.Tags.ToImmutableDictionary();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(tags["otel.status_code"], Is.EqualTo("ERROR"));
             Assert.That(tags["otel.status_description"], Is.EqualTo(exception.Message));
-        });
+        }
 
         var errorEvent = activity.Events.Single();
         Assert.That(errorEvent.Name, Is.EqualTo("exception"));

--- a/src/NServiceBus.Core.Tests/Performance/TimeToBeReceived/TimeToBeReceivedAttributeTests.cs
+++ b/src/NServiceBus.Core.Tests/Performance/TimeToBeReceived/TimeToBeReceivedAttributeTests.cs
@@ -13,11 +13,11 @@ public class TimeToBeReceivedAttributeTests
             typeof(InheritedClassWithAttribute)
         }, TimeToBeReceivedMappings.DefaultConvention, true);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(mappings.TryGetTimeToBeReceived(typeof(InheritedClassWithAttribute), out var timeToBeReceived), Is.True);
             Assert.That(timeToBeReceived, Is.EqualTo(TimeSpan.FromSeconds(2)));
-        });
+        }
     }
 
     [Test]
@@ -28,11 +28,11 @@ public class TimeToBeReceivedAttributeTests
             typeof(InheritedClassWithNoAttribute)
         }, TimeToBeReceivedMappings.DefaultConvention, true);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(mappings.TryGetTimeToBeReceived(typeof(InheritedClassWithNoAttribute), out var timeToBeReceived), Is.True);
             Assert.That(timeToBeReceived, Is.EqualTo(TimeSpan.FromSeconds(1)));
-        });
+        }
     }
 
     [Test]
@@ -49,11 +49,11 @@ public class TimeToBeReceivedAttributeTests
     {
         var mappings = new TimeToBeReceivedMappings(Array.Empty<Type>(), TimeToBeReceivedMappings.DefaultConvention, true);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(mappings.TryGetTimeToBeReceived(typeof(InheritedClassWithAttribute), out var timeToBeReceived), Is.True);
             Assert.That(timeToBeReceived, Is.EqualTo(TimeSpan.FromSeconds(2)));
-        });
+        }
     }
 
     [Test]
@@ -61,11 +61,11 @@ public class TimeToBeReceivedAttributeTests
     {
         var mappings = new TimeToBeReceivedMappings(Array.Empty<Type>(), TimeToBeReceivedMappings.DefaultConvention, true);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(mappings.TryGetTimeToBeReceived(typeof(InheritedClassWithNoAttribute), out var timeToBeReceived), Is.True);
             Assert.That(timeToBeReceived, Is.EqualTo(TimeSpan.FromSeconds(1)));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Persistence/PersistenceStorageMergerTests.cs
+++ b/src/NServiceBus.Core.Tests/Persistence/PersistenceStorageMergerTests.cs
@@ -45,11 +45,11 @@ public class When_storage_overrides_are_provided
 
         var resultedEnabledPersistences = config.Settings.MergePersistences(persistences);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(resultedEnabledPersistences[0].SelectedStorages, Is.EquivalentTo([typeof(StorageType.Subscriptions)]));
             Assert.That(resultedEnabledPersistences[1].SelectedStorages, Is.EquivalentTo([typeof(StorageType.Sagas)]));
-        });
+        }
     }
 
     class FakePersistence2 : PersistenceDefinition

--- a/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/BehaviorRegistrationsCoordinatorTests.cs
@@ -44,12 +44,12 @@ class BehaviorRegistrationsCoordinatorTests
 
         var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(model[0].StepId, Is.EqualTo("1"));
             Assert.That(model[1].StepId, Is.EqualTo("2"));
             Assert.That(model[2].StepId, Is.EqualTo("3"));
-        });
+        }
     }
 
     [Test]
@@ -64,12 +64,12 @@ class BehaviorRegistrationsCoordinatorTests
 
         var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(model[0].BehaviorType.FullName, Is.EqualTo(typeof(ReplacedBehavior).FullName));
             Assert.That(model[0].Description, Is.EqualTo("new"));
             Assert.That(model[1].Description, Is.EqualTo("2"));
-        });
+        }
     }
 
     [Test]
@@ -80,11 +80,11 @@ class BehaviorRegistrationsCoordinatorTests
         var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 
         Assert.That(model.Count, Is.EqualTo(1));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(model[0].BehaviorType.FullName, Is.EqualTo(typeof(ReplacedBehavior).FullName));
             Assert.That(model[0].Description, Is.EqualTo("new"));
-        });
+        }
     }
 
     [Test]
@@ -97,11 +97,11 @@ class BehaviorRegistrationsCoordinatorTests
         var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 
         Assert.That(model.Count, Is.EqualTo(1));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(model[0].BehaviorType.FullName, Is.EqualTo(typeof(ReplacedBehavior).FullName));
             Assert.That(model[0].Description, Is.EqualTo("new"));
-        });
+        }
     }
 
     [Test]
@@ -117,7 +117,7 @@ class BehaviorRegistrationsCoordinatorTests
 
         var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(model[0].StepId, Is.EqualTo("1"));
             Assert.That(model[1].StepId, Is.EqualTo("1.5"));
@@ -125,7 +125,7 @@ class BehaviorRegistrationsCoordinatorTests
             Assert.That(model[3].StepId, Is.EqualTo("2.5"));
             Assert.That(model[4].StepId, Is.EqualTo("3"));
             Assert.That(model[5].StepId, Is.EqualTo("3.5"));
-        });
+        }
     }
 
     [Test]
@@ -140,14 +140,14 @@ class BehaviorRegistrationsCoordinatorTests
 
         var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(model[0].StepId, Is.EqualTo("1"));
             Assert.That(model[1].StepId, Is.EqualTo("1.5"));
             Assert.That(model[2].StepId, Is.EqualTo("2"));
             Assert.That(model[3].StepId, Is.EqualTo("2.5"));
             Assert.That(model[4].StepId, Is.EqualTo("3"));
-        });
+        }
     }
 
     [Test]
@@ -163,7 +163,7 @@ class BehaviorRegistrationsCoordinatorTests
 
         var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(model[0].StepId, Is.EqualTo("1"));
             Assert.That(model[1].StepId, Is.EqualTo("1.5"));
@@ -171,7 +171,7 @@ class BehaviorRegistrationsCoordinatorTests
             Assert.That(model[3].StepId, Is.EqualTo("2.5"));
             Assert.That(model[4].StepId, Is.EqualTo("3"));
             Assert.That(model[5].StepId, Is.EqualTo("3.5"));
-        });
+        }
     }
 
     [Test]
@@ -187,7 +187,7 @@ class BehaviorRegistrationsCoordinatorTests
 
         var model = coordinator.BuildPipelineModelFor<IRootContext>().ToList();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(model[0].StepId, Is.EqualTo("1"));
             Assert.That(model[1].StepId, Is.EqualTo("1.1"));
@@ -195,7 +195,7 @@ class BehaviorRegistrationsCoordinatorTests
             Assert.That(model[3].StepId, Is.EqualTo("1.6"));
             Assert.That(model[4].StepId, Is.EqualTo("2"));
             Assert.That(model[5].StepId, Is.EqualTo("3"));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Incoming/InvokeHandlerTerminatorTest.cs
@@ -94,13 +94,13 @@ public class InvokeHandlerTerminatorTest
         var caughtException = Assert.ThrowsAsync<InvalidOperationException>(async () => await terminator.Invoke(behaviorContext, _ => Task.CompletedTask));
 
         Assert.That(caughtException, Is.SameAs(thrownException));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(caughtException.Data["Message type"], Is.EqualTo("System.Object"));
             Assert.That(caughtException.Data["Handler type"], Is.EqualTo("NServiceBus.Core.Tests.Pipeline.Incoming.InvokeHandlerTerminatorTest+FakeMessageHandler"));
             Assert.That(DateTimeOffsetHelper.ToDateTimeOffset((string)caughtException.Data["Handler start time"]), Is.EqualTo(DateTimeOffset.UtcNow).Within(TimeSpan.FromSeconds(5)));
             Assert.That(DateTimeOffsetHelper.ToDateTimeOffset((string)caughtException.Data["Handler failure time"]), Is.EqualTo(DateTimeOffset.UtcNow).Within(TimeSpan.FromSeconds(5)));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Pipeline/Incoming/MessageTypeEnricherTest.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Incoming/MessageTypeEnricherTest.cs
@@ -18,11 +18,11 @@ public class MessageTypeEnricherTest
 
         await behavior.Invoke(context, messageContext => Task.CompletedTask);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Headers.ContainsKey(Headers.EnclosedMessageTypes), Is.True);
             Assert.That(typeof(object).FullName, Is.EqualTo(context.Headers[Headers.EnclosedMessageTypes]));
-        });
+        }
     }
 
     [Test]
@@ -34,11 +34,11 @@ public class MessageTypeEnricherTest
 
         await mutator.Invoke(context, messageContext => Task.CompletedTask);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Headers.ContainsKey(Headers.EnclosedMessageTypes), Is.True);
             Assert.That(typeof(string).FullName, Is.EqualTo(context.Headers[Headers.EnclosedMessageTypes]));
-        });
+        }
 
     }
 }

--- a/src/NServiceBus.Core.Tests/Pipeline/MainPipelineExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/MainPipelineExecutorTests.cs
@@ -77,12 +77,12 @@ public class MainPipelineExecutorTests
             await executor.Invoke(messageContext);
 
             Assert.That(receivePipeline.PipelineAcitivty, Is.Not.Null);
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(receivePipeline.PipelineAcitivty.OperationName, Is.EqualTo(ActivityNames.IncomingMessageActivityName));
                 Assert.That(receivePipeline.PipelineAcitivty.DisplayName, Is.EqualTo("process message"));
                 Assert.That(receivePipeline.TransportReceiveContext.Extensions.Get<Activity>(ActivityExtensions.IncomingActivityKey), Is.EqualTo(receivePipeline.PipelineAcitivty));
-            });
+            }
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/AttachSenderRelatedInfoOnMessageTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/AttachSenderRelatedInfoOnMessageTests.cs
@@ -32,11 +32,11 @@ public class AttachSenderRelatedInfoOnMessageTests
             {Headers.TimeSent, timeSent}
         });
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(message.Headers.ContainsKey(Headers.TimeSent), Is.True);
             Assert.That(message.Headers[Headers.TimeSent], Is.EqualTo(timeSent));
-        });
+        }
     }
 
     [Test]
@@ -56,11 +56,11 @@ public class AttachSenderRelatedInfoOnMessageTests
              {Headers.NServiceBusVersion, nsbVersion}
         });
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(message.Headers.ContainsKey(Headers.NServiceBusVersion), Is.True);
             Assert.That(message.Headers[Headers.NServiceBusVersion], Is.EqualTo(nsbVersion));
-        });
+        }
     }
 
     [Test]
@@ -83,11 +83,11 @@ public class AttachSenderRelatedInfoOnMessageTests
             DoNotDeliverBefore = new DoNotDeliverBefore(doNotDeliverBefore)
         });
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(message.Headers.ContainsKey(Headers.DeliverAt), Is.True);
             Assert.That(message.Headers[Headers.DeliverAt], Is.EqualTo(DateTimeOffsetHelper.ToWireFormattedString(doNotDeliverBefore)));
-        });
+        }
     }
 
     [Test]
@@ -102,11 +102,11 @@ public class AttachSenderRelatedInfoOnMessageTests
             DelayDeliveryWith = new DelayDeliveryWith(TimeSpan.FromSeconds(2))
         });
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(message.Headers.ContainsKey(Headers.DeliverAt), Is.True);
             Assert.That(message.Headers[Headers.DeliverAt], Is.EqualTo(DateTimeOffsetHelper.ToWireFormattedString(doNotDeliverBefore)));
-        });
+        }
     }
 
     static async Task<OutgoingMessage> InvokeBehaviorAsync(Dictionary<string, string> headers = null, DispatchProperties dispatchProperties = null, CancellationToken cancellationToken = default)

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingLogicalMessageContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingLogicalMessageContextTests.cs
@@ -28,11 +28,11 @@ public class OutgoingLogicalMessageContextTests
 
         context.UpdateMessage(newMessage);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(context.Message.MessageType, Is.EqualTo(typeof(IMyMessage)));
             Assert.That(((IMyMessage)context.Message.Instance).Id, Is.EqualTo(newMessageId));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingPublishContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingPublishContextTests.cs
@@ -18,18 +18,18 @@ public class OutgoingPublishContextTests
         testee.Extensions.Set("someKey", "updatedValue");
         testee.Extensions.Set("anotherKey", "anotherValue");
         options.Context.TryGet("someKey", out string value);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(value, Is.EqualTo("someValue"));
             Assert.That(options.Context.TryGet("anotherKey", out string _), Is.False);
-        });
+        }
         testee.Extensions.TryGet("someKey", out string updatedValue);
         testee.Extensions.TryGet("anotherKey", out string anotherValue2);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(updatedValue, Is.EqualTo("updatedValue"));
             Assert.That(anotherValue2, Is.EqualTo("anotherValue"));
-        });
+        }
     }
 
     [Test]
@@ -76,19 +76,19 @@ public class OutgoingPublishContextTests
         var innerContext = new OutgoingPublishContext(new OutgoingLogicalMessage(typeof(object), new object()), "message-id", [], innerOptions, parentContext);
 
         var innerOperationProperties = innerContext.GetOperationProperties();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(innerOperationProperties.Get<string>("inner key"), Is.EqualTo("inner value"));
             Assert.That(innerOperationProperties.Get<string>("shared key"), Is.EqualTo("inner shared value"));
             Assert.That(innerOperationProperties.TryGet("outer key", out string _), Is.False);
-        });
+        }
 
         var outerOperationProperties = parentContext.GetOperationProperties();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(outerOperationProperties.Get<string>("outer key"), Is.EqualTo("outer value"));
             Assert.That(outerOperationProperties.Get<string>("shared key"), Is.EqualTo("outer shared value"));
             Assert.That(outerOperationProperties.TryGet("inner key", out string _), Is.False);
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingReplyContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingReplyContextTests.cs
@@ -19,18 +19,18 @@ public class OutgoingReplyContextTests
         testee.Extensions.Set("anotherKey", "anotherValue");
 
         options.Context.TryGet("someKey", out string value);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(value, Is.EqualTo("someValue"));
             Assert.That(options.Context.TryGet("anotherKey", out string _), Is.False);
-        });
+        }
         testee.Extensions.TryGet("someKey", out string updatedValue);
         testee.Extensions.TryGet("anotherKey", out string anotherValue2);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(updatedValue, Is.EqualTo("updatedValue"));
             Assert.That(anotherValue2, Is.EqualTo("anotherValue"));
-        });
+        }
     }
 
     [Test]
@@ -77,19 +77,19 @@ public class OutgoingReplyContextTests
         var innerContext = new OutgoingReplyContext(new OutgoingLogicalMessage(typeof(object), new object()), "message-id", [], innerOptions, parentContext);
 
         var innerOperationProperties = innerContext.GetOperationProperties();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(innerOperationProperties.Get<string>("inner key"), Is.EqualTo("inner value"));
             Assert.That(innerOperationProperties.Get<string>("shared key"), Is.EqualTo("inner shared value"));
             Assert.That(innerOperationProperties.TryGet("outer key", out string _), Is.False);
-        });
+        }
 
         var outerOperationProperties = parentContext.GetOperationProperties();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(outerOperationProperties.Get<string>("outer key"), Is.EqualTo("outer value"));
             Assert.That(outerOperationProperties.Get<string>("shared key"), Is.EqualTo("outer shared value"));
             Assert.That(outerOperationProperties.TryGet("inner key", out string _), Is.False);
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingSendContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/Outgoing/OutgoingSendContextTests.cs
@@ -18,18 +18,18 @@ public class OutgoingSendContextTests
         testee.Extensions.Set("someKey", "updatedValue");
         testee.Extensions.Set("anotherKey", "anotherValue");
         options.Context.TryGet("someKey", out string value);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(value, Is.EqualTo("someValue"));
             Assert.That(options.Context.TryGet("anotherKey", out string _), Is.False);
-        });
+        }
         testee.Extensions.TryGet("someKey", out string updatedValue);
         testee.Extensions.TryGet("anotherKey", out string anotherValue2);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(updatedValue, Is.EqualTo("updatedValue"));
             Assert.That(anotherValue2, Is.EqualTo("anotherValue"));
-        });
+        }
     }
 
     [Test]
@@ -76,19 +76,19 @@ public class OutgoingSendContextTests
         var innerContext = new OutgoingSendContext(new OutgoingLogicalMessage(typeof(object), new object()), "message-id", [], innerOptions, parentContext);
 
         var innerOperationProperties = innerContext.GetOperationProperties();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(innerOperationProperties.Get<string>("inner key"), Is.EqualTo("inner value"));
             Assert.That(innerOperationProperties.Get<string>("shared key"), Is.EqualTo("inner shared value"));
             Assert.That(innerOperationProperties.TryGet("outer key", out string _), Is.False);
-        });
+        }
 
         var outerOperationProperties = parentContext.GetOperationProperties();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(outerOperationProperties.Get<string>("outer key"), Is.EqualTo("outer value"));
             Assert.That(outerOperationProperties.Get<string>("shared key"), Is.EqualTo("outer shared value"));
             Assert.That(outerOperationProperties.TryGet("inner key", out string _), Is.False);
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Pipeline/RegisterStepTests.cs
+++ b/src/NServiceBus.Core.Tests/Pipeline/RegisterStepTests.cs
@@ -81,11 +81,11 @@ public class RegisterStepTests
         registerStep.Replace(replacement);
         var behavior = registerStep.CreateBehavior(builder);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(originalBehaviorFactoryCalled, Is.False);
             Assert.That(behavior, Is.InstanceOf<BehaviorB>());
-        });
+        }
     }
 
     [Test]
@@ -105,11 +105,11 @@ public class RegisterStepTests
         registerStep.Replace(replacement);
         var behavior = registerStep.CreateBehavior(builder);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(replacementBehaviorFactoryCalled, Is.True);
             Assert.That(behavior, Is.InstanceOf<BehaviorB>());
-        });
+        }
     }
 
     class BehaviorA : IBehavior<IRoutingContext, IRoutingContext>

--- a/src/NServiceBus.Core.Tests/Recoverability/DefaultRecoverabilityPolicyTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/DefaultRecoverabilityPolicyTests.cs
@@ -71,11 +71,11 @@ public class DefaultRecoverabilityPolicyTests
         var recoverabilityAction = policy(errorContext);
         var delayedRetryAction = recoverabilityAction as DelayedRetry;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(recoverabilityAction, Is.InstanceOf<DelayedRetry>(), "When immediate retries turned off and delayed retries left, recoverability policy should return DelayedRetry");
             Assert.That(delayedRetryAction.Delay, Is.EqualTo(deliveryDelay));
-        });
+        }
     }
 
     [Test]
@@ -137,12 +137,12 @@ public class DefaultRecoverabilityPolicyTests
         errorContext = CreateErrorContext(retryNumber: 2);
         var result3 = policy(errorContext);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result1.Delay, Is.EqualTo(baseDelay));
             Assert.That(result2.Delay, Is.EqualTo(TimeSpan.FromSeconds(20)));
             Assert.That(result3, Is.InstanceOf<MoveToError>());
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Recoverability/DelayedRetryRecoverabilityActionTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/DelayedRetryRecoverabilityActionTests.cs
@@ -23,12 +23,12 @@ public class DelayedRetryRecoverabilityActionTests
 
         var routingStrategy = routingContext.RoutingStrategies.Single() as UnicastRoutingStrategy;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That((routingStrategy.Apply([]) as UnicastAddressTag).Destination, Is.EqualTo(recoverabilityContext.ReceiveAddress));
             Assert.That(routingContext.Extensions.Get<DispatchProperties>().DelayDeliveryWith.Delay, Is.EqualTo(delay));
             Assert.That(delayedRetryAction.ErrorHandleResult, Is.EqualTo(ErrorHandleResult.Handled));
-        });
+        }
     }
 
     [Test]
@@ -50,20 +50,20 @@ public class DelayedRetryRecoverabilityActionTests
 
         var outgoingMessageHeaders = routingContexts.Single().Message.Headers;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(outgoingMessageHeaders[Headers.DelayedRetries], Is.EqualTo("3"));
             Assert.That(incomingMessage.Headers[Headers.DelayedRetries], Is.EqualTo(delayedDeliveriesPerformed.ToString()));
-        });
+        }
 
         var utcDateTime = DateTimeOffsetHelper.ToDateTimeOffset(outgoingMessageHeaders[Headers.DelayedRetriesTimestamp]);
         // the serialization removes precision which may lead to now being greater than the deserialized header value
         var adjustedNow = DateTimeOffsetHelper.ToDateTimeOffset(DateTimeOffsetHelper.ToWireFormattedString(now));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(utcDateTime, Is.GreaterThanOrEqualTo(adjustedNow));
             Assert.That(incomingMessage.Headers[Headers.DelayedRetriesTimestamp], Is.EqualTo(originalHeadersTimestamp));
-        });
+        }
     }
 
     [Test]
@@ -76,13 +76,13 @@ public class DelayedRetryRecoverabilityActionTests
 
         var outgoingMessageHeaders = routingContexts.Single().Message.Headers;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(outgoingMessageHeaders[Headers.DelayedRetries], Is.EqualTo("1"));
             Assert.That(recoverabilityContext.FailedMessage.Headers.ContainsKey(Headers.DelayedRetries), Is.False);
             Assert.That(outgoingMessageHeaders.ContainsKey(Headers.DelayedRetriesTimestamp), Is.True);
             Assert.That(recoverabilityContext.FailedMessage.Headers.ContainsKey(Headers.DelayedRetriesTimestamp), Is.False);
-        });
+        }
     }
 
     static TestableRecoverabilityContext CreateRecoverabilityContext(Dictionary<string, string> headers = null, int delayedDeliveriesPerformed = 0)

--- a/src/NServiceBus.Core.Tests/Recoverability/FaultMetadataExtractorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/FaultMetadataExtractorTests.cs
@@ -20,7 +20,7 @@ public class FaultMetadataExtractorTests
 
         var metadata = extractor.Extract(CreateErrorContext(exception));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(metadata["NServiceBus.ExceptionInfo.ExceptionType"], Is.EqualTo("System.AggregateException"));
             Assert.That(metadata["NServiceBus.ExceptionInfo.StackTrace"], Is.EqualTo(exception.ToString()));
@@ -30,7 +30,7 @@ public class FaultMetadataExtractorTests
             Assert.That(metadata["NServiceBus.ExceptionInfo.HelpLink"], Is.EqualTo("A fake help link"));
             Assert.That(metadata["NServiceBus.ExceptionInfo.Source"], Is.EqualTo("NServiceBus.Core.Tests"));
             Assert.That(metadata[FaultsHeaderKeys.FailedQ], Is.EqualTo("my-address"));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
+++ b/src/NServiceBus.Core.Tests/Recoverability/MoveToErrorsExecutorTests.cs
@@ -24,11 +24,11 @@ public class MoveToErrorsExecutorTests
         var addressTag = (UnicastAddressTag)((UnicastRoutingStrategy)routingContext.RoutingStrategies.Single())
             .Apply([]);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(addressTag.Destination, Is.EqualTo(customErrorQueue));
             Assert.That(moveToErrorAction.ErrorHandleResult, Is.EqualTo(ErrorHandleResult.Handled));
-        });
+        }
     }
 
     [Test]
@@ -81,12 +81,12 @@ public class MoveToErrorsExecutorTests
             .Single();
         var outgoingMessageHeaders = transportOperation.Message.Headers;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(outgoingMessageHeaders, Contains.Item(new KeyValuePair<string, string>("staticFaultMetadataKey", "staticFaultMetadataValue")));
             // check for leaking headers
             Assert.That(recoverabilityContext.FailedMessage.Headers.ContainsKey("staticFaultMetadataKey"), Is.False);
-        });
+        }
     }
 
     static TestableRecoverabilityContext CreateRecoverabilityContext(Exception raisedException = null, string exceptionMessage = "default-message", string messageId = "default-id", Dictionary<string, string> messageHeaders = default, Dictionary<string, string> metadata = default)

--- a/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Reliability/Outbox/TransportReceiveToPhysicalMessageConnectorTests.cs
@@ -53,12 +53,12 @@ public class TransportReceiveToPhysicalMessageConnectorTests
 
         var discard = operationProperties.DiscardIfNotReceivedBefore;
         Assert.That(discard, Is.Not.Null);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(discard.MaxTime, Is.EqualTo(maxTime));
 
             Assert.That(fakeOutbox.StoredMessage, Is.Null);
-        });
+        }
     }
 
     [Test]
@@ -79,11 +79,11 @@ public class TransportReceiveToPhysicalMessageConnectorTests
 
         var routing = fakeBatchPipeline.TransportOperations.First().AddressTag as UnicastAddressTag;
         Assert.That(routing, Is.Not.Null);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(routing.Destination, Is.EqualTo("myEndpoint"));
             Assert.That(fakeOutbox.StoredMessage, Is.Null);
-        });
+        }
     }
 
 
@@ -108,11 +108,11 @@ public class TransportReceiveToPhysicalMessageConnectorTests
 
         var routing = fakeBatchPipeline.TransportOperations.First().AddressTag as MulticastAddressTag;
         Assert.That(routing, Is.Not.Null);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(routing.MessageType, Is.EqualTo(typeof(MyEvent)));
             Assert.That(fakeOutbox.StoredMessage, Is.Null);
-        });
+        }
     }
 
     [Test]
@@ -169,11 +169,11 @@ public class TransportReceiveToPhysicalMessageConnectorTests
 
         await Invoke(context);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(pipelineActivity.Events.Count(e => e.Name == "Start dispatching"), Is.EqualTo(0));
             Assert.That(pipelineActivity.Events.Count(e => e.Name == "Finished dispatching"), Is.EqualTo(0));
-        });
+        }
     }
 
     static TestableTransportReceiveContext CreateContext(FakeBatchPipeline pipeline, string messageId)

--- a/src/NServiceBus.Core.Tests/Routing/EndpointInstancesTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/EndpointInstancesTests.cs
@@ -64,10 +64,10 @@ public class EndpointInstancesTests
         var salesInstances = instances.FindInstances("Sales");
 
         var singleInstance = salesInstances.Single();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(singleInstance.Discriminator, Is.Null);
             Assert.That(singleInstance.Properties, Is.Empty);
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscribeTerminatorTests.cs
@@ -35,11 +35,11 @@ public class MessageDrivenSubscribeTerminatorTests
             var unicastTransportOperations = dispatchedTransportOperation.UnicastTransportOperations;
             var operations = new List<UnicastTransportOperation>(unicastTransportOperations);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(operations[0].Message.Headers.ContainsKey(Headers.TimeSent), Is.True);
                 Assert.That(operations[0].Message.Headers.ContainsKey(Headers.NServiceBusVersion), Is.True);
-            });
+            }
         }
     }
 
@@ -67,11 +67,11 @@ public class MessageDrivenSubscribeTerminatorTests
 
         await subscribeTerminator.Invoke(context, c => Task.CompletedTask);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(dispatcher.DispatchedTransportOperations.Count, Is.EqualTo(1));
             Assert.That(dispatcher.FailedNumberOfTimes, Is.EqualTo(10));
-        });
+        }
     }
 
     [Test]
@@ -88,11 +88,11 @@ public class MessageDrivenSubscribeTerminatorTests
             await subscribeTerminator.Invoke(context, c => Task.CompletedTask);
         }, Throws.InstanceOf<QueueNotFoundException>());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(dispatcher.DispatchedTransportOperations.Count, Is.EqualTo(0));
             Assert.That(dispatcher.FailedNumberOfTimes, Is.EqualTo(11));
-        });
+        }
     }
 
     [Test]
@@ -151,11 +151,11 @@ public class MessageDrivenSubscribeTerminatorTests
         var exception = Assert.ThrowsAsync<AggregateException>(() => subscribeTerminator.Invoke(context, c => Task.CompletedTask));
 
         Assert.That(exception.InnerExceptions.Count, Is.EqualTo(2));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(exception.InnerExceptions.Any(e => e is QueueNotFoundException), Is.True); // exception from dispatcher
             Assert.That(exception.InnerExceptions.Any(e => e.Message.Contains($"No publisher address could be found for message type '{typeof(EventB)}'")), Is.True); // exception from terminator
-        });
+        }
     }
 
 

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/AssemblyPublisherSourceTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/AssemblyPublisherSourceTests.cs
@@ -15,11 +15,11 @@ public class AssemblyPublisherSourceTests
         var source = new AssemblyPublisherSource(Assembly.GetExecutingAssembly(), PublisherAddress.CreateFromEndpointName("Destination"));
         var routes = source.GenerateWithBestPracticeEnforcement(new Conventions()).ToArray();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(routes.Any(r => r.EventType == typeof(NonMessage)), Is.False);
             Assert.That(routes.Any(r => r.EventType == typeof(NonEvent)), Is.False);
-        });
+        }
     }
 
 

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensionsTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenSubscriptions/MessageDrivenSubscriptionsConfigExtensionsTests.cs
@@ -70,11 +70,11 @@ namespace NServiceBus.Core.Tests.Routing.MessageDrivenSubscriptions
             var publishersForEvent = publishers.GetPublisherFor(typeof(Event)).SingleOrDefault();
             var publishersForEventWithNamespace = publishers.GetPublisherFor(typeof(EventWithNamespace)).SingleOrDefault();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(publishersForEvent, Is.Not.Null);
                 Assert.That(publishersForEventWithNamespace, Is.Not.Null);
-            });
+            }
         }
 
         [Test]
@@ -88,11 +88,11 @@ namespace NServiceBus.Core.Tests.Routing.MessageDrivenSubscriptions
             var publishersForEvent = publishers.GetPublisherFor(typeof(Event)).SingleOrDefault();
             var publishersForEventWithNamespace = publishers.GetPublisherFor(typeof(EventWithNamespace)).SingleOrDefault();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(publishersForEvent, Is.Null);
                 Assert.That(publishersForEventWithNamespace, Is.Not.Null);
-            });
+            }
         }
 
         [Test]
@@ -108,13 +108,13 @@ namespace NServiceBus.Core.Tests.Routing.MessageDrivenSubscriptions
             var result3 = publishers.GetPublisherFor(typeof(EventWithoutNamespace)).SingleOrDefault();
             var result4 = publishers.GetPublisherFor(typeof(IMessageInterface)).SingleOrDefault();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result1, Is.Not.Null);
                 Assert.That(result2, Is.Not.Null);
                 Assert.That(result3, Is.Not.Null);
                 Assert.That(result4, Is.Not.Null);
-            });
+            }
         }
 
         [Test]
@@ -130,13 +130,13 @@ namespace NServiceBus.Core.Tests.Routing.MessageDrivenSubscriptions
             var result3 = publishers.GetPublisherFor(typeof(EventWithoutNamespace)).SingleOrDefault();
             var result4 = publishers.GetPublisherFor(typeof(IMessageInterface)).SingleOrDefault();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result1, Is.Not.Null);
                 Assert.That(result4, Is.Not.Null);
                 Assert.That(result2, Is.Null);
                 Assert.That(result3, Is.Null);
-            });
+            }
         }
 
         [Theory]
@@ -154,13 +154,13 @@ namespace NServiceBus.Core.Tests.Routing.MessageDrivenSubscriptions
             var result3 = publishers.GetPublisherFor(typeof(EventWithoutNamespace)).SingleOrDefault();
             var result4 = publishers.GetPublisherFor(typeof(IMessageInterface)).SingleOrDefault();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result3, Is.Not.Null);
                 Assert.That(result1, Is.Null);
                 Assert.That(result2, Is.Null);
                 Assert.That(result4, Is.Null);
-            });
+            }
         }
 
         static Publishers ApplyPublisherRegistrations(RoutingSettings<MessageDrivenTransportDefinition> routingSettings)

--- a/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/MessageDrivenUnsubscribeTerminatorTests.cs
@@ -53,11 +53,11 @@ public class MessageDrivenUnsubscribeTerminatorTests
 
         await terminator.Invoke(context, c => Task.CompletedTask);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(dispatcher.DispatchedTransportOperations.Count, Is.EqualTo(1));
             Assert.That(dispatcher.FailedNumberOfTimes, Is.EqualTo(10));
-        });
+        }
     }
 
     [Test]
@@ -76,11 +76,11 @@ public class MessageDrivenUnsubscribeTerminatorTests
 
         Assert.That(async () => await terminator.Invoke(context, c => Task.CompletedTask), Throws.InstanceOf<QueueNotFoundException>());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(dispatcher.DispatchedTransportOperations.Count, Is.EqualTo(0));
             Assert.That(dispatcher.FailedNumberOfTimes, Is.EqualTo(11));
-        });
+        }
     }
 
     class FakeDispatcher : IMessageDispatcher

--- a/src/NServiceBus.Core.Tests/Routing/NamespaceRouteSourceTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/NamespaceRouteSourceTests.cs
@@ -16,11 +16,11 @@
             var source = new NamespaceRouteSource(Assembly.GetExecutingAssembly(), "NServiceBus.Core.Tests.Routing.NamespaceRouteSourceTest", UnicastRoute.CreateFromEndpointName("Destination"));
             var routes = source.GenerateRoutes(new Conventions()).ToArray();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(routes.Any(r => r.MessageType == typeof(Message)), Is.True);
                 Assert.That(routes.Any(r => r.MessageType == typeof(NonMessage)), Is.False);
-            });
+            }
         }
 
         [Test]
@@ -29,11 +29,11 @@
             var source = new NamespaceRouteSource(Assembly.GetExecutingAssembly(), "NServiceBus.Core.Tests.Routing.NamespaceRouteSourceTest", UnicastRoute.CreateFromEndpointName("Destination"));
             var routes = source.GenerateRoutes(new Conventions()).ToArray();
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(routes.Any(r => r.MessageType == typeof(Message)), Is.True);
                 Assert.That(routes.Any(r => r.MessageType == typeof(ExcludedMessage)), Is.False);
-            });
+            }
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/Routers/UnicastSendRouterTests.cs
@@ -217,12 +217,12 @@ public class UnicastSendRouterTests
         var route2 = router.Route(context);
         var route3 = router.Route(context);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ExtractDestination(route1), Is.EqualTo("Sales-1"));
             Assert.That(ExtractDestination(route2), Is.EqualTo("Sales-2"));
             Assert.That(ExtractDestination(route3), Is.EqualTo("Sales-1"));
-        });
+        }
     }
 
     [Test]
@@ -328,12 +328,12 @@ public class UnicastSendRouterTests
         var route2 = router.Route(context);
         var route3 = router.Route(context);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ExtractDestination(route1), Is.EqualTo("Endpoint-2"));
             Assert.That(ExtractDestination(route2), Is.EqualTo("Endpoint-2"));
             Assert.That(ExtractDestination(route3), Is.EqualTo("Endpoint-2"));
-        });
+        }
     }
 
     [Test]
@@ -358,12 +358,12 @@ public class UnicastSendRouterTests
         var route2 = router.Route(context);
         var route3 = router.Route(context);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ExtractDestination(route1), Is.EqualTo("Endpoint-1"));
             Assert.That(ExtractDestination(route2), Is.EqualTo("Endpoint-2"));
             Assert.That(ExtractDestination(route3), Is.EqualTo("Endpoint-1"));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Routing/RoutingSettingsTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingSettingsTests.cs
@@ -77,12 +77,12 @@
             var otherMessageRoute = routingTable.GetRouteFor(typeof(OtherMessageType));
             var messageWithoutNamespaceRoute = routingTable.GetRouteFor(typeof(MessageWithoutNamespace));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(someMessageRoute, Is.Not.Null);
                 Assert.That(otherMessageRoute, Is.Not.Null);
                 Assert.That(messageWithoutNamespaceRoute, Is.Not.Null);
-            });
+            }
         }
 
         [Test]
@@ -97,12 +97,12 @@
             var otherMessageRoute = routingTable.GetRouteFor(typeof(OtherMessageType));
             var messageWithoutNamespaceRoute = routingTable.GetRouteFor(typeof(MessageWithoutNamespace));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(someMessageRoute, Is.Not.Null, "because SomeMessageType is in the given namespace");
                 Assert.That(otherMessageRoute, Is.Null, "because OtherMessageType is not in the given namespace");
                 Assert.That(messageWithoutNamespaceRoute, Is.Null, "because MessageWithoutNamespace is not in the given namespace");
-            });
+            }
         }
 
         [Theory]
@@ -119,12 +119,12 @@
             var otherMessageRoute = routingTable.GetRouteFor(typeof(OtherMessageType));
             var messageWithoutNamespaceRoute = routingTable.GetRouteFor(typeof(MessageWithoutNamespace));
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(someMessageRoute, Is.Null);
                 Assert.That(otherMessageRoute, Is.Null);
                 Assert.That(messageWithoutNamespaceRoute, Is.Not.Null);
-            });
+            }
         }
 
         static UnicastRoutingTable ApplyConfiguredRoutes(RoutingSettings routingSettings)

--- a/src/NServiceBus.Core.Tests/Routing/RoutingToDispatchConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingToDispatchConnectorTests.cs
@@ -42,11 +42,11 @@ public class RoutingToDispatchConnectorTests
         Assert.That(operations.ToList(), Has.Count.EqualTo(1));
 
         TransportOperation destination1Operation = operations.ElementAt(0);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(destination1Operation.Message.MessageId, Is.EqualTo("ID"));
             Assert.That((destination1Operation.AddressTag as UnicastAddressTag)?.Destination, Is.EqualTo("destination1"));
-        });
+        }
         Dictionary<string, string> destination1Headers = destination1Operation.Message.Headers;
         Assert.That(destination1Headers, Contains.Item(new KeyValuePair<string, string>("SomeHeaderKey", "SomeHeaderValue")));
         Assert.That(destination1Headers, Contains.Item(new KeyValuePair<string, string>("HeaderKeyAddedByTheRoutingStrategy1", "HeaderValueAddedByTheRoutingStrategy1")));
@@ -85,11 +85,11 @@ public class RoutingToDispatchConnectorTests
         Assert.That(operations.ToList(), Has.Count.EqualTo(2));
 
         TransportOperation destination1Operation = operations.ElementAt(0);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(destination1Operation.Message.MessageId, Is.EqualTo("ID"));
             Assert.That((destination1Operation.AddressTag as UnicastAddressTag)?.Destination, Is.EqualTo("destination1"));
-        });
+        }
         Dictionary<string, string> destination1Headers = destination1Operation.Message.Headers;
         Assert.That(destination1Headers, Contains.Item(new KeyValuePair<string, string>("SomeHeaderKey", "SomeHeaderValue")));
         Assert.That(destination1Headers, Contains.Item(new KeyValuePair<string, string>("HeaderKeyAddedByTheRoutingStrategy1", "HeaderValueAddedByTheRoutingStrategy1")));
@@ -100,11 +100,11 @@ public class RoutingToDispatchConnectorTests
         Assert.That(destination1DispatchProperties, Is.Not.SameAs(originalDispatchProperties));
 
         TransportOperation destination2Operation = operations.ElementAt(1);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(destination2Operation.Message.MessageId, Is.EqualTo("ID"));
             Assert.That((destination2Operation.AddressTag as UnicastAddressTag)?.Destination, Is.EqualTo("destination2"));
-        });
+        }
         Dictionary<string, string> destination2Headers = destination2Operation.Message.Headers;
         Assert.That(destination2Headers, Contains.Item(new KeyValuePair<string, string>("SomeHeaderKey", "SomeHeaderValue")));
         Assert.That(destination2Headers, Contains.Item(new KeyValuePair<string, string>("HeaderKeyAddedByTheRoutingStrategy2", "HeaderValueAddedByTheRoutingStrategy2")));
@@ -112,13 +112,13 @@ public class RoutingToDispatchConnectorTests
         Assert.That(destination2Headers, Is.Not.SameAs(originalHeaders));
         DispatchProperties destination2DispatchProperties = destination2Operation.Properties;
         Assert.That(destination2DispatchProperties, Is.Not.SameAs(originalDispatchProperties));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(destination2DispatchProperties, Contains.Item(new KeyValuePair<string, string>("SomeKey", "SomeValue")));
 
             Assert.That(destination1Headers, Is.Not.SameAs(destination2Headers));
             Assert.That(destination1DispatchProperties, Is.Not.SameAs(destination2DispatchProperties));
-        });
+        }
     }
 
     [Test]
@@ -204,12 +204,12 @@ public class RoutingToDispatchConnectorTests
         await behavior.Invoke(routingContext, _ => Task.CompletedTask);
 
         var contentTypeTag = pipelineActivity.GetTagItem(ActivityTags.ContentType);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(contentTypeTag, Is.EqualTo("test content type"), "should set tags on activity from pipeline context");
 
             Assert.That(ambientActivity.GetTagItem(ActivityTags.ContentType), Is.Null, "should not set tags on Activity.Current");
-        });
+        }
     }
 
     static OutgoingSendContext CreateContext(SendOptions options, bool fromHandler)

--- a/src/NServiceBus.Core.Tests/Routing/SubscribeContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/SubscribeContextTests.cs
@@ -17,18 +17,18 @@ public class SubscribeContextTests
         testee.Extensions.Set("someKey", "updatedValue");
         testee.Extensions.Set("anotherKey", "anotherValue");
         context.TryGet("someKey", out string value);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(value, Is.EqualTo("someValue"));
             Assert.That(context.TryGet("anotherKey", out string _), Is.False);
-        });
+        }
         testee.Extensions.TryGet("someKey", out string updatedValue);
         testee.Extensions.TryGet("anotherKey", out string anotherValue2);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(updatedValue, Is.EqualTo("updatedValue"));
             Assert.That(anotherValue2, Is.EqualTo("anotherValue"));
-        });
+        }
     }
 
     [Test]
@@ -73,19 +73,19 @@ public class SubscribeContextTests
         var innerContext = new SubscribeContext(parentContext, Type.EmptyTypes, innerOptions);
 
         var innerOperationProperties = innerContext.GetOperationProperties();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(innerOperationProperties.Get<string>("inner key"), Is.EqualTo("inner value"));
             Assert.That(innerOperationProperties.Get<string>("shared key"), Is.EqualTo("inner shared value"));
             Assert.That(innerOperationProperties.TryGet("outer key", out string _), Is.False);
-        });
+        }
 
         var outerOperationProperties = parentContext.GetOperationProperties();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(outerOperationProperties.Get<string>("outer key"), Is.EqualTo("outer value"));
             Assert.That(outerOperationProperties.Get<string>("shared key"), Is.EqualTo("outer shared value"));
             Assert.That(outerOperationProperties.TryGet("inner key", out string _), Is.False);
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnicastPublisherRouterTests.cs
@@ -69,11 +69,11 @@ public class UnicastPublisherRouterTests
 
         var routes = await router.Route(typeof(Event), new DistributionPolicy(), new TestableOutgoingPublishContext());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(routes.Count(), Is.EqualTo(1));
             Assert.That(ExtractDestination(routes.Single()), Is.EqualTo("address"));
-        });
+        }
     }
 
     [Test]
@@ -89,11 +89,11 @@ public class UnicastPublisherRouterTests
 
         var routes = await router.Route(typeof(Event), new DistributionPolicy(), new TestableOutgoingPublishContext());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(routes.Count(), Is.EqualTo(1));
             Assert.That(ExtractDestination(routes.First()), Is.EqualTo("address"));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Routing/UnsubscribeContextTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/UnsubscribeContextTests.cs
@@ -16,18 +16,18 @@ public class UnsubscribeContextTests
         testee.Extensions.Set("someKey", "updatedValue");
         testee.Extensions.Set("anotherKey", "anotherValue");
         context.TryGet("someKey", out string value);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(value, Is.EqualTo("someValue"));
             Assert.That(context.TryGet("anotherKey", out string _), Is.False);
-        });
+        }
         testee.Extensions.TryGet("someKey", out string updatedValue);
         testee.Extensions.TryGet("anotherKey", out string anotherValue2);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(updatedValue, Is.EqualTo("updatedValue"));
             Assert.That(anotherValue2, Is.EqualTo("anotherValue"));
-        });
+        }
     }
 
     [Test]
@@ -72,19 +72,19 @@ public class UnsubscribeContextTests
         var innerContext = new UnsubscribeContext(parentContext, typeof(object), innerOptions);
 
         var innerOperationProperties = innerContext.GetOperationProperties();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(innerOperationProperties.Get<string>("inner key"), Is.EqualTo("inner value"));
             Assert.That(innerOperationProperties.Get<string>("shared key"), Is.EqualTo("inner shared value"));
             Assert.That(innerOperationProperties.TryGet("outer key", out string _), Is.False);
-        });
+        }
 
         var outerOperationProperties = parentContext.GetOperationProperties();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(outerOperationProperties.Get<string>("outer key"), Is.EqualTo("outer value"));
             Assert.That(outerOperationProperties.Get<string>("shared key"), Is.EqualTo("outer shared value"));
             Assert.That(outerOperationProperties.TryGet("inner key", out string _), Is.False);
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaMetadataCreationTests.cs
@@ -38,11 +38,11 @@ public class SagaMetadataCreationTests
     public void DetectUniquePropertiesByAttribute()
     {
         var metadata = SagaMetadata.Create(typeof(MySaga));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(metadata.TryGetCorrelationProperty(out var correlatedProperty), Is.True);
             Assert.That(correlatedProperty.Name, Is.EqualTo("UniqueProperty"));
-        });
+        }
     }
 
     [Test]
@@ -83,11 +83,11 @@ public class SagaMetadataCreationTests
     public void HandleBothUniqueAttributeAndMapping()
     {
         var metadata = SagaMetadata.Create(typeof(MySagaWithMappedAndUniqueProperty));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(metadata.TryGetCorrelationProperty(out var correlatedProperty), Is.True);
             Assert.That(correlatedProperty.Name, Is.EqualTo("UniqueProperty"));
-        });
+        }
     }
 
     [TestCase(typeof(MySagaWithMappedProperty))]
@@ -95,11 +95,11 @@ public class SagaMetadataCreationTests
     public void AutomaticallyAddUniqueForMappedProperties(Type sagaType)
     {
         var metadata = SagaMetadata.Create(sagaType);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(metadata.TryGetCorrelationProperty(out var correlatedProperty), Is.True);
             Assert.That(correlatedProperty.Name, Is.EqualTo("UniqueProperty"));
-        });
+        }
     }
 
     [Test]
@@ -125,7 +125,7 @@ public class SagaMetadataCreationTests
 
         var messages = metadata.AssociatedMessages;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(messages.Count, Is.EqualTo(4));
 
@@ -136,7 +136,7 @@ public class SagaMetadataCreationTests
             Assert.That(metadata.IsMessageAllowedToStartTheSaga(typeof(SagaWith2StartersAnd1Handler.Message3).FullName), Is.False);
 
             Assert.That(metadata.IsMessageAllowedToStartTheSaga(typeof(SagaWith2StartersAnd1Handler.MyTimeout).FullName), Is.False);
-        });
+        }
     }
 
     [Test]
@@ -146,12 +146,12 @@ public class SagaMetadataCreationTests
 
         var finder = GetFinder(metadata, typeof(SomeMessage).FullName);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(finder.Type, Is.EqualTo(typeof(PropertySagaFinder<MySagaWithMappedProperty.SagaData>)));
             Assert.That(finder.Properties["property-accessor"], Is.Not.Null);
             Assert.That(finder.Properties["saga-property-name"], Is.EqualTo("UniqueProperty"));
-        });
+        }
     }
 
     [Test]
@@ -161,13 +161,13 @@ public class SagaMetadataCreationTests
 
         var finder = GetFinder(metadata, typeof(SomeMessage).FullName);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(finder.Type, Is.EqualTo(typeof(HeaderPropertySagaFinder<MySagaWithMappedHeader.SagaData>)));
             Assert.That(finder.Properties["message-header-name"], Is.EqualTo("CorrelationHeader"));
             Assert.That(finder.Properties["saga-property-name"], Is.EqualTo("UniqueProperty"));
             Assert.That(finder.Properties["saga-property-type"], Is.EqualTo(typeof(int)));
-        });
+        }
     }
 
     [Test]
@@ -216,11 +216,11 @@ public class SagaMetadataCreationTests
 
         var finder = GetFinder(metadata, typeof(SomeMessage).FullName);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(finder.Type, Is.EqualTo(typeof(CustomFinderAdapter<MySagaWithScannedFinder.SagaData, SomeMessage>)));
             Assert.That(finder.Properties["custom-finder-clr-type"], Is.EqualTo(typeof(MySagaWithScannedFinder.CustomFinder)));
-        });
+        }
     }
 
     [TestCase(typeof(SagaThatMapsMessageItDoesntHandle))]

--- a/src/NServiceBus.Core.Tests/Sagas/SagaModelTests.cs
+++ b/src/NServiceBus.Core.Tests/Sagas/SagaModelTests.cs
@@ -59,7 +59,7 @@ public class SagaModelTests
 
         Assert.That(metadata, Is.Not.Null);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(metadata.SagaEntityType, Is.EqualTo(typeof(MyEntity)));
             Assert.That(metadata.EntityName, Is.EqualTo(typeof(MyEntity).FullName));
@@ -67,8 +67,8 @@ public class SagaModelTests
             Assert.That(metadata.Name, Is.EqualTo(typeof(MySaga).FullName));
 
             Assert.That(metadata.AssociatedMessages.Count, Is.EqualTo(2));
-        });
-        Assert.Multiple(() =>
+        }
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(metadata.AssociatedMessages.Count(am => am.MessageTypeName == typeof(Message1).FullName && am.IsAllowedToStartSaga), Is.EqualTo(1));
             Assert.That(metadata.AssociatedMessages.Count(am => am.MessageTypeName == typeof(Message2).FullName && !am.IsAllowedToStartSaga), Is.EqualTo(1));
@@ -77,12 +77,12 @@ public class SagaModelTests
             Assert.That(correlatedProperty.Name, Is.EqualTo("UniqueProperty"));
 
             Assert.That(metadata.Finders.Count, Is.EqualTo(2));
-        });
-        Assert.Multiple(() =>
+        }
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(metadata.Finders.Count(f => f.MessageType == typeof(Message1)), Is.EqualTo(1));
             Assert.That(metadata.Finders.Count(f => f.MessageType == typeof(Message2)), Is.EqualTo(1));
-        });
+        }
     }
 
     [Test]
@@ -100,11 +100,11 @@ public class SagaModelTests
 
         var metadata = model.Find(typeof(MyHeaderMappedSaga));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(metadata.TryGetCorrelationProperty(out var correlatedProperty), Is.True);
             Assert.That(correlatedProperty.Name, Is.EqualTo("UniqueProperty"));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Serializers/SystemTextJson/SystemJsonSerializerTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/SystemTextJson/SystemJsonSerializerTests.cs
@@ -97,7 +97,7 @@ public class JsonMessageSerializerTest
         Assert.That(result[0], Is.TypeOf(typeof(A)));
         var a = (A)result[0];
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(a.Data, Is.EqualTo(obj.Data));
             Assert.That(a.I, Is.EqualTo(23));
@@ -115,7 +115,7 @@ public class JsonMessageSerializerTest
 
             Assert.That(a.Bs[0], Is.InstanceOf<B>());
             Assert.That(a.Bs[1], Is.Not.InstanceOf<BB>());
-        });
+        }
     }
 
     [Test]
@@ -171,19 +171,19 @@ public class JsonMessageSerializerTest
         Assert.That(result[0], Is.AssignableTo(typeof(IA)));
         var a = (IA)result[0];
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(obj.Data, Is.EqualTo(a.Data));
             Assert.That(a.I, Is.EqualTo(42));
             Assert.That(a.S, Is.EqualTo("kalle"));
             Assert.That(a.B, Is.Not.Null);
-        });
-        Assert.Multiple(() =>
+        }
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(a.B.BString, Is.EqualTo("BOO"));
             Assert.That(a.B.C, Is.TypeOf(typeof(JsonElement)));
             Assert.That(((JsonElement)a.B.C).GetProperty("Cstr").GetString(), Is.EqualTo("COO"));
-        });
+        }
 
     }
 
@@ -216,7 +216,7 @@ public class JsonMessageSerializerTest
             typeof(DateTimeMessage)
         ]).Cast<DateTimeMessage>().Single();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result.DateTime.Kind, Is.EqualTo(expectedDateTime.Kind));
             Assert.That(result.DateTime, Is.EqualTo(expectedDateTime));
@@ -226,17 +226,17 @@ public class JsonMessageSerializerTest
             Assert.That(result.DateTimeUtc, Is.EqualTo(expectedDateTimeUtc));
 
             Assert.That(result.DateTimeOffset, Is.EqualTo(expectedDateTimeOffset));
-        });
-        Assert.Multiple(() =>
+        }
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result.DateTimeOffset.Offset, Is.EqualTo(expectedDateTimeOffset.Offset));
             Assert.That(result.DateTimeOffsetLocal, Is.EqualTo(expectedDateTimeOffsetLocal));
-        });
-        Assert.Multiple(() =>
+        }
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result.DateTimeOffsetLocal.Offset, Is.EqualTo(expectedDateTimeOffsetLocal.Offset));
             Assert.That(result.DateTimeOffsetUtc, Is.EqualTo(expectedDateTimeOffsetUtc));
-        });
+        }
         Assert.That(result.DateTimeOffsetUtc.Offset, Is.EqualTo(expectedDateTimeOffsetUtc.Offset));
     }
 

--- a/src/NServiceBus.Core.Tests/Serializers/XML/Issue_934.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/Issue_934.cs
@@ -27,11 +27,11 @@ public class Issue_934
             messageDeserialized = serializer.Deserialize(stream.ToArray(), new[] { message.GetType() });
         }
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(((TestMessageWithChar)messageDeserialized[0]).InvalidCharacter, Is.EqualTo(message.InvalidCharacter));
             Assert.That(((TestMessageWithChar)messageDeserialized[0]).ValidCharacter, Is.EqualTo(message.ValidCharacter));
-        });
+        }
     }
 
     public class TestMessageWithChar : IMessage

--- a/src/NServiceBus.Core.Tests/Serializers/XML/SerializerTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/SerializerTests.cs
@@ -82,11 +82,11 @@ namespace NServiceBus.Serializers.XML.Test
 
                 var result = (StructMessage)serializer.Deserialize(stream.ToArray())[0];
 
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(result.SomeField, Is.EqualTo(message.SomeField));
                     Assert.That(result.SomeProperty, Is.EqualTo(message.SomeProperty));
-                });
+                }
             }
         }
 
@@ -235,11 +235,11 @@ namespace NServiceBus.Serializers.XML.Test
                 stream.Position = 0;
                 var msgArray = SerializerFactory.Create(typeof(Command1), typeof(Command2)).Deserialize(stream.ToArray());
 
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(msgArray[0].GetType(), Is.EqualTo(typeof(Command1)));
                     Assert.That(msgArray[1].GetType(), Is.EqualTo(typeof(Command2)));
-                });
+                }
             }
         }
 
@@ -284,11 +284,11 @@ namespace NServiceBus.Serializers.XML.Test
                 });
                 var a = (IMyEventA)result[0];
                 var b = (IMyEventB)result[1];
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(b.IntValue, Is.EqualTo(42));
                     Assert.That(a.StringValue, Is.EqualTo("Answer"));
-                });
+                }
             }
         }
 
@@ -496,11 +496,11 @@ namespace NServiceBus.Serializers.XML.Test
                         typeof(EmptyMessage)
                     });
 
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(((MessageWithDouble)msgArray[0]).Double, Is.EqualTo(23.4));
                     Assert.That(msgArray[1].GetType(), Is.EqualTo(typeof(EmptyMessage)));
-                });
+                }
             }
         }
 
@@ -521,11 +521,11 @@ namespace NServiceBus.Serializers.XML.Test
                         typeof(EmptyMessage)
                     });
 
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(((MessageWithDouble)msgArray[0]).Double, Is.EqualTo(23.4));
                     Assert.That(msgArray[1].GetType(), Is.EqualTo(typeof(EmptyMessage)));
-                });
+                }
             }
         }
 
@@ -1126,13 +1126,13 @@ namespace NServiceBus.Serializers.XML.Test
             var result = ExecuteSerializer.ForMessage<MessageWithSystemClassAsProperty>(
                 m => { m.MailMessage = message; });
             Assert.That(result.MailMessage, Is.Not.Null);
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.MailMessage.From.Address, Is.EqualTo("from@gmail.com"));
                 Assert.That(result.MailMessage.To.First(), Is.EqualTo(message.To.First()));
                 Assert.That(result.MailMessage.BodyEncoding.CodePage, Is.EqualTo(message.BodyEncoding.CodePage));
                 Assert.That(result.MailMessage.BodyEncoding.EncoderFallback.MaxCharCount, Is.EqualTo(message.BodyEncoding.EncoderFallback.MaxCharCount));
-            });
+            }
         }
 
         [Test]
@@ -1150,12 +1150,12 @@ namespace NServiceBus.Serializers.XML.Test
 
             var result = ExecuteSerializer.ForMessage<PolyMessage>(message);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.BaseType.BaseTypeProp, Is.EqualTo(message.BaseType.BaseTypeProp));
 
                 Assert.That(((ChildOfBase)result.BaseType).ChildProp, Is.EqualTo(((ChildOfBase)message.BaseType).ChildProp));
-            });
+            }
         }
 
         [Test]
@@ -1176,11 +1176,11 @@ namespace NServiceBus.Serializers.XML.Test
             var resultXDocument = ExecuteSerializer.ForMessage<MessageWithXDocument>(messageWithXDocument);
             var resultXElement = ExecuteSerializer.ForMessage<MessageWithXElement>(messageWithXElement);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(resultXDocument.Document.ToString(), Is.EqualTo(messageWithXDocument.Document.ToString()));
                 Assert.That(resultXElement.Document.ToString(), Is.EqualTo(messageWithXElement.Document.ToString()));
-            });
+            }
         }
 
         [Test]
@@ -1235,11 +1235,11 @@ namespace NServiceBus.Serializers.XML.Test
                 });
             }
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(((SerializedPair)messageDeserialized[0]).Key, Is.EqualTo(message.Key));
                 Assert.That(((SerializedPair)messageDeserialized[0]).Value, Is.EqualTo(message.Value));
-            });
+            }
         }
 
         [Test]

--- a/src/NServiceBus.Core.Tests/Serializers/XML/SerializingArrayTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/SerializingArrayTests.cs
@@ -75,11 +75,11 @@ public class SerializingArrayTests
 
         Assert.That(result.SomeInts, Is.Not.Null);
         Assert.That(result.SomeInts, Has.Length.EqualTo(2));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result.SomeInts[0], Is.EqualTo(1234));
             Assert.That(result.SomeInts[1], Is.EqualTo(5323));
-        });
+        }
     }
 
     [Test]
@@ -244,13 +244,13 @@ public class SerializingArrayTests
 
         var result = ExecuteSerializer.ForMessage<MessageWithNullableArray>(message);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result.SomeInts[0], Is.Null);
             Assert.That(result.SomeInts[1], Is.EqualTo(1));
             Assert.That(result.SomeInts[2], Is.Null);
             Assert.That(result.SomeInts[3], Is.EqualTo(3));
             Assert.That(result.SomeInts[4], Is.Null);
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Serializers/XML/SerializingGenericTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/SerializingGenericTests.cs
@@ -30,10 +30,10 @@ public class SerializingGenericTests
 
         var result = ExecuteSerializer.ForMessage<GenericMessage<int, string>>(message);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result.Data1, Is.EqualTo(1234));
             Assert.That(result.Data2, Is.EqualTo("Lorem ipsum"));
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Serializers/XML/Using_Infer_Type_With_Mixed_Namespace.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/Using_Infer_Type_With_Mixed_Namespace.cs
@@ -31,11 +31,11 @@
                 var serializer = SerializerFactory.Create(typeof(IMyBusMessage), typeof(Namespace1.FirstMessage), typeof(Namespace2.FirstMessage));
 
                 var messageDeserialized = serializer.Deserialize(stream.ToArray());
-                Assert.Multiple(() =>
+                using (Assert.EnterMultipleScope())
                 {
                     Assert.That(messageDeserialized[0], Is.InstanceOf<Namespace2.FirstMessage>());
                     Assert.That(messageDeserialized[1], Is.InstanceOf<Namespace1.FirstMessage>());
-                });
+                }
             }
         }
     }

--- a/src/NServiceBus.Core.Tests/Serializers/XML/Using_Infer_Type_With_Non_Nested_Class.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/Using_Infer_Type_With_Non_Nested_Class.cs
@@ -26,13 +26,13 @@ public class Using_Infer_Type_With_Non_Nested_Class
     {
         var serializer = SerializerFactory.Create(typeof(IMyBusMessage), typeof(FirstMessage), typeof(SecondMessage));
         var messageDeserialized = serializer.Deserialize(StringToByteArray(XmlWithBaseType));
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(messageDeserialized[0], Is.InstanceOf<FirstMessage>());
             Assert.That(messageDeserialized[1], Is.InstanceOf<SecondMessage>());
             Assert.That(messageDeserialized[2], Is.InstanceOf<SecondMessage>());
             Assert.That(messageDeserialized[3], Is.InstanceOf<SecondMessage>());
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Serializers/XML/XmlSerializerCacheTests.cs
+++ b/src/NServiceBus.Core.Tests/Serializers/XML/XmlSerializerCacheTests.cs
@@ -26,12 +26,12 @@ public class XmlSerializerCacheTests
         cache.InitType(typeof(RecursiveType));
 
         var members = cache.typeMembers[typeof(RecursiveType)];
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(members.Item1.Single().FieldType, Is.EqualTo(typeof(RecursiveType)));
             Assert.That(members.Item2[0].PropertyType, Is.EqualTo(typeof(RecursiveType)));
             Assert.That(members.Item2[1].PropertyType, Is.EqualTo(typeof(RecursiveType[])));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/ServicePlatform/Retries/RetryAcknowledgementBehaviorTests.cs
+++ b/src/NServiceBus.Core.Tests/ServicePlatform/Retries/RetryAcknowledgementBehaviorTests.cs
@@ -28,7 +28,7 @@ public class RetryAcknowledgementBehaviorTests
         await behavior.Invoke(context, _ => Task.CompletedTask);
 
         var outgoingMessage = routingPipeline.ForkInvocations.Single();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(
                     outgoingMessage.Message.Headers["ServiceControl.Retry.UniqueMessageId"],
@@ -39,15 +39,15 @@ public class RetryAcknowledgementBehaviorTests
             Assert.That(outgoingMessage.Message.Body.Length, Is.EqualTo(0));
 
             Assert.That(outgoingMessage.Message.Headers[Headers.ControlMessageHeader], Is.EqualTo(bool.TrueString));
-        });
+        }
 
         var addressTag = outgoingMessage.RoutingStrategies.Single().Apply([]) as UnicastAddressTag;
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(addressTag.Destination, Is.EqualTo(acknowledgementQueue));
 
             Assert.That(context.Extensions.TryGet<MarkAsAcknowledgedBehavior.State>(out _), Is.True);
-        });
+        }
     }
 
     [Test]
@@ -64,11 +64,11 @@ public class RetryAcknowledgementBehaviorTests
         var exception = new Exception("some pipeline failure");
         var thrownException = Assert.ThrowsAsync<Exception>(async () => await behavior.Invoke(context, _ => Task.FromException(exception)));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(exception, Is.SameAs(thrownException));
             Assert.That(routingPipeline.ForkInvocations.Count, Is.EqualTo(0));
-        });
+        }
     }
 
     [Test]
@@ -83,11 +83,11 @@ public class RetryAcknowledgementBehaviorTests
 
         await behavior.Invoke(context, _ => Task.CompletedTask);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(routingPipeline.ForkInvocations.Count, Is.EqualTo(0));
             Assert.That(context.Extensions.TryGet<MarkAsAcknowledgedBehavior.State>(out _), Is.False);
-        });
+        }
     }
 
     [Test]
@@ -101,11 +101,11 @@ public class RetryAcknowledgementBehaviorTests
 
         await behavior.Invoke(context, _ => Task.CompletedTask);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(routingPipeline.ForkInvocations.Count, Is.EqualTo(0));
             Assert.That(context.Extensions.TryGet<MarkAsAcknowledgedBehavior.State>(out _), Is.False);
-        });
+        }
     }
 
     static TestableTransportReceiveContext SetupTestableContext(RoutingPipeline routingPipeline)

--- a/src/NServiceBus.Core.Tests/Settings/SettingsHolderTests.cs
+++ b/src/NServiceBus.Core.Tests/Settings/SettingsHolderTests.cs
@@ -50,11 +50,11 @@ public class SettingsHolderTests
         var result1 = settings.Get<string>("SomeDefaultSettingThatGetsMerged");
         var result2 = settings.Get<string>("SomeSettingThatGetsMerged");
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result1, Is.EqualTo("Value1"));
             Assert.That(result2, Is.EqualTo("Value1"));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/StandardsTests.cs
+++ b/src/NServiceBus.Core.Tests/StandardsTests.cs
@@ -17,11 +17,11 @@ public class StandardsTests
     {
         foreach (var featureType in GetFeatures())
         {
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(featureType.Namespace, Is.EqualTo("NServiceBus.Features"), "Features should be in the NServiceBus.Features namespace. " + featureType.FullName);
                 Assert.That(featureType.Name, Does.Not.EndWith("Feature"), "Features should not be suffixed with 'Feature'. " + featureType.FullName);
-            });
+            }
             if (featureType.IsPublic)
             {
                 var constructorInfo = featureType.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, null, [], null);
@@ -81,12 +81,12 @@ public class StandardsTests
     {
         foreach (var featureType in GetBehaviors())
         {
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(featureType.IsPublic, Is.False, "Behaviors should internal " + featureType.FullName);
                 Assert.That(featureType.Namespace, Is.EqualTo("NServiceBus"), "Behaviors should be in the NServiceBus namespace since it reduces the 'wall of text' problem when looking at pipeline stack traces. " + featureType.FullName);
                 Assert.That(featureType.Name.EndsWith("Terminator") || featureType.Name.EndsWith("Behavior") || featureType.Name.EndsWith("Connector"), Is.True, "Behaviors should be suffixed with 'Behavior' or 'Connector'. " + featureType.FullName);
-            });
+            }
         }
     }
 

--- a/src/NServiceBus.Core.Tests/Transports/IncomingMessageTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/IncomingMessageTests.cs
@@ -13,12 +13,12 @@ public class IncomingMessageTests
         var headers = new Dictionary<string, string>();
         var message = new IncomingMessage("nativeId", headers, System.Array.Empty<byte>());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(message.NativeMessageId, Is.EqualTo("nativeId"));
             Assert.That(message.MessageId, Is.EqualTo("nativeId"));
             Assert.That(headers[Headers.MessageId], Is.EqualTo("nativeId"));
-        });
+        }
     }
 
     [Test]
@@ -30,11 +30,11 @@ public class IncomingMessageTests
         };
         var message = new IncomingMessage("nativeId", headers, System.Array.Empty<byte>());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(message.NativeMessageId, Is.EqualTo("nativeId"));
             Assert.That(message.MessageId, Is.EqualTo("coreId"));
-        });
+        }
     }
 
     [Test]
@@ -46,10 +46,10 @@ public class IncomingMessageTests
         };
         var message = new IncomingMessage("nativeId", headers, System.Array.Empty<byte>());
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(message.NativeMessageId, Is.EqualTo("nativeId"));
             Assert.That(message.MessageId, Is.EqualTo("nativeId"));
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Transports/MulticastTransportOperationTest.cs
+++ b/src/NServiceBus.Core.Tests/Transports/MulticastTransportOperationTest.cs
@@ -16,10 +16,10 @@ public class MulticastTransportOperationTest
 
         transportOperation.Properties.DiscardIfNotReceivedBefore = new DiscardIfNotReceivedBefore(TimeSpan.FromDays(1));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(secondTransportOperation.Properties, Is.Empty);
             Assert.That(transportOperation.Properties, Is.Not.Empty);
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Transports/TransportOperationTest.cs
+++ b/src/NServiceBus.Core.Tests/Transports/TransportOperationTest.cs
@@ -14,11 +14,11 @@ public class TransportOperationTest
         var transportOperation = new TransportOperation(new OutgoingMessage(Guid.NewGuid().ToString(), [], Array.Empty<byte>()), new UnicastAddressTag("destination"));
         var secondTransportOperation = new TransportOperation(new OutgoingMessage(Guid.NewGuid().ToString(), [], Array.Empty<byte>()), new UnicastAddressTag("destination2"));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(secondTransportOperation.Properties, Is.Not.SameAs(transportOperation.Properties));
             Assert.That(transportOperation.Properties, Is.Empty);
-        });
+        }
         Assert.That(secondTransportOperation.Properties, Is.Empty);
     }
 }

--- a/src/NServiceBus.Core.Tests/Transports/TransportOperationsTests.cs
+++ b/src/NServiceBus.Core.Tests/Transports/TransportOperationsTests.cs
@@ -24,7 +24,7 @@ public class TransportOperationsTests
 
         Assert.That(result.MulticastTransportOperations.Count, Is.EqualTo(1));
         var multicastOp = result.MulticastTransportOperations.Single();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(multicastOp.Message, Is.EqualTo(multicastOperation.Message));
             Assert.That(multicastOp.MessageType, Is.EqualTo((multicastOperation.AddressTag as MulticastAddressTag)?.MessageType));
@@ -32,15 +32,15 @@ public class TransportOperationsTests
             Assert.That(multicastOp.RequiredDispatchConsistency, Is.EqualTo(multicastOperation.RequiredDispatchConsistency));
 
             Assert.That(result.UnicastTransportOperations.Count, Is.EqualTo(1));
-        });
+        }
         var unicastOp = result.UnicastTransportOperations.Single();
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(unicastOp.Message, Is.EqualTo(unicastOperation.Message));
             Assert.That(unicastOp.Destination, Is.EqualTo((unicastOperation.AddressTag as UnicastAddressTag)?.Destination));
             Assert.That(unicastOp.Properties, Is.EqualTo(unicastOperation.Properties));
             Assert.That(unicastOp.RequiredDispatchConsistency, Is.EqualTo(unicastOperation.RequiredDispatchConsistency));
-        });
+        }
     }
 
     [Test]
@@ -48,11 +48,11 @@ public class TransportOperationsTests
     {
         var result = new TransportOperations();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(result.MulticastTransportOperations.Count, Is.EqualTo(0));
             Assert.That(result.UnicastTransportOperations.Count, Is.EqualTo(0));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Transports/UnicastTransportOperationTest.cs
+++ b/src/NServiceBus.Core.Tests/Transports/UnicastTransportOperationTest.cs
@@ -16,10 +16,10 @@ public class UnicastTransportOperationTest
 
         transportOperation.Properties.DiscardIfNotReceivedBefore = new DiscardIfNotReceivedBefore(TimeSpan.FromDays(1));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(secondTransportOperation.Properties, Is.Empty);
             Assert.That(transportOperation.Properties, Is.Not.Empty);
-        });
+        }
     }
 }

--- a/src/NServiceBus.Core.Tests/Unicast/MessageOperationsTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/MessageOperationsTests.cs
@@ -35,11 +35,11 @@ public class MessageOperationsTests
         await messageOperations.Send<MyMessage>(new FakeRootContext(), m => { }, new SendOptions());
 
         var messageId = messageOperations.SendPipeline.LastContext.MessageId;
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(messageId, Is.Not.Null);
             Assert.That(messageOperations.SendPipeline.LastContext.Headers[Headers.MessageId], Is.EqualTo(messageId));
-        });
+        }
     }
 
     [Test]
@@ -53,11 +53,11 @@ public class MessageOperationsTests
         sendOptions.SetMessageId(expectedMessageID);
         await messageOperations.Send<MyMessage>(new FakeRootContext(), m => { }, sendOptions);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(messageOperations.SendPipeline.LastContext.MessageId, Is.EqualTo(expectedMessageID));
             Assert.That(messageOperations.SendPipeline.LastContext.Headers[Headers.MessageId], Is.EqualTo(expectedMessageID));
-        });
+        }
     }
 
     [Test]
@@ -104,11 +104,11 @@ public class MessageOperationsTests
         await messageOperations.Reply<MyMessage>(new FakeRootContext(), m => { }, new ReplyOptions());
 
         var messageId = messageOperations.ReplyPipeline.LastContext.MessageId;
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(messageId, Is.Not.Null);
             Assert.That(messageOperations.ReplyPipeline.LastContext.Headers[Headers.MessageId], Is.EqualTo(messageId));
-        });
+        }
     }
 
     [Test]
@@ -122,11 +122,11 @@ public class MessageOperationsTests
         replyOptions.SetMessageId(expectedMessageID);
         await messageOperations.Reply<MyMessage>(new FakeRootContext(), m => { }, replyOptions);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(messageOperations.ReplyPipeline.LastContext.MessageId, Is.EqualTo(expectedMessageID));
             Assert.That(messageOperations.ReplyPipeline.LastContext.Headers[Headers.MessageId], Is.EqualTo(expectedMessageID));
-        });
+        }
     }
 
     [Test]
@@ -173,11 +173,11 @@ public class MessageOperationsTests
         await messageOperations.Publish<MyMessage>(new FakeRootContext(), m => { }, new PublishOptions());
 
         var messageId = messageOperations.PublishPipeline.LastContext.MessageId;
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(messageId, Is.Not.Null);
             Assert.That(messageOperations.PublishPipeline.LastContext.Headers[Headers.MessageId], Is.EqualTo(messageId));
-        });
+        }
     }
 
     [Test]
@@ -191,11 +191,11 @@ public class MessageOperationsTests
         publishOptions.SetMessageId(expectedMessageID);
         await messageOperations.Publish<MyMessage>(new FakeRootContext(), m => { }, publishOptions);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(messageOperations.PublishPipeline.LastContext.MessageId, Is.EqualTo(expectedMessageID));
             Assert.That(messageOperations.PublishPipeline.LastContext.Headers[Headers.MessageId], Is.EqualTo(expectedMessageID));
-        });
+        }
     }
 
     [Test]

--- a/src/NServiceBus.Core.Tests/Unicast/MessageTypeTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/MessageTypeTests.cs
@@ -11,11 +11,11 @@ public class MessageTypeTests
     {
         var messageType = new Subscriptions.MessageType(typeof(TestMessage));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(typeof(TestMessage).FullName, Is.EqualTo(messageType.TypeName));
             Assert.That(typeof(TestMessage).Assembly.GetName().Version, Is.EqualTo(messageType.Version));
-        });
+        }
     }
 
     [Test]
@@ -23,11 +23,11 @@ public class MessageTypeTests
     {
         var messageType = new Subscriptions.MessageType(typeof(TestMessage).AssemblyQualifiedName);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(typeof(TestMessage).FullName, Is.EqualTo(messageType.TypeName));
             Assert.That(typeof(TestMessage).Assembly.GetName().Version, Is.EqualTo(messageType.Version));
-        });
+        }
     }
 
     [Test]
@@ -35,11 +35,11 @@ public class MessageTypeTests
     {
         var messageType = new Subscriptions.MessageType("TestMessage", "1.2.3.4");
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(messageType.TypeName, Is.EqualTo("TestMessage"));
             Assert.That(new Version(1, 2, 3, 4), Is.EqualTo(messageType.Version));
-        });
+        }
     }
 
     [Test]
@@ -52,11 +52,11 @@ public class MessageTypeTests
 
         var messageType = new Subscriptions.MessageType(input);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(expectedTypeName, Is.EqualTo(messageType.TypeName));
             Assert.That(expectedVersion, Is.EqualTo(messageType.Version));
-        });
+        }
     }
 
     class TestMessage

--- a/src/NServiceBus.Core.Tests/Unicast/Messages/DefaultMessageRegistryTests.cs
+++ b/src/NServiceBus.Core.Tests/Unicast/Messages/DefaultMessageRegistryTests.cs
@@ -34,11 +34,11 @@ public class MessageMetadataRegistryTests
 
         var messageMetadata = defaultMessageRegistry.GetMessageMetadata(typeof(int));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(messageMetadata.MessageType, Is.EqualTo(typeof(int)));
             Assert.That(messageMetadata.MessageHierarchy, Has.Length.EqualTo(1));
-        });
+        }
     }
 
 
@@ -52,14 +52,14 @@ public class MessageMetadataRegistryTests
 
         Assert.That(messageMetadata.MessageHierarchy, Has.Length.EqualTo(5));
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(messageMetadata.MessageHierarchy.ToList()[0], Is.EqualTo(typeof(MyEvent)));
             Assert.That(messageMetadata.MessageHierarchy.ToList()[1], Is.EqualTo(typeof(IInterfaceParent1)));
             Assert.That(messageMetadata.MessageHierarchy.ToList()[2], Is.EqualTo(typeof(ConcreteParent1)));
             Assert.That(messageMetadata.MessageHierarchy.ToList()[3], Is.EqualTo(typeof(IInterfaceParent1Base)));
             Assert.That(messageMetadata.MessageHierarchy.ToList()[4], Is.EqualTo(typeof(ConcreteParentBase)));
-        });
+        }
     }
 
     [TestCase("NServiceBus.Unicast.Tests.MessageMetadataRegistryTests+MyEvent, NonExistingAssembly, Version=1.0.0.0, Culture=neutral, PublicKeyToken=b50674d1e0c6ce54")]

--- a/src/NServiceBus.Core.Tests/Utils/Reflection/ExtensionMethodsTests.cs
+++ b/src/NServiceBus.Core.Tests/Utils/Reflection/ExtensionMethodsTests.cs
@@ -12,13 +12,13 @@ public class ExtensionMethodsTests
     [Test]
     public void SerializationFriendlyNameTests()
     {
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(typeof(string).SerializationFriendlyName(), Is.EqualTo("String"));
             Assert.That(typeof(Dictionary<string, int>).SerializationFriendlyName(), Is.EqualTo("DictionaryOfStringAndInt32"));
             Assert.That(typeof(Dictionary<string, Tuple<int>>).SerializationFriendlyName(), Is.EqualTo("DictionaryOfStringAndTupleOfInt32"));
             Assert.That(typeof(KeyValuePair<string, Tuple<int>>).SerializationFriendlyName(), Is.EqualTo("NServiceBus.KeyValuePairOfStringAndTupleOfInt32"));
-        });
+        }
     }
 
     [Test]
@@ -28,11 +28,11 @@ public class ExtensionMethodsTests
         var customTypeResult = typeof(Target).IsSystemType();
         var systemTypeResult = typeof(string).IsSystemType();
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(systemTypeResult, Is.True, "Expected string to be a system type.");
             Assert.That(customTypeResult, Is.False, "Expected Target to be a custom type.");
-        });
+        }
     }
 
     public class Target

--- a/src/NServiceBus.PersistenceTests/Outbox/OutboxStorageTests.cs
+++ b/src/NServiceBus.PersistenceTests/Outbox/OutboxStorageTests.cs
@@ -44,11 +44,11 @@ public class OutboxStorageTests(TestVariant param)
         var message = await storage.Get(messageId, configuration.GetContextBagForOutbox());
 
         Assert.That(message, Is.Not.Null);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(message.MessageId, Is.EqualTo(messageId));
             Assert.That(message.TransportOperations, Has.Length.EqualTo(1));
-        });
+        }
         Assert.That(message.TransportOperations[0].MessageId, Is.EqualTo(transportOperationMessageId));
     }
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_an_escalated_DTC_transaction.cs
@@ -83,12 +83,12 @@ public class When_persisting_a_saga_with_an_escalated_DTC_transaction : SagaPers
         var notUpdatedSagaData = await GetById<TestSagaData>(startingSagaData.Id);
 
         Assert.That(notUpdatedSagaData, Is.Not.Null);
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(notUpdatedSagaData.LastUpdatedBy, Is.EqualTo("Unchanged"));
             Assert.That(enlistmentNotifier.CommitWasCalled, Is.False);
             Assert.That(enlistmentNotifier.RollbackWasCalled, Is.True);
-        });
+        }
     }
 
     public class TestSaga : Saga<TestSagaData>, IAmStartedByMessages<StartMessage>

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_the_same_unique_prop_as_another_saga.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_a_saga_with_the_same_unique_prop_as_another_saga.cs
@@ -41,11 +41,11 @@ public class When_persisting_a_saga_with_the_same_unique_prop_as_another_saga : 
 
             var saga2Result = await persister.Get<AnotherSagaWithCorrelatedPropertyData>(nameof(AnotherSagaWithCorrelatedPropertyData.CorrelatedProperty), saga2.CorrelatedProperty, readSession, readContextBag);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(saga1Result.CorrelatedProperty, Is.EqualTo(saga1.CorrelatedProperty));
                 Assert.That(saga2Result.CorrelatedProperty, Is.EqualTo(saga2.CorrelatedProperty));
-            });
+            }
         }
     }
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_persisting_different_sagas_without_mapping.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_persisting_different_sagas_without_mapping.cs
@@ -45,11 +45,11 @@ public class When_persisting_different_sagas_without_mapping : SagaPersisterTest
 
             var saga2Result = await configuration.SagaStorage.Get<AnotherSagaWithoutCorrelationPropertyData>(saga2.Id, readSession, readContextBag);
 
-            Assert.Multiple(() =>
+            using (Assert.EnterMultipleScope())
             {
                 Assert.That(saga1Result.FoundByFinderProperty, Is.EqualTo(saga1.FoundByFinderProperty));
                 Assert.That(saga2Result.FoundByFinderProperty, Is.EqualTo(saga2.FoundByFinderProperty));
-            });
+            }
         }
     }
 

--- a/src/NServiceBus.PersistenceTests/Sagas/When_retrieving_the_same_saga_twice.cs
+++ b/src/NServiceBus.PersistenceTests/Sagas/When_retrieving_the_same_saga_twice.cs
@@ -17,11 +17,11 @@ public class When_retrieving_the_same_saga_twice : SagaPersisterTests
         var returnedSaga1 = await GetById<TestSagaData>(saga.Id);
         var returnedSaga2 = await GetById<TestSagaData>(saga.Id);
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(returnedSaga1, Is.Not.SameAs(returnedSaga2));
             Assert.That(saga, Is.Not.SameAs(returnedSaga1));
-        });
+        }
         Assert.That(saga, Is.Not.SameAs(returnedSaga2));
     }
 

--- a/src/NServiceBus.TransportTests/When_message_is_available.cs
+++ b/src/NServiceBus.TransportTests/When_message_is_available.cs
@@ -30,11 +30,11 @@ public class When_message_is_available : NServiceBusTransportTest
 
         var messageContext = await onMessageInvoked.Task;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(string.IsNullOrEmpty(messageContext.NativeMessageId), Is.False, "Should pass the native message id");
             Assert.That(messageContext.Headers["MyHeader"], Is.EqualTo("MyValue"), "Should pass the message headers");
             Assert.That(messageBody, Is.EqualTo(new byte[] { 1, 2, 3 }), "Should pass the body");
-        });
+        }
     }
 }

--- a/src/NServiceBus.TransportTests/When_multiple_messages_are_available.cs
+++ b/src/NServiceBus.TransportTests/When_multiple_messages_are_available.cs
@@ -55,10 +55,10 @@ public class When_multiple_messages_are_available : NServiceBusTransportTest
             TestTimeoutCancellationToken.ThrowIfCancellationRequested();
         }
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(maximumConcurrentMessages, Is.EqualTo(concurrencyLevel), "should not process more messages than configured at once");
             Assert.That(messagesProcessed, Is.EqualTo(concurrencyLevel * 2), "should process all enqueued messages");
-        });
+        }
     }
 }

--- a/src/NServiceBus.TransportTests/When_multiple_messages_are_available_and_concurrency_is_increased_after_pump_started.cs
+++ b/src/NServiceBus.TransportTests/When_multiple_messages_are_available_and_concurrency_is_increased_after_pump_started.cs
@@ -58,10 +58,10 @@ public class When_multiple_messages_are_available_and_concurrency_is_increased_a
             TestTimeoutCancellationToken.ThrowIfCancellationRequested();
         }
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(maximumConcurrentMessages, Is.EqualTo(newConcurrencyLevel), "should not process more messages than configured at once");
             Assert.That(messagesProcessed, Is.EqualTo(startConcurrencyLevel * 2), "should process all enqueued messages");
-        });
+        }
     }
 }

--- a/src/NServiceBus.TransportTests/When_multiple_messages_are_available_and_concurrency_is_increased_and_decreased_after_pump_started.cs
+++ b/src/NServiceBus.TransportTests/When_multiple_messages_are_available_and_concurrency_is_increased_and_decreased_after_pump_started.cs
@@ -60,10 +60,10 @@ public class When_multiple_messages_are_available_and_concurrency_is_increased_a
             TestTimeoutCancellationToken.ThrowIfCancellationRequested();
         }
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(maximumConcurrentMessages, Is.EqualTo(lastConcurrencyLevel), "should not process more messages than configured at once");
             Assert.That(messagesProcessed, Is.EqualTo(startConcurrencyLevel * 2), "should process all enqueued messages");
-        });
+        }
     }
 }

--- a/src/NServiceBus.TransportTests/When_multiple_messages_are_available_and_concurrency_is_lowered_after_pump_started.cs
+++ b/src/NServiceBus.TransportTests/When_multiple_messages_are_available_and_concurrency_is_lowered_after_pump_started.cs
@@ -58,10 +58,10 @@ public class When_multiple_messages_are_available_and_concurrency_is_lowered_aft
             TestTimeoutCancellationToken.ThrowIfCancellationRequested();
         }
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(maximumConcurrentMessages, Is.EqualTo(newConcurrencyLevel), "should not process more messages than configured at once");
             Assert.That(messagesProcessed, Is.EqualTo(startConcurrencyLevel * 2), "should process all enqueued messages");
-        });
+        }
     }
 }

--- a/src/NServiceBus.TransportTests/When_on_error_throws.cs
+++ b/src/NServiceBus.TransportTests/When_on_error_throws.cs
@@ -54,12 +54,12 @@ public class When_on_error_throws : NServiceBusTransportTest
 
         await retried.Task;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(criticalErrorCalled, Is.True, "Should invoke critical error");
             Assert.That(criticalErrorMessage, Is.EqualTo($"Failed to execute recoverability policy for message with native ID: `{nativeMessageId}`"));
             Assert.That(criticalErrorException, Is.EqualTo(exceptionFromOnError));
-        });
+        }
 
         var logItemsAboveInfo = LogFactory.LogItems.Where(item => item.Level > LogLevel.Info).Select(log => $"{log.Level}: {log.Message}").ToArray();
         Assert.That(logItemsAboveInfo, Is.Empty, "Transport should not log anything above LogLevel.Info:" + string.Join(Environment.NewLine, logItemsAboveInfo));

--- a/src/NServiceBus.TransportTests/When_on_message_throws.cs
+++ b/src/NServiceBus.TransportTests/When_on_message_throws.cs
@@ -29,11 +29,11 @@ public class When_on_message_throws : NServiceBusTransportTest
 
         var errorContext = await onErrorCalled.Task;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(errorContext.Exception.Message, Is.EqualTo("Simulated exception"), "Should preserve the exception");
             Assert.That(errorContext.ImmediateProcessingFailures, Is.EqualTo(1), "Should track the number of delivery attempts");
             Assert.That(errorContext.Message.Headers["MyHeader"], Is.EqualTo("MyValue"), "Should pass the message headers");
-        });
+        }
     }
 }

--- a/src/NServiceBus.TransportTests/When_scope_complete_throws.cs
+++ b/src/NServiceBus.TransportTests/When_scope_complete_throws.cs
@@ -34,14 +34,14 @@ public class When_scope_complete_throws : NServiceBusTransportTest
 
         var errorContext = await onErrorCalled.Task;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(errorContext.Exception, Is.InstanceOf<TransactionAbortedException>());
 
             // since some transports doesn't have native retry counters we can't expect the attempts to be fully consistent since if
             // dispose throws the message might be picked up before the counter is incremented
             Assert.That(errorContext.ImmediateProcessingFailures, Is.LessThanOrEqualTo(1));
-        });
+        }
     }
 
     class EnlistmentWhichFailsDuringPrepare : IEnlistmentNotification

--- a/src/NServiceBus.TransportTests/When_scope_throws_after_successful_message_processing.cs
+++ b/src/NServiceBus.TransportTests/When_scope_throws_after_successful_message_processing.cs
@@ -40,11 +40,11 @@ public class When_scope_throws_after_successful_message_processing : NServiceBus
 
         var errorContext = await secondFailure.Task;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(errorContext.Exception, Is.InstanceOf<TransactionAbortedException>());
             Assert.That(errorContext.ImmediateProcessingFailures, Is.LessThanOrEqualTo(2));
-        });
+        }
     }
 }
 

--- a/src/NServiceBus.TransportTests/When_transaction_level_TransactionScope.cs
+++ b/src/NServiceBus.TransportTests/When_transaction_level_TransactionScope.cs
@@ -29,10 +29,10 @@ public class When_transaction_level_TransactionScope : NServiceBusTransportTest
 
         await messageProcessed.Task;
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(currentTransaction, Is.Not.Null);
             Assert.That(contextTransaction, Is.SameAs(currentTransaction));
-        });
+        }
     }
 }


### PR DESCRIPTION
This PR updates the tests to use [`Assert.EnterMultipleScope`](https://github.com/nunit/nunit.analyzers/blob/master/documentation/NUnit2056.md) instead of `Assert.Multiple`.