### PR TITLE
Consolidate Microsoft.Extensions dependencies by replacing specific packages with Microsoft.Extensions.Hosting

### DIFF
--- a/src/NServiceBus.Core/NServiceBus.Core.csproj
+++ b/src/NServiceBus.Core/NServiceBus.Core.csproj
@@ -13,9 +13,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Public dependencies">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" AutomaticVersionRange="false" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics" Version="10.0.5" AutomaticVersionRange="false" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.5" AutomaticVersionRange="false" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" AutomaticVersionRange="false" />
     <PackageReference Include="NServiceBus.MessageInterfaces" Version="1.0.0" />
     <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.5" AutomaticVersionRange="false" />
   </ItemGroup>


### PR DESCRIPTION
This pull request makes a minor update to the project's dependencies. The most important change is replacing three separate Microsoft dependency packages with a single consolidated package reference.

Dependency update:

* Replaced `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Diagnostics`, and `Microsoft.Extensions.Hosting.Abstractions` with a single `Microsoft.Extensions.Hosting` package reference in `NServiceBus.Core.csproj`.

This is the first step in unifying the hosting experience in the next minor