### PR TITLE
Bring back settings holder EnableFeature because we need it for the transactional session

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -1329,6 +1329,8 @@ namespace NServiceBus.Features
     }
     public static class SettingsExtensions
     {
+        public static void EnableFeature<T>(this NServiceBus.Settings.SettingsHolder settings)
+            where T : NServiceBus.Features.Feature { }
         [System.Obsolete("It is no longer possible to enable features by default on the settings. Features " +
             "can enable other features by calling EnableByDefault<T> in the constructor. Will" +
             " be removed in version 11.0.0.", true)]

--- a/src/NServiceBus.Core/Features/EndpointConfigurationExtensions.cs
+++ b/src/NServiceBus.Core/Features/EndpointConfigurationExtensions.cs
@@ -17,7 +17,7 @@ public static partial class EndpointConfigurationExtensions
     public static void EnableFeature<T>(this EndpointConfiguration config) where T : Feature
     {
         ArgumentNullException.ThrowIfNull(config);
-        config.Settings.Get<FeatureComponent.Settings>().EnableFeature<T>();
+        config.Settings.EnableFeature<T>();
     }
 
     /// <summary>

--- a/src/NServiceBus.Core/Features/SettingsExtensions.cs
+++ b/src/NServiceBus.Core/Features/SettingsExtensions.cs
@@ -11,6 +11,14 @@ using Settings;
 public static partial class SettingsExtensions
 {
     /// <summary>
+    /// Enables the given feature.
+    /// </summary>
+    /// <remarks>Enabling features is intended to be used for downstream components that only have access to settings. Features that need to enable other features should use <see cref="Feature.EnableByDefault{T}"/>.</remarks>
+    /// <typeparam name="T">The feature to enable.</typeparam>
+    public static void EnableFeature<T>(this SettingsHolder settings) where T : Feature
+        => settings.Get<FeatureComponent.Settings>().EnableFeature<T>();
+
+    /// <summary>
     /// Returns if a given feature has been activated in this endpoint.
     /// </summary>
     public static bool IsFeatureActive<T>(this IReadOnlySettings settings) where T : Feature


### PR DESCRIPTION
This PR adds `EnableFeature` to the settings holder. This is required so that extension points like routing settings, persistence settings and other settings based extension points can enable a feature. Our initial assumption was that we always have a starting point on top of `EndpointConfiguration` which at first sight turned out to be the case but now that we are rolling it out further, we have discovered some more edge cases.

`Settings.EnableFeatureByDefault` is still not restored because that is a previous API that was mostly only used to enable other features from within a feature defaults which has a suitable replacement in the constructor of the feature. While technically this would enable someone to call `Default(s => s.EnableFeature<OtherFeature>())` we think the existing guidance on the obsolete should be enough to discourage that usage.

For MSMQ this allows us to, for example, enable the feature as part of the routing extensions only when the instance mapping file-specific extensions are called.