### PR TITLE
Switch to symbol based analysis

### DIFF
--- a/src/NServiceBus.Core.Analyzer/Handlers/HandlerInjectsMessageSessionAnalyzer.cs
+++ b/src/NServiceBus.Core.Analyzer/Handlers/HandlerInjectsMessageSessionAnalyzer.cs
@@ -2,7 +2,6 @@
 
 namespace NServiceBus.Core.Analyzer.Handlers;
 
-using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;


### PR DESCRIPTION
This PR updates the analyzer to use a symbol-based approach for detecting handler injections of IMessageSession. This makes the rule more accurate because it works directly with real type information instead of relying on syntax patterns, and it also improves performance since named type symbols are far fewer than syntax nodes. The implementation becomes more robust because it handles source, generated, and metadata types consistently, and it avoids extra semantic lookups that were required in the syntax-based version. The logic is now simpler to follow by focusing on handler types, inspecting their constructors and properties, and reporting diagnostics on the correct TypeSyntax. The update also avoids throwing when NServiceBus types are missing by skipping registration in those cases, which makes the analyzer safer overall.