### PR TITLE
Obsolete IWantToRunBeforeConfigurationIsFinalized with a warning

### DIFF
--- a/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
+++ b/src/NServiceBus.Core.Tests/ApprovalFiles/APIApprovals.ApproveNServiceBus.approved.txt
@@ -529,6 +529,7 @@ namespace NServiceBus
     {
         void ToSaga(System.Linq.Expressions.Expression<System.Func<TSagaData, object>> sagaEntityProperty);
     }
+    [System.Obsolete(@"Final adjustments to settings before configuration is finalized should be applied via an explicit last configuration step on the endpoint configuration, instead of via implementations of this interface discovered by scanning. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
     public interface IWantToRunBeforeConfigurationIsFinalized
     {
         void Run(NServiceBus.Settings.SettingsHolder settings);

--- a/src/NServiceBus.Core/EndpointConfiguration.cs
+++ b/src/NServiceBus.Core/EndpointConfiguration.cs
@@ -100,7 +100,9 @@ public class EndpointConfiguration : ExposeSettings
         Settings.SetDefault(conventionsBuilder.Conventions);
 
         ActivateAndInvoke<INeedInitialization>(availableTypes, t => t.Customize(this));
+#pragma warning disable CS0618 // Type or member is obsolete
         ActivateAndInvoke<IWantToRunBeforeConfigurationIsFinalized>(availableTypes, t => t.Run(Settings));
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 
     readonly ConventionsBuilder conventionsBuilder;

--- a/src/NServiceBus.Core/IWantToRunBeforeConfigurationIsFinalized.cs
+++ b/src/NServiceBus.Core/IWantToRunBeforeConfigurationIsFinalized.cs
@@ -2,12 +2,16 @@
 
 namespace NServiceBus;
 
+using System;
+using Particular.Obsoletes;
 using Settings;
 
 /// <summary>
 /// Indicates that this class contains logic that needs to run just before
 /// configuration is finalized.
 /// </summary>
+[ObsoleteMetadata(Message = "Final adjustments to settings before configuration is finalized should be applied via an explicit last configuration step on the endpoint configuration, instead of via implementations of this interface discovered by scanning", TreatAsErrorFromVersion = "11.0", RemoveInVersion = "12.0")]
+[Obsolete("Final adjustments to settings before configuration is finalized should be applied via an explicit last configuration step on the endpoint configuration, instead of via implementations of this interface discovered by scanning. Will be treated as an error from version 11.0.0. Will be removed in version 12.0.0.", false)]
 public interface IWantToRunBeforeConfigurationIsFinalized
 {
     /// <summary>


### PR DESCRIPTION
This PR marks `IWantToRunBeforeConfigurationIsFinalized` as obsolete and updates its obsoletion message to guide users towards explicit configuration steps at the endpoint configuration level.

### Motivation

Over time, our APIs will be moving towards patterns that are:

- More explicit
- Ahead-of-time (AOT) friendly
- Trimming friendly

Implicit hooks discovered via assembly scanning work against these goals. By steering consumers towards explicit, ordered configuration calls on `EndpointConfiguration`, the overall model becomes clearer, easier to reason about, and more compatible with modern deployment scenarios (AOT, trimming, and similar).

This change also brings behavior more in line with expectations set by widely used dependency injection containers. For example, the Microsoft DI model already promotes explicit wiring and ordering of configuration logic rather than relying on runtime discovery hooks. For most software professionals, this explicitness aligns well with existing mental models (for example last one wins) and should not be surprising.

- There is no remaining usage of this interface across the platform, so the obsoletion is fully aligned with current internal usage patterns.
- External users relying on this interface will receive a clear compiler warning with guidance on how to transition to explicit endpoint configuration steps.
- This is a stepping stone towards eventually removing the interface in a future major version while giving users time to adjust their usages.