### PR TITLE
Adds a settings-only option to use Outbox in SendsAtomicWithReceive mode

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Outbox/When_outbox_enabled_with_transaction_mode_above_receive_only.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Outbox/When_outbox_enabled_with_transaction_mode_above_receive_only.cs
@@ -15,7 +15,7 @@ public class When_outbox_enabled_with_transaction_mode_above_receive_only : NSer
             .Done(_ => false)
             .Run());
 
-        Assert.That(exception.Message, Does.Contain($"Outbox requires transport to be running in `{nameof(TransportTransactionMode.ReceiveOnly)}` mode"));
+        Assert.That(exception.Message, Does.Contain($"The `{nameof(TransportTransactionMode.SendsAtomicWithReceive)}` mode of Outbox has not been enabled."));
     }
 
     public class Context : ScenarioContext

--- a/src/NServiceBus.Core.Tests/Reliability/Outbox/FakeOutboxSeam.cs
+++ b/src/NServiceBus.Core.Tests/Reliability/Outbox/FakeOutboxSeam.cs
@@ -6,7 +6,7 @@ using Extensibility;
 using Fakes;
 using NServiceBus.Outbox;
 
-class FakeOutboxStorage : IOutboxStorage
+class FakeOutboxSeam : IOutboxSeam
 {
     public OutboxMessage ExistingMessage { get; set; }
     public OutboxMessage StoredMessage { get; set; }

--- a/src/NServiceBus.Core/Reliability/Outbox/DefaultOutboxSeam.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/DefaultOutboxSeam.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus;
+
+using System.Threading;
+using System.Threading.Tasks;
+using Extensibility;
+using Outbox;
+
+class DefaultOutboxSeam(IOutboxStorage outboxStorage) : IOutboxSeam
+{
+    public Task<OutboxMessage> Get(string messageId, ContextBag context, CancellationToken cancellationToken = default)
+        => outboxStorage.Get(messageId, context, cancellationToken);
+
+    public Task Store(OutboxMessage message, IOutboxTransaction transaction, ContextBag context,
+        CancellationToken cancellationToken = default)
+        => outboxStorage.Store(message, transaction, context, cancellationToken);
+
+    public Task SetAsDispatched(string messageId, ContextBag context, CancellationToken cancellationToken = default)
+        => outboxStorage.SetAsDispatched(messageId, context, cancellationToken);
+
+    public Task<IOutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken = default)
+        => outboxStorage.BeginTransaction(context, cancellationToken);
+}

--- a/src/NServiceBus.Core/Reliability/Outbox/IOutboxSeam.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/IOutboxSeam.cs
@@ -1,0 +1,14 @@
+﻿namespace NServiceBus;
+
+using System.Threading;
+using System.Threading.Tasks;
+using Extensibility;
+using Outbox;
+
+interface IOutboxSeam
+{
+    Task<OutboxMessage> Get(string messageId, ContextBag context, CancellationToken cancellationToken = default);
+    Task Store(OutboxMessage message, IOutboxTransaction transaction, ContextBag context, CancellationToken cancellationToken = default);
+    Task SetAsDispatched(string messageId, ContextBag context, CancellationToken cancellationToken = default);
+    Task<IOutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken = default);
+}

--- a/src/NServiceBus.Core/Reliability/Outbox/NoOpOutboxSeam.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/NoOpOutboxSeam.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Extensibility;
 using Outbox;
 
-class NoOpOutboxStorage : IOutboxStorage
+class NoOpOutboxSeam : IOutboxSeam
 {
     public Task<OutboxMessage> Get(string messageId, ContextBag options, CancellationToken cancellationToken = default) => NoOutboxMessageTask;
 

--- a/src/NServiceBus.Core/Reliability/Outbox/SendsAtomicWithReceiveOutboxSeam.cs
+++ b/src/NServiceBus.Core/Reliability/Outbox/SendsAtomicWithReceiveOutboxSeam.cs
@@ -1,0 +1,22 @@
+﻿namespace NServiceBus;
+
+using System.Threading;
+using System.Threading.Tasks;
+using Extensibility;
+using Outbox;
+
+class SendsAtomicWithReceiveOutboxSeam(IOutboxStorage outboxStorage) : IOutboxSeam
+{
+    public Task<OutboxMessage> Get(string messageId, ContextBag context, CancellationToken cancellationToken = default)
+        => outboxStorage.Get(messageId, context, cancellationToken);
+
+    public Task Store(OutboxMessage message, IOutboxTransaction transaction, ContextBag context,
+        CancellationToken cancellationToken = default)
+        => outboxStorage.Store(message, transaction, context, cancellationToken);
+
+    public Task SetAsDispatched(string messageId, ContextBag context, CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+
+    public Task<IOutboxTransaction> BeginTransaction(ContextBag context, CancellationToken cancellationToken = default)
+        => outboxStorage.BeginTransaction(context, cancellationToken);
+}


### PR DESCRIPTION
- Adds option to use Outbox feature with `SendsAtomicWithReceive` transaction mode (enabled via a settings value)
- Adds option to intercept the communication between `TransportReceiveToBlaBlaConnector` and the `IOutbosStorage` by introducing `IOutboxSeam`. This change is needed to implement outbox scenarios that diverge from the default one.