### PR TITLE
Add acceptance test to verify custom dispatch properties are preserved with outbox on failure

### DIFF
--- a/src/NServiceBus.AcceptanceTests/Outbox/When_using_custom_dispatch_properties.cs
+++ b/src/NServiceBus.AcceptanceTests/Outbox/When_using_custom_dispatch_properties.cs
@@ -13,11 +13,11 @@ using Transport;
 public class When_using_custom_dispatch_properties : NServiceBusAcceptanceTest
 {
     [Test]
-    public async Task Should_preserve_them_even_on_failure()
+    public async Task Should_preserve_them_on_failure()
     {
         Requires.OutboxPersistence();
 
-        Context context = await Scenario.Define<Context>()
+        var context = await Scenario.Define<Context>()
             .WithEndpoint<NonDtcReceivingEndpoint>(b => b
                 .DoNotFailOnErrorMessages()
                 .When(session => session.SendLocal(new KickoffMessage())))


### PR DESCRIPTION
This pull request introduces a new acceptance test to verify that custom dispatch properties are preserved when using the outbox feature, even if message dispatch initially fails and is retried. The test ensures that these properties are correctly loaded from outbox records after a failure scenario.