### PR TITLE
Turn off allowPrerelease

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.0",
+    "allowPrerelease": false,
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
Now that .NET 10 has been released, we can disable the preview flag for the SDK version