### PR TITLE
Auto attach incoming message dispatch properties to outgoing

### DIFF
--- a/src/NServiceBus.Core.Tests/Routing/RoutingToDispatchConnectorTests.cs
+++ b/src/NServiceBus.Core.Tests/Routing/RoutingToDispatchConnectorTests.cs
@@ -17,7 +17,7 @@ public class RoutingToDispatchConnectorTests
     [Test]
     public async Task Should_preserve_message_state_for_one_routing_strategy_for_allocation_reasons()
     {
-        var behavior = new RoutingToDispatchConnector();
+        var behavior = new RoutingToDispatchConnector([]);
         IEnumerable<TransportOperation> operations = null;
         var testableRoutingContext = new TestableRoutingContext
         {
@@ -59,7 +59,7 @@ public class RoutingToDispatchConnectorTests
     [Test]
     public async Task Should_copy_message_state_for_multiple_routing_strategies()
     {
-        var behavior = new RoutingToDispatchConnector();
+        var behavior = new RoutingToDispatchConnector([]);
         IEnumerable<TransportOperation> operations = null;
         var testableRoutingContext = new TestableRoutingContext
         {
@@ -124,7 +124,7 @@ public class RoutingToDispatchConnectorTests
     [Test]
     public async Task Should_preserve_headers_generated_by_custom_routing_strategy()
     {
-        var behavior = new RoutingToDispatchConnector();
+        var behavior = new RoutingToDispatchConnector([]);
         Dictionary<string, string> headers = null;
         await behavior.Invoke(new TestableRoutingContext { RoutingStrategies = [new HeaderModifyingRoutingStrategy()] }, context =>
             {
@@ -142,7 +142,7 @@ public class RoutingToDispatchConnectorTests
         options.RequireImmediateDispatch();
 
         var dispatched = false;
-        var behavior = new RoutingToDispatchConnector();
+        var behavior = new RoutingToDispatchConnector([]);
         var message = new OutgoingMessage("ID", [], Array.Empty<byte>());
 
         await behavior.Invoke(new RoutingContext(message,
@@ -159,7 +159,7 @@ public class RoutingToDispatchConnectorTests
     public async Task Should_dispatch_immediately_if_not_sending_from_a_handler()
     {
         var dispatched = false;
-        var behavior = new RoutingToDispatchConnector();
+        var behavior = new RoutingToDispatchConnector([]);
         var message = new OutgoingMessage("ID", [], Array.Empty<byte>());
 
         await behavior.Invoke(new RoutingContext(message,
@@ -176,7 +176,7 @@ public class RoutingToDispatchConnectorTests
     public async Task Should_not_dispatch_by_default()
     {
         var dispatched = false;
-        var behavior = new RoutingToDispatchConnector();
+        var behavior = new RoutingToDispatchConnector([]);
         var message = new OutgoingMessage("ID", [], Array.Empty<byte>());
 
         await behavior.Invoke(new RoutingContext(message,
@@ -192,7 +192,7 @@ public class RoutingToDispatchConnectorTests
     [Test]
     public async Task Should_promote_message_headers_to_pipeline_activity()
     {
-        var behavior = new RoutingToDispatchConnector();
+        var behavior = new RoutingToDispatchConnector([]);
         var routingContext = new TestableRoutingContext();
         routingContext.Message.Headers[Headers.ContentType] = "test content type"; // one of the headers that will be mapped to tags
 

--- a/src/NServiceBus.Core/Pipeline/Outgoing/ImmediateDispatchTerminator.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/ImmediateDispatchTerminator.cs
@@ -2,24 +2,16 @@
 
 namespace NServiceBus;
 
-using System.Linq;
 using System.Threading.Tasks;
 using Pipeline;
 using Transport;
 
-class ImmediateDispatchTerminator : PipelineTerminator<IDispatchContext>
+class ImmediateDispatchTerminator(IMessageDispatcher dispatcher) : PipelineTerminator<IDispatchContext>
 {
-    public ImmediateDispatchTerminator(IMessageDispatcher dispatcher)
-    {
-        this.dispatcher = dispatcher;
-    }
-
     protected override Task Terminate(IDispatchContext context)
     {
         var transaction = context.Extensions.GetOrCreate<TransportTransaction>();
-        var operations = context.Operations as TransportOperation[] ?? context.Operations.ToArray();
+        var operations = context.Operations as TransportOperation[] ?? [.. context.Operations];
         return dispatcher.Dispatch(new TransportOperations(operations), transaction, context.CancellationToken);
     }
-
-    readonly IMessageDispatcher dispatcher;
 }

--- a/src/NServiceBus.Core/Pipeline/Outgoing/SendComponent.cs
+++ b/src/NServiceBus.Core/Pipeline/Outgoing/SendComponent.cs
@@ -6,6 +6,7 @@ using System;
 using MessageInterfaces;
 using Microsoft.Extensions.DependencyInjection;
 using Pipeline;
+using Settings;
 using Transport;
 
 class SendComponent
@@ -27,7 +28,7 @@ class SendComponent
 
 
         pipelineSettings.Register(new OutgoingPhysicalToRoutingConnector(), "Starts the message dispatch pipeline");
-        pipelineSettings.Register(new RoutingToDispatchConnector(), "Decides if the current message should be batched or immediately be dispatched to the transport");
+        pipelineSettings.Register(b => new RoutingToDispatchConnector(b.GetRequiredService<IReadOnlySettings>().Get<TransportDefinition>().DispatchPropertyNamesToPreserve), "Decides if the current message should be batched or immediately be dispatched to the transport");
         pipelineSettings.Register(new BatchToDispatchConnector(), "Passes batched messages over to the immediate dispatch part of the pipeline");
         pipelineSettings.Register(b => new ImmediateDispatchTerminator(b.GetRequiredService<IMessageDispatcher>()), "Hands the outgoing messages over to the transport for immediate delivery");
 

--- a/src/NServiceBus.Core/Transports/ErrorContext.cs
+++ b/src/NServiceBus.Core/Transports/ErrorContext.cs
@@ -38,6 +38,13 @@ public class ErrorContext
 
         DelayedDeliveriesPerformed = Message.GetDelayedDeliveriesPerformed();
         Extensions = context;
+
+        if (context.TryGet<DispatchProperties>(out var dispatchProperties))
+        {
+            context.Remove<DispatchProperties>();
+            // Hack hardcoded string for now
+            context.Set("IncomingMessage.DispatchProperties", dispatchProperties);
+        }
     }
 
     /// <summary>

--- a/src/NServiceBus.Core/Transports/MessageContext.cs
+++ b/src/NServiceBus.Core/Transports/MessageContext.cs
@@ -33,6 +33,13 @@ public partial class MessageContext : IExtendable
         ReceiveAddress = receiveAddress;
         TransportTransaction = transportTransaction;
 
+        if (context.TryGet<DispatchProperties>(out var dispatchProperties))
+        {
+            context.Remove<DispatchProperties>();
+            // Hack hardcoded string for now
+            context.Set("IncomingMessage.DispatchProperties", dispatchProperties);
+        }
+
         context.GetOrCreate<IncomingPipelineMetricTags>();
     }
 

--- a/src/NServiceBus.Core/Transports/TransportDefinition.cs
+++ b/src/NServiceBus.Core/Transports/TransportDefinition.cs
@@ -3,6 +3,7 @@
 namespace NServiceBus.Transport;
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -83,6 +84,11 @@ public abstract class TransportDefinition
     /// Indicates whether this transport supports time-to-be-received settings for messages.
     /// </summary>
     public bool SupportsTTBR { get; }
+
+    /// <summary>
+    /// TBD
+    /// </summary>
+    protected internal virtual FrozenSet<string> DispatchPropertyNamesToPreserve { get; } = [];
 
     /// <summary>
     /// Allows the transport to register required services into the service collection.


### PR DESCRIPTION
Quick spike to automatically propagate incoming message dispatch properties to the outgoing messages. If we did this for real we probably would have to differentiate the dispatch properties that always need to be copied to all messages vs the dispatch properties that should only be copied when the incoming message is copied in the recoverability and audit contexts. 

This way headers do not need to be polluted with transport-specific key-value pairs, the headers are not extended for information that is natively stored on the underlying transport message and the information is also preserved in the outbox. 

ServiceControl could easily store this information in the metadata and bring it back when materializing the transport operations for staging and retries. Then no native information is lost anymore because the dispatcher can always map it from the dispatch properties, and during transition we don't duplicate the information to headers that is natively available on the underlying SDK type. The information is only persisted separately for external persistences like outbox and SC.

This would allow storing native attributes and preserve them in SQS. It would allow using native concepts like the message group id. In ASB we could store things like subject, session ID etc. and never lose it again. 

Complexity like https://github.com/Particular/NServiceBus.AmazonSQS/blob/master/src/NServiceBus.Transport.SQS/Sending/MessageDispatcher.cs#L429-L436 would be handled in Core