### PR TITLE
Ensure the handler invocation infrastructure does not pollute the stack trace

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_message_is_moved_to_error_queue.cs
+++ b/src/NServiceBus.AcceptanceTests/Core/Recoverability/When_message_is_moved_to_error_queue.cs
@@ -1,0 +1,81 @@
+namespace NServiceBus.AcceptanceTests.Core.Recoverability;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AcceptanceTesting;
+using AcceptanceTesting.Customization;
+using EndpointTemplates;
+using NUnit.Framework;
+
+public class When_message_is_moved_to_error_queue : NServiceBusAcceptanceTest
+{
+    [Test]
+    public async Task Should_provide_clean_stack_trace()
+    {
+        var context = await Scenario.Define<Context>()
+            .WithEndpoint<EndpointWithFailingHandler>(b => b
+                .DoNotFailOnErrorMessages()
+                .When((session, ctx) => session.SendLocal(new InitiatingMessage
+                {
+                    Id = ctx.TestRunId
+                }))
+            )
+            .WithEndpoint<ErrorSpy>()
+            .Run();
+
+        using (Assert.EnterMultipleScope())
+        {
+            var stackTrace = context.Headers["NServiceBus.ExceptionInfo.StackTrace"];
+            Assert.That(stackTrace, Does.Not.Contain("MessageHandlerInvoker"));
+            Assert.That(stackTrace, Does.Not.Contain("MessageHandlerFactory"));
+        }
+    }
+
+    class Context : ScenarioContext
+    {
+        public Dictionary<string, string> Headers { get; set; }
+    }
+
+    class EndpointWithFailingHandler : EndpointConfigurationBuilder
+    {
+        public EndpointWithFailingHandler() =>
+            EndpointSetup<DefaultServer>((b, context) =>
+            {
+                b.Recoverability().AddUnrecoverableException<SimulatedException>();
+                b.SendFailedMessagesTo(Conventions.EndpointNamingConvention(typeof(ErrorSpy)));
+            });
+
+        class InitiatingHandler : IHandleMessages<InitiatingMessage>
+        {
+            public Task Handle(InitiatingMessage initiatingMessage, IMessageHandlerContext context) => throw new SimulatedException();
+        }
+    }
+
+    class ErrorSpy : EndpointConfigurationBuilder
+    {
+        public ErrorSpy() => EndpointSetup<DefaultServer>();
+
+        class InitiatingMessageHandler(Context testContext) : IHandleMessages<InitiatingMessage>
+        {
+            public Task Handle(InitiatingMessage initiatingMessage, IMessageHandlerContext context)
+            {
+                if (initiatingMessage.Id != testContext.TestRunId)
+                {
+                    return Task.CompletedTask;
+                }
+
+                testContext.Headers = context.MessageHeaders.Where(x => x.Key.StartsWith("NServiceBus.ExceptionInfo"))
+                    .ToDictionary(x => x.Key, x => x.Value);
+                testContext.MarkAsCompleted();
+                return Task.CompletedTask;
+            }
+        }
+    }
+
+    public class InitiatingMessage : IMessage
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/src/NServiceBus.Core/Pipeline/Incoming/MessageHandlerInvoker.cs
+++ b/src/NServiceBus.Core/Pipeline/Incoming/MessageHandlerInvoker.cs
@@ -2,9 +2,11 @@
 namespace NServiceBus;
 
 using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Pipeline;
 
+// Be cautious when renaming this class because it is used in Core acceptance tests to verify it is hidden from the stack traces
 sealed class MessageHandlerInvoker<THandler, TMessage>(
     Func<IServiceProvider, THandler> createHandler,
     Func<THandler, TMessage, IMessageHandlerContext, Task> invocation,
@@ -33,6 +35,9 @@ sealed class MessageHandlerInvoker<THandler, TMessage>(
         instance = createHandler(provider);
     }
 
+    [DebuggerNonUserCode]
+    [DebuggerStepThrough]
+    [StackTraceHidden]
     public override Task Invoke(object message, IMessageHandlerContext handlerContext)
     {
         ArgumentNullException.ThrowIfNull(message);


### PR DESCRIPTION
I realized .NET has had for a while the [StackTraceHiddenAttribute](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.stacktracehiddenattribute) which makes in the majority of the cases things disappear from the stack trace and the stack trace when it is turned into a string. Since we replaced the exception tree part with a bit of class infrastructure, we are essentially adding more "weight" to the stack trace which has implications on transports that have limited message sizes because it might make it more likely to go over the message size limits. 

This pull request improves the clarity of stack traces for error messages in NServiceBus by ensuring internal framework classes are hidden from stack traces, making it easier for users to diagnose issues. The changes include new attributes on key handler invoker and factory methods, and an acceptance test to verify the improvement.

**Stack trace cleanliness improvements:**

* Added `[DebuggerNonUserCode]`, `[DebuggerStepThrough]`, and [`[StackTraceHidden]`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.stacktracehiddenattribute) attributes to the `Invoke` method in `MessageHandlerInvoker` to hide it from stack traces.
* Refactored handler invocation in `TimeoutHandlerFactory` and `MessageHandlerFactory` to use dedicated static methods (`InvokeTimeout` and `InvokeHandler`) with the same stack trace hiding attributes, ensuring these methods do not appear in stack traces. [[1]](diffhunk://#diff-061a40688c363931c975b9c4b9075bcfc60ec7a3d3d47b01cf8b139bc9574574L211-R231) [[2]](diffhunk://#diff-061a40688c363931c975b9c4b9075bcfc60ec7a3d3d47b01cf8b139bc9574574L231-R250)

**Test coverage:**

* Added a new acceptance test `When_message_is_moved_to_error_queue.cs` to verify that stack traces for moved error messages do not contain internal NServiceBus classes like `MessageHandlerInvoker` and `MessageHandlerFactory`.

**Documentation and maintainability:**

* Added comments to warn against renaming `MessageHandlerInvoker`, `TimeoutHandlerFactory`, and `MessageHandlerFactory` since they are referenced in acceptance tests for stack trace verification. [[1]](diffhunk://#diff-37aa0998f7752010b502774d60112d00907e895e8da1905179a237824f69d9b3R5-R9) [[2]](diffhunk://#diff-061a40688c363931c975b9c4b9075bcfc60ec7a3d3d47b01cf8b139bc9574574R205) [[3]](diffhunk://#diff-061a40688c363931c975b9c4b9075bcfc60ec7a3d3d47b01cf8b139bc9574574L211-R231) [[4]](diffhunk://#diff-061a40688c363931c975b9c4b9075bcfc60ec7a3d3d47b01cf8b139bc9574574L231-R250)

**Before:**

```text
NServiceBus.AcceptanceTesting.SimulatedException: Exception of type 'NServiceBus.AcceptanceTesting.SimulatedException' was thrown.
   at NServiceBus.AcceptanceTests.Recoverability.When_custom_policy_discards_failed_message.FailingMessageHandler.Handle(FailingMessage message, IMessageHandlerContext context) in /Users/danielmarbach/Projects/NServiceBus/src/NServiceBus.AcceptanceTests/Recoverability/When_custom_policy_discards_message.cs:line 51
   at NServiceBus.Unicast.MessageHandlerRegistry.MessageHandlerFactory`2.<>c.<InvokeHandler>b__4_0(IHandleMessages`1 handler, TMessage message, IMessageHandlerContext handlerContext) in /Users/danielmarbach/Projects/NServiceBus/src/NServiceBus.Core/Unicast/MessageHandlerRegistry.cs:line 247
   at NServiceBus.MessageHandlerInvoker`2.Invoke(Object message, IMessageHandlerContext handlerContext) in /Users/danielmarbach/Projects/NServiceBus/src/NServiceBus.Core/Pipeline/Incoming/MessageHandlerInvoker.cs:line 45
   at NServiceBus.InvokeHandlerTerminator.Terminate(IInvokeHandlerContext context) in /Users/danielmarbach/Projects/NServiceBus/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs:line 31
   at NServiceBus.LoadHandlersConnector.Invoke(IIncomingLogicalMessageContext context, Func`2 stage) in /Users/danielmarbach/Projects/NServiceBus/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs:line 59
````
**after:**

```text
NServiceBus.AcceptanceTesting.SimulatedException: Exception of type 'NServiceBus.AcceptanceTesting.SimulatedException' was thrown.
   at NServiceBus.AcceptanceTests.Recoverability.When_custom_policy_discards_failed_message.FailingMessageHandler.Handle(FailingMessage message, IMessageHandlerContext context) in /Users/danielmarbach/Projects/NServiceBus/src/NServiceBus.AcceptanceTests/Recoverability/When_custom_policy_discards_message.cs:line 51
   at NServiceBus.InvokeHandlerTerminator.Terminate(IInvokeHandlerContext context) in /Users/danielmarbach/Projects/NServiceBus/src/NServiceBus.Core/Pipeline/Incoming/InvokeHandlerTerminator.cs:line 31
   at NServiceBus.LoadHandlersConnector.Invoke(IIncomingLogicalMessageContext context, Func`2 stage) in /Users/danielmarbach/Projects/NServiceBus/src/NServiceBus.Core/Pipeline/Incoming/LoadHandlersConnector.cs:line 59
```
